### PR TITLE
[PLU-100] feat(worker): exponential backoff on connectivity issues

### DIFF
--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -72,7 +72,6 @@ export default defineAction({
       disable_notification: $.step.parameters.disableNotification,
       parse_mode: 'markdown', // legacy markdown to allow only a small set of modifiers
     }
-
     const response = await $.http.post('/sendMessage', payload)
 
     $.setActionItem({

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -36,3 +36,7 @@ export async function doesActionProcessFiles(
     getCompositeKey(appKey, actionKey),
   )
 }
+
+export enum ActionBackoffStrategy {
+  ExponentialConnectivity = 'exponential-backoff-connectivity',
+}

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -1,5 +1,7 @@
 import { JobsOptions } from 'bullmq'
 
+import { ActionBackoffStrategy } from './actions'
+
 export const REMOVE_AFTER_30_DAYS = {
   age: 30 * 24 * 3600,
 }
@@ -14,4 +16,8 @@ export const DEFAULT_JOB_DELAY_DURATION = 0
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   removeOnFail: REMOVE_AFTER_30_DAYS,
+  attempts: 3,
+  backoff: {
+    type: ActionBackoffStrategy.ExponentialConnectivity,
+  },
 }

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -1,7 +1,8 @@
-import { Worker } from 'bullmq'
+import { Job, UnrecoverableError, Worker } from 'bullmq'
 
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
+import { ActionBackoffStrategy } from '@/helpers/actions'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
 import logger from '@/helpers/logger'
@@ -61,6 +62,28 @@ export const worker = new Worker(
     prefix: '{actionQ}',
     connection: createRedisClient(),
     concurrency: appConfig.workerActionConcurrency,
+    settings: {
+      backoffStrategy: (
+        attemptsMade: number,
+        type: string,
+        err: Error,
+        _job: Job,
+      ) => {
+        const connectivityErrSigns = ['ETIMEDOUT', 'ECONNRESET']
+        switch (type) {
+          case ActionBackoffStrategy.ExponentialConnectivity: {
+            if (!connectivityErrSigns.some((s) => err.message.includes(s))) {
+              // stop retrying
+              throw new UnrecoverableError(err.message)
+            }
+            return Math.pow(2, attemptsMade) * 5000 // 5, 10, 20, 40, ...
+          }
+          default: {
+            throw new Error('invalid type')
+          }
+        }
+      },
+    },
   },
 )
 


### PR DESCRIPTION
## Problem

Sometimes there're connectivity issues (particularly with Telegram) that could be retried exponentially and auto-resolved. However, under our current setup, for all errors, bullmq will retry once immediately

## Solution

Implement a custom backoff strategy and default retry attempts number to 3

**Extra consideration**: 
- Right now there's only one strategy and it's the default for all actions, however, the backoff strategy setting is set up to support multiple types in anticipation of future strategies devised for different kinds of actions
- The implementation is generic rather than specific to Telegram as the same issues could happen to any other integrations that we have.

**Before**:
- Retried once immediately for all errors

**After**
- If it's a connectivity issue (i.e. containing `ETIMEDOUT` or `ECONNRESET`), we will retry 3 times with exponential back-off with a base of 5s (5, 10, 20, 40, ...)
- If the error is not connectivity, we won't retry

## Tests

- [x] throw an `ETIMEDOUT` error inside an action, it will be retried 3 times at 5, 10, and 20 second after intervals
- [x] throw an error that's something else, it won't be retried

## Deploy Notes

N/A