### PR TITLE
PLU-145: Add error catching for toolbox app

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
@@ -229,6 +229,9 @@ describe('If-then', () => {
         step: {
           ...FLAT_PIPE_STEPS[1],
         },
+        app: {
+          name: 'Toolbox',
+        },
         setActionItem: mocks.setActionItem,
       } as unknown as IGlobalVariable
     })
@@ -288,6 +291,31 @@ describe('If-then', () => {
       expect(mocks.setActionItem).toBeCalledWith({
         raw: { isConditionMet: false },
       })
+    })
+
+    it('should throw step error if no condition is configured', async () => {
+      $.step.parameters.conditions = undefined
+      // throw partial step error message
+      await expect(ifThenAction.run($)).rejects.toThrowError(
+        `Cannot read properties of undefined (reading 'every')`,
+      )
+    })
+
+    it('should throw step error if invalid condition is configured', async () => {
+      const invalidCondition = '==='
+      $.step.parameters.conditions = [
+        {
+          field: 1,
+          is: 'is',
+          condition: invalidCondition,
+          text: 9999,
+        },
+      ]
+
+      // throw partial step error message
+      await expect(ifThenAction.run($)).rejects.toThrowError(
+        `Conditional logic block contains an unknown operator: ${invalidCondition}`,
+      )
     })
   })
 

--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -23,6 +23,9 @@ describe('Only continue if', () => {
         position: 2,
         parameters: {},
       },
+      app: {
+        name: 'Toolbox',
+      },
       setActionItem: mocks.setActionItem,
     } as unknown as IGlobalVariable
   })
@@ -61,5 +64,20 @@ describe('Only continue if', () => {
     expect(mocks.setActionItem).toBeCalledWith({
       raw: { result: false },
     })
+  })
+
+  it('should throw step error if invalid condition is configured', async () => {
+    const invalidCondition = '==='
+    $.step.parameters = {
+      field: 1,
+      is: 'is',
+      condition: invalidCondition,
+      text: 0,
+    }
+
+    // throw partial step error message
+    await expect(onlyContinueIfAction.run($)).rejects.toThrowError(
+      `Conditional logic block contains an unknown operator: ${invalidCondition}`,
+    )
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -10,6 +10,7 @@ import Step from '@/models/step'
 import toolboxApp from '../..'
 import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
+import { throwInvalidConditionError } from '../../common/throw-errors'
 
 const ACTION_KEY = 'ifThen'
 
@@ -89,7 +90,12 @@ const action: IRawAction = {
   ],
 
   async run($) {
-    const isConditionMet = shouldTakeBranch($)
+    let isConditionMet
+    try {
+      isConditionMet = shouldTakeBranch($)
+    } catch (err) {
+      throwInvalidConditionError(err.message, $.step.position, $.app.name)
+    }
     $.setActionItem({
       raw: { isConditionMet },
     })

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -2,6 +2,7 @@ import { IRawAction } from '@plumber/types'
 
 import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
+import { throwInvalidConditionError } from '../../common/throw-errors'
 
 const action: IRawAction = {
   name: 'Only continue if',
@@ -10,7 +11,12 @@ const action: IRawAction = {
   arguments: getConditionArgs({ usePlaceholders: false }),
 
   async run($) {
-    const result = conditionIsTrue($.step.parameters)
+    let result
+    try {
+      result = conditionIsTrue($.step.parameters)
+    } catch (err) {
+      throwInvalidConditionError(err.message, $.step.position, $.app.name)
+    }
     $.setActionItem({
       raw: { result },
     })

--- a/packages/backend/src/apps/toolbox/common/throw-errors.ts
+++ b/packages/backend/src/apps/toolbox/common/throw-errors.ts
@@ -1,0 +1,18 @@
+import { generateStepError } from '@/helpers/generate-step-error'
+
+export function throwInvalidConditionError(
+  errorName: string,
+  position: number,
+  appName: string,
+) {
+  let stepErrorSolution = ''
+  if (errorName.includes('every')) {
+    // ifThen has an additional error to catch: no conditions configured
+    stepErrorSolution =
+      'Click on set up action and check that the condition has been configured properly.'
+  } else {
+    stepErrorSolution =
+      'Click on set up action and check that one of valid options in the condition dropdown is being selected.'
+  }
+  throw generateStepError(errorName, stepErrorSolution, position, appName)
+}


### PR DESCRIPTION
## Problem

Errors are not properly caught as StepError in the Toolbox app.

## Solution

Toolbox app is relatively error free :-) thanks to @ogp-weeloong 
Caught errors:
- Unknown operator in logic block
- No condition is configured

Added unit tests for newly added code only because previously added code has good test coverage.