### PR TITLE
[PLU-102] feat(rich-text-editor): backward compat with old templates

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -20,7 +20,6 @@ import TableRow from '@tiptap/extension-table-row'
 import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { genVariableInfoMap } from 'components/PowerInput/utils'
 import { StepExecutionsContext } from 'contexts/StepExecutions'
 import { extractVariables, filterVariables, Variable } from 'helpers/variables'
 
@@ -28,7 +27,7 @@ import { MenuBar } from './MenuBar'
 import ImageResize from './ResizableImageExtension'
 import { StepVariable } from './StepVariablePlugin'
 import { SuggestionsPopper } from './SuggestionPopper'
-import { substituteOldTemplates } from './utils'
+import { genVariableInfoMap, substituteOldTemplates } from './utils'
 
 interface EditorProps {
   onChange: (...event: any[]) => void
@@ -48,7 +47,7 @@ const Editor = ({
   const [showVarSuggestions, setShowVarSuggestions] = useState(false)
   const editorRef = useRef<HTMLDivElement | null>(null)
 
-  const [stepsWithVariables] = useMemo(() => {
+  const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
       extractVariables(priorStepsWithExecutions),
       (variable) => (variable.type ?? 'text') === 'text',
@@ -85,7 +84,7 @@ const Editor = ({
       }),
       StepVariable,
     ],
-    content: substituteOldTemplates(initialValue), // back-ward compatibility with old values from PowerInput
+    content: substituteOldTemplates(initialValue, varInfo), // back-ward compatibility with old values from PowerInput
     onUpdate: ({ editor }) => {
       const content = editor.getHTML()
       if (content === '<p></p>') {

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -28,6 +28,7 @@ import { MenuBar } from './MenuBar'
 import ImageResize from './ResizableImageExtension'
 import { StepVariable } from './StepVariablePlugin'
 import { SuggestionsPopper } from './SuggestionPopper'
+import { substituteOldTemplates } from './utils'
 
 interface EditorProps {
   onChange: (...event: any[]) => void
@@ -84,7 +85,7 @@ const Editor = ({
       }),
       StepVariable,
     ],
-    content: initialValue,
+    content: substituteOldTemplates(initialValue), // back-ward compatibility with old values from PowerInput
     onUpdate: ({ editor }) => {
       const content = editor.getHTML()
       if (content === '<p></p>') {

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -2,38 +2,54 @@ import { describe, expect, it } from 'vitest'
 
 import { substituteOldTemplates } from './utils'
 
+const varInfo = new Map<
+  string,
+  {
+    label: string
+    testRunValue: string
+  }
+>()
+varInfo.set('{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}', {
+  label: 'hello',
+  testRunValue: 'world',
+})
+varInfo.set('{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}', {
+  label: 'papa',
+  testRunValue: 'mama',
+})
+
 describe('replaceOldTemplates', () => {
   it('should replace old {{.}} with correct <span /> value', () => {
     const testCases = [
       {
         input: '{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}',
         expected:
-          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
       },
       {
         input:
           'Aloha. {{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}} world!',
         expected:
-          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
       },
       {
         input:
           '{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}} world! {{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}',
         expected:
-          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world! <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span>',
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world! <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="mama">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span>',
       },
     ]
     for (const t of testCases) {
-      expect(substituteOldTemplates(t.input)).toEqual(t.expected)
+      expect(substituteOldTemplates(t.input, varInfo)).toEqual(t.expected)
     }
   })
   it('should not replace {{.}} that is followed by </span>', () => {
     const testCases = [
       {
         input:
-          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
         expected:
-          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
       },
       {
         // won't substitute even if it's a span-wrap entered by user
@@ -44,13 +60,13 @@ describe('replaceOldTemplates', () => {
       },
       {
         input:
-          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
         expected:
-          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
       },
     ]
     for (const t of testCases) {
-      expect(substituteOldTemplates(t.input)).toEqual(t.expected)
+      expect(substituteOldTemplates(t.input, varInfo)).toEqual(t.expected)
     }
   })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -43,6 +43,7 @@ describe('replaceOldTemplates', () => {
       expect(substituteOldTemplates(t.input, varInfo)).toEqual(t.expected)
     }
   })
+
   it('should not replace {{.}} that is followed by </span>', () => {
     const testCases = [
       {
@@ -67,6 +68,13 @@ describe('replaceOldTemplates', () => {
     ]
     for (const t of testCases) {
       expect(substituteOldTemplates(t.input, varInfo)).toEqual(t.expected)
+    }
+  })
+
+  it('should handle undefined values', () => {
+    const testInputs = [undefined, null] as unknown as string[] // this is to force the value in
+    for (const input of testInputs) {
+      expect(substituteOldTemplates(input, varInfo)).toEqual('')
     }
   })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { substituteOldTemplates } from './utils'
+
+describe('replaceOldTemplates', () => {
+  it('should replace old {{.}} with correct <span /> value', () => {
+    const testCases = [
+      {
+        input: '{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}',
+        expected:
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+      },
+      {
+        input:
+          'Aloha. {{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}} world!',
+        expected:
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+      },
+      {
+        input:
+          '{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}} world! {{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}',
+        expected:
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world! <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span>',
+      },
+    ]
+    for (const t of testCases) {
+      expect(substituteOldTemplates(t.input)).toEqual(t.expected)
+    }
+  })
+  it('should not replace {{.}} that is followed by </span>', () => {
+    const testCases = [
+      {
+        input:
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+        expected:
+          '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+      },
+      {
+        // won't substitute even if it's a span-wrap entered by user
+        input:
+          '<span>{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+        expected:
+          '<span>{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
+      },
+      {
+        input:
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+        expected:
+          'Aloha. <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world!',
+      },
+    ]
+    for (const t of testCases) {
+      expect(substituteOldTemplates(t.input)).toEqual(t.expected)
+    }
+  })
+})

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -1,4 +1,40 @@
-export function substituteOldTemplates(original: string): string {
+import { StepWithVariables } from 'helpers/variables'
+
+export type VariableInfoMap = Map<
+  string,
+  {
+    label: string
+    testRunValue: string
+  }
+>
+
+export function genVariableInfoMap(
+  stepsWithVariables: StepWithVariables[],
+): VariableInfoMap {
+  const result: VariableInfoMap = new Map()
+
+  for (const [stepPosition, step] of stepsWithVariables.entries()) {
+    for (const variable of step.output) {
+      const placeholderString = `{{${variable.name}}}`
+      const label =
+        variable.label ??
+        variable.name.replace(`step.${step.id}.`, `step${stepPosition + 1}.`)
+      const testRunValue = variable.displayedValue ?? String(variable.value)
+
+      result.set(placeholderString, {
+        label,
+        testRunValue,
+      })
+    }
+  }
+
+  return result
+}
+
+export function substituteOldTemplates(
+  original: string,
+  varInfo: VariableInfoMap,
+): string {
   const searchRegex = /({{[^{}]+}})(?!<\/span>)/
   const nodes = original.split(searchRegex)
   for (const i in nodes) {
@@ -8,9 +44,10 @@ export function substituteOldTemplates(original: string): string {
     const id = nodes[i].replace('{{', '').replace('}}', '')
     const idComponents = id.split('.')
     const label = idComponents[idComponents.length - 1]
+    const value = varInfo.get(nodes[i])?.testRunValue || ''
     nodes[
       i
-    ] = `<span data-type="variable" data-id="${id}" data-label="${label}" data-value="">${nodes[i]}</span>`
+    ] = `<span data-type="variable" data-id="${id}" data-label="${label}" data-value="${value}">${nodes[i]}</span>`
   }
   return nodes.join('')
 }

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -1,0 +1,16 @@
+export function substituteOldTemplates(original: string): string {
+  const searchRegex = /({{[^{}]+}})(?!<\/span>)/
+  const nodes = original.split(searchRegex)
+  for (const i in nodes) {
+    if (!searchRegex.test(nodes[i])) {
+      continue
+    }
+    const id = nodes[i].replace('{{', '').replace('}}', '')
+    const idComponents = id.split('.')
+    const label = idComponents[idComponents.length - 1]
+    nodes[
+      i
+    ] = `<span data-type="variable" data-id="${id}" data-label="${label}" data-value="">${nodes[i]}</span>`
+  }
+  return nodes.join('')
+}

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -35,6 +35,9 @@ export function substituteOldTemplates(
   original: string,
   varInfo: VariableInfoMap,
 ): string {
+  if (!original) {
+    return ''
+  }
   const searchRegex = /({{[^{}]+}})(?!<\/span>)/
   const nodes = original.split(searchRegex)
   for (const i in nodes) {


### PR DESCRIPTION
## Problem

Handle template string from prior to new rich text editor

## Solution

Replace all `{{ . }}` that are wrapped by `<span />` with the new span tag nodes 

## Tests

- [x] execute published pipes
- [x] edit value and execute test unpublished pipes
- [x] editing of email bodies with old values
- [x] creating new pipes with rich text editor

## Deploy Notes

N/A