### PR TITLE
Bump axios from 0.24.0 to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3926,20 +3926,13 @@
       }
     },
     "node_modules/@opengovsg/formsg-sdk": {
-      "version": "0.10.0",
-      "license": "MIT",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.11.0.tgz",
+      "integrity": "sha512-cNSKxOWr42w9bpK9hIjcRrt3w78DAGg3gotYvzHnawvcOsG0WVMQR3Dvat59CNehioKjNH5SkJxLSSE2crhF0g==",
       "dependencies": {
-        "axios": "^0.24.0",
+        "axios": "^1.6.2",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
-      }
-    },
-    "node_modules/@opengovsg/formsg-sdk/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
       }
     },
     "node_modules/@opengovsg/sgid-client": {
@@ -15848,7 +15841,7 @@
         "@aws-sdk/client-s3": "3.369.0",
         "@bull-board/express": "5.6.0",
         "@graphql-tools/schema": "10.0.0",
-        "@opengovsg/formsg-sdk": "0.10.0",
+        "@opengovsg/formsg-sdk": "0.11.0",
         "@opengovsg/sgid-client": "2.1.0",
         "@plumber/types": "file:../types",
         "ajv-formats": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3934,6 +3934,14 @@
         "tweetnacl-util": "^0.15.1"
       }
     },
+    "node_modules/@opengovsg/formsg-sdk/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "node_modules/@opengovsg/sgid-client": {
       "version": "2.1.0",
       "license": "MIT",
@@ -6320,10 +6328,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "license": "MIT",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -12859,6 +12883,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "dev": true,
@@ -15823,7 +15852,7 @@
         "@opengovsg/sgid-client": "2.1.0",
         "@plumber/types": "file:../types",
         "ajv-formats": "^2.1.1",
-        "axios": "0.24.0",
+        "axios": "1.6.2",
         "bullmq": "^3.0.0",
         "cookie-parser": "1.4.6",
         "copyfiles": "^2.4.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -25,7 +25,7 @@
     "@aws-sdk/client-s3": "3.369.0",
     "@bull-board/express": "5.6.0",
     "@graphql-tools/schema": "10.0.0",
-    "@opengovsg/formsg-sdk": "0.10.0",
+    "@opengovsg/formsg-sdk": "0.11.0",
     "@opengovsg/sgid-client": "2.1.0",
     "@plumber/types": "file:../types",
     "ajv-formats": "^2.1.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,7 +29,7 @@
     "@opengovsg/sgid-client": "2.1.0",
     "@plumber/types": "file:../types",
     "ajv-formats": "^2.1.1",
-    "axios": "0.24.0",
+    "axios": "1.6.2",
     "bullmq": "^3.0.0",
     "cookie-parser": "1.4.6",
     "copyfiles": "^2.4.1",

--- a/packages/backend/src/apps/custom-api/common/add-headers.ts
+++ b/packages/backend/src/apps/custom-api/common/add-headers.ts
@@ -3,11 +3,10 @@ import { TBeforeRequest } from '@plumber/types'
 const addHeaders: TBeforeRequest = ($, requestConfig) => {
   const authData = $.auth.data
   if (authData?.headers) {
-    requestConfig.headers = {
-      ...requestConfig.headers,
-      'Content-Type': 'application/json',
-      ...(authData.headers as Record<string, string>),
-    }
+    requestConfig.headers['Content-Type'] = 'application/json'
+    Object.entries(authData.headers).forEach(([key, value]) =>
+      requestConfig.headers.set(key, value),
+    )
   }
 
   return requestConfig

--- a/packages/backend/src/apps/custom-api/common/add-headers.ts
+++ b/packages/backend/src/apps/custom-api/common/add-headers.ts
@@ -3,7 +3,7 @@ import { TBeforeRequest } from '@plumber/types'
 const addHeaders: TBeforeRequest = ($, requestConfig) => {
   const authData = $.auth.data
   if (authData?.headers) {
-    requestConfig.headers['Content-Type'] = 'application/json'
+    requestConfig.headers.set('Content-Type', 'application/json', true)
     Object.entries(authData.headers).forEach(([key, value]) =>
       requestConfig.headers.set(key, value),
     )

--- a/packages/backend/src/helpers/http-client/index.ts
+++ b/packages/backend/src/helpers/http-client/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig } from 'axios'
+import axios, { InternalAxiosRequestConfig } from 'axios'
 
 export { AxiosInstance as IHttpClient } from 'axios'
 import { IHttpClientParams } from '@plumber/types'
@@ -8,8 +8,8 @@ import { URL } from 'url'
 import HttpError from '@/errors/http'
 
 const removeBaseUrlForAbsoluteUrls = (
-  requestConfig: AxiosRequestConfig,
-): AxiosRequestConfig => {
+  requestConfig: InternalAxiosRequestConfig,
+): InternalAxiosRequestConfig => {
   try {
     const url = new URL(requestConfig.url)
     requestConfig.baseURL = url.origin
@@ -31,12 +31,14 @@ export default function createHttpClient({
   })
 
   instance.interceptors.request.use(
-    (requestConfig: AxiosRequestConfig): AxiosRequestConfig => {
+    (requestConfig: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
       const newRequestConfig = removeBaseUrlForAbsoluteUrls(requestConfig)
 
-      return beforeRequest.reduce((newConfig, beforeRequestFunc) => {
+      const result = beforeRequest.reduce((newConfig, beforeRequestFunc) => {
         return beforeRequestFunc($, newConfig)
       }, newRequestConfig)
+      // axios specifically wants InternalAxiosRequestConfig instead of AxiosRequestConfig, can utilise an assertion since both interfaces are similar
+      return result as InternalAxiosRequestConfig
     },
   )
 

--- a/packages/backend/src/helpers/http-client/index.ts
+++ b/packages/backend/src/helpers/http-client/index.ts
@@ -34,11 +34,9 @@ export default function createHttpClient({
     (requestConfig: InternalAxiosRequestConfig): InternalAxiosRequestConfig => {
       const newRequestConfig = removeBaseUrlForAbsoluteUrls(requestConfig)
 
-      const result = beforeRequest.reduce((newConfig, beforeRequestFunc) => {
+      return beforeRequest.reduce((newConfig, beforeRequestFunc) => {
         return beforeRequestFunc($, newConfig)
       }, newRequestConfig)
-      // axios specifically wants InternalAxiosRequestConfig instead of AxiosRequestConfig, can utilise an assertion since both interfaces are similar
-      return result as InternalAxiosRequestConfig
     },
   )
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,4 +1,8 @@
-import type { AxiosInstance, AxiosRequestConfig } from 'axios'
+import type {
+  AxiosInstance,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+} from 'axios'
 
 export type IHttpClient = AxiosInstance
 import type { Request } from 'express'
@@ -273,7 +277,10 @@ export interface IApp {
 }
 
 export type TBeforeRequest = {
-  ($: IGlobalVariable, requestConfig: AxiosRequestConfig): AxiosRequestConfig
+  (
+    $: IGlobalVariable,
+    requestConfig: InternalAxiosRequestConfig,
+  ): InternalAxiosRequestConfig
 }
 
 export interface DynamicDataOutput {


### PR DESCRIPTION
## Problem

Our axios version is very outdated and is vulnerable to CSRF attacks. Refer to #323 for more details.
However, we do not use axios on the frontend so this upgrade is more of a precaution.

## Solution

- Upgrade axios from 0.24.0 to 1.6.2
- Re-type interceptors because of the mismatch.
- Have also updated formsg to upgrade axios because we are using their `formsg-sdk`

## Tests
- Check that formsg trigger to actions still work
- Check that webhook trigger works successfully
- Check that webhook trigger fails and returns http error