### PR TITLE
PLU-159: Remove myinfo fields from metadata

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -1,4 +1,9 @@
-import { IDataOutMetadatum, IExecutionStep, IJSONObject } from '@plumber/types'
+import {
+  IDataOutMetadata,
+  IDataOutMetadatum,
+  IExecutionStep,
+  IJSONObject,
+} from '@plumber/types'
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -16,6 +21,9 @@ describe('new submission trigger', () => {
             answer: 'herp derp',
             fieldType: 'textField',
             order: 1,
+            myInfo: {
+              attr: 'name',
+            },
           },
         },
         verifiedSubmitterInfo: {
@@ -35,6 +43,12 @@ describe('new submission trigger', () => {
       for (const [propName, data] of Object.entries(
         metadata.fields.textFieldId,
       )) {
+        // only myInfo contains IDataOutMetadata instead of IDataOutMetadatum
+        if (propName === 'myInfo') {
+          expect((data as IDataOutMetadata)['attr'].isHidden)
+          continue
+        }
+
         if (['question', 'answer', 'answerArray'].includes(propName)) {
           expect((data as IDataOutMetadatum).isHidden).toBeUndefined()
         } else {

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -138,6 +138,7 @@ async function getDataOutMetadata(
       answer: buildAnswerMetadatum(fieldData),
       fieldType: { isHidden: true },
       order: { isHidden: true },
+      myInfo: { attr: { isHidden: true } },
     }
     if (isAnswerArrayValid(fieldData)) {
       fieldMetadata[fieldId].answerArray = buildAnswerArrayMetadatum(
@@ -186,7 +187,7 @@ async function getDataOutMetadata(
 
 export default getDataOutMetadata
 
-// Reference dataOut
+// Reference dataOut with myInfo fields
 // ---
 // {
 //   fields: {
@@ -194,19 +195,28 @@ export default getDataOutMetadata
 //       answer: 'zzz',
 //       question: 'What is the air speed velocity of an unladen swallow?',
 //       fieldType: 'textfield',
-//       order: 2
+//       order: 2,
 //     },
 //     648fe18a9175ce001196b3d5: {
 //       answer: 'aaaa',
 //       question: 'What is your name?',
 //       fieldType: 'textfield',
-//       order: 1
-//     }
+//       order: 1,
+//     },
 //     649d3183c4c52f00124ceb16: {
 //       question: 'Attach your sparrow velocity readings.',
 //       answer: 's3:common-bucket:649306c1ac8851001149af0a/649d3183c4c52f00124ceb16/my readings.txt',
 //       fieldType: 'attachment',
-//       order: 3
+//       order: 3,
+//     },
+//     655c766835b8460012ed7475: {
+//       answer: 'Male',
+//       question: '[MyInfo] Gender',
+//       fieldType: 'dropdown',
+//       order: 4,
+//       myInfo: {
+//         attr: 'sex',
+//       }
 //     },
 //   },
 //   # verifiedSubmitterInfo may not exist!


### PR DESCRIPTION
## Problem

MyInfo fields are being displayed on our `dataOut`.

## Solution

Add `isHidden` property to the metadata for `myInfo.attr`.
Refer to [formsg pr](https://github.com/opengovsg/FormSG/pull/6870/files#diff-9b9824a990729c6ab5548a354920a5a139ea57054e0ee5984adfb0404716878f) to check that all data is stored similarly in the attribute.


## Before and After screenshots
Before:
<img width="841" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/8d0f896d-c936-455b-a38e-fc7b89ef3e2b">


After:
<img width="823" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/b557bc6c-3d89-4394-b969-393e7e9cbea4">


## Tests
- Check that variables still can be used in the later steps.
- Check that pipe still can be published