### PR TITLE
[PLU-6] Phase 1: Add execution status and update workers

### DIFF
--- a/packages/backend/src/db/migrations/20231012025018_add_execution_status.ts
+++ b/packages/backend/src/db/migrations/20231012025018_add_execution_status.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('executions', (table) => {
+    table.string('status').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('executions', (table) => {
+    table.dropColumn('status')
+  })
+}

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -1,5 +1,6 @@
 import { ref } from 'objection'
 
+import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import actionQueue from '@/queues/action'
 import Context from '@/types/express/context'
@@ -38,6 +39,10 @@ const retryExecutionStep = async (
     throw new Error('Job not found or has expired')
   }
   await job.retry()
+  // allow for status to change to null in case there are delay actions after
+  await Execution.query()
+    .patch({ status: null })
+    .findById(executionStep.executionId)
   return true
 }
 

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -2,13 +2,14 @@ import Base from './base'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
 
+type ExecutionStatus = 'success' | 'failure' | null
 class Execution extends Base {
   id!: string
   flowId!: string
   testRun: boolean
   internalId: string
   executionSteps: ExecutionStep[]
-  status: string
+  status: ExecutionStatus
 
   static tableName = 'executions'
 

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -8,6 +8,7 @@ class Execution extends Base {
   testRun: boolean
   internalId: string
   executionSteps: ExecutionStep[]
+  status: string
 
   static tableName = 'executions'
 

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -20,6 +20,7 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
     flowId,
     testRun,
     internalId: triggerItem?.meta.internalId,
+    ...(error && { status: 'failure' }),
   })
 
   const executionStep = await execution

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -11,6 +11,7 @@ import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
 import { checkErrorEmail, sendErrorEmail } from '@/helpers/generate-error-email'
 import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
+import Execution from '@/models/execution'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import actionQueue from '@/queues/action'
@@ -29,6 +30,7 @@ export const worker = new Worker(
       await processAction({ ...(job.data as JobData), jobId: job.id })
 
     if (executionStep.isFailed) {
+      await Execution.query().patch({ status: 'failure' }).findById(executionId)
       return handleErrorAndThrow(executionStep.errorDetails)
     }
 
@@ -44,6 +46,7 @@ export const worker = new Worker(
     })
 
     if (!nextStep) {
+      await Execution.query().patch({ status: 'success' }).findById(executionId)
       return
     }
 


### PR DESCRIPTION
## Problem

Obtaining the status from execution steps is too troublesome as a long query is needed.

## Solution

Add a status to each `execution` and let the trigger and action workers update it accordingly. This allows us to obtain the status of an execution much quicker and more conveniently.

## Migration
New migration to add a status column for execution:
`npm run -w backend db -- migrate:up 20231012025018_add_execution_status.ts`

## Follow up
Phase 2 PR is to add the execution status filter and search bar. Amend the query for `get-executions` accordingly as well.
Refer to #173 .

## Tests
Workflows to check:
1. Successful pipe execution
2. Failed pipe execution at trigger level
3. Failed pipe execution at action level
4. Retry pipe execution --> should change to success status
5. Incomplete pipe execution (with delay) should be pending status
6. Cancelled pipes due to logic still show success status