### PR TITLE
chore: upgrade axios to to address CSRF issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12054,6 +12054,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "dev": true,
@@ -15039,7 +15044,7 @@
         "@opengovsg/sgid-client": "2.1.0",
         "@plumber/types": "file:../types",
         "ajv-formats": "^2.1.1",
-        "axios": "0.24.0",
+        "axios": "^1.6.0",
         "bullmq": "^3.0.0",
         "cookie-parser": "1.4.6",
         "copyfiles": "^2.4.1",
@@ -15100,6 +15105,16 @@
         "ts-node": "^10.9.1",
         "tsc-alias": "^1.8.6",
         "tsconfig-paths": "^4.2.0"
+      }
+    },
+    "packages/backend/node_modules/axios": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/backend/node_modules/form-data": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,7 @@
     "@opengovsg/sgid-client": "2.1.0",
     "@plumber/types": "file:../types",
     "ajv-formats": "^2.1.1",
-    "axios": "0.24.0",
+    "axios": "^1.6.0",
     "bullmq": "^3.0.0",
     "cookie-parser": "1.4.6",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
## Problem

Addresses failing Snyk upgrade in #295 

## Solution

Upgrade `axios` from `0.24.0` to `^1.6.0`.

TODO: address compilation errors

