### PR TITLE
chore: some small css changes

### DIFF
--- a/packages/frontend/src/components/ThemeProvider/index.tsx
+++ b/packages/frontend/src/components/ThemeProvider/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Box } from '@chakra-ui/react'
 import {
   THEME_ID,
   ThemeProvider as MaterialThemeProvider,
@@ -18,7 +19,9 @@ const ThemeProvider = ({
   return (
     <ChakraThemeProvider theme={chakraTheme}>
       <MaterialThemeProvider theme={{ [THEME_ID]: materialTheme }}>
-        {children}
+        <Box display="flex" flexDir="column" minH="100vh">
+          {children}
+        </Box>
       </MaterialThemeProvider>
     </ChakraThemeProvider>
   )

--- a/packages/frontend/src/pages/Applications/index.tsx
+++ b/packages/frontend/src/pages/Applications/index.tsx
@@ -57,7 +57,13 @@ export default function Applications(): React.ReactElement {
   return (
     <Box sx={{ py: 3 }}>
       <Container variant="page">
-        <Grid container sx={{ mb: [0, 3] }} columnSpacing={1.5} rowSpacing={3}>
+        <Grid
+          container
+          sx={{ mb: [0, 3] }}
+          columnSpacing={1.5}
+          paddingLeft={[0, 4.5]}
+          rowSpacing={3}
+        >
           <Grid container item xs sm alignItems="center" order={{ xs: 0 }}>
             <PageTitle title={APPS_TITLE} />
           </Grid>

--- a/packages/frontend/src/pages/Executions/index.tsx
+++ b/packages/frontend/src/pages/Executions/index.tsx
@@ -49,7 +49,13 @@ export default function Executions(): React.ReactElement {
   return (
     <Box sx={{ py: 3 }}>
       <Container variant="page">
-        <Grid container sx={{ mb: [0, 3] }} columnSpacing={1.5} rowSpacing={3}>
+        <Grid
+          container
+          sx={{ mb: [0, 3] }}
+          paddingLeft={[0, 4.5]}
+          columnSpacing={1.5}
+          rowSpacing={3}
+        >
           <Grid
             container
             item

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -105,7 +105,13 @@ export default function Flows(): React.ReactElement {
   return (
     <Box sx={{ py: 3 }}>
       <Container variant="page">
-        <Grid container sx={{ mb: [0, 3] }} columnSpacing={1.5} rowSpacing={3}>
+        <Grid
+          container
+          sx={{ mb: [0, 3] }}
+          paddingLeft={[0, 4.5]}
+          columnSpacing={1.5}
+          rowSpacing={3}
+        >
           <Grid container item xs sm alignItems="center" order={{ xs: 0 }}>
             <PageTitle title={FLOWS_TITLE} />
           </Grid>


### PR DESCRIPTION
BEFORE: 
<img width="1389" alt="Screenshot 2023-10-18 at 1 20 31 PM" src="https://github.com/opengovsg/plumber/assets/10072985/8e2c5310-e6b2-496e-b999-aabc4ae7f297">

AFTER:
<img width="816" alt="Screenshot 2023-10-18 at 1 49 35 PM" src="https://github.com/opengovsg/plumber/assets/10072985/23bb816c-8134-419d-ab01-2fa75fd53d67">

## Changes
- extend the sidebar border all the way down
- Vertically align page headers (Pipes/ Apps/Executions) to content below