### PR TITLE
PLU-7: [MULTI-ROW-4] Migrate "choose app" form to chakra

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -11,7 +11,7 @@ import Collapse from '@mui/material/Collapse'
 import ListItem from '@mui/material/ListItem'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { FormHelperText, FormLabel } from '@opengovsg/design-system-react'
+import { FormLabel } from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { EditorContext } from 'contexts/Editor'
 import { GET_APPS } from 'graphql/queries/get-apps'
@@ -192,11 +192,6 @@ function ChooseAppAndEventSubstep(
                     <FormLabel isRequired>
                       {formatMessage('flowEditor.chooseEvent')}
                     </FormLabel>
-                    <FormHelperText>
-                      {isTrigger
-                        ? formatMessage('flowEditor.triggerEvent')
-                        : formatMessage('flowEditor.actionEvent')}
-                    </FormHelperText>
                     <TextField
                       {...params}
                       InputProps={{


### PR DESCRIPTION
## Problem

We are building a new multi-row input, which will use Chakra's `FormLabel` instead of MUI's labels. This will make our "choose app" form look super inconsistent.

## Solution
We will migrate to Chakra's `FormLabel` in our choose app step form.

**BEFORE**:
<img width="440" alt="Screenshot 2023-07-17 at 10 32 28 PM" src="https://github.com/opengovsg/plumber/assets/135598754/ea562ec7-db52-41d2-81cf-0c2042cdc880">

**AFTER**:
<img width="440" alt="Screenshot 2023-07-17 at 10 33 08 PM" src="https://github.com/opengovsg/plumber/assets/135598754/2377dd59-8df1-40cf-b9cb-aee33ec054de">

## Tests
- Regression test: check that I can still create and run new pipes.
- Regression test: check that I can still edit existing pipes.
