### PR TITLE
HACKFIX: Scrappy HTTP 429 support

### DIFF
--- a/packages/backend/src/helpers/__tests__/actions.test.ts
+++ b/packages/backend/src/helpers/__tests__/actions.test.ts
@@ -75,6 +75,7 @@ describe('action helper functions', () => {
       { details: { error: 'read ECONNRESET' } },
       { details: { error: 'connect ETIMEDOUT 1.2.3.4:123' } },
       { status: 504 },
+      { status: 429 },
     ])('retries connectivity errors', (errorDetails: IJSONObject) => {
       const callback = () => handleErrorAndThrow(errorDetails)
 

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -31,4 +31,15 @@ describe('Backoff', () => {
     expect(exponentialBackoffWithJitter(3)).toEqual(INITIAL_DELAY_MS * 4)
     expect(exponentialBackoffWithJitter(4)).toEqual(INITIAL_DELAY_MS * 8)
   })
+
+  it('EDGE CASE: base delay is 1 minute on 429', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    expect(
+      exponentialBackoffWithJitter(1, '', new Error('"status":429')),
+    ).toEqual(60000)
+    expect(
+      exponentialBackoffWithJitter(2, '', new Error('"status":429')),
+    ).toEqual(120000)
+  })
 })

--- a/packages/backend/src/helpers/actions.ts
+++ b/packages/backend/src/helpers/actions.ts
@@ -41,7 +41,7 @@ export async function doesActionProcessFiles(
 }
 
 const CONNECTIVITY_ERROR_SIGNS = ['ETIMEDOUT', 'ECONNRESET']
-const CONNECTIVITY_STATUS_CODE = [504]
+const CONNECTIVITY_STATUS_CODE = [504, 429]
 
 export function handleErrorAndThrow(errorDetails: IJSONObject): never {
   const errorVariable = get(errorDetails, 'details.error', '') as unknown

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -25,7 +25,7 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   // fix later.
   //
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const initialDelay_HACKFIX = err.message.includes('"status":429')
+  const initialDelay_HACKFIX = err?.message?.includes('"status":429')
     ? 60 * 1000
     : INITIAL_DELAY_MS
 

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -19,10 +19,13 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
   //
-  // Edge case for 429, telegram-only for now. We need to cooldown 1 minute.
+  // Edge case for 429.
+  //
+  // We need to cooldown 1 minute to support telegram 429. To provide proper
+  // fix later.
   //
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const initialDelay_HACKFIX = err.message.includes('"statusCode": 429')
+  const initialDelay_HACKFIX = err.message.includes('"status":429')
     ? 60 * 1000
     : INITIAL_DELAY_MS
 

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -5,7 +5,7 @@ export const INITIAL_DELAY_MS = 3000
 export const exponentialBackoffWithJitter: BackoffStrategy = function (
   attemptsMade: number,
   _type: string,
-  _err: Error,
+  err: Error,
   _job: Job,
 ): number {
   // This implements FullJitter-like jitter, with the following changes:
@@ -18,6 +18,14 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   // Reference:
   // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
-  const prevFullDelay = Math.pow(2, attemptsMade - 1) * INITIAL_DELAY_MS
+  //
+  // Edge case for 429, telegram-only for now. We need to cooldown 1 minute.
+  //
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const initialDelay_HACKFIX = err.message.includes('"statusCode": 429')
+    ? 60 * 1000
+    : INITIAL_DELAY_MS
+
+  const prevFullDelay = Math.pow(2, attemptsMade - 1) * initialDelay_HACKFIX
   return prevFullDelay + Math.round(Math.random() * prevFullDelay)
 }


### PR DESCRIPTION
## Problem
Telegram 429s are killing our pipes

## Solution
We will properly support 429 later on, but for now, hackfix by retrying using our default exponential backoff strategy.

## Tests
- Updated unit test.
- Check that 429 is retried.
- Regression test: check that successful pipes don't retry.