### PR TITLE
PLU-14: [ATTACHMENTS-10] Allow launch darkly in CSP

### DIFF
--- a/packages/backend/src/helpers/csp.ts
+++ b/packages/backend/src/helpers/csp.ts
@@ -12,6 +12,8 @@ const helmetOptions: HelmetOptions = {
         "'self'",
         // For Datadog RUM
         'https://*.browser-intake-datadoghq.com',
+        // Launch Darkly feature flags
+        'https://*.launchdarkly.com',
         appConfig.baseUrl,
       ],
       // for google fonts


### PR DESCRIPTION
## Problem
Launch Darkly flags are not populating on prod because CSP stops clients from requesting them.

## Solution
Allow `https://*.launchdarkly.com` in our CSP (as per their [Salesforce configuration](https://docs.launchdarkly.com/guides/sdk/lightning-web-components) guide)

## Tests
- Verify that LD flags work on staging