### PR TITLE
test/scheduler: Help improve test coverage starting with get-data-out-metadata

### DIFF
--- a/packages/backend/src/apps/scheduler/__tests__/triggers/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/triggers/get-data-out-metadata.test.ts
@@ -15,7 +15,7 @@ describe('Test getDataOutMetadata', () => {
     expect(testMetadata.pretty_date.label).toEqual('Date')
   })
 
-  it('pretty_date to convert to Date', async () => {
+  it('pretty_time to convert to Time', async () => {
     const testExecutionStep = {
       dataOut: {
         pretty_time: {},
@@ -25,7 +25,7 @@ describe('Test getDataOutMetadata', () => {
     expect(testMetadata.pretty_time.label).toEqual('Time')
   })
 
-  it('pretty_date to convert to Date', async () => {
+  it('ISO_date_time to convert to date and time', async () => {
     const testExecutionStep = {
       dataOut: {
         ISO_date_time: {},
@@ -35,7 +35,7 @@ describe('Test getDataOutMetadata', () => {
     expect(testMetadata.ISO_date_time.label).toEqual('Standard date and time')
   })
 
-  it('pretty_date to convert to Date', async () => {
+  it('pretty_day_of_week to convert to day of the week', async () => {
     const testExecutionStep = {
       dataOut: {
         pretty_day_of_week: {},

--- a/packages/backend/src/apps/scheduler/__tests__/triggers/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/triggers/get-data-out-metadata.test.ts
@@ -1,0 +1,57 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import getDataOutMetadata from '../../triggers/get-data-out-metadata'
+
+describe('Test getDataOutMetadata', () => {
+  it('pretty_date to convert to Date', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        pretty_date: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata.pretty_date.label).toEqual('Date')
+  })
+
+  it('pretty_date to convert to Date', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        pretty_time: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata.pretty_time.label).toEqual('Time')
+  })
+
+  it('pretty_date to convert to Date', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        ISO_date_time: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata.ISO_date_time.label).toEqual('Standard date and time')
+  })
+
+  it('pretty_date to convert to Date', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        pretty_day_of_week: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata.pretty_day_of_week.label).toEqual('Day of the week')
+  })
+
+  it('default keys to remain untouched', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        someDefaultKey: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata.someDefaultKey.label).toEqual('someDefaultKey')
+  })
+})

--- a/packages/backend/src/apps/scheduler/triggers/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/scheduler/triggers/get-data-out-metadata.ts
@@ -3,12 +3,12 @@ import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
-  const data = executionStep.dataOut
+  const { dataOut: data } = executionStep
   if (!data) {
     return null
   }
 
-  const metadata = Object.create(null)
+  const metadata: IDataOutMetadata = {}
   for (const key of Object.keys(data)) {
     // re-label "pretty" variables for scheduler
     switch (key) {


### PR DESCRIPTION
I'm writing some test cases to better familiarise myself with the Plumber codebase.

Based on the Vitest UI, this scheduler trigger function were one of the areas with lower test coverage, so I thought I'd start with this quick and simple file first.