### PR TITLE
[PLU-102] feat(rich-text): variable support in rich text editor

### DIFF
--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -82,6 +82,7 @@ export default function InputCreator(
         description={description}
         disabled={disabled}
         placeholder={placeholder}
+        variablesEnabled={variables}
       />
     )
   }

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -172,6 +172,9 @@
     p {
       margin: 0;
     }
+    .chakra-badge .chakra-text {
+      margin-right: 4px;
+    }
     span.variable {
       color: red;
     }

--- a/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
+++ b/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
@@ -1,0 +1,104 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { PluginKey } from '@tiptap/pm/state'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+
+import { VariableBadge } from './VariableBadge'
+
+export type VariableOptions = {
+  HTMLAttributes: Record<string, any>
+}
+const key = 'variable'
+export const VariablePluginKey = new PluginKey(key)
+
+export const StepVariable = Node.create<VariableOptions>({
+  name: key,
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    }
+  },
+  group: 'inline',
+  inline: true,
+  selectable: false,
+  atom: true,
+  addAttributes() {
+    // attributes equivalent of
+    // id: step name
+    // label: step label
+    // value: step test value
+    // these are only used for NodeView purpose
+    // we technically don't need to render them into the final HTML value, however
+    // they need to be rendered there for rich text editor to be able to resume
+    // where user left off. The resulting content render won't be affected by
+    // these data- attributes
+    return {
+      id: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-id'),
+        renderHTML: (attrs) => {
+          if (!attrs.id) {
+            return {}
+          }
+
+          return {
+            'data-id': attrs.id,
+          }
+        },
+      },
+      label: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-label'),
+        renderHTML: (attrs) => {
+          if (!attrs.label) {
+            return {}
+          }
+
+          return {
+            'data-label': attrs.label,
+          }
+        },
+      },
+      value: {
+        default: null,
+        parseHTML: (el) => el.getAttribute('data-value'),
+        renderHTML: (attrs) => {
+          if (!attrs.value) {
+            return {}
+          }
+
+          return {
+            'data-value': attrs.value,
+          }
+        },
+      },
+    }
+  },
+  parseHTML() {
+    return [
+      {
+        tag: `span[data-type="${this.name}"]`,
+      },
+    ]
+  },
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(
+        { 'data-type': this.name },
+        this.options.HTMLAttributes,
+        HTMLAttributes,
+      ),
+      `{{${node.attrs.id}}}`,
+    ]
+  },
+  renderText({ node }) {
+    return node.attrs.id
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(VariableBadge, {
+      attrs: {
+        style: 'display: inline-block;',
+      },
+    })
+  },
+})

--- a/packages/frontend/src/components/RichTextEditor/SuggestionPopper.tsx
+++ b/packages/frontend/src/components/RichTextEditor/SuggestionPopper.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react'
+import { ExpandLess, ExpandMore } from '@mui/icons-material'
+import {
+  Button,
+  Collapse,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Popper,
+  Typography,
+} from '@mui/material'
+import VariablesList from 'components/VariablesList'
+import { StepWithVariables, Variable } from 'helpers/variables'
+
+interface SuggestionsProps {
+  data: StepWithVariables[]
+  onSuggestionClick: (variable: Variable) => void
+}
+
+const SHORT_LIST_LENGTH = 4
+const LIST_HEIGHT = 256
+
+export default function Suggestions(props: SuggestionsProps) {
+  const { data, onSuggestionClick = () => null } = props
+  const [current, setCurrent] = useState<number | null>(0)
+  const [listLength, setListLength] = useState<number>(SHORT_LIST_LENGTH)
+
+  const expandList = () => {
+    setListLength(Infinity)
+  }
+
+  const collapseList = () => {
+    setListLength(SHORT_LIST_LENGTH)
+  }
+
+  useEffect(() => {
+    setListLength(SHORT_LIST_LENGTH)
+  }, [current])
+
+  return (
+    <Paper elevation={5} sx={{ width: '100%' }}>
+      <Typography variant="subtitle2" sx={{ p: 2 }}>
+        Variables
+      </Typography>
+      <List disablePadding>
+        {data.map((option, index) => (
+          <div key={`primary-suggestion-${option.name}`}>
+            <ListItemButton
+              divider
+              onClick={() =>
+                setCurrent((currentIndex) =>
+                  currentIndex === index ? null : index,
+                )
+              }
+              sx={{ py: 0.5 }}
+            >
+              <ListItemText primary={option.name} />
+              {!!option.output?.length &&
+                (current === index ? <ExpandLess /> : <ExpandMore />)}
+            </ListItemButton>
+
+            <Collapse in={current === index} timeout="auto" unmountOnExit>
+              <VariablesList
+                variables={(option.output ?? []).slice(0, listLength)}
+                onClick={onSuggestionClick}
+                listHeight={LIST_HEIGHT}
+              />
+
+              {(option.output?.length || 0) > listLength && (
+                <Button fullWidth onClick={expandList}>
+                  Show all
+                </Button>
+              )}
+
+              {listLength === Infinity && (
+                <Button fullWidth onClick={collapseList}>
+                  Show less
+                </Button>
+              )}
+            </Collapse>
+          </div>
+        ))}
+      </List>
+    </Paper>
+  )
+}
+
+interface SuggestionsPopperProps {
+  open: boolean
+  anchorEl: HTMLDivElement | null
+  data: StepWithVariables[]
+  onSuggestionClick: (variable: Variable) => void
+}
+
+export const SuggestionsPopper = (props: SuggestionsPopperProps) => {
+  const { open, anchorEl, data, onSuggestionClick } = props
+
+  return (
+    <Popper
+      open={open}
+      anchorEl={anchorEl}
+      // Allow (ugly) scrolling in nested modals for small viewports; modals
+      // can't account for popper overflow if it is portalled to body.
+      disablePortal
+      style={{
+        width: anchorEl?.clientWidth,
+        // FIXME (ogp-weeloong): HACKY, temporary workaround. Needed to render
+        // sugestions within nested editors, since Chakra renders modals at 40
+        // z-index. Will migrate to chakra Popover in separate PR if team is
+        // agreeable to flip change.
+        zIndex: 40,
+      }}
+      modifiers={[
+        {
+          name: 'flip',
+          enabled: true,
+        },
+      ]}
+    >
+      <Suggestions data={data} onSuggestionClick={onSuggestionClick} />
+    </Popper>
+  )
+}

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -1,0 +1,20 @@
+import { Badge, Text } from '@chakra-ui/react'
+import { Node } from '@tiptap/pm/model'
+import { NodeViewWrapper } from '@tiptap/react'
+
+export const VariableBadge = ({ node }: { node: Node }) => {
+  return (
+    <NodeViewWrapper>
+      <Badge maxW="full" variant="solid" bg="primary.100" borderRadius="50px">
+        <Text isTruncated color="base.content.strong" mr={1}>
+          {node.attrs.label}
+        </Text>
+        {node.attrs.value && (
+          <Text isTruncated maxW="50ch" color="base.content.medium">
+            {node.attrs.value}
+          </Text>
+        )}
+      </Badge>
+    </NodeViewWrapper>
+  )
+}

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -114,6 +114,7 @@ const Editor = ({
           value: variable.value,
         },
       })
+      editor?.commands.focus()
     },
     [editor],
   )

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -15,7 +15,8 @@ function makeListItemComponent(
     return (props: ListItemButtonProps) => (
       <ListItemButton
         {...props}
-        onClick={() => {
+        // onClick doesn't work sometimes due to latency between mousedown and immediate mouseup event after
+        onMouseDown={() => {
           onClick(variable)
         }}
       />


### PR DESCRIPTION
## Problem

Variable support for rich text editor

## Solution

Retro-fit our current solution from the old `PowerInput` into tiptap by creating a custom extension that can support our template string

## Tests

Input (covering variables in different places like lists and table cells)
**Note**: variables cannot be selected and formatted

![Screenshot 2023-10-19 at 12 56 07 AM](https://github.com/opengovsg/plumber/assets/12974927/2e709e1c-5394-4c23-99e0-e549b9773467)

- [x] Test email
![Screenshot 2023-10-19 at 1 03 33 AM](https://github.com/opengovsg/plumber/assets/12974927/168675b6-2277-469a-bce4-e2ddf1449e8b)

- [x] actual email triggered via webhook
![Screenshot 2023-10-19 at 1 03 19 AM](https://github.com/opengovsg/plumber/assets/12974927/1d1b938d-bfa3-4f03-a78b-f9cfc74e84d8)

- [x] disable variable suggestions if the flag is not turn on for the field

## Deploy Notes

N/A