### PR TITLE
Fix: UAT frontend env

### DIFF
--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -22,6 +22,7 @@ function getAppConfig(): AppConfig {
         sgidClientId: 'PLUMBER-c24255a5',
         ...commonEnv,
       }
+    case 'uat':
     case 'staging':
       return {
         launchDarklyClientId: '65016ca0b45b7712e6c95703',


### PR DESCRIPTION
## Problem
LaunchDarkly and SGID was broken on UAT env because it was trying to use local dev credentials.

## Solution
This PR configures LD and SGID to point UAT env to staging env credentials.

## Tests
- Cherry pick on UAT and check that SGID works.
