### PR TITLE
[SECURITY-PATCH] fix: verify origin of opener and message source

### DIFF
--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -41,12 +41,19 @@ export default function AddAppConnection(
     : auth?.authenticationSteps
 
   React.useEffect(() => {
-    if (window.opener) {
-      window.opener.postMessage({
-        source: 'plumber',
-        payload: window.location.search,
-      })
-      window.close()
+    if (
+      window.opener &&
+      // checks if this window/popup is opened by the same origin
+      document.referrer.startsWith(window.location.origin + '/')
+    ) {
+      window.opener.postMessage(
+        {
+          source: 'plumber',
+          payload: window.location.search,
+        },
+        // ensures that the message is only sent to the origin that opened the popup
+        window.location.origin,
+      )
     }
   }, [])
 

--- a/packages/frontend/src/components/AddAppConnection/index.tsx
+++ b/packages/frontend/src/components/AddAppConnection/index.tsx
@@ -11,6 +11,7 @@ import DialogTitle from '@mui/material/DialogTitle'
 import InputCreator from 'components/InputCreator'
 import { processStep } from 'helpers/authenticationSteps'
 import computeAuthStepVariables from 'helpers/computeAuthStepVariables'
+import { getOpenerOrigin } from 'helpers/window'
 import useFormatMessage from 'hooks/useFormatMessage'
 
 import { generateExternalLink } from '../../helpers/translation-values'
@@ -42,9 +43,8 @@ export default function AddAppConnection(
 
   React.useEffect(() => {
     if (
-      window.opener &&
       // checks if this window/popup is opened by the same origin
-      document.referrer.startsWith(window.location.origin + '/')
+      getOpenerOrigin() === window.location.origin
     ) {
       window.opener.postMessage(
         {

--- a/packages/frontend/src/helpers/authenticationSteps.ts
+++ b/packages/frontend/src/helpers/authenticationSteps.ts
@@ -65,9 +65,18 @@ const processOpenWithPopup = (
     }, 1000)
 
     const messageHandler = async (event: MessageEvent) => {
-      if (event.data.source !== 'plumber') {
+      if (
+        event.data.source !== 'plumber' ||
+        // if message source is from a different origin, reject
+        event.origin !== window.location.origin ||
+        // event source should be the same reference as popup window
+        event.source !== popup
+      ) {
         return
       }
+
+      // close the popup after receving the message
+      popup?.close()
 
       const data = parseUrlSearchParams(event)
       window.removeEventListener('message', messageHandler)

--- a/packages/frontend/src/helpers/window.ts
+++ b/packages/frontend/src/helpers/window.ts
@@ -1,0 +1,13 @@
+// Helper function to get origin from window.opener
+// try catch need since opener.location will throw error if opener is from different origin
+export function getOpenerOrigin(): string | undefined {
+  const opener = window.opener
+  if (opener) {
+    try {
+      return opener.location.origin
+    } catch (error) {
+      console.error(error)
+    }
+  }
+  return undefined
+}


### PR DESCRIPTION
## Problem

Users are facing issue where AddNewConnection modal closes the tab/window, preventing them from add new connection.

![image](https://github.com/opengovsg/plumber/assets/10072985/0133dff5-3334-437f-a8c3-0d40902cfbf8)

## Hypothesis

Since `window.close()` is called when window.opener exists, there could be a possibility that users are redirected to Plumber from a link with `rel=opener` set (which populates window.opener).

### Is security concern
The possible vulnerability here is that since the popup window sends the OAuth authorization code to window.opener, a malicious site might redirect users to Plumber wth `rel=opener` and obtain the auth code. 

### But is it exploitable in practice?
Highly unlikely due to the following reasons
- Users cant even enter the OAuth flow because the tab just closes immediately
- The auth code is nothing without the client ID and client secret 

_but we must fix this nonetheless, both as a UI bug and possible security loophole_

## Solution
Firstly, we need to ensure that the rel.opener origin must be legit aka `https://plumber.gov.sg`, before calling `window.opener.postMessage`. Additionally, we must specify the targetOrigin  for this function which is `https://plumber.gov.sg`.

Secondly, on the receiving end of the message (aka opener of the popup), it MUST verify that the message source is indeed from Plumber by checking the `event.origin` and it MUST check that the `event.source` is referencing the same window object as the popup.

Lastly, upon verification of the event source, the opener will then close the popup, rather than having the popup try to close its own window.


## Tests
- [x] Tested on staging on normal internet laptops
- [x] Tested on staging on GSIB