### PR TITLE
[PLU-134] Add redirect for otp and sgid login for email notifications

### DIFF
--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 
+import appConfig from '@/config/app'
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import { sendEmail } from '@/helpers/send-email'
 import Flow from '@/models/flow'
@@ -15,6 +16,10 @@ function truncateFlowName(flowName: string) {
 
 export function createBodyErrorMessage(flowName: string): string {
   const currDateTime = DateTime.now().toFormat('MMM dd yyyy, hh:mm a')
+  const redirectURL = `/executions/?status=failure&input=${flowName}`
+  const formattedURL = `${
+    appConfig.webAppUrl
+  }/login/?redirect=${encodeURIComponent(redirectURL)}`
   const bodyMessage = `
     Dear fellow plumber,
     <br>
@@ -29,7 +34,7 @@ export function createBodyErrorMessage(flowName: string): string {
     </ol>
     <p>What should you do?</p>
     <ol>
-      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution.</li>
+      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution through this link: ${formattedURL}</li>
       <li>Check our status page at https://status.plumber.gov.sg/ to see if Plumber or any of the apps you are using are down.</li>
       <li>Correct the configuration for your broken pipe.</li>
     </ol>

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -16,11 +16,13 @@ function truncateFlowName(flowName: string) {
 
 export function createBodyErrorMessage(flowName: string): string {
   const currDateTime = DateTime.now().toFormat('MMM dd yyyy, hh:mm a')
-  const appPrefixURL = appConfig.isDev ? appConfig.webAppUrl : appConfig.baseUrl
-  const redirectURL = `/executions/?status=failure&input=${flowName}`
-  const formattedURL = `${appPrefixURL}/login/?redirect=${encodeURIComponent(
-    redirectURL,
-  )}`
+  const searchParams = new URLSearchParams()
+  searchParams.set('status', 'failure')
+  searchParams.set('input', flowName)
+
+  const appPrefixUrl = appConfig.isDev ? appConfig.webAppUrl : appConfig.baseUrl
+  const redirectUrl = `/executions?${searchParams.toString()}`
+  const formattedUrl = `${appPrefixUrl}${redirectUrl}`
 
   const bodyMessage = `
     Dear fellow plumber,
@@ -36,7 +38,7 @@ export function createBodyErrorMessage(flowName: string): string {
     </ol>
     <p>What should you do?</p>
     <ol>
-      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution using this link: ${formattedURL}</li>
+      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution using this link: ${formattedUrl}</li>
       <li>Check our status page at https://status.plumber.gov.sg/ to see if Plumber or any of the apps you are using are down.</li>
       <li>Correct the configuration for your broken pipe.</li>
     </ol>

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -16,10 +16,12 @@ function truncateFlowName(flowName: string) {
 
 export function createBodyErrorMessage(flowName: string): string {
   const currDateTime = DateTime.now().toFormat('MMM dd yyyy, hh:mm a')
+  const appPrefixURL = appConfig.isDev ? appConfig.webAppUrl : appConfig.baseUrl
   const redirectURL = `/executions/?status=failure&input=${flowName}`
-  const formattedURL = `${
-    appConfig.webAppUrl
-  }/login/?redirect=${encodeURIComponent(redirectURL)}`
+  const formattedURL = `${appPrefixURL}/login/?redirect=${encodeURIComponent(
+    redirectURL,
+  )}`
+
   const bodyMessage = `
     Dear fellow plumber,
     <br>
@@ -34,7 +36,7 @@ export function createBodyErrorMessage(flowName: string): string {
     </ol>
     <p>What should you do?</p>
     <ol>
-      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution through this link: ${formattedURL}</li>
+      <li>Retry the failed execution by heading to the executions tab, and clicking the <strong>Retry</strong> button on the failed execution using this link: ${formattedURL}</li>
       <li>Check our status page at https://status.plumber.gov.sg/ to see if Plumber or any of the apps you are using are down.</li>
       <li>Correct the configuration for your broken pipe.</li>
     </ol>

--- a/packages/frontend/src/components/Layout/index.tsx
+++ b/packages/frontend/src/components/Layout/index.tsx
@@ -49,7 +49,12 @@ export default function Layout({
   const closeDrawer = () => setDrawerOpen(false)
 
   if (!currentUser) {
-    return <Navigate to={URLS.LOGIN} />
+    const redirectQueryParam = window.location.pathname + window.location.search
+    return (
+      <Navigate
+        to={URLS.ADD_REDIRECT_TO_LOGIN(encodeURIComponent(redirectQueryParam))}
+      />
+    )
   }
 
   return (

--- a/packages/frontend/src/components/PublicLayout/index.tsx
+++ b/packages/frontend/src/components/PublicLayout/index.tsx
@@ -13,7 +13,13 @@ type LayoutProps = {
 export default function Layout({ children }: LayoutProps): React.ReactElement {
   const { currentUser } = useAuthentication()
   if (currentUser) {
-    return <Navigate to={URLS.DASHBOARD} />
+    const urlParams = new URLSearchParams(window.location.search)
+    const redirectURL = urlParams.get('redirect') ?? urlParams.get('state')
+    return redirectURL === null ? (
+      <Navigate to={URLS.DASHBOARD} />
+    ) : (
+      <Navigate to={redirectURL} />
+    )
   }
 
   return (

--- a/packages/frontend/src/components/PublicLayout/index.tsx
+++ b/packages/frontend/src/components/PublicLayout/index.tsx
@@ -14,12 +14,8 @@ export default function Layout({ children }: LayoutProps): React.ReactElement {
   const { currentUser } = useAuthentication()
   if (currentUser) {
     const urlParams = new URLSearchParams(window.location.search)
-    const redirectURL = urlParams.get('redirect') ?? urlParams.get('state')
-    return redirectURL === null ? (
-      <Navigate to={URLS.DASHBOARD} />
-    ) : (
-      <Navigate to={redirectURL} />
-    )
+    const redirectUrl = urlParams.get('redirect') ?? urlParams.get('state')
+    return <Navigate to={redirectUrl ?? URLS.DASHBOARD} />
   }
 
   return (

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -7,6 +7,8 @@ export const ROOT = '/'
 
 export const LOGIN = '/login'
 export const LOGIN_SGID_REDIRECT = '/login/sgid/redirect'
+export const ADD_REDIRECT_TO_LOGIN = (redirectQueryParam: string): string =>
+  `${LOGIN}/?redirect=${redirectQueryParam}`
 
 export const APPS = '/apps'
 export const NEW_APP_CONNECTION = '/apps/new'

--- a/packages/frontend/src/helpers/sgid.ts
+++ b/packages/frontend/src/helpers/sgid.ts
@@ -33,6 +33,12 @@ export async function generateSgidAuthUrl(): Promise<{
   verifier: string
   nonce: string
 }> {
+  const redirectQueryParam = new URLSearchParams(window.location.search).get(
+    'redirect',
+  )
+  const stateQueryParamString = redirectQueryParam
+    ? `&state=${encodeURIComponent(redirectQueryParam)}`
+    : ''
   const { challenge, verifier, nonce } = await generatePkceAndNonce()
   const sgidUrl =
     'https://api.id.gov.sg/v2/oauth/authorize?' +
@@ -42,7 +48,8 @@ export async function generateSgidAuthUrl(): Promise<{
     `&nonce=${nonce}` +
     `&client_id=${appConfig.sgidClientId}` +
     `&redirect_uri=${encodeURIComponent(REDIRECT_URL)}` +
-    `&scope=${encodeURIComponent(SCOPE)}`
+    `&scope=${encodeURIComponent(SCOPE)}` +
+    stateQueryParamString
 
   return {
     url: sgidUrl,

--- a/packages/frontend/src/pages/SgidCallback/SgidAccountSelect.tsx
+++ b/packages/frontend/src/pages/SgidCallback/SgidAccountSelect.tsx
@@ -26,7 +26,7 @@ export default function SgidAccountSelect(
 
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const redirectURL = searchParams.get('state')
+  const redirectUrl = searchParams.get('state')
 
   const [loginWithSelectedSgid] = useMutation(LOGIN_WITH_SELECTED_SGID, {
     refetchQueries: [GET_CURRENT_USER],
@@ -49,12 +49,10 @@ export default function SgidAccountSelect(
       if (!success) {
         setFailed(true)
       } else {
-        return redirectURL === null
-          ? navigate(URLS.FLOWS, { replace: true })
-          : navigate(redirectURL, { replace: true })
+        return navigate(redirectUrl ?? URLS.DASHBOARD, { replace: true })
       }
     },
-    [loginWithSelectedSgid, navigate, setFailed, redirectURL],
+    [loginWithSelectedSgid, navigate, setFailed, redirectUrl],
   )
 
   return (

--- a/packages/frontend/src/pages/SgidCallback/SgidAccountSelect.tsx
+++ b/packages/frontend/src/pages/SgidCallback/SgidAccountSelect.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { BiChevronRight } from 'react-icons/bi'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import { Box, Divider, Flex, Heading, Icon, Link, Text } from '@chakra-ui/react'
 import * as URLS from 'config/urls'
@@ -25,6 +25,8 @@ export default function SgidAccountSelect(
   const { employments, setFailed } = props
 
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const redirectURL = searchParams.get('state')
 
   const [loginWithSelectedSgid] = useMutation(LOGIN_WITH_SELECTED_SGID, {
     refetchQueries: [GET_CURRENT_USER],
@@ -47,10 +49,12 @@ export default function SgidAccountSelect(
       if (!success) {
         setFailed(true)
       } else {
-        navigate(URLS.FLOWS, { replace: true })
+        return redirectURL === null
+          ? navigate(URLS.FLOWS, { replace: true })
+          : navigate(redirectURL, { replace: true })
       }
     },
-    [loginWithSelectedSgid, navigate, setFailed],
+    [loginWithSelectedSgid, navigate, setFailed, redirectURL],
   )
 
   return (

--- a/packages/frontend/src/pages/SgidCallback/index.tsx
+++ b/packages/frontend/src/pages/SgidCallback/index.tsx
@@ -83,6 +83,7 @@ export default function SgidCallback(): JSX.Element {
     return <Navigate to={`${URLS.LOGIN}/?not_sgid_eligible=1`} replace />
   }
 
+  // this doesn't occur because of auth cookie set in login-with-sgid mutation
   if (employments?.length === 1) {
     return <Navigate to={URLS.FLOWS} replace />
   }


### PR DESCRIPTION
TODO

- [x] Change local vs staging/prod config for app url
- [x] Check final email format (should include another redirect link to editor for the failed pipe?)

## Problem

Email notifications should have an email to link users to retry failed executions or configure malfunctioning pipes.

## Solution

Add link and configure redirect for both OTP and SGID login.
Both uses the search param: `redirect` but SGID require an extra `state` storage to pass the query params over to `redirect`.

## Screenshot
With redirect link
<img width="1102" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/6d3b23d9-ff3b-4d79-bca1-155947f02dd7">


## Tests
Local dev
- [x] OTP login redirect works for any pipe name
- [x] Single hat SGID login redirect works for any pipe name
- [x] Multi hat SGID login redirect works for any pipe name

Staging
- [x] OTP login redirect works for any pipe name
- [x] Single hat SGID login redirect works for any pipe name
- [x] Multi hat SGID login redirect works for any pipe name (have to directly modify code for number of employments in staging to test this?)


