### PR TITLE
PLU-14: [ATTACHMENTS-9] Gate postman email attachments

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -101,7 +101,7 @@ function ChooseAppAndEventSubstep(
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         .map((trigger) => eventOptionGenerator(trigger)),
-    [app?.key, launchDarkly],
+    [app?.key, launchDarkly.flags],
   )
   const selectedActionOrTrigger = actionsOrTriggers.find(
     (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === step?.key,


### PR DESCRIPTION
## Problem
We want to gate postman email attachments behind a feature flag.

## Solution
We will enable filtering available actions and triggers through Launch Darkly.

The high level approach:
1. Instead of instrumenting our backend, we will adopt a fixed LD feature flag naming convention for actions and triggers: `app_${app.key}_${'action' if action, else 'trigger'}_${action/trigger.key}`.
   - e.g. To control vault workspace's "update table data" action, we can add an LD feature flag named `app_vault-workspace_action_updateTableData`
   - This feature flag **must** be boolean.
2. For each action / trigger we process, we check if LD has a flag matching their naming convention. If so, we check the LD flag and remove the action / trigger if the flag is `false`.
   - This is cheap as LD grabs _all_ flags upon load, so we're not making repeated LD calls when doing this.

Misc design notes:
- I chose to use underscore in the LD flag naming convention as it's ugly, so less likely to be used.
   - _Note:_ LD flags must only contain letters, numbers, `.`, `_` or `-`.
- The flag naming convention might introduce ambiguity if we have app / action / trigger keys that have underscores. But this is unlikely (_action/trigger keys are `camelCase`, while app keys use `-` as a separator_). I also have plans to add a lint rule for this.

## Tests
- Target `open.gov.sg` in LD, and check that postman email attachment action is only shown to OGP users.
- Regression test: check that actions without flags are shown to everyone.