### PR TITLE
Add logs for email notifications

### DIFF
--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -124,9 +124,9 @@ worker.on('failed', async (job, err) => {
       .findById(job.data.flowId)
       .withGraphFetched('user')
       .throwIfNotFound()
-    const errorDetails = await sendErrorEmail(flow)
+    const emailErrorDetails = await sendErrorEmail(flow)
     logger.info(`Sent error email for FLOW ID: ${job.data.flowId}`, {
-      errorDetails: { ...errorDetails, ...job.data },
+      errorDetails: { ...emailErrorDetails, ...job.data },
     })
   }
 })

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -126,7 +126,7 @@ worker.on('failed', async (job, err) => {
       .throwIfNotFound()
     const errorDetails = await sendErrorEmail(flow)
     logger.info(`Sent error email for FLOW ID: ${job.data.flowId}`, {
-      errorDetails,
+      errorDetails: { ...errorDetails, ...job.data },
     })
   }
 })


### PR DESCRIPTION
## Problem

Currently, it is troublesome to trace the actual execution that failed for email notifications because only the flow id is logged, we have to go to the DB and find the respective execution and step ids.

## Solution

Add execution and step id to the logs.