### PR TITLE
PLU-81: [IF-THEN-9001] Create 2 branches by default

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -91,7 +91,7 @@ function ChooseAppAndEventSubstep(
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
-  const isIfThenSelectable = useIsIfThenSelectable(isLastStep)
+  const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
   const appOptions = useMemo(
     () =>
       apps
@@ -122,7 +122,7 @@ function ChooseAppAndEventSubstep(
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         ?.map((app) => optionGenerator(app)) ?? [],
-    [apps, step.position, isIfThenSelectable, launchDarkly.flags],
+    [apps, isIfThenSelectable, launchDarkly.flags],
   )
 
   const actionsOrTriggers: Array<ITrigger | IAction> =

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -14,7 +14,12 @@ import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { EditorContext } from 'contexts/Editor'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { GET_APPS } from 'graphql/queries/get-apps'
-import { isIfThenSelectable, TOOLBOX_APP_KEY } from 'helpers/toolbox'
+import {
+  isIfThenSelectable,
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIfThenInitializer,
+} from 'helpers/toolbox'
 import useFormatMessage from 'hooks/useFormatMessage'
 
 type ChooseAppAndEventSubstepProps = {
@@ -125,7 +130,6 @@ function ChooseAppAndEventSubstep(
   const actionOrTriggerOptions = useMemo(
     () =>
       actionsOrTriggers
-
         .filter((actionOrTrigger) => {
           //
           // ** EDGE CASE AGAIN **
@@ -173,14 +177,43 @@ function ChooseAppAndEventSubstep(
 
   const valid: boolean = !!step.key && !!step.appKey
 
-  // placeholders
+  //
+  // Handle app or event changes
+  //
+  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
   const onEventChange = useCallback(
-    (event: React.SyntheticEvent, selectedOption: unknown) => {
+    async (_event: SyntheticEvent, selectedOption: unknown) => {
       if (typeof selectedOption === 'object') {
         // TODO: try to simplify type casting below.
         const typedSelectedOption = selectedOption as { value: string }
         const option: { value: string } = typedSelectedOption
         const eventKey = option?.value as string
+
+        //
+        // ** EDGE CASE AGAIN V2 **
+        //
+        // Hello, the if-then edge case demon here again and again!
+        //
+        // If-then is weird in that we need to pre-populate with 2 branches
+        // upon initial selection (the only action that spawns 2 steps upon
+        // first selection), and we also need to update the first branch's
+        // parameters.
+        //
+        // Since there are a bunch of edge cases for If-Then in this component
+        // already, let's localize the damage and continue adding edge cases
+        // here.
+        //
+        // Note that we don't need to check for inequality to the current
+        // step.key, since we don't display the action drop-down after someone
+        // selects If-Then.
+        //
+        if (
+          app?.key === TOOLBOX_APP_KEY &&
+          eventKey === TOOLBOX_ACTIONS.IfThen
+        ) {
+          await initializeIfThen(step)
+          return
+        }
 
         if (step.key !== eventKey) {
           onChange({
@@ -192,11 +225,11 @@ function ChooseAppAndEventSubstep(
         }
       }
     },
-    [step, onChange],
+    [app?.key, step, onChange, initializeIfThen],
   )
 
   const onAppChange = useCallback(
-    (event: SyntheticEvent, selectedOption: unknown) => {
+    (_event: SyntheticEvent, selectedOption: unknown) => {
       if (typeof selectedOption === 'object') {
         // TODO: try to simplify type casting below.
         const typedSelectedOption = selectedOption as { value: string }
@@ -220,6 +253,8 @@ function ChooseAppAndEventSubstep(
 
   const onToggle = expanded ? onCollapse : onExpand
 
+  const isLoading = launchDarkly.isLoading || isInitializingIfThen
+
   return (
     <>
       <FlowSubstepTitle
@@ -242,8 +277,10 @@ function ChooseAppAndEventSubstep(
             fullWidth
             disablePortal
             disableClearable
-            disabled={editorContext.readOnly}
-            options={appOptions}
+            disabled={isLoading || editorContext.readOnly}
+            loading={isLoading}
+            // Don't display options until we can check feature flags!
+            options={launchDarkly.isLoading ? [] : appOptions}
             renderOption={(optionProps, option) => (
               <li
                 {...optionProps}
@@ -295,9 +332,10 @@ function ChooseAppAndEventSubstep(
                 fullWidth
                 disablePortal
                 disableClearable
-                disabled={editorContext.readOnly}
-                options={launchDarkly.isLoading ? [] : actionOrTriggerOptions}
-                loading={launchDarkly.isLoading}
+                disabled={isLoading || editorContext.readOnly}
+                loading={isLoading}
+                // Don't display options until we can check feature flags!
+                options={isLoading ? [] : actionOrTriggerOptions}
                 renderInput={(params) => (
                   <FormControl>
                     <FormLabel isRequired>

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -86,7 +86,7 @@ function ChooseAppAndEventSubstep(
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
 
-  apps.sort((a, b) => {
+  apps?.sort((a, b) => {
     if (a.description) {
       return -1
     }

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -10,44 +10,16 @@ import Collapse from '@mui/material/Collapse'
 import ListItem from '@mui/material/ListItem'
 import TextField from '@mui/material/TextField'
 import { Badge, FormLabel } from '@opengovsg/design-system-react'
-import { BranchContext as IfThenBranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { EditorContext } from 'contexts/Editor'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { GET_APPS } from 'graphql/queries/get-apps'
-import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from 'helpers/toolbox'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIsIfThenSelectable,
+} from 'helpers/toolbox'
 import useFormatMessage from 'hooks/useFormatMessage'
-import { LDFlagSet } from 'launchdarkly-js-client-sdk'
-
-/**
- * If-Then should only be selectable if:
- * - We're the last step.
- * - We are not inside a branch (unless we're whitelisted for nested
- *   branches via LD).
- *
- * Using many consts as purpose of the conditions may not be immediately
- * apparent.
- */
-function useIsIfThenSelectable(
-  isLastStep: boolean,
-  ldFlags?: LDFlagSet | null,
-): boolean {
-  const { depth } = useContext(IfThenBranchContext)
-
-  return useMemo(() => {
-    if (!isLastStep) {
-      return false
-    }
-
-    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-    if (canUseNestedBranch) {
-      return true
-    }
-
-    const isNestedBranch = depth > 0
-    return !isNestedBranch
-  }, [isLastStep, depth, ldFlags])
-}
 
 type ChooseAppAndEventSubstepProps = {
   substep: ISubstep
@@ -119,10 +91,7 @@ function ChooseAppAndEventSubstep(
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
-  const isIfThenSelectable = useIsIfThenSelectable(
-    isLastStep,
-    launchDarkly?.flags,
-  )
+  const isIfThenSelectable = useIsIfThenSelectable(isLastStep)
   const appOptions = useMemo(
     () =>
       apps

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -222,33 +222,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [stepsBeforeGroup],
   )
 
-  //
-  // Build callback which ChooseAppAndEventSubstep uses to check which actions
-  // are banned. This returns a 2-tuple, (true/false, banned reason if true).
-  //
-  // NOTE: This can also be extended to triggers if needed.
-  //
-  const isBannedAction = useCallback(
-    (
-      step: IStep,
-      appKey: string,
-      actionKey: string,
-    ): [boolean, string | null] => {
-      // Only handle grouping actions for now :x
-      if (
-        groupingActions?.has(`${appKey}-${actionKey}`) &&
-        (groupedSteps.length > 0 ||
-          step.position !==
-            stepsBeforeGroup[stepsBeforeGroup.length - 1]?.position)
-      ) {
-        return [true, 'This must be the last step.']
-      }
-
-      return [false, null]
-    },
-    [groupingActions, groupedSteps],
-  )
-
   if (loadingApps) {
     return <CircularProgress isIndeterminate my={2} />
   }
@@ -261,6 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
+                flow={flow}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}
@@ -269,7 +243,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onContinue={() => {
                   setCurrentStepId(steps[index + 1]?.id)
                 }}
-                isBannedAction={isBannedAction}
               />
               <AddStepButton
                 onClick={() => addStep(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -234,7 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
-                flow={flow}
+                allEditorSteps={steps}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -234,7 +234,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
-                allEditorSteps={steps}
+                isLastStep={index === steps.length - 1}
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -230,7 +230,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
     <Flex w="full" justifyContent="center">
       <Flex flexDir="column" alignItems="center" py={3} w="53.25rem">
         <StepExecutionsToIncludeProvider value={stepExecutionsToInclude}>
-          {stepsBeforeGroup.map((step, index, steps) => (
+          {stepsBeforeGroup.map((step, index) => (
             <Fragment key={`${step.id}-${index}`}>
               <FlowStep
                 step={step}
@@ -241,7 +241,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onClose={() => setCurrentStepId(null)}
                 onChange={onStepChange}
                 onContinue={() => {
-                  setCurrentStepId(steps[index + 1]?.id)
+                  setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
                 }}
               />
               <AddStepButton

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -94,7 +94,19 @@ export default function Editor(props: EditorProps): React.ReactElement {
     { refetchQueries: [GET_FLOW] },
   )
 
-  const { flow, steps } = props
+  const { flow, steps: rawSteps } = props
+  const steps = useMemo(
+    // Populate each step's flowId so that IStep isn't LYING about flowId being
+    // non-undefined. We do it here instead of fetching in GraphQL since all
+    // steps have same pipe, so a bit wasteful to repeat this data over the wire.
+    () =>
+      rawSteps.map((step) => ({
+        ...step,
+        flow,
+        flowId: flow.id,
+      })),
+    [flow, rawSteps],
+  )
 
   const [currentStepId, setCurrentStepId] = useState<string | null>(
     steps[0]?.id,

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -32,7 +32,7 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
-  allEditorSteps: IStep[]
+  isLastStep: boolean
   index?: number
   onOpen: () => void
   onClose: () => void
@@ -104,15 +104,8 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const {
-    step,
-    allEditorSteps,
-    collapsed,
-    onOpen,
-    onClose,
-    onChange,
-    onContinue,
-  } = props
+  const { step, isLastStep, collapsed, onOpen, onClose, onChange, onContinue } =
+    props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -248,7 +241,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              allEditorSteps={allEditorSteps}
+              isLastStep={isLastStep}
             />
           )}
 

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,4 +1,11 @@
-import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
+import type {
+  IAction,
+  IApp,
+  IFlow,
+  IStep,
+  ISubstep,
+  ITrigger,
+} from '@plumber/types'
 
 import {
   Fragment,
@@ -32,16 +39,12 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
+  flow: IFlow
   index?: number
   onOpen: () => void
   onClose: () => void
   onChange: (step: IStep) => void
   onContinue?: () => void
-  isBannedAction: (
-    step: IStep,
-    appKey: string,
-    actionKey: string,
-  ) => [boolean, string | null]
 }
 
 function generateValidationSchema(substeps: ISubstep[]) {
@@ -108,9 +111,7 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { collapsed, onOpen, onClose, onChange, onContinue, isBannedAction } =
-    props
-  const step: IStep = props.step
+  const { step, flow, collapsed, onOpen, onClose, onChange, onContinue } = props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -246,7 +247,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              isBannedAction={isBannedAction}
+              flow={flow}
             />
           )}
 

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,11 +1,4 @@
-import type {
-  IAction,
-  IApp,
-  IFlow,
-  IStep,
-  ISubstep,
-  ITrigger,
-} from '@plumber/types'
+import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import {
   Fragment,
@@ -39,7 +32,7 @@ import * as yup from 'yup'
 type FlowStepProps = {
   collapsed?: boolean
   step: IStep
-  flow: IFlow
+  allEditorSteps: IStep[]
   index?: number
   onOpen: () => void
   onClose: () => void
@@ -111,7 +104,15 @@ function generateValidationSchema(substeps: ISubstep[]) {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, flow, collapsed, onOpen, onClose, onChange, onContinue } = props
+  const {
+    step,
+    allEditorSteps,
+    collapsed,
+    onOpen,
+    onClose,
+    onChange,
+    onContinue,
+  } = props
   const isTrigger = step.type === 'trigger'
 
   const editorContext = useContext(EditorContext)
@@ -247,7 +248,7 @@ export default function FlowStep(
               onSubmit={expandNextStep}
               onChange={handleChange}
               step={step}
-              flow={flow}
+              allEditorSteps={allEditorSteps}
             />
           )}
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -21,7 +21,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
-import { Button, IconButton, Spinner } from '@opengovsg/design-system-react'
+import { Button, IconButton } from '@opengovsg/design-system-react'
 import NestedEditor from 'components/FlowStepGroup/NestedEditor'
 import { EditorContext } from 'contexts/Editor'
 import {
@@ -29,7 +29,6 @@ import {
   StepDisplayOverridesProvider,
 } from 'contexts/StepDisplayOverrides'
 import { DELETE_STEP } from 'graphql/mutations/delete-step'
-import { UPDATE_STEP } from 'graphql/mutations/update-step'
 import { GET_FLOW } from 'graphql/queries/get-flow'
 import { isIfThenBranchCompleted } from 'helpers/toolbox'
 
@@ -91,64 +90,13 @@ export default function Branch(props: BranchProps): JSX.Element {
     closeDeleteConfirmation()
   }, [deleteStep, steps])
 
-  //
-  // ** EDGE CASE **
-  //
-  // The 1st step of a branch series can have undefined depth if the user has
-  // just chosen "If... Then" via the "Choose app & event" substep. However, our
-  // back end cannot have undefined depth. Luckily, we know that the user _must_
-  // open the branch editor to test any steps within it; thus, we
-  // opportunistically set the depth when the user does this.
-  //
-  // We do this instead of relying on other mechanisms like useEffect (even more
-  // clunk) or handling undefined depth in backend (super complex; needs
-  // additional callbacks or 300+ LoC)
-  //
-  const [updateStep, { loading: isUpdatingBranch }] = useMutation(UPDATE_STEP, {
-    refetchQueries: [GET_FLOW],
-  })
-  const onOpenBranch = useCallback(async () => {
-    if (isUpdatingBranch) {
-      return
-    }
-
-    const storedDepth = parseInt(initialStep.parameters.depth as string)
-
-    if (!isNaN(storedDepth)) {
-      openEditor()
-      return
-    }
-
-    await updateStep({
-      variables: {
-        input: {
-          id: initialStep.id,
-          appKey: initialStep.appKey,
-          key: initialStep.key,
-          flow: {
-            id: flow.id,
-          },
-          parameters: {
-            ...initialStep.parameters,
-            branchName: 'Branch 1',
-            depth,
-          },
-          connection: {
-            id: null,
-          },
-        },
-      },
-    })
-    openEditor()
-  }, [openEditor, depth, flow, initialStep])
-
   return (
     <>
       {/*
        * Branch row
        */}
       <Flex
-        onClick={onOpenBranch}
+        onClick={openEditor}
         h={16}
         w="full"
         alignItems="center"
@@ -156,33 +104,26 @@ export default function Branch(props: BranchProps): JSX.Element {
         _hover={{ bg: 'interaction.muted.main.hover', cursor: 'pointer' }}
         _active={{ bg: 'interaction.muted.main.active' }}
       >
-        {isUpdatingBranch ? (
-          <Spinner />
-        ) : (
-          <>
-            <Text textStyle="subhead-1">
-              {(steps[0].parameters.branchName as string | undefined) ??
-                'Branch 1'}
-            </Text>
-            {isCompleted && (
-              <Icon
-                ml={1}
-                boxSize={4}
-                color="interaction.success.default"
-                as={BiSolidCheckCircle}
-              />
-            )}
-            <IconButton
-              onClick={openDeleteConfirmation}
-              variant="clear"
-              aria-label="Delete Branch"
-              icon={<BiTrashAlt />}
-              isLoading={isDeletingBranch}
-              isDisabled={isEditorReadOnly}
-              ml="auto"
-            />
-          </>
+        <Text textStyle="subhead-1">
+          {(steps[0].parameters.branchName as string | undefined) ?? 'Branch 1'}
+        </Text>
+        {isCompleted && (
+          <Icon
+            ml={1}
+            boxSize={4}
+            color="interaction.success.default"
+            as={BiSolidCheckCircle}
+          />
         )}
+        <IconButton
+          onClick={openDeleteConfirmation}
+          variant="clear"
+          aria-label="Delete Branch"
+          icon={<BiTrashAlt />}
+          isLoading={isDeletingBranch}
+          isDisabled={isEditorReadOnly}
+          ml="auto"
+        />
       </Flex>
       {/*
        * Delete Confirmation Modal

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,6 +1,6 @@
 import { type IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { BranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 
@@ -131,21 +131,23 @@ export function areAllIfThenBranchesCompleted(
  * Using many consts as purpose of the conditions may not be immediately
  * apparent.
  */
-export function useIsIfThenSelectable(isLastStep: boolean): boolean {
+export function useIsIfThenSelectable({
+  isLastStep,
+}: {
+  isLastStep: boolean
+}): boolean {
   const { depth } = useContext(BranchContext)
   const { flags: ldFlags } = useContext(LaunchDarklyContext)
 
-  return useMemo(() => {
-    if (!isLastStep) {
-      return false
-    }
+  if (!isLastStep) {
+    return false
+  }
 
-    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-    if (canUseNestedBranch) {
-      return true
-    }
+  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
+  if (canUseNestedBranch) {
+    return true
+  }
 
-    const isNestedBranch = depth > 0
-    return !isNestedBranch
-  }, [isLastStep, depth, ldFlags])
+  const isNestedBranch = depth > 0
+  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,7 +1,5 @@
 import { type IStep } from '@plumber/types'
 
-import { LDFlagSet } from 'launchdarkly-js-client-sdk'
-
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -115,41 +113,4 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
-}
-
-/**
- * Helper to check if If-Then action should be selectable.
- *
- * If-Then should only be selectable if:
- * - We're the last step.
- * - We are not inside a branch (unless we're whitelisted for nested
- *   branches via LD).
- *
- * Using many consts as purpose of the conditions may not be immediately
- * apparent.
- *
- * @param allEditorSteps All steps currently displayed in the editor, including
- *   grouped steps at the end (NOT all flow steps)! We need currently displayed
- *   steps to handle nested branches.
- * @param currStep The step currently being edited.
- * @param ldFlags LaunchDarkly flags, if avaialble.
- */
-export function isIfThenSelectable(
-  allEditorSteps: IStep[],
-  currStep: IStep,
-  ldFlags?: LDFlagSet | null,
-): boolean {
-  const isLastStep =
-    allEditorSteps[allEditorSteps.length - 1].position === currStep.position
-  if (!isLastStep) {
-    return false
-  }
-
-  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
-  if (canUseNestedBranch) {
-    return true
-  }
-
-  const isNestedBranch = isIfThenStep(allEditorSteps[0])
-  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,5 +1,9 @@
 import { type IStep } from '@plumber/types'
 
+import { useContext, useMemo } from 'react'
+import { BranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
+
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -113,4 +117,35 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
+}
+
+/**
+ * Helper hook to check if If-Then action should be selectable; supports edge
+ * case in ChooseAppAndEventSubstep.
+ *
+ * If-Then should only be selectable if:
+ * - We're the last step.
+ * - We are not inside a branch (unless we're whitelisted for nested
+ *   branches via LD).
+ *
+ * Using many consts as purpose of the conditions may not be immediately
+ * apparent.
+ */
+export function useIsIfThenSelectable(isLastStep: boolean): boolean {
+  const { depth } = useContext(BranchContext)
+  const { flags: ldFlags } = useContext(LaunchDarklyContext)
+
+  return useMemo(() => {
+    if (!isLastStep) {
+      return false
+    }
+
+    const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
+    if (canUseNestedBranch) {
+      return true
+    }
+
+    const isNestedBranch = depth > 0
+    return !isNestedBranch
+  }, [isLastStep, depth, ldFlags])
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,5 +1,7 @@
 import { type IStep } from '@plumber/types'
 
+import { LDFlagSet } from 'launchdarkly-js-client-sdk'
+
 export const TOOLBOX_APP_KEY = 'toolbox'
 
 export enum TOOLBOX_ACTIONS {
@@ -113,4 +115,41 @@ export function areAllIfThenBranchesCompleted(
 ): boolean {
   const branches = extractBranchesWithSteps(allBranches, depth)
   return branches.every(isIfThenBranchCompleted)
+}
+
+/**
+ * Helper to check if If-Then action should be selectable.
+ *
+ * If-Then should only be selectable if:
+ * - We're the last step.
+ * - We are not inside a branch (unless we're whitelisted for nested
+ *   branches via LD).
+ *
+ * Using many consts as purpose of the conditions may not be immediately
+ * apparent.
+ *
+ * @param allEditorSteps All steps currently displayed in the editor, including
+ *   grouped steps at the end (NOT all flow steps)! We need currently displayed
+ *   steps to handle nested branches.
+ * @param currStep The step currently being edited.
+ * @param ldFlags LaunchDarkly flags, if avaialble.
+ */
+export function isIfThenSelectable(
+  allEditorSteps: IStep[],
+  currStep: IStep,
+  ldFlags?: LDFlagSet | null,
+): boolean {
+  const isLastStep =
+    allEditorSteps[allEditorSteps.length - 1].position === currStep.position
+  if (!isLastStep) {
+    return false
+  }
+
+  const canUseNestedBranch = ldFlags?.['feat_nested_if_then'] ?? false
+  if (canUseNestedBranch) {
+    return true
+  }
+
+  const isNestedBranch = isIfThenStep(allEditorSteps[0])
+  return !isNestedBranch
 }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -145,7 +145,7 @@ export function isIfThenSelectable(
     return false
   }
 
-  const canUseNestedBranch = ldFlags?.['feat_nested_if_then'] ?? false
+  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
   if (canUseNestedBranch) {
     return true
   }


### PR DESCRIPTION
## Problem
From user testing, it looks like people are confused about how to create the 2nd branch onwards.

We'll create 2 branches by default to make it clear that you're supposed to click the "Add Branches" button at the same level as your original branch.

## Solution
We'll add another edge case to `ChooseAppAndEventSubstep`, since we already have edge cases for If-Then there. Not good to spread this edge-case demon outside this component.

Note that I also disable the app & event drop down when we're creating the initial 2 branches. From user testing, it's apparent that some users have _really_ slow connections, and I don't want users to selecting another action while branch creation is going on. That's going to be _super_ confusing.

**VIDEO WITH THROTTLED CONNECTION**
https://github.com/opengovsg/plumber/assets/135598754/75ed9c87-0151-4ab3-aeb3-21e16caeb862

## Tests
- Test that selecting If-Then from the "Choose app & event" substep will create 2 branches.
- Throttle my connection and check that both branches appear at the same time.
- Regression test: check that I can still choose and edit other apps / events.
