### PR TITLE
chore(npm): add missing npm scripts to main package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "start": "npm run -w backend start",
     "start:worker": "npm run -w backend start:worker",
     "lint": "npm run --workspaces --if-present lint",
-    "test": "vitest"
+    "test": "vitest",
+    "migrate": "npm run -w backend db:migrate",
+    "teardown": "npm run -w backend teardown"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
## Problem

There're missing scripts in the main package that might cause confusion for first-timer

## Solution

Add them to `package.json`

## Tests

Run the setup command from root

## Deploy Notes

N/A