### PR TITLE
Enable email whitelisting

### DIFF
--- a/ecs-task-definition.json
+++ b/ecs-task-definition.json
@@ -110,6 +110,10 @@
         {
           "name": "WORKER_ACTION_CONCURRENCY",
           "valueFrom": "plumber-<ENVIRONMENT>-worker-action-concurrency"
+        },
+        {
+          "name": "WHITELISTED_EMAILS",
+          "valueFrom": "plumber-<ENVIRONMENT>-whitelisted-emails"
         }
       ],
       "logConfiguration": {

--- a/packages/backend/src/helpers/email-validator.ts
+++ b/packages/backend/src/helpers/email-validator.ts
@@ -1,11 +1,28 @@
 import validator from 'email-validator'
+import assert from 'node:assert'
+
+// FIXME (ogp-weeloong): Remove after VAPT
+function getWhitelistedEmails(): ReadonlyArray<string> {
+  try {
+    const emails = JSON.parse(process.env.WHITELISTED_EMAILS)
+    assert(Array.isArray(emails))
+    return emails
+  } catch {
+    return []
+  }
+}
+
+const WHITELISTED_EMAILS = getWhitelistedEmails()
 
 export function validateAndParseEmail(input: unknown): string | false {
   if (typeof input !== 'string') {
     return false
   }
   const email = input.toLowerCase().trim()
-  if (!validator.validate(email) || !email.endsWith('.gov.sg')) {
+  if (
+    !validator.validate(email) ||
+    !(email.endsWith('.gov.sg') || WHITELISTED_EMAILS.includes(email))
+  ) {
     return false
   }
   return email


### PR DESCRIPTION
## Description
This PR allows whitelisted emails outside of .gov.sg to login. For easier updates & revocations, emails are controlled via an environment variable.

This code will be removed after VAPT, because there's no real reason to enable non .gov.sg emails (hence I didn't stuff this list into `appConfig`).

## Tests
_Scrappy as plumber is still in PMF stage..._

* Check that .gov.sg emails can login even if the env var is malformed or not defined.
* Check that .gov.sg emails still can login even if they're not on the whitelist.
* Check that whitelisted emails outside .gov.sg can login.
* Check that non-whitelisted emails outside .gov.sg cannot login (_whew, so many negatives_)