### PR TITLE
chore: reduce otp resend interval to 30 sec, 5 mins too painful

### DIFF
--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -13,7 +13,7 @@ type Params = {
 }
 
 // 5 minutes in milliseconds
-const OTP_RESEND_TIMEOUT_IN_MS = 5 * 60 * 1000
+const OTP_RESEND_TIMEOUT_IN_MS = 1 * 30 * 1000
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "prebuild": "rimraf ./build",
     "lint": "eslint . --ignore-path ../../.eslintignore"


### PR DESCRIPTION
Change resend otp to 30 seconds.

Also expose host for frontend's `npm run dev` so you can test it on other devices like mobile phones