### PR TITLE
Revert to allow empty recipient emails

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -38,17 +38,16 @@ describe('postman transactional email schema zod validation', () => {
     ])
   })
 
-  it('should invalidate empty email strings or strings with only whitespaces', () => {
-    const expectedErrorMessage = 'Empty recipient email'
+  it('should validate empty email strings or strings with only whitespaces', () => {
     validPayload.destinationEmail = '   '
     const result = transactionalEmailSchema.safeParse(validPayload)
-    assert(result.success === false) // using assert here for type assertion
-    expect(result.error?.errors[0].message).toEqual(expectedErrorMessage)
+    assert(result.success === true) // using assert here for type assertion
+    expect(result.data.destinationEmail).toEqual([])
 
     validPayload.destinationEmail = ''
     const result2 = transactionalEmailSchema.safeParse(validPayload)
-    assert(result2.success === false) // using assert here for type assertion
-    expect(result.error?.errors[0].message).toEqual(expectedErrorMessage)
+    assert(result2.success === true) // using assert here for type assertion
+    expect(result2.data.destinationEmail).toEqual([])
   })
 
   it('should allow for empty values', () => {

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -74,12 +74,6 @@ export const transactionalEmailSchema = z.object({
     .transform((v) => v.replace(/\n/g, '<br>')),
   destinationEmail: z.string().transform((value, ctx) => {
     const recipients = recipientStringToArray(value)
-    if (recipients.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Empty recipient email',
-      })
-    }
     if (recipients.some((recipient) => !validator.validate(recipient))) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Problem
Currently, throwing an error for empty recipient emails (as intended) is causing pipes to stop executing beyond that failed step, raising alarms.

## Solution
Hack fix: Revert code to allow for empty recipient emails.