### PR TITLE
Implement dataOutMetadata for FormSG

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/metadata/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/metadata/get-data-out-metadata.test.ts
@@ -1,0 +1,49 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import getDataOutMetadata from '../../metadata/get-data-out-metadata'
+import newSubmissionTrigger from '../../triggers/new-submission'
+
+const SAMPLE_EXECUTION_STEP = {
+  dataOut: {
+    fields: {
+      textFieldId: {
+        question: 'What is your name?',
+        answer: 'herp derp',
+        fieldType: 'textField',
+      },
+    },
+  },
+} as unknown as IExecutionStep
+
+describe('formsg data-out metadata', () => {
+  it('is null if step is not new submission', async () => {
+    const metadata = await getDataOutMetadata(
+      'herp derp',
+      SAMPLE_EXECUTION_STEP,
+    )
+    expect(metadata).toBeNull()
+  })
+
+  it('hides the question and field type', async () => {
+    const metadata = await getDataOutMetadata(
+      newSubmissionTrigger.key,
+      SAMPLE_EXECUTION_STEP,
+    )
+
+    expect(metadata.fields.textFieldId.question.isVisible).toEqual(false)
+    expect(metadata.fields.textFieldId.fieldType.isVisible).toEqual(false)
+  })
+
+  it('changes the answer label to include the question', async () => {
+    const metadata = await getDataOutMetadata(
+      newSubmissionTrigger.key,
+      SAMPLE_EXECUTION_STEP,
+    )
+
+    expect(metadata.fields.textFieldId.answer.label).toEqual(
+      `Answer (What is your name?)`,
+    )
+  })
+})

--- a/packages/backend/src/apps/formsg/index.ts
+++ b/packages/backend/src/apps/formsg/index.ts
@@ -1,5 +1,6 @@
 import defineApp from '@/helpers/define-app'
 
+import getDataOutMetadata from './metadata/get-data-out-metadata'
 import auth from './auth'
 import triggers from './triggers'
 
@@ -16,4 +17,5 @@ export default defineApp({
   auth,
   triggers,
   actions: [],
+  getDataOutMetadata,
 })

--- a/packages/backend/src/apps/formsg/metadata/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/metadata/get-data-out-metadata.ts
@@ -1,0 +1,56 @@
+import { IDataOutMetadata, IExecutionStep, IStep } from '@plumber/types'
+
+import newSubmissionTrigger from '../triggers/new-submission'
+
+async function getDataOutMetadata(
+  stepKey: IStep['key'],
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  if (stepKey !== newSubmissionTrigger.key) {
+    return null
+  }
+
+  const data = executionStep.dataOut
+  if (!data) {
+    return null
+  }
+
+  const fieldMetadata: IDataOutMetadata = Object.create(null)
+
+  for (const [fieldId, fieldData] of Object.entries(data.fields)) {
+    fieldMetadata[fieldId] = {
+      question: { isVisible: false },
+      fieldType: { isVisible: false },
+      answer: {
+        type: 'text',
+        isVisible: true,
+        label: `Answer (${fieldData.question})`,
+      },
+    }
+  }
+
+  return {
+    fields: fieldMetadata,
+    submissionId: { isVisible: false },
+  }
+}
+
+export default getDataOutMetadata
+
+// Reference dataOut for FormSG
+// ---
+// {
+//   "fields": {
+//     "647edbd2026dc800116b21f9": {
+//       "answer": "zzz",
+//       "question": "What is the air speed velocity of an unladen swallow?",
+//       "fieldType": "textfield"
+//     },
+//     "648fe18a9175ce001196b3d5": {
+//       "answer": "aaaa",
+//       "question": "What is your name?",
+//       "fieldType": "textfield"
+//     }
+//   },
+//   "submissionId": "649306c1ac8851001149af0a"
+// }


### PR DESCRIPTION
## Problem
We have user feedback that FormSG variables are hard to use.

## Solution
This PR adds `dataOutMetadata` for FormSG to achieve the following:
1. Hides all fields except for question and responses.
2. Make `PowerInput` render questions & responses in the same order as the source form.
3. Includes value in the pill.

## Tests
- New unit test