### PR TITLE
PLU-146: Add error catching and tests for Delay app

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-for.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-for.test.ts
@@ -1,0 +1,66 @@
+import { type IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import delayForAction from '../actions/delay-for'
+import delayApp from '../index'
+
+const DELAY_UNIT = 'minutes'
+const DELAY_VALUE = 1
+const INVALID_DELAY_VALUE = 'x'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('Delay for action', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      flow: {
+        id: '123',
+      },
+      step: {
+        id: '456',
+        appKey: delayApp.name,
+        key: delayForAction.key,
+        position: 2,
+        parameters: {},
+      },
+      app: {
+        name: delayApp.name,
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns void if delay for has a valid configuration of unit and value', async () => {
+    $.step.parameters = {
+      delayForUnit: DELAY_UNIT,
+      delayForValue: DELAY_VALUE,
+    }
+
+    const result = await delayForAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayForUnit: DELAY_UNIT, delayForValue: DELAY_VALUE },
+    })
+  })
+
+  it('throws step error if delay for has an invalid configuration', async () => {
+    $.step.parameters = {
+      delayForUnit: DELAY_UNIT,
+      delayForValue: INVALID_DELAY_VALUE,
+    }
+
+    // throw partial step error message
+    await expect(delayForAction.run($)).rejects.toThrowError(
+      'Invalid delay for value entered',
+    )
+  })
+})

--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -1,0 +1,79 @@
+import { type IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import delayUntilAction from '../actions/delay-until'
+import delayApp from '../index'
+
+const VALID_DATE = '2023-11-08'
+const VALID_TIME = '12:00'
+const DEFAULT_TIME = '00:00'
+const INVALID_TIME = '25:00'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('Delay until action', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      flow: {
+        id: '123',
+      },
+      step: {
+        id: '456',
+        appKey: delayApp.name,
+        key: delayUntilAction.key,
+        position: 2,
+        parameters: {},
+      },
+      app: {
+        name: delayApp.name,
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns void if delay until has a valid configuration of only the date', async () => {
+    $.step.parameters = {
+      delayUntil: VALID_DATE,
+    }
+
+    const result = await delayUntilAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayUntil: VALID_DATE, delayUntilTime: DEFAULT_TIME },
+    })
+  })
+
+  it('returns void if delay until has a valid configuration of both date and time', async () => {
+    $.step.parameters = {
+      delayUntil: VALID_DATE,
+      delayUntilTime: VALID_TIME,
+    }
+
+    const result = await delayUntilAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayUntil: VALID_DATE, delayUntilTime: VALID_TIME },
+    })
+  })
+
+  it('throws step error if delay until has an invalid configuration', async () => {
+    $.step.parameters = {
+      delayUntil: VALID_DATE,
+      delayUntilTime: INVALID_TIME,
+    }
+
+    // throw partial step error message
+    await expect(delayUntilAction.run($)).rejects.toThrowError(
+      'Invalid timestamp entered',
+    )
+  })
+})

--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -65,6 +65,20 @@ describe('Delay until action', () => {
     })
   })
 
+  it('returns void if delay until has a valid configuration of both date and time but with whitespaces', async () => {
+    const whitespaces = '   '
+    $.step.parameters = {
+      delayUntil: whitespaces + VALID_DATE,
+      delayUntilTime: VALID_TIME + whitespaces,
+    }
+
+    const result = await delayUntilAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayUntil: VALID_DATE, delayUntilTime: VALID_TIME },
+    })
+  })
+
   it('throws step error if delay until has an invalid configuration', async () => {
     $.step.parameters = {
       delayUntil: VALID_DATE,

--- a/packages/backend/src/apps/delay/__tests__/generate-timestamp.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/generate-timestamp.test.ts
@@ -103,6 +103,12 @@ describe('delay until date and time handler', () => {
       expect(generateTimestamp(date, time)).toBeTruthy()
     })
 
+    it('[Valid]: Long date format for SG (with time)', () => {
+      const date = '05 Sept 2023'
+      const time = VALID_TIME
+      expect(generateTimestamp(date, time)).toBeTruthy()
+    })
+
     it('[Invalid]: Wrong day format', () => {
       const date = '32 Sep 2023'
       const time = DEFAULT_TIME

--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -49,12 +49,9 @@ const action: IRawAction = {
     const { delayForUnit, delayForValue } = $.step.parameters
 
     if (isNaN(Number(delayForValue))) {
-      const stepErrorName = 'Invalid delay for value entered'
-      const stepErrorSolution =
-        'Click on set up action and check that the value is a valid number.'
       throw generateStepError(
-        stepErrorName,
-        stepErrorSolution,
+        'Invalid delay for value entered',
+        'Click on set up action and check that the value is a valid number.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -1,5 +1,7 @@
 import { IRawAction } from '@plumber/types'
 
+import { generateStepError } from '@/helpers/generate-step-error'
+
 const action: IRawAction = {
   name: 'Delay For',
   key: 'delayFor',
@@ -47,8 +49,14 @@ const action: IRawAction = {
     const { delayForUnit, delayForValue } = $.step.parameters
 
     if (isNaN(Number(delayForValue))) {
-      throw new Error(
-        'Invalid delay for value entered, please check that you keyed in a number',
+      const stepErrorName = 'Invalid delay for value entered'
+      const stepErrorSolution =
+        'Click on set up action and check that the value is a valid number.'
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -32,10 +32,10 @@ const action: IRawAction = {
     const defaultTime = '00:00'
     // trim the date and time for user
     const { delayUntil, delayUntilTime } = $.step.parameters
-    const delayUntilString = (delayUntil as string).trim()
+    const delayUntilString = new String(delayUntil).trim()
     // catch empty string (user input), null, undefined (backwards compat)
     const delayUntilTimeString = delayUntilTime
-      ? (delayUntilTime as string).trim()
+      ? new String(delayUntilTime).trim()
       : defaultTime
 
     const delayTimestamp = generateTimestamp(

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -39,7 +39,7 @@ const action: IRawAction = {
     if (isNaN(delayTimestamp)) {
       const stepErrorName = 'Invalid timestamp entered'
       const stepErrorSolution =
-        'Click on set up action and check for the validity of the format of the date or time entered.'
+        'Click on set up action and check that the date or time entered is of a valid format.'
       throw generateStepError(
         stepErrorName,
         stepErrorSolution,

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -31,30 +31,30 @@ const action: IRawAction = {
   async run($) {
     const defaultTime = '00:00'
     // trim the date and time for user
-    let { delayUntil, delayUntilTime } = $.step.parameters
-    delayUntil = (delayUntil as string).trim()
+    const { delayUntil, delayUntilTime } = $.step.parameters
+    const delayUntilString = (delayUntil as string).trim()
     // catch empty string (user input), null, undefined (backwards compat)
-    delayUntilTime = delayUntilTime
+    const delayUntilTimeString = delayUntilTime
       ? (delayUntilTime as string).trim()
       : defaultTime
 
-    const delayTimestamp = generateTimestamp(delayUntil, delayUntilTime)
+    const delayTimestamp = generateTimestamp(
+      delayUntilString,
+      delayUntilTimeString,
+    )
 
     if (isNaN(delayTimestamp)) {
-      const stepErrorName = 'Invalid timestamp entered'
-      const stepErrorSolution =
-        'Click on set up action and check that the date or time entered is of a valid format.'
       throw generateStepError(
-        stepErrorName,
-        stepErrorSolution,
+        'Invalid timestamp entered',
+        'Click on set up action and check that the date or time entered is of a valid format.',
         $.step.position,
         $.app.name,
       )
     }
 
     const dataItem = {
-      delayUntil,
-      delayUntilTime,
+      delayUntil: delayUntilString,
+      delayUntilTime: delayUntilTimeString,
     }
 
     $.setActionItem({ raw: dataItem })

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -30,11 +30,15 @@ const action: IRawAction = {
 
   async run($) {
     const defaultTime = '00:00'
-    const { delayUntil, delayUntilTime } = $.step.parameters
-    const delayTimestamp = generateTimestamp(
-      delayUntil as string,
-      (delayUntilTime as string) || defaultTime, // catch empty string (user input), null, undefined (backwards compat)
-    )
+    // trim the date and time for user
+    let { delayUntil, delayUntilTime } = $.step.parameters
+    delayUntil = (delayUntil as string).trim()
+    // catch empty string (user input), null, undefined (backwards compat)
+    delayUntilTime = delayUntilTime
+      ? (delayUntilTime as string).trim()
+      : defaultTime
+
+    const delayTimestamp = generateTimestamp(delayUntil, delayUntilTime)
 
     if (isNaN(delayTimestamp)) {
       const stepErrorName = 'Invalid timestamp entered'
@@ -50,7 +54,7 @@ const action: IRawAction = {
 
     const dataItem = {
       delayUntil,
-      delayUntilTime: delayUntilTime || defaultTime,
+      delayUntilTime,
     }
 
     $.setActionItem({ raw: dataItem })

--- a/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
+++ b/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
@@ -11,7 +11,9 @@ export default function generateTimestamp(date: string, time: string): number {
   // check through our accepted formats
   for (const datetimeFormat of VALID_DATETIME_FORMATS) {
     // check both en-SG and en-US because Sept accepted for SG but Sep accepted for US
-    let datetime = DateTime.fromFormat(datetimeString, datetimeFormat)
+    let datetime = DateTime.fromFormat(datetimeString, datetimeFormat, {
+      locale: 'en-SG',
+    })
     if (datetime.isValid) {
       return datetime.toMillis()
     }


### PR DESCRIPTION
## Problem

Errors are not properly caught as StepError in the Delay app. 

## Solution

- Caught input errors in Delay app
  - Delay for invalid configuration
  - Delay until invalid configuration
- Added backend tests to improve test coverage

**Test Coverage**:
Before:
![image](https://github.com/opengovsg/plumber/assets/65110268/d65bf5b4-db14-48b3-97d8-f7e6e5b3b5f8)

After:
![image](https://github.com/opengovsg/plumber/assets/65110268/df330692-2a5a-48db-a260-988b2e81955e)


## Tests
- Valid configuration for Delay for action works
- Valid configuration for Delay until action works
- Invalid configuration for Delay for action throws `StepError`
- Invalid configuration for Delay until action throws `StepError`