### PR TITLE
chore(datadog): add datadog RUM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,6 +2807,36 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@datadog/browser-core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.2.0.tgz",
+      "integrity": "sha512-/4kgRCaSJQoOFJpIx7H+ope3bpBaS55rZzoLwXNwjQyZW5wBH1wzs4JZdIexbogNLfvj6BqiAEZ+oCDbQf1a/Q=="
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.2.0.tgz",
+      "integrity": "sha512-IsRPyGeYxpejZuM8y6Xd8dLi2A7elq0WSSsc/an8neIm+tKqITfBiAHT65BiamTKO0mfyXdwg9mlmvtRyxAjsw==",
+      "dependencies": {
+        "@datadog/browser-core": "5.2.0",
+        "@datadog/browser-rum-core": "5.2.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "5.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.2.0.tgz",
+      "integrity": "sha512-+ItifrOLste8p5VskkmAQu2l3209Qhq3gjOR9BVmECD5hptLBSIxsac8KQnWckKtjBvCQL62hcSSlDGEcd6/Jw==",
+      "dependencies": {
+        "@datadog/browser-core": "5.2.0"
+      }
+    },
     "node_modules/@datadog/native-appsec": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@datadog/native-appsec/-/native-appsec-4.0.0.tgz",
@@ -15124,6 +15154,7 @@
       "dependencies": {
         "@apollo/client": "3.8.7",
         "@chakra-ui/react": "2.6.1",
+        "@datadog/browser-rum": "^5.2.0",
         "@emotion/react": "11.10.5",
         "@emotion/styled": "11.10.5",
         "@fontsource/space-grotesk": "4.5.13",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@apollo/client": "3.8.7",
     "@chakra-ui/react": "2.6.1",
+    "@datadog/browser-rum": "^5.2.0",
     "@emotion/react": "11.10.5",
     "@emotion/styled": "11.10.5",
     "@fontsource/space-grotesk": "4.5.13",

--- a/packages/frontend/src/contexts/Authentication.tsx
+++ b/packages/frontend/src/contexts/Authentication.tsx
@@ -1,8 +1,9 @@
 import { IUser } from '@plumber/types'
 
-import { createContext } from 'react'
-import { type FetchResult, useMutation, useQuery } from '@apollo/client'
+import { createContext, useEffect } from 'react'
+import { FetchResult, useMutation, useQuery } from '@apollo/client'
 import { Center, Spinner } from '@chakra-ui/react'
+import { datadogRum } from '@datadog/browser-rum'
 import { LOGOUT } from 'graphql/mutations/logout'
 import { GET_CURRENT_USER } from 'graphql/queries/get-current-user'
 
@@ -29,11 +30,16 @@ export const AuthenticationProvider = ({
   }>(GET_CURRENT_USER, {
     fetchPolicy: 'no-cache',
   })
-
+  const currentUser = data?.getCurrentUser
   const [logout] = useMutation(LOGOUT, {
     refetchQueries: [GET_CURRENT_USER],
     awaitRefetchQueries: true,
   })
+  useEffect(() => {
+    if (currentUser) {
+      datadogRum.setUser(currentUser)
+    }
+  }, [currentUser])
 
   if (fetchingCurrentUser) {
     return (
@@ -46,7 +52,7 @@ export const AuthenticationProvider = ({
   return (
     <AuthenticationContext.Provider
       value={{
-        currentUser: data?.getCurrentUser ?? null,
+        currentUser: currentUser ?? null,
         logout,
       }}
     >

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -2,11 +2,13 @@ import '@fontsource/space-grotesk'
 
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
+import { datadogRum } from '@datadog/browser-rum'
 import ApolloProvider from 'components/ApolloProvider'
 import IntlProvider from 'components/IntlProvider'
 import router from 'components/Router'
 import SnackbarProvider from 'components/SnackbarProvider'
 import ThemeProvider from 'components/ThemeProvider'
+import appConfig from 'config/app'
 import { AuthenticationProvider } from 'contexts/Authentication'
 import { LaunchDarklyProvider } from 'contexts/LaunchDarkly'
 
@@ -18,6 +20,21 @@ if (!container) {
 
 const root = createRoot(container)
 
+if (['prod', 'staging'].includes(appConfig.env)) {
+  datadogRum.init({
+    applicationId: '3bd09f62-dad8-4107-a907-1242dda9ee4d',
+    clientToken: 'pubdc3dfc4ab0145729ebc91a19e9fae167',
+    site: 'datadoghq.com',
+    service: 'plumber',
+    env: appConfig.env,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 100,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: 'mask-user-input',
+  })
+}
 root.render(
   <SnackbarProvider>
     <ThemeProvider>


### PR DESCRIPTION
## Problem

We don't know where users usually drop off when trying to create their first pipe

## Solution

Implement datadog RUM UX monitoring

**Note**: Right now we're recording 100% of the sessions as our user base is still small enough, which might change in the future. We will monitor cost

## Tests

- [x] Check in datadog if these monitors show up

## Deploy Notes

N/A