### PR TITLE
fix: exexcute flow mutation auth check

### DIFF
--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -17,6 +17,7 @@ const executeFlow = async (
   const untilStep = await context.currentUser
     .$relatedQuery('steps')
     .findById(stepId)
+    .throwIfNotFound()
 
   const { executionStep } = await testRun({ stepId })
 


### PR DESCRIPTION
Fixes: GTA-14-006 WP1: Suboptimal ACL allows triggering other users' pipes

Checks that step id belongs to user before running test flow