### PR TITLE
PLU-80: [NEW-VARIABLE-BADGES] Show values in PowerInput variable badges

### DIFF
--- a/packages/frontend/src/components/PowerInput/index.tsx
+++ b/packages/frontend/src/components/PowerInput/index.tsx
@@ -241,10 +241,12 @@ const VariableBadge = ({
 
   return (
     <Badge variant="solid" bg="primary.100" borderRadius={50} {...attributes}>
-      <Text color="#2C2E34" mr={1}>
-        {label}
-      </Text>
-      {value && <Text color="#666C7A">{value}</Text>}
+      <Text color="#2C2E34">{label}</Text>
+      {value && (
+        <Text color="#666C7A" ml={1}>
+          {value}
+        </Text>
+      )}
       {children}
     </Badge>
   )

--- a/packages/frontend/src/components/PowerInput/utils.ts
+++ b/packages/frontend/src/components/PowerInput/utils.ts
@@ -10,24 +10,38 @@ import type {
   VariableSlateElement,
 } from './types'
 
-// Map of variable placeholder strings to its label (its actual label, if
-// defined, otherwise something like 'step2.field.1.xyz').
-export type VariableLabelMap = Map<string, string>
+/**
+ * Map of variable placeholders strings to their associated info:
+ * 1. Label obtained from dataOutMetadata (if defined). Otherwise,
+ *    'step2.field.1.xyz'.
+ * 2. Value obtained from the test run.
+ */
+export type VariableInfoMap = Map<
+  string,
+  {
+    label: string
+    value: string
+  }
+>
 
-export function genVariableLabelMap(
+export function genVariableInfoMap(
   stepsWithVariables: StepWithVariables[],
-): VariableLabelMap {
-  const result: VariableLabelMap = new Map()
+): VariableInfoMap {
+  const result: VariableInfoMap = new Map()
 
   for (const [stepPosition, step] of stepsWithVariables.entries()) {
     for (const variable of step.output) {
-      result.set(
-        variable.placeholderString,
+      const label =
         variable.label ??
-          variable.placeholderString
-            .slice(2, -2) // Remove curly braces
-            .replace(`step.${step.id}.`, `step${stepPosition + 1}.`),
-      )
+        variable.placeholderString
+          .slice(2, -2) // Remove curly braces
+          .replace(`step.${step.id}.`, `step${stepPosition + 1}.`)
+      const value = variable.displayedValue ?? String(variable.value)
+
+      result.set(variable.placeholderString, {
+        label,
+        value,
+      })
     }
   }
 


### PR DESCRIPTION
## Problem
In addition to labels, we also want to show the variable's value in PowerInput:

![Screenshot 2023-08-14 at 10 08 06 AM](https://github.com/opengovsg/plumber/assets/135598754/bc73c8fe-1649-45e4-9b87-1705e50ee2bb)

## Solution
This PR implements this by updating `VariableLabelMapContext` to also include the test run's value.

**Before**
<img width=450 src="https://github.com/opengovsg/plumber/assets/135598754/db015242-7148-49a7-91ae-5b2c5925203c" />

**After**
<img width=450 src="https://github.com/opengovsg/plumber/assets/135598754/e6e2de68-b7ec-4cfd-a6eb-2088e3138e43" />

## Tests
- Check that value shows up inside the variable badge.
- Check that if value is falsy (e.g. unfilled optional form field), value is not shown.