### PR TITLE
PLU-125: [EXCEL] Write cell values action

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/index.ts
@@ -1,4 +1,5 @@
 import createTableRow from './create-table-row'
 import getCellValues from './get-cell-values'
+import writeCellValues from './write-cell-values'
 
-export default [createTableRow, getCellValues]
+export default [createTableRow, getCellValues, writeCellValues]

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
@@ -1,0 +1,119 @@
+import type { IRawAction } from '@plumber/types'
+
+import { generateStepError } from '@/helpers/generate-step-error'
+
+import WorkbookSession from '../../common/workbook-session'
+
+import { parametersSchema } from './parameters-schema'
+
+const action: IRawAction = {
+  name: 'Write cell values',
+  key: 'writeCellValues',
+  description: "Write values into a spreadsheet's cells",
+  arguments: [
+    {
+      key: 'fileId',
+      label: 'Excel File',
+      required: true,
+      description: 'File to edit',
+      type: 'dropdown' as const,
+      variables: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listFiles',
+          },
+        ],
+      },
+    },
+    {
+      key: 'worksheetId',
+      label: 'Worksheet',
+      required: true,
+      description: 'Worksheet to edit',
+      type: 'dropdown' as const,
+      variables: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listWorksheets',
+          },
+          {
+            name: 'parameters.fileId',
+            value: '{parameters.fileId}',
+          },
+        ],
+      },
+    },
+    {
+      label: 'Values',
+      key: 'cells',
+      type: 'multirow' as const,
+      required: true,
+      // We need to make 1 separate request for each cell, so limit to 3 as a
+      // balance between convenience and API quota usage.
+      description:
+        'Specify cells you want to write values to (max 3). Leave a value blank to clear the cell.',
+      subFields: [
+        {
+          label: 'Cell Address (e.g. A1)',
+          key: 'address',
+          type: 'string' as const,
+          required: true,
+          variables: true,
+        },
+        {
+          label: 'Value',
+          key: 'value',
+          type: 'string' as const,
+          required: false,
+          variables: true,
+        },
+      ],
+    },
+  ],
+
+  async run($) {
+    const parametersParseResult = parametersSchema.safeParse($.step.parameters)
+
+    if (parametersParseResult.success === false) {
+      throw generateStepError(
+        'Action is set up incorrectly.',
+        parametersParseResult.error.issues[0].message,
+        $.step?.position,
+        $.app.name,
+      )
+    }
+
+    const { fileId, worksheetId, cells } = parametersParseResult.data
+    const session = await WorkbookSession.acquire($, fileId)
+
+    await Promise.all(
+      cells.map(async (cell) =>
+        session.request(
+          `/worksheets/${worksheetId}/range(address='${cell.address}')`,
+          'patch',
+          {
+            data: {
+              values: [[cell.value]],
+            },
+          },
+        ),
+      ),
+    )
+
+    $.setActionItem({
+      raw: {
+        success: true,
+      },
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/parameters-schema.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/parameters-schema.ts
@@ -1,0 +1,39 @@
+import z from 'zod'
+
+import { CELL_A1_ADDRESS_REGEX } from '../../common/workbook-helpers'
+
+// TODO: We should probably store zod schemas in app / action / trigger
+// definitions.
+export const parametersSchema = z.object({
+  fileId: z
+    .string()
+    .trim()
+    .min(1, { message: 'Please choose a file to edit.' }),
+  worksheetId: z
+    .string()
+    .trim()
+    .min(1, { message: 'Please select a worksheet to edit.' }),
+  cells: z
+    .array(
+      z.object({
+        address: z
+          .string()
+          .trim()
+          .min(1, {
+            message: 'Please make sure there are no empty cell addresses.',
+          })
+          .refine(
+            (input) => CELL_A1_ADDRESS_REGEX.test(input),
+            (input) => ({
+              message: `Please input cell address '${input}' in A1 notation.`,
+            }),
+          ),
+        // Not trimming value; we should write user's input as-is.
+        value: z.string().nullish(),
+      }),
+    )
+    .min(1)
+    .max(3, {
+      message: 'Please write to no more than 3 cells in a single step.',
+    }),
+})

--- a/packages/backend/src/apps/m365-excel/common/workbook-helpers.ts
+++ b/packages/backend/src/apps/m365-excel/common/workbook-helpers.ts
@@ -1,0 +1,1 @@
+export const CELL_A1_ADDRESS_REGEX = /^[a-zA-Z]+[1-9][0-9]*$/

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -50,9 +50,17 @@ function validateSubstep(substep: ISubstep, step: IStep): boolean {
         return false
       }
 
-      return arg.subFields.every((subField) =>
-        rows.every((row) => isValidArgValue(row[subField.key])),
-      )
+      return arg.subFields
+        .filter(
+          // Ignore hidden or optional subfields
+          (subField) => !(subField.hidden || subField.required === false),
+        )
+        .every((subField) =>
+          rows.every((row) => {
+            subField
+            return isValidArgValue(row[subField.key])
+          }),
+        )
     }
 
     return isValidArgValue(step.parameters[arg.key])


### PR DESCRIPTION
## Problem
Users have no way to write to a single cell in excel. We should probably allow that.

## Solution
This implements write cell action. Like `getCellValues`, this action is limited to 3 cells max; the intent is to add UX friction to help with rate limiting.

## Tests
- Check that I can write values to cells.
- Check that cell values are not trimmed.
- Check that I can clear cell values by leaving the value blank.
- Check that I get an error if I specify an invalid cell address.
- Check that I get an error if I try to add more than 3 cells.
- Regression test: check that multirow validation for required subfields still works properly