### PR TITLE
[VAULT] fix: support commas and double quotes

### DIFF
--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
@@ -76,11 +76,11 @@ describe('create row', () => {
   describe('should decode url-encoded commas and double quotes properly', async () => {
     it('should decode escaped commas', async () => {
       $.step.parameters.columns = 'column_1, column_2'
-      $.step.parameters.values = 'value_1, value %2Cwith%2C quotes'
+      $.step.parameters.values = 'value_1, value %2Cwith%2C commas'
       await expect(createRowAction.run($)).resolves.toBe(undefined)
       expect(mocks.createTableRow).toHaveBeenCalledWith($, {
         column_1: 'value_1',
-        column_2: 'value ,with, quotes',
+        column_2: 'value ,with, commas',
       })
     })
     it('should decode escaped double quotes', async () => {

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
@@ -73,28 +73,6 @@ describe('create row', () => {
     },
   )
 
-  it.each([
-    { columns: 'column_1, column_2', values: 'value_1, value_"with"_quotes' },
-    {
-      columns: 'column_1, column_with_one_quote"',
-      values: 'value_1, value_2',
-    },
-    {
-      columns: 'column_1, column_"with"_quotes',
-      values: 'value_1, "value_with_"single_quote',
-    },
-    // Edge case: this will unexpectedly work if col/val is quoted in accordance
-    // with CSV format - e.g. "column". Although the user will notice that the
-    // quotes are missing. But that's OK.
-  ])(
-    'errors if columns or values contain double quotes',
-    async ({ columns, values }) => {
-      $.step.parameters.columns = columns
-      $.step.parameters.values = values
-      await expect(createRowAction.run($)).rejects.toThrowError()
-    },
-  )
-
   describe('should decode url-encoded commas and double quotes properly', async () => {
     it('should decode escaped commas', async () => {
       $.step.parameters.columns = 'column_1, column_2'

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
@@ -94,4 +94,44 @@ describe('create row', () => {
       await expect(createRowAction.run($)).rejects.toThrowError()
     },
   )
+
+  describe('should decode url-encoded commas and double quotes properly', async () => {
+    it('should decode escaped commas', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = 'value_1, value %2Cwith%2C quotes'
+      await expect(createRowAction.run($)).resolves.toBe(undefined)
+      expect(mocks.createTableRow).toHaveBeenCalledWith($, {
+        column_1: 'value_1',
+        column_2: 'value ,with, quotes',
+      })
+    })
+    it('should decode escaped double quotes', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = 'value_1, %22value %22with%22 quotes%22'
+      await expect(createRowAction.run($)).resolves.toBe(undefined)
+      expect(mocks.createTableRow).toHaveBeenCalledWith($, {
+        column_1: 'value_1',
+        column_2: '"value "with" quotes"',
+      })
+    })
+    it('should decode escaped double quotes within double quotes', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = 'value_1, "%22value %22with%22 quotes%22"'
+      await expect(createRowAction.run($)).resolves.toBe(undefined)
+      expect(mocks.createTableRow).toHaveBeenCalledWith($, {
+        column_1: 'value_1',
+        column_2: '"value "with" quotes"',
+      })
+    })
+
+    it('should decode escaped double quotes within other double quotes', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = 'value_1, asas"%22value %22with%22 quotes%22"'
+      await expect(createRowAction.run($)).resolves.toBe(undefined)
+      expect(mocks.createTableRow).toHaveBeenCalledWith($, {
+        column_1: 'value_1',
+        column_2: 'asas""value "with" quotes""',
+      })
+    })
+  })
 })

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -3,6 +3,10 @@ import { parse as parseAsCsv } from 'csv-parse/sync'
 import defineAction from '@/helpers/define-action'
 
 import createTableRow from '../../common/create-table-row'
+import {
+  escapeSpecialChars,
+  unescapeSpecialChars,
+} from '../../common/escape-characters'
 
 export default defineAction({
   name: 'Create row',
@@ -29,14 +33,14 @@ export default defineAction({
     },
   ],
   preprocessVariable: (key, value) => {
-    if (key !== 'values' && key !== 'columns') {
+    if (key !== 'values') {
       return value
     }
     if (typeof value !== 'string') {
       return value
     }
     // url encode commas and double quotes
-    return value.replace(/,/g, '%2C').replace(/"/g, '%22')
+    return escapeSpecialChars(value)
   },
 
   async run($) {
@@ -58,8 +62,8 @@ export default defineAction({
 
     const row: { [key: string]: string } = {}
     for (let i = 0; i < columns.length; i++) {
-      const columnName = decodeURIComponent(columns[i])
-      const rowValue = decodeURIComponent(values[i])
+      const columnName = columns[i]
+      const rowValue = unescapeSpecialChars(values[i])
       row[columnName] = rowValue
     }
 

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -28,16 +28,28 @@ export default defineAction({
         'Put a comma between each value. Enclose values with double-quotes (") if you think it may contain commas (e.g. form answers). Values CANNOT contain double quotes.',
     },
   ],
+  preprocessVariable: (key, value) => {
+    if (key !== 'values' && key !== 'columns') {
+      return value
+    }
+    if (typeof value !== 'string') {
+      return value
+    }
+    // url encode commas and double quotes
+    return value.replace(/,/g, '%2C').replace(/"/g, '%22')
+  },
 
   async run($) {
     const columns = parseAsCsv($.step.parameters.columns as string, {
       columns: false,
       trim: true,
+      relaxQuotes: true,
     })[0] as string[]
 
     const values = parseAsCsv($.step.parameters.values as string as string, {
       columns: false,
       trim: true,
+      relaxQuotes: true,
     })[0] as string[]
 
     if (columns.length !== values.length) {
@@ -46,7 +58,9 @@ export default defineAction({
 
     const row: { [key: string]: string } = {}
     for (let i = 0; i < columns.length; i++) {
-      row[columns[i]] = values[i]
+      const columnName = decodeURIComponent(columns[i])
+      const rowValue = decodeURIComponent(values[i])
+      row[columnName] = rowValue
     }
 
     await createTableRow($, row)

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -28,8 +28,7 @@ export default defineAction({
       type: 'string' as const,
       required: true,
       variables: true,
-      description:
-        'Put a comma between each value. Enclose values with double-quotes (") if you think it may contain commas (e.g. form answers). Values CANNOT contain double quotes.',
+      description: 'Put a comma between each value.',
     },
   ],
   preprocessVariable: (key, value) => {

--- a/packages/backend/src/apps/vault-workspace/common/escape-characters.ts
+++ b/packages/backend/src/apps/vault-workspace/common/escape-characters.ts
@@ -1,0 +1,7 @@
+export function escapeSpecialChars(str: string) {
+  return str.replace(/,/g, '%2C').replace(/"/g, '%22')
+}
+
+export function unescapeSpecialChars(str: string) {
+  return str.replace(/%2C/g, ',').replace(/%22/g, '"')
+}


### PR DESCRIPTION
## Problem

When adding rows in Vault, having values with commas `,` will require double quotes enclosing them or else it will fail.

However, having a double quote `"` without the enclosing quotes will result in more errors.

## Solution

Use `preprocessVariables` to encode commas `,` and double quotes `"` before substitution. Then decode them before making the API request to Vault.

Possible regression case:
This might cause url-encoded values to be unintentionally decoded since it is impossible to tell which ones are encoded by Plumber. i.e. if a user sends a url https://examples.com?query=abc%2C, it will decode the URL.

A quick DB query 
```
SELECT
	*
FROM
	execution_steps
WHERE
	app_key = 'vault-workspace'
	AND job_id IS NOT NULL
	AND data_out->>'addedRows'::text LIKE '%\%%' ESCAPE '\';
```

shows that there are no such cases. Also, this change can easily be rolledback without the need for backwards compatibility.

## Test
**Variables**
![image](https://github.com/opengovsg/plumber/assets/10072985/a6fb0017-694a-477d-a853-e2e2b4fc76e2)
**Input**
![image](https://github.com/opengovsg/plumber/assets/10072985/b031a749-b602-4648-a58d-c6e14944b4f8)
**Result**
![image](https://github.com/opengovsg/plumber/assets/10072985/abfeb591-a7e0-435b-8a05-52487c44b1ac)
