### PR TITLE
chore: do not fetch test execution steps that do not belong to the same app

### DIFF
--- a/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
+++ b/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
@@ -30,6 +30,7 @@ const getStepWithTestExecutions = async (
         .where('step_id', '=', ref('steps.id'))
         .andWhere('status', 'success'),
     )
+    .andWhere('executionSteps.app_key', '=', ref('steps.app_key'))
     .orderBy('steps.position', 'asc')
 
   return previousStepsWithCurrentStep

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -119,8 +119,10 @@ class Step extends Base {
       .orderBy('created_at', 'desc')
       .limit(1)
       .first()
-
-    return await lastExecutionStep
+    if (lastExecutionStep.appKey !== this.appKey) {
+      return undefined
+    }
+    return lastExecutionStep
   }
 
   async getNextStep() {


### PR DESCRIPTION
Currently, clicking test step after changing the app  / action still shows results from the previous app-action. 

This PR checks and filters by app_key before returning.