### PR TITLE
fix: optimise query to fetch latest execution

### DIFF
--- a/packages/backend/src/db/migrations/20231103080044_add-execution-step-index.ts
+++ b/packages/backend/src/db/migrations/20231103080044_add-execution-step-index.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  // Add index for step_id in execution_steps table
+  await knex.schema.table('execution_steps', (table) => {
+    table.index('step_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('execution_steps', (table) => {
+    table.dropIndex('step_id')
+  })
+}

--- a/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
+++ b/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
@@ -42,6 +42,7 @@ const getStepWithTestExecutions = async (
           'step_id',
           previousSteps.map((step) => step.id),
         )
+        .andWhere('status', '=', 'success')
     })
     .select('*')
     .from('latest_execution_steps')
@@ -50,11 +51,11 @@ const getStepWithTestExecutions = async (
 
   previousSteps.map((previousStep) => {
     previousStep.executionSteps = []
-    const latestExecustionStep = latestExecutionSteps.find(
+    const latestExecutionStep = latestExecutionSteps.find(
       (latestExecutionStep) => latestExecutionStep.stepId === previousStep.id,
     )
-    if (latestExecustionStep) {
-      previousStep.executionSteps.push(latestExecustionStep)
+    if (latestExecutionStep) {
+      previousStep.executionSteps.push(latestExecutionStep)
     }
   })
 

--- a/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
+++ b/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
@@ -1,6 +1,7 @@
-import { ref } from 'objection'
+import { raw } from 'objection'
 
 import ExecutionStep from '@/models/execution-step'
+import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 type Params = {
@@ -17,23 +18,45 @@ const getStepWithTestExecutions = async (
     .findOne({ 'steps.id': params.stepId })
     .throwIfNotFound()
 
-  const previousStepsWithCurrentStep = await context.currentUser
-    .$relatedQuery('steps')
-    .withGraphJoined('executionSteps')
+  const previousSteps = await Step.query()
+    .select('*')
     .where('flow_id', '=', step.flowId)
-    .andWhere('position', '<', step.position)
-    .andWhere(
-      'executionSteps.created_at',
-      '=',
-      ExecutionStep.query()
-        .max('created_at')
-        .where('step_id', '=', ref('steps.id'))
-        .andWhere('status', 'success'),
-    )
-    .andWhere('executionSteps.app_key', '=', ref('steps.app_key'))
-    .orderBy('steps.position', 'asc')
+    .where('position', '<', step.position)
+    .orderBy('position', 'asc')
 
-  return previousStepsWithCurrentStep
+  if (previousSteps.length === 0) {
+    return []
+  }
+
+  const latestExecutionSteps = await ExecutionStep.query()
+    .with('latest_execution_steps', (builder) => {
+      builder
+        .select(
+          '*',
+          raw(
+            'ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY created_at DESC) as rn',
+          ),
+        )
+        .from('execution_steps')
+        .whereIn('step_id', [...previousSteps.map((step) => step.id), step.id])
+    })
+    .select('*')
+    .from('latest_execution_steps')
+    .where('rn', '=', 1)
+    .withSoftDeleted()
+    .debug()
+
+  previousSteps.map((previousStep) => {
+    previousStep.executionSteps = []
+    const latestExecustionStep = latestExecutionSteps.find(
+      (latestExecutionStep) => latestExecutionStep.stepId === previousStep.id,
+    )
+    if (latestExecustionStep) {
+      previousStep.executionSteps.push(latestExecustionStep)
+    }
+  })
+
+  return previousSteps
 }
 
 export default getStepWithTestExecutions

--- a/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
+++ b/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
@@ -38,7 +38,10 @@ const getStepWithTestExecutions = async (
           ),
         )
         .from('execution_steps')
-        .whereIn('step_id', [...previousSteps.map((step) => step.id), step.id])
+        .whereIn(
+          'step_id',
+          previousSteps.map((step) => step.id),
+        )
     })
     .select('*')
     .from('latest_execution_steps')

--- a/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
+++ b/packages/backend/src/graphql/queries/get-step-with-test-executions.ts
@@ -44,7 +44,6 @@ const getStepWithTestExecutions = async (
     .from('latest_execution_steps')
     .where('rn', '=', 1)
     .withSoftDeleted()
-    .debug()
 
   previousSteps.map((previousStep) => {
     previousStep.executionSteps = []


### PR DESCRIPTION
Migrations already run on staging and prod

For your approval, @ogp-weeloong 