### PR TITLE
[COOKIE-2] feat (backend): set auth token in cookie, remove on logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,16 +55,17 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.7.5",
-      "license": "MIT",
+      "version": "3.7.17",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.17.tgz",
+      "integrity": "sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.0",
         "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/trie": "^0.4.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -92,6 +93,17 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -3406,6 +3418,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.13",
       "dev": true,
@@ -5004,6 +5025,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11301,6 +11342,7 @@
         "ajv-formats": "^2.1.1",
         "axios": "0.24.0",
         "bullmq": "^3.0.0",
+        "cookie-parser": "1.4.6",
         "copyfiles": "^2.4.1",
         "cors": "^2.8.5",
         "crypto-js": "^4.1.1",
@@ -11336,6 +11378,7 @@
       "devDependencies": {
         "@types/bcrypt": "^5.0.0",
         "@types/bull": "^3.15.8",
+        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.12",
         "@types/crypto-js": "^4.0.2",
         "@types/express": "^4.17.15",
@@ -11355,7 +11398,7 @@
     },
     "packages/frontend": {
       "dependencies": {
-        "@apollo/client": "^3.6.9",
+        "@apollo/client": "3.7.17",
         "@chakra-ui/react": "2.6.1",
         "@emotion/react": "11.10.5",
         "@emotion/styled": "11.10.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,7 @@
     "ajv-formats": "^2.1.1",
     "axios": "0.24.0",
     "bullmq": "^3.0.0",
+    "cookie-parser": "1.4.6",
     "copyfiles": "^2.4.1",
     "cors": "^2.8.5",
     "crypto-js": "^4.1.1",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/bull": "^3.15.8",
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.12",
     "@types/crypto-js": "^4.0.2",
     "@types/express": "^4.17.15",

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2,6 +2,7 @@ import '@/config/orm'
 
 import { IRequest } from '@plumber/types'
 
+import cookieParser from 'cookie-parser'
 import cors from 'cors'
 import express from 'express'
 import createError from 'http-errors'
@@ -27,6 +28,7 @@ const app = express()
 app.disable('x-powered-by')
 app.use(csp)
 app.use(morgan)
+app.use(cookieParser())
 app.use(
   express.json({
     verify(req, _res, buf) {

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -6,6 +6,7 @@ import deleteFlow from './mutations/delete-flow'
 import deleteStep from './mutations/delete-step'
 import executeFlow from './mutations/execute-flow'
 import generateAuthUrl from './mutations/generate-auth-url'
+import logout from './mutations/logout'
 import requestOtp from './mutations/request-otp'
 import resetConnection from './mutations/reset-connection'
 import retryExecutionStep from './mutations/retry-execution-step'
@@ -34,6 +35,7 @@ const mutationResolvers = {
   requestOtp,
   verifyOtp,
   retryExecutionStep,
+  logout,
 }
 
 export default mutationResolvers

--- a/packages/backend/src/graphql/mutations/logout.ts
+++ b/packages/backend/src/graphql/mutations/logout.ts
@@ -1,0 +1,13 @@
+import { deleteAuthCookie } from '@/helpers/cookie'
+import Context from '@/types/express/context'
+
+const logout = async (
+  _parent: unknown,
+  _params: unknown,
+  context: Context,
+): Promise<boolean> => {
+  deleteAuthCookie(context.res)
+  return true
+}
+
+export default logout

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -48,8 +48,9 @@ type Mutation {
   updateStep(input: UpdateStepInput): Step
   deleteStep(input: DeleteStepInput): Step
   requestOtp(input: RequestOtpInput): Boolean
-  verifyOtp(input: VerifyOtpInput): Auth
+  verifyOtp(input: VerifyOtpInput): Boolean
   retryExecutionStep(input: RetryExecutionStepInput): Boolean
+  logout: Boolean
 }
 
 """
@@ -124,11 +125,6 @@ type AppAuth {
 enum ArgumentEnumType {
   integer
   string
-}
-
-type Auth {
-  user: User
-  token: String
 }
 
 type AuthenticationStep {

--- a/packages/backend/src/helpers/cookie.ts
+++ b/packages/backend/src/helpers/cookie.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express'
+import jwt from 'jsonwebtoken'
+
+import appConfig from '@/config/app'
+
+const AUTH_COOKIE_NAME = 'plumber.sid'
+// 3 days expiry
+const TOKEN_EXPIRES_IN_SEC = 3 * 24 * 60 * 60
+
+export function setAuthCookie(
+  res: Response,
+  payload: { userId: string },
+): void {
+  // create jwt
+  const token = jwt.sign(payload, appConfig.sessionSecretKey, {
+    expiresIn: TOKEN_EXPIRES_IN_SEC,
+  })
+
+  res.cookie(AUTH_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: 'strict',
+    secure: !appConfig.isDev,
+    maxAge: 1000 * TOKEN_EXPIRES_IN_SEC, // 3 days expressed in milliseconds
+  })
+  return
+}
+
+export function getAuthCookie(req: Request) {
+  return req.cookies[AUTH_COOKIE_NAME]
+}
+
+export function deleteAuthCookie(res: Response) {
+  res.clearCookie(AUTH_COOKIE_NAME)
+}


### PR DESCRIPTION
# Backend changes only for moving cookie-based auth

> Note: does not work with this PR alone! this is mainly for easier PR reviews.

## Changes
- in `verify-otp`, set jwt in cookie header rather returning in response
- added cookie parser package
- in new endpoint `logout`, clear cookie
