### PR TITLE
PLU-7: [MULTI-ROW-10] Move refresh icon into autocomplete list

### DIFF
--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -2,8 +2,8 @@ import type { IFieldDropdownOption } from '@plumber/types'
 
 import * as React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { BiRefresh } from 'react-icons/bi'
 import { Flex, FormControl } from '@chakra-ui/react'
-import RefreshIcon from '@mui/icons-material/Refresh'
 import { Paper, PaperProps } from '@mui/material'
 import Autocomplete, {
   AutocompleteProps,
@@ -28,7 +28,7 @@ function PaperWithRefresh(props: PaperWithRefreshProps): JSX.Element {
       {children}
       {onRefresh && (
         <Button
-          leftIcon={<RefreshIcon />}
+          leftIcon={<BiRefresh />}
           w="100%"
           variant="clear"
           onMouseDown={(e) => {

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -4,16 +4,45 @@ import * as React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { Flex, FormControl } from '@chakra-ui/react'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import { Paper, PaperProps } from '@mui/material'
 import Autocomplete, {
   AutocompleteProps,
   createFilterOptions,
 } from '@mui/material/Autocomplete'
 import Typography from '@mui/material/Typography'
 import {
+  Button,
   FormErrorMessage,
   FormLabel,
-  IconButton,
 } from '@opengovsg/design-system-react'
+
+interface PaperWithRefreshProps extends PaperProps {
+  onRefresh?: () => void
+  loading?: boolean
+}
+
+function PaperWithRefresh(props: PaperWithRefreshProps): JSX.Element {
+  const { onRefresh, loading, children, ...paperProps } = props
+  return (
+    <Paper {...paperProps}>
+      {children}
+      {onRefresh && (
+        <Button
+          leftIcon={<RefreshIcon />}
+          w="100%"
+          variant="clear"
+          onMouseDown={(e) => {
+            e.preventDefault()
+          }}
+          onClick={onRefresh}
+          isLoading={loading}
+        >
+          Refresh items
+        </Button>
+      )}
+    </Paper>
+  )
+}
 
 interface ControlledAutocompleteProps
   extends AutocompleteProps<IFieldDropdownOption, boolean, boolean, boolean> {
@@ -162,17 +191,14 @@ function ControlledAutocomplete(
                     )}
                   </li>
                 )}
+                PaperComponent={(props) => (
+                  <PaperWithRefresh
+                    {...props}
+                    onRefresh={onRefresh}
+                    loading={loading}
+                  />
+                )}
               />
-              {onRefresh && (
-                <IconButton
-                  aria-label="refresh"
-                  variant="clear"
-                  isLoading={loading}
-                  icon={<RefreshIcon />}
-                  onClick={onRefresh}
-                  rounded="50%"
-                />
-              )}
             </Flex>
             {isError && (
               <FormErrorMessage>{fieldState.error?.message}</FormErrorMessage>


### PR DESCRIPTION
## Problem
The "Refresh" button on `ControlledAutocomplete` is placed outside the drop-down, which looks jank next to the "delete row" icon in our multi row input

<img width="550" alt="Screenshot 2023-08-08 at 3 17 18 PM" src="https://github.com/opengovsg/plumber/assets/135598754/b6057639-22aa-4fc8-9d40-687329bf693b">

## Solution
We will move the refresh button into the drop down itself:

https://github.com/opengovsg/plumber/assets/135598754/c8e97ee2-7fef-4f7e-a4b9-3b919a0d46cc


## Tests
- Check that refreshing items work.
- Check that the "refresh items" button is not shown for non-dynamic drop downs.
- Regression test: check that I can still select items from the actual drop down list