### PR TITLE
[PLU-53] fix: boolean values not displayed

### DIFF
--- a/packages/frontend/src/components/PowerInput/Suggestions.tsx
+++ b/packages/frontend/src/components/PowerInput/Suggestions.tsx
@@ -89,7 +89,11 @@ const Suggestions = (props: SuggestionsProps) => {
                           sx: { fontWeight: 700 },
                         }}
                         secondary={
-                          suboption.displayedValue ?? suboption.value ?? ''
+                          <>
+                            {suboption.displayedValue ??
+                              suboption.value?.toString() ??
+                              ''}
+                          </>
                         }
                         secondaryTypographyProps={{
                           variant: 'subtitle2',


### PR DESCRIPTION
## Problem

Boolean values not displayed in dropdown variable selection list.
React does not automatically cast booleans into strings in their element nodes.

## Solution

Cast to string if boolean