### PR TITLE
PLU-74, PLU-64: Add check for scheduler midnight selection

### DIFF
--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -39,6 +39,11 @@ const validateSubstep = (substep: ISubstep, step: IStep) => {
       return true
     }
 
+    // '0' is a valid value for scheduling hour
+    if (argValue === 0) {
+      return true
+    }
+
     return Boolean(argValue)
   })
 }

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -27,12 +27,8 @@ type FlowSubstepProps = {
 }
 
 function isValidArgValue(value: IJSONValue): boolean {
-  // `false` is an exceptional valid value
-  if (value === false) {
-    return true
-  }
-
-  return Boolean(value)
+  // `false` and 0 are valid values, only null, undefined and empty string are invalid
+  return value != null && value !== ''
 }
 
 function validateSubstep(substep: ISubstep, step: IStep): boolean {


### PR DESCRIPTION
## Problem

There is a bug when trying to select 00:00 for the scheduler trigger.

## Solution

There is a boolean check for values in the field to validate the submission.
Allow value: '0' to pass through the boolean check.

