### PR TITLE
[PLU-69]: Remove banner with LD

### DIFF
--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import { Box, IconButton } from '@mui/material'
-import { getItem, getItemForSession, setItemForSession } from 'helpers/storage'
-import useFormatMessage from 'hooks/useFormatMessage'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
-import { set } from 'lodash'
+import { getItemForSession, setItemForSession } from 'helpers/storage'
 
 const LAUNCH_DARKLY_BANNER_KEY = 'app_banner_display'
 const EMPTY_BANNER_MESSAGE = ''

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -1,28 +1,53 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import { Box, IconButton } from '@mui/material'
-import { getItemForSession, setItemForSession } from 'helpers/storage'
+import { getItem, getItemForSession, setItemForSession } from 'helpers/storage'
 import useFormatMessage from 'hooks/useFormatMessage'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
+import { set } from 'lodash'
 
-const BANNER_TEXT_ID = 'bannerText'
+const LAUNCH_DARKLY_BANNER_KEY = 'app_banner_display'
+const EMPTY_BANNER_MESSAGE = ''
 
 const SiteWideBanner = (): JSX.Element | null => {
-  const formatMessage = useFormatMessage()
-  // seems like this cant return empty string, so using _ as hacky empty string alternative
-  const message = formatMessage(BANNER_TEXT_ID)
+  const [bannerMessage, setBannerMessage] = useState('')
   const [showBanner, setShowBanner] = useState(false)
-  useEffect(() => {
-    const bannerTextStored = getItemForSession('hide-banner')
-    setShowBanner(message !== bannerTextStored)
-  }, [])
 
+  const launchDarkly = useContext(LaunchDarklyContext)
+
+  useEffect(() => {
+    const bannerMessageStored = getItemForSession('banner-text')
+    // either banner should never be displayed based on LD or banner is 'closed'
+    setShowBanner(
+      !!bannerMessageStored && bannerMessageStored !== EMPTY_BANNER_MESSAGE,
+    )
+  }, [showBanner])
+
+  // TODO: check why use callback when there are no dependencies?
   const closeBanner = useCallback(() => {
     setShowBanner(false)
-    setItemForSession('hide-banner', message)
+    setItemForSession('banner-text', EMPTY_BANNER_MESSAGE)
   }, [])
 
-  // this means the banner text is empty, so dont show the banner
-  if (message === BANNER_TEXT_ID) {
+  // check for feature flag (takes time to load) to display banner: by default it should be not visible
+  useEffect(() => {
+    if (
+      launchDarkly.flags &&
+      launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY] !== 'none' // this is the value set in LD
+    ) {
+      // message needs to be fetched everytime the page is re-rendered
+      const message = launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY]
+      setBannerMessage(message)
+      if (getItemForSession('banner-text') === null) {
+        // banner should only be enabled once at the start
+        setShowBanner(true)
+        setItemForSession('banner-text', message)
+      }
+    }
+  }, [launchDarkly])
+
+  // this means the banner text is empty, so dont show the banner even if session storage is not cleared yet!
+  if (bannerMessage === EMPTY_BANNER_MESSAGE) {
     return null
   }
   return (
@@ -44,7 +69,7 @@ const SiteWideBanner = (): JSX.Element | null => {
         },
       }}
     >
-      {message}
+      {bannerMessage}
       <IconButton
         size="small"
         onClick={closeBanner}

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -4,7 +4,7 @@ import { Box, IconButton } from '@mui/material'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { getItemForSession, setItemForSession } from 'helpers/storage'
 
-const LAUNCH_DARKLY_BANNER_KEY = 'app_banner_display'
+const LAUNCH_DARKLY_BANNER_KEY = 'banner_display'
 const EMPTY_BANNER_MESSAGE = ''
 
 const SiteWideBanner = (): JSX.Element | null => {
@@ -14,37 +14,24 @@ const SiteWideBanner = (): JSX.Element | null => {
   const launchDarkly = useContext(LaunchDarklyContext)
 
   useEffect(() => {
-    const bannerMessageStored = getItemForSession('banner-text')
-    // either banner should never be displayed based on LD or banner is 'closed'
-    setShowBanner(
-      !!bannerMessageStored && bannerMessageStored !== EMPTY_BANNER_MESSAGE,
-    )
-  }, [showBanner])
-
-  // TODO: check why use callback when there are no dependencies?
-  const closeBanner = useCallback(() => {
-    setShowBanner(false)
-    setItemForSession('banner-text', EMPTY_BANNER_MESSAGE)
+    const bannerMessageStored = getItemForSession('hide-banner')
+    setShowBanner(bannerMessageStored !== EMPTY_BANNER_MESSAGE)
   }, [])
 
-  // check for feature flag (takes time to load) to display banner: by default it should be not visible
+  const closeBanner = useCallback(() => {
+    setShowBanner(false)
+    setItemForSession('hide-banner', EMPTY_BANNER_MESSAGE)
+  }, [])
+
+  // check for feature flag (takes time to load) to display banner
   useEffect(() => {
-    if (
-      launchDarkly.flags &&
-      launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY] !== 'none' // this is the value set in LD
-    ) {
+    if (launchDarkly.flags) {
       // message needs to be fetched everytime the page is re-rendered
       const message = launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY]
       setBannerMessage(message)
-      if (getItemForSession('banner-text') === null) {
-        // banner should only be enabled once at the start
-        setShowBanner(true)
-        setItemForSession('banner-text', message)
-      }
     }
   }, [launchDarkly])
 
-  // this means the banner text is empty, so dont show the banner even if session storage is not cleared yet!
   if (bannerMessage === EMPTY_BANNER_MESSAGE) {
     return null
   }

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -8,27 +8,25 @@ const LAUNCH_DARKLY_BANNER_KEY = 'banner_display'
 const EMPTY_BANNER_MESSAGE = ''
 
 const SiteWideBanner = (): JSX.Element | null => {
-  const [bannerMessage, setBannerMessage] = useState('')
-  const [showBanner, setShowBanner] = useState(false)
-
+  const [bannerMessage, setBannerMessage] = useState(EMPTY_BANNER_MESSAGE)
   const launchDarkly = useContext(LaunchDarklyContext)
 
-  useEffect(() => {
-    const bannerMessageStored = getItemForSession('hide-banner')
-    setShowBanner(bannerMessageStored !== EMPTY_BANNER_MESSAGE)
-  }, [])
-
   const closeBanner = useCallback(() => {
-    setShowBanner(false)
-    setItemForSession('hide-banner', EMPTY_BANNER_MESSAGE)
-  }, [])
+    setBannerMessage(EMPTY_BANNER_MESSAGE)
+    setItemForSession('hide-banner', bannerMessage)
+  }, [bannerMessage])
 
   // check for feature flag (takes time to load) to display banner
   useEffect(() => {
     if (launchDarkly.flags) {
       // message needs to be fetched everytime the page is re-rendered
       const message = launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY]
-      setBannerMessage(message)
+      const bannerMessageStored = getItemForSession('hide-banner')
+      if (message !== bannerMessageStored) {
+        setBannerMessage(message)
+      } else {
+        setBannerMessage(EMPTY_BANNER_MESSAGE)
+      }
     }
   }, [launchDarkly])
 
@@ -43,7 +41,7 @@ const SiteWideBanner = (): JSX.Element | null => {
         textAlign: 'center',
         backgroundColor: 'primary.dark',
         color: 'white',
-        display: showBanner ? 'flex' : 'none',
+        display: 'flex',
         justifyContent: 'center',
         alignItems: 'center',
         position: 'relative',

--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -1,6 +1,5 @@
 {
   "brandText": "plumber",
-  "bannerText": "Plumber is a pilot project from OGP's HFPG 2023 hackathon",
   "searchPlaceholder": "Search",
   "accountDropdownMenu.logout": "Logout",
   "drawer.dashboard": "Dashboard",


### PR DESCRIPTION
## Problem

Currently, the banner on the top of the app is always being displayed.

## Solution

- Using LD feature flag, we can set a feature flag called `app_banner_display`, when switched off, it will not show the banner and when switched on, it will show the banner with the message value set in LD.
- Modified the logic in `SiteWideBanner` to only show the banner when LD flag has the message value set by checking that `bannerMessage` is the same as the `sessionStorage` message. 
  - Else, if no flag is set or the user closes it, the `sessionStorage` will be emptied and the banner will be hidden.
