### PR TITLE
PLU-125: [EXCEL-11] Optimize plumber folder creation

### DIFF
--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -22,19 +22,6 @@ export async function createPlumberFolder(
   )
   const folderId = createFolderResult.data.id
 
-  // Clear inherited permissions to make folder fully private.
-  const folderPermissions = await $.http.get<{ value: Array<{ id: string }> }>(
-    `/v1.0/sites/${tenant.sharePointSiteId}/drive/items/${folderId}/permissions`,
-  )
-
-  await Promise.all(
-    folderPermissions.data.value.map(async (permission) =>
-      $.http.delete(
-        `/v1.0/sites/${tenant.sharePointSiteId}/drive/items/${folderId}/permissions/${permission.id}`,
-      ),
-    ),
-  )
-
   // Allow user R/W access to folder.
   await $.http.post(
     `/v1.0/sites/${tenant.sharePointSiteId}/drive/items/${folderId}/invite`,


### PR DESCRIPTION
## Problem
When creating a user's plumber folder, I initially had a loop to remove all initial permissions so that I could prevent other users from seeing a user's folder. It worked like this:
1. Remove all folder permissions
2. Grant user read + write permission to their plumber folder

It turns out I don't need to do this; I can achieve the same outcome by:
1. Creating a new sharepoint [permission level](https://learn.microsoft.com/en-us/sharepoint/sites/user-permissions-and-permission-levels) that blocks access to all folders
3. Assigning all sharepoint visitors + members to that restrictive permission level
4. For each user, separately grant the read + write permission to their plumber folder only

## Solution
Steps 1 and 2 are done on SharePoint and not in code. This PR implement step 3 by removing the initial "remove all folder permissions" loop.

## Tests
- Check (using another person's account) that they can _only_ access their own plumber folder on the SG Govt M365 tenant.