### PR TITLE
PLU-62: Add one liner fix for webhook broken link

### DIFF
--- a/packages/backend/src/apps/webhook/index.ts
+++ b/packages/backend/src/apps/webhook/index.ts
@@ -9,7 +9,7 @@ export default defineApp({
   name: 'Webhook',
   key: 'webhook',
   iconUrl: '{BASE_URL}/apps/webhook/assets/favicon.svg',
-  authDocUrl: 'https://automatisch.io/docs/apps/webhooks/connection',
+  authDocUrl: 'https://guide.plumber.gov.sg/user-guides/triggers/webhooks',
   supportsConnections: true,
   beforeRequest: [addHeaders],
   auth,


### PR DESCRIPTION
## Problem

Broken webhook documentation link

## Solution

Modify `authDocUrl` in raw webhook index.ts