### PR TITLE
PLU-70: [TILES-13] frontend: allow side scrolling

### DIFF
--- a/packages/backend/src/models/dynamodb/table-row.ts
+++ b/packages/backend/src/models/dynamodb/table-row.ts
@@ -150,6 +150,7 @@ export const getAllTableRows = async ({
 }): Promise<ITableRow[]> => {
   const rows = await TableRow.query('tableId')
     .eq(tableId)
+    // TODO: select only existing columns
     .attributes(['rowId', 'data'])
     // sort by createdAt ascending
     .using('createdAtIndex')

--- a/packages/frontend/src/components/Layout/index.tsx
+++ b/packages/frontend/src/components/Layout/index.tsx
@@ -75,7 +75,7 @@ export default function Layout({
           onClose={closeDrawer}
         />
 
-        <Box sx={{ flex: 1 }}>{children}</Box>
+        <Box sx={{ flex: 1, overflowX: 'hidden' }}>{children}</Box>
       </Box>
     </>
   )

--- a/packages/frontend/src/graphql/mutations/create-row.ts
+++ b/packages/frontend/src/graphql/mutations/create-row.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client'
+
+export const CREATE_ROW = gql`
+  mutation CreateRow($input: CreateTableRowInput!) {
+    createRow(input: $input)
+  }
+`

--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -20,6 +20,7 @@ import { useUpdateRow } from '../hooks/useUpdateRow'
 import { CellType, GenericRowData } from '../types'
 
 import TableFooter from './TableFooter'
+import TableRow from './TableRow'
 
 interface TableProps {
   tableId: string
@@ -42,7 +43,7 @@ export default function Table({
   // it's only used as a cache
   const tempRowData = useRef<GenericRowData | null>(null)
 
-  const isAddingNewRow = data[data.length - 1].rowId === NEW_ROW_ID
+  const isAddingNewRow = data[data.length - 1]?.rowId === NEW_ROW_ID
 
   const rowVirtualizer = useVirtualizer({
     count: isAddingNewRow ? data.length - 1 : data.length,
@@ -146,7 +147,7 @@ export default function Table({
   const virtualRows = rowVirtualizer.getVirtualItems()
 
   return (
-    <Box
+    <Flex
       borderRadius="lg"
       overflow="auto"
       w="100%"
@@ -155,8 +156,10 @@ export default function Table({
       ref={parentRef}
       h="calc(100vh - 210px)"
       minH="300px"
+      flexDir="column"
+      position="relative"
     >
-      <Box w="fit-content" minW="100%">
+      <Flex flexDir="column" w="fit-content" minW="100%" flex={1}>
         <Flex
           bgColor="primary.700"
           alignItems="stretch"
@@ -182,52 +185,25 @@ export default function Table({
           ))}
         </Flex>
 
-        <Box overflow="auto" position="relative" borderY="none">
-          <Box h={rowVirtualizer.getTotalSize()}>
-            {virtualRows.map((virtualRow) => {
-              const row = rows[virtualRow.index] as Row<GenericRowData>
-              return (
-                <Flex
-                  key={row.id}
-                  position="absolute"
-                  transform={`translateY(${virtualRow.start}px)`}
-                  alignItems="stretch"
-                  _even={{
-                    bg: 'primary.50',
-                  }}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <Flex key={cell.id} w={cell.column.getSize()} padding={0}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </Flex>
-                  ))}
-                </Flex>
-              )
-            })}
-          </Box>
+        <Box position="relative" borderY="none">
+          {rows.length ? (
+            <Box h={rowVirtualizer.getTotalSize()}>
+              {virtualRows.map((virtualRow) => {
+                const row = rows[virtualRow.index] as Row<GenericRowData>
+                return (
+                  <TableRow key={row.id} row={row} virtualRow={virtualRow} />
+                )
+              })}
+            </Box>
+          ) : (
+            <>{/* insert some call to action to add new row here */}</>
+          )}
           {isAddingNewRow && (
-            <Flex
-              w="100%"
-              position="sticky"
-              bottom={0}
-              alignItems="stretch"
-              bg="white"
-              borderTopWidth={1}
-              borderTopColor="primary.800"
-            >
-              {rows[rows.length - 1].getVisibleCells().map((cell) => (
-                <Flex key={cell.id} w={cell.column.getSize()} padding={0}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </Flex>
-              ))}
-            </Flex>
+            <TableRow row={rows[rows.length - 1]} stickyBottom />
           )}
         </Box>
-      </Box>
+      </Flex>
       <TableFooter table={table} parentRef={parentRef} />
-    </Box>
+    </Flex>
   )
 }

--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -146,81 +146,86 @@ export default function Table({
   const virtualRows = rowVirtualizer.getVirtualItems()
 
   return (
-    <Box borderRadius="lg" overflow="hidden">
-      {table.getHeaderGroups().map((headerGroup) => (
-        <Flex key={headerGroup.id}>
-          {headerGroup.headers.map((header) => (
-            <Flex
-              key={header.id}
-              paddingX={4}
-              paddingY={3}
-              flexGrow={1}
-              flexShrink={0}
-              bgColor="primary.700"
-              color="white"
-              fontWeight="bold"
-            >
-              {header.isPlaceholder
-                ? null
-                : flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-            </Flex>
-          ))}
-        </Flex>
-      ))}
-
-      <Box
-        ref={parentRef}
-        h="calc(100vh - 300px)"
-        minH="300px"
-        overflow="auto"
-        position="relative"
-        borderColor="primary.800"
-        borderWidth={1}
-        borderY="none"
-      >
-        <Box h={rowVirtualizer.getTotalSize()} w="100%">
-          {virtualRows.map((virtualRow) => {
-            const row = rows[virtualRow.index] as Row<GenericRowData>
-            return (
-              <Flex
-                key={row.id}
-                w="100%"
-                position="absolute"
-                transform={`translateY(${virtualRow.start}px)`}
-                alignItems="stretch"
-                _even={{
-                  bg: 'primary.50',
-                }}
+    <Box
+      borderRadius="lg"
+      overflowY="hidden"
+      w="100%"
+      borderColor="primary.800"
+      borderWidth={1}
+    >
+      <Box w="fit-content" minW="100%">
+        {table.getHeaderGroups().map((headerGroup) => (
+          <Flex key={headerGroup.id} bgColor="primary.700" alignItems="stretch">
+            {headerGroup.headers.map((header) => (
+              <Box
+                key={header.id}
+                p={0}
+                w={header.getSize()}
+                color="white"
+                fontWeight="bold"
               >
-                {row.getVisibleCells().map((cell) => (
-                  <Flex key={cell.id} w="100%" padding={0}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Flex>
-                ))}
-              </Flex>
-            )
-          })}
-        </Box>
-        {isAddingNewRow && (
-          <Flex
-            w="100%"
-            position="sticky"
-            bottom={0}
-            alignItems="stretch"
-            bg="white"
-            borderTopWidth={1}
-            borderTopColor="primary.800"
-          >
-            {rows[rows.length - 1].getVisibleCells().map((cell) => (
-              <Flex key={cell.id} w="100%" padding={0}>
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Flex>
+                {header.isPlaceholder
+                  ? null
+                  : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+              </Box>
             ))}
           </Flex>
-        )}
+        ))}
+
+        <Box
+          ref={parentRef}
+          h="calc(100vh - 300px)"
+          minH="300px"
+          overflow="auto"
+          position="relative"
+          borderY="none"
+        >
+          <Box h={rowVirtualizer.getTotalSize()}>
+            {virtualRows.map((virtualRow) => {
+              const row = rows[virtualRow.index] as Row<GenericRowData>
+              return (
+                <Flex
+                  key={row.id}
+                  position="absolute"
+                  transform={`translateY(${virtualRow.start}px)`}
+                  alignItems="stretch"
+                  _even={{
+                    bg: 'primary.50',
+                  }}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <Flex key={cell.id} w={cell.column.getSize()} padding={0}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </Flex>
+                  ))}
+                </Flex>
+              )
+            })}
+          </Box>
+          {isAddingNewRow && (
+            <Flex
+              w="100%"
+              position="sticky"
+              bottom={0}
+              alignItems="stretch"
+              bg="white"
+              borderTopWidth={1}
+              borderTopColor="primary.800"
+            >
+              {rows[rows.length - 1].getVisibleCells().map((cell) => (
+                <Flex key={cell.id} w="100%" padding={0}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </Flex>
+              ))}
+            </Flex>
+          )}
+        </Box>
       </Box>
       <TableFooter table={table} parentRef={parentRef} />
     </Box>

--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -148,41 +148,41 @@ export default function Table({
   return (
     <Box
       borderRadius="lg"
-      overflowY="hidden"
+      overflow="auto"
       w="100%"
       borderColor="primary.800"
       borderWidth={1}
+      ref={parentRef}
+      h="calc(100vh - 210px)"
+      minH="300px"
     >
       <Box w="fit-content" minW="100%">
-        {table.getHeaderGroups().map((headerGroup) => (
-          <Flex key={headerGroup.id} bgColor="primary.700" alignItems="stretch">
-            {headerGroup.headers.map((header) => (
-              <Box
-                key={header.id}
-                p={0}
-                w={header.getSize()}
-                color="white"
-                fontWeight="bold"
-              >
-                {header.isPlaceholder
-                  ? null
-                  : flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-              </Box>
-            ))}
-          </Flex>
-        ))}
-
-        <Box
-          ref={parentRef}
-          h="calc(100vh - 300px)"
-          minH="300px"
-          overflow="auto"
-          position="relative"
-          borderY="none"
+        <Flex
+          bgColor="primary.700"
+          alignItems="stretch"
+          position="sticky"
+          top={0}
+          zIndex={10}
         >
+          {table.getFlatHeaders().map((header) => (
+            <Box
+              key={header.id}
+              p={0}
+              w={header.getSize()}
+              color="white"
+              fontWeight="bold"
+            >
+              {header.isPlaceholder
+                ? null
+                : flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+            </Box>
+          ))}
+        </Flex>
+
+        <Box overflow="auto" position="relative" borderY="none">
           <Box h={rowVirtualizer.getTotalSize()}>
             {virtualRows.map((virtualRow) => {
               const row = rows[virtualRow.index] as Row<GenericRowData>
@@ -219,7 +219,7 @@ export default function Table({
               borderTopColor="primary.800"
             >
               {rows[rows.length - 1].getVisibleCells().map((cell) => (
-                <Flex key={cell.id} w="100%" padding={0}>
+                <Flex key={cell.id} w={cell.column.getSize()} padding={0}>
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </Flex>
               ))}

--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -10,7 +10,7 @@ import {
 } from '@tanstack/react-table'
 import { useVirtualizer } from '@tanstack/react-virtual'
 
-import { DELAY, NEW_ROW_ID } from '../constants'
+import { DELAY, NEW_ROW_ID, ROW_HEIGHT } from '../constants'
 import { createColumns } from '../helpers/columns-helper'
 import { flattenRows } from '../helpers/flatten-rows'
 import { scrollToBottom } from '../helpers/scroll-helper'
@@ -48,7 +48,10 @@ export default function Table({
     count: isAddingNewRow ? data.length - 1 : data.length,
     getScrollElement: () => parentRef.current,
     estimateSize: useCallback(
-      (index) => (index === editingCell?.row.index ? 132 : 50),
+      (index) =>
+        index === editingCell?.row.index
+          ? ROW_HEIGHT.EXPANDED
+          : ROW_HEIGHT.DEFAULT,
       [editingCell?.row.index],
     ),
     overscan: 35,

--- a/packages/frontend/src/pages/Tile/components/TableCell.module.css
+++ b/packages/frontend/src/pages/Tile/components/TableCell.module.css
@@ -7,6 +7,10 @@
   animation: completeSaving 1s linear;
 }
 
+.cell:hover {
+  background-color: var(--chakra-colors-primary-200);
+}
+
 @keyframes completeSaving {
   0% {
     background-color: #ffeac0;

--- a/packages/frontend/src/pages/Tile/components/TableCell.module.css
+++ b/packages/frontend/src/pages/Tile/components/TableCell.module.css
@@ -1,5 +1,5 @@
 .saving {
-  background-color: #efce8b;
+  background-color: #ffeac0;
 }
 
 .saved {
@@ -9,13 +9,13 @@
 
 @keyframes completeSaving {
   0% {
-    background-color: #efce8b;
+    background-color: #ffeac0;
   }
   20% {
-    background-color: #98ef8b;
+    background-color: #9af5ab;
   }
   60% {
-    background-color: #98ef8b;
+    background-color: #9af5ab;
   }
   100% {
     background-color: transparent;

--- a/packages/frontend/src/pages/Tile/components/TableCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableCell.tsx
@@ -5,11 +5,14 @@ import {
   MouseEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
 } from 'react'
 import { Box, Flex, Textarea } from '@chakra-ui/react'
 import { CellContext } from '@tanstack/react-table'
 
+import { NEW_ROW_ID, TEMP_ROW_ID_PREFIX } from '../constants'
+import { shallowCompare } from '../helpers/shallow-compare'
 import { CellType, GenericRowData } from '../types'
 
 import styles from './TableCell.module.css'
@@ -28,8 +31,6 @@ export default function TableCell({
 
   const originalValue = getValue()
   const columnIds = table.getAllLeafColumns().map((c) => c.id)
-
-  const isSavingRow = tableMeta?.rowsUpdating[row.id]
 
   const startEditing = useCallback(
     (
@@ -61,6 +62,17 @@ export default function TableCell({
     (e: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault()
+        if (row.id === NEW_ROW_ID) {
+          if (
+            !shallowCompare(tableMeta?.tempRowData.current, {
+              rowId: NEW_ROW_ID,
+            })
+          ) {
+            tableMeta?.setActiveCell(null)
+            tableMeta?.focusOnNewRow()
+          }
+          return
+        }
         const nextRowId = table.getSortedRowModel().rows[row.index + 1]?.id
         const nextActiveCell = getCell(nextRowId, column.id)
         tableMeta?.setActiveCell(nextActiveCell)
@@ -77,6 +89,10 @@ export default function TableCell({
         const nextColumnId = columnIds[nextColumnIndex]
         const nextActiveCell = getCell(row.id, nextColumnId)
         tableMeta?.setActiveCell(nextActiveCell)
+      }
+
+      if (e.key === 'Escape') {
+        tableMeta?.setActiveCell(null)
       }
     },
     [table, row, getCell, column.id, tableMeta, columnIds],
@@ -97,19 +113,40 @@ export default function TableCell({
     }
   }, [isEditingCell])
 
+  const className = useMemo(() => {
+    const isSavingRow = tableMeta?.rowsUpdating[row.id]
+    const isSavedRow = tableMeta?.rowsCreated.has(row.id)
+    if (isSavingRow === true) {
+      return styles.saving
+    }
+    if (isSavingRow === false) {
+      return styles.saved
+    }
+    if (row.id.startsWith(TEMP_ROW_ID_PREFIX)) {
+      return styles.saving
+    }
+    if (isSavedRow) {
+      return styles.saved
+    }
+    return undefined
+  }, [row.id, tableMeta?.rowsCreated, tableMeta?.rowsUpdating])
+
   return (
     <Box
       h="100%"
+      minH="50px"
       w="100%"
       alignItems="center"
       onClick={startEditing}
       cursor="default"
       borderWidth="0.5px"
       borderStyle="solid"
-      borderColor={isEditingCell ? 'primary.600' : 'primary.50'}
+      borderColor={isEditingCell ? 'primary.600' : 'primary.100'}
       _hover={{
         bg: isEditingRow ? 'transparent' : 'gray.50',
       }}
+      position={row.id === 'new-row' ? 'sticky' : undefined}
+      bottom={row.id === 'new-row' ? 0 : undefined}
     >
       {isEditingRow ? (
         <Textarea
@@ -125,28 +162,23 @@ export default function TableCell({
             bgColor: 'primary.100',
           }}
           rows={5}
-          minH="100%"
-          h="100%"
+          resize="none"
+          h="130px"
           onKeyDown={onKeyDown}
           borderRadius={0}
           borderWidth={0}
         />
       ) : (
         <Flex
-          h="100%"
+          h="48px"
           w="100%"
           minWidth="100%"
           maxW={0}
-          alignItems="center"
+          alignItems="flex-start"
           px={4}
           wordBreak="break-word"
-          className={
-            isSavingRow === true
-              ? styles.saving
-              : isSavingRow === false
-              ? styles.saved
-              : undefined
-          }
+          className={className}
+          overflow="hidden"
         >
           {originalValue}
         </Flex>

--- a/packages/frontend/src/pages/Tile/components/TableCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableCell.tsx
@@ -8,10 +8,10 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import { Box, Flex, Textarea } from '@chakra-ui/react'
+import { Box, Flex, Text, Textarea } from '@chakra-ui/react'
 import { CellContext } from '@tanstack/react-table'
 
-import { NEW_ROW_ID, TEMP_ROW_ID_PREFIX } from '../constants'
+import { NEW_ROW_ID, ROW_HEIGHT, TEMP_ROW_ID_PREFIX } from '../constants'
 import { shallowCompare } from '../helpers/shallow-compare'
 import { CellType, GenericRowData } from '../types'
 
@@ -133,8 +133,8 @@ export default function TableCell({
 
   return (
     <Box
-      h="100%"
-      minH="50px"
+      h={isEditingRow ? ROW_HEIGHT.EXPANDED : ROW_HEIGHT.DEFAULT}
+      minH={ROW_HEIGHT.DEFAULT}
       w="100%"
       alignItems="center"
       onClick={startEditing}
@@ -157,30 +157,30 @@ export default function TableCell({
           zIndex={isEditingCell ? 1 : 0}
           defaultValue={originalValue}
           onChange={onChange}
+          h="100%"
           _focusWithin={{
             boxShadow: 'none',
             bgColor: 'primary.100',
           }}
           rows={5}
           resize="none"
-          h="130px"
           onKeyDown={onKeyDown}
           borderRadius={0}
           borderWidth={0}
         />
       ) : (
         <Flex
-          h="48px"
+          h="100%"
           w="100%"
           minWidth="100%"
           maxW={0}
-          alignItems="flex-start"
+          alignItems="center"
           px={4}
           wordBreak="break-word"
           className={className}
           overflow="hidden"
         >
-          {originalValue}
+          <Text maxH="100%">{originalValue}</Text>
         </Flex>
       )}
     </Box>

--- a/packages/frontend/src/pages/Tile/components/TableCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableCell.tsx
@@ -8,7 +8,7 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import { Box, Flex, Text, Textarea } from '@chakra-ui/react'
+import { Textarea } from '@chakra-ui/react'
 import { CellContext } from '@tanstack/react-table'
 
 import { NEW_ROW_ID, ROW_HEIGHT, TEMP_ROW_ID_PREFIX } from '../constants'
@@ -74,7 +74,7 @@ export default function TableCell({
           return
         }
         const nextRowId = table.getSortedRowModel().rows[row.index + 1]?.id
-        const nextActiveCell = getCell(nextRowId, column.id)
+        const nextActiveCell = nextRowId ? getCell(nextRowId, column.id) : null
         tableMeta?.setActiveCell(nextActiveCell)
       }
       // on tab
@@ -132,21 +132,20 @@ export default function TableCell({
   }, [row.id, tableMeta?.rowsCreated, tableMeta?.rowsUpdating])
 
   return (
-    <Box
-      h={isEditingRow ? ROW_HEIGHT.EXPANDED : ROW_HEIGHT.DEFAULT}
-      minH={ROW_HEIGHT.DEFAULT}
-      w="100%"
-      alignItems="center"
-      onClick={startEditing}
-      cursor="default"
-      borderWidth="0.5px"
-      borderStyle="solid"
-      borderColor={isEditingCell ? 'primary.600' : 'primary.100'}
-      _hover={{
-        bg: isEditingRow ? 'transparent' : 'gray.50',
+    <div
+      style={{
+        height: isEditingRow ? ROW_HEIGHT.EXPANDED : ROW_HEIGHT.DEFAULT,
+        minHeight: ROW_HEIGHT.DEFAULT,
+        width: '100%',
+        cursor: 'default',
+        borderWidth: '0.5px',
+        borderStyle: 'solid',
+        borderColor: isEditingCell
+          ? 'var(--chakra-colors-primary-600)'
+          : 'var(--chakra-colors-primary-100)',
       }}
-      position={row.id === 'new-row' ? 'sticky' : undefined}
-      bottom={row.id === 'new-row' ? 0 : undefined}
+      className={!isEditingCell ? styles.cell : undefined}
+      onClick={startEditing}
     >
       {isEditingRow ? (
         <Textarea
@@ -169,20 +168,30 @@ export default function TableCell({
           borderWidth={0}
         />
       ) : (
-        <Flex
-          h="100%"
-          w="100%"
-          minWidth="100%"
-          maxW={0}
-          alignItems="center"
-          px={4}
-          wordBreak="break-word"
+        <div
+          style={{
+            display: 'flex',
+            height: '100%',
+            width: '100%',
+            minWidth: '100%',
+            maxWidth: 0,
+            alignItems: 'center',
+            paddingLeft: '1rem',
+            paddingRight: '1rem',
+            wordBreak: 'break-word',
+            overflow: 'hidden',
+          }}
           className={className}
-          overflow="hidden"
         >
-          <Text maxH="100%">{originalValue}</Text>
-        </Flex>
+          <p
+            style={{
+              maxHeight: '100%',
+            }}
+          >
+            {originalValue}
+          </p>
+        </div>
       )}
-    </Box>
+    </div>
   )
 }

--- a/packages/frontend/src/pages/Tile/components/TableFooter.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter.tsx
@@ -21,7 +21,9 @@ export default function TableFooter({ table, parentRef }: TableFooterProps) {
   return (
     <Flex
       w="100%"
+      bg="white"
       position="sticky"
+      bottom={0}
       left={0}
       justifyContent="space-between"
       borderColor="primary.800"

--- a/packages/frontend/src/pages/Tile/components/TableFooter.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter.tsx
@@ -21,10 +21,11 @@ export default function TableFooter({ table, parentRef }: TableFooterProps) {
   return (
     <Flex
       w="100%"
+      position="sticky"
+      left={0}
       justifyContent="space-between"
       borderColor="primary.800"
-      borderWidth={1}
-      borderBottomRadius="lg"
+      borderTopWidth={1}
     >
       <Flex>
         <Button

--- a/packages/frontend/src/pages/Tile/components/TableFooter.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter.tsx
@@ -1,0 +1,55 @@
+import { useCallback } from 'react'
+import { BsPlus } from 'react-icons/bs'
+import { Flex, Kbd } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+import { Table } from '@tanstack/react-table'
+
+import { scrollToBottom, scrollToTop } from '../helpers/scroll-helper'
+import { GenericRowData } from '../types'
+
+interface TableFooterProps {
+  table: Table<GenericRowData>
+  parentRef: React.RefObject<HTMLDivElement>
+}
+
+export default function TableFooter({ table, parentRef }: TableFooterProps) {
+  const onAddNewRow = useCallback(() => {
+    table.options.meta?.addNewRow()
+    table.options.meta?.focusOnNewRow()
+  }, [table])
+
+  return (
+    <Flex
+      w="100%"
+      justifyContent="space-between"
+      borderColor="primary.800"
+      borderWidth={1}
+      borderBottomRadius="lg"
+    >
+      <Flex>
+        <Button
+          variant="clear"
+          size="sm"
+          onClick={() => scrollToTop(parentRef)}
+        >
+          Scroll to Top <Kbd bg="white">home</Kbd>
+        </Button>
+        <Button
+          variant="clear"
+          size="sm"
+          onClick={() => scrollToBottom(parentRef)}
+        >
+          Scroll to bottom <Kbd bg="white">end</Kbd>
+        </Button>
+      </Flex>
+      <Button
+        variant="clear"
+        size="sm"
+        leftIcon={<BsPlus />}
+        onClick={onAddNewRow}
+      >
+        Add New Row
+      </Button>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/pages/Tile/components/TableFooter.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter.tsx
@@ -4,6 +4,7 @@ import { Flex, Kbd } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 import { Table } from '@tanstack/react-table'
 
+import { ROW_HEIGHT } from '../constants'
 import { scrollToBottom, scrollToTop } from '../helpers/scroll-helper'
 import { GenericRowData } from '../types'
 
@@ -25,21 +26,25 @@ export default function TableFooter({ table, parentRef }: TableFooterProps) {
       position="sticky"
       bottom={0}
       left={0}
+      maxH={ROW_HEIGHT.FOOTER}
       justifyContent="space-between"
       borderColor="primary.800"
+      boxSizing="content-box"
       borderTopWidth={1}
     >
       <Flex>
         <Button
           variant="clear"
-          size="sm"
+          size="xs"
+          h="100%"
           onClick={() => scrollToTop(parentRef)}
         >
           Scroll to Top <Kbd bg="white">home</Kbd>
         </Button>
         <Button
           variant="clear"
-          size="sm"
+          size="xs"
+          h="100%"
           onClick={() => scrollToBottom(parentRef)}
         >
           Scroll to bottom <Kbd bg="white">end</Kbd>
@@ -47,11 +52,12 @@ export default function TableFooter({ table, parentRef }: TableFooterProps) {
       </Flex>
       <Button
         variant="clear"
-        size="sm"
+        size="xs"
+        h="100%"
         leftIcon={<BsPlus />}
         onClick={onAddNewRow}
       >
-        Add New Row
+        Add new row
       </Button>
     </Flex>
   )

--- a/packages/frontend/src/pages/Tile/components/TableRow.module.css
+++ b/packages/frontend/src/pages/Tile/components/TableRow.module.css
@@ -1,0 +1,3 @@
+.row:nth-child(even) {
+  background-color: var(--chakra-colors-primary-50);
+}

--- a/packages/frontend/src/pages/Tile/components/TableRow.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableRow.tsx
@@ -1,0 +1,55 @@
+import { flexRender, Row } from '@tanstack/react-table'
+import { VirtualItem } from '@tanstack/react-virtual'
+
+import { ROW_HEIGHT } from '../constants'
+import { GenericRowData } from '../types'
+
+import styles from './TableRow.module.css'
+
+interface TableRowProps {
+  row: Row<GenericRowData>
+  virtualRow?: VirtualItem
+  stickyBottom?: boolean
+}
+
+export default function TableRow({
+  row,
+  stickyBottom,
+  virtualRow,
+}: TableRowProps) {
+  return (
+    <div
+      style={
+        stickyBottom
+          ? {
+              width: '100%',
+              position: 'sticky',
+              bottom: ROW_HEIGHT.FOOTER,
+              display: 'flex',
+              alignItems: 'stretch',
+              backgroundColor: 'white',
+              borderTop: '1px solid var(--chakra-colors-primary-800)',
+            }
+          : {
+              position: 'absolute',
+              transform: `translateY(${virtualRow?.start}px)`,
+              display: 'flex',
+              alignItems: 'stretch',
+            }
+      }
+      className={styles.row}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <div
+          key={cell.column.id}
+          style={{
+            width: cell.column.getSize(),
+            padding: 0,
+          }}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/Tile/constants.ts
+++ b/packages/frontend/src/pages/Tile/constants.ts
@@ -7,3 +7,9 @@ export const DELAY = {
   FOCUS_CELL: 0,
   SCROLL: 1,
 }
+
+// Fixed height need for virtualized list
+export const ROW_HEIGHT = {
+  DEFAULT: 50,
+  EXPANDED: 132,
+}

--- a/packages/frontend/src/pages/Tile/constants.ts
+++ b/packages/frontend/src/pages/Tile/constants.ts
@@ -1,0 +1,9 @@
+export const NEW_ROW_ID = 'new-row'
+export const TEMP_ROW_ID_PREFIX = 'temp-'
+
+// Used in setTimeout delay, to allow for the browser to render
+// This determines the order in which the functions are executed
+export const DELAY = {
+  FOCUS_CELL: 0,
+  SCROLL: 1,
+}

--- a/packages/frontend/src/pages/Tile/constants.ts
+++ b/packages/frontend/src/pages/Tile/constants.ts
@@ -12,4 +12,5 @@ export const DELAY = {
 export const ROW_HEIGHT = {
   DEFAULT: 50,
   EXPANDED: 132,
+  FOOTER: 40,
 }

--- a/packages/frontend/src/pages/Tile/helpers/columns-helper.tsx
+++ b/packages/frontend/src/pages/Tile/helpers/columns-helper.tsx
@@ -1,5 +1,6 @@
 import { ITableColumnMetadata } from '@plumber/types'
 
+import { Box } from '@chakra-ui/react'
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table'
 
 import TableCell from '../components/TableCell'

--- a/packages/frontend/src/pages/Tile/helpers/columns-helper.tsx
+++ b/packages/frontend/src/pages/Tile/helpers/columns-helper.tsx
@@ -13,8 +13,13 @@ export function createColumns(
   return columns.map(({ id, name }) =>
     columnHelper.accessor(id, {
       id,
-      header: () => <span>{name}</span>,
+      header: () => (
+        <Box py={2} px={4}>
+          {name}
+        </Box>
+      ),
       cell: TableCell,
+      minSize: 200,
     }),
   )
 }

--- a/packages/frontend/src/pages/Tile/helpers/scroll-helper.tsx
+++ b/packages/frontend/src/pages/Tile/helpers/scroll-helper.tsx
@@ -1,0 +1,28 @@
+import { RefObject } from 'react'
+
+import { DELAY } from '../constants'
+
+export function scrollToBottom(parentRef: RefObject<HTMLDivElement>) {
+  setTimeout(() => {
+    parentRef.current?.scrollTo({
+      top: parentRef.current.scrollHeight,
+      behavior:
+        parentRef.current.scrollHeight - parentRef.current.scrollTop <
+        parentRef.current.clientHeight * 10
+          ? 'smooth'
+          : 'auto',
+    })
+  }, DELAY.SCROLL)
+}
+
+export function scrollToTop(parentRef: RefObject<HTMLDivElement>) {
+  setTimeout(() => {
+    parentRef.current?.scrollTo({
+      top: 0,
+      behavior:
+        parentRef.current.scrollTop < parentRef.current.clientHeight * 10
+          ? 'smooth'
+          : 'auto',
+    })
+  }, DELAY.SCROLL)
+}

--- a/packages/frontend/src/pages/Tile/hooks/useCreateRow.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useCreateRow.tsx
@@ -51,7 +51,6 @@ export function useCreateRow(
         } else {
           oldData.push(newTempRow)
         }
-        console.log(oldData.slice(-5))
         return [...oldData]
       })
       const { data: mutationData } = await createRowMutation({

--- a/packages/frontend/src/pages/Tile/hooks/useCreateRow.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useCreateRow.tsx
@@ -1,0 +1,82 @@
+import { Dispatch, SetStateAction, useCallback, useState } from 'react'
+import { useMutation } from '@apollo/client'
+import { CREATE_ROW } from 'graphql/mutations/create-row'
+
+import { NEW_ROW_ID, TEMP_ROW_ID_PREFIX } from '../constants'
+import { GenericRowData } from '../types'
+
+interface CreateRowInput {
+  input: {
+    tableId: string
+    data: Record<string, string>
+  }
+}
+
+interface CreateRowOutput {
+  createRow: string
+}
+
+export function useCreateRow(
+  tableId: string,
+  setData: Dispatch<SetStateAction<GenericRowData[]>>,
+) {
+  const [rowsCreated, setRowsCreated] = useState<Set<string>>(new Set())
+
+  const [createRowMutation] = useMutation<CreateRowOutput, CreateRowInput>(
+    CREATE_ROW,
+    {
+      onCompleted({ createRow: createdRowId }) {
+        setRowsCreated((prev) => new Set(prev.add(createdRowId)))
+        setTimeout(() => {
+          setRowsCreated((prev) => {
+            prev.delete(createdRowId)
+            return new Set(prev)
+          })
+        }, 1000)
+      },
+    },
+  )
+
+  const createRow = useCallback(
+    async (newRow: GenericRowData) => {
+      const { rowId: _, ...data } = newRow
+      const tempRowId = TEMP_ROW_ID_PREFIX + crypto.randomUUID()
+      setData((oldData) => {
+        const newTempRow = {
+          ...data,
+          rowId: tempRowId,
+        }
+        if (oldData[oldData.length - 1].rowId === NEW_ROW_ID) {
+          oldData.splice(-1, 0, newTempRow)
+        } else {
+          oldData.push(newTempRow)
+        }
+        console.log(oldData.slice(-5))
+        return [...oldData]
+      })
+      const { data: mutationData } = await createRowMutation({
+        variables: {
+          input: {
+            tableId,
+            data,
+          },
+        },
+      })
+      if (mutationData?.createRow) {
+        setData((oldData) => {
+          const rowIndex = oldData.findIndex((row) => row.rowId === tempRowId)
+          oldData[rowIndex] = {
+            ...oldData[rowIndex],
+            rowId: mutationData.createRow,
+          }
+          return [...oldData]
+        })
+      }
+    },
+    [createRowMutation, setData, tableId],
+  )
+  return {
+    rowsCreated,
+    createRow,
+  }
+}

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -3,7 +3,6 @@ import { ITableMetadata, ITableRow } from '@plumber/types'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Center, Flex, Spinner, Text } from '@chakra-ui/react'
-import Container from 'components/Container'
 import { GET_ALL_ROWS } from 'graphql/queries/get-all-rows'
 import { GET_TABLE } from 'graphql/queries/get-table'
 
@@ -47,16 +46,15 @@ export default function Tile(): JSX.Element {
   const { getAllRows: rows } = getAllRowsData
 
   return (
-    <Container py={7}>
-      <Flex
-        flexDir={{ base: 'column' }}
-        justifyContent="space-between"
-        alignItems="stretch"
-        gap={4}
-      >
-        <Text textStyle="h4">{name}</Text>
-        <Table tableId={id} tableColumns={columns} tableRows={rows} />
-      </Flex>
-    </Container>
+    <Flex
+      flexDir={{ base: 'column' }}
+      justifyContent="space-between"
+      alignItems="stretch"
+      gap={4}
+      p={8}
+    >
+      <Text textStyle="h4">{name}</Text>
+      <Table tableId={id} tableColumns={columns} tableRows={rows} />
+    </Flex>
   )
 }

--- a/packages/frontend/src/pages/Tile/types.ts
+++ b/packages/frontend/src/pages/Tile/types.ts
@@ -7,7 +7,11 @@ declare module '@tanstack/react-table' {
     activeCell: CellType | null
     setActiveCell: (newCell: CellType | null) => void
     rowsUpdating: Record<string, boolean>
+    rowsCreated: Set<string>
     tempRowData: MutableRefObject<GenericRowData | null>
+    addNewRow: () => void
+    isAddingNewRow: boolean
+    focusOnNewRow: () => void
   }
 }
 


### PR DESCRIPTION
## Styling changes to allow for side-scrolling

Right now, the widths of each column are equal, and it will be too narrow for more than 4/5 columns. So side-scrolling is required for that and to allow adjustable widths.

**How to test**
1. in `column-helper.tsx`, set the minSize to a larger number like 700. 
2. Refresh page and scroll sideways 
3. Check adding new rows work with the new scroll


https://github.com/opengovsg/plumber/assets/10072985/3ed6df9d-dcd4-45ce-a065-3d45c336b246

