### PR TITLE
PLU-81 [IF-THEN]: Remove ellipsis from conditional actions

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
@@ -211,7 +211,7 @@ vi.mock('@/models/step', () => ({
   },
 }))
 
-describe('If-Then', () => {
+describe('If-then', () => {
   let $: IGlobalVariable
 
   afterEach(() => {

--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   setActionItem: vi.fn(),
 }))
 
-describe('Only continue if...', () => {
+describe('Only continue if', () => {
   let $: IGlobalVariable
 
   beforeEach(() => {

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -51,7 +51,7 @@ async function getBranchStepIdToSkipTo(
 }
 
 export default defineAction({
-  name: 'If... Then',
+  name: 'If-Then',
   key: ACTION_KEY,
   description: '',
   groupsLaterSteps: true,

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -51,7 +51,7 @@ async function getBranchStepIdToSkipTo(
 }
 
 export default defineAction({
-  name: 'If-Then',
+  name: 'If-then',
   key: ACTION_KEY,
   description: '',
   groupsLaterSteps: true,

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -4,9 +4,9 @@ import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
 
 export default defineAction({
-  name: 'Only continue if...',
+  name: 'Only continue if',
   key: 'onlyContinueIf',
-  description: 'Only continue if...',
+  description: 'Only continue if',
   arguments: getConditionArgs({ usePlaceholders: false }),
 
   async run($) {

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -114,7 +114,7 @@ function ChooseAppAndEventSubstep(
           //
           // ** EDGE CASE **
           //
-          // We want to hide If-Then in some cases (see useIsIfThenSelectable
+          // We want to hide If-then in some cases (see useIsIfThenSelectable
           // comments).
           //
           if (
@@ -174,13 +174,13 @@ function ChooseAppAndEventSubstep(
         // first selection), and we also need to update the first branch's
         // parameters.
         //
-        // Since there are a bunch of edge cases for If-Then in this component
+        // Since there are a bunch of edge cases for If-then in this component
         // already, let's localize the damage and continue adding edge cases
         // here.
         //
         // Note that we don't need to check for inequality to the current
         // step.key, since we don't display the action drop-down after someone
-        // selects If-Then.
+        // selects If-then.
         //
         if (
           app?.key === TOOLBOX_APP_KEY &&

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -54,7 +54,7 @@ export default function Branch(props: BranchProps): JSX.Element {
   const initialStepDisplayOverride = useMemo<StepDisplayOverridesContextData>(
     () => ({
       [initialStep.id]: {
-        hintAboveCaption: 'If-Then',
+        hintAboveCaption: 'If-then',
         // Only the 1st branch can have an undefined name.
         caption: (initialStep.parameters.branchName as string) ?? 'Branch 1',
         disableActionChanges: true,
@@ -158,7 +158,7 @@ export default function Branch(props: BranchProps): JSX.Element {
       {/*
        * Nexted branch editor (pops up in modal)
        */}
-      {/* Nested If-Thens should have depth = depth + 1 */}
+      {/* Nested If-thens should have depth = depth + 1 */}
       <BranchContext.Provider value={{ depth: depth + 1 }}>
         <StepDisplayOverridesProvider value={initialStepDisplayOverride}>
           <NestedEditor

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -54,7 +54,7 @@ export default function Branch(props: BranchProps): JSX.Element {
   const initialStepDisplayOverride = useMemo<StepDisplayOverridesContextData>(
     () => ({
       [initialStep.id]: {
-        hintAboveCaption: 'If... Then',
+        hintAboveCaption: 'If-Then',
         // Only the 1st branch can have an undefined name.
         caption: (initialStep.parameters.branchName as string) ?? 'Branch 1',
         disableActionChanges: true,

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -21,7 +21,7 @@ function getStepContent(steps: IStep[]): {
     return {
       StepContent: IfThen,
       hintAboveCaption: 'Action',
-      caption: 'If-Then',
+      caption: 'If-then',
       isStepGroupCompleted: areAllIfThenBranchesCompleted(steps, 0),
     }
   }

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -21,7 +21,7 @@ function getStepContent(steps: IStep[]): {
     return {
       StepContent: IfThen,
       hintAboveCaption: 'Action',
-      caption: 'If... Then',
+      caption: 'If-Then',
       isStepGroupCompleted: areAllIfThenBranchesCompleted(steps, 0),
     }
   }

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -21,7 +21,7 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     tag: NEW_FEATURE_TAG,
     title: `Introducing Toolbox`,
     details: dedent`
-      Toolbox is a new app that you can find when you add an action. This will contain built in tools that can enhance your workflows! Logic has been moved into Toolbox and renamed to **Only continue if**. Stay tuned for the release of our new feature **If... Then** in the coming weeks!
+      Toolbox is a new app that you can find when you add an action. This will contain built in tools that can enhance your workflows! Logic has been moved into Toolbox and renamed to **Only continue if**. Stay tuned for the release of our new feature **If-Then** in the coming weeks!
     `,
   },
   {

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -21,7 +21,7 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     tag: NEW_FEATURE_TAG,
     title: `Introducing Toolbox`,
     details: dedent`
-      Toolbox is a new app that you can find when you add an action. This will contain built in tools that can enhance your workflows! Logic has been moved into Toolbox and renamed to **Only continue if**. Stay tuned for the release of our new feature **If-Then** in the coming weeks!
+      Toolbox is a new app that you can find when you add an action. This will contain built in tools that can enhance your workflows! Logic has been moved into Toolbox and renamed to **Only continue if**. Stay tuned for the release of our new feature **If-then** in the coming weeks!
     `,
   },
   {

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -62,7 +62,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
     )
   }
 
-  // Edge case for If-Then
+  // Edge case for If-then
   //
   // FIXME (ogp-weeloong): Revamp UI to allow special handling for
   // toolbox actions in an isolated codepath.

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -38,7 +38,7 @@ export function extractBranchesWithSteps(
   steps: IStep[],
 
   // We can't extract current depth from steps[0].parameters.depth - it may be
-  // undefined if the user has just chosen "If... Then" via the
+  // undefined if the user has just chosen "If-Then" via the
   // "Choose app & event" substep. We grab it from the context instead; it's
   // guaranteed to be correct via induction.
   //

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -16,7 +16,7 @@ export enum TOOLBOX_ACTIONS {
 }
 
 //
-// Helpers for If-Then
+// Helpers for If-then
 //
 // TODO: Move into separate file if we get more toolbox stuff.
 //
@@ -38,7 +38,7 @@ export function extractBranchesWithSteps(
   steps: IStep[],
 
   // We can't extract current depth from steps[0].parameters.depth - it may be
-  // undefined if the user has just chosen "If-Then" via the
+  // undefined if the user has just chosen "If-then" via the
   // "Choose app & event" substep. We grab it from the context instead; it's
   // guaranteed to be correct via induction.
   //
@@ -111,7 +111,7 @@ export function isIfThenBranchCompleted(branchSteps: IStep[]): boolean {
 /**
  * Scrappy O(n) function to check branch completion, including nested branches.
  *
- * NOTE: This is not optimal, since nested If-Thens will re-check their steps
+ * NOTE: This is not optimal, since nested If-thens will re-check their steps
  * again. But it's a lot less complex than re-parsing steps or doing some sort
  * of callback system. We can optimize this in a separate PR if this is too
  * jank.
@@ -125,10 +125,10 @@ export function areAllIfThenBranchesCompleted(
 }
 
 /**
- * Helper hook to check if If-Then action should be selectable; supports edge
+ * Helper hook to check if If-then action should be selectable; supports edge
  * case in ChooseAppAndEventSubstep.
  *
- * If-Then should only be selectable if:
+ * If-then should only be selectable if:
  * - We're the last step.
  * - We are not inside a branch (unless we're whitelisted for nested
  *   branches via LD).
@@ -158,7 +158,7 @@ export function useIsIfThenSelectable({
 }
 
 /**
- * Hook used for initializing If-Then when the user _first_ chooses it via the
+ * Hook used for initializing If-then when the user _first_ chooses it via the
  * "Choose App & Event" substep.
  */
 export function useIfThenInitializer(): [


### PR DESCRIPTION
## Problem
`...` is irritating to type, so we shall remove it from "if...then" and "only continue if...".

## Solution
Update strings in code.

**BEFORE**
<img width="550" alt="Screenshot 2023-10-18 at 3 07 07 PM" src="https://github.com/opengovsg/plumber/assets/135598754/3b4ec1f9-a38c-4122-a517-2dd07d1c739d">
<img width="550" alt="Screenshot 2023-10-18 at 3 06 39 PM" src="https://github.com/opengovsg/plumber/assets/135598754/1cd9b7ab-56ae-4f35-b299-e955ccb570b7">

**AFTER**
<img width="550" alt="Screenshot 2023-10-18 at 3 05 14 PM" src="https://github.com/opengovsg/plumber/assets/135598754/3f552379-37f8-463b-8263-564fdf504cd4">

<img width="550" alt="Screenshot 2023-10-18 at 3 04 49 PM" src="https://github.com/opengovsg/plumber/assets/135598754/b030df36-f761-473e-8bbf-10edff0f21f5">


## Tests
- Check that new captions show up
- Regression test: check that if-then still works
- Regression test: check that only-continue-if still works.