### PR TITLE
PLU-2: Disable autocomplete for auth fields

### DIFF
--- a/packages/backend/src/apps/formsg/auth/index.ts
+++ b/packages/backend/src/apps/formsg/auth/index.ts
@@ -15,7 +15,7 @@ export default {
       description:
         'Enter your Form URL e.g. https://form.gov.sg/654ab1234abc1a012345f1e0b',
       clickToCopy: false,
-      browserAutoComplete: 'url' as const,
+      autoComplete: 'url' as const,
     },
     {
       key: 'privateKey',
@@ -27,7 +27,7 @@ export default {
       placeholder: null,
       description: 'Secret key for your Form',
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
   verifyCredentials,

--- a/packages/backend/src/apps/postman/auth/index.ts
+++ b/packages/backend/src/apps/postman/auth/index.ts
@@ -30,7 +30,7 @@ export default {
       placeholder: null,
       description: 'Postman API key.',
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
   verifyCredentials,

--- a/packages/backend/src/apps/slack/auth/index.ts
+++ b/packages/backend/src/apps/slack/auth/index.ts
@@ -15,7 +15,7 @@ export default {
       description:
         'When asked to input an OAuth callback or redirect URL in Slack OAuth, enter the URL above.',
       clickToCopy: true,
-      browserAutoComplete: 'url' as const,
+      autoComplete: 'url' as const,
     },
     {
       key: 'consumerKey',
@@ -27,7 +27,7 @@ export default {
       placeholder: null,
       description: null,
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
     {
       key: 'consumerSecret',
@@ -39,7 +39,7 @@ export default {
       placeholder: null,
       description: null,
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
 

--- a/packages/backend/src/apps/telegram-bot/auth/index.ts
+++ b/packages/backend/src/apps/telegram-bot/auth/index.ts
@@ -13,7 +13,7 @@ export default {
       placeholder: null,
       description: 'Bot token which should be retrieved from @botfather.',
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
 

--- a/packages/backend/src/apps/twilio/auth/index.ts
+++ b/packages/backend/src/apps/twilio/auth/index.ts
@@ -40,7 +40,7 @@ export default {
       description:
         "If an API Key SID was provided, please provide your API Key Secret. If not, please provide your account's auth token.",
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
 

--- a/packages/backend/src/apps/vault-workspace/auth/index.ts
+++ b/packages/backend/src/apps/vault-workspace/auth/index.ts
@@ -24,7 +24,7 @@ export default {
       placeholder: null,
       description: 'API key which should be retrieved from Vault Workspace.',
       clickToCopy: false,
-      browserAutoComplete: 'off' as const,
+      autoComplete: 'off' as const,
     },
   ],
   verifyCredentials,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -196,7 +196,7 @@ type Field {
   allowArbitrary: Boolean
   docUrl: String
   clickToCopy: Boolean
-  browserAutoComplete: String
+  autoComplete: String
   options: [ArgumentOption]
 }
 

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -105,7 +105,7 @@ export default function InputCreator(
         multiline={type === 'multiline'}
         helperText={description}
         clickToCopy={clickToCopy}
-        autoComplete={schema.browserAutoComplete}
+        autoComplete={schema.autoComplete}
       />
     )
   }

--- a/packages/frontend/src/graphql/queries/get-app.ts
+++ b/packages/frontend/src/graphql/queries/get-app.ts
@@ -22,7 +22,7 @@ export const GET_APP = gql`
           docUrl
           allowArbitrary
           clickToCopy
-          browserAutoComplete
+          autoComplete
           options {
             label
             value

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -31,7 +31,7 @@ export const GET_APPS = gql`
           description
           docUrl
           clickToCopy
-          browserAutoComplete
+          autoComplete
           options {
             label
             value

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -128,7 +128,7 @@ export interface IUser {
 }
 
 // Subset of HTML autocomplete values.
-type BrowserAutoComplete = 'off' | 'url' | 'email'
+type AutoCompleteValue = 'off' | 'url' | 'email'
 
 export interface IBaseField {
   key: string
@@ -171,7 +171,7 @@ export interface IFieldText extends IBaseField {
   value?: string
 
   // Not applicable if field has variables.
-  browserAutoComplete?: BrowserAutoComplete
+  autoComplete?: AutoCompleteValue
 }
 
 export interface IFieldMultiline extends IBaseField {
@@ -179,7 +179,7 @@ export interface IFieldMultiline extends IBaseField {
   value?: string
 
   // Not applicable if field has variables.
-  browserAutoComplete?: BrowserAutoComplete
+  autoComplete?: AutoCompleteValue
 }
 
 export type IField = IFieldDropdown | IFieldText | IFieldMultiline


### PR DESCRIPTION
## Problem
Autocomplete may end up storing sensitive keys used in our connection setup steps.

Closes GTA-14-007.

## Solution
We will disable autocomplete for sensitive auth fields, by allowing apps to specify the html autocomplete behaviour for each field.

Note that this attribute is only supported for fields without variables enabled.

## Tests
- Use Chrome developer tools and check that `autocomplete` property is set to `off` on sensitive fields.

<img width="750" alt="Screenshot 2023-07-11 at 5 53 00 PM" src="https://github.com/opengovsg/plumber/assets/135598754/16f8d72c-3d74-42f8-9276-1b616802c6ab">