### PR TITLE
PLU-91: [SGID-LOGIN-6] Set up per-env SGID client IDs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
 
       - name: Construct ECR Image URI
         id: ecr-image-uri
@@ -83,7 +85,7 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: |
-          docker build . -t ${{ steps.ecr-image-uri.outputs.image }}
+          docker build . -t ${{ steps.ecr-image-uri.outputs.image }} --build-arg APP_ENV=${{ inputs.environment }}
           docker push ${{ steps.ecr-image-uri.outputs.image }}
 
   deploy:
@@ -108,6 +110,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+        with:
+          mask-password: 'true'
 
       - name: Construct ECR Image URI
         id: ecr-image-uri

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -20,5 +20,5 @@ jobs:
       - run: echo "✅ Your code has been linted."
       - run: npm run test
       - run: echo "✅ All tests passed."
-      - run: npm run build
+      - run: VITE_MODE=test npm run build
       - run: echo "✅ Your code has been built."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:18-alpine as build
 
+ARG APP_ENV=prod
+ENV VITE_MODE=$APP_ENV
+
 WORKDIR /opt/plumber
 COPY . ./
 RUN npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -13688,6 +13688,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-plugin-package-version": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-package-version/-/vite-plugin-package-version-1.0.2.tgz",
+      "integrity": "sha512-xCJMR0KD4rqSUwINyHJlLizio2VzYzaMrRkqC9xWaVGXgw1lIrzdD+wBUf1XDM8EhL1JoQ7aykLOfKrlZd1SoQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": ">=2.0.0-beta.69"
+      }
+    },
     "node_modules/vite-tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.0.tgz",
@@ -14170,6 +14179,7 @@
       }
     },
     "packages/frontend": {
+      "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "3.7.17",
         "@chakra-ui/react": "2.6.1",
@@ -14218,6 +14228,7 @@
         "prettier": "^2.5.1",
         "type-fest": "^3.11.0",
         "vite": "^4.3.9",
+        "vite-plugin-package-version": "^1.0.2",
         "vite-tsconfig-paths": "^4.2.0"
       }
     },

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,8 +1,9 @@
 {
   "name": "frontend",
+  "version": "1.0.0",
   "scripts": {
     "dev": "vite --host",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --mode=${VITE_MODE:-prod}",
     "prebuild": "rimraf ./build",
     "lint": "eslint . --ignore-path ../../.eslintignore",
     "test": "vitest"
@@ -55,6 +56,7 @@
     "prettier": "^2.5.1",
     "type-fest": "^3.11.0",
     "vite": "^4.3.9",
+    "vite-plugin-package-version": "^1.0.2",
     "vite-tsconfig-paths": "^4.2.0"
   },
   "browserslist": {

--- a/packages/frontend/src/components/Footer/index.tsx
+++ b/packages/frontend/src/components/Footer/index.tsx
@@ -1,4 +1,5 @@
 import { RestrictedFooter } from '@opengovsg/design-system-react'
+import appConfig from 'config/app'
 import { FEEDBACK_FORM_LINK, GUIDE_LINK } from 'config/urls'
 
 export const Footer = () => (
@@ -25,6 +26,10 @@ export const Footer = () => (
       {
         label: 'Report Vulnerability',
         href: 'https://www.tech.gov.sg/report_vulnerability',
+      },
+      {
+        label: `${appConfig.version}-${appConfig.env}`,
+        href: '',
       },
     ]}
     containerProps={{

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -1,9 +1,42 @@
-type Config = {
-  [key: string]: string
+interface AppConfig {
+  launchDarklyClientId: string
+  sgidClientId: string
+  env: string
+  version: string
 }
 
-const config: Config = {
-  graphqlUrl: `/graphql`,
+function getAppConfig(): AppConfig {
+  // important: although import.meta.env.VITE_MODE is available, do not use
+  // use it as it is not available in development mode
+  const env = import.meta.env.MODE
+  const version = import.meta.env.PACKAGE_VERSION
+  const commonEnv = {
+    env,
+    version,
+  }
+
+  switch (env) {
+    case 'prod':
+      return {
+        launchDarklyClientId: '64bf4b539077f112ef24e4ae',
+        sgidClientId: 'TBC',
+        ...commonEnv,
+      }
+    case 'staging':
+      return {
+        launchDarklyClientId: '65016ca0b45b7712e6c95703',
+        sgidClientId: 'TBC',
+        ...commonEnv,
+      }
+    default:
+      return {
+        launchDarklyClientId: '64bf4b539077f112ef24e4ad',
+        sgidClientId: 'TBC',
+        ...commonEnv,
+      }
+  }
 }
 
-export default config
+const appConfig = getAppConfig()
+
+export default appConfig

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -19,19 +19,19 @@ function getAppConfig(): AppConfig {
     case 'prod':
       return {
         launchDarklyClientId: '64bf4b539077f112ef24e4ae',
-        sgidClientId: 'TBC',
+        sgidClientId: 'PLUMBER-c24255a5',
         ...commonEnv,
       }
     case 'staging':
       return {
         launchDarklyClientId: '65016ca0b45b7712e6c95703',
-        sgidClientId: 'TBC',
+        sgidClientId: 'PLUMBERSTAGING-776896b1',
         ...commonEnv,
       }
     default:
       return {
         launchDarklyClientId: '64bf4b539077f112ef24e4ad',
-        sgidClientId: 'TBC',
+        sgidClientId: 'PLUMBERLOCALDEV-dc1a72f7',
         ...commonEnv,
       }
   }

--- a/packages/frontend/src/contexts/LaunchDarkly.tsx
+++ b/packages/frontend/src/contexts/LaunchDarkly.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { createContext, useEffect, useState } from 'react'
+import appConfig from 'config/app'
 import type { AuthenticationContextParams } from 'contexts/Authentication'
 import useAuthentication from 'hooks/useAuthentication'
 import type { LDContext, LDFlagSet } from 'launchdarkly-js-client-sdk'
@@ -31,11 +32,8 @@ const ANON_LD_CONTEXT: LDContext = {
   key: 'anon-plumber',
 }
 
-const PROD_ENV_CLIENT_ID = '64bf4b539077f112ef24e4ae'
-const TEST_ENV_CLIENT_ID = '64bf4b539077f112ef24e4ad'
-
 const INITIAL_SETTINGS: LDProviderConfig = {
-  clientSideID: import.meta.env.PROD ? PROD_ENV_CLIENT_ID : TEST_ENV_CLIENT_ID,
+  clientSideID: appConfig.launchDarklyClientId,
   options: {
     logger: LDLogger({ level: 'none' }),
 

--- a/packages/frontend/src/graphql/client.ts
+++ b/packages/frontend/src/graphql/client.ts
@@ -1,5 +1,4 @@
 import { ApolloClient } from '@apollo/client'
-import appConfig from 'config/app'
 
 import cache from './cache'
 import createLink from './link'
@@ -9,9 +8,11 @@ type CreateClientOptions = {
   token?: string | null
 }
 
+const GRAPHQL_URL = '/graphql'
+
 const client = new ApolloClient({
   cache,
-  link: createLink({ uri: appConfig.graphqlUrl }),
+  link: createLink({ uri: GRAPHQL_URL }),
   defaultOptions: {
     watchQuery: {
       fetchPolicy: 'cache-and-network',
@@ -21,7 +22,7 @@ const client = new ApolloClient({
 
 export function createClient(options: CreateClientOptions): typeof client {
   const { onError, token } = options
-  const link = createLink({ uri: appConfig.graphqlUrl, token, onError })
+  const link = createLink({ uri: GRAPHQL_URL, token, onError })
 
   client.setLink(link)
 

--- a/packages/frontend/src/helpers/sgid.ts
+++ b/packages/frontend/src/helpers/sgid.ts
@@ -1,7 +1,6 @@
+import appConfig from 'config/app'
 import * as URLS from 'config/urls'
 
-// FIXME (ogp-weeloong): Add prod client ID later.
-const CLIENT_ID = 'PLUMBERSTAGINGDEV-f49a9cb6'
 const SCOPE = 'openid pocdex.public_officer_employments'
 const REDIRECT_URL = `${window.location.origin}${URLS.LOGIN_SGID_REDIRECT}`
 
@@ -41,7 +40,7 @@ export async function generateSgidAuthUrl(): Promise<{
     '&code_challenge_method=S256' +
     `&code_challenge=${challenge}` +
     `&nonce=${nonce}` +
-    `&client_id=${CLIENT_ID}` +
+    `&client_id=${appConfig.sgidClientId}` +
     `&redirect_uri=${encodeURIComponent(REDIRECT_URL)}` +
     `&scope=${encodeURIComponent(SCOPE)}`
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -1,10 +1,12 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
+import loadVersion from 'vite-plugin-package-version'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), viteTsconfigPaths()],
+  // loadVersion injects package.json version into import.meta.env.PACKAGE_VERSION
+  plugins: [react(), viteTsconfigPaths(), loadVersion()],
   server: {
     open: 'http://localhost:3001',
     port: 3001,


### PR DESCRIPTION
## Problem
We want to use different SGID clients for each of our environments (prod, staging and local dev)

## Solution
Leverage our new vite env to assign different SGID client ids to each environment.

## Tests
- Regression test: check that I can still login using sgid locally
- **TO TEST ON STAGING AFTER LGTM**: check for sgid login regression for single-hat user
- **TO TEST ON STAGING AFTER LGTM**: check for sgid login regression for multi-hat user