### PR TITLE
Handle non-response errors

### DIFF
--- a/packages/backend/src/helpers/http-client/index.ts
+++ b/packages/backend/src/helpers/http-client/index.ts
@@ -43,22 +43,24 @@ export default function createHttpClient({
   instance.interceptors.response.use(
     (response) => response,
     async (error) => {
-      const { config } = error
-      const { status } = error.response
+      if (error.response) {
+        const { config } = error
+        const { status } = error.response
 
-      if (
-        (status === 401 || status === 403) &&
-        $.app.auth.refreshToken &&
-        !$.app.auth.isRefreshTokenRequested
-      ) {
-        $.app.auth.isRefreshTokenRequested = true
-        await $.app.auth.refreshToken($)
+        if (
+          (status === 401 || status === 403) &&
+          $.app.auth.refreshToken &&
+          !$.app.auth.isRefreshTokenRequested
+        ) {
+          $.app.auth.isRefreshTokenRequested = true
+          await $.app.auth.refreshToken($)
 
-        // retry the previous request before the expired token error
-        const newResponse = await instance.request(config)
-        $.app.auth.isRefreshTokenRequested = false
+          // retry the previous request before the expired token error
+          const newResponse = await instance.request(config)
+          $.app.auth.isRefreshTokenRequested = false
 
-        return newResponse
+          return newResponse
+        }
       }
 
       throw new HttpError(error)

--- a/packages/backend/src/helpers/http-client/index.ts
+++ b/packages/backend/src/helpers/http-client/index.ts
@@ -43,6 +43,8 @@ export default function createHttpClient({
   instance.interceptors.response.use(
     (response) => response,
     async (error) => {
+      // This handles system errors like ECONNREFUSED, which don't have a
+      // response body.
       if (!error.response) {
         throw new HttpError(error)
       }


### PR DESCRIPTION
## Problem

On datadog, we're seeing

```
{"error":"Cannot destructure property 'status' of 'error.response' as it is undefined."}
```

instead of more fine-grained error details. This is slowing down our debugging.

## Solution
The root cause is because our http error handler assumes that it will only ever handle response errors. But it's also possible for axios to throw other errors: https://axios-http.com/docs/handling_errors

We will fix this by surrounding the response error handling code in an `if` statement. We don't need to specially handle the rest of the errors because we wrap and re-throw the exception, and DD parses the exception for us.

**BEFORE**
![Screenshot 2023-09-09 at 2 22 55 PM](https://github.com/opengovsg/plumber/assets/135598754/457fbf97-4733-4b93-90a2-dc62ce29555c)

**AFTER**
![Screenshot 2023-09-09 at 2 22 04 PM](https://github.com/opengovsg/plumber/assets/135598754/ae77a472-54d2-4c98-870a-49d6e09f0e1b)

## Tests
- Simulate a `ECONNREFUSED` error using HTTP request to a endpoint that doesn't exist, and check that we correctly throw a `HttpError`.
- Regression test: check that pipes still run
