### PR TITLE
PLU-131: Disable if-then action instead of hiding it

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -114,20 +114,6 @@ function ChooseAppAndEventSubstep(
     () =>
       actionsOrTriggers
         .filter((actionOrTrigger) => {
-          //
-          // ** EDGE CASE **
-          //
-          // We want to hide If-then in some cases (see useIsIfThenSelectable
-          // comments).
-          //
-          if (
-            app?.key === TOOLBOX_APP_KEY &&
-            actionOrTrigger?.key === TOOLBOX_ACTIONS.IfThen &&
-            !isIfThenSelectable
-          ) {
-            return false
-          }
-
           // Filter away stuff hidden behind feature flags
           if (!launchDarkly.flags || !app?.key) {
             return true
@@ -142,13 +128,7 @@ function ChooseAppAndEventSubstep(
         })
         //
         .map((trigger) => eventOptionGenerator(trigger)),
-    [
-      actionsOrTriggers,
-      app?.key,
-      isIfThenSelectable,
-      launchDarkly.flags,
-      isTrigger,
-    ],
+    [actionsOrTriggers, app?.key, launchDarkly.flags, isTrigger],
   )
   const selectedActionOrTrigger = actionsOrTriggers.find(
     (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === step?.key,
@@ -174,9 +154,8 @@ function ChooseAppAndEventSubstep(
         const eventKey = option?.value as string
 
         //
-        // ** EDGE CASE AGAIN V2 **
-        //
-        // Hello, the if-then edge case demon here again!
+        // ** EDGE CASE **
+        // The if-then edge case demon here!
         //
         // If-then is weird in that we need to pre-populate with 2 branches
         // upon initial selection (the only action that spawns 2 steps upon
@@ -233,6 +212,21 @@ function ChooseAppAndEventSubstep(
       }
     },
     [step, onChange],
+  )
+
+  //
+  // ** EDGE CASE V2 **
+  // The if-then edge case demon again!
+  //
+  // To prevent user confusion, we want to show If-Then as a disabled option
+  // when we're not the last step.
+  //
+  const getIsIfThenDisabled = useCallback(
+    ({ value: actionKey }: ReturnType<typeof eventOptionGenerator>) =>
+      step.appKey === TOOLBOX_APP_KEY &&
+      actionKey === TOOLBOX_ACTIONS.IfThen &&
+      !isIfThenSelectable,
+    [step.appKey, isIfThenSelectable],
   )
 
   const onToggle = expanded ? onCollapse : onExpand
@@ -318,6 +312,7 @@ function ChooseAppAndEventSubstep(
                 loading={isLoading}
                 // Don't display options until we can check feature flags!
                 options={isLoading ? [] : actionOrTriggerOptions}
+                getOptionDisabled={getIsIfThenDisabled}
                 renderInput={(params) => (
                   <FormControl>
                     <FormLabel isRequired>Choose an event</FormLabel>
@@ -345,7 +340,14 @@ function ChooseAppAndEventSubstep(
                       justifyContent: 'space-between',
                     }}
                   >
-                    <Text>{option.label}</Text>
+                    <Flex flexDir="column">
+                      <Text>{option.label}</Text>
+                      {getIsIfThenDisabled(option) && (
+                        <Text fontSize="xs" color="red.500">
+                          This can only be used in the last step
+                        </Text>
+                      )}
+                    </Flex>
 
                     {option.type === 'webhook' && (
                       <Chip label="Instant" sx={{ mr: 3 }} />


### PR DESCRIPTION
## Problem
Users are confused because they cannot find the if-then action. It turns out they keep trying to add it in the middle of their pipe.

## Solution
We will disable If-then action instead of hiding it.

<img width="893" alt="Screenshot 2023-10-25 at 2 11 19 PM" src="https://github.com/opengovsg/plumber/assets/135598754/2c6fa96b-40ad-4219-a4aa-0473969b13d1">

## Tests
- Check that I can see, but cannot select if-then when I'm not the last step.
- Check that I can still select if-then if I'm the last step.
- Regression test: check that I can select other actions in the middle of a pipe.