### PR TITLE
PLU-78: **HACKFIX** PowerInput not capturing input initially on GSIB

### DIFF
--- a/packages/frontend/src/components/PowerInput/index.tsx
+++ b/packages/frontend/src/components/PowerInput/index.tsx
@@ -89,6 +89,11 @@ const PowerInput = (props: PowerInputProps) => {
     [variableLabelMap],
   )
 
+  const handleFocus = React.useCallback(
+    () => setShowVariableSuggestions(true),
+    [setShowVariableSuggestions],
+  )
+
   return (
     <Controller
       rules={{ required }}
@@ -131,9 +136,9 @@ const PowerInput = (props: PowerInputProps) => {
                       readOnly={disabled}
                       style={{ width: '100%' }}
                       renderElement={renderElement}
-                      onFocus={() => {
-                        setShowVariableSuggestions(true)
-                      }}
+                      // FIXME (ogp-weeloong): Hackfix for GSIB. Will migrate to chakra for long-term fix.
+                      onMouseDown={handleFocus}
+                      onFocus={handleFocus}
                       onBlur={() => {
                         controllerOnBlur()
                         handleBlur(value)


### PR DESCRIPTION
## Problem
On GSIB, `PowerInput` does not capture keyboard input unless the user right clicks on the field, or clicks on a variable first.

## Solution (Temp)
The root cause remains unclear; one hypothesis is an edge case interaction in how clicks are intercepted by the GSIB client.

**However**, by trial and error, I found that providing a `onMouseDown` handler makes the problem go away.

This is _totally_ a hackfix; the long term fix should be to migrate `PowerInput` to Chakra, since our own `MultiSelect` doesn't exhibit this problem.

Shipping this hackfix first as long term fix will take some time (we also need to migrate `TextField`)

## Tests
- Check that PowerInput can capture keyboard input correctly on GSIB without using workarounds mentioned above.
- Regression test: check that I can still edit Plumber pipes on non-GSIB computers.