### PR TITLE
PLU-160: Add fix for scheduler date format

### DIFF
--- a/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
@@ -1,0 +1,22 @@
+import { DateTime } from 'luxon'
+import { describe, expect, it } from 'vitest'
+
+import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
+
+describe('Test get date time object format', () => {
+  describe('Test pretty_date', () => {
+    it('Single digit date should be double padded', () => {
+      const dateTime = DateTime.local(2023, 11, 1)
+      expect(getDateTimeObjectRepresentation(dateTime).pretty_date).toEqual(
+        '01 Nov 2023',
+      )
+    })
+
+    it('Double digit date should be double padded', () => {
+      const dateTime = DateTime.local(2023, 10, 21)
+      expect(getDateTimeObjectRepresentation(dateTime).pretty_date).toEqual(
+        '21 Oct 2023',
+      )
+    })
+  })
+})

--- a/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
@@ -12,7 +12,7 @@ describe('Test get date time object format', () => {
       )
     })
 
-    it('Double digit date should be double padded', () => {
+    it('Double digit date should not require extra padding', () => {
       const dateTime = DateTime.local(2023, 10, 21)
       expect(getDateTimeObjectRepresentation(dateTime).pretty_date).toEqual(
         '21 Oct 2023',

--- a/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
+++ b/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
@@ -8,7 +8,7 @@ export default function getDateTimeObjectRepresentation(dateTime: DateTime) {
   return {
     ...defaults,
     ISO_date_time: dateTime.toISO(),
-    pretty_date: dateTime.toLocaleString(DateTime.DATE_MED),
+    pretty_date: dateTime.toFormat('dd MMM yyyy'),
     pretty_time: dateTime.toLocaleString(DateTime.TIME_WITH_SECONDS),
     pretty_day_of_week: dateTime.toFormat('cccc'),
     day_of_week: dateTime.weekday,


### PR DESCRIPTION
## Problem
Scheduler date format is single padded but formsg is double padded.

## Solution
- Simple fix of scheduler date format
- Sanity test case added.

## Test
- Make sure scheduler still works

## Follow up
- Email user to inform that format is updated after PR is merged into production