### PR TITLE
PLU-26: [FORMSG-WEBHOOK-4] add metadata supportsWebhookRegistration to app

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -393,6 +393,7 @@ type Trigger {
   description: String
   pollInterval: Int
   type: String
+  supportsWebhookRegistration: Boolean
   webhookTriggerInstructions: TriggerInstructions
   substeps: [TriggerSubstep]
 }

--- a/packages/backend/src/helpers/get-app.ts
+++ b/packages/backend/src/helpers/get-app.ts
@@ -43,11 +43,11 @@ const getApp = async (appKey: string, stripFuncs = true) => {
   }
 
   appData.triggers = appData?.triggers?.map((trigger: IRawTrigger) => {
-    return addStaticSubsteps('trigger', appData, trigger)
+    return addStaticSubsteps('trigger', appData, trigger) as ITrigger
   })
 
   appData.actions = appData?.actions?.map((action: IRawAction) => {
-    return addStaticSubsteps('action', appData, action)
+    return addStaticSubsteps('action', appData, action) as IAction
   })
 
   if (stripFuncs) {
@@ -69,17 +69,29 @@ const testStep = (stepType: 'trigger' | 'action') => {
   }
 }
 
+function isTrigger(
+  stepType: 'trigger' | 'action',
+  computedStep: any,
+): computedStep is ITrigger {
+  return stepType === 'trigger'
+}
+
 const addStaticSubsteps = (
   stepType: 'trigger' | 'action',
   appData: IApp,
   step: IRawTrigger | IRawAction,
-) => {
+): ITrigger | IAction => {
   const computedStep: ITrigger | IAction = omit(step, ['arguments'])
 
   computedStep.substeps = []
 
   if (appData.supportsConnections) {
     computedStep.substeps.push(chooseConnectionStep)
+  }
+
+  if (isTrigger(stepType, computedStep)) {
+    computedStep.supportsWebhookRegistration =
+      !!computedStep.verifyHook && !!computedStep.registerHook
   }
 
   if (step.arguments) {

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -75,6 +75,7 @@ export const GET_APPS = gql`
           afterUrlMsg
           errorMsg
         }
+        supportsWebhookRegistration
         substeps {
           key
           name


### PR DESCRIPTION
## IApp now has supportsWebhookRegistration

This new metadata property is automatically set when verifyHook and registerHook are implemented, and decides if stepId is passed into testConnection query.