### PR TITLE
PLU-95: Fix steps being addable on published pipes

### DIFF
--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -1,4 +1,3 @@
-import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 type Params = {
@@ -27,7 +26,7 @@ const createFlow = async (
       .throwIfNotFound()
   }
 
-  await Step.query().insert({
+  await flow.$relatedQuery('steps').insert({
     flowId: flow.id,
     type: 'trigger',
     position: 1,
@@ -35,7 +34,7 @@ const createFlow = async (
     connectionId,
   })
 
-  await Step.query().insert({
+  await flow.$relatedQuery('steps').insert({
     flowId: flow.id,
     type: 'action',
     position: 2,

--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -26,19 +26,18 @@ const createFlow = async (
       .throwIfNotFound()
   }
 
-  await flow.$relatedQuery('steps').insert({
-    flowId: flow.id,
-    type: 'trigger',
-    position: 1,
-    appKey,
-    connectionId,
-  })
-
-  await flow.$relatedQuery('steps').insert({
-    flowId: flow.id,
-    type: 'action',
-    position: 2,
-  })
+  await flow.$relatedQuery('steps').insert([
+    {
+      type: 'trigger',
+      position: 1,
+      appKey,
+      connectionId,
+    },
+    {
+      type: 'action',
+      position: 2,
+    },
+  ])
 
   return flow
 }

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -1,7 +1,5 @@
 import { IJSONObject } from '@plumber/types'
 
-import { type StaticHookArguments, ValidationError } from 'objection'
-
 import Base from './base'
 import Execution from './execution'
 import Step from './step'
@@ -57,30 +55,6 @@ class ExecutionStep extends Base {
 
   get isFailed() {
     return this.status === 'failure'
-  }
-
-  static async beforeUpdate(args: StaticHookArguments<Step>): Promise<void> {
-    await super.beforeUpdate(args)
-
-    // We _have_ to use asFindQuery here instead of iterating through
-    // args.inputItems because patch queries don't
-    // provide the full object - fields like flowId will be undefined.
-    //
-    // Luckily, we _shouldn't_ run into the same problem as beforeInsert: patch
-    // or update queries should _not_ start from the root unless we want to
-    // update _all_ steps.
-    const numNonDistinctActivePipes = await args
-      .asFindQuery()
-      .joinRelated({ step: { flow: true } })
-      .where('step:flow.active', true)
-      .resultSize()
-
-    if (numNonDistinctActivePipes > 0) {
-      throw new ValidationError({
-        message: 'Cannot edit published pipe.',
-        type: 'editingPublishedPipeError',
-      })
-    }
   }
 }
 

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -1,5 +1,7 @@
 import { IJSONObject } from '@plumber/types'
 
+import { type StaticHookArguments, ValidationError } from 'objection'
+
 import Base from './base'
 import Execution from './execution'
 import Step from './step'
@@ -55,6 +57,30 @@ class ExecutionStep extends Base {
 
   get isFailed() {
     return this.status === 'failure'
+  }
+
+  static async beforeUpdate(args: StaticHookArguments<Step>): Promise<void> {
+    await super.beforeUpdate(args)
+
+    // We _have_ to use asFindQuery here instead of iterating through
+    // args.inputItems because patch queries don't
+    // provide the full object - fields like flowId will be undefined.
+    //
+    // Luckily, we _shouldn't_ run into the same problem as beforeInsert: patch
+    // or update queries should _not_ start from the root unless we want to
+    // update _all_ steps.
+    const numNonDistinctActivePipes = await args
+      .asFindQuery()
+      .joinRelated({ step: { flow: true } })
+      .where('step:flow.active', true)
+      .resultSize()
+
+    if (numNonDistinctActivePipes > 0) {
+      throw new ValidationError({
+        message: 'Cannot edit published pipe.',
+        type: 'editingPublishedPipeError',
+      })
+    }
   }
 }
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -165,7 +165,7 @@ class Step extends Base {
     // args.inputItems (like in beforeInsert), because patch queries don't
     // provide the full object - fields like flowId will be undefined.
     //
-    // Luckily,  we _shouldn't_ run into the same problem as beforeInsert: patch
+    // Luckily, we _shouldn't_ run into the same problem as beforeInsert: patch
     // or update queries should _not_ start from the root unless we want to
     // update _all_ steps.
     const numNonDistinctActivePipes = await args

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -164,10 +164,14 @@ class Step extends Base {
     // We _have_ to use asFindQuery here instead of iterating through
     // args.inputItems (like in beforeInsert), because patch queries don't
     // provide the full object - fields like flowId will be undefined.
+    // Furthermore, we use patchAndFetchById from the root so args.items will
+    // be empty.
     //
     // Luckily, we _shouldn't_ run into the same problem as beforeInsert: patch
-    // or update queries should _not_ start from the root unless we want to
-    // update _all_ steps.
+    // or update queries should _not_ start _purely_ from the root ("purely"
+    // means we exclude the ...byId() functions like patchAndFetchById; those
+    // don't count as starting from the root because they filter first) unless
+    // we want to update _all_ steps.
     const numNonDistinctActivePipes = await args
       .asFindQuery()
       .joinRelated({ flow: true })

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -1,11 +1,12 @@
 import type { IFlow, IStep } from '@plumber/types'
 
-import { Fragment, useCallback, useState } from 'react'
+import { Fragment, useCallback, useContext, useState } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import { AbsoluteCenter, Box, Divider, Flex } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 import FlowStep from 'components/FlowStep'
+import { EditorContext } from 'contexts/Editor'
 import { CREATE_STEP } from 'graphql/mutations/create-step'
 import { UPDATE_STEP } from 'graphql/mutations/update-step'
 import { GET_FLOW } from 'graphql/queries/get-flow'
@@ -89,6 +90,8 @@ export default function Editor(props: EditorProps): React.ReactElement {
     triggerStep.id,
   )
 
+  const { readOnly: isReadOnlyEditor } = useContext(EditorContext)
+
   const onStepChange = useCallback(
     (step: IStep) => {
       const mutationInput: Record<string, unknown> = {
@@ -155,7 +158,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
 
           <AddStepButton
             onClick={() => addStep(step.id)}
-            isDisabled={creationInProgress || flow.active}
+            isDisabled={creationInProgress || isReadOnlyEditor}
             isLastStep={index === steps.length - 1}
           />
         </Fragment>

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -12,12 +12,12 @@ import { GET_FLOW } from 'graphql/queries/get-flow'
 
 interface AddStepButtonProps {
   onClick: () => void
-  disabled: boolean
+  isDisabled: boolean
   isLastStep: boolean
 }
 
 function AddStepButton(props: AddStepButtonProps): JSX.Element {
-  const { onClick, disabled, isLastStep } = props
+  const { onClick, isDisabled, isLastStep } = props
 
   return (
     <Box pos="relative" h={24}>
@@ -34,7 +34,7 @@ function AddStepButton(props: AddStepButtonProps): JSX.Element {
       <AbsoluteCenter>
         <IconButton
           onClick={onClick}
-          disabled={disabled}
+          isDisabled={isDisabled}
           aria-label="Add Step"
           icon={<BiPlus />}
           variant="outline"
@@ -155,7 +155,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
 
           <AddStepButton
             onClick={() => addStep(step.id)}
-            disabled={creationInProgress || flow.active}
+            isDisabled={creationInProgress || flow.active}
             isLastStep={index === steps.length - 1}
           />
         </Fragment>


### PR DESCRIPTION
## Problem
Users can add steps to published pipes.

## Solution
Turns out I was using the wrong prop for `IconButton`: I used `disabled` instead of `isDisabled`. Going to submit a PR to OGP DS to fix this also, why do we have 2 of the same props?

We also add an additional guard on the backend via validation hooks.

**BEFORE**
<img width="500" alt="Screenshot 2023-09-13 at 2 07 19 PM" src="https://github.com/opengovsg/plumber/assets/135598754/02d4b635-e91b-4fee-bf24-3130d0d9f5be">

**AFTER**
<img width="500" alt="Screenshot 2023-09-13 at 2 07 33 PM" src="https://github.com/opengovsg/plumber/assets/135598754/4cb66cc6-ad84-4263-9909-6d40bc2ba5cb">

## Tests
_UX only_
- Check that I cannot click the add step button in published pipes / after publishing a pipe.
- Regression test: check that I can add steps in unpublished pipes / after un-publishing a pipe.

_Backend validation_
Before these tests, I forced `readOnly` to false in `EditorContext`.

- Check that I get an exception if I try to add steps to a published pipe
- Check that I get an exception if I try to edit steps in a published pipe
- Check that I get an exception if I try to delete steps in a published pipe, and that associated execution steps are not deleted.
- Regression test: Check that I can create a new pipe
- Regression test: Check that I can add steps to an un-published pipe
- Regression test: Check that I can edit steps in an un-published pipe
- Regression test: Check that I can delete steps in an un-published pipe
- Regression test: Check that new execution steps are created during test runs
- Regression test: Check that new execution steps are created during prod runs