### PR TITLE
PLU-37: Change labels for scheduler test step

### DIFF
--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -7,6 +7,7 @@ import defineTrigger from '@/helpers/define-trigger'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
+import getDataOutMetadata from '../get-data-out-metadata'
 
 export default defineTrigger({
   name: 'Daily - triggers every day, choose at what hour of time',
@@ -140,6 +141,7 @@ export default defineTrigger({
       ],
     },
   ],
+  getDataOutMetadata,
 
   getInterval(parameters: IGlobalVariable['step']['parameters']) {
     if (parameters.triggersOnWeekend as boolean) {

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -7,6 +7,7 @@ import defineTrigger from '@/helpers/define-trigger'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
+import getDataOutMetadata from '../get-data-out-metadata'
 
 export default defineTrigger({
   name: 'Hourly - triggers every hour',
@@ -33,6 +34,7 @@ export default defineTrigger({
       ],
     },
   ],
+  getDataOutMetadata,
 
   getInterval(parameters: IGlobalVariable['step']['parameters']) {
     if (parameters.triggersOnWeekend) {

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -7,6 +7,7 @@ import defineTrigger from '@/helpers/define-trigger'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
+import getDataOutMetadata from '../get-data-out-metadata'
 
 export default defineTrigger({
   name: 'Monthly - triggers every month, choose what day of the month',
@@ -256,6 +257,7 @@ export default defineTrigger({
       ],
     },
   ],
+  getDataOutMetadata,
 
   getInterval(parameters: IGlobalVariable['step']['parameters']) {
     const interval = cronTimes.everyMonthOnAndAt(

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -7,6 +7,7 @@ import defineTrigger from '@/helpers/define-trigger'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
+import getDataOutMetadata from '../get-data-out-metadata'
 
 export default defineTrigger({
   name: 'Weekly - triggers every week, choose what day of the week',
@@ -160,6 +161,7 @@ export default defineTrigger({
       ],
     },
   ],
+  getDataOutMetadata,
 
   getInterval(parameters: IGlobalVariable['step']['parameters']) {
     const interval = cronTimes.everyWeekOnAndAt(

--- a/packages/backend/src/apps/scheduler/triggers/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/scheduler/triggers/get-data-out-metadata.ts
@@ -1,0 +1,44 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const data = executionStep.dataOut
+  if (!data) {
+    return null
+  }
+
+  const metadata = Object.create(null)
+  for (const key of Object.keys(data)) {
+    // re-label "pretty" variables for scheduler
+    switch (key) {
+      case 'pretty_date':
+        metadata[key] = {
+          label: 'Date',
+        }
+        break
+      case 'pretty_time':
+        metadata[key] = {
+          label: 'Time',
+        }
+        break
+      case 'ISO_date_time':
+        metadata[key] = {
+          label: 'Standard date and time',
+        }
+        break
+      case 'pretty_day_of_week':
+        metadata[key] = {
+          label: 'Day of the week',
+        }
+        break
+      default:
+        metadata[key] = {
+          label: key,
+        }
+    }
+  }
+  return metadata
+}
+
+export default getDataOutMetadata


### PR DESCRIPTION
## Problem

Currently, the test step label for scheduler has extra words such as "pretty" which may confuse users when they see it.

## Solution

Add metadata to scheduler to process the labels.

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/opengovsg/plumber/assets/65110268/ab487172-1945-48ea-8a4c-b78804c9cd78)


**AFTER**:
<img width="843" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/35e16cd0-d776-41d0-a400-3bc55ad3e6e0">
