### PR TITLE
chore: show spinner when loading dynamic data

### DIFF
--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -36,6 +36,7 @@ function PaperWithRefresh(props: PaperWithRefreshProps): JSX.Element {
           onMouseDown={(e) => {
             e.preventDefault()
           }}
+          spinner={<Spinner fontSize={24} color="primary.600" />}
           onClick={onRefresh}
           isLoading={loading}
         >

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -5,7 +5,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { BiRefresh } from 'react-icons/bi'
 import Markdown from 'react-markdown'
 import { Flex, FormControl } from '@chakra-ui/react'
-import { Paper, PaperProps } from '@mui/material'
+import { Paper, PaperProps, TextField } from '@mui/material'
 import Autocomplete, {
   AutocompleteProps,
   createFilterOptions,
@@ -15,6 +15,7 @@ import {
   Button,
   FormErrorMessage,
   FormLabel,
+  Spinner,
 } from '@opengovsg/design-system-react'
 
 interface PaperWithRefreshProps extends PaperProps {
@@ -145,6 +146,22 @@ function ControlledAutocomplete(
                 freeSolo={freeSolo}
                 options={options}
                 value={getOption(options, field.value, freeSolo)}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    InputProps={{
+                      ...params.InputProps,
+                      endAdornment: (
+                        <>
+                          {loading && (
+                            <Spinner fontSize={24} color="primary.600" />
+                          )}
+                          {params.InputProps.endAdornment}
+                        </>
+                      ),
+                    }}
+                  />
+                )}
                 onChange={(_event, selectedOption) => {
                   const typedSelectedOption =
                     selectedOption as IFieldDropdownOption


### PR DESCRIPTION
## Problem

For dropdown fields that depend on dynamic data, it shows an empty field until the data is loaded.

## Solution 

Add spinner to indicate that dropdown options are loading.

![Screenshot 2024-01-04 at 4 24 42 PM](https://github.com/opengovsg/plumber/assets/10072985/40340972-4e92-4d45-833e-b31f0bfb63bc)
