### PR TITLE
PLU-81: [IF-THEN-25] Remove onPublish hook

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -26,6 +26,7 @@ describe('make http request', () => {
       step: {
         id: 'herp-derp',
         appKey: 'webhook',
+        position: 1,
         parameters: {},
       },
       http: {

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -74,6 +74,7 @@ describe('decrypt form response', () => {
       step: {
         id: '123',
         appKey: app.key,
+        position: 0,
         parameters: {
           nricFilter: undefined,
         },

--- a/packages/backend/src/apps/toolbelt/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbelt/__tests__/actions/if-then.test.ts
@@ -1,0 +1,426 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import toolbeltApp from '../..'
+import ifThenAction from '../../actions/if-then'
+
+/**
+ * [T = trigger S = normal step, B = branch]
+ *
+ *   T
+ *   |
+ *   B1 (branch-1)
+ *     \
+ *      S1 (branch-1-action-1)
+ *     /
+ *   B2 (branch-2)
+ *     \
+ *      S2 (branch-2-action-1)
+ */
+const FLAT_PIPE_STEPS = [
+  {
+    id: 'trigger',
+    appKey: 'fakeTrigger',
+    key: 'nom-nom-nom',
+    position: 1,
+  },
+  // Branch 1 is the default branch under test.
+  {
+    id: 'branch-1',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 2,
+    parameters: {
+      depth: 0,
+    },
+  },
+  {
+    id: 'branch-1-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 3,
+  },
+  {
+    id: 'branch-2',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 4,
+    parameters: {
+      depth: 0,
+    },
+  },
+  {
+    id: 'branch-2-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 5,
+  },
+]
+
+/**
+ * [T = trigger S = normal step, B = branch]
+ *
+ *   T
+ *   |
+ *   B1 (branch-1)
+ *     \
+ *      S1 (branch-1-action-1)
+ *      |
+ *      B1.1 (branch-1.1)
+ *        \
+ *         S2 (branch-1.1-action-1)
+ *        /
+ *      B1.2 (branch-1.2)
+ *        \
+ *         B1.2.1 (branch-1.2.1)
+ *         |
+ *         | // Intentionally no action in B1.2.1
+ *         |
+ *         B1.2.2 (branch-1.2.2)
+ *           \
+ *            S2 (branch-1.2.2-action-1)
+ *           /
+ *         /
+ *       /
+ *     /
+ *   B2 (branch-2)
+ *     \
+ *      S5 (branch-2-action-1)
+ *       |
+ *      B2.1 (branch-2.1)
+ *        \
+ *         S6 (branch-2.1-action-1)
+ */
+const NESTED_BRANCH_PIPE_STEPS = [
+  {
+    id: 'trigger',
+    appKey: 'fakeTrigger',
+    key: 'nom-nom-nom',
+    position: 1,
+  },
+  {
+    id: 'branch-1',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 2,
+    parameters: {
+      depth: 0,
+    },
+  },
+  {
+    id: 'branch-1-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 3,
+  },
+  {
+    id: 'branch-1.1',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 4,
+    parameters: {
+      depth: 1,
+    },
+  },
+  {
+    id: 'branch-1.1-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 5,
+  },
+  {
+    id: 'branch-1.2',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 6,
+    parameters: {
+      depth: 1,
+    },
+  },
+  {
+    id: 'branch-1.2.1',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 7,
+    parameters: {
+      depth: 2,
+    },
+  },
+  {
+    id: 'branch-1.2.2',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 8,
+    parameters: {
+      depth: 2,
+    },
+  },
+  {
+    id: 'branch-1.2.2-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 9,
+  },
+  {
+    id: 'branch-2',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 10,
+    parameters: {
+      depth: 0,
+    },
+  },
+  {
+    id: 'branch-2-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 11,
+  },
+  {
+    id: 'branch-2.1',
+    appKey: toolbeltApp.key,
+    key: ifThenAction.key,
+    position: 12,
+    parameters: {
+      depth: 1,
+    },
+  },
+  {
+    id: 'branch-2.1-action-1',
+    appKey: 'coffeeMaker',
+    key: 'makeEspresso',
+    position: 13,
+  },
+]
+
+const mocks = vi.hoisted(() => ({
+  stepQueryResult: vi.fn(),
+  setActionItem: vi.fn(),
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      where: vi.fn(() => ({
+        orderBy: vi.fn(() => ({
+          throwIfNotFound: mocks.stepQueryResult,
+        })),
+      })),
+    })),
+  },
+}))
+
+describe('If-Then', () => {
+  let $: IGlobalVariable
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('pipes without nested branches', () => {
+    beforeEach(() => {
+      mocks.stepQueryResult.mockResolvedValue(FLAT_PIPE_STEPS)
+
+      $ = {
+        flow: {
+          id: 'fake-pipe',
+        },
+        step: {
+          ...FLAT_PIPE_STEPS[1],
+        },
+        setActionItem: mocks.setActionItem,
+      } as unknown as IGlobalVariable
+    })
+
+    it('runs the branch and returns void if branch condition passes', async () => {
+      $.step.parameters.conditions = [
+        {
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          value: 1,
+        },
+      ]
+      const result = await ifThenAction.run($)
+
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isBranchTaken: true },
+      })
+    })
+
+    it('skips to the next branch if branch condition fails and there is a next branch', async () => {
+      $.step.parameters.conditions = [
+        {
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          value: 9999,
+        },
+      ]
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'jump-to-step', stepId: 'branch-2' },
+      })
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isBranchTaken: false },
+      })
+    })
+
+    it('ends the pipe if branch condition fails and there is no next branch', async () => {
+      $.step.parameters.conditions = [
+        {
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          value: 9999,
+        },
+      ]
+      // Exclude all of branch-2 from pipe for this test.
+      mocks.stepQueryResult.mockResolvedValueOnce(FLAT_PIPE_STEPS.slice(0, 3))
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'stop-execution' },
+      })
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isBranchTaken: false },
+      })
+    })
+  })
+
+  describe('pipes with nested branches', () => {
+    beforeEach(() => {
+      mocks.stepQueryResult.mockResolvedValue(NESTED_BRANCH_PIPE_STEPS)
+
+      $ = {
+        flow: {
+          id: 'fake-pipe',
+        },
+        step: {
+          ...NESTED_BRANCH_PIPE_STEPS[1],
+        },
+        setActionItem: mocks.setActionItem,
+      } as unknown as IGlobalVariable
+    })
+
+    it.each([
+      // Test depth = 0 branch
+      { stepId: 'branch-1' },
+      // Test deeper depth
+      { stepId: 'branch-1.2.1' },
+    ])(
+      'runs the branch and returns void if the branch condition passes',
+      async () => {
+        $.step.parameters.conditions = [
+          {
+            field: 1,
+            is: 'is',
+            condition: 'equals',
+            value: 1,
+          },
+        ]
+        const result = await ifThenAction.run($)
+
+        expect(result).toBeFalsy()
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isBranchTaken: true },
+        })
+      },
+    )
+
+    it.each([
+      { stepId: 'branch-1', expectedNextStepId: 'branch-2' },
+      { stepId: 'branch-1.1', expectedNextStepId: 'branch-1.2' },
+      { stepId: 'branch-1.2.1', expectedNextStepId: 'branch-1.2.2' },
+    ])(
+      'skips to the next branch of the same depth if branch condition fails and such a branch exists',
+      async ({ stepId, expectedNextStepId }) => {
+        // We use stepId instead of index because it's easier to read.
+        $.step = {
+          ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
+        } as unknown as IGlobalVariable['step']
+        $.step.parameters.conditions = [
+          {
+            field: 1,
+            is: 'is',
+            condition: 'equals',
+            value: 9999,
+          },
+        ]
+
+        const result = await ifThenAction.run($)
+
+        expect(result).toEqual({
+          nextStep: { command: 'jump-to-step', stepId: expectedNextStepId },
+        })
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isBranchTaken: false },
+        })
+      },
+    )
+
+    it.each([
+      { stepId: 'branch-1.2', expectedNextStepId: 'branch-2' },
+      { stepId: 'branch-1.2.2', expectedNextStepId: 'branch-2' },
+    ])(
+      'skips to a branch of a higher depth if branch condition fails and no branch with the same depth exists',
+      async ({ stepId, expectedNextStepId }) => {
+        // We use stepId instead of index because it's easier to read.
+        $.step = {
+          ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
+        } as unknown as IGlobalVariable['step']
+        $.step.parameters.conditions = [
+          {
+            field: 1,
+            is: 'is',
+            condition: 'equals',
+            value: 9999,
+          },
+        ]
+
+        const result = await ifThenAction.run($)
+
+        expect(result).toEqual({
+          nextStep: { command: 'jump-to-step', stepId: expectedNextStepId },
+        })
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isBranchTaken: false },
+        })
+      },
+    )
+
+    it.each([
+      // Test depth = 0
+      { stepId: 'branch-2' },
+      // Test deeper depth
+      { stepId: 'branch-2.1' },
+    ])(
+      'ends the pipe if branch condition fails and there is no next branch',
+      async ({ stepId }) => {
+        $.step = {
+          ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
+        } as unknown as IGlobalVariable['step']
+        $.step.parameters.conditions = [
+          {
+            field: 1,
+            is: 'is',
+            condition: 'equals',
+            value: 9999,
+          },
+        ]
+
+        const result = await ifThenAction.run($)
+
+        expect(result).toEqual({
+          nextStep: { command: 'stop-execution' },
+        })
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isBranchTaken: false },
+        })
+      },
+    )
+  })
+})

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
@@ -27,6 +27,7 @@ describe('create row', () => {
       step: {
         id: 'herp-derp',
         appKey: 'vault-workspace',
+        position: 1,
         parameters: {},
       },
       app,

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/update-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/update-row.test.ts
@@ -70,6 +70,7 @@ describe('update row', () => {
       step: {
         id: 'herp-derp',
         appKey: 'vault-workspace',
+        position: 1,
         parameters: {},
       },
       app,

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -1,6 +1,3 @@
-import { IAction } from '@plumber/types'
-
-import { getOnPipePublishOrBeforeTestRunHook } from '@/helpers/actions'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
@@ -43,31 +40,6 @@ const updateFlowStatus = async (
   const interval = trigger.getInterval?.(triggerStep.parameters)
   const repeatOptions = {
     pattern: interval || EVERY_15_MINUTES_CRON,
-  }
-
-  // Process actions' on-publish hooks.
-  if (flow.active) {
-    const hooksToRun: ReturnType<
-      NonNullable<IAction['onPipePublishOrBeforeTestRun']>
-    >[] = []
-
-    for (const step of flow.steps) {
-      if (step.type !== 'action') {
-        continue
-      }
-
-      const hook = await getOnPipePublishOrBeforeTestRunHook(
-        step.appKey,
-        step.key,
-      )
-      if (!hook) {
-        continue
-      }
-
-      hooksToRun.push(hook(flow))
-    }
-
-    await Promise.all(hooksToRun)
   }
 
   if (trigger.type !== 'webhook') {

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -1,5 +1,3 @@
-import { type IAction } from '@plumber/types'
-
 import { memoize } from 'lodash'
 
 import App from '@/models/app'
@@ -37,39 +35,4 @@ export async function doesActionProcessFiles(
   return (await getFileProcessingActions()).has(
     getCompositeKey(appKey, actionKey),
   )
-}
-
-// Memoize since we can't use top-level await yet. Returns a map of composite
-// app-action key to the action's on-publish hook.
-const getAllOnPipePublishOrBeforeTestRunHooks = memoize(
-  async (): Promise<
-    ReadonlyMap<string, NonNullable<IAction['onPipePublishOrBeforeTestRun']>>
-  > => {
-    const result = new Map<
-      string,
-      NonNullable<IAction['onPipePublishOrBeforeTestRun']>
-    >()
-    const apps = await App.getAllAppsWithFunctions()
-
-    for (const app of apps) {
-      for (const action of app.actions ?? []) {
-        if (action.onPipePublishOrBeforeTestRun) {
-          result.set(
-            getCompositeKey(app.key, action.key),
-            action.onPipePublishOrBeforeTestRun,
-          )
-        }
-      }
-    }
-
-    return result
-  },
-)
-
-export async function getOnPipePublishOrBeforeTestRunHook(
-  appKey: string,
-  actionKey: string,
-): Promise<IAction['onPipePublishOrBeforeTestRun'] | null> {
-  const allHooks = await getAllOnPipePublishOrBeforeTestRunHooks()
-  return allHooks.get(getCompositeKey(appKey, actionKey)) ?? null
 }

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -72,6 +72,7 @@ const globalVariable = async (
     step: {
       id: step?.id,
       appKey: step?.appKey,
+      position: step?.position,
       parameters: step?.parameters || {},
     },
     nextStep: {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite --host --force",
     "build": "tsc && vite build",
     "prebuild": "rimraf ./build",
     "lint": "eslint . --ignore-path ../../.eslintignore",

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -111,6 +111,7 @@ export default function Branch(props: BranchProps): JSX.Element {
 
     if (!isNaN(storedDepth)) {
       openEditor()
+      return
     }
 
     await updateStep({

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -1,6 +1,12 @@
 import { type IFlow, type IStep } from '@plumber/types'
 
-import { type MouseEventHandler, useCallback, useMemo, useRef } from 'react'
+import {
+  type MouseEventHandler,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+} from 'react'
 import { BiTrashAlt } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import {
@@ -14,13 +20,17 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
-import { Button, IconButton } from '@opengovsg/design-system-react'
+import { Button, IconButton, Spinner } from '@opengovsg/design-system-react'
 import NestedEditor from 'components/FlowStepGroup/NestedEditor'
 import {
   type StepDisplayOverridesContextData,
   StepDisplayOverridesProvider,
 } from 'contexts/StepDisplayOverrides'
 import { DELETE_STEP } from 'graphql/mutations/delete-step'
+import { UPDATE_STEP } from 'graphql/mutations/update-step'
+import { GET_FLOW } from 'graphql/queries/get-flow'
+
+import { BranchContext } from './BranchContext'
 
 interface BranchProps {
   flow: IFlow
@@ -35,6 +45,7 @@ export default function Branch(props: BranchProps): JSX.Element {
     onOpen: openEditor,
     onClose: closeEditor,
   } = useDisclosure()
+  const branchContext = useContext(BranchContext)
 
   const initialStep = steps[0]
   const initialStepDisplayOverride = useMemo<StepDisplayOverridesContextData>(
@@ -49,6 +60,9 @@ export default function Branch(props: BranchProps): JSX.Element {
     [initialStep.id, initialStep.parameters.branchName, defaultName],
   )
 
+  //
+  // Handle branch deletion
+  //
   const {
     isOpen: deleteConfirmationIsOpen,
     onOpen: openDeleteConfirmationImpl,
@@ -56,7 +70,7 @@ export default function Branch(props: BranchProps): JSX.Element {
   } = useDisclosure()
   const cancelDeleteButton = useRef<HTMLButtonElement>(null)
   const [deleteStep, { loading: isDeletingBranch }] = useMutation(DELETE_STEP, {
-    refetchQueries: ['GetFlow'],
+    refetchQueries: [GET_FLOW],
   })
   const openDeleteConfirmation = useCallback<MouseEventHandler>(
     (e) => {
@@ -72,13 +86,64 @@ export default function Branch(props: BranchProps): JSX.Element {
     closeDeleteConfirmation()
   }, [deleteStep, steps])
 
+  //
+  // ** EDGE CASE **
+  //
+  // The 1st step of a branch series can have undefined depth if the user has
+  // just chosen "If... Then" via the "Choose app & event" substep. However, our
+  // back end cannot have undefined depth. Luckily, we know that the user _must_
+  // open the branch editor to test any steps within it; thus, we
+  // opportunistically set the depth when the user does this.
+  //
+  // We do this instead of relying on other mechanisms like useEffect (even more
+  // clunk) or handling undefined depth in backend (super complex; needs
+  // additional callbacks or 300+ LoC)
+  //
+  const [updateStep, { loading: isUpdatingBranch }] = useMutation(UPDATE_STEP, {
+    refetchQueries: [GET_FLOW],
+  })
+  const onOpenBranch = useCallback(async () => {
+    if (isUpdatingBranch) {
+      return
+    }
+
+    const branchDepth = parseInt(initialStep.parameters.depth as string)
+
+    if (!isNaN(branchDepth)) {
+      openEditor()
+    }
+
+    await updateStep({
+      variables: {
+        input: {
+          id: initialStep.id,
+          appKey: initialStep.appKey,
+          key: initialStep.key,
+          flow: {
+            id: flow.id,
+          },
+          parameters: {
+            ...initialStep.parameters,
+            depth: branchContext.depth,
+          },
+          connection: {
+            id: null,
+          },
+        },
+      },
+      onCompleted: () => {
+        openEditor()
+      },
+    })
+  }, [openEditor, branchContext, flow, initialStep])
+
   return (
     <>
       {/*
        * Branch row
        */}
       <Flex
-        onClick={openEditor}
+        onClick={onOpenBranch}
         h={16}
         w="full"
         alignItems="center"
@@ -86,19 +151,25 @@ export default function Branch(props: BranchProps): JSX.Element {
         _hover={{ bg: 'interaction.muted.main.hover', cursor: 'pointer' }}
         _active={{ bg: 'interaction.muted.main.active' }}
       >
-        <Text textStyle="subhead-1">
-          {steps[0].parameters.branchName
-            ? String(steps[0].parameters.branchName)
-            : defaultName}
-        </Text>
-        <IconButton
-          onClick={openDeleteConfirmation}
-          variant="clear"
-          aria-label="Delete Branch"
-          icon={<BiTrashAlt />}
-          isLoading={isDeletingBranch}
-          ml="auto"
-        />
+        {isUpdatingBranch ? (
+          <Spinner />
+        ) : (
+          <>
+            <Text textStyle="subhead-1">
+              {steps[0].parameters.branchName
+                ? String(steps[0].parameters.branchName)
+                : defaultName}
+            </Text>
+            <IconButton
+              onClick={openDeleteConfirmation}
+              variant="clear"
+              aria-label="Delete Branch"
+              icon={<BiTrashAlt />}
+              isLoading={isDeletingBranch}
+              ml="auto"
+            />
+          </>
+        )}
       </Flex>
       {/*
        * Delete Confirmation Modal
@@ -135,14 +206,17 @@ export default function Branch(props: BranchProps): JSX.Element {
       {/*
        * Nexted branch editor (pops up in modal)
        */}
-      <StepDisplayOverridesProvider value={initialStepDisplayOverride}>
-        <NestedEditor
-          onClose={closeEditor}
-          isOpen={editorIsOpen}
-          flow={flow}
-          steps={steps}
-        />
-      </StepDisplayOverridesProvider>
+      {/* Nested If-Thens should have depth = depth + 1 */}
+      <BranchContext.Provider value={{ depth: branchContext.depth + 1 }}>
+        <StepDisplayOverridesProvider value={initialStepDisplayOverride}>
+          <NestedEditor
+            onClose={closeEditor}
+            isOpen={editorIsOpen}
+            flow={flow}
+            steps={steps}
+          />
+        </StepDisplayOverridesProvider>
+      </BranchContext.Provider>
     </>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -45,7 +45,7 @@ export default function Branch(props: BranchProps): JSX.Element {
     onOpen: openEditor,
     onClose: closeEditor,
   } = useDisclosure()
-  const branchContext = useContext(BranchContext)
+  const { depth } = useContext(BranchContext)
 
   const initialStep = steps[0]
   const initialStepDisplayOverride = useMemo<StepDisplayOverridesContextData>(
@@ -107,9 +107,9 @@ export default function Branch(props: BranchProps): JSX.Element {
       return
     }
 
-    const branchDepth = parseInt(initialStep.parameters.depth as string)
+    const storedDepth = parseInt(initialStep.parameters.depth as string)
 
-    if (!isNaN(branchDepth)) {
+    if (!isNaN(storedDepth)) {
       openEditor()
     }
 
@@ -124,7 +124,7 @@ export default function Branch(props: BranchProps): JSX.Element {
           },
           parameters: {
             ...initialStep.parameters,
-            depth: branchContext.depth,
+            depth,
           },
           connection: {
             id: null,
@@ -135,7 +135,7 @@ export default function Branch(props: BranchProps): JSX.Element {
         openEditor()
       },
     })
-  }, [openEditor, branchContext, flow, initialStep])
+  }, [openEditor, depth, flow, initialStep])
 
   return (
     <>
@@ -207,7 +207,7 @@ export default function Branch(props: BranchProps): JSX.Element {
        * Nexted branch editor (pops up in modal)
        */}
       {/* Nested If-Thens should have depth = depth + 1 */}
-      <BranchContext.Provider value={{ depth: branchContext.depth + 1 }}>
+      <BranchContext.Provider value={{ depth: depth + 1 }}>
         <StepDisplayOverridesProvider value={initialStepDisplayOverride}>
           <NestedEditor
             onClose={closeEditor}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchContext.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react'
+
+interface BranchContextData {
+  depth: number
+}
+
+export const BranchContext = createContext<BranchContextData>({
+  depth: 0,
+})

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchDepthContext.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchDepthContext.tsx
@@ -1,3 +1,0 @@
-import { createContext } from 'react'
-
-export const BranchDepthContext = createContext<number | null>(null)

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -402,17 +402,6 @@ export interface IBaseAction {
    * action.
    */
   groupsLaterSteps?: boolean
-
-  /**
-   * Hook that is invoked when user publishes a pipe, or right before a test run
-   * begins. This is typically used by actions that need to pre-compute / cache
-   * data.
-   *
-   * @param flow The flow that will be published or test ran. It will also have
-   *   its steps available (i.e. instantiated with withGraphFetched('steps')).
-   *   However, there are no guarantees on the order of steps in the step array.
-   */
-  onPipePublishOrBeforeTestRun?(flow: Flow): Promise<void>
 }
 
 export interface IRawAction extends IBaseAction {
@@ -458,6 +447,7 @@ export type IGlobalVariable = {
   step?: {
     id: string
     appKey: string
+    position: number
     parameters: IJSONObject
   }
   nextStep?: {


### PR DESCRIPTION
## Problem
As discussed over code review, we will no longer use the `onPublishOrBeforeTestRun` hook + `nextStepIdIfSkipped` approach.

We can reduce code complexity instead and live-compute the next step to on each if-then action; this other approach is still O(n) overall anyway.

## Solution
Remove the hook and make if-then compute the correct next step. This requires 2 changes:
1. Ensure that `depth` is never undefined when performing test or prod run. We will do this by doing an `updateStep` mutation (if needed) when the user **opens** the nested branch editor.
   * Doing this when the user opens the editor allows this edge case to be localized in if-then code, instead of adding edge cases to the generic flow substeps.
3. Change the if-then `run` logic to compute the next step at runtime.

## Tests
- New unit test for if-then action
- Check that if-then functionality works.
- Check that nested if-thens functionality still works (even if we're not releasing it yet).
- Regression test: check that pipes without if-then still work.
