### PR TITLE
fix(frontend): rich text editor backward compat with variables-in-attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12031,6 +12031,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6486,6 +6486,11 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "license": "MIT"
@@ -7313,6 +7318,32 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "license": "MIT"
@@ -7691,6 +7722,68 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -9376,6 +9469,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/helmet": {
@@ -11820,6 +11921,15 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.11.tgz",
+      "integrity": "sha512-FAgwwZ6h0DSDWxfD0Iq1tsDcBCxdJB1nXpLPPxX8YyVWzbfCjKWEzaynF4gZZ/8hziUmp7ZSaKylcn0iKhufUQ==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
       }
     },
     "node_modules/node-releases": {
@@ -15909,6 +16019,7 @@
         "launchdarkly-react-client-sdk": "3.0.8",
         "lodash": "^4.17.21",
         "luxon": "^2.3.1",
+        "node-html-parser": "6.1.11",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.17.2",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -37,6 +37,7 @@
     "launchdarkly-react-client-sdk": "3.0.8",
     "lodash": "^4.17.21",
     "luxon": "^2.3.1",
+    "node-html-parser": "6.1.11",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.17.2",

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -44,20 +44,13 @@ describe('replaceOldTemplates', () => {
     }
   })
 
-  it('should not replace {{.}} that is followed by </span>', () => {
+  it('should not replace {{.}} that is already inside a variable span', () => {
     const testCases = [
       {
         input:
           '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
         expected:
           '<span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
-      },
-      {
-        // won't substitute even if it's a span-wrap entered by user
-        input:
-          '<span>{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
-        expected:
-          '<span>{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span>',
       },
       {
         input:
@@ -75,6 +68,26 @@ describe('replaceOldTemplates', () => {
     const testInputs = [undefined, null] as unknown as string[] // this is to force the value in
     for (const input of testInputs) {
       expect(substituteOldTemplates(input, varInfo)).toEqual('')
+    }
+  })
+
+  it('should be not parse {{.}} inside element attributes', () => {
+    const testCases = [
+      {
+        input:
+          '<a href="https://form.gov.sg/abc?prefilled_value={{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}">Click here</a>',
+        expected:
+          '<a href="https://form.gov.sg/abc?prefilled_value={{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}">Click here</a>',
+      },
+      {
+        input:
+          '<img src="https://myownhosting.website/{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}" >',
+        expected:
+          '<img src="https://myownhosting.website/{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}" >',
+      },
+    ]
+    for (const t of testCases) {
+      expect(substituteOldTemplates(t.input, varInfo)).toEqual(t.expected)
     }
   })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -36,7 +36,7 @@ function substituteTemplateStringWithSpan(
   s: string,
   varInfo: VariableInfoMap,
 ): HTMLElement {
-  const searchRegex = /({{[^{}]+}})(?!<\/span>)/
+  const searchRegex = /({{[^{}]+}})/
   const nodes = s.split(searchRegex)
   for (const i in nodes) {
     if (!searchRegex.test(nodes[i])) {


### PR DESCRIPTION
## Problem

Some users are using raw HTML with injected variable values inside element attributes (like `href` in `<a/>` for prefilled form)

## Solution

Parse the existing content from database as HTML elements to make sure that we're only replacing `{{ . }}` inside textContent of elements only

## Tests

- [x] Existing raw HTML content with `{{ . }} ` inside element attributes

## Deploy Notes

N/A