### PR TITLE
feat: allow updates to succeed even if no rows updated

### DIFF
--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/update-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/update-row.test.ts
@@ -1,0 +1,123 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import app from '../..'
+import updateTableDataAction from '../../actions/update-table-data'
+import { VAULT_ID } from '../../common/constants'
+
+const mocks = vi.hoisted(() => {
+  return {
+    updateTableRow: vi.fn((_$, vaultId, delta) => {
+      if (vaultId === '123') {
+        return {
+          _metadata: {
+            success: true,
+            rowsUpdated: 1,
+          },
+          ...delta,
+          [VAULT_ID]: '123',
+        }
+      }
+      return {
+        _metadata: {
+          success: false,
+          rowsUpdated: 0,
+        },
+      }
+    }),
+    filterTableRows: vi.fn((_$, columnName, value) => {
+      if (
+        columnName === 'valid_lookup_column' &&
+        value === 'valid_lookup_value'
+      ) {
+        return {
+          _metadata: {
+            success: true,
+            rowsFound: 1,
+          },
+          valid_lookup_column: value,
+          [VAULT_ID]: '123',
+        }
+      }
+      return {
+        _metadata: {
+          success: false,
+          rowsFound: 0,
+        },
+      }
+    }),
+  }
+})
+
+vi.mock('../../common/update-table-row', () => ({
+  default: mocks.updateTableRow,
+}))
+
+vi.mock('../../common/filter-table-rows', () => ({
+  default: mocks.filterTableRows,
+}))
+
+describe('update row', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      auth: {
+        set: vi.fn(),
+        data: {},
+      },
+      step: {
+        id: 'herp-derp',
+        appKey: 'vault-workspace',
+        parameters: {},
+      },
+      app,
+      setActionItem: vi.fn(),
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Success if row found
+   */
+  it('update row if row found', async () => {
+    $.step.parameters.lookupColumn = 'valid_lookup_column'
+    $.step.parameters.lookupValue = 'valid_lookup_value'
+    $.step.parameters.updateColumn = 'update_column'
+    $.step.parameters.updateValue = 'update_value'
+    await expect(updateTableDataAction.run($)).resolves.toEqual(undefined)
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        _metadata: {
+          success: true,
+          rowsUpdated: 1,
+        },
+        update_column: 'update_value',
+        [VAULT_ID]: '123',
+      },
+    })
+  })
+
+  /**
+   * Failure if no rows found
+   */
+  it('return success as false if no rows found', async () => {
+    $.step.parameters.lookupColumn = 'valid_lookup_column'
+    $.step.parameters.lookupValue = 'wrong_lookup_value'
+    $.step.parameters.updateColumn = 'update_column'
+    $.step.parameters.updateValue = 'update_value'
+    await expect(updateTableDataAction.run($)).resolves.toEqual(undefined)
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        _metadata: {
+          success: false,
+          rowsUpdated: 0,
+        },
+      },
+    })
+  })
+})

--- a/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
@@ -74,9 +74,22 @@ export default defineAction({
     }
 
     const row = await filterTableRows($, lookupColumn, lookupValue)
-
+    if (row._metadata && row._metadata?.rowsFound === 0) {
+      $.setActionItem({
+        raw: {
+          _metadata: {
+            success: false,
+            rowsUpdated: 0,
+          },
+        },
+      })
+      return
+    }
     // update row
     const payload: { [key: string]: string } = { [updateColumn]: updateValue }
-    await updateTableRow($, row['vault_id'], payload)
+    const response = await updateTableRow($, row['vault_id'], payload)
+    $.setActionItem({
+      raw: response,
+    })
   },
 })

--- a/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
@@ -74,7 +74,7 @@ export default defineAction({
     }
 
     const row = await filterTableRows($, lookupColumn, lookupValue)
-    if (row._metadata && row._metadata?.rowsFound === 0) {
+    if (row._metadata?.rowsFound === 0) {
       $.setActionItem({
         raw: {
           _metadata: {
@@ -87,7 +87,7 @@ export default defineAction({
     }
     // update row
     const payload: { [key: string]: string } = { [updateColumn]: updateValue }
-    const response = await updateTableRow($, row['vault_id'], payload)
+    const response = await updateTableRow($, row[VAULT_ID], payload)
     $.setActionItem({
       raw: response,
     })

--- a/packages/backend/src/apps/vault-workspace/common/update-table-row.ts
+++ b/packages/backend/src/apps/vault-workspace/common/update-table-row.ts
@@ -4,14 +4,22 @@ const updateTableRow = async (
   $: IGlobalVariable,
   vaultId: string,
   update: { [key: string]: string }, // column name: value
-): Promise<void> => {
+): Promise<{
+  [key: string]: any & {
+    _metadata: {
+      success: boolean
+      rowsUpdated: number
+    }
+  }
+}> => {
   const res = await $.http.put('/api/tables/row', { id: vaultId, update })
-  $.setActionItem({
-    raw: {
+  return {
+    _metadata: {
       success: true,
-      ...res.data,
+      rowsUpdated: 1,
     },
-  })
+    ...res.data,
+  }
 }
 
 export default updateTableRow


### PR DESCRIPTION
## Allow update actions to succeed even if lookup found no rows

### Before: 

<img width="840" alt="Screenshot 2023-08-07 at 6 23 06 PM" src="https://github.com/opengovsg/plumber/assets/10072985/31625c3f-2400-4cc7-8836-5921f3249616">

### After: 

<img width="839" alt="Screenshot 2023-08-07 at 6 21 32 PM" src="https://github.com/opengovsg/plumber/assets/10072985/789cacdb-07e6-43a7-9857-9087f87da1e7">


### Success is the same but move success: true to _metadata for consistency
<img width="848" alt="Screenshot 2023-08-07 at 6 21 16 PM" src="https://github.com/opengovsg/plumber/assets/10072985/9129e4ac-ca69-46e9-9f68-64d62ef2f8a1">

