### PR TITLE
Improve error message for relative webhook URLs

### DIFF
--- a/packages/backend/src/apps/webhook/__tests__/actions/make-request.test.ts
+++ b/packages/backend/src/apps/webhook/__tests__/actions/make-request.test.ts
@@ -64,4 +64,17 @@ describe('create row', () => {
       'Recursively invoking Plumber webhooks is prohibited.',
     )
   })
+
+  it.each([
+    'test-domain.com/webhooks/abc-def-123',
+    'webhooks/abc-def-123',
+    '/webhooks/abc-def-123',
+  ])('rejects webhooks with relative URLs', async (url: string) => {
+    $.step.parameters.method = 'GET'
+    $.step.parameters.data = 'meep meep'
+    $.step.parameters.url = url
+    expect(makeRequestAction.run($)).rejects.toThrowError(
+      'Webhook URLs need to begin with http:// or https://',
+    )
+  })
 })

--- a/packages/backend/src/apps/webhook/actions/make-request/index.ts
+++ b/packages/backend/src/apps/webhook/actions/make-request/index.ts
@@ -30,7 +30,7 @@ export default defineAction({
       type: 'string' as const,
       required: true,
       description:
-        'Any URL with a querystring will be re-encoded properly. Plumber URLs (e.g. https://plumber.gov.sg/webhooks/...) are prohibited.',
+        'Any URL with a querystring will be re-encoded properly. Only absolute URLs (https://... or http://...) are supported. Plumber URLs (e.g. https://plumber.gov.sg/webhooks/...) are prohibited.',
       variables: true,
     },
     {
@@ -48,8 +48,21 @@ export default defineAction({
     const data = $.step.parameters.data as string
     const url = $.step.parameters.url as string
 
+    // Only for checking protocol and for plumber domain - URLs are case
+    // sensitive in general.
+    const lowercaseUrl = url.toLowerCase()
+
+    if (
+      !(
+        lowercaseUrl.startsWith('https://') ||
+        lowercaseUrl.startsWith('http://')
+      )
+    ) {
+      throw new Error('Webhook URLs need to begin with http:// or https://')
+    }
+
     // Prohibit calling ourselves to prevent self-DoS.
-    if (new URL(url).hostname.toLowerCase().endsWith('plumber.gov.sg')) {
+    if (new URL(lowercaseUrl).hostname.endsWith('plumber.gov.sg')) {
       throw new Error('Recursively invoking Plumber webhooks is prohibited.')
     }
 


### PR DESCRIPTION
## Problem
Currently, using relative URLs in our webhook action results in this confusing error message:

> Cannot destructure property 'status' of 'error.response' as it is undefined.

The root cause is due to Axios sending the request to `localhost` (since we're making a relative URL request, but our webhook app's `baseURI` is an empty string) and our error interceptor exploding while handling axios' error _(...we'll need to fix the interceptor a separate PR)._

## Solution
There's no reason for anyone to use relative webhook URLs, so let's force absolute HTTP URLs and stick a nice error message on top.

## Tests
- Added unit tests
- Check that I can still configure an absolute webhook URL
- Check that the "Webhook URLs need to begin with http:// or https://" error appears if I configure a relative webhook URL
- Checked that there are no relative URL webhooks on prod (so nothing will break)