### PR TITLE
PLU-70 [TILES-ACTIONS-2]: create new row action

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -81,6 +81,7 @@ describe('decrypt form response', () => {
       },
       flow: {
         id: 'flowid',
+        userId: 'userid',
         hasFileProcessingActions: false,
       },
       app,

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -1,0 +1,115 @@
+import { IRawAction } from '@plumber/types'
+
+import { generateStepError } from '@/helpers/generate-step-error'
+import { createTableRow } from '@/models/dynamodb/table-row/functions'
+import TableMetadata from '@/models/table-metadata'
+
+import { validateTileAccess } from '../../common/validate-tile-access'
+
+const action: IRawAction = {
+  name: 'Create row',
+  key: 'createTileRow',
+  description: 'Creates a new row in Tile',
+  arguments: [
+    {
+      label: 'Select Tile',
+      key: 'tableId',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      description: 'Select the tile you want to create a row in.',
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTables',
+          },
+        ],
+      },
+    },
+    {
+      label: 'New row data',
+      key: 'rowData',
+      type: 'multirow' as const,
+      required: false,
+      subFields: [
+        {
+          placeholder: 'Column',
+          key: 'columnId',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          source: {
+            type: 'query' as const,
+            name: 'getDynamicData' as const,
+            arguments: [
+              {
+                name: 'key',
+                value: 'listColumns',
+              },
+              {
+                name: 'parameters.tableId',
+                value: '{parameters.tableId}',
+              },
+            ],
+          },
+        },
+        {
+          placeholder: 'Value',
+          key: 'cellValue',
+          type: 'string' as const,
+          required: false,
+          variables: true,
+        },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { tableId, rowData } = $.step.parameters as {
+      tableId: string
+      rowData: { columnId: string; cellValue: string }[]
+    }
+    await validateTileAccess($.flow?.userId, tableId as string)
+
+    const table = await TableMetadata.query().findById(tableId)
+
+    /**
+     * convert array to object
+     * [{columnId: 'abc', cellValue: 'test'}] => {abc: 'test'}
+     */
+    const rowDataObject = rowData.reduce((acc, { columnId, cellValue }) => {
+      acc[columnId] = cellValue
+      return acc
+    }, {} as Record<string, string>)
+
+    if (!(await table.validateRows([rowDataObject]))) {
+      throw generateStepError(
+        'Invalid column id',
+        'Column(s) may have been deleted or modified. Please check your tile and pipe setup.',
+        $.step.position,
+        'tiles',
+      )
+    }
+
+    const newRow = await createTableRow({ tableId, data: rowDataObject })
+
+    /**
+     * convert row data keys from column ids to column names
+     */
+    const newRowData = await table.mapColumnIdsToNames(newRow.data)
+    $.setActionItem({
+      raw: {
+        success: true,
+        rowId: newRow.rowId,
+        data: newRowData,
+      },
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/tiles/actions/index.ts
+++ b/packages/backend/src/apps/tiles/actions/index.ts
@@ -1,0 +1,3 @@
+import createRow from './create-row'
+
+export default [createRow]

--- a/packages/backend/src/apps/tiles/common/validate-tile-access.ts
+++ b/packages/backend/src/apps/tiles/common/validate-tile-access.ts
@@ -1,0 +1,15 @@
+import TableCollaborator from '@/models/table-collaborators'
+
+export async function validateTileAccess(
+  userId: string,
+  tableId: string,
+): Promise<void | never> {
+  const collaborator = await TableCollaborator.query().findOne({
+    table_id: tableId,
+    user_id: userId,
+  })
+  if (!collaborator) {
+    throw new Error('User does not have access to tile')
+  }
+  return
+}

--- a/packages/backend/src/apps/tiles/index.ts
+++ b/packages/backend/src/apps/tiles/index.ts
@@ -1,5 +1,6 @@
 import { IApp } from '@plumber/types'
 
+import actions from './actions'
 import dynamicData from './dynamic-data'
 
 const app: IApp = {
@@ -11,6 +12,7 @@ const app: IApp = {
   baseUrl: '',
   apiBaseUrl: '',
   primaryColor: '',
+  actions,
   dynamicData,
 }
 

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -25,17 +25,18 @@ const getDynamicData = async (
     })
     .findById(stepId)
 
-  if (!step) {
-    return null
-  }
-
-  const connection = step.connection
-
-  if (!connection || !step.appKey) {
+  if (!step || !step.appKey) {
     return null
   }
 
   const app = apps[step.appKey]
+  const connection = step.connection
+
+  // if app requires connection, only proceed if connection has been set up
+  if (app.auth && !connection) {
+    return null
+  }
+
   const $ = await globalVariable({
     connection,
     app,

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -66,6 +66,7 @@ const globalVariable = async (
     app: app,
     flow: {
       id: flow?.id,
+      userId: flow?.userId,
       hasFileProcessingActions:
         (await flow?.containsFileProcessingActions()) ?? false,
     },
@@ -125,7 +126,6 @@ const globalVariable = async (
 
   if (flow) {
     const webhookUrl = appConfig.webhookUrl + '/webhooks/' + flow.id
-
     $.webhookUrl = webhookUrl
   }
 

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -69,6 +69,19 @@ class TableMetadata extends Base {
     }
     return true
   }
+
+  async mapColumnIdsToNames(
+    data: Record<string, string>,
+  ): Promise<Record<string, string>> {
+    const columns = await this.$relatedQuery('columns')
+    const columnMap = new Map(columns.map((column) => [column.id, column.name]))
+
+    const mappedData: Record<string, string> = {}
+    for (const [key, value] of Object.entries(data)) {
+      mappedData[columnMap.get(key)] = value
+    }
+    return mappedData
+  }
 }
 
 export default TableMetadata

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -146,6 +146,7 @@ export interface IFlow {
 export interface IUser {
   id: string
   email: string
+  // TODO: remove these unused properties?
   connections?: IConnection[]
   flows?: IFlow[]
   steps?: IStep[]
@@ -488,6 +489,7 @@ export type IGlobalVariable = {
   flow?: {
     id: string
     hasFileProcessingActions: boolean
+    userId: string
     remoteWebhookId?: string
     setRemoteWebhookId?: (remoteWebhookId: string) => Promise<void>
   }


### PR DESCRIPTION
## Create new row action

![image](https://github.com/opengovsg/plumber/assets/10072985/07e4f969-237d-4529-a8b3-62c2879af9d6)

### things to take note off
1. This PR returns row data by mapping column ids to column names. This is a shitty decision since variables cannot have spaces in the nested keys and column names will most definitely contain spaces. Ignore this implementation for now as it will be fixed in the later PR.
2. All Tiles actions will need to validate that the user (pipe owner) has access to the tiles. This is because the user might have access while the pipe is being set up but might have his permissions revoked later on. This might get a bit confusing when we implement pipe collaborators.
3. Get-dynamic-data query requires connection to be setup before it fetches the dynamic data. However, since tiles do not support connections, the condition has been changed from
```
if (!connection) return null
```
to
```
if (app.auth && !connection) return null
```
This only requires connection when app.auth is implemented.