### PR TITLE
fix: for oauth login

### DIFF
--- a/packages/backend/src/helpers/add-csp-headers.ts
+++ b/packages/backend/src/helpers/add-csp-headers.ts
@@ -44,7 +44,8 @@ const addCspHeaders = async (app: Application) => {
         },
       },
       crossOriginOpenerPolicy: {
-        policy: 'same-origin-allow-popups',
+        // required for using window.opener
+        policy: 'unsafe-none',
       },
       crossOriginResourcePolicy: {
         policy: appConfig.isDev ? 'cross-origin' : 'same-site',


### PR DESCRIPTION
fix for oauth login i.e. slack.

requires cross origin opener policy to be set to `unsafe-none` for it to work