### PR TITLE
PLU-143: Add error handling for vault workspace app

### DIFF
--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/create-row.test.ts
@@ -48,8 +48,9 @@ describe('create row', () => {
   it('errors if columns and values have different lengths', async () => {
     $.step.parameters.columns = 'column_1, column_2'
     $.step.parameters.values = 'value_1'
+    // throw partial step error message
     await expect(createRowAction.run($)).rejects.toThrowError(
-      'The number of columns and values must be equal.',
+      'Unequal number of columns and values',
     )
   })
 
@@ -110,6 +111,42 @@ describe('create row', () => {
         column_1: 'value_1',
         column_2: 'asas""value "with" quotes""',
       })
+    })
+
+    it('should throw step error for invalid usage of double quotes', async () => {
+      $.step.parameters.columns = 'column_1, "column"2"'
+      $.step.parameters.values = 'value_1, value_2'
+      // throw partial step error message
+      await expect(createRowAction.run($)).rejects.toThrowError(
+        'Invalid usage of double quotes',
+      )
+    })
+
+    it('should throw step error for no closing quotes', async () => {
+      $.step.parameters.columns = 'column_1, "column_2'
+      $.step.parameters.values = 'value_1, value_2'
+      // throw partial step error message
+      await expect(createRowAction.run($)).rejects.toThrowError(
+        'No closing quote',
+      )
+    })
+
+    it('should throw step error for newline characters in values field', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = 'value_1\n, value_2'
+      // throw partial step error message
+      await expect(createRowAction.run($)).rejects.toThrowError(
+        'Incorrect format for values field',
+      )
+    })
+
+    it('should throw step error for undefined values field', async () => {
+      $.step.parameters.columns = 'column_1, column_2'
+      $.step.parameters.values = undefined
+      // throw partial step error message
+      await expect(createRowAction.run($)).rejects.toThrowError(
+        'Undefined values field',
+      )
     })
   })
 })

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/get-data-out-metadata.test.ts
@@ -1,0 +1,65 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import getDataOutMetadata from '../../actions/get-table-data/get-data-out-metadata'
+import { VAULT_ID } from '../../common/constants'
+
+function convertKeyToHex(key: string) {
+  return Buffer.from(key).toString('hex')
+}
+
+describe('Test getDataOutMetadata', () => {
+  it('vault metadata example that has not dataOut (should not occur)', async () => {
+    const testExecutionStep = {
+      empty: '',
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata).toBeNull()
+  })
+
+  it('vault metadata example that is not keysEncoded (should not occur)', async () => {
+    const testExecutionStep = {
+      dataOut: {
+        _metadata: {},
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    expect(testMetadata).toBeNull()
+  })
+
+  it('vault metadata example that is keysEncoded', async () => {
+    const testLabel1 = 'test label 1'
+    const testLabel2 = 'test label 2'
+    const testLabel1InHex = convertKeyToHex(testLabel1)
+    const testLabel2InHex = convertKeyToHex(testLabel2)
+    const testExecutionStep = {
+      dataOut: {
+        [VAULT_ID]: '123',
+        [testLabel1InHex]: 'test value 1',
+        [testLabel2InHex]: 'test value 2',
+        _metadata: {
+          success: true,
+          rowsFound: 2,
+          keysEncoded: true,
+        },
+      },
+    } as unknown as IExecutionStep
+    const testMetadata = await getDataOutMetadata(testExecutionStep)
+    const outputMetadata = {
+      [testLabel1InHex]: {
+        label: testLabel1,
+      },
+      [testLabel2InHex]: {
+        label: testLabel2,
+      },
+      _metadata: {
+        label: '',
+      },
+      '_metadata.keysEncoded': {
+        isHidden: true,
+      },
+    }
+    expect(testMetadata).toEqual(outputMetadata)
+  })
+})

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/get-data-out-metadata.test.ts
@@ -10,7 +10,7 @@ function convertKeyToHex(key: string) {
 }
 
 describe('Test getDataOutMetadata', () => {
-  it('vault metadata example that has not dataOut (should not occur)', async () => {
+  it('vault metadata example that has no dataOut should not occur', async () => {
     const testExecutionStep = {
       empty: '',
     } as unknown as IExecutionStep
@@ -18,7 +18,7 @@ describe('Test getDataOutMetadata', () => {
     expect(testMetadata).toBeNull()
   })
 
-  it('vault metadata example that is not keysEncoded (should not occur)', async () => {
+  it('vault metadata example that is not keysEncoded should not occur', async () => {
     const testExecutionStep = {
       dataOut: {
         _metadata: {},

--- a/packages/backend/src/apps/vault-workspace/__tests__/actions/get-table-row.test.ts
+++ b/packages/backend/src/apps/vault-workspace/__tests__/actions/get-table-row.test.ts
@@ -1,0 +1,170 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { AxiosError } from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
+
+import app from '../..'
+import getTableDataAction from '../../actions/get-table-data'
+import { VAULT_ID } from '../../common/constants'
+
+const VAULT_COLUMN_INTERNAL_ID = 'abcxyz'
+const VAULT_COLUMN_NAME = 'column 1'
+const VAULT_COLUMN_VALUE = 'value 1'
+
+const mocks = vi.hoisted(() => ({
+  httpGet: vi.fn(),
+  getColumnMapping: vi.fn(),
+}))
+
+vi.mock('../../common/get-column-mapping', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../common/get-column-mapping')
+  >('../../common/get-column-mapping')
+  return {
+    ...actual,
+    getColumnMapping: mocks.getColumnMapping,
+  }
+})
+
+describe('get table row', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      auth: {
+        set: vi.fn(),
+        data: {},
+      },
+      step: {
+        id: '123',
+        appKey: 'vault-workspace',
+        position: 2,
+        parameters: {},
+      },
+      http: {
+        get: mocks.httpGet,
+      } as unknown as IGlobalVariable['http'],
+      setActionItem: vi.fn(),
+      app,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('get row if row found', async () => {
+    $.step.parameters.lookupColumn = VAULT_COLUMN_NAME
+    $.step.parameters.lookupValue = VAULT_COLUMN_VALUE
+    const mockHttpResponse = {
+      data: {
+        rows: [
+          {
+            [VAULT_COLUMN_INTERNAL_ID]: VAULT_COLUMN_VALUE,
+            [VAULT_ID]: '123',
+          },
+        ],
+      },
+    }
+    mocks.httpGet.mockResolvedValueOnce(mockHttpResponse)
+
+    mocks.getColumnMapping.mockImplementationOnce((_$) => {
+      return {
+        [VAULT_COLUMN_INTERNAL_ID]: VAULT_COLUMN_NAME,
+      }
+    })
+
+    await getTableDataAction.run($)
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        [Buffer.from(VAULT_COLUMN_NAME).toString('hex')]: VAULT_COLUMN_VALUE, // convert key to hex
+        _metadata: {
+          success: true,
+          rowsFound: 1,
+          keysEncoded: true,
+        },
+        [VAULT_ID]: '123',
+      },
+    })
+  })
+
+  it('should throw step error for invalid get request: bad request error', async () => {
+    $.step.parameters.lookupColumn = VAULT_COLUMN_NAME
+    $.step.parameters.lookupValue = VAULT_COLUMN_VALUE
+    const error400 = {
+      response: {
+        status: 400,
+        statusText: 'Bad request',
+      },
+    } as AxiosError
+    const httpError = new HttpError(error400)
+
+    mocks.httpGet.mockRejectedValueOnce(httpError)
+    // throw partial step error message
+    await expect(getTableDataAction.run($)).rejects.toThrowError(
+      'Status code: 400',
+    )
+  })
+
+  it('should throw step error for invalid get request: internal status error', async () => {
+    $.step.parameters.lookupColumn = VAULT_COLUMN_NAME
+    $.step.parameters.lookupValue = VAULT_COLUMN_VALUE
+    const error500 = {
+      response: {
+        status: 500,
+        statusText: 'Internal Status Error',
+      },
+    } as AxiosError
+    const httpError = new HttpError(error500)
+
+    mocks.httpGet.mockRejectedValueOnce(httpError)
+    // throw partial step error message
+    await expect(getTableDataAction.run($)).rejects.toThrowError(
+      'Status code: 500',
+    )
+  })
+
+  it('return success as false if no rows found', async () => {
+    $.step.parameters.lookupColumn = VAULT_COLUMN_NAME
+    $.step.parameters.lookupValue = 'invalid value'
+    const mockHttpResponse = {
+      data: {
+        rows: [] as any[],
+      },
+    }
+    mocks.httpGet.mockResolvedValueOnce(mockHttpResponse)
+    await getTableDataAction.run($)
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        _metadata: {
+          success: false,
+          rowsFound: 0,
+        },
+      },
+    })
+  })
+
+  it('should throw step error for undefined column bug', async () => {
+    $.step.parameters.lookupColumn = VAULT_COLUMN_NAME
+    $.step.parameters.lookupValue = VAULT_COLUMN_VALUE
+    // getColumnMapping will have no columns at all, so default mock implementation is used
+    const mockHttpResponse = {
+      data: {
+        rows: [
+          {
+            [VAULT_COLUMN_INTERNAL_ID]: VAULT_COLUMN_VALUE,
+            [VAULT_ID]: '123',
+          },
+        ],
+      },
+    }
+    mocks.httpGet.mockResolvedValueOnce(mockHttpResponse)
+
+    // throw partial step error message
+    await expect(getTableDataAction.run($)).rejects.toThrowError(
+      'Undefined column name in Vault',
+    )
+  })
+})

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -9,6 +9,7 @@ import {
   escapeSpecialChars,
   unescapeSpecialChars,
 } from '../../common/escape-characters'
+import { throwParseAsCsvError } from '../../common/throw-errors'
 
 const action: IRawAction = {
   name: 'Create row',
@@ -59,30 +60,7 @@ const action: IRawAction = {
         relaxQuotes: true,
       })[0] as string[]
     } catch (err) {
-      // only three possible errors caught in DB
-      let stepErrorName, stepErrorSolution
-      if (err.code === 'CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE') {
-        stepErrorName = 'Invalid usage of double quotes'
-        stepErrorSolution =
-          'Click on set up action and check that double quotes should only be used if column or value contains commas. Use single quotes instead if necessary.'
-      } else if (err.code === 'CSV_QUOTE_NOT_CLOSED') {
-        stepErrorName = 'No closing quote'
-        stepErrorSolution =
-          'Click on set up action and check if an opening quote is used for a column or value, a closing quote is paired with it.'
-      } else if (err.code === 'CSV_RECORD_INCONSISTENT_FIELDS_LENGTH') {
-        stepErrorName = 'Incorrect format for values field'
-        stepErrorSolution =
-          'Click on set up action and check that the values field has no newline. Separate each value with a comma on the same line.'
-      } else {
-        // return original error since uncaught
-        throw err
-      }
-      throw generateStepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throwParseAsCsvError(err, $.step.position, $.app.name)
     }
 
     if (values === undefined) {

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -2,6 +2,8 @@ import { IRawAction } from '@plumber/types'
 
 import { parse as parseAsCsv } from 'csv-parse/sync'
 
+import { generateStepError } from '@/helpers/generate-step-error'
+
 import createTableRow from '../../common/create-table-row'
 import {
   escapeSpecialChars,
@@ -20,7 +22,7 @@ const action: IRawAction = {
       required: true,
       variables: false,
       description:
-        'Put a comma between each column. Enclose columns with double-quotes (") if it contains commas. Columns CANNOT contain double quotes.',
+        'Put a comma between each column. Enclose columns with double-quotes (") if it contains commas. Columns can contain double quotes, but use single quotes if problems arise.',
     },
     {
       label: 'Values',
@@ -43,20 +45,68 @@ const action: IRawAction = {
   },
 
   async run($) {
-    const columns = parseAsCsv($.step.parameters.columns as string, {
-      columns: false,
-      trim: true,
-      relaxQuotes: true,
-    })[0] as string[]
+    let columns, values
+    try {
+      columns = parseAsCsv($.step.parameters.columns as string, {
+        columns: false,
+        trim: true,
+        relaxQuotes: true,
+      })[0] as string[]
 
-    const values = parseAsCsv($.step.parameters.values as string as string, {
-      columns: false,
-      trim: true,
-      relaxQuotes: true,
-    })[0] as string[]
+      values = parseAsCsv($.step.parameters.values as string as string, {
+        columns: false,
+        trim: true,
+        relaxQuotes: true,
+      })[0] as string[]
+    } catch (err) {
+      // only three possible errors caught in DB
+      let stepErrorName, stepErrorSolution
+      if (err.code === 'CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE') {
+        stepErrorName = 'Invalid usage of double quotes'
+        stepErrorSolution =
+          'Click on set up action and check that double quotes should only be used if column or value contains commas. Use single quotes instead if necessary.'
+      } else if (err.code === 'CSV_QUOTE_NOT_CLOSED') {
+        stepErrorName = 'No closing quote'
+        stepErrorSolution =
+          'Click on set up action and check if an opening quote is used for a column or value, a closing quote is paired with it.'
+      } else if (err.code === 'CSV_RECORD_INCONSISTENT_FIELDS_LENGTH') {
+        stepErrorName = 'Incorrect format for values field'
+        stepErrorSolution =
+          'Click on set up action and check that the values field has no newline. Separate each value with a comma on the same line.'
+      } else {
+        // return original error since uncaught
+        throw err
+      }
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    if (values === undefined) {
+      const stepErrorName = 'Undefined values field'
+      const stepErrorSolution =
+        'Click on set up action and check that the values field is not empty. This is most likely because you are using a single variable that could be empty.'
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    }
 
     if (columns.length !== values.length) {
-      throw new Error('The number of columns and values must be equal.')
+      const stepErrorName = 'Unequal number of columns and values'
+      const stepErrorSolution =
+        'Click on set up action and check that every column or value is separated by a comma when intended. Then, verify that the number of columns and values are exactly equal in quantity.'
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
     }
 
     const row: { [key: string]: string } = {}

--- a/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
+++ b/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
@@ -1,12 +1,10 @@
 import { IGlobalVariable } from '@plumber/types'
 
-import {
-  generateHttpStepError,
-  generateStepError,
-} from '@/helpers/generate-step-error'
+import { generateStepError } from '@/helpers/generate-step-error'
 
 import { VAULT_ID } from './constants'
 import { getColumnMapping } from './get-column-mapping'
+import { throwGetFilteredRowsError } from './throw-errors'
 
 const filterTableRows = async (
   $: IGlobalVariable,
@@ -26,25 +24,7 @@ const filterTableRows = async (
       },
     })
     .catch((err): never => {
-      let stepErrorSolution
-      if (err.response.status === 400) {
-        // note this catches two different errors: when user doesn't select a column and when user deletes column on vault
-        stepErrorSolution =
-          'Click on set up action and check that the lookup column is not empty and is present on your vault table. The column could have been accidentally deleted on your vault table, please re-create the column or select another valid lookup column.'
-      } else if (err.response.status === 500) {
-        // invalid lookup column used
-        stepErrorSolution =
-          'Click on set up action and ensure that you have selected a valid column instead.'
-      } else {
-        // return original error since uncaught
-        throw err
-      }
-      throw generateHttpStepError(
-        err,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throwGetFilteredRowsError(err, $.step.position, $.app.name)
     })
 
   if (response.data.rows.length < 1) {

--- a/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
+++ b/packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts
@@ -1,5 +1,10 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import {
+  generateHttpStepError,
+  generateStepError,
+} from '@/helpers/generate-step-error'
+
 import { VAULT_ID } from './constants'
 import { getColumnMapping } from './get-column-mapping'
 
@@ -8,17 +13,39 @@ const filterTableRows = async (
   columnName: string,
   value: string,
 ): Promise<{ [key: string]: any }> => {
-  const response = await $.http.get('/api/tables', {
-    data: {
-      filter: [
-        {
-          columnName,
-          type: 'EQ',
-          value,
-        },
-      ],
-    },
-  })
+  const response = await $.http
+    .get('/api/tables', {
+      data: {
+        filter: [
+          {
+            columnName,
+            type: 'EQ',
+            value,
+          },
+        ],
+      },
+    })
+    .catch((err): never => {
+      let stepErrorSolution
+      if (err.response.status === 400) {
+        // note this catches two different errors: when user doesn't select a column and when user deletes column on vault
+        stepErrorSolution =
+          'Click on set up action and check that the lookup column is not empty and is present on your vault table. The column could have been accidentally deleted on your vault table, please re-create the column or select another valid lookup column.'
+      } else if (err.response.status === 500) {
+        // invalid lookup column used
+        stepErrorSolution =
+          'Click on set up action and ensure that you have selected a valid column instead.'
+      } else {
+        // return original error since uncaught
+        throw err
+      }
+      throw generateHttpStepError(
+        err,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    })
 
   if (response.data.rows.length < 1) {
     return {
@@ -34,16 +61,32 @@ const filterTableRows = async (
   // to replace column name with alias
   const mapping = await getColumnMapping($)
   const row: { [key: string]: string } = {}
-  for (const name in rawData) {
-    if (name === VAULT_ID) {
-      row[name] = rawData[name]
-    } else {
-      // keys are converted to hex here to satisfy our requirement for template
-      // keys to be alphanumeric, and will be decoded by getDataOutMetadata before
-      // displayed on frontend
-      const key = Buffer.from(mapping[name]).toString('hex')
-      row[key] = rawData[name]
+
+  try {
+    for (const name in rawData) {
+      if (name === VAULT_ID) {
+        row[name] = rawData[name]
+      } else {
+        // keys are converted to hex here to satisfy our requirement for template
+        // keys to be alphanumeric, and will be decoded by getDataOutMetadata before
+        // displayed on frontend
+        const key = Buffer.from(mapping[name]).toString('hex')
+        row[key] = rawData[name]
+      }
     }
+  } catch (err) {
+    if (err instanceof TypeError) {
+      const stepErrorName = 'Undefined column name in Vault'
+      const stepErrorSolution =
+        'Your vault table has an undefined column due to a bug. Please create a new vault table to be used.'
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    }
+    throw err
   }
 
   return {

--- a/packages/backend/src/apps/vault-workspace/common/get-column-mapping.ts
+++ b/packages/backend/src/apps/vault-workspace/common/get-column-mapping.ts
@@ -1,7 +1,6 @@
 import { IGlobalVariable } from '@plumber/types'
 
-import HttpError from '@/errors/http'
-import { generateHttpStepError } from '@/helpers/generate-step-error'
+import { throwGetColumnMappingError } from './throw-errors'
 
 const getColumnMappingInAlias = async (
   $: IGlobalVariable,
@@ -15,21 +14,8 @@ const getColumnMapping = async (
 ): Promise<{ [key: string]: string }> => {
   const response = await $.http
     .get('/api/tables/column-mapping')
-    .catch((err: HttpError): never => {
-      let stepErrorSolution
-      if (err.response.status === 403) {
-        stepErrorSolution =
-          'Click on choose connection and ensure that your vault table is still connected. If not, please copy the new api key generated on vault and re-establish the connection on Plumber.'
-      } else {
-        // return original error since uncaught
-        throw err
-      }
-      throw generateHttpStepError(
-        err,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+    .catch((err): never => {
+      throwGetColumnMappingError(err, $.step.position, $.app.name)
     })
   return response.data
 }

--- a/packages/backend/src/apps/vault-workspace/common/get-column-mapping.ts
+++ b/packages/backend/src/apps/vault-workspace/common/get-column-mapping.ts
@@ -1,5 +1,8 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import HttpError from '@/errors/http'
+import { generateHttpStepError } from '@/helpers/generate-step-error'
+
 const getColumnMappingInAlias = async (
   $: IGlobalVariable,
 ): Promise<{ [key: string]: string }> => {
@@ -10,7 +13,24 @@ const getColumnMappingInAlias = async (
 const getColumnMapping = async (
   $: IGlobalVariable,
 ): Promise<{ [key: string]: string }> => {
-  const response = await $.http.get('/api/tables/column-mapping')
+  const response = await $.http
+    .get('/api/tables/column-mapping')
+    .catch((err: HttpError): never => {
+      let stepErrorSolution
+      if (err.response.status === 403) {
+        stepErrorSolution =
+          'Click on choose connection and ensure that your vault table is still connected. If not, please copy the new api key generated on vault and re-establish the connection on Plumber.'
+      } else {
+        // return original error since uncaught
+        throw err
+      }
+      throw generateHttpStepError(
+        err,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    })
   return response.data
 }
 

--- a/packages/backend/src/apps/vault-workspace/common/throw-errors.ts
+++ b/packages/backend/src/apps/vault-workspace/common/throw-errors.ts
@@ -1,0 +1,70 @@
+import { CsvError } from 'csv-parse/.'
+
+import HttpError from '@/errors/http'
+import {
+  generateHttpStepError,
+  generateStepError,
+} from '@/helpers/generate-step-error'
+
+export function throwParseAsCsvError(
+  err: CsvError,
+  position: number,
+  appName: string,
+): never {
+  // only three possible errors caught in DB
+  let stepErrorName, stepErrorSolution
+  if (err.code === 'CSV_NON_TRIMABLE_CHAR_AFTER_CLOSING_QUOTE') {
+    stepErrorName = 'Invalid usage of double quotes'
+    stepErrorSolution =
+      'Click on set up action and check that double quotes should only be used if column or value contains commas. Use single quotes instead if necessary.'
+  } else if (err.code === 'CSV_QUOTE_NOT_CLOSED') {
+    stepErrorName = 'No closing quote'
+    stepErrorSolution =
+      'Click on set up action and check if an opening quote is used for a column or value, a closing quote is paired with it.'
+  } else if (err.code === 'CSV_RECORD_INCONSISTENT_FIELDS_LENGTH') {
+    stepErrorName = 'Incorrect format for values field'
+    stepErrorSolution =
+      'Click on set up action and check that the values field has no newline. Separate each value with a comma on the same line.'
+  } else {
+    // return original error since uncaught
+    throw err
+  }
+  throw generateStepError(stepErrorName, stepErrorSolution, position, appName)
+}
+
+export function throwGetFilteredRowsError(
+  err: HttpError,
+  position: number,
+  appName: string,
+): never {
+  let stepErrorSolution
+  if (err.response.status === 400) {
+    // note this catches two different errors: when user doesn't select a column and when user deletes column on vault
+    stepErrorSolution =
+      'Click on set up action and check that the lookup column is not empty and is present on your vault table. The column could have been accidentally deleted on your vault table, please re-create the column or select another valid lookup column.'
+  } else if (err.response.status === 500) {
+    // invalid lookup column used
+    stepErrorSolution =
+      'Click on set up action and ensure that you have selected a valid column instead.'
+  } else {
+    // return original error since uncaught
+    throw err
+  }
+  throw generateHttpStepError(err, stepErrorSolution, position, appName)
+}
+
+export function throwGetColumnMappingError(
+  err: HttpError,
+  position: number,
+  appName: string,
+): never {
+  let stepErrorSolution
+  if (err.response.status === 403) {
+    stepErrorSolution =
+      'Click on choose connection and ensure that your vault table is still connected. If not, please copy the new api key generated on vault and re-establish the connection on Plumber.'
+  } else {
+    // return original error since uncaught
+    throw err
+  }
+  throw generateHttpStepError(err, stepErrorSolution, position, appName)
+}


### PR DESCRIPTION
## Problem

Errors are not properly caught as StepError in the Vault Workspace app.

## Solution

Caught errors:
> In file: `packages/backend/src/apps/vault-workspace/actions/create-row/index.ts`
- Invalid closing quotes
- No closing quote
- Incorrect format for values field
- Undefined values field
- Unequal number of columns and values

> In file: `packages/backend/src/apps/vault-workspace/common/filter-table-rows.ts`

- Column not found
- Missing lookup column
- Invalid lookup column selected (this may be a local dev issue, couldn't replicate on staging)
- Same column name in vault workspace creates an “undefined” column bug on vault

> In file: `packages/backend/src/apps/vault-workspace/common/get-column-mapping.ts`
- Forbidden error (wrong API key)

## Test Coverage
Most files in common folder are http requests, a bit hard to test other than just pure mocking.
Before:
![image](https://github.com/opengovsg/plumber/assets/65110268/59e4ea67-2ad7-48da-aae9-5f2196ef9f64)

After:
![image](https://github.com/opengovsg/plumber/assets/65110268/9fbc747b-6417-41ea-a1f0-9ce9fe724140)

