### PR TITLE
Apply jitter to our exponential backoff

### DIFF
--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -10,35 +10,34 @@ describe('Backoff', () => {
   it('backs off exponentially with jitter disabled', () => {
     vi.spyOn(Math, 'random').mockReturnValue(1)
 
-    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
-    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 2)
-    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 4)
-    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 8)
+    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS * 2)
+    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 4)
+    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 8)
+    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 16)
   })
 
-  it('waits the full duration on the 1st retry', () => {
+  it('applies jitter', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
-    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
-  })
-
-  it('applies jitter after 1st attempt (attemptsMade = $attemptsMade)', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.5)
-
-    expect(exponentialBackoffWithJitter(2)).toEqual(
+    expect(exponentialBackoffWithJitter(1)).toEqual(
       INITIAL_DELAY_MS + INITIAL_DELAY_MS / 2,
     )
+    expect(exponentialBackoffWithJitter(2)).toEqual(
+      INITIAL_DELAY_MS * 2 /* Full delay for 1st retry */ +
+        INITIAL_DELAY_MS /* 50% of full delay*/,
+    )
     expect(exponentialBackoffWithJitter(3)).toEqual(
-      INITIAL_DELAY_MS * 2 + INITIAL_DELAY_MS,
+      INITIAL_DELAY_MS * 4 /* Full delay for 2nd retry */ +
+        INITIAL_DELAY_MS * 2 /* 50% of full delay*/,
     )
   })
 
   it('will wait at least the full duration of the previous delay', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0)
 
-    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS)
-    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 2)
-    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 4)
-    expect(exponentialBackoffWithJitter(5)).toEqual(INITIAL_DELAY_MS * 8)
+    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
+    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 2)
+    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 4)
+    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 8)
   })
 })

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { exponentialBackoffWithJitter, INITIAL_DELAY_MS } from '../backoff'
+
+describe('Backoff', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('backs off exponentially before jitter', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
+    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 2)
+    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 4)
+  })
+
+  it('applies jitter', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    expect(exponentialBackoffWithJitter(1)).toEqual(
+      Math.round(INITIAL_DELAY_MS / 2),
+    )
+  })
+})

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -7,17 +7,38 @@ describe('Backoff', () => {
     vi.restoreAllMocks()
   })
 
-  it('backs off exponentially before jitter', () => {
+  it('backs off exponentially with jitter disabled', () => {
     vi.spyOn(Math, 'random').mockReturnValue(1)
+
     expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
     expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 2)
     expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 4)
+    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 8)
   })
 
-  it('applies jitter', () => {
+  it('waits the full duration on the 1st retry', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
-    expect(exponentialBackoffWithJitter(1)).toEqual(
-      Math.round(INITIAL_DELAY_MS / 2),
+
+    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS)
+  })
+
+  it('applies jitter after 1st attempt (attemptsMade = $attemptsMade)', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    expect(exponentialBackoffWithJitter(2)).toEqual(
+      INITIAL_DELAY_MS + INITIAL_DELAY_MS / 2,
     )
+    expect(exponentialBackoffWithJitter(3)).toEqual(
+      INITIAL_DELAY_MS * 2 + INITIAL_DELAY_MS,
+    )
+  })
+
+  it('will wait at least the full duration of the previous delay', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS)
+    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 2)
+    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 4)
+    expect(exponentialBackoffWithJitter(5)).toEqual(INITIAL_DELAY_MS * 8)
   })
 })

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -7,15 +7,6 @@ describe('Backoff', () => {
     vi.restoreAllMocks()
   })
 
-  it('backs off exponentially with jitter disabled', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(1)
-
-    expect(exponentialBackoffWithJitter(1)).toEqual(INITIAL_DELAY_MS * 2)
-    expect(exponentialBackoffWithJitter(2)).toEqual(INITIAL_DELAY_MS * 4)
-    expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 8)
-    expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 16)
-  })
-
   it('applies jitter', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.5)
 

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -8,13 +8,20 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   _err: Error,
   _job: Job,
 ): number {
-  // This implements (uncapped) FullJitter; we want to minimize outgoing calls
-  // to be a nice API consumer. Capping should not matter here since we cap
-  // total attempts.
+  // This implements FullJitter-like jitter, with the following changes:
+  //
+  // * We wait the full delay on the 1st retry.
+  // * We wait at least the full duration of the previous delay.
+  // * No cap on wait time; capping should not matter here since we cap total
+  //   attempts.
   //
   // Reference:
   // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
-  const baseDelay = Math.round(Math.pow(2, attemptsMade - 1) * INITIAL_DELAY_MS)
-  return Math.round(Math.random() * baseDelay)
+  if (attemptsMade === 1) {
+    return INITIAL_DELAY_MS
+  }
+
+  const prevFullDelay = Math.pow(2, attemptsMade - 2) * INITIAL_DELAY_MS
+  return prevFullDelay + Math.round(Math.random() * prevFullDelay)
 }

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -9,9 +9,9 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   _job: Job,
 ): number {
   // This implements FullJitter-like jitter, with the following changes:
-  //.
+  //
   // * We wait _at least_ the full duration of the previous delay (or on the 1st
-  //   retry, at least full initial delay).
+  //   retry, at least the full initial delay).
   // * No cap on wait time; capping should not matter here since we cap total
   //   attempts.
   //

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -1,6 +1,6 @@
 import { type BackoffStrategy, type Job } from 'bullmq'
 
-export const INITIAL_DELAY_MS = 5000
+export const INITIAL_DELAY_MS = 3000
 
 export const exponentialBackoffWithJitter: BackoffStrategy = function (
   attemptsMade: number,
@@ -9,19 +9,15 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   _job: Job,
 ): number {
   // This implements FullJitter-like jitter, with the following changes:
-  //
-  // * We wait the full delay on the 1st retry.
-  // * We wait at least the full duration of the previous delay.
+  //.
+  // * We wait _at least_ the full duration of the previous delay (or on the 1st
+  //   retry, at least full initial delay).
   // * No cap on wait time; capping should not matter here since we cap total
   //   attempts.
   //
   // Reference:
   // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
-  if (attemptsMade === 1) {
-    return INITIAL_DELAY_MS
-  }
-
-  const prevFullDelay = Math.pow(2, attemptsMade - 2) * INITIAL_DELAY_MS
+  const prevFullDelay = Math.pow(2, attemptsMade - 1) * INITIAL_DELAY_MS
   return prevFullDelay + Math.round(Math.random() * prevFullDelay)
 }

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -1,0 +1,20 @@
+import { type BackoffStrategy, type Job } from 'bullmq'
+
+export const INITIAL_DELAY_MS = 5000
+
+export const exponentialBackoffWithJitter: BackoffStrategy = function (
+  attemptsMade: number,
+  _type: string,
+  _err: Error,
+  _job: Job,
+): number {
+  // This implements (uncapped) FullJitter; we want to minimize outgoing calls
+  // to be a nice API consumer. Capping should not matter here since we cap
+  // total attempts.
+  //
+  // Reference:
+  // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+
+  const baseDelay = Math.round(Math.pow(2, attemptsMade - 1) * INITIAL_DELAY_MS)
+  return Math.round(Math.random() * baseDelay)
+}

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -12,14 +12,11 @@ export const REMOVE_AFTER_7_DAYS_OR_50_JOBS = {
 export const DEFAULT_JOB_DELAY_DURATION = 0
 export const MAXIMUM_JOB_ATTEMPTS = 4
 
-const EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS = 5000
-
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   removeOnFail: REMOVE_AFTER_30_DAYS,
   attempts: MAXIMUM_JOB_ATTEMPTS,
   backoff: {
-    type: 'exponential',
-    delay: EXPONENTIAL_BACKOFF_INITIAL_DELAY_MS,
+    type: 'custom',
   },
 }

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -1,0 +1,162 @@
+import { UnrecoverableError } from 'bullmq'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import actionQueue from '@/queues/action'
+import { worker } from '@/workers/action'
+
+const mocks = vi.hoisted(() => ({
+  processAction: vi.fn(),
+  exponentialBackoffWithJitter: vi.fn(() => 0),
+  handleErrorAndThrow: vi.fn(),
+}))
+
+vi.mock('@/helpers/tracer', () => ({
+  default: {
+    scope: vi.fn(() => ({
+      active: vi.fn(),
+    })),
+    wrap: vi.fn((_, callback) => callback),
+  },
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(),
+    })),
+  },
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    setStatus: vi.fn(),
+  },
+}))
+
+vi.mock('@/services/action', () => ({
+  processAction: mocks.processAction,
+}))
+
+vi.mock('@/helpers/actions', () => ({
+  handleErrorAndThrow: mocks.handleErrorAndThrow,
+}))
+
+vi.mock('@/helpers/backoff', () => ({
+  exponentialBackoffWithJitter: mocks.exponentialBackoffWithJitter,
+}))
+
+describe('Action worker', () => {
+  beforeAll(async () => {
+    await worker.waitUntilReady()
+  })
+
+  afterAll(async () => {
+    await worker.close()
+    await actionQueue.close()
+  })
+
+  beforeEach(async () => {
+    worker.removeAllListeners()
+    await actionQueue.obliterate()
+    actionQueue.resume()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Automatic retries with default job options', () => {
+    it('does not retry successful executions', async () => {
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: false, nextStep: null },
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        worker.on('completed', async (_) => {
+          resolve()
+        })
+      })
+      await actionQueue.add(
+        'test-job',
+        {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        DEFAULT_JOB_OPTIONS,
+      )
+      await jobProcessed
+
+      expect(mocks.exponentialBackoffWithJitter).not.toBeCalled()
+    })
+
+    it('retries retriable executions using our custom backoff strategy', async () => {
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: true },
+      })
+      mocks.handleErrorAndThrow.mockImplementationOnce(() => {
+        throw new Error('retriable error')
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        worker.on('failed', async (job) => {
+          if (job.attemptsMade === DEFAULT_JOB_OPTIONS.attempts) {
+            resolve()
+          }
+        })
+      })
+      await actionQueue.add(
+        'test-job',
+        {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        DEFAULT_JOB_OPTIONS,
+      )
+      await jobProcessed
+
+      expect(mocks.exponentialBackoffWithJitter).toBeCalled()
+    })
+
+    it('does not retry non-executable executions', async () => {
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: true },
+      })
+      mocks.handleErrorAndThrow.mockImplementationOnce(() => {
+        throw new UnrecoverableError('not retriable error')
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        worker.on('failed', async (_job, err) => {
+          if (err instanceof UnrecoverableError) {
+            resolve()
+          }
+        })
+      })
+      await actionQueue.add(
+        'test-job',
+        {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        DEFAULT_JOB_OPTIONS,
+      )
+      await jobProcessed
+
+      // Should not be called, since it was not retried.
+      expect(mocks.exponentialBackoffWithJitter).not.toBeCalled()
+    })
+  })
+})

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -5,6 +5,7 @@ import { UnrecoverableError, Worker } from 'bullmq'
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
 import { handleErrorAndThrow } from '@/helpers/actions'
+import { exponentialBackoffWithJitter } from '@/helpers/backoff'
 import {
   DEFAULT_JOB_OPTIONS,
   MAXIMUM_JOB_ATTEMPTS,
@@ -86,6 +87,9 @@ export const worker = new Worker(
     prefix: '{actionQ}',
     connection: createRedisClient(),
     concurrency: appConfig.workerActionConcurrency,
+    settings: {
+      backoffStrategy: exponentialBackoffWithJitter,
+    },
   },
 )
 


### PR DESCRIPTION
## Problem
BullMQ [doesn't apply jitter](https://github.com/taskforcesh/bullmq/blob/b026a3aef991aaa535cf77e0501e7ef68fa5b5b8/src/classes/backoffs.ts#L18) to exponential backoff, which is bad (tm).

## Solution
We will use our own exponential backoff strategy with jitter. I chose to implement [FullJitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) as that (empirically) minimises outgoing calls; this should make us a good-ish API consumer.

## Tests
* New unit and integration tests
* Trigger some 504s and check that our retry delays are jittered and exponential.
* Regression test: Check that non-retriable errors are not retried.

