### PR TITLE
chore: worker action refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2817,9 +2817,10 @@
       }
     },
     "node_modules/@datadog/native-appsec": {
-      "version": "2.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
+      "integrity": "sha512-myTguXJ3VQHS2E1ylNsSF1avNpDmq5t+K4Q47wdzeakGc3sDIDDyEbvuFTujl9c9wBIkup94O1mZj5DR37ajzA==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       },
@@ -2828,18 +2829,29 @@
       }
     },
     "node_modules/@datadog/native-iast-rewriter": {
-      "version": "2.0.1",
-      "license": "Apache-2.0",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.1.3.tgz",
+      "integrity": "sha512-4oxMFz5ZEpOK3pRc9KjquMgkRP6D+oPQVIzOk4dgG8fl2iepHtCa3gna/fQBfdWIiX5a2j65O3R1zNp2ckk8JA==",
       "dependencies": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "engines": {
         "node": ">= 10"
       }
     },
+    "node_modules/@datadog/native-iast-rewriter/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@datadog/native-iast-rewriter/node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "license": "MIT",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -2847,17 +2859,21 @@
       }
     },
     "node_modules/@datadog/native-iast-taint-tracking": {
-      "version": "1.1.1",
-      "license": "Apache-2.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-1.6.1.tgz",
+      "integrity": "sha512-V1X0UbEROcEkqP4IIovqK9uu8jPXq80m8xOW1Vb6xJ9otO3eBphvDFDSa/OJ4pEYhajjjmGlraLlV6rXjaSGlQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^3.9.0"
       }
     },
     "node_modules/@datadog/native-metrics": {
-      "version": "1.5.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/native-metrics/-/native-metrics-2.0.0.tgz",
+      "integrity": "sha512-YklGVwUtmKGYqFf1MNZuOHvTYdKuR4+Af1XkWcMD8BwOAjxmd9Z+97328rCOY8TFUJzlGUPaXzB8j2qgG/BMwA==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
+        "node-addon-api": "^6.1.0",
         "node-gyp-build": "^3.9.0"
       },
       "engines": {
@@ -2865,25 +2881,25 @@
       }
     },
     "node_modules/@datadog/pprof": {
-      "version": "2.1.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@datadog/pprof/-/pprof-4.0.0.tgz",
+      "integrity": "sha512-1rQV6arh5fp7BWshjHgKmhNzXELAIod1Y4ydkI7XRcRim35uBoxQgPy1VgMCuLjfzco7112Vt8bkfQxo9bIdoA==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "delay": "^5.0.0",
-        "node-gyp-build": "^3.9.0",
+        "node-gyp-build": "<4.0",
         "p-limit": "^3.1.0",
-        "pify": "^5.0.0",
-        "pprof-format": "^2.0.6",
-        "source-map": "^0.7.3",
-        "split": "^1.0.1"
+        "pprof-format": "^2.0.7",
+        "source-map": "^0.7.4"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@datadog/pprof/node_modules/source-map": {
       "version": "0.7.4",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
       }
@@ -3874,6 +3890,36 @@
         "jose": "4.9.2",
         "node-rsa": "1.1.1",
         "openid-client": "5.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.17.1.tgz",
+      "integrity": "sha512-I6LrZvl1FF97FQXPR0iieWQmKnGxYtMbWA1GrAXnLUR+B1Hn2m8KqQNEIlZAucyv00GBgpWkpllmULmZfG8P3g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.17.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.17.1.tgz",
+      "integrity": "sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@plumber/types": {
@@ -5348,12 +5394,19 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -5641,13 +5694,6 @@
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
-      }
-    },
-    "node_modules/async-retry/node_modules/retry": {
-      "version": "0.13.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/asynckit": {
@@ -6146,6 +6192,11 @@
       "version": "1.1.4",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "node_modules/clipboard-copy": {
       "version": "4.0.1",
@@ -6687,22 +6738,27 @@
       "license": "MIT"
     },
     "node_modules/dd-trace": {
-      "version": "3.16.0",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/dd-trace/-/dd-trace-4.17.0.tgz",
+      "integrity": "sha512-qLutasPUGy5JiR42XVXWH4/KScqf01Xhpkp3d+ykEr5Bha1F5P8IuP6Ule9285fBQClEgVvIB0Frm+PSDO5idQ==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
-        "@datadog/native-appsec": "2.0.0",
-        "@datadog/native-iast-rewriter": "2.0.1",
-        "@datadog/native-iast-taint-tracking": "1.1.1",
-        "@datadog/native-metrics": "^1.5.0",
-        "@datadog/pprof": "^2.1.0",
+        "@datadog/native-appsec": "^4.0.0",
+        "@datadog/native-iast-rewriter": "2.1.3",
+        "@datadog/native-iast-taint-tracking": "1.6.1",
+        "@datadog/native-metrics": "^2.0.0",
+        "@datadog/pprof": "4.0.0",
         "@datadog/sketches-js": "^2.1.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "^1.14.0",
         "crypto-randomuuid": "^1.0.0",
         "diagnostics_channel": "^1.1.0",
-        "ignore": "^5.2.0",
-        "import-in-the-middle": "^1.3.4",
-        "ipaddr.js": "^2.0.1",
+        "ignore": "^5.2.4",
+        "import-in-the-middle": "^1.4.2",
+        "int64-buffer": "^0.1.9",
+        "ipaddr.js": "^2.1.0",
         "istanbul-lib-coverage": "3.2.0",
+        "jest-docblock": "^29.7.0",
         "koalas": "^1.0.2",
         "limiter": "^1.1.4",
         "lodash.kebabcase": "^4.1.1",
@@ -6712,15 +6768,16 @@
         "lru-cache": "^7.14.0",
         "methods": "^1.1.2",
         "module-details-from-path": "^1.0.3",
-        "node-abort-controller": "^3.0.1",
+        "msgpack-lite": "^0.1.26",
+        "node-abort-controller": "^3.1.1",
         "opentracing": ">=0.12.1",
         "path-to-regexp": "^0.1.2",
-        "protobufjs": "^7.1.2",
-        "retry": "^0.10.1",
-        "semver": "^5.5.0"
+        "protobufjs": "^7.2.4",
+        "retry": "^0.13.1",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/dd-trace/node_modules/lru-cache": {
@@ -6728,13 +6785,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/dd-trace/node_modules/semver": {
-      "version": "5.7.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/debug": {
@@ -6813,7 +6863,8 @@
     },
     "node_modules/delay": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
       "engines": {
         "node": ">=10"
       },
@@ -6855,6 +6906,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node-es": {
@@ -7682,6 +7741,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-lite": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.3.tgz",
+      "integrity": "sha512-8qz9nOz5VeD2z96elrEKD2U433+L3DWdUdDkOINLGOJvx1GsMBbMn0aCeu28y8/e85A6mCigBiFlYMnTBEGlSw=="
     },
     "node_modules/express": {
       "version": "4.18.2",
@@ -8622,7 +8686,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8681,9 +8744,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.5",
-      "license": "Apache-2.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -8710,6 +8777,11 @@
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
       "license": "MIT"
+    },
+    "node_modules/int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha512-v7cSY1J8ydZ0GyjUHqF+1bshJ6cnEVLo9EnjB8p+4HDRPZc9N5jjmvUV7NvEsqQOKyH0pmIBFWXVQbiS0+OBbA=="
     },
     "node_modules/inter-ui": {
       "version": "3.19.3",
@@ -9072,6 +9144,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -9290,6 +9367,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
@@ -10608,7 +10696,8 @@
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
     },
     "node_modules/morgan": {
       "version": "1.10.0",
@@ -10664,6 +10753,20 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
+    },
+    "node_modules/msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha512-SZ2IxeqZ1oRFGo0xFGbvBJWMp3yLIY9rlIJyxy8CGrwZn1f0ZK4r6jV/AM1r0FZMDUkWkglOk/eeKIL9g77Nxw==",
+      "dependencies": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      },
+      "bin": {
+        "msgpack": "bin/msgpack"
+      }
     },
     "node_modules/msgpackr": {
       "version": "1.8.2",
@@ -10785,6 +10888,11 @@
       "version": "3.1.1",
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
     "node_modules/node-fetch": {
       "version": "2.6.12",
       "license": "MIT",
@@ -10805,7 +10913,8 @@
     },
     "node_modules/node-gyp-build": {
       "version": "3.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -11368,16 +11477,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pkg-types": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
@@ -11457,7 +11556,8 @@
     },
     "node_modules/pprof-format": {
       "version": "2.0.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pprof-format/-/pprof-format-2.0.7.tgz",
+      "integrity": "sha512-1qWaGAzwMpaXJP9opRa23nPnt2Egi7RMNoNBptEE/XwHbcn4fC2b/4U4bKc5arkGkIh2ZabpF2bEb+c5GNHEKA=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -12077,10 +12177,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT"
@@ -12286,10 +12382,11 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.10.1",
-      "license": "MIT",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "engines": {
-        "node": "*"
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -12486,8 +12583,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -12774,16 +12872,6 @@
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "dev": true
-    },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/split-ca": {
       "version": "1.0.1",
@@ -13166,10 +13254,6 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -14448,7 +14532,7 @@
         "cors": "^2.8.5",
         "crypto-js": "^4.1.1",
         "csv-parse": "5.4.0",
-        "dd-trace": "3.16.0",
+        "dd-trace": "4.17.0",
         "dedent": "1.5.1",
         "dotenv": "^10.0.0",
         "email-validator": "2.0.4",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,7 +36,7 @@
     "cors": "^2.8.5",
     "crypto-js": "^4.1.1",
     "csv-parse": "5.4.0",
-    "dd-trace": "3.16.0",
+    "dd-trace": "4.17.0",
     "dedent": "1.5.1",
     "dotenv": "^10.0.0",
     "email-validator": "2.0.4",

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -44,7 +44,12 @@ const CONNECTIVITY_ERROR_SIGNS = ['ETIMEDOUT', 'ECONNRESET']
 const CONNECTIVITY_STATUS_CODE = [504]
 
 export function handleErrorAndThrow(errorDetails: IJSONObject): never {
-  const errorString = get(errorDetails, 'details.error', '') as string
+  const errorVariable = get(errorDetails, 'details.error', '') as unknown
+  const errorString =
+    typeof errorVariable === 'string'
+      ? errorVariable
+      : JSON.stringify(errorVariable)
+
   const statusCode = Number(get(errorDetails, 'status', 0))
   if (!errorString && !statusCode) {
     throw new UnrecoverableError(JSON.stringify(errorDetails))

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -42,6 +42,10 @@ class Execution extends Base {
       },
     },
   })
+
+  static async setStatus(executionId: string, status: ExecutionStatus) {
+    return Execution.query().findById(executionId).patch({ status })
+  }
 }
 
 export default Execution

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -31,7 +31,9 @@ export const worker = new Worker(
   tracer.wrap('workers.action', async (job) => {
     const jobData = job.data as JobData
 
-    const step = await Step.query().findById(jobData.stepId)
+    // the reason why we dont add .throwIfNotFound() here is to prevent job retries
+    // delegating the error throwing and handling to processAction where it also queries for Step
+    const step: Step = await Step.query().findById(jobData.stepId)
 
     const span = tracer.scope().active()
     span?.addTags({

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -29,33 +29,34 @@ type JobData = {
 export const worker = new Worker(
   'action',
   tracer.wrap('workers.action', async (job) => {
-    const {
-      stepId,
-      flowId,
-      executionId,
-      nextStep,
-      executionStep,
-      nextStepMetadata,
-    } = await processAction({ ...(job.data as JobData), jobId: job.id })
+    const jobData = job.data as JobData
+
+    const step = await Step.query().findById(jobData.stepId)
+
+    const span = tracer.scope().active()
+    span?.addTags({
+      flowId: jobData.flowId,
+      executionId: jobData.executionId,
+      stepId: jobData.stepId,
+      actionKey: step?.key,
+      appKey: step?.appKey,
+    })
+
+    const { flowId, executionId, nextStep, executionStep, nextStepMetadata } =
+      await processAction({ ...jobData, jobId: job.id }).catch(async (err) => {
+        // this happens when the prerequisite steps for the action fails (e.g. db error, missing execution, flow, step, etc...)
+        // in such cases, we do not want to retry
+        await Execution.setStatus(jobData.executionId, 'failure')
+        throw new UnrecoverableError(err.message || 'Action failed to execute')
+      })
 
     if (executionStep.isFailed) {
-      await Execution.query().patch({ status: 'failure' }).findById(executionId)
+      await Execution.setStatus(executionId, 'failure')
       return handleErrorAndThrow(executionStep.errorDetails)
     }
 
-    const step = await Step.query().findById(stepId).throwIfNotFound()
-
-    // dd-trace span tagging
-    const span = tracer.scope().active()
-    span?.addTags({
-      flowId,
-      executionId,
-      stepId,
-      appKey: step.appKey,
-    })
-
     if (!nextStep) {
-      await Execution.query().patch({ status: 'success' }).findById(executionId)
+      await Execution.setStatus(executionId, 'success')
       return
     }
 


### PR DESCRIPTION
## Problem 1

Currently, span tags (consisting of execution id, step id, app key, etc...) are not added to the workers.action spans on Datadog because it throws before reaching the addTags function.

NOW:
![image](https://github.com/opengovsg/plumber/assets/10072985/e5912b13-7b32-4dd8-bb36-5a9d4811975f)
IDEAL:
![image](https://github.com/opengovsg/plumber/assets/10072985/d664a08b-bf28-4b3e-94b7-991b7c2bab27)

Because of this, we are unable to filter out such errors when monitoring for worker latency.

## Solution 1

Move addSpans to the top before processAction.

## Test 1
- [x] Test on datadog staging to see if span tags are added to failed worker actions

## Problem 2

When a user deletes step when a job is being run or is retrying, it results in the worker failing because step corresponding to the step id in the job data is now deleted. This is an expected side effect but it defaults to retrying because a generic Error is being thrown.

## Solution 2

For all uncaught errors in `processAction`, throw `UnrecoverableError` and set status to `failure`.

## Test 2

Since there's no unit test written for this yet, you can:
1. manually throw an error in processAction,
2. trigger the published pipe.
- [x] Expected: the execution should NOT retry and status should be set to `failure`.