### PR TITLE
PLU-70: [TILES-3] Set up dynamodb test container

### DIFF
--- a/packages/backend/src/config/dynamodb.ts
+++ b/packages/backend/src/config/dynamodb.ts
@@ -10,7 +10,11 @@ const ddb = new dynamoose.aws.ddb.DynamoDB({
 
 if (appConfig.isDev) {
   // Use local dynamodb in development env
-  dynamoose.aws.ddb.local()
+  // LOCAL_DYNAMODB_PORT is set in packages/backend/test/ddb-global-setup.ts
+  // and is only specified when running integration tests.
+  dynamoose.aws.ddb.local(
+    `http://localhost:${process.env.LOCAL_DYNAMODB_PORT ?? 8000}`,
+  )
 } else {
   dynamoose.aws.ddb.set(ddb)
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -57,8 +57,8 @@ type Mutation {
     input: LoginWithSelectedSgidInput!
   ): LoginWithSelectedSgidResult!
   # Tiles
-  createTable(input: CreateTableInput!): Table!
-  updateTable(input: UpdateTableInput!): Table!
+  createTable(input: CreateTableInput!): TableMetadata!
+  updateTable(input: UpdateTableInput!): TableMetadata!
   deleteTable(input: DeleteTableInput!): Boolean!
 }
 
@@ -504,10 +504,15 @@ input CreateTableInput {
   name: String!
 }
 
+input TableColumnMetadataInput {
+  id: String!
+  name: String
+}
+
 input UpdateTableInput {
   id: String!
   name: String
-  modifiedColumns: [TableColumnMetadata]
+  modifiedColumns: [TableColumnMetadataInput]
   addedColumns: [String]
   deletedColumns: [String]
 }
@@ -518,7 +523,7 @@ input DeleteTableInput {
 
 type TableColumnMetadata {
   id: String!
-  name: String
+  name: String!
 }
 
 type TableMetadata {

--- a/packages/backend/test/ddb-global-setup.ts
+++ b/packages/backend/test/ddb-global-setup.ts
@@ -3,6 +3,11 @@ import { GenericContainer, StartedTestContainer } from 'testcontainers'
 
 let dynamodbContainer: StartedTestContainer
 
+// Set dummy AWS credentials for local DynamoDB to work
+process.env.AWS_REGION = 'ap-southeast-1'
+process.env.AWS_ACCESS_KEY_ID = 'awsaccesskeyid'
+process.env.AWS_SECRET_ACCESS_KEY = 'awssecretaccesskey'
+
 export async function setup() {
   dynamodbContainer = await new GenericContainer('amazon/dynamodb-local')
     .withExposedPorts(8000)

--- a/packages/backend/test/ddb-global-setup.ts
+++ b/packages/backend/test/ddb-global-setup.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+import { GenericContainer, StartedTestContainer } from 'testcontainers'
+
+let dynamodbContainer: StartedTestContainer
+
+export async function setup() {
+  dynamodbContainer = await new GenericContainer('amazon/dynamodb-local')
+    .withExposedPorts(8000)
+    .withEnvironment({
+      REGION: 'ap-southeast-1',
+    })
+    .withCommand(['-jar', 'DynamoDBLocal.jar', '-inMemory', '-sharedDb'])
+    .start()
+
+  const mappedPort = dynamodbContainer.getMappedPort(8000).toString()
+  process.env.LOCAL_DYNAMODB_PORT = mappedPort
+
+  console.info(`DynamoDB container started at port ${mappedPort}`)
+}
+
+export async function teardown() {
+  if (!dynamodbContainer) {
+    return
+  }
+  await dynamodbContainer.stop({ remove: true })
+  console.info(`DynamoDB container stopped`)
+}

--- a/packages/backend/test/ddb-reset-db-setup.ts
+++ b/packages/backend/test/ddb-reset-db-setup.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-console */
+import '../src/config/dynamodb'
+
+import { afterEach } from 'vitest'
+
+afterEach(async () => {
+  // there isnt a good way to truncate all tables
+  // but since there is no the mock tables are re-created each time,
+  // there is no conflict in keys for table rows.
+  // thus, we can just leave it there without truncating
+})

--- a/packages/backend/test/pg-reset-db-setup.ts
+++ b/packages/backend/test/pg-reset-db-setup.ts
@@ -17,7 +17,7 @@ beforeEach(async () => {
     const { seed } = await import(join(config.seeds.directory, seedFile))
     await seed(client)
   }
-  console.info(`PostgreSQL seeds run`)
+  console.info(`vite: PostgreSQL seeds run`)
 })
 
 afterEach(async () => {
@@ -30,5 +30,5 @@ afterEach(async () => {
   for (const table of tables) {
     await client.raw(`TRUNCATE TABLE "${table}" CASCADE`)
   }
-  console.info(`PostgreSQL tables truncated`)
+  console.info(`vite: PostgreSQL tables truncated`)
 })

--- a/packages/backend/vitest.config.integration.ts
+++ b/packages/backend/vitest.config.integration.ts
@@ -20,10 +20,22 @@ export default defineConfig({
   test: {
     name: 'backend-integration',
     // load env variables
-    setupFiles: ['dotenv/config', getPath('./test/pg-reset-db-setup.ts')],
-    globalSetup: [getPath('./test/pg-global-setup.ts')],
+    setupFiles: [
+      'dotenv/config',
+      getPath('./test/pg-reset-db-setup.ts'),
+      getPath('./test/ddb-reset-db-setup.ts'),
+    ],
+    globalSetup: [
+      getPath('./test/pg-global-setup.ts'),
+      getPath('./test/ddb-global-setup.ts'),
+    ],
     include: ['src/**/*.itest.{js,ts}'],
     threads: false,
+    onConsoleLog: (log: string, _type: 'stdout' | 'stderr'): false | void => {
+      if (log.startsWith('vite:')) {
+        return false
+      }
+    },
   },
   resolve: {
     alias: {

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -17,6 +17,11 @@ export default defineConfig({
     // load env variables
     setupFiles: ['dotenv/config'],
     include: ['src/**/*.test.{js,ts}'],
+    onConsoleLog: (log: string, _type: 'stdout' | 'stderr'): false | void => {
+      if (log.startsWith('vite:')) {
+        return false
+      }
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Dynamodb test container 
- allows testing of dynamodb queries in integration test files
- there's no fast way to truncate the entire table now and i dont see the need to for each test so the setup file hook is left empty
- hiding setup scripts logs by default