### PR TITLE
PLU-81: [IF-THEN-9004] Migrate "Only continue if..." to toolbox

### DIFF
--- a/packages/backend/src/apps/logic/index.ts
+++ b/packages/backend/src/apps/logic/index.ts
@@ -3,7 +3,7 @@ import defineApp from '@/helpers/define-app'
 import actions from './actions'
 
 export default defineApp({
-  name: 'Logic (DEPRECATED)',
+  name: 'Logic',
   key: 'logic',
   iconUrl: '{BASE_URL}/apps/logic/assets/favicon.svg',
   authDocUrl: '',

--- a/packages/backend/src/apps/logic/index.ts
+++ b/packages/backend/src/apps/logic/index.ts
@@ -3,7 +3,7 @@ import defineApp from '@/helpers/define-app'
 import actions from './actions'
 
 export default defineApp({
-  name: 'Logic',
+  name: 'Logic (DEPRECATED)',
   key: 'logic',
   iconUrl: '{BASE_URL}/apps/logic/assets/favicon.svg',
   authDocUrl: '',

--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -1,0 +1,66 @@
+import { type IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import toolboxApp from '../..'
+import onlyContinueIfAction from '../../actions/only-continue-if'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('Only continue if...', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      flow: {
+        id: 'fake-pipe',
+      },
+      step: {
+        id: 'test-step',
+        appKey: toolboxApp.key,
+        key: onlyContinueIfAction.key,
+        position: 2,
+        parameters: {},
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns void if condition passes', async () => {
+    $.step.parameters = {
+      field: 1,
+      is: 'is',
+      condition: 'equals',
+      text: 1,
+    }
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: true },
+    })
+  })
+
+  it('stops execution if condition fails', async () => {
+    $.step.parameters = {
+      field: 1,
+      is: 'is',
+      condition: 'equals',
+      text: 0,
+    }
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toEqual({
+      nextStep: { command: 'stop-execution' },
+    })
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: false },
+    })
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import conditionIsTrue from '../../common/condition-is-true'
+
+describe('Condition is true', () => {
+  it.each([
+    { text: 'abc', expectedResult: true },
+    { text: 'def', expectedResult: false },
+  ])('supports equals', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: 'abc',
+      is: 'is',
+      condition: 'equals',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { text: -9.9, expectedResult: true },
+    { text: 10, expectedResult: true },
+    { text: 11, expectedResult: false },
+  ])('supports >=', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: 10,
+      is: 'is',
+      condition: 'gte',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { text: 9, expectedResult: true },
+    { text: 10, expectedResult: false },
+    { text: 11, expectedResult: false },
+  ])('supports >', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: 10,
+      is: 'is',
+      condition: 'gt',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { text: 9.9, expectedResult: false },
+    { text: 10, expectedResult: true },
+    { text: 11, expectedResult: true },
+  ])('supports <=', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: 10,
+      is: 'is',
+      condition: 'lte',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { text: -11.123, expectedResult: false },
+    { text: -10, expectedResult: false },
+    { text: 11, expectedResult: true },
+  ])('supports <', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: -10,
+      is: 'is',
+      condition: 'lt',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { field: 'hello', text: 'hello', expectedResult: true },
+    { field: 'hello', text: 'll', expectedResult: true },
+    { field: 'hello', text: 'abc', expectedResult: false },
+    { field: '9.9', text: 9, expectedResult: true },
+    { field: '9.9', text: 1, expectedResult: false },
+  ])('supports contains', ({ field, text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field,
+      is: 'is',
+      condition: 'contains',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { field: 'hello', text: 9.9, condition: 'equals', expectedResult: true },
+    { field: 10, text: 10, condition: 'gte', expectedResult: false },
+    { field: 1, text: -100, condition: 'lt', expectedResult: true },
+  ])('supports negation', ({ field, text, condition, expectedResult }) => {
+    const result = conditionIsTrue({
+      field,
+      is: 'not',
+      condition,
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('throws an error for unsupported conditions', () => {
+    expect(() =>
+      conditionIsTrue({
+        field: 10,
+        is: 'is',
+        condition: 'herp derp',
+        text: 11,
+      }),
+    ).toThrowError(
+      'Conditional logic block contains an unknown operator: herp derp',
+    )
+  })
+})

--- a/packages/backend/src/apps/toolbox/actions/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/index.ts
@@ -1,3 +1,4 @@
 import ifThen from './if-then'
+import onlyContinueIf from './only-continue-if'
 
-export default [ifThen]
+export default [ifThen, onlyContinueIf]

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -1,0 +1,24 @@
+import defineAction from '@/helpers/define-action'
+
+import conditionIsTrue from '../../common/condition-is-true'
+import getConditionArgs from '../../common/get-condition-args'
+
+export default defineAction({
+  name: 'Only continue if...',
+  key: 'onlyContinueIf',
+  description: 'Only continue if...',
+  arguments: getConditionArgs({ usePlaceholders: false }),
+
+  async run($) {
+    const result = conditionIsTrue($.step.parameters)
+    $.setActionItem({
+      raw: { result },
+    })
+
+    if (!result) {
+      return {
+        nextStep: { command: 'stop-execution' },
+      }
+    }
+  },
+})

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -1,0 +1,38 @@
+import type { IJSONObject } from '@plumber/types'
+
+export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
+  // `value` is named `text` for legacy reasons.
+  const { field, is, condition, text: value } = conditionArgs
+
+  let result: boolean
+  switch (condition) {
+    case 'equals':
+      result = field === value
+      break
+    case 'gte':
+      result = Number(field) >= Number(value)
+      break
+    case 'gt':
+      result = Number(field) > Number(value)
+      break
+    case 'lte':
+      result = Number(field) <= Number(value)
+      break
+    case 'lt':
+      result = Number(field) < Number(value)
+      break
+    case 'contains':
+      result = field.toString().includes(value.toString())
+      break
+    default:
+      throw new Error(
+        `Conditional logic block contains an unknown operator: ${condition}`,
+      )
+  }
+
+  if (is === 'not') {
+    result = !result
+  }
+
+  return result
+}

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -1,0 +1,58 @@
+import type { IField } from '@plumber/types'
+
+interface GetConditionArgsOptions {
+  usePlaceholders: boolean
+}
+
+// FIXME (ogp-weeloong): migrate to multi-row for both ifThen and
+// onlyContinueIf.
+export default function getConditionArgs({
+  usePlaceholders,
+}: GetConditionArgsOptions): IField[] {
+  const labelPropName = usePlaceholders ? 'placeholder' : 'label'
+
+  return [
+    {
+      [labelPropName]: 'Field',
+      key: 'field',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      [labelPropName]: 'Is or is not',
+      key: 'is',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      showOptionValue: false,
+      options: [
+        { label: 'Is', value: 'is' },
+        { label: 'Is not', value: 'not' },
+      ],
+    },
+    {
+      [labelPropName]: 'Condition',
+      key: 'condition',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      showOptionValue: false,
+      options: [
+        { label: 'Equals to', value: 'equals' },
+        { label: 'Greater than ', value: 'gt' },
+        { label: 'Greater than or equals to', value: 'gte' },
+        { label: 'Less than', value: 'lt' },
+        { label: 'Less than or equals to', value: 'lte' },
+        { label: 'Contains', value: 'contains' },
+      ],
+    },
+    {
+      [labelPropName]: 'Value',
+      key: 'text', // Legacy naming
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+  ]
+}

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -92,29 +92,10 @@ function ChooseAppAndEventSubstep(
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
-  const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
   const appOptions = useMemo(
     () =>
       apps
         ?.filter((app) => {
-          //
-          // ** EDGE CASE **
-          //
-          // We want to hide If-Then in some cases (see useIsIfThenSelectable
-          // comments).
-          //
-          // We edge case since a generic implementation adds too much
-          // complexity; we'll move to generic if there's another use case for
-          // such hiding.
-          //
-          // If everyone forgets about this, it's OK because the next guy to
-          // add a new toolbox action will get confused why toolbox is missing
-          // ... and find this.
-          //
-          if (app.key === TOOLBOX_APP_KEY && !isIfThenSelectable) {
-            return false
-          }
-
           // Filter away stuff hidden behind feature flags
           if (!launchDarkly.flags || !app?.key) {
             return true
@@ -123,26 +104,21 @@ function ChooseAppAndEventSubstep(
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         ?.map((app) => optionGenerator(app)) ?? [],
-    [apps, isIfThenSelectable, launchDarkly.flags],
+    [apps, launchDarkly.flags],
   )
 
   const actionsOrTriggers: Array<ITrigger | IAction> =
     (isTrigger ? app?.triggers : app?.actions) || []
+  const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
   const actionOrTriggerOptions = useMemo(
     () =>
       actionsOrTriggers
         .filter((actionOrTrigger) => {
           //
-          // ** EDGE CASE AGAIN **
+          // ** EDGE CASE **
           //
-          // Hello, the if-then edge case demon here again!
-          //
-          // To ensure if-then is always the last step, we also need to guard
-          // against users selecting toolbox first, then adding steps after the
-          // toolbox step, then selecting If-Then in the toolbox step.
-          //
-          // Luckily, we can remove the top app-hiding edge case once we
-          // implement for-each, and toolbox will have multiple actions.
+          // We want to hide If-Then in some cases (see useIsIfThenSelectable
+          // comments).
           //
           if (
             app?.key === TOOLBOX_APP_KEY &&
@@ -194,7 +170,7 @@ function ChooseAppAndEventSubstep(
         //
         // ** EDGE CASE AGAIN V2 **
         //
-        // Hello, the if-then edge case demon here again and again!
+        // Hello, the if-then edge case demon here again!
         //
         // If-then is weird in that we need to pre-populate with 2 branches
         // upon initial selection (the only action that spawns 2 steps upon


### PR DESCRIPTION
## Problem
Having a separate "Logic" app is confusing when we have if-then in toolbox.

## Solution
For the short term, we will migrate the existing "Only continue if..." action from logic app to toolbox app. We will re-use the approach used to migrate the HTTP request action in #131 :
1. Land a PR (_this PR!_) which duplicates the action code into the destination app
2. Run a DB migration to change the appkey and action key of relevant steps and executionSteps
3. Land another PR (#239) to delete the old app / action code ()

Note that this PR _only_ migrates the action; it does not deal with enhancing "Only continue if..." to support multiple conditions.

That said, we need a longer term fix where we have a solid system & process for deprecating and migrating apps / actions. Can look at doing this for Q4 or Q1'24

## Tests
- New unit tests
- Create a pipe with the old "Only continue if", update `appKey` and `key` using SQL and check that pipe still works.
- Update old "Only cotinue if" `executionStep`s' `appKey` and `key` using SQL, and check that it shows up properly in execution page.
- Regression test: check that if-then still works
- Regression test: check that if-then is still only selectable when it's the last step.