### PR TITLE
fix: add rate limit by ip for auth queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,22 @@
         }
       }
     },
+    "node_modules/@ardatan/aggregate-error": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@ardatan/aggregate-error/-/aggregate-error-0.0.6.tgz",
+      "integrity": "sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==",
+      "dependencies": {
+        "tslib": "~2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@ardatan/aggregate-error/node_modules/tslib": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+      "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
       "license": "MIT",
@@ -4239,6 +4255,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001448",
       "funding": [
@@ -6413,6 +6438,42 @@
         "node": ">=12"
       }
     },
+    "node_modules/graphql-rate-limit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/graphql-rate-limit/-/graphql-rate-limit-3.3.0.tgz",
+      "integrity": "sha512-mbbEv5z3SjkDLvVVdHi0XrVLavw2Mwo93GIqgQB/fx8dhcNSEv3eYI1OGdp8mhsm/MsZm7hjrRlwQMVRKBVxhA==",
+      "dependencies": {
+        "@graphql-tools/utils": "^7.6.0",
+        "graphql-shield": "^7.5.0",
+        "lodash.get": "^4.4.2",
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=12.0",
+        "pnpm": ">=6"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-rate-limit/node_modules/@graphql-tools/utils": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-7.10.0.tgz",
+      "integrity": "sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==",
+      "dependencies": {
+        "@ardatan/aggregate-error": "0.0.6",
+        "camel-case": "4.1.2",
+        "tslib": "~2.2.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/graphql-rate-limit/node_modules/tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
     "node_modules/graphql-shield": {
       "version": "7.6.5",
       "license": "MIT",
@@ -7468,6 +7529,14 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "license": "ISC",
@@ -7760,6 +7829,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/node-abort-controller": {
@@ -8115,6 +8193,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -10750,6 +10837,7 @@
         "express-basic-auth": "^1.2.1",
         "express-graphql": "^0.12.0",
         "graphql-middleware": "^6.1.15",
+        "graphql-rate-limit": "3.3.0",
         "graphql-shield": "^7.5.0",
         "graphql-tools": "^8.2.0",
         "graphql-type-json": "^0.3.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,7 @@
     "express-basic-auth": "^1.2.1",
     "express-graphql": "^0.12.0",
     "graphql-middleware": "^6.1.15",
+    "graphql-rate-limit": "3.3.0",
     "graphql-shield": "^7.5.0",
     "graphql-tools": "^8.2.0",
     "graphql-type-json": "^0.3.2",

--- a/packages/backend/src/config/redis.ts
+++ b/packages/backend/src/config/redis.ts
@@ -2,7 +2,12 @@ import iosRedis from 'ioredis'
 
 import appConfig from './app'
 
-export const createRedisClient = () =>
+export const REDIS_DB_INDEX = {
+  JOBS: 0,
+  RATE_LIMIT: 1,
+}
+
+export const createRedisClient = (db = REDIS_DB_INDEX.JOBS) =>
   appConfig.redisClusterMode
     ? new iosRedis.Cluster(
         [
@@ -17,6 +22,7 @@ export const createRedisClient = () =>
             tls: appConfig.redisTls ? {} : undefined,
             username: appConfig.redisUsername,
             password: appConfig.redisPassword,
+            db,
           },
         },
       )
@@ -28,6 +34,7 @@ export const createRedisClient = () =>
         password: appConfig.redisPassword,
         enableReadyCheck: false,
         maxRetriesPerRequest: null, // commands wait forever until the connection is alive again.
+        db,
         reconnectOnError(err) {
           const targetError = 'READONLY'
           if (err.message.includes(targetError)) {

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -1,8 +1,11 @@
+import { createRateLimitRule, RedisStore } from 'graphql-rate-limit'
 import { allow, rule, shield } from 'graphql-shield'
 import jwt from 'jsonwebtoken'
 
 import appConfig from '@/config/app'
+import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import User from '@/models/user'
+import Context from '@/types/express/context'
 
 const isAuthenticated = rule()(async (_parent, _args, req) => {
   const token = req.headers['authorization']
@@ -23,6 +26,19 @@ const isAuthenticated = rule()(async (_parent, _args, req) => {
   }
 })
 
+const rateLimitRule = createRateLimitRule({
+  identifyContext: (ctx: Context) => {
+    // get ip address of request in this order: cf-connecting-ip -> remoteAddress
+    const userIp =
+      (ctx.headers['cf-connecting-ip'] as string) ||
+      ctx.socket.remoteAddress.split(',')[0].trim()
+    return userIp
+  },
+  // recommended flag: https://github.com/teamplanes/graphql-rate-limit#enablebatchrequestcache
+  enableBatchRequestCache: true,
+  store: new RedisStore(createRedisClient(REDIS_DB_INDEX.RATE_LIMIT)),
+})
+
 const authentication = shield(
   {
     Query: {
@@ -31,8 +47,8 @@ const authentication = shield(
     },
     Mutation: {
       '*': isAuthenticated,
-      requestOtp: allow,
-      verifyOtp: allow,
+      requestOtp: rateLimitRule({ window: '1s', max: 5 }),
+      verifyOtp: rateLimitRule({ window: '1s', max: 5 }),
     },
   },
   {


### PR DESCRIPTION
## Problem
Our current auth graphql queries are not rate-limited. User can keep different email otp combinations infinitely.

## Solution
Use `graphql-rate-limit` to limit the 2 auth queries (actually mutations) `verifyOtp` and `requestOtp` by user ip address. We check for cf-connecting-ip header first before req.socket.remoteAddress as user ip.

Limit 5 queries per second (sliding window) for the 2 queries.
