### PR TITLE
PLU-70 [TILES-ACTIONS-4]: update row by id

### DIFF
--- a/packages/backend/src/apps/tiles/actions/index.ts
+++ b/packages/backend/src/apps/tiles/actions/index.ts
@@ -1,4 +1,5 @@
 import createRow from './create-row'
 import findSingleRow from './find-single-row'
+import updateRow from './update-row'
 
-export default [createRow, findSingleRow]
+export default [findSingleRow, createRow, updateRow]

--- a/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/get-data-out-metadata.ts
@@ -1,0 +1,29 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+import { generateColumnNameMetadata } from '../../common/column-name-metadata'
+import { UpdateRowOutput } from '../../types'
+
+/**
+ * Maps column ids to column names since there is a possibility that column names could be the same
+ * and/or contains spaces
+ */
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut?.row || typeof dataOut.row !== 'object') {
+    return null
+  }
+
+  const metadata: IDataOutMetadata = {
+    rowId: {
+      label: 'Row ID',
+    },
+  }
+  const rowData = (dataOut as UpdateRowOutput).row
+  const columnNameMetadata = await generateColumnNameMetadata(rowData)
+
+  return { ...metadata, ...columnNameMetadata }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -1,0 +1,134 @@
+import { IRawAction } from '@plumber/types'
+
+import { stripInvalidKeys } from '@/models/dynamodb/helpers'
+import { getRawRowById, updateTableRow } from '@/models/dynamodb/table-row'
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+import { validateTileAccess } from '../../common/validate-tile-access'
+import { UpdateRowOutput } from '../../types'
+
+import getDataOutMetadata from './get-data-out-metadata'
+
+const action: IRawAction = {
+  name: 'Update single row',
+  key: 'updateSingleRow',
+  description: 'Updates a single row by row ID',
+  arguments: [
+    {
+      label: 'Select Tile',
+      key: 'tableId',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      description: 'Select the tile you want to create a row in.',
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTables',
+          },
+        ],
+      },
+    },
+    {
+      label: 'Row ID',
+      key: 'rowId',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+      description:
+        'Enter the row ID of the row to update. Use Find Single Row action to lookup the row ID.',
+    },
+    {
+      label: 'Row data',
+      key: 'rowData',
+      type: 'multirow' as const,
+      required: true,
+      subFields: [
+        {
+          placeholder: 'Column',
+          key: 'columnId',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          source: {
+            type: 'query' as const,
+            name: 'getDynamicData' as const,
+            arguments: [
+              {
+                name: 'key',
+                value: 'listColumns',
+              },
+              {
+                name: 'parameters.tableId',
+                value: '{parameters.tableId}',
+              },
+            ],
+          },
+        },
+        {
+          placeholder: 'Value',
+          key: 'cellValue',
+          type: 'string' as const,
+          required: false,
+          variables: true,
+        },
+      ],
+    },
+  ],
+  getDataOutMetadata,
+
+  async run($) {
+    const { tableId, rowId, rowData } = $.step.parameters as {
+      tableId: string
+      rowId: string
+      rowData: { columnId: string; cellValue: string }[]
+    }
+    await validateTileAccess($.flow?.userId, tableId as string)
+
+    const columns = await TableColumnMetadata.query()
+      .where({
+        table_id: tableId,
+      })
+      .select('id', 'name')
+    const columnIds = columns.map((c) => c.id)
+
+    const row = await getRawRowById({
+      tableId,
+      rowId,
+      columnIds,
+    })
+
+    const updatedData = {
+      ...row.data,
+      ...rowData.reduce((acc, { columnId, cellValue }) => {
+        acc[columnId] = cellValue
+        return acc
+      }, {} as Record<string, string>),
+    }
+
+    const strippedUpdatedData = stripInvalidKeys({
+      columnIds,
+      data: updatedData,
+    })
+
+    await updateTableRow({
+      tableId,
+      rowId,
+      data: strippedUpdatedData,
+    })
+
+    $.setActionItem({
+      raw: {
+        row: strippedUpdatedData,
+        rowId,
+      } satisfies UpdateRowOutput,
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -10,3 +10,8 @@ export interface CreateRowOutput extends IJSONObject {
   rowId: string
   row: Record<string, string | number>
 }
+
+export interface UpdateRowOutput extends IJSONObject {
+  rowId: string
+  row: Record<string, string | number>
+}


### PR DESCRIPTION
## Update row by row ID

This action is to be used in conjunction with `find single row` action. This will be documented in the guide and is also in the field description.

Pretty straight forward PR.

![image](https://github.com/opengovsg/plumber/assets/10072985/8bb7be97-75b4-4828-816f-4307fb1ea8d0)
