### PR TITLE
fix: increase telegram timeout and max attempts

### DIFF
--- a/packages/backend/src/apps/telegram-bot/common/interceptor/rate-limit.ts
+++ b/packages/backend/src/apps/telegram-bot/common/interceptor/rate-limit.ts
@@ -1,0 +1,32 @@
+import type { IApp } from '@plumber/types'
+
+import logger from '@/helpers/logger'
+
+const rateLimitHandler: IApp['requestErrorHandler'] = async function (
+  $,
+  error,
+) {
+  if (error.response.status !== 429) {
+    return // use default error handling
+  }
+
+  const retryAfter = +error.response.headers['retry-after']
+  if (isNaN(retryAfter)) {
+    return
+  }
+
+  logger.error('Telegram rate limit error', {
+    executionId: $.execution.id,
+    flowId: $.flow.id,
+    stepId: $.step.id,
+    data: error.response.data,
+    headers: error.response.headers,
+    oldRetryAfter: retryAfter,
+    newRetryAfter: retryAfter + 30,
+  })
+
+  error.response.headers['retry-after'] = `${retryAfter + 30}`
+  throw error
+}
+
+export default rateLimitHandler

--- a/packages/backend/src/apps/telegram-bot/common/interceptor/rate-limit.ts
+++ b/packages/backend/src/apps/telegram-bot/common/interceptor/rate-limit.ts
@@ -2,6 +2,8 @@ import type { IApp } from '@plumber/types'
 
 import logger from '@/helpers/logger'
 
+const ADDITONAL_RATE_LIMIT_IN_SEC = 45
+
 const rateLimitHandler: IApp['requestErrorHandler'] = async function (
   $,
   error,
@@ -15,6 +17,8 @@ const rateLimitHandler: IApp['requestErrorHandler'] = async function (
     return
   }
 
+  const newRetryAfter = retryAfter + ADDITONAL_RATE_LIMIT_IN_SEC
+
   logger.error('Telegram rate limit error', {
     executionId: $.execution.id,
     flowId: $.flow.id,
@@ -22,10 +26,10 @@ const rateLimitHandler: IApp['requestErrorHandler'] = async function (
     data: error.response.data,
     headers: error.response.headers,
     oldRetryAfter: retryAfter,
-    newRetryAfter: retryAfter + 30,
+    newRetryAfter,
   })
 
-  error.response.headers['retry-after'] = `${retryAfter + 30}`
+  error.response.headers['retry-after'] = newRetryAfter.toString()
   throw error
 }
 

--- a/packages/backend/src/apps/telegram-bot/index.ts
+++ b/packages/backend/src/apps/telegram-bot/index.ts
@@ -1,6 +1,7 @@
 import { IApp } from '@plumber/types'
 
 import addAuthHeader from './common/add-auth-header'
+import rateLimitHandler from './common/interceptor/rate-limit'
 import actions from './actions'
 import auth from './auth'
 import dynamicData from './dynamic-data'
@@ -14,6 +15,7 @@ const app: IApp = {
   apiBaseUrl: 'https://api.telegram.org',
   primaryColor: '2AABEE',
   beforeRequest: [addAuthHeader],
+  requestErrorHandler: rateLimitHandler,
   dynamicData,
   auth,
   actions,

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/helpers/logger', () => ({
   default: {
     error: mocks.logError,
+    info: vi.fn(),
   },
 }))
 

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -25,7 +25,7 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   attemptsMade: number,
   _type: string,
   err: Error,
-  _job: Job,
+  job: Job,
 ): number {
   // This implements FullJitter-like jitter, with the following changes:
   //
@@ -40,5 +40,11 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   const initialDelay = computeInitialDelay(err)
 
   const prevFullDelay = Math.pow(2, attemptsMade - 1) * initialDelay
-  return prevFullDelay + Math.round(Math.random() * prevFullDelay)
+  const totalDelay = prevFullDelay + Math.round(Math.random() * prevFullDelay)
+  logger.info('Job delay calculation', {
+    ...job?.data,
+    attemptsMade,
+    delay: totalDelay,
+  })
+  return totalDelay
 }

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -42,7 +42,9 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   const prevFullDelay = Math.pow(2, attemptsMade - 1) * initialDelay
   const totalDelay = prevFullDelay + Math.round(Math.random() * prevFullDelay)
   logger.info('Job delay calculation', {
-    ...job?.data,
+    flowId: job?.data?.flowId,
+    executionId: job?.data?.executionId,
+    stepId: job?.data?.stepId,
     attemptsMade,
     delay: totalDelay,
   })

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -10,7 +10,7 @@ export const REMOVE_AFTER_7_DAYS_OR_50_JOBS = {
 }
 
 export const DEFAULT_JOB_DELAY_DURATION = 0
-export const MAXIMUM_JOB_ATTEMPTS = 4
+export const MAXIMUM_JOB_ATTEMPTS = 6
 
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,


### PR DESCRIPTION
## Temp fix for failing telegram jobs.

### Problem
For pipes with large volume of telegram messages, jobs still fail after 4 attempts as delays are not long enough for rate limits to recover.

### Solution

Increase timeouts for telegram and extend max attempts for all apps to 6 (from 4).
This uses the requestHandler callback that was extended for m365 and adds `30` more seconds to the retry-after header.

Note that this is just a temporary fix while we plan out rate limit by connection id.

### Tests

There's no easy way to test this properly. So I triggered a large number of messages on local dev to proc the rate limit.
Results:

in `/telegram-bot/common/interceptor/rate-limit.ts`
```
[worker] {
[worker]   dd: {
[worker]     trace_id: '8175086654720958621',
[worker]     span_id: '8175086654720958621',
[worker]     service: 'plumber',
[worker]     version: '1.7.1',
[worker]     env: 'development'
[worker]   },
[worker]   executionId: '5be799fe-3e44-4d32-b79f-6910038ff874',
[worker]   flowId: '050cfba9-e061-49e3-8bc9-5c45dad30839',
[worker]   stepId: '1322ae56-5174-4580-961b-530eab9515f7',
[worker]   data: {
[worker]     ok: false,
[worker]     error_code: 429,
[worker]     description: 'Too Many Requests: retry after 8',
[worker]     parameters: { retry_after: 8 }
[worker]   },
[worker]   headers: Object [AxiosHeaders] {
[worker]     server: 'nginx/1.18.0',
[worker]     date: 'Mon, 15 Jan 2024 09:06:08 GMT',
[worker]     'content-type': 'application/json',
[worker]     'content-length': '109',
[worker]     connection: 'close',
[worker]     'retry-after': '8',
[worker]     'strict-transport-security': 'max-age=31536000; includeSubDomains; preload',
[worker]     'access-control-allow-origin': '*',
[worker]     'access-control-expose-headers': 'Content-Length,Content-Type,Date,Server,Connection'
[worker]   },
[worker]   oldRetryAfter: 8,
[worker]   newRetryAfter: 38,
[worker]   level: 'error',
[worker]   message: 'Telegram rate limit error',
[worker]   timestamp: '2024-01-15T09:06:07.749Z'
[worker] }
```
in `/helpers/backoff.ts`
```
[worker] {
[worker]   dd: { service: 'plumber', version: '1.7.1', env: 'development' },
[worker]   flowId: '050cfba9-e061-49e3-8bc9-5c45dad30839',
[worker]   executionId: '5be799fe-3e44-4d32-b79f-6910038ff874',
[worker]   stepId: '1322ae56-5174-4580-961b-530eab9515f7',
[worker]   delay: 39415,
[worker]   level: 'info',
[worker]   message: 'Job delay calculation',
[worker]   timestamp: '2024-01-15T09:06:07.855Z'
[worker] }
```


