### PR TITLE
chore: set COEP to false

### DIFF
--- a/packages/backend/src/helpers/csp.ts
+++ b/packages/backend/src/helpers/csp.ts
@@ -56,7 +56,7 @@ const helmetOptions: HelmetOptions = {
   crossOriginResourcePolicy: {
     policy: appConfig.isDev ? 'cross-origin' : 'same-site',
   },
-  crossOriginEmbedderPolicy: !appConfig.isDev,
+  crossOriginEmbedderPolicy: false,
 }
 
 export default helmet(helmetOptions)


### PR DESCRIPTION
## Problem

Images not loading properly despite being whitelisted in `imgSrc` csp header. Issue is that COEP is enabled and assets by go.gov.sg does not explicitly allow cross origin loading.

## Solution

Disable COEP instead of hosting in the repo to allow for better scalability when using assets.