### PR TITLE
PLU-86: feat(backend): allow white space in variable names for Vault get table data

### DIFF
--- a/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
@@ -1,5 +1,7 @@
 import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
+import { VAULT_ID } from '../../common/constants'
+
 async function getDataOutMetadata(
   step: IExecutionStep,
 ): Promise<IDataOutMetadata> {
@@ -7,9 +9,20 @@ async function getDataOutMetadata(
   if (!data) {
     return null
   }
+  const _metadata = data?._metadata as Record<string, any>
+  if (!_metadata.keysEncoded) {
+    return null
+  }
 
   const metadata = Object.create(null)
   for (const key of Object.keys(data)) {
+    if (key === VAULT_ID) {
+      continue
+    } else if (key === '_metadata') {
+      metadata['_metadata.keysEncoded'] = {
+        isHidden: true,
+      }
+    }
     // the key used for data retrieved from vault workspace are converted to hex
     // to be compatible with our policy to only allow alphanumeric in template keys
     // hence we need to decode here for display on frontend

--- a/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
@@ -1,0 +1,23 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+async function getDataOutMetadata(
+  step: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const data = step.dataOut
+  if (!data) {
+    return null
+  }
+
+  const metadata = Object.create(null)
+  for (const key of Object.keys(data)) {
+    // the key used for data retrieved from vault workspace are converted to hex
+    // to be compatible with our policy to only allow alphanumeric in template keys
+    // hence we need to decode here for display on frontend
+    metadata[key] = {
+      label: Buffer.from(key, 'hex').toString(),
+    }
+  }
+  return metadata
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/get-table-data/get-data-out-metadata.ts
@@ -1,4 +1,4 @@
-import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+import { IDataOutMetadata, IExecutionStep, IJSONObject } from '@plumber/types'
 
 import { VAULT_ID } from '../../common/constants'
 
@@ -9,7 +9,7 @@ async function getDataOutMetadata(
   if (!data) {
     return null
   }
-  const _metadata = data?._metadata as Record<string, any>
+  const _metadata = data?._metadata as IJSONObject
   if (!_metadata.keysEncoded) {
     return null
   }

--- a/packages/backend/src/apps/vault-workspace/actions/get-table-data/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/get-table-data/index.ts
@@ -2,6 +2,8 @@ import defineAction from '@/helpers/define-action'
 
 import filterTableRows from '../../common/filter-table-rows'
 
+import getDataOutMetadata from './get-data-out-metadata'
+
 export default defineAction({
   name: 'Get table data',
   key: 'getTableData',
@@ -26,6 +28,7 @@ export default defineAction({
         ],
       },
     },
+
     {
       label: 'Lookup Value',
       key: 'lookupValue',
@@ -34,6 +37,7 @@ export default defineAction({
       variables: true,
     },
   ],
+  getDataOutMetadata,
 
   async run($) {
     const lookupColumn = $.step.parameters.lookupColumn as string

--- a/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
+++ b/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
@@ -51,6 +51,7 @@ const filterTableRows = async (
     _metadata: {
       success: true,
       rowsFound: response.data.rows.length,
+      keysEncoded: true,
     },
   }
 }

--- a/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
+++ b/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
@@ -38,7 +38,11 @@ const filterTableRows = async (
     if (name === VAULT_ID) {
       row[name] = rawData[name]
     } else {
-      row[mapping[name]] = rawData[name]
+      // keys are converted to hex here to satisfy our requirement for template
+      // keys to be alphanumeric, and will be decoded by getDataOutMetadata before
+      // displayed on frontend
+      const key = Buffer.from(mapping[name]).toString('hex')
+      row[key] = rawData[name]
     }
   }
 

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import vaultWorkspace from '@/apps/vault-workspace'
 import ExecutionStep from '@/models/execution-step'
 
 import computeParameters from '../compute-parameters'
@@ -232,5 +233,27 @@ describe('compute parameters', () => {
         '123',
       ],
     })
+  })
+  it('can compute on  templates with non-hex-encoded param keys using new vault WS objects whose keys hex-encoded', () => {
+    const vaultWSExecutionStep = [
+      {
+        stepId: 'some-step-id',
+        appKey: vaultWorkspace.key,
+        dataOut: {
+          '4974732d612d6d65': 'Mario!', // key is hex-encoded `Its a me`
+          _metadata: {
+            keysEncoded: true,
+          },
+        },
+      } as unknown as ExecutionStep,
+    ]
+    const params = {
+      toSubstitute: 'Its a me {{step.some-step-id.Its-a-me}}',
+    }
+    const expected = {
+      toSubstitute: 'Its a me Mario!',
+    }
+    const result = computeParameters(params, vaultWSExecutionStep)
+    expect(result).toEqual(expected)
   })
 })

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -70,7 +70,7 @@ function findAndSubstituteVariables(
         // attempt to convert the template string to use hex-encoded key
         if (
           dataValue === undefined &&
-          executionStep.appKey === vaultWorkspace.key &&
+          executionStep?.appKey === vaultWorkspace.key &&
           data &&
           data._metadata &&
           (data._metadata as Record<string, any>).keysEncoded

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -2,6 +2,7 @@ import { IAction } from '@plumber/types'
 
 import get from 'lodash.get'
 
+import vaultWorkspace from '@/apps/vault-workspace'
 import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
@@ -55,12 +56,30 @@ function findAndSubstituteVariables(
       if (isVariable) {
         const stepIdAndKeyPath = part.replace(/{{step.|}}/g, '') as string
         const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
-        const keyPath = keyPaths.join('.')
         const executionStep = executionSteps.find((executionStep) => {
           return executionStep.stepId === stepId
         })
         const data = executionStep?.dataOut
-        const dataValue = get(data, keyPath)
+
+        const keyPath = keyPaths.join('.')
+        let dataValue = get(data, keyPath)
+        // custom logic to deal with backward compatibility of key encoding for
+        // data from vault. Under the new logic, data from vault will always have
+        // hex-encoded key while the old templates might still used non-encoded
+        // hence if the value is not defined and keysEncoded flag was set, we
+        // attempt to convert the template string to use hex-encoded key
+        if (
+          dataValue === undefined &&
+          executionStep.appKey === vaultWorkspace.key &&
+          data &&
+          data._metadata &&
+          (data._metadata as Record<string, any>).keysEncoded
+        ) {
+          keyPaths[keyPaths.length - 1] = Buffer.from(
+            keyPaths[keyPaths.length - 1],
+          ).toString('hex')
+          dataValue = get(data, keyPaths.join('.'))
+        }
         return preprocessVariable
           ? preprocessVariable(parameterKey, dataValue)
           : dataValue

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -1,4 +1,4 @@
-import { IAction } from '@plumber/types'
+import { IAction, IJSONObject } from '@plumber/types'
 
 import get from 'lodash.get'
 
@@ -68,12 +68,12 @@ function findAndSubstituteVariables(
         // hex-encoded key while the old templates might still used non-encoded
         // hence if the value is not defined and keysEncoded flag was set, we
         // attempt to convert the template string to use hex-encoded key
+        // FIXME: Remove this custom logic after we migrate off Vault WS
         if (
           dataValue === undefined &&
           executionStep?.appKey === vaultWorkspace.key &&
-          data &&
-          data._metadata &&
-          (data._metadata as Record<string, any>).keysEncoded
+          (data?._metadata as IJSONObject)?.keysEncoded &&
+          keyPaths.length > 0
         ) {
           keyPaths[keyPaths.length - 1] = Buffer.from(
             keyPaths[keyPaths.length - 1],


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Closes https://linear.app/ogp/issue/PLU-86/vault-variable

## Solution

_How did you solve the problem?_

**Features**:

Save vault data key names as hex strings

## Before & After Screenshots

**BEFORE**:
<img width="895" alt="Screenshot 2023-09-11 at 11 01 29 AM" src="https://github.com/opengovsg/plumber/assets/12974927/1c5113ff-294c-434f-b13a-3d527854ff58">


**AFTER**:
<img width="906" alt="Screenshot 2023-09-11 at 11 01 10 AM" src="https://github.com/opengovsg/plumber/assets/12974927/c064ef70-ba40-42e2-968d-eeaf5fa435ce">

## Tests

- Created a table look up in vault with a column that has whitespace in its name
- Use that column value for other action's template

## Deploy Notes

N/A