### PR TITLE
feat: use alphanumeric characters for otp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7736,8 +7736,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "license": "MIT",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -10761,6 +10768,7 @@
         "luxon": "2.5.2",
         "morgan": "^1.10.0",
         "multer": "1.4.5-lts.1",
+        "nanoid": "3.3.6",
         "objection": "^3.0.0",
         "pg": "^8.7.1",
         "typescript": "^4.6.3",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,6 +50,7 @@
     "luxon": "2.5.2",
     "morgan": "^1.10.0",
     "multer": "1.4.5-lts.1",
+    "nanoid": "3.3.6",
     "objection": "^3.0.0",
     "pg": "^8.7.1",
     "typescript": "^4.6.3",

--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto'
+import { customAlphabet } from 'nanoid/async'
 
 import appConfig from '@/config/app'
 import BaseError from '@/errors/base'
@@ -11,6 +11,10 @@ type Params = {
     email: string
   }
 }
+
+const OTP_LENGTH = 6
+const OTP_ALLOWED_CHARS = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
+const generateOtpAsync = customAlphabet(OTP_ALLOWED_CHARS, OTP_LENGTH)
 
 // 30 seconds in milliseconds
 const OTP_RESEND_TIMEOUT_IN_MS = 1 * 30 * 1000
@@ -42,7 +46,7 @@ const requestOtp = async (
       )} seconds before requesting a new OTP`,
     )
   }
-  const otp = crypto.randomInt(0, 1000000).toString().padStart(6, '0')
+  const otp = await generateOtpAsync()
   await user.$query().patch({
     otpHash: user.hashOtp(otp),
     otpAttempts: 0,

--- a/packages/frontend/src/components/LoginForm/OtpInput.tsx
+++ b/packages/frontend/src/components/LoginForm/OtpInput.tsx
@@ -18,11 +18,14 @@ const OtpInput = ({ isLoading, email, otp, setOtp }: Props): JSX.Element => {
         </FormLabel>
         <Input
           autoFocus
-          type="tel"
-          placeholder="123456"
+          type="text"
+          autoCapitalize="true"
+          autoCorrect="false"
+          autoComplete="one-time-code"
+          placeholder="ABC123"
           value={otp}
           onChange={(e) => {
-            setOtp(e.target.value)
+            setOtp(e.target.value?.toUpperCase())
           }}
         />
       </FormControl>


### PR DESCRIPTION
## Problem

With the current 6 digit OTP, it is quite easy for a bad actor to enumerate. 

000000 - 999999 has 1,000,000 different possibilities
Assuming with the current rate of 5 req/s for verifyOtp, it will only take them 2.31 days to brute force with a single machine.

## Solution

Move to alphanumeric OTP with the following character set : `23456789ABCDEFGHJKLMNPQRSTUVWXYZ` (possibly-confusing characters removed)

Number of possibilities = 32 ^ 6 = 1,073,741,824
Numer of days required for a single IP = 2,400+ days

**Other considerations**
Use 8 digit OTP: it will require a heavier mental overhead to remember an 8-digit OTP (equivalent to memorising a mobile phone number) vs a 6 character alphanumeric otp.