### PR TITLE
PLU-125: add m365 env vars to task definition

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -125,6 +125,26 @@
     {
       "name": "POSTMAN_RATE_LIMIT",
       "valueFrom": "plumber-<ENVIRONMENT>-postman-rate-limit"
+    },
+    {
+      "name": "M365_SG_GOVT_TENANT_ID",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-tenant-id"
+    },
+    {
+      "name": "M365_SG_GOVT_SHAREPOINT_SITE_ID",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-sharepoint-site-id"
+    },
+    {
+      "name": "M365_SG_GOVT_CLIENT_ID",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-client-id"
+    },
+    {
+      "name": "M365_SG_GOVT_CLIENT_THUMBPRINT",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-client-thumbprint"
+    },
+    {
+      "name": "M365_SG_GOVT_CLIENT_PRIVATE_KEY",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-client-private-key"
     }
   ]
 }


### PR DESCRIPTION
## Problem
Deploy is broken because i forgot to add to M365 env (#352) vars to `env.json`.

## Solution
Add M365 env vars to `env.json`. For deployment, only the env vars for the `SG_GOVT` tenant need to be specified.

Since we have different sharepoint site IDs for staging and prod, I allowed for specifying different env vars for staging and prod.

## Tests
* Check that the following env vars are set in AWS for both staging and prod:
    * `plumber-<ENVIRONMENT>-sg-govt-tenant-id`: For `M365_SG_GOVT_TENANT_ID`
    * `plumber-<ENVIRONMENT>-m365-sg-govt-sharepoint-site-id`: For `M365_SG_GOVT_SHAREPOINT_SITE_ID`
    * `plumber-<ENVIRONMENT>-m365-sg-govt-client-id`: For `M365_SG_GOVT_CLIENT_ID`
    * `plumber-<ENVIRONMENT>-m365-sg-govt-client-thumbprint`: For `M365_SG_GOVT_CLIENT_THUMBPRINT`
    * `plumber-<ENVIRONMENT>-m365-sg-govt-client-private-key`: For `M365_SG_GOVT_CLIENT_PRIVATE_KEY`
* Push to staging and check that it successfully deploys