### PR TITLE
fix(frontend): override paragraph margin to 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4792,9 +4792,9 @@
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.1.12.tgz",
-      "integrity": "sha512-nqKcAYGEOafg9D+2cy1E4gHNGuL12LerVa0eS2SQOb+PT8vSel9OTKU1RyZldsWSQJ5rq/w4uIjmLnrSR2w6Yw==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.1.16.tgz",
+      "integrity": "sha512-H3Bk8Gu5pV7xH8TrzH0WAoXrJVEKsDA6Evyl7H7aCAMAvotQL0ehuuX88bjPMCSAvBXZE39wYnJCJshGbVx0BA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -4906,9 +4906,9 @@
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.1.12.tgz",
-      "integrity": "sha512-hoH/uWPX+KKnNAZagudlsrr4Xu57nusGekkJWBcrb5MCDE91BS+DN2xifuhwXiTHxnwOMVFjluc0bPzQbkArsw==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.1.16.tgz",
+      "integrity": "sha512-JwCKSFjBLd9xAmxLe7hf1h4AucDvkGTfDb/wA1jId64g+uf0/tm6RDjnk/QD+D2YzoLGFLjQm0GAdPXTmyTPdA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -16115,6 +16115,7 @@
         "@plumber/types": "file:../types",
         "@tiptap/extension-image": "2.1.12",
         "@tiptap/extension-link": "2.1.12",
+        "@tiptap/extension-paragraph": "2.1.16",
         "@tiptap/extension-placeholder": "2.1.12",
         "@tiptap/extension-table": "2.1.12",
         "@tiptap/extension-table-cell": "2.1.12",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -23,6 +23,7 @@
     "@plumber/types": "file:../types",
     "@tiptap/extension-image": "2.1.12",
     "@tiptap/extension-link": "2.1.12",
+    "@tiptap/extension-paragraph": "2.1.16",
     "@tiptap/extension-placeholder": "2.1.12",
     "@tiptap/extension-table": "2.1.12",
     "@tiptap/extension-table-cell": "2.1.12",

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -12,6 +12,7 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { ClickAwayListener, FormControl } from '@mui/material'
 import { FormLabel } from '@opengovsg/design-system-react'
 import Link from '@tiptap/extension-link'
+import Paragraph from '@tiptap/extension-paragraph'
 import Placeholder from '@tiptap/extension-placeholder'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
@@ -84,6 +85,11 @@ const Editor = ({
       inline: true,
     }),
     StepVariable,
+    Paragraph.configure({
+      HTMLAttributes: {
+        style: 'margin: 0;',
+      },
+    }),
   ]
   let content = substituteOldTemplates(initialValue, varInfo) // back-ward compatibility with old values from PowerInput
 


### PR DESCRIPTION
## Problem

Default style for <p> in some email clients has margins and renders the paragraphs weirdly

## Solution

Override the styles to margin 0

## Before & After Screenshots

**BEFORE**:
<img width="536" alt="Screenshot 2024-01-16 at 5 23 43 PM" src="https://github.com/opengovsg/plumber/assets/12974927/0ecf93ac-559b-40c3-85ea-23b31fa7a4f4">


**AFTER**:
<img width="503" alt="Screenshot 2024-01-16 at 5 23 23 PM" src="https://github.com/opengovsg/plumber/assets/12974927/ec41b738-26be-440f-bfc4-94be4bf972ee">

## Tests

_What tests should be run to confirm functionality?_

## Deploy Notes

N/A