### PR TITLE
fix: handling of undefined formsg dataout fields property

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -175,7 +175,7 @@ describe('new submission trigger', () => {
       expect(metadata).toEqual(null)
     })
 
-    it('should handle undefined fields roperty', async () => {
+    it('should handle undefined `dataOut.fields` property', async () => {
       executionStep.dataOut = {}
 
       const metadata = await trigger.getDataOutMetadata(executionStep)

--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -167,5 +167,19 @@ describe('new submission trigger', () => {
       const metadata = await trigger.getDataOutMetadata(executionStep)
       expect(metadata.fields.fileFieldId.question.isHidden).toEqual(true)
     })
+
+    it('should handle null dataOut', async () => {
+      executionStep.dataOut = null
+
+      const metadata = await trigger.getDataOutMetadata(executionStep)
+      expect(metadata).toEqual(null)
+    })
+
+    it('should handle undefined fields roperty', async () => {
+      executionStep.dataOut = {}
+
+      const metadata = await trigger.getDataOutMetadata(executionStep)
+      expect(metadata).toEqual(null)
+    })
   })
 })

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -54,7 +54,7 @@ async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
   const data = executionStep.dataOut
-  if (!data) {
+  if (!data || !data.fields) {
     return null
   }
 


### PR DESCRIPTION
`GetStepWithTestExecutions` fails when trigger app is changed from webhook --> formsg. It attempts to generate metadata out using webhook payload and fails when dataOut.fields is undefined.

This PR adds a check that dataOut.fields is defined before returning metadata out.