### PR TITLE
PLU-153: Add fix for pagination issue for flows

### DIFF
--- a/packages/frontend/src/locales/en.json
+++ b/packages/frontend/src/locales/en.json
@@ -33,8 +33,6 @@
   "flowEditor.actionEvent": "Action event",
   "flow.view": "View",
   "flow.delete": "Delete",
-  "flows.create": "Create pipe",
-  "flows.noFlows": "You don't have any pipes yet.",
   "flowEditor.goBack": "Go back to pipes",
   "executions.noExecutions": "There is no execution data point to show.",
   "execution.noDataTitle": "No data",

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -130,7 +130,7 @@ export default function Flows(): React.ReactElement {
             page={pageInfo?.currentPage}
             count={pageInfo?.totalPages}
             onChange={(_event, page) =>
-              setSearchParams({ page: page.toString() })
+              setSearchParams(page === 1 ? {} : { page: page.toString() })
             }
           />
         )}

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -10,7 +10,6 @@ import CircularProgress from '@mui/material/CircularProgress'
 import Divider from '@mui/material/Divider'
 import Grid from '@mui/material/Grid'
 import Pagination from '@mui/material/Pagination'
-import PaginationItem from '@mui/material/PaginationItem'
 import ConditionalIconButton from 'components/ConditionalIconButton'
 import Container from 'components/Container'
 import FlowRow from 'components/FlowRow'
@@ -66,12 +65,18 @@ export default function Flows(): React.ReactElement {
     [fetchData, flowName],
   )
 
+  // setSearchParams is "unstable": updates whenever searchParams change
+  const setSearchParamsRef = React.useRef(setSearchParams)
+  const stableSetSearchParams = React.useCallback(
+    (...args: Parameters<typeof setSearchParams>) =>
+      setSearchParamsRef.current(...args),
+    [],
+  )
+
   React.useEffect(
-    function resetPageOnSearch() {
-      // reset search params which only consists of `page`
-      setSearchParams({})
-    },
-    [flowName, setSearchParams],
+    // reset search params which only consists of `page`
+    () => stableSetSearchParams({}),
+    [flowName, stableSetSearchParams],
   )
 
   React.useEffect(
@@ -165,15 +170,8 @@ export default function Flows(): React.ReactElement {
             page={pageInfo?.currentPage}
             count={pageInfo?.totalPages}
             onChange={(event, page) =>
-              setSearchParams({ page: page.toString() })
+              stableSetSearchParams({ page: page.toString() })
             }
-            renderItem={(item) => (
-              <PaginationItem
-                component={Link}
-                to={`${item.page === 1 ? '' : `?page=${item.page}`}`}
-                {...item}
-              />
-            )}
           />
         )}
       </Container>


### PR DESCRIPTION
## Problem

Pagination does not work for flows because of extra dependency: `setSearchParams`. Basically, when `setSearchParams` is used as dependency, every time `searchParams` change, it gets re-created, causing the resetting of search params to occur whenever the page is changed (because the search params is changed)

## Solution

Made the `setSearchParams` function stable by using `useRef`. Not sure if this is the best approach but this is a typical solution to this common issue: https://github.com/remix-run/react-router/issues/9991

Easier hack fix:
- Disable linting right above the dependency: `// eslint-disable-next-line react-hooks/exhaustive-deps`

## Tests
- Changing page works
- Changing page with search input works
- Changing search input resets the page back to the first page
