### PR TITLE
PLU-80: [NEW-VARIABLE-BADGES] improve PowerInput typing

### DIFF
--- a/packages/frontend/src/components/PowerInput/Suggestions.tsx
+++ b/packages/frontend/src/components/PowerInput/Suggestions.tsx
@@ -1,5 +1,3 @@
-import type { IStep } from '@plumber/types'
-
 import * as React from 'react'
 import ExpandLess from '@mui/icons-material/ExpandLess'
 import ExpandMore from '@mui/icons-material/ExpandMore'
@@ -11,18 +9,19 @@ import MuiListItemText from '@mui/material/ListItemText'
 import Paper from '@mui/material/Paper'
 import { styled } from '@mui/material/styles'
 import Typography from '@mui/material/Typography'
+import type { StepWithVariables, Variable } from 'helpers/variables'
 
 const ListItemText = styled(MuiListItemText)``
 
 type SuggestionsProps = {
-  data: any[]
-  onSuggestionClick: (variable: any) => void
+  data: StepWithVariables[]
+  onSuggestionClick: (variable: Variable) => void
 }
 
 const SHORT_LIST_LENGTH = 4
 const LIST_HEIGHT = 256
 
-const getPartialArray = (array: any[], length = array.length) => {
+function getPartialArray<T>(array: T[], length = array.length) {
   return array.slice(0, length)
 }
 
@@ -49,7 +48,7 @@ const Suggestions = (props: SuggestionsProps) => {
         Variables
       </Typography>
       <List disablePadding>
-        {data.map((option: IStep, index: number) => (
+        {data.map((option, index) => (
           <div key={`primary-suggestion-${option.name}`}>
             <ListItemButton
               divider
@@ -72,8 +71,8 @@ const Suggestions = (props: SuggestionsProps) => {
                 sx={{ maxHeight: LIST_HEIGHT, overflowY: 'auto' }}
                 data-test="power-input-suggestion-group"
               >
-                {getPartialArray((option.output as any) || [], listLength).map(
-                  (suboption: any) => (
+                {getPartialArray(option.output ?? [], listLength).map(
+                  (suboption) => (
                     <ListItemButton
                       sx={{ pl: 4 }}
                       divider
@@ -106,7 +105,7 @@ const Suggestions = (props: SuggestionsProps) => {
                 )}
               </List>
 
-              {(option.output?.length || 0) > listLength && (
+              {option.output?.length > listLength && (
                 <Button fullWidth onClick={expandList}>
                   Show all
                 </Button>

--- a/packages/frontend/src/components/PowerInput/types.ts
+++ b/packages/frontend/src/components/PowerInput/types.ts
@@ -1,9 +1,9 @@
-import type { BaseEditor, Descendant, Text } from 'slate'
+import type { BaseEditor, BaseElement } from 'slate'
 import type { ReactEditor } from 'slate-react'
 
-export type VariableElement = {
+export interface VariableSlateElement extends BaseElement {
   type: 'variable'
-  value?: unknown
+  value?: string
 
   /**
    * CAVEAT: not _just_ a name; it contains the lodash.get path for dataOut. Do
@@ -11,22 +11,20 @@ export type VariableElement = {
    */
   name?: string
 
-  children: Text[]
   label?: string
 }
 
-export type ParagraphElement = {
+export interface ParagraphSlateElement extends BaseElement {
   type: 'paragraph'
-  children: Descendant[]
 }
 
-export type CustomEditor = BaseEditor & ReactEditor
+export type CustomSlateEditor = BaseEditor & ReactEditor
 
-export type CustomElement = VariableElement | ParagraphElement
+export type CustomSlateElement = VariableSlateElement | ParagraphSlateElement
 
 declare module 'slate' {
   interface CustomTypes {
-    Editor: CustomEditor
-    Element: CustomElement
+    Editor: CustomSlateEditor
+    Element: CustomSlateElement
   }
 }

--- a/packages/frontend/src/components/PowerInput/utils.ts
+++ b/packages/frontend/src/components/PowerInput/utils.ts
@@ -1,9 +1,14 @@
 import type { StepWithVariables } from 'helpers/variables'
+import { Variable } from 'helpers/variables'
 import { Descendant, Text, Transforms } from 'slate'
 import { withHistory } from 'slate-history'
 import { withReact } from 'slate-react'
 
-import type { CustomEditor, CustomElement, VariableElement } from './types'
+import type {
+  CustomSlateEditor,
+  CustomSlateElement,
+  VariableSlateElement,
+} from './types'
 
 // Map of variable name with curlies (e.g. '{{step.abc-def.field.1.xyz}}') to
 // its label (its actual label, if defined, otherwise something like
@@ -74,7 +79,7 @@ export const serialize = (value: Descendant[]): string => {
   return value.map((node) => serializeNode(node)).join('\n')
 }
 
-const serializeNode = (node: CustomElement | Descendant): string => {
+const serializeNode = (node: CustomSlateElement | Descendant): string => {
   if (Text.isText(node)) {
     return node.text
   }
@@ -86,14 +91,14 @@ const serializeNode = (node: CustomElement | Descendant): string => {
   return node.children.map((n) => serializeNode(n)).join('')
 }
 
-export const withVariables = (editor: CustomEditor) => {
+export const withVariables = (editor: CustomSlateEditor) => {
   const { isInline, isVoid } = editor
 
-  editor.isInline = (element: CustomElement) => {
+  editor.isInline = (element: CustomSlateElement) => {
     return element.type === 'variable' ? true : isInline(element)
   }
 
-  editor.isVoid = (element: CustomElement) => {
+  editor.isVoid = (element: CustomSlateElement) => {
     return element.type === 'variable' ? true : isVoid(element)
   }
 
@@ -101,13 +106,13 @@ export const withVariables = (editor: CustomEditor) => {
 }
 
 export function insertVariable(
-  editor: CustomEditor,
-  variableData: Pick<VariableElement, 'name' | 'value'>,
+  editor: CustomSlateEditor,
+  variableData: Variable,
   variableLabels: VariableLabelMap,
 ) {
   const value = `{{${variableData.name}}}`
 
-  const variable: VariableElement = {
+  const variable: VariableSlateElement = {
     type: 'variable',
     name: variableLabels.get(value),
     value,
@@ -118,6 +123,8 @@ export function insertVariable(
   Transforms.move(editor)
 }
 
-export const customizeEditor = (editor: CustomEditor): CustomEditor => {
+export const customizeEditor = (
+  editor: CustomSlateEditor,
+): CustomSlateEditor => {
   return withVariables(withReact(withHistory(editor)))
 }


### PR DESCRIPTION
## Problem
In addition to labels, we also want to show the variable's value in PowerInput:

![Screenshot 2023-08-14 at 10 08 06 AM](https://github.com/opengovsg/plumber/assets/135598754/bc73c8fe-1649-45e4-9b87-1705e50ee2bb)

But before we can do that, we need to improve PowerInput's typing so that we can safely grab the value from variables.

## Solution
This PR removes `any` from PowerInput code and replaces it with their actual types. In some cases, I relied on TS's type inference instead of explicitly typing.

_Note:_ This **only** adds types; it does not change any functions (even though I disagree with some stuff, such as `getPartialArray`. Who doesn't know `slice`?)

## Tests
- Regression test: check that I can still edit pipes


