### PR TITLE
fix: prevent user-input values when allowArbitrary is not set to true

### DIFF
--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -166,7 +166,7 @@ function ControlledAutocomplete(
                 filterOptions={(options, params) => {
                   const filtered = filter(options, params)
 
-                  if (params.inputValue !== '') {
+                  if (freeSolo && params.inputValue !== '') {
                     filtered.push({
                       value: params.inputValue,
                       label: `Use: ${params.inputValue}`,


### PR DESCRIPTION
Before

<img width="849" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/5fca334c-1db4-486b-948c-add32e15aa98">

After

<img width="857" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/aa5dd8c4-026d-4b52-b71c-24fb4ba41aa8">
