### PR TITLE
chore: bump zod, graphql, apollo-server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,17 +53,16 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.4.tgz",
-      "integrity": "sha512-QFXE4ylSHUa6LgYoOGsPysJCm4YJOOM1NwHyF6msZdZXIerqUVpLvxQOdQEXgS0RWvYiBMC1wGOWKzJKSWBdAg==",
+      "version": "3.7.17",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.3",
-        "@wry/equality": "^0.5.6",
-        "@wry/trie": "^0.4.3",
+        "@wry/context": "^0.7.0",
+        "@wry/equality": "^0.5.0",
+        "@wry/trie": "^0.4.0",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.5",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -91,6 +90,16 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apollo/client/node_modules/@wry/trie": {
+      "version": "0.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -5198,9 +5207,8 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
-      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
+      "version": "0.7.0",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5209,9 +5217,8 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
-      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
+      "version": "0.5.3",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5220,9 +5227,8 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
-      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
+      "version": "0.3.2",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -10942,13 +10948,11 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
-      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
+      "version": "0.16.2",
+      "license": "MIT",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.4.3",
-        "tslib": "^2.3.0"
+        "@wry/trie": "^0.3.0"
       }
     },
     "node_modules/optionator": {
@@ -14289,7 +14293,7 @@
     "packages/frontend": {
       "version": "1.2.1",
       "dependencies": {
-        "@apollo/client": "3.8.4",
+        "@apollo/client": "3.7.17",
         "@chakra-ui/react": "2.6.1",
         "@emotion/react": "11.10.5",
         "@emotion/styled": "11.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,16 +53,17 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.7.17",
-      "license": "MIT",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.4.tgz",
+      "integrity": "sha512-QFXE4ylSHUa6LgYoOGsPysJCm4YJOOM1NwHyF6msZdZXIerqUVpLvxQOdQEXgS0RWvYiBMC1wGOWKzJKSWBdAg==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.4.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.2",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -90,16 +91,6 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@apollo/client/node_modules/@wry/trie": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -130,8 +121,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@apollo/server": {
-      "version": "4.7.5",
-      "license": "MIT",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.9.4.tgz",
+      "integrity": "sha512-lopNDM3sZerTcYH/P85QX5HqSNV4HoVbtX3zOrf0ak7eplhPDiGVyF0jQWRbL64znG6KXW+nMuLDTyFTMQnvgA==",
       "dependencies": {
         "@apollo/cache-control-types": "^1.0.3",
         "@apollo/server-gateway-interface": "^1.1.1",
@@ -5206,8 +5198,9 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.7.0",
-      "license": "MIT",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5216,8 +5209,9 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.3",
-      "license": "MIT",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -5226,8 +5220,9 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.3.2",
-      "license": "MIT",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -8284,6 +8279,7 @@
     "node_modules/graphql": {
       "version": "16.7.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -10946,11 +10942,13 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.2",
-      "license": "MIT",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.5.tgz",
+      "integrity": "sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.4.3",
+        "tslib": "^2.3.0"
       }
     },
     "node_modules/optionator": {
@@ -14168,15 +14166,17 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "license": "MIT",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-validation-error": {
-      "version": "1.3.0",
-      "license": "MIT",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-1.5.0.tgz",
+      "integrity": "sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw==",
       "engines": {
         "node": ">=16.0.0"
       },
@@ -14194,7 +14194,7 @@
     },
     "packages/backend": {
       "dependencies": {
-        "@apollo/server": "4.7.5",
+        "@apollo/server": "4.9.4",
         "@aws-sdk/client-s3": "3.369.0",
         "@bull-board/express": "5.6.0",
         "@graphql-tools/schema": "10.0.0",
@@ -14216,7 +14216,7 @@
         "express": "4.18.2",
         "express-basic-auth": "^1.2.1",
         "form-data": "4.0.0",
-        "graphql": "16.7.1",
+        "graphql": "16.8.1",
         "graphql-middleware": "6.1.35",
         "graphql-rate-limit": "3.3.0",
         "graphql-shield": "7.6.5",
@@ -14240,8 +14240,8 @@
         "remark-gfm": "3.0.1",
         "typescript": "^4.6.3",
         "winston": "^3.7.1",
-        "zod": "3.21.4",
-        "zod-validation-error": "1.3.0"
+        "zod": "3.22.4",
+        "zod-validation-error": "1.5.0"
       },
       "devDependencies": {
         "@testcontainers/postgresql": "^10.2.1",
@@ -14278,10 +14278,18 @@
         "node": ">= 6"
       }
     },
+    "packages/backend/node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "packages/frontend": {
       "version": "1.2.1",
       "dependencies": {
-        "@apollo/client": "3.7.17",
+        "@apollo/client": "3.8.4",
         "@chakra-ui/react": "2.6.1",
         "@emotion/react": "11.10.5",
         "@emotion/styled": "11.10.5",
@@ -14294,7 +14302,7 @@
         "@plumber/types": "file:../types",
         "clipboard-copy": "^4.0.1",
         "compare-versions": "^4.1.3",
-        "graphql": "16.7.1",
+        "graphql": "16.8.1",
         "launchdarkly-react-client-sdk": "3.0.8",
         "lodash": "^4.17.21",
         "luxon": "^2.3.1",
@@ -14330,6 +14338,14 @@
         "vite": "^4.3.9",
         "vite-plugin-package-version": "^1.0.2",
         "vite-tsconfig-paths": "^4.2.0"
+      }
+    },
+    "packages/frontend/node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "packages/types": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,7 @@
     "copy-statics": "copyfiles -u 1 src/**/*.{graphql,json,svg} dist"
   },
   "dependencies": {
-    "@apollo/server": "4.7.5",
+    "@apollo/server": "4.9.4",
     "@aws-sdk/client-s3": "3.369.0",
     "@bull-board/express": "5.6.0",
     "@graphql-tools/schema": "10.0.0",
@@ -43,7 +43,7 @@
     "express": "4.18.2",
     "express-basic-auth": "^1.2.1",
     "form-data": "4.0.0",
-    "graphql": "16.7.1",
+    "graphql": "16.8.1",
     "graphql-middleware": "6.1.35",
     "graphql-rate-limit": "3.3.0",
     "graphql-shield": "7.6.5",
@@ -67,8 +67,8 @@
     "remark-gfm": "3.0.1",
     "typescript": "^4.6.3",
     "winston": "^3.7.1",
-    "zod": "3.21.4",
-    "zod-validation-error": "1.3.0"
+    "zod": "3.22.4",
+    "zod-validation-error": "1.5.0"
   },
   "devDependencies": {
     "@testcontainers/postgresql": "^10.2.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@apollo/client": "3.8.4",
+    "@apollo/client": "3.7.17",
     "@chakra-ui/react": "2.6.1",
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,7 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@apollo/client": "3.7.17",
+    "@apollo/client": "3.8.4",
     "@chakra-ui/react": "2.6.1",
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
@@ -22,7 +22,7 @@
     "@plumber/types": "file:../types",
     "clipboard-copy": "^4.0.1",
     "compare-versions": "^4.1.3",
-    "graphql": "16.7.1",
+    "graphql": "16.8.1",
     "launchdarkly-react-client-sdk": "3.0.8",
     "lodash": "^4.17.21",
     "luxon": "^2.3.1",


### PR DESCRIPTION
## Problem
We have some old packages with potential vulns:

* #243 
* #222 
* #221
* #191 

## Tests
Reviewed changelogs, no breaking change that impacts us.

### GraphQL
- **Queries**
   - [x] get-app-connections
   - [x] get-app
   - [x] get-apps
   - [x] get-connected-apps
   - [x] get-current-user
   - [x] get-dynamic-data
   - [x] get-execution-steps
   - [x] get-execution
   - [x] get-executions
   - [x] get-flow
   - [x] get-flows
   - [x] get-step-with-test-executions
   - [x] healthcheck
   - [x] test-connection
- **Mutations**
   - [x] create-connection
   - [x] create-flow
   - [x] create-step
   - [x] delete-connection
   - [x] delete-flow
   - [x] delete-step
   - [x] execute-flow
   - [x] ~generate-auth-url~ (Not used)
   - [x] login-with-selected-sgid
   - [x] login-with-sgid
   - [x] logout
   - [x] register-webhook
   - [x] request-otp
   - [x] ~reset-connection~ (Not used)
   - [x] retry-execution-step
   - [x] ~update-connection~ (Not used)
   - [x] update-flow-status
   - [x] update-flow
   - [x] update-step
   - [x] verify-connection
   - [x] verify-otp

### Zod
- [x] Check that postman action still works

### Generic Tests
- [x] Check that published pipes still work
- [x] Check that formsg webhook connect button still works

## Deploy Notes
**Updated dependencies**:
Backend
- `@apollo/server`: 4.7.5 -> 4.9.4 ([changelog](https://github.com/apollographql/apollo-server/releases))
- `graphql`: 16.7.1 -> 16.8.1 ([changelog](https://github.com/graphql/graphql-js/releases))
- `zod`: 3.21.4 -> 3.22.4 ([changelog](https://github.com/colinhacks/zod/releases))
- `zod-validation-error`: 1.3.0 -> 1.5.0 ([changelog](https://github.com/causaly/zod-validation-error))
   -  Note: not required, but I thought might as well since we're testing zod.

Frontend
- ~~`@apollo/client`: 3.7.17 -> 3.8.4 ([changelog](https://github.com/apollographql/apollo-client/releases))~~
   - ~~Note: not required, but I thought might as well since we're testing apollo~~
   - Not upgrading; appears to have regression with `refetchQueries` in `useMutation`, which blocks our login. (See https://github.com/apollographql/apollo-client/issues/11044)
- `graphql`: 16.7.1 -> 16.8.1 ([changelog](https://github.com/graphql/graphql-js/releases))