### PR TITLE
Add execution and step id logs for email notifications

### DIFF
--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import { sendEmail } from '@/helpers/send-email'
 import Flow from '@/models/flow'
+import { ActionJobData } from '@/workers/action'
 
 const MAX_LENGTH = 80
 export const redisClient = createRedisClient(REDIS_DB_INDEX.PIPE_ERRORS)
@@ -49,7 +50,7 @@ export async function checkErrorEmail(flowId: string): Promise<boolean> {
   return !!(await redisClient.exists(errorKey))
 }
 
-export async function sendErrorEmail(flow: Flow) {
+export async function sendErrorEmail(flow: Flow, jobData: ActionJobData) {
   const truncatedFlowName = truncateFlowName(flow.name)
   const flowId = flow.id
   const userEmail = flow.user.email
@@ -61,6 +62,8 @@ export async function sendErrorEmail(flow: Flow) {
     flowName: flow.name,
     userEmail,
     timestamp: currDatetime.toMillis(),
+    executionId: jobData.executionId,
+    stepId: jobData.stepId,
   }
 
   await sendEmail({

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -19,7 +19,7 @@ import Step from '@/models/step'
 import actionQueue from '@/queues/action'
 import { processAction } from '@/services/action'
 
-type JobData = {
+export type ActionJobData = {
   flowId: string
   executionId: string
   stepId: string
@@ -29,7 +29,7 @@ type JobData = {
 export const worker = new Worker(
   'action',
   tracer.wrap('workers.action', async (job) => {
-    const jobData = job.data as JobData
+    const jobData = job.data as ActionJobData
 
     // the reason why we dont add .throwIfNotFound() here is to prevent job retries
     // delegating the error throwing and handling to processAction where it also queries for Step
@@ -124,7 +124,7 @@ worker.on('failed', async (job, err) => {
       .findById(job.data.flowId)
       .withGraphFetched('user')
       .throwIfNotFound()
-    const errorDetails = await sendErrorEmail(flow)
+    const errorDetails = await sendErrorEmail(flow, job.data)
     logger.info(`Sent error email for FLOW ID: ${job.data.flowId}`, {
       errorDetails,
     })

--- a/packages/backend/src/workers/trigger.ts
+++ b/packages/backend/src/workers/trigger.ts
@@ -9,7 +9,7 @@ import Step from '@/models/step'
 import actionQueue from '@/queues/action'
 import { processTrigger } from '@/services/trigger'
 
-type JobData = {
+type TriggerJobData = {
   flowId: string
   stepId: string
   triggerItem?: ITriggerItem
@@ -20,7 +20,7 @@ export const worker = new Worker(
   'trigger',
   async (job) => {
     const { flowId, executionId, stepId, executionStep } = await processTrigger(
-      job.data as JobData,
+      job.data as TriggerJobData,
     )
 
     if (executionStep.isFailed) {


### PR DESCRIPTION
## Problem

Currently, it is troublesome to trace the actual execution that failed for email notifications because only the flow id is logged, we have to go to the DB and find the respective execution and step ids.

## Solution

Add execution and step id to the logs.
