### PR TITLE
M365 Excel - UX nit & logging improvement

### DIFF
--- a/packages/backend/src/apps/m365-excel/common/interceptors/before-request.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/before-request.ts
@@ -19,6 +19,7 @@ import { consumeOrThrowLimiterWithLongestDelay } from '../rate-limiter'
 const usageTracker: TBeforeRequest = async function ($, requestConfig) {
   logger.info('Making request to MS Graph', {
     event: 'm365-ms-graph-request',
+    tenant: $.auth.data?.tenantKey as string,
     baseUrl: requestConfig.baseURL, // base URL is different for auth requests
     urlPath: requestConfig.url,
     flowId: $.flow?.id,

--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -7,7 +7,7 @@ import auth from './auth'
 import dynamicData from './dynamic-data'
 
 const app: IApp = {
-  name: 'M365 Excel',
+  name: 'M365 Excel (Pilot)',
   key: 'm365-excel',
   iconUrl: '{BASE_URL}/apps/m365-excel/assets/favicon.svg',
   authDocUrl: 'https://guide.plumber.gov.sg/user-guides/actions/m365-excel',

--- a/packages/backend/src/config/app-env-vars/m365.ts
+++ b/packages/backend/src/config/app-env-vars/m365.ts
@@ -77,7 +77,7 @@ function makeTenantInfo(opts: Partial<M365TenantInfo>): M365TenantInfo {
 
 export const m365TenantInfo = Object.freeze({
   'sg-govt': makeTenantInfo({
-    label: 'SG Govt',
+    label: 'SG Govt SharePoint',
     id: process.env.M365_SG_GOVT_TENANT_ID,
     sharePointSiteId: process.env.M365_SG_GOVT_SHAREPOINT_SITE_ID,
     clientId: process.env.M365_SG_GOVT_CLIENT_ID,
@@ -90,7 +90,7 @@ export const m365TenantInfo = Object.freeze({
   ...(appConfig.isDev
     ? {
         'govtech-staging': makeTenantInfo({
-          label: 'GovTech Staging',
+          label: 'GovTech Staging SharePoint',
           id: process.env.M365_GOVTECH_STAGING_TENANT_ID,
           sharePointSiteId: process.env.M365_GOVTECH_STAGING_SHAREPOINT_SITE_ID,
           clientId: process.env.M365_GOVTECH_STAGING_CLIENT_ID,
@@ -102,7 +102,7 @@ export const m365TenantInfo = Object.freeze({
           ),
         }),
         'local-dev': makeTenantInfo({
-          label: 'Local Development',
+          label: 'Local Development SharePoint',
           id: process.env.M365_LOCAL_DEV_TENANT_ID,
           sharePointSiteId: process.env.M365_LOCAL_DEV_SHAREPOINT_SITE_ID,
           clientId: process.env.M365_LOCAL_DEV_CLIENT_ID,


### PR DESCRIPTION
## Problem
1. M365 tenant names are confusing to users (e.g. "SG Govt" = ..?)
2. We don't log tenant key in our usage logs, but we need to differentiate between tenants.

## Solution
1. Add "SharePoint" suffix to tenant names ("SG Govt SharePoint").
2. Log `tenantKey` during usage logging

Also, this PR adds a "(Pilot)" suffix to the app name as we're in pilot.

## Tests
- Check that "SharePoint" suffix shows up when selecting a M365 tenant
- Check that tenant key is logged
- Check that excel app has "(Pilot)" suffix