### PR TITLE
PLU-70: [TILES-5] Get all dynamodb rows query

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -61,6 +61,7 @@ describe('get all rows query', () => {
   it('should return rows in ascending order of createdAt', async () => {
     // Insert rows in descending order of createdAt
     const numRowsToInsert = 10
+    const currentDate = Date.now()
     const rowsToInsert = []
     for (let i = 0; i < numRowsToInsert; i++) {
       const rowId = randomUUID()
@@ -68,7 +69,7 @@ describe('get all rows query', () => {
         rowId,
         tableId: dummyTable.id,
         data: {},
-        createdAt: Date.now() - i,
+        createdAt: currentDate - i,
       })
     }
     await insertMockTableRows(rowsToInsert)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import getAllRows from '@/graphql/queries/tiles/get-all-rows'
+import TableMetadata from '@/models/table-metadata'
+import Context from '@/types/express/context'
+
+import {
+  generateMockContext,
+  generateMockTable,
+  generateMockTableColumns,
+  generateMockTableRowData,
+} from '../../mutations/tiles/table.mock'
+
+import { insertMockTableRows } from './table-row.mock'
+
+describe('get all rows query', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+  let dummyColumnIds: string[] = []
+
+  // cant use before all here since the data is re-seeded each time
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    dummyTable = await generateMockTable({ userId: context.currentUser.id })
+
+    dummyColumnIds = await generateMockTableColumns({
+      tableId: dummyTable.id,
+      numColumns: 5,
+    })
+  })
+
+  it('should fetch all rows in a given table', async () => {
+    const numRowsToInsert = 100
+    const rowsToInsert = []
+    for (let i = 0; i < numRowsToInsert; i++) {
+      const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+      rowsToInsert.push({
+        tableId: dummyTable.id,
+        rowId: randomUUID(),
+        data,
+        createdAt: Date.now(),
+      })
+    }
+
+    await insertMockTableRows(rowsToInsert)
+
+    const rows = await getAllRows(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+        },
+      },
+      context,
+    )
+    expect(rows).toHaveLength(numRowsToInsert)
+  })
+
+  it('should return rows in ascending order of createdAt', async () => {
+    // Insert rows in descending order of createdAt
+    const numRowsToInsert = 10
+    const rowsToInsert = []
+    for (let i = 0; i < numRowsToInsert; i++) {
+      const rowId = randomUUID()
+      rowsToInsert.push({
+        rowId,
+        tableId: dummyTable.id,
+        data: {},
+        createdAt: Date.now() - i,
+      })
+    }
+    await insertMockTableRows(rowsToInsert)
+
+    const rows = await getAllRows(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+        },
+      },
+      context,
+    )
+
+    // Get row ids in ascending order of createdAt
+    const expectedOrderedRowIds = rowsToInsert.map((r) => r.rowId).reverse()
+
+    expect(rows.map((r) => r.rowId)).toEqual(expectedOrderedRowIds)
+  })
+
+  it('should fetch all rows even if more than 1MB', async () => {
+    // 1 randomly generated row is about 470 bytes
+    // 4000 rows will be about about 1.8MB
+    const numRowsToInsert = 4000
+    const rowsToInsert = []
+    for (let i = 0; i < numRowsToInsert; i++) {
+      const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+      rowsToInsert.push({
+        tableId: dummyTable.id,
+        rowId: randomUUID(),
+        data,
+        createdAt: Date.now(),
+      })
+    }
+
+    await insertMockTableRows(rowsToInsert)
+
+    const rows = await getAllRows(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+        },
+      },
+      context,
+    )
+
+    expect(rows).toHaveLength(numRowsToInsert)
+  }, 100000)
+
+  it('should return empty array if no rows', async () => {
+    const rows = await getAllRows(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+        },
+      },
+      context,
+    )
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('should strip keys that are not in table columns', async () => {
+    const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+    // add a key that is not in the table columns
+    data[randomUUID()] = 'test'
+    const rowToInsert = {
+      tableId: dummyTable.id,
+      rowId: randomUUID(),
+      data,
+      createdAt: Date.now(),
+    }
+
+    await insertMockTableRows([rowToInsert])
+
+    const rows = await getAllRows(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+        },
+      },
+      context,
+    )
+
+    expect(Object.keys(rows[0].data).sort()).toEqual(dummyColumnIds.sort())
+  })
+})

--- a/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
@@ -1,0 +1,28 @@
+import dynamoose from 'dynamoose'
+
+import appConfig from '@/config/app'
+import { TableRowSchema } from '@/models/dynamodb/table-row'
+
+const TABLE_NAME = `${appConfig.appEnv}-plumber-table`
+
+type MockTableRow = Pick<TableRowSchema, 'tableId' | 'rowId'> & {
+  data: Record<string, string>
+  createdAt?: number
+}
+const ddb = dynamoose.aws.ddb()
+const converter = dynamoose.aws.converter()
+
+export async function insertMockTableRows(rows: MockTableRow[]): Promise<void> {
+  // batch in 25 rows at a time
+  const BATCH_SIZE = 25
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    const batch = rows.slice(i, i + BATCH_SIZE)
+    await ddb.batchWriteItem({
+      RequestItems: {
+        [TABLE_NAME]: batch.map((row) => ({
+          PutRequest: { Item: converter.marshall(row) },
+        })),
+      },
+    })
+  }
+}

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -1,0 +1,26 @@
+import { getAllTableRows, TableRowSchema } from '@/models/dynamodb/table-row'
+import Context from '@/types/express/context'
+
+type Params = {
+  input: {
+    tableId: string
+  }
+}
+
+const getAllRows = async (
+  _parent: unknown,
+  params: Params,
+  context: Context,
+): Promise<Pick<TableRowSchema, 'rowId' | 'data'>[]> => {
+  const { tableId } = params.input
+  const table = await context.currentUser
+    .$relatedQuery('tables')
+    .findById(tableId)
+    .throwIfNotFound()
+
+  const rawRows = await getAllTableRows({ tableId })
+
+  return table.stripInvalidKeys(rawRows)
+}
+
+export default getAllRows

--- a/packages/backend/src/models/dynamodb/table-row.ts
+++ b/packages/backend/src/models/dynamodb/table-row.ts
@@ -1,4 +1,4 @@
-import { IJSONPrimitive } from '@plumber/types'
+import { IJSONPrimitive, ITableRow } from '@plumber/types'
 
 import { randomUUID } from 'crypto'
 import dynamoose from 'dynamoose'
@@ -137,4 +137,21 @@ export const deleteTableRow = async ({
   } catch (e: unknown) {
     wrapDynamoDBError(e)
   }
+}
+
+export const getAllTableRows = async ({
+  tableId,
+}: {
+  tableId: string
+}): Promise<ITableRow[]> => {
+  const rows = await TableRow.query('tableId')
+    .eq(tableId)
+    .attributes(['rowId', 'data'])
+    // sort by createdAt ascending
+    .using('createdAtIndex')
+    .sort('ascending')
+    // return all rows even if more than 1MB
+    .all()
+    .exec()
+  return rows.map((row) => row.toJSON() as ITableRow)
 }

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -1,3 +1,5 @@
+import { ITableRow } from '@plumber/types'
+
 import Base from './base'
 import TableColumnMetadata from './table-column-metadata'
 import User from './user'
@@ -52,6 +54,22 @@ class TableMetadata extends Base {
       }
     }
     return true
+  }
+
+  async stripInvalidKeys(rows: ITableRow[]): Promise<ITableRow[]> {
+    const columns = await this.$relatedQuery('columns')
+    const columnIdsSet = new Set(columns.map((column) => column.id))
+
+    return rows.map((row) => {
+      const validKeys = Object.keys(row.data).filter((key) =>
+        columnIdsSet.has(key),
+      )
+      const validData = validKeys.reduce(
+        (acc, key) => ({ ...acc, [key]: row.data[key] }),
+        {},
+      )
+      return { ...row, data: validData }
+    })
   }
 }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -506,3 +506,9 @@ export interface IVerifyHookOutput {
 export interface ITestConnectionOutput extends Partial<IVerifyHookOutput> {
   connectionVerified: boolean
 }
+
+// Tiles
+export interface ITableRow {
+  rowId: string
+  data: Record<string, IJSONPrimitive>
+}


### PR DESCRIPTION
One query to fetch all table rows for a given table.
- sorted by createdAt asc
- sequentially fetch next 1MB of data if exceeds
- strips aways deleted/invalid keys

Again, not touching graphql schema yet