### PR TITLE
PLU-144: Add error catching and tests for telegram app

### DIFF
--- a/packages/backend/src/apps/telegram-bot/__tests__/actions/send-message.test.ts
+++ b/packages/backend/src/apps/telegram-bot/__tests__/actions/send-message.test.ts
@@ -1,0 +1,190 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { AxiosError } from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
+
+import app from '../..'
+import sendMessageAction from '../../actions/send-message'
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(),
+  setActionItem: vi.fn(),
+}))
+
+describe('send message', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      auth: {
+        set: vi.fn(),
+        data: {},
+      },
+      step: {
+        id: '123',
+        appKey: 'telegram-bot',
+        position: 2,
+        parameters: {},
+      },
+      http: {
+        post: mocks.httpPost,
+      } as unknown as IGlobalVariable['http'],
+      setActionItem: mocks.setActionItem,
+      app,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns void if message is sent successfully', async () => {
+    $.step.parameters.text = 'test message'
+    $.step.parameters.chatId = '123'
+    $.step.parameters.disableNotification = null
+
+    const mockHttpResponse = {
+      data: {
+        ok: true,
+      },
+    }
+    mocks.httpPost.mockResolvedValueOnce(mockHttpResponse)
+    const result = await sendMessageAction.run($)
+    expect(result).toBeUndefined()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: mockHttpResponse.data,
+    })
+  })
+
+  it('should throw step error if message text is empty', async () => {
+    $.step.parameters.text = ''
+    $.step.parameters.chatId = '123'
+    $.step.parameters.disableNotification = null
+
+    await expect(sendMessageAction.run($)).rejects.toThrowError(
+      'Empty message text',
+    )
+  })
+
+  it('should throw step error if message text is filled with new lines only', async () => {
+    $.step.parameters.text = '\n\n\n'
+    $.step.parameters.chatId = '123'
+    $.step.parameters.disableNotification = null
+
+    await expect(sendMessageAction.run($)).rejects.toThrowError(
+      'Empty message text',
+    )
+  })
+
+  it.each([
+    { errorDescription: 'read ECONNRESET' },
+    { errorDescription: 'connect ETIMEDOUT 127.0.0.1:3002' },
+  ])(
+    'should throw step error for non-http format errors',
+    async ({ errorDescription }) => {
+      $.step.parameters.text = 'test message'
+      $.step.parameters.chatId = '123'
+      $.step.parameters.disableNotification = null
+
+      const error = {
+        response: {
+          data: {
+            error: errorDescription,
+          },
+        },
+      } as unknown as AxiosError
+      const httpError = new HttpError(error)
+      mocks.httpPost.mockRejectedValueOnce(httpError)
+      // throw partial step error message
+      await expect(sendMessageAction.run($)).rejects.toThrowError(
+        'Empty status code',
+      )
+    },
+  )
+
+  it.each([
+    { errorDescription: 'Bad Request: chat not found' },
+    {
+      errorDescription:
+        'Bad Request: group chat was upgraded to a supergroup chat',
+    },
+    {
+      errorDescription:
+        'Bad Request: not enough rights to send text messages to the chat',
+    },
+  ])(
+    'should throw step error for 400 error codes',
+    async ({ errorDescription }) => {
+      $.step.parameters.text = 'test message'
+      $.step.parameters.chatId = '123'
+      $.step.parameters.disableNotification = null
+
+      const error400 = {
+        response: {
+          data: {
+            description: errorDescription,
+          },
+          status: 400,
+          statusText: 'Bad request',
+        },
+      } as AxiosError
+      const httpError = new HttpError(error400)
+      mocks.httpPost.mockRejectedValueOnce(httpError)
+      // throw partial step error message
+      await expect(sendMessageAction.run($)).rejects.toThrowError(
+        'Status code: 400',
+      )
+    },
+  )
+
+  it.each([{ errorStatusCode: 403 }, { errorStatusCode: 429 }])(
+    'should throw step error for other recognised error codes',
+    async ({ errorStatusCode }) => {
+      $.step.parameters.text = 'test message'
+      $.step.parameters.chatId = '123'
+      $.step.parameters.disableNotification = null
+
+      const error = {
+        response: {
+          status: errorStatusCode,
+        },
+      } as AxiosError
+      const httpError = new HttpError(error)
+      mocks.httpPost.mockRejectedValueOnce(httpError)
+      // throw partial step error message
+      await expect(sendMessageAction.run($)).rejects.toThrowError(
+        `Status code: ${errorStatusCode}`,
+      )
+    },
+  )
+
+  it.each([
+    { errorStatusCode: 500 },
+    {
+      errorStatusCode: 400,
+      errorDescription: 'never seen before error description',
+    },
+  ])(
+    'should throw normal error for uncaught errors',
+    async ({ errorStatusCode, errorDescription }) => {
+      $.step.parameters.text = 'test message'
+      $.step.parameters.chatId = '123'
+      $.step.parameters.disableNotification = null
+
+      const error = {
+        response: {
+          data: {
+            description: errorDescription,
+          },
+          status: errorStatusCode,
+        },
+      } as AxiosError
+      const httpError = new HttpError(error)
+      mocks.httpPost.mockRejectedValueOnce(httpError)
+      // throw uncaught error
+      await expect(sendMessageAction.run($)).rejects.toThrowError()
+    },
+  )
+})

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -1,13 +1,9 @@
 import { IRawAction } from '@plumber/types'
 
-import get from 'lodash.get'
-
-import {
-  generateHttpStepError,
-  generateStepError,
-} from '@/helpers/generate-step-error'
+import { generateStepError } from '@/helpers/generate-step-error'
 
 import { escapeMarkdown, sanitizeMarkdown } from '../../common/markdown-v1'
+import { throwSendMessageError } from '../../common/throw-errors'
 
 const action: IRawAction = {
   name: 'Send message',
@@ -95,43 +91,8 @@ const action: IRawAction = {
     const response = await $.http
       .post('/sendMessage', payload)
       .catch((err): never => {
-        // different error format for ETIMEDOUT and ECONNRESET
-
-        const status = err.response.status
-        let stepErrorSolution = ''
-        if (status === 400) {
-          // many sub errors caught by telegram for this status
-          const errorString = JSON.stringify(
-            get(err, 'details.description', ''),
-          )
-          if (errorString.includes('not enough rights')) {
-            stepErrorSolution =
-              'Please give permission for your bot in telegram to send messages in the group chat used in your action.'
-          } else if (errorString.includes('supergroup')) {
-            stepErrorSolution =
-              'Please re-connect the chat ID because chat ID changes when your group gets upgraded to a supergroup chat.'
-          } else if (errorString.includes('chat not found')) {
-            stepErrorSolution =
-              'Click on set up action and check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.'
-          }
-        } else if (status === 403) {
-          stepErrorSolution =
-            'Check that the bot is added in the group chat used in your action.'
-        } else if (status === 429) {
-          stepErrorSolution =
-            'Too many messages are being sent. Please wait for a minute before retrying and avoid sending more than 20 messages per minute to the same group.'
-        } else {
-          // return original error since uncaught
-          throw err
-        }
-        throw generateHttpStepError(
-          err,
-          stepErrorSolution,
-          $.step.position,
-          $.app.name,
-        )
+        throwSendMessageError(err, $.step.position, $.app.name)
       })
-    console.log({ response: response.data.result })
 
     $.setActionItem({
       raw: response.data,

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -1,5 +1,12 @@
 import { IRawAction } from '@plumber/types'
 
+import get from 'lodash.get'
+
+import {
+  generateHttpStepError,
+  generateStepError,
+} from '@/helpers/generate-step-error'
+
 import { escapeMarkdown, sanitizeMarkdown } from '../../common/markdown-v1'
 
 const action: IRawAction = {
@@ -65,14 +72,66 @@ const action: IRawAction = {
   },
 
   async run($) {
-    const sanitizedMarkdown = sanitizeMarkdown($.step.parameters.text as string)
+    const messageText = ($.step.parameters.text as string).trim()
+    if (!messageText) {
+      const stepErrorName = 'Empty message text'
+      const stepErrorSolution =
+        'Click on set up action and check that the message text is not empty, especially if variables are used.'
+      throw generateStepError(
+        stepErrorName,
+        stepErrorSolution,
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    const sanitizedMarkdown = sanitizeMarkdown(messageText)
     const payload = {
       chat_id: $.step.parameters.chatId,
       text: sanitizedMarkdown,
       disable_notification: $.step.parameters.disableNotification,
       parse_mode: 'markdown', // legacy markdown to allow only a small set of modifiers
     }
-    const response = await $.http.post('/sendMessage', payload)
+    const response = await $.http
+      .post('/sendMessage', payload)
+      .catch((err): never => {
+        // different error format for ETIMEDOUT and ECONNRESET
+
+        const status = err.response.status
+        let stepErrorSolution = ''
+        if (status === 400) {
+          // many sub errors caught by telegram for this status
+          const errorString = JSON.stringify(
+            get(err, 'details.description', ''),
+          )
+          if (errorString.includes('not enough rights')) {
+            stepErrorSolution =
+              'Please give permission for your bot in telegram to send messages in the group chat used in your action.'
+          } else if (errorString.includes('supergroup')) {
+            stepErrorSolution =
+              'Please re-connect the chat ID because chat ID changes when your group gets upgraded to a supergroup chat.'
+          } else if (errorString.includes('chat not found')) {
+            stepErrorSolution =
+              'Click on set up action and check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.'
+          }
+        } else if (status === 403) {
+          stepErrorSolution =
+            'Check that the bot is added in the group chat used in your action.'
+        } else if (status === 429) {
+          stepErrorSolution =
+            'Too many messages are being sent. Please wait for a minute before retrying and avoid sending more than 20 messages per minute to the same group.'
+        } else {
+          // return original error since uncaught
+          throw err
+        }
+        throw generateHttpStepError(
+          err,
+          stepErrorSolution,
+          $.step.position,
+          $.app.name,
+        )
+      })
+    console.log({ response: response.data.result })
 
     $.setActionItem({
       raw: response.data,

--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -32,6 +32,9 @@ export function throwSendMessageError(
     } else if (errorString.includes('chat not found')) {
       stepErrorSolution =
         'Click on set up action and check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.'
+    } else {
+      // return original error since uncaught
+      throw err
     }
   } else if (status === 403) {
     stepErrorSolution =

--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -1,0 +1,47 @@
+import get from 'lodash.get'
+
+import HttpError from '@/errors/http'
+import { generateHttpStepError } from '@/helpers/generate-step-error'
+
+export function throwSendMessageError(
+  err: HttpError,
+  position: number,
+  appName: string,
+): never {
+  let stepErrorSolution = ''
+
+  // catch telegram errors with different error format for ETIMEDOUT and ECONNRESET: e.g. details: { error: 'connect ECONNREFUSED 127.0.0.1:3002' }
+  const errorString = JSON.stringify(get(err, 'details.error', ''))
+  if (errorString.includes('ECONNRESET') || errorString.includes('ETIMEDOUT')) {
+    stepErrorSolution =
+      'Please retry in a few minutes because telegram is currently experiencing issues.'
+    throw generateHttpStepError(err, stepErrorSolution, position, appName)
+  }
+
+  // catch telegram errors with proper http error format
+  const status = err.response.status
+  if (status === 400) {
+    // many sub errors caught by telegram for this status
+    const errorString = JSON.stringify(get(err, 'details.description', ''))
+    if (errorString.includes('not enough rights')) {
+      stepErrorSolution =
+        'Please give permission for your bot in telegram to send messages in the group chat used in your action.'
+    } else if (errorString.includes('supergroup')) {
+      stepErrorSolution =
+        'Please re-connect the chat ID because chat ID changes when your group gets upgraded to a supergroup chat.'
+    } else if (errorString.includes('chat not found')) {
+      stepErrorSolution =
+        'Click on set up action and check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.'
+    }
+  } else if (status === 403) {
+    stepErrorSolution =
+      'Check that the bot is added in the group chat used in your action.'
+  } else if (status === 429) {
+    stepErrorSolution =
+      'Too many messages are being sent. Please wait for a minute before retrying and avoid sending more than 20 messages per minute to the same group.'
+  } else {
+    // return original error since uncaught
+    throw err
+  }
+  throw generateHttpStepError(err, stepErrorSolution, position, appName)
+}

--- a/packages/backend/src/helpers/generate-step-error.ts
+++ b/packages/backend/src/helpers/generate-step-error.ts
@@ -9,7 +9,12 @@ export function generateHttpStepError(
   position: number,
   appName: string,
 ) {
-  const stepErrorName = `Status code: ${error.response.status} (${error.response.statusText})`
+  let stepErrorName
+  if (!error.response.status && !error.response.statusText) {
+    stepErrorName = 'Empty status code'
+  } else {
+    stepErrorName = `Status code: ${error.response.status} (${error.response.statusText})`
+  }
   return new StepError(
     {
       name: stepErrorName,


### PR DESCRIPTION
Problem

Errors are not properly caught as StepError in the Telegram app.

## Solution

Caught errors:
- ETIMEDOUT and ECONNRESET
- Bad request: group chat was upgraded to a supergroup chat (Status code: 400)
- Incorrect bot configuration (Status code: 400)
- No permission given for bot to send message (Status code: 400)
- Exceeded rate limit (Status code: 429)
- Forbidden (Status code: 403)
- Empty message text + Empty message text with purely newlines + No text due to step being not configured

Test coverage is similar but added tests for catching errors.