### PR TITLE
PLU-81: [IF-THEN-9000] Disable nested branches

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -91,7 +91,7 @@ function ChooseAppAndEventSubstep(
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
-  const isIfThenSelectable = useIsIfThenSelectable(isLastStep)
+  const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
   const appOptions = useMemo(
     () =>
       apps
@@ -122,7 +122,7 @@ function ChooseAppAndEventSubstep(
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         ?.map((app) => optionGenerator(app)) ?? [],
-    [apps, step.position, isIfThenSelectable, launchDarkly.flags],
+    [apps, isIfThenSelectable, launchDarkly.flags],
   )
 
   const actionsOrTriggers: Array<ITrigger | IAction> =

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -86,7 +86,7 @@ function ChooseAppAndEventSubstep(
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
 
-  apps.sort((a, b) => {
+  apps?.sort((a, b) => {
     if (a.description) {
       return -1
     }

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -10,44 +10,16 @@ import Collapse from '@mui/material/Collapse'
 import ListItem from '@mui/material/ListItem'
 import TextField from '@mui/material/TextField'
 import { Badge, FormLabel } from '@opengovsg/design-system-react'
-import { BranchContext as IfThenBranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { EditorContext } from 'contexts/Editor'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { GET_APPS } from 'graphql/queries/get-apps'
-import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from 'helpers/toolbox'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIsIfThenSelectable,
+} from 'helpers/toolbox'
 import useFormatMessage from 'hooks/useFormatMessage'
-import { LDFlagSet } from 'launchdarkly-js-client-sdk'
-
-/**
- * If-Then should only be selectable if:
- * - We're the last step.
- * - We are not inside a branch (unless we're whitelisted for nested
- *   branches via LD).
- *
- * Using many consts as purpose of the conditions may not be immediately
- * apparent.
- */
-function useIsIfThenSelectable(
-  isLastStep: boolean,
-  ldFlags?: LDFlagSet | null,
-): boolean {
-  const { depth } = useContext(IfThenBranchContext)
-
-  return useMemo(() => {
-    if (!isLastStep) {
-      return false
-    }
-
-    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-    if (canUseNestedBranch) {
-      return true
-    }
-
-    const isNestedBranch = depth > 0
-    return !isNestedBranch
-  }, [isLastStep, depth, ldFlags])
-}
 
 type ChooseAppAndEventSubstepProps = {
   substep: ISubstep
@@ -119,10 +91,7 @@ function ChooseAppAndEventSubstep(
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
-  const isIfThenSelectable = useIsIfThenSelectable(
-    isLastStep,
-    launchDarkly?.flags,
-  )
+  const isIfThenSelectable = useIsIfThenSelectable(isLastStep)
   const appOptions = useMemo(
     () =>
       apps

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -222,33 +222,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [stepsBeforeGroup],
   )
 
-  //
-  // Build callback which ChooseAppAndEventSubstep uses to check which actions
-  // are banned. This returns a 2-tuple, (true/false, banned reason if true).
-  //
-  // NOTE: This can also be extended to triggers if needed.
-  //
-  const isBannedAction = useCallback(
-    (
-      step: IStep,
-      appKey: string,
-      actionKey: string,
-    ): [boolean, string | null] => {
-      // Only handle grouping actions for now :x
-      if (
-        groupingActions?.has(`${appKey}-${actionKey}`) &&
-        (groupedSteps.length > 0 ||
-          step.position !==
-            stepsBeforeGroup[stepsBeforeGroup.length - 1]?.position)
-      ) {
-        return [true, 'This must be the last step.']
-      }
-
-      return [false, null]
-    },
-    [groupingActions, groupedSteps],
-  )
-
   if (loadingApps) {
     return <CircularProgress isIndeterminate my={2} />
   }
@@ -261,6 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
+                flow={flow}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}
@@ -269,7 +243,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onContinue={() => {
                   setCurrentStepId(steps[index + 1]?.id)
                 }}
-                isBannedAction={isBannedAction}
               />
               <AddStepButton
                 onClick={() => addStep(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -234,7 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
-                flow={flow}
+                allEditorSteps={steps}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -234,7 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
-                allEditorSteps={steps}
+                isLastStep={index === steps.length - 1}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -230,7 +230,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
     <Flex w="full" justifyContent="center">
       <Flex flexDir="column" alignItems="center" py={3} w="53.25rem">
         <StepExecutionsToIncludeProvider value={stepExecutionsToInclude}>
-          {stepsBeforeGroup.map((step, index, steps) => (
+          {stepsBeforeGroup.map((step, index) => (
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
@@ -241,7 +241,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onClose={() => setCurrentStepId(null)}
                 onChange={onStepChange}
                 onContinue={() => {
-                  setCurrentStepId(steps[index + 1]?.id)
+                  setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
                 }}
               />
               <AddStepButton

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -32,7 +32,7 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
-  allEditorSteps: IStep[]
+  isLastStep: boolean
   index?: number
   onOpen: () => void
   onClose: () => void
@@ -104,15 +104,8 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const {
-    step,
-    allEditorSteps,
-    collapsed,
-    onOpen,
-    onClose,
-    onChange,
-    onContinue,
-  } = props
+  const { step, isLastStep, collapsed, onOpen, onClose, onChange, onContinue } =
+    props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -248,7 +241,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              allEditorSteps={allEditorSteps}
+              isLastStep={isLastStep}
             />
           )}
 

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,4 +1,11 @@
-import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
+import type {
+  IAction,
+  IApp,
+  IFlow,
+  IStep,
+  ISubstep,
+  ITrigger,
+} from '@plumber/types'
 
 import {
   Fragment,
@@ -32,16 +39,12 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
+  flow: IFlow
   index?: number
   onOpen: () => void
   onClose: () => void
   onChange: (step: IStep) => void
   onContinue?: () => void
-  isBannedAction: (
-    step: IStep,
-    appKey: string,
-    actionKey: string,
-  ) => [boolean, string | null]
 }
 
 function generateValidationSchema(substeps: ISubstep[]) {
@@ -108,9 +111,7 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { collapsed, onOpen, onClose, onChange, onContinue, isBannedAction } =
-    props
-  const step: IStep = props.step
+  const { step, flow, collapsed, onOpen, onClose, onChange, onContinue } = props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -246,7 +247,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              isBannedAction={isBannedAction}
+              flow={flow}
             />
           )}
 

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,11 +1,4 @@
-import type {
-  IAction,
-  IApp,
-  IFlow,
-  IStep,
-  ISubstep,
-  ITrigger,
-} from '@plumber/types'
+import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import {
   Fragment,
@@ -39,7 +32,7 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
-  flow: IFlow
+  allEditorSteps: IStep[]
   index?: number
   onOpen: () => void
   onClose: () => void
@@ -111,7 +104,15 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, flow, collapsed, onOpen, onClose, onChange, onContinue } = props
+  const {
+    step,
+    allEditorSteps,
+    collapsed,
+    onOpen,
+    onClose,
+    onChange,
+    onContinue,
+  } = props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -247,7 +248,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              flow={flow}
+              allEditorSteps={allEditorSteps}
             />
           )}
 

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,6 +1,6 @@
 import { type IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { BranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 
@@ -131,21 +131,23 @@ export function areAllIfThenBranchesCompleted(
  * Using many consts as purpose of the conditions may not be immediately
  * apparent.
  */
-export function useIsIfThenSelectable(isLastStep: boolean): boolean {
+export function useIsIfThenSelectable({
+  isLastStep,
+}: {
+  isLastStep: boolean
+}): boolean {
   const { depth } = useContext(BranchContext)
   const { flags: ldFlags } = useContext(LaunchDarklyContext)
 
-  return useMemo(() => {
-    if (!isLastStep) {
-      return false
-    }
+  if (!isLastStep) {
+    return false
+  }
 
-    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-    if (canUseNestedBranch) {
-      return true
-    }
+  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
+  if (canUseNestedBranch) {
+    return true
+  }
 
-    const isNestedBranch = depth > 0
-    return !isNestedBranch
-  }, [isLastStep, depth, ldFlags])
+  const isNestedBranch = depth > 0
+  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,7 +1,5 @@
 import { type IStep } from '@plumber/types'
 
-import { LDFlagSet } from 'launchdarkly-js-client-sdk'
-
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -115,41 +113,4 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
-}
-
-/**
- * Helper to check if If-Then action should be selectable.
- *
- * If-Then should only be selectable if:
- * - We're the last step.
- * - We are not inside a branch (unless we're whitelisted for nested
- *   branches via LD).
- *
- * Using many consts as purpose of the conditions may not be immediately
- * apparent.
- *
- * @param allEditorSteps All steps currently displayed in the editor, including
- *   grouped steps at the end (NOT all flow steps)! We need currently displayed
- *   steps to handle nested branches.
- * @param currStep The step currently being edited.
- * @param ldFlags LaunchDarkly flags, if avaialble.
- */
-export function isIfThenSelectable(
-  allEditorSteps: IStep[],
-  currStep: IStep,
-  ldFlags?: LDFlagSet | null,
-): boolean {
-  const isLastStep =
-    allEditorSteps[allEditorSteps.length - 1].position === currStep.position
-  if (!isLastStep) {
-    return false
-  }
-
-  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-  if (canUseNestedBranch) {
-    return true
-  }
-
-  const isNestedBranch = isIfThenStep(allEditorSteps[0])
-  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,5 +1,9 @@
 import { type IStep } from '@plumber/types'
 
+import { useContext, useMemo } from 'react'
+import { BranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
+
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -113,4 +117,35 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
+}
+
+/**
+ * Helper hook to check if If-Then action should be selectable; supports edge
+ * case in ChooseAppAndEventSubstep.
+ *
+ * If-Then should only be selectable if:
+ * - We're the last step.
+ * - We are not inside a branch (unless we're whitelisted for nested
+ *   branches via LD).
+ *
+ * Using many consts as purpose of the conditions may not be immediately
+ * apparent.
+ */
+export function useIsIfThenSelectable(isLastStep: boolean): boolean {
+  const { depth } = useContext(BranchContext)
+  const { flags: ldFlags } = useContext(LaunchDarklyContext)
+
+  return useMemo(() => {
+    if (!isLastStep) {
+      return false
+    }
+
+    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
+    if (canUseNestedBranch) {
+      return true
+    }
+
+    const isNestedBranch = depth > 0
+    return !isNestedBranch
+  }, [isLastStep, depth, ldFlags])
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,5 +1,7 @@
 import { type IStep } from '@plumber/types'
 
+import { LDFlagSet } from 'launchdarkly-js-client-sdk'
+
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -113,4 +115,41 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
+}
+
+/**
+ * Helper to check if If-Then action should be selectable.
+ *
+ * If-Then should only be selectable if:
+ * - We're the last step.
+ * - We are not inside a branch (unless we're whitelisted for nested
+ *   branches via LD).
+ *
+ * Using many consts as purpose of the conditions may not be immediately
+ * apparent.
+ *
+ * @param allEditorSteps All steps currently displayed in the editor, including
+ *   grouped steps at the end (NOT all flow steps)! We need currently displayed
+ *   steps to handle nested branches.
+ * @param currStep The step currently being edited.
+ * @param ldFlags LaunchDarkly flags, if avaialble.
+ */
+export function isIfThenSelectable(
+  allEditorSteps: IStep[],
+  currStep: IStep,
+  ldFlags?: LDFlagSet | null,
+): boolean {
+  const isLastStep =
+    allEditorSteps[allEditorSteps.length - 1].position === currStep.position
+  if (!isLastStep) {
+    return false
+  }
+
+  const canUseNestedBranch = ldFlags?.['feat_nested_if_then'] ?? false
+  if (canUseNestedBranch) {
+    return true
+  }
+
+  const isNestedBranch = isIfThenStep(allEditorSteps[0])
+  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -145,7 +145,7 @@ export function isIfThenSelectable(
     return false
   }
 
-  const canUseNestedBranch = ldFlags?.['feat_nested_if_then'] ?? false
+  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
   if (canUseNestedBranch) {
     return true
   }


### PR DESCRIPTION
## Problem
From user tests, it doesn't look like we need nested branches. Let's disable it for now to prevent user confusion.

I still think there is a chance a subset of users might need it, so for now, I've gated it behind a LD flag `feature_nested_if_then`. 

## Solution
We'll add an edge case to `ChooseAppAndEventSubstep` to  support this, because making stuff too generic is early unneeded complexity.

## Tests
- Check that I cannot select if-then unless I'm the final step
- Check that I cannot select nested if-then 
- Check if LD flag is enabled, I can select nested if-then
- Regression test: check I can still edit pipes without if-then