### PR TITLE
Fix: Empty variable pills in PowerInput

### DIFF
--- a/packages/frontend/src/components/PowerInput/utils.ts
+++ b/packages/frontend/src/components/PowerInput/utils.ts
@@ -29,10 +29,7 @@ export function genVariableLabelMap(
 }
 
 const variableRegExp = /({{.*?}})/
-export const deserialize = (
-  value: string,
-  variableLabels: VariableLabelMap,
-): Descendant[] => {
+export function deserialize(value: string): Descendant[] {
   if (!value) {
     return [
       {
@@ -52,7 +49,6 @@ export const deserialize = (
           if (node.match(variableRegExp)) {
             return {
               type: 'variable',
-              name: variableLabels.get(node),
               value: node,
               children: [{ text: '' }],
             }


### PR DESCRIPTION
## Problem
Variable labels are stored in a map using data fetched from GraphQL. Before GraphQL completes, the map is empty, which results in variable pills being empty.

![Screenshot 2023-07-13 at 8 21 01 PM](https://github.com/opengovsg/plumber/assets/135598754/d5f61d0f-7e24-4897-a244-c046dd419115)

However, Slate does not seem to re-process pills correctly after GraphQL updates - the `name` prop in `renderElement`'s arguments remains `undefined` even after we set a new label. So variable pills remain empty (unless the user forces a rerender by collapsing and opening the "Set up Action" section).

## Solution
We will stop storing labels inside the `name` prop; instead, we will make our `Variable` pill component fetch labels ourselves.

## Tests
- Check that pills have the correct labels after GraphQL completes.
- Regression test: check that I can create new pipes and edit existing pipes.
- Regression test: check that existing pipes still work.