### PR TITLE
hotfix: retry only on connectivity error

### DIFF
--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -44,9 +44,11 @@ const CONNECTIVITY_ERROR_SIGNS = ['ETIMEDOUT', 'ECONNRESET']
 export function isRetriableError(errorDetails: IJSONObject): boolean {
   // Connectivity error
   if (
-    errorDetails.error &&
+    (errorDetails?.details as IJSONObject)?.error &&
     CONNECTIVITY_ERROR_SIGNS.some((errorSign) =>
-      (errorDetails.error as string).includes(errorSign),
+      ((errorDetails.details as IJSONObject).error as string).includes(
+        errorSign,
+      ),
     )
   ) {
     return true

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -46,16 +46,16 @@ export function handleErrorAndThrow(errorDetails: IJSONObject): void {
   //
   // Retriable errors.
   //
-  if (
-    (errorDetails?.details as IJSONObject)?.error &&
-    CONNECTIVITY_ERROR_SIGNS.some((errorSign) =>
-      ((errorDetails.details as IJSONObject).error as string).includes(
-        errorSign,
-      ),
-    )
-  ) {
-    throw new Error(JSON.stringify(errorDetails))
+  const errorString = errorDetails?.error as string
+  if (!errorString) {
+    throw new UnrecoverableError(JSON.stringify(errorDetails))
+  }
+  const isConnectivityIssue = CONNECTIVITY_ERROR_SIGNS.some((errorSign) =>
+    errorString.includes(errorSign),
+  )
+  if (!isConnectivityIssue) {
+    throw new UnrecoverableError(JSON.stringify(errorDetails))
   }
 
-  throw new UnrecoverableError(JSON.stringify(errorDetails))
+  throw new Error(JSON.stringify(errorDetails))
 }

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -1,5 +1,6 @@
 import { IJSONObject } from '@plumber/types'
 
+import { UnrecoverableError } from 'bullmq'
 import { memoize } from 'lodash'
 
 import App from '@/models/app'
@@ -41,8 +42,10 @@ export async function doesActionProcessFiles(
 
 const CONNECTIVITY_ERROR_SIGNS = ['ETIMEDOUT', 'ECONNRESET']
 
-export function isRetriableError(errorDetails: IJSONObject): boolean {
-  // Connectivity error
+export function handleErrorAndThrow(errorDetails: IJSONObject): void {
+  //
+  // Retriable errors.
+  //
   if (
     (errorDetails?.details as IJSONObject)?.error &&
     CONNECTIVITY_ERROR_SIGNS.some((errorSign) =>
@@ -51,8 +54,8 @@ export function isRetriableError(errorDetails: IJSONObject): boolean {
       ),
     )
   ) {
-    return true
+    throw new Error(JSON.stringify(errorDetails))
   }
 
-  return false
+  throw new UnrecoverableError(JSON.stringify(errorDetails))
 }

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -1,3 +1,5 @@
+import { IJSONObject } from '@plumber/types'
+
 import { memoize } from 'lodash'
 
 import App from '@/models/app'
@@ -37,6 +39,18 @@ export async function doesActionProcessFiles(
   )
 }
 
-export enum ActionBackoffStrategy {
-  ExponentialConnectivity = 'exponential-backoff-connectivity',
+const CONNECTIVITY_ERROR_SIGNS = ['ETIMEDOUT', 'ECONNRESET']
+
+export function isRetriableError(errorDetails: IJSONObject): boolean {
+  // Connectivity error
+  if (
+    errorDetails.error &&
+    CONNECTIVITY_ERROR_SIGNS.some((errorSign) =>
+      (errorDetails.error as string).includes(errorSign),
+    )
+  ) {
+    return true
+  }
+
+  return false
 }

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -16,7 +16,7 @@ const EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS = 5000
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   removeOnFail: REMOVE_AFTER_30_DAYS,
-  attempts: 3,
+  attempts: 4,
   backoff: {
     type: 'exponential',
     delay: EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS,

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -1,7 +1,5 @@
 import { JobsOptions } from 'bullmq'
 
-import { ActionBackoffStrategy } from './actions'
-
 export const REMOVE_AFTER_30_DAYS = {
   age: 30 * 24 * 3600,
 }
@@ -13,11 +11,14 @@ export const REMOVE_AFTER_7_DAYS_OR_50_JOBS = {
 
 export const DEFAULT_JOB_DELAY_DURATION = 0
 
+const EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS = 5000
+
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   removeOnFail: REMOVE_AFTER_30_DAYS,
   attempts: 3,
   backoff: {
-    type: ActionBackoffStrategy.ExponentialConnectivity,
+    type: 'exponential',
+    delay: EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS,
   },
 }

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -1,8 +1,8 @@
-import { Job, UnrecoverableError, Worker } from 'bullmq'
+import { UnrecoverableError, Worker } from 'bullmq'
 
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
-import { ActionBackoffStrategy } from '@/helpers/actions'
+import { isRetriableError } from '@/helpers/actions'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
 import logger from '@/helpers/logger'
@@ -24,7 +24,10 @@ export const worker = new Worker(
       await processAction({ ...(job.data as JobData), jobId: job.id })
 
     if (executionStep.isFailed) {
-      throw new Error(JSON.stringify(executionStep.errorDetails))
+      if (isRetriableError(executionStep.errorDetails)) {
+        throw new Error(JSON.stringify(executionStep.errorDetails))
+      }
+      throw new UnrecoverableError(JSON.stringify(executionStep.errorDetails))
     }
 
     const step = await Step.query().findById(stepId).throwIfNotFound()
@@ -65,28 +68,6 @@ export const worker = new Worker(
     prefix: '{actionQ}',
     connection: createRedisClient(),
     concurrency: appConfig.workerActionConcurrency,
-    settings: {
-      backoffStrategy: (
-        attemptsMade: number,
-        type: string,
-        err: Error,
-        _job: Job,
-      ) => {
-        const connectivityErrSigns = ['ETIMEDOUT', 'ECONNRESET']
-        switch (type) {
-          case ActionBackoffStrategy.ExponentialConnectivity: {
-            if (!connectivityErrSigns.some((s) => err.message.includes(s))) {
-              // stop retrying
-              throw new UnrecoverableError(err.message)
-            }
-            return Math.pow(2, attemptsMade) * 5000 // 5, 10, 20, 40, ...
-          }
-          default: {
-            throw new Error('invalid type')
-          }
-        }
-      },
-    },
   },
 )
 

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -1,8 +1,8 @@
-import { UnrecoverableError, Worker } from 'bullmq'
+import { Worker } from 'bullmq'
 
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
-import { isRetriableError } from '@/helpers/actions'
+import { handleErrorAndThrow } from '@/helpers/actions'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
 import logger from '@/helpers/logger'
@@ -24,10 +24,7 @@ export const worker = new Worker(
       await processAction({ ...(job.data as JobData), jobId: job.id })
 
     if (executionStep.isFailed) {
-      if (isRetriableError(executionStep.errorDetails)) {
-        throw new Error(JSON.stringify(executionStep.errorDetails))
-      }
-      throw new UnrecoverableError(JSON.stringify(executionStep.errorDetails))
+      return handleErrorAndThrow(executionStep.errorDetails)
     }
 
     const step = await Step.query().findById(stepId).throwIfNotFound()


### PR DESCRIPTION
## Problem
We are retrying on all pipe failures, not just connectivity failures.

## Solution
Root cause was because `UnrecoverableError` must be thrown in the worker processor, not the `backoffStrategy` callback.

## Tests
- Successful pipes are not retried
- Non-retriable errors (e.g. HTTP 500 via mock.codes) is not retried
- Retriable errors are retried