### PR TITLE
chore: add minio to docker compose

### DIFF
--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -28,6 +28,17 @@ services:
     command: tunnel run
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN}
+  minio:
+    image: 'bitnami/minio:latest'
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    environment:
+      - MINIO_ROOT_USER=minio-username
+      - MINIO_ROOT_PASSWORD=minio-password
+    volumes:
+      - plumber-minio:/data
 volumes:
   plumber-postgres:
   plumber-redis:
+  plumber-minio:


### PR DESCRIPTION
## Add minio to docker compose

Minio is a S3 compatible file storage service, so we could interact with it via s3 api library.

Not using localstack since free version doesnt allow persistence. (i.e. everything gets deleted when docker container restarts). Also localstack is super large and we're only using s3 service.