### PR TITLE
PLU-70 [TILES-ACTIONS-3]: find single row action

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -19,7 +19,10 @@
     "db:rollback": "npm run db -- migrate:rollback",
     "db:migrate": "npm run db -- migrate:latest",
     "postsetup": "ts-node src/db/dynamodb_seeds/create_table.ts",
+    "readme:dynamodb:seed": "echo 'Seeds the specified table with 10k rows, use with -- <YOUR_TABLE_ID>'",
     "dynamodb:seed": "ts-node src/db/dynamodb_seeds/seed_rows.ts",
+    "readme:dynamodb:setup": "echo 'Run this function to create the required tile table in dynamodb locally.'",
+    "dynamodb:setup": "ts-node src/db/dynamodb_seeds/create_table.ts",
     "copy-statics": "copyfiles -u 1 src/**/*.{graphql,json,svg} dist"
   },
   "dependencies": {

--- a/packages/backend/src/apps/tiles/actions/create-row.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row.ts
@@ -4,7 +4,7 @@ import { generateStepError } from '@/helpers/generate-step-error'
 import { createTableRow } from '@/models/dynamodb/table-row/functions'
 import TableMetadata from '@/models/table-metadata'
 
-import { validateTileAccess } from '../../common/validate-tile-access'
+import { validateTileAccess } from '../common/validate-tile-access'
 
 const action: IRawAction = {
   name: 'Create row',

--- a/packages/backend/src/apps/tiles/actions/create-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/get-data-out-metadata.ts
@@ -1,0 +1,29 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+import { generateColumnNameMetadata } from '../../common/column-name-metadata'
+import { CreateRowOutput } from '../../types'
+
+/**
+ * Maps column ids to column names since there is a possibility that column names could be the same
+ * and/or contains spaces
+ */
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut?.row || typeof dataOut.row !== 'object') {
+    return null
+  }
+
+  const metadata: IDataOutMetadata = {
+    rowId: {
+      label: 'Row ID',
+    },
+  }
+  const rowData = (dataOut as CreateRowOutput).row
+  const columnNameMetadata = await generateColumnNameMetadata(rowData)
+
+  return { ...metadata, ...columnNameMetadata }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -4,7 +4,10 @@ import { generateStepError } from '@/helpers/generate-step-error'
 import { createTableRow } from '@/models/dynamodb/table-row/functions'
 import TableMetadata from '@/models/table-metadata'
 
-import { validateTileAccess } from '../common/validate-tile-access'
+import { validateTileAccess } from '../../common/validate-tile-access'
+import { CreateRowOutput } from '../../types'
+
+import getDataOutMetadata from './get-data-out-metadata'
 
 const action: IRawAction = {
   name: 'Create row',
@@ -69,6 +72,8 @@ const action: IRawAction = {
     },
   ],
 
+  getDataOutMetadata,
+
   async run($) {
     const { tableId, rowData } = $.step.parameters as {
       tableId: string
@@ -98,16 +103,11 @@ const action: IRawAction = {
 
     const newRow = await createTableRow({ tableId, data: rowDataObject })
 
-    /**
-     * convert row data keys from column ids to column names
-     */
-    const newRowData = await table.mapColumnIdsToNames(newRow.data)
     $.setActionItem({
       raw: {
-        success: true,
         rowId: newRow.rowId,
-        data: newRowData,
-      },
+        row: newRow.data,
+      } satisfies CreateRowOutput,
     })
   },
 }

--- a/packages/backend/src/apps/tiles/actions/find-single-row.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row.ts
@@ -1,0 +1,123 @@
+import { IRawAction } from '@plumber/types'
+
+import {
+  findTableRows,
+  TableRowFilter,
+  TableRowFilterOperator,
+} from '@/models/dynamodb/table-row'
+
+import { validateTileAccess } from '../common/validate-tile-access'
+
+const action: IRawAction = {
+  name: 'Find single row',
+  key: 'findSingleRow',
+  description: 'Finds a single row in Tile',
+  arguments: [
+    {
+      label: 'Select Tile',
+      key: 'tableId',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      description: 'Select the tile you want to create a row in.',
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTables',
+          },
+        ],
+      },
+    },
+    {
+      label: 'Lookup conditions',
+      key: 'filters',
+      type: 'multirow' as const,
+      required: false,
+      subFields: [
+        {
+          placeholder: 'Column',
+          key: 'columnId',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          source: {
+            type: 'query' as const,
+            name: 'getDynamicData' as const,
+            arguments: [
+              {
+                name: 'key',
+                value: 'listColumns',
+              },
+              {
+                name: 'parameters.tableId',
+                value: '{parameters.tableId}',
+              },
+            ],
+          },
+        },
+        {
+          placeholder: 'Operator',
+          key: 'operator',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          options: [
+            { label: 'Equals to', value: TableRowFilterOperator.Equals },
+            {
+              label: 'Greater than ',
+              value: TableRowFilterOperator.GreaterThan,
+            },
+            {
+              label: 'Greater than or equals to',
+              value: TableRowFilterOperator.GreaterThanOrEquals,
+            },
+            { label: 'Less than', value: TableRowFilterOperator.LessThan },
+            {
+              label: 'Less than or equals to',
+              value: TableRowFilterOperator.LessThanOrEquals,
+            },
+            { label: 'Begins with', value: TableRowFilterOperator.BeginsWith },
+            { label: 'Contains', value: TableRowFilterOperator.Contains },
+            {
+              label: 'is empty (leave value blank)',
+              value: TableRowFilterOperator.IsEmpty,
+            },
+          ],
+        },
+        {
+          placeholder: 'Value',
+          key: 'value',
+          type: 'string' as const,
+          required: false,
+          variables: true,
+        },
+      ],
+    },
+  ],
+
+  async run($) {
+    const { tableId, filters } = $.step.parameters as {
+      tableId: string
+      filters: TableRowFilter[]
+    }
+    await validateTileAccess($.flow?.userId, tableId as string)
+
+    const result = await findTableRows({ tableId, filters })
+
+    $.setActionItem({
+      raw: {
+        success: true,
+        rowCount: result.length,
+        row: result.length > 0 ? result[0].data : null,
+      },
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
@@ -1,0 +1,32 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+import { generateColumnNameMetadata } from '../../common/column-name-metadata'
+import { FindSingleRowOutput } from '../../types'
+
+/**
+ * Maps column ids to column names since there is a possibility that column names could be the same
+ * and/or contains spaces
+ */
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut?.row || typeof dataOut.row !== 'object') {
+    return null
+  }
+
+  const metadata: IDataOutMetadata = {
+    rowId: {
+      label: 'Row ID',
+    },
+    rowsFound: {
+      label: 'Rows found',
+    },
+  }
+  const rowData = (dataOut as FindSingleRowOutput).row
+  const columnNameMetadata = await generateColumnNameMetadata(rowData)
+
+  return { ...metadata, ...columnNameMetadata }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/tiles/actions/index.ts
+++ b/packages/backend/src/apps/tiles/actions/index.ts
@@ -1,3 +1,4 @@
 import createRow from './create-row'
+import findSingleRow from './find-single-row'
 
-export default [createRow]
+export default [createRow, findSingleRow]

--- a/packages/backend/src/apps/tiles/common/column-name-metadata.ts
+++ b/packages/backend/src/apps/tiles/common/column-name-metadata.ts
@@ -1,0 +1,28 @@
+import { IDataOutMetadata } from '@plumber/types'
+
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+/**
+ * Helper function to generate dataOut metadata
+ * Maps column ids to column names since there is a possibility that column names could be the same
+ * and/or contains spaces
+ */
+export async function generateColumnNameMetadata(
+  rowData: Record<string, string | number>,
+  prefix = 'row.', // this is the parent key for the row data
+): Promise<IDataOutMetadata> {
+  const metadata: IDataOutMetadata = {}
+
+  const columnIds = Object.keys(rowData)
+
+  const columns = await TableColumnMetadata.query()
+    .findByIds(columnIds)
+    .select('id', 'name')
+
+  columns.forEach((column) => {
+    metadata[`${prefix}${column.id}`] = {
+      label: column.name,
+    }
+  })
+  return metadata
+}

--- a/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
@@ -33,10 +33,10 @@ const dynamicData: IDynamicData = {
         .orderBy('position', 'asc')
 
       return {
-        data: columns.map(({ id, name, position }) => ({
+        data: columns.map(({ id, name }) => ({
           value: id,
           // + 1 since zero-indexed
-          name: `${position + 1}. ${name}`,
+          name: name,
         })),
       }
     } catch (e) {

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -1,0 +1,12 @@
+import { IJSONObject } from '@plumber/types'
+
+export interface FindSingleRowOutput extends IJSONObject {
+  rowsFound: number
+  rowId?: string
+  row?: Record<string, string | number>
+}
+
+export interface CreateRowOutput extends IJSONObject {
+  rowId: string
+  row: Record<string, string | number>
+}

--- a/packages/backend/src/db/dynamodb_seeds/seed_rows.ts
+++ b/packages/backend/src/db/dynamodb_seeds/seed_rows.ts
@@ -7,8 +7,8 @@ import { argv } from 'process'
 import {
   createTableRows,
   deleteTableRows,
-  getAllTableRows,
   getTableRowCount,
+  getTableRows,
 } from '@/models/dynamodb/table-row'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
@@ -25,7 +25,7 @@ const COUNT_ONLY = argv[3]
 const ROW_COUNT = 10000
 async function seedRows(tableId: string) {
   // delete existing rows
-  const existingRows = await getAllTableRows({ tableId })
+  const existingRows = await getTableRows({ tableId })
   console.log('count', existingRows.length)
 
   if (COUNT_ONLY === 'count') {

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
@@ -14,7 +14,7 @@ import {
 describe('create row mutation', () => {
   let context: Context
   let dummyTable: TableMetadata
-  let dummyColumnIds: string[] = []
+  let dummyColumnIds: string[]
 
   // cant use before all here since the data is re-seeded each time
   beforeEach(async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import createRows from '@/graphql/mutations/tiles/create-rows'
-import { getAllTableRows } from '@/models/dynamodb/table-row/functions'
+import { getTableRows } from '@/models/dynamodb/table-row/functions'
 import TableMetadata from '@/models/table-metadata'
 import Context from '@/types/express/context'
 
@@ -47,7 +47,7 @@ describe('create row mutation', () => {
       context,
     )
 
-    const rows = await getAllTableRows({
+    const rows = await getTableRows({
       tableId: dummyTable.id,
       columnIds: dummyColumnIds,
     })
@@ -72,7 +72,7 @@ describe('create row mutation', () => {
       context,
     )
 
-    const rows = await getAllTableRows({
+    const rows = await getTableRows({
       tableId: dummyTable.id,
       columnIds: dummyColumnIds,
     })

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -1,4 +1,4 @@
-import { getAllTableRows, TableRowItem } from '@/models/dynamodb/table-row'
+import { getTableRows, TableRowItem } from '@/models/dynamodb/table-row'
 import Context from '@/types/express/context'
 
 type Params = {
@@ -18,7 +18,7 @@ const getAllRows = async (
     .throwIfNotFound()
 
   const columnIds = table.columns.map((column) => column.id)
-  return getAllTableRows({ tableId, columnIds })
+  return getTableRows({ tableId, columnIds })
 }
 
 export default getAllRows

--- a/packages/backend/src/models/dynamodb/__tests__/helper.test.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/helper.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+import {
+  autoMarshallDataObj,
+  mapColumnIdsToNames,
+  stripInvalidKeys,
+} from '../helpers'
+
+describe('dynamodb helpers', () => {
+  describe('auto marshall data value types', () => {
+    it('should correctly identify numberic strings', () => {
+      const rawValue = {
+        text: 'abc',
+        int: '123',
+        float: '12.444',
+        invalidFloat: '12.444.444',
+        exponential: '1e+3',
+        mixed: '123abc',
+      }
+
+      expect(autoMarshallDataObj(rawValue)).toEqual({
+        text: 'abc',
+        int: 123,
+        float: 12.444,
+        invalidFloat: '12.444.444',
+        exponential: '1e+3',
+        mixed: '123abc',
+      })
+    })
+    it('should leave unknown types as is', () => {
+      const rawValue = {
+        bool: true,
+        undefined: undefined,
+        null: null,
+        date: new Date(),
+      } as unknown as Record<string, string> // for bypassing type checks
+
+      expect(autoMarshallDataObj(rawValue)).toEqual(rawValue)
+    })
+  })
+
+  describe('map column ids to names', () => {
+    it('should map column ids to names correct', () => {
+      const columns = [
+        { id: '1', name: 'name1' },
+        { id: '2', name: 'name2' },
+        { id: '3', name: 'name3' },
+      ] as TableColumnMetadata[]
+      const data = {
+        '1': 'value1',
+        '2': 'value2',
+        '3': 'value3',
+      }
+      expect(mapColumnIdsToNames(data, columns)).toEqual({
+        name1: 'value1',
+        name2: 'value2',
+        name3: 'value3',
+      })
+    })
+
+    it('should strip away unknown column ids', () => {
+      const columns = [
+        { id: '1', name: 'name1' },
+        { id: '3', name: 'name3' },
+      ] as TableColumnMetadata[]
+      const data = {
+        '1': 'value1',
+        '2': 'value2',
+        '3': 'value3',
+      }
+      expect(mapColumnIdsToNames(data, columns)).toEqual({
+        name1: 'value1',
+        name3: 'value3',
+      })
+    })
+  })
+
+  describe('strip invalid keys', () => {
+    it('should strip away unknown column ids', () => {
+      const columnIds = ['1', '3']
+      const data = {
+        '1': 'value1',
+        '2': 'value2',
+        '3': 'value3',
+      }
+      expect(stripInvalidKeys({ columnIds, data })).toEqual({
+        '1': 'value1',
+        '3': 'value3',
+      })
+    })
+  })
+})

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  generateMockContext,
+  generateMockTable,
+  generateMockTableColumns,
+  generateMockTableRowData,
+} from '@/graphql/__tests__/mutations/tiles/table.mock'
+import TableMetadata from '@/models/table-metadata'
+import Context from '@/types/express/context'
+
+import { TableRowFilterOperator } from '../../table-row'
+import {
+  createTableRow,
+  createTableRows,
+  getRawRowById,
+  getTableRowCount,
+  getTableRows,
+  updateTableRow,
+} from '../../table-row/functions'
+
+describe('dynamodb table row functions', () => {
+  let dummyTable: TableMetadata
+  let dummyColumnIds: string[] = []
+  let context: Context
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    dummyTable = await generateMockTable({ userId: context.currentUser.id })
+
+    dummyColumnIds = await generateMockTableColumns({
+      tableId: dummyTable.id,
+      numColumns: 5,
+    })
+  })
+
+  describe('createTableRow', () => {
+    it('should create a single row', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+      expect(row).toBeDefined()
+    })
+  })
+
+  describe('createTableRows', () => {
+    it('should create multiple rows', async () => {
+      const dataArray = new Array(1000)
+        .fill(null)
+        .map(() => generateMockTableRowData({ columnIds: dummyColumnIds }))
+      const rows = await createTableRows({ tableId: dummyTable.id, dataArray })
+      expect(rows).toBeDefined()
+      expect(rows.length).toEqual(1000)
+    })
+  })
+
+  describe('getTableRowCount', () => {
+    it('should get the correct row count', async () => {
+      const dataArray = new Array(1000)
+        .fill(null)
+        .map(() => generateMockTableRowData({ columnIds: dummyColumnIds }))
+      await createTableRows({ tableId: dummyTable.id, dataArray })
+      const count = await getTableRowCount({ tableId: dummyTable.id })
+      expect(count).toEqual(1000)
+    })
+  })
+
+  describe('get table rows', async () => {
+    it('should get all rows with specified columns', async () => {
+      const dataArray = []
+      for (let i = 0; i < 1000; i++) {
+        dataArray.push({
+          a: `${i}`,
+          b: `string${i}`,
+        })
+      }
+      await createTableRows({ tableId: dummyTable.id, dataArray })
+      const rows = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b', 'randomcol'],
+      })
+      expect(rows.length).toEqual(1000)
+      // should not include randomcol
+      expect(Object.keys(rows[0])).not.toContain('randomcol')
+    })
+
+    it('should get relevant rows based on a single filter', async () => {
+      const dataArray = []
+      for (let i = 0; i < 1000; i++) {
+        dataArray.push({
+          a: `${i}`,
+          b: `string${i}`,
+        })
+      }
+      await createTableRows({ tableId: dummyTable.id, dataArray })
+
+      // LTE
+      const rows1 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.LessThanOrEquals,
+            value: '500',
+          },
+        ],
+      })
+      expect(rows1.length).toEqual(501)
+
+      // LT
+      const rows2 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.LessThan,
+            value: '500',
+          },
+        ],
+      })
+      expect(rows2.length).toEqual(500)
+
+      // GT
+      const rows3 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.GreaterThan,
+            value: '500',
+          },
+        ],
+      })
+      expect(rows3.length).toEqual(499)
+
+      // GTE
+      const rows4 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.GreaterThanOrEquals,
+            value: '500',
+          },
+        ],
+      })
+      expect(rows4.length).toEqual(500)
+
+      // EQUALS
+      const rows5 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.Equals,
+            value: '500',
+          },
+        ],
+      })
+      expect(rows5.length).toEqual(1)
+
+      // Contains
+      const rows6 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.Contains,
+            value: '99',
+          },
+        ],
+      })
+      expect(rows6.length).toEqual(19)
+
+      // Contains
+      const rows7 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.BeginsWith,
+            value: 'string9',
+          },
+        ],
+      })
+      expect(rows7.length).toEqual(111)
+
+      // Empty
+      const rows8 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'c',
+            operator: TableRowFilterOperator.IsEmpty,
+            value: '',
+          },
+        ],
+      })
+      expect(rows8.length).toEqual(1000)
+    })
+
+    it('should get relevant rows based on composite filters', async () => {
+      const dataArray = []
+      for (let i = 0; i < 1000; i++) {
+        dataArray.push({
+          a: `${i}`,
+          b: `string${i}`,
+        })
+      }
+      await createTableRows({ tableId: dummyTable.id, dataArray })
+
+      // LTE & GTE
+      const rows1 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.LessThanOrEquals,
+            value: '500',
+          },
+
+          {
+            columnId: 'a',
+            operator: TableRowFilterOperator.GreaterThanOrEquals,
+            value: '200',
+          },
+        ],
+      })
+      expect(rows1.length).toEqual(301)
+
+      // CONTAINS & BEGINS WITH
+      const rows2 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.Contains,
+            value: '99',
+          },
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.BeginsWith,
+            value: 'string9',
+          },
+        ],
+      })
+      expect(rows2.length).toEqual(11)
+
+      // IS EMPTY & EQUALS
+      const rows3 = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'c',
+            operator: TableRowFilterOperator.IsEmpty,
+            value: '',
+          },
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.Equals,
+            value: 'string999',
+          },
+        ],
+      })
+      expect(rows3.length).toEqual(1)
+    })
+  })
+
+  describe('getRawRowById', () => {
+    it('should get a row by id', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+      const rawRow = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        columnIds: dummyColumnIds,
+      })
+      expect(rawRow.data).toEqual(rawRow.data)
+    })
+
+    it('should strip out unspecified columns', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+      const rawRow = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        columnIds: [dummyColumnIds[0]],
+      })
+      expect(Object.keys(rawRow.data)).toEqual([dummyColumnIds[0]])
+    })
+  })
+
+  describe('updateTableRow', () => {
+    it('should update the data map for the row', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const newData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+
+      await updateTableRow({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        data: newData,
+      })
+      const updatedRow = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        columnIds: dummyColumnIds,
+      })
+      expect(updatedRow.data).toEqual(newData)
+    })
+  })
+})

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -1,5 +1,7 @@
 import { ElectroError } from 'electrodb'
 
+import TableColumnMetadata from '../table-column-metadata'
+
 export function handleDynamoDBError(error: unknown): never {
   console.error(error)
   if (error instanceof ElectroError) {
@@ -25,4 +27,42 @@ export function handleDynamoDBError(error: unknown): never {
     throw new Error('DynamoDB Error: ' + error.message)
   }
   throw new Error('DynamoDB Unknown Error')
+}
+
+export function autoMarshallNumberStrings(value: string): string | number {
+  // convert all numeric strings such as '123' to numbers
+  // only accepts string that contains only numbers and a single decimal point
+  if (
+    typeof value === 'string' &&
+    /^\d+(\.\d+)?$/.test(value) &&
+    !isNaN(+value)
+  ) {
+    return +value
+  }
+  return value
+}
+
+export function autoMarshallDataObj(
+  dataObj: Record<string, string>,
+): Record<string, string | number> {
+  const newObj: Record<string, string | number> = {}
+  for (const key in dataObj) {
+    newObj[key] = autoMarshallNumberStrings(dataObj[key])
+  }
+  return newObj
+}
+
+export function mapColumnIdsToNames(
+  data: Record<string, string | number>,
+  columns: TableColumnMetadata[],
+): Record<string, string | number> {
+  const columnMap = new Map(columns.map((column) => [column.id, column.name]))
+
+  const mappedData: Record<string, string | number> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (columnMap.get(key)) {
+      mappedData[columnMap.get(key)] = value
+    }
+  }
+  return mappedData
 }

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -66,3 +66,20 @@ export function mapColumnIdsToNames(
   }
   return mappedData
 }
+
+export function stripInvalidKeys({
+  columnIds,
+  data,
+}: {
+  columnIds: string[]
+  data: Record<string, string | number>
+}) {
+  const validKeys = new Set(columnIds)
+  const strippedData: Record<string, string | number> = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (validKeys.has(key)) {
+      strippedData[key] = value
+    }
+  }
+  return strippedData
+}

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -192,6 +192,9 @@ export const createTableRows = async ({
   }
 }
 
+/**
+ * This replaces the entire data object for the row
+ */
 export const updateTableRow = async ({
   rowId,
   tableId,

--- a/packages/backend/src/models/dynamodb/table-row/index.ts
+++ b/packages/backend/src/models/dynamodb/table-row/index.ts
@@ -1,2 +1,3 @@
 export * from './functions'
 export * from './model'
+export * from './types'

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -2,6 +2,8 @@ import { Entity } from 'electrodb'
 
 import client, { tableName } from '@/config/dynamodb'
 
+import { autoMarshallDataObj } from '../helpers'
+
 export const TableRow = new Entity(
   {
     model: {
@@ -23,13 +25,7 @@ export const TableRow = new Entity(
       data: {
         type: 'any',
         required: true,
-        validate: (value) => {
-          for (const key in value) {
-            if (typeof value[key] !== 'string') {
-              throw new Error('value must be a string')
-            }
-          }
-        },
+        set: autoMarshallDataObj,
       },
       createdAt: {
         type: 'number',

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -1,0 +1,33 @@
+import { CreateEntityItem } from 'electrodb'
+
+import { TableRow } from './model'
+
+export type TableRowItem = CreateEntityItem<typeof TableRow>
+export type CreateRowInput = Pick<TableRowItem, 'tableId' | 'data'>
+export type CreateRowsInput = {
+  tableId: string
+  dataArray: Record<string, string>[]
+}
+export type UpdateRowInput = Pick<TableRowItem, 'tableId' | 'data' | 'rowId'>
+export interface DeleteRowsInput {
+  tableId: string
+  rowIds: string[]
+}
+export type TableRowOutput = Pick<TableRowItem, 'rowId' | 'data'>
+
+export enum TableRowFilterOperator {
+  Equals = 'equals',
+  GreaterThan = 'gt',
+  GreaterThanOrEquals = 'gte',
+  LessThan = 'lt',
+  LessThanOrEquals = 'lte',
+  BeginsWith = 'begins',
+  Contains = 'contains',
+  IsEmpty = 'empty',
+}
+
+export type TableRowFilter = {
+  columnId: string
+  operator: TableRowFilterOperator
+  value?: string
+}

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -70,6 +70,10 @@ class TableMetadata extends Base {
     return true
   }
 
+  /**
+   * Maps column ids to column names
+   * Strips away any keys that are not column ids
+   */
   async mapColumnIdsToNames(
     data: Record<string, string>,
   ): Promise<Record<string, string>> {
@@ -78,7 +82,9 @@ class TableMetadata extends Base {
 
     const mappedData: Record<string, string> = {}
     for (const [key, value] of Object.entries(data)) {
-      mappedData[columnMap.get(key)] = value
+      if (columnMap.get(key)) {
+        mappedData[columnMap.get(key)] = value
+      }
     }
     return mappedData
   }


### PR DESCRIPTION
## Find single row action

Pretty big PR ahead 🙇🏻  sorry

![image](https://github.com/opengovsg/plumber/assets/10072985/264ad100-74ec-4f51-ad5d-cb4eba1a1b63)

### Details

1. As mentioned in the previous PR, column names were returned rather than column ids which will cause spacing problems in the variable path names. This PR refactors this and use data out metadata to display column names.
2. Previously, **ALL values were stored as strings**. This results in issues with filter expressions such as >, < , >= and <=  as it does a lexical comparison rather than a numerical comparison. We also want to prevent the need for users to indicate whether the column is a number or string column. Therefore, the PR includes a change with the dynamodb library such that it now checks if the string is a numerical-like string and automatically marshall it as a number before saving to the db. This is similar to Excel where the cell is automatically formatted as a number if a number-like string is entered. 

Valid number-like strings include: '0100', '100', '12.33', '0.9999'. Invalid number like strings include '1e9', '1.2.34', '+651298312', anything with alphabets. 

### Tests
1. Unit tests have been implemented for the helper functions but not for the `run($)` actions.
2. Tested on UAT using filters on a large table (10k) without indexing and it's pretty fast, almost instantaneous. 