### PR TITLE
[PLU-110] build(ecs): extend container stopTimeout

### DIFF
--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -11,6 +11,7 @@
           "protocol": "tcp"
         }
       ],
+      "stopTimeout": 120,
       "essential": true,
       "logConfiguration": {
         "logDriver": "awslogs",
@@ -26,6 +27,7 @@
       "cpu": 512,
       "command": ["npm", "run", "start:worker"],
       "essential": true,
+      "stopTimeout": 120,
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {


### PR DESCRIPTION
## Problem

Extending container shutdown timeout (i.e. the time between sending `SIGTERM`, which triggers worker to finish all current processing and shutdown, and when `SIGKILL` is sent which force shutdown the container) to ensure that processing has enough time to wrap up properly before container shutdown

## Solution

Added configs to task definition

## Tests

Check inside AWS console to see the container configs to be correct

## Deploy Notes

N/A