### PR TITLE
fix: properly handle invalid webhook urls

### DIFF
--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -14,9 +14,11 @@ export default async (request: IRequest, response: Response) => {
   const span = tracer.scope().active()
   span?.setOperationName('webhooks.handler')
 
-  const flow = await Flow.query()
-    .findById(request.params.flowId)
-    .throwIfNotFound()
+  const flow = await Flow.query().findById(request.params.flowId)
+
+  if (!flow) {
+    return response.sendStatus(404)
+  }
 
   const testRun = !flow.active
   const triggerStep = await flow.getTriggerStep()


### PR DESCRIPTION
## Problem

Currently, invalid webhook urls result in internal server error.

## Solution

Return 404 if webhook url (or corresponding flow) is not found.