### PR TITLE
PLU-80: [NEW-VARIABLE-BADGES] Rename variable "name" prop to "placeholderString"

### DIFF
--- a/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
+++ b/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
@@ -22,9 +22,14 @@ function extractVariablesAsItems(
       }
 
       result.push({
-        label: `[${step.name}] ${variable.label ?? variable.name}`,
+        label: `[${step.name}] ${
+          variable.label ??
+          variable.placeholderString
+            // Remove curly braces from placeholder
+            .slice(2, -2)
+        }`,
         description: variable.displayedValue ?? String(variable.value),
-        value: `{{${variable.name}}}`,
+        value: variable.placeholderString,
       })
     }
   }

--- a/packages/frontend/src/components/PowerInput/Suggestions.tsx
+++ b/packages/frontend/src/components/PowerInput/Suggestions.tsx
@@ -78,10 +78,13 @@ const Suggestions = (props: SuggestionsProps) => {
                       divider
                       onClick={() => onSuggestionClick(suboption)}
                       data-test="power-input-suggestion-item"
-                      key={`suggestion-${suboption.name}`}
+                      key={`suggestion-${suboption.placeholderString}`}
                     >
                       <ListItemText
-                        primary={suboption.label ?? suboption.name}
+                        primary={
+                          suboption.label ??
+                          suboption.placeholderString.slice(2, -2)
+                        }
                         primaryTypographyProps={{
                           variant: 'subtitle1',
                           title: 'Property name',

--- a/packages/frontend/src/components/PowerInput/index.tsx
+++ b/packages/frontend/src/components/PowerInput/index.tsx
@@ -94,9 +94,9 @@ const PowerInput = (props: PowerInputProps) => {
 
   const handleVariableSuggestionClick = React.useCallback(
     (variable: Variable) => {
-      insertVariable(editor, variable, variableLabelMap)
+      insertVariable(editor, variable)
     },
-    [variableLabelMap],
+    [editor],
   )
 
   return (
@@ -238,7 +238,8 @@ const VariablePill = ({ attributes, children, element }: VariablePillProps) => {
   const variableLabelMap = React.useContext(VariableLabelMapContext)
   const label = (
     <>
-      {(element.value && variableLabelMap.get(element.value)) ?? element.value}
+      {variableLabelMap.get(element.placeholderString) ??
+        element.placeholderString.slice(2, -2)}
       {children}
     </>
   )

--- a/packages/frontend/src/components/PowerInput/types.ts
+++ b/packages/frontend/src/components/PowerInput/types.ts
@@ -3,15 +3,7 @@ import type { ReactEditor } from 'slate-react'
 
 export interface VariableSlateElement extends BaseElement {
   type: 'variable'
-  value?: string
-
-  /**
-   * CAVEAT: not _just_ a name; it contains the lodash.get path for dataOut. Do
-   * not clobber unles you know what you're doing!
-   */
-  name?: string
-
-  label?: string
+  placeholderString: string
 }
 
 export interface ParagraphSlateElement extends BaseElement {

--- a/packages/frontend/src/components/PowerInput/utils.ts
+++ b/packages/frontend/src/components/PowerInput/utils.ts
@@ -10,9 +10,8 @@ import type {
   VariableSlateElement,
 } from './types'
 
-// Map of variable name with curlies (e.g. '{{step.abc-def.field.1.xyz}}') to
-// its label (its actual label, if defined, otherwise something like
-// 'step2.field.1.xyz').
+// Map of variable placeholder strings to its label (its actual label, if
+// defined, otherwise something like 'step2.field.1.xyz').
 export type VariableLabelMap = Map<string, string>
 
 export function genVariableLabelMap(
@@ -23,9 +22,11 @@ export function genVariableLabelMap(
   for (const [stepPosition, step] of stepsWithVariables.entries()) {
     for (const variable of step.output) {
       result.set(
-        `{{${variable.name}}}`,
+        variable.placeholderString,
         variable.label ??
-          variable.name.replace(`step.${step.id}.`, `step${stepPosition + 1}.`),
+          variable.placeholderString
+            .slice(2, -2) // Remove curly braces
+            .replace(`step.${step.id}.`, `step${stepPosition + 1}.`),
       )
     }
   }
@@ -110,12 +111,10 @@ export function insertVariable(
   variableData: Variable,
   variableLabels: VariableLabelMap,
 ) {
-  const value = `{{${variableData.name}}}`
-
   const variable: VariableSlateElement = {
     type: 'variable',
-    name: variableLabels.get(value),
-    value,
+    name: variableLabels.get(variableData.placeholderString),
+    value: variableData.placeholderString,
     children: [{ text: '' }],
   }
 

--- a/packages/frontend/src/components/PowerInput/utils.ts
+++ b/packages/frontend/src/components/PowerInput/utils.ts
@@ -57,7 +57,7 @@ export function deserialize(value: string): Descendant[] {
           if (node.match(variableRegExp)) {
             return {
               type: 'variable',
-              value: node,
+              placeholderString: node,
               children: [{ text: '' }],
             }
           }
@@ -86,7 +86,7 @@ const serializeNode = (node: CustomSlateElement | Descendant): string => {
   }
 
   if (node.type === 'variable') {
-    return node.value as string
+    return node.placeholderString
   }
 
   return node.children.map((n) => serializeNode(n)).join('')
@@ -106,19 +106,14 @@ export const withVariables = (editor: CustomSlateEditor) => {
   return editor
 }
 
-export function insertVariable(
-  editor: CustomSlateEditor,
-  variableData: Variable,
-  variableLabels: VariableLabelMap,
-) {
-  const variable: VariableSlateElement = {
+export function insertVariable(editor: CustomSlateEditor, variable: Variable) {
+  const slateElement: VariableSlateElement = {
     type: 'variable',
-    name: variableLabels.get(variableData.placeholderString),
-    value: variableData.placeholderString,
+    placeholderString: variable.placeholderString,
     children: [{ text: '' }],
   }
 
-  Transforms.insertNodes(editor, variable)
+  Transforms.insertNodes(editor, slateElement)
   Transforms.move(editor)
 }
 

--- a/packages/frontend/src/helpers/__tests__/variables.test.ts
+++ b/packages/frontend/src/helpers/__tests__/variables.test.ts
@@ -48,7 +48,7 @@ describe('variables', () => {
           output: [
             // Use objectContaining to avoid enumerating all metadata props
             expect.objectContaining({
-              name: 'step.step1-id.stringProp',
+              placeholderString: '{{step.step1-id.stringProp}}',
               value: 'string value',
             }),
           ],
@@ -58,7 +58,7 @@ describe('variables', () => {
           name: '2. App2',
           output: [
             expect.objectContaining({
-              name: 'step.step2-id.numberProp',
+              placeholderString: '{{step.step2-id.numberProp}}',
               value: 456,
             }),
           ],
@@ -76,15 +76,15 @@ describe('variables', () => {
         const result = extractVariables(steps)
         expect(result[0].output).toEqual([
           expect.objectContaining({
-            name: 'step.step1-id.stringProp',
+            placeholderString: '{{step.step1-id.stringProp}}',
             value: 'string value',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.objectProp.a',
+            placeholderString: '{{step.step1-id.objectProp.a}}',
             value: 1,
           }),
           expect.objectContaining({
-            name: 'step.step1-id.objectProp.b',
+            placeholderString: '{{step.step1-id.objectProp.b}}',
             value: 'str-2',
           }),
         ])
@@ -100,26 +100,26 @@ describe('variables', () => {
         const result = extractVariables(steps)
         expect(result[0].output).toEqual([
           expect.objectContaining({
-            name: 'step.step1-id.stringProp',
+            placeholderString: '{{step.step1-id.stringProp}}',
             value: 'string value',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.0',
+            placeholderString: '{{step.step1-id.arrayProp.0}}',
             label: null,
             value: 9000,
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.1',
+            placeholderString: '{{step.step1-id.arrayProp.1}}',
             label: null,
             value: 'HI THAR',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.2.c',
+            placeholderString: '{{step.step1-id.arrayProp.2.c}}',
             label: null,
             value: '1',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.2.d',
+            placeholderString: '{{step.step1-id.arrayProp.2.d}}',
             label: null,
             value: 2,
           }),
@@ -138,7 +138,7 @@ describe('variables', () => {
         const result = extractVariables(steps)
         expect(result[0].output[0]).toEqual(
           expect.objectContaining({
-            name: 'step.step1-id.stringProp',
+            placeholderString: '{{step.step1-id.stringProp}}',
             label: 'test label',
             value: 'string value',
           }),
@@ -161,12 +161,12 @@ describe('variables', () => {
         const result = extractVariables(steps)
         expect(result[0].output).toEqual([
           expect.objectContaining({
-            name: 'step.step1-id.objectProp.a',
+            placeholderString: '{{step.step1-id.objectProp.a}}',
             label: 'label a',
             value: 1,
           }),
           expect.objectContaining({
-            name: 'step.step1-id.objectProp.b',
+            placeholderString: '{{step.step1-id.objectProp.b}}',
             label: 'label b',
             value: 'stringy 2',
           }),
@@ -187,22 +187,22 @@ describe('variables', () => {
         const result = extractVariables(steps)
         expect(result[0].output).toEqual([
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.0',
+            placeholderString: '{{step.step1-id.arrayProp.0}}',
             label: 'label 9000',
             value: 9000,
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.1',
+            placeholderString: '{{step.step1-id.arrayProp.1}}',
             label: 'label HI THAR',
             value: 'HI THAR',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.2.c',
+            placeholderString: '{{step.step1-id.arrayProp.2.c}}',
             label: 'label c prop',
             value: '1',
           }),
           expect.objectContaining({
-            name: 'step.step1-id.arrayProp.2.d',
+            placeholderString: '{{step.step1-id.arrayProp.2.d}}',
             label: 'label d prop',
             value: 2,
           }),
@@ -314,7 +314,7 @@ describe('variables', () => {
               type: 'text',
               order: 1,
               displayedValue: null,
-              name: 'step1-id.abc-def.textVar',
+              placeholderString: '{{step1-id.abc-def.textVar}}',
               value: 'abcd',
             },
             {
@@ -322,7 +322,7 @@ describe('variables', () => {
               type: 'file',
               order: 2,
               displayedValue: null,
-              name: 'step1-id.abc-def.fileVar',
+              placeholderString: '{{step1-id.abc-def.fileVar}}',
               value: '01010010010',
             },
           ],
@@ -336,7 +336,7 @@ describe('variables', () => {
               type: 'text',
               order: 1,
               displayedValue: null,
-              name: 'step2-id.wx-yz.anotherTextVar',
+              placeholderString: '{{step2-id.wx-yz.anotherTextVar}}',
               value: 'wxyz',
             },
           ],
@@ -359,7 +359,7 @@ describe('variables', () => {
               type: 'text',
               order: 1,
               displayedValue: null,
-              name: 'step1-id.abc-def.textVar',
+              placeholderString: '{{step1-id.abc-def.textVar}}',
               value: 'abcd',
             },
           ],
@@ -373,7 +373,7 @@ describe('variables', () => {
               type: 'text',
               order: 1,
               displayedValue: null,
-              name: 'step2-id.wx-yz.anotherTextVar',
+              placeholderString: '{{step2-id.wx-yz.anotherTextVar}}',
               value: 'wxyz',
             },
           ],


### PR DESCRIPTION
## Problem
In addition to labels, we also want to show the variable's value in PowerInput:

![Screenshot 2023-08-14 at 10 08 06 AM](https://github.com/opengovsg/plumber/assets/135598754/bc73c8fe-1649-45e4-9b87-1705e50ee2bb)

But before that, code readability needs to be improved so that future engineers don't get confused.

In particular, the `name` prop in our `Variable` type is _terribly_ named; it actually contains the placeholder string (_curly braces omitted_) used during variable substitution.

## Solution
This PR:
1. Renames the badly named `name` prop in `Variable` to `placeholderString`.
2. Updates its value to also contain curly braces (`step.abc-xyz.field.answer` -> `{{step.abc-xyz.field.answer}}`)
   * Since our variable substitution code looks for curly braces, it makes more sense to think of these braces as being part of the placeholder.
   * _The tradeoff_: we need to add `slice`s into frontend code to remove the curly braces. But at the same time, we also remove frontend code that _adds_ these curly braces. So complexity pretty much remains the same.

## Tests
- Regression test: check that variable substitution is still done correctly
- Regression test: check that I can edit and save pipes