### PR TITLE
chore: disable graphql landing page by default

### DIFF
--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -34,8 +34,21 @@ const server = new ApolloServer<UnauthenticatedContext>({
       : ApolloServerPluginLandingPageDisabled(),
   ],
   formatError: (error) => {
-    logger.error(error.path + ' : ' + error.message)
-    return error
+    logger.error(error)
+    let errorMessage = error.message
+    if (error.message.includes('Did you mean')) {
+      errorMessage = 'Invalid request'
+    }
+    if (
+      error.message.includes("Please either specify a 'content-type' header")
+    ) {
+      errorMessage = 'Blocked request'
+    }
+    const newError = {
+      message: errorMessage,
+      code: error.extensions?.code,
+    }
+    return newError
   },
 })
 


### PR DESCRIPTION
## Problem

Right now it `/graphql` endpoint returns the editor page (altho it's blocked by CSP)

<img width="728" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/6a26b96e-384f-4397-86e8-edcc39027ce1">

## Solution 

Totally disable this page
