### PR TITLE
chore: refactor ld flag keys

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -11,6 +11,7 @@ import ListItem from '@mui/material/ListItem'
 import TextField from '@mui/material/TextField'
 import { Badge, FormLabel } from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
+import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from 'config/flags'
 import { EditorContext } from 'contexts/Editor'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { GET_APPS } from 'graphql/queries/get-apps'
@@ -99,8 +100,8 @@ function ChooseAppAndEventSubstep(
           if (!launchDarkly.flags || !app?.key) {
             return true
           }
-          const launchDarklyKey = ['app', app.key].join('_')
-          return launchDarkly.flags[launchDarklyKey] ?? true
+          const ldAppFlag = getAppFlag(app.key)
+          return launchDarkly.flags[ldAppFlag] ?? true
         })
         ?.map((app) => optionGenerator(app)) ?? [],
     [apps, launchDarkly.flags],
@@ -120,12 +121,9 @@ function ChooseAppAndEventSubstep(
           if (!launchDarkly.flags || !app?.key) {
             return true
           }
-          const launchDarklyKey = [
-            'app',
-            app.key,
-            isTrigger ? 'trigger' : 'action',
-            actionOrTrigger.key,
-          ].join('_')
+          const launchDarklyKey = isTrigger
+            ? getAppTriggerFlag(app.key, actionOrTrigger.key)
+            : getAppActionFlag(app.key, actionOrTrigger.key)
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         //

--- a/packages/frontend/src/components/Layout/index.tsx
+++ b/packages/frontend/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { BiHistory, BiSolidGrid } from 'react-icons/bi'
 import { HiOutlineSquare3Stack3D } from 'react-icons/hi2'
 import { Navigate } from 'react-router-dom'
@@ -9,7 +9,6 @@ import { PipeIcon } from 'components/Icons'
 import SiteWideBanner from 'components/SiteWideBanner'
 import { TILES_FEATURE_FLAG } from 'config/flags'
 import * as URLS from 'config/urls'
-import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import {
   LayoutNavigationProvider,
   LayoutNavigationProviderData,
@@ -26,6 +25,7 @@ export type DrawerLink = {
   Icon: React.ElementType
   text: string
   to: string
+  badge?: string
   // Optional LaunchDarkly flag key to control visibility of link
   ldFlagKey?: string
 }
@@ -40,6 +40,7 @@ const drawerLinks = [
     Icon: HiOutlineSquare3Stack3D,
     text: 'Tiles',
     to: URLS.TILES,
+    badge: '✨ Coming soon',
     ldFlagKey: TILES_FEATURE_FLAG,
   },
   {
@@ -56,7 +57,6 @@ const drawerLinks = [
 
 export default function Layout({ children }: PublicLayoutProps): JSX.Element {
   const { currentUser } = useAuthentication()
-  const { flags } = useContext(LaunchDarklyContext)
 
   const [isDrawerOpen, setDrawerOpen] = useState(false)
 
@@ -64,23 +64,13 @@ export default function Layout({ children }: PublicLayoutProps): JSX.Element {
   const closeDrawer = () => setDrawerOpen(false)
 
   const layoutNavigationProviderData = useMemo(() => {
-    // dont show all drawer links while flags are loading
-    const filteredLinks = flags
-      ? drawerLinks.filter((link) => {
-          // If flag is removed, default to show tab
-          if (!link.ldFlagKey) {
-            return true
-          }
-          return flags[link.ldFlagKey] !== false
-        })
-      : []
     return {
-      links: filteredLinks,
+      links: drawerLinks,
       isDrawerOpen,
       openDrawer,
       closeDrawer,
     } as LayoutNavigationProviderData
-  }, [flags, isDrawerOpen])
+  }, [isDrawerOpen])
 
   if (!currentUser) {
     const redirectQueryParam = window.location.pathname + window.location.search

--- a/packages/frontend/src/components/LoginForm/index.tsx
+++ b/packages/frontend/src/components/LoginForm/index.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { Flex } from '@chakra-ui/react'
+import { SGID_FEATURE_FLAG } from 'config/flags'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { REQUEST_OTP } from 'graphql/mutations/request-otp'
 import { VERIFY_OTP } from 'graphql/mutations/verify-otp'
@@ -9,9 +10,6 @@ import { GET_CURRENT_USER } from 'graphql/queries/get-current-user'
 import EmailInput from './EmailInput'
 import OtpInput from './OtpInput'
 import SgidLoginSection from './SgidLoginSection'
-
-// TODO: consolidate all feature flags keys in a single file
-const SGID_FEATURE_FLAG = 'sgid-login'
 
 export const LoginForm = (): JSX.Element => {
   const { flags } = useContext(LaunchDarklyContext)

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import { Box, IconButton } from '@mui/material'
-import { BANNER_DISPLAY_FLAG } from 'config/flags'
+import { BANNER_TEXT_FLAG } from 'config/flags'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { getItemForSession, setItemForSession } from 'helpers/storage'
 
@@ -21,7 +21,7 @@ const SiteWideBanner = (): JSX.Element | null => {
   useEffect(() => {
     if (launchDarkly.flags) {
       // message needs to be fetched everytime the page is re-rendered
-      const message = launchDarkly.flags[BANNER_DISPLAY_FLAG]
+      const message = launchDarkly.flags[BANNER_TEXT_FLAG]
       const bannerMessageStored = getItemForSession(
         SESSION_STORAGE_HIDE_BANNER_KEY,
       )

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useContext, useEffect, useState } from 'react'
 import CloseIcon from '@mui/icons-material/Close'
 import { Box, IconButton } from '@mui/material'
+import { BANNER_DISPLAY_FLAG } from 'config/flags'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { getItemForSession, setItemForSession } from 'helpers/storage'
 
-const LAUNCH_DARKLY_BANNER_KEY = 'banner_display'
 const EMPTY_BANNER_MESSAGE = ''
 const SESSION_STORAGE_HIDE_BANNER_KEY = 'hide-banner'
 
@@ -21,7 +21,7 @@ const SiteWideBanner = (): JSX.Element | null => {
   useEffect(() => {
     if (launchDarkly.flags) {
       // message needs to be fetched everytime the page is re-rendered
-      const message = launchDarkly.flags[LAUNCH_DARKLY_BANNER_KEY]
+      const message = launchDarkly.flags[BANNER_DISPLAY_FLAG]
       const bannerMessageStored = getItemForSession(
         SESSION_STORAGE_HIDE_BANNER_KEY,
       )

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -1,0 +1,23 @@
+/**
+ * List of all supported Launch Darkly flags on frontend.
+ */
+/**
+ * Display flags
+ */
+export const BANNER_DISPLAY_FLAG = 'banner_display'
+
+/**
+ * Feature flags
+ */
+export const SGID_FEATURE_FLAG = 'feature_sgid-login'
+export const TILES_FEATURE_FLAG = 'feature_tiles'
+export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
+
+/**
+ * App/events flags
+ */
+export const getAppFlag = (appKey: string) => `app_${appKey}`
+export const getAppTriggerFlag = (appKey: string, triggerKey: string) =>
+  `action_${appKey}_trigger_${triggerKey}`
+export const getAppActionFlag = (appKey: string, actionKey: string) =>
+  `action_${appKey}_action_${actionKey}`

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -4,7 +4,7 @@
 /**
  * Display flags
  */
-export const BANNER_DISPLAY_FLAG = 'banner_display'
+export const BANNER_TEXT_FLAG = 'banner_display'
 
 /**
  * Feature flags
@@ -18,6 +18,6 @@ export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
  */
 export const getAppFlag = (appKey: string) => `app_${appKey}`
 export const getAppTriggerFlag = (appKey: string, triggerKey: string) =>
-  `action_${appKey}_trigger_${triggerKey}`
+  `app_${appKey}_trigger_${triggerKey}`
 export const getAppActionFlag = (appKey: string, actionKey: string) =>
-  `action_${appKey}_action_${actionKey}`
+  `app_${appKey}_action_${actionKey}`

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -65,7 +65,7 @@ export const FLOW_PATTERN = '/flows/:flowId'
 // Tiles routes
 export const TILES = '/tiles'
 export const TILE = (tableId: string): string => `/tiles/${tableId}`
-export const TILE_PATTERN = '/tiles/:tileId' // unused for now
+export const TILE_PATTERN = '/tiles/:tileId'
 
 export const DASHBOARD = FLOWS
 

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -3,6 +3,7 @@ import { type IStep } from '@plumber/types'
 import { useCallback, useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { BranchContext } from 'components/FlowStepGroup/Content/IfThen/BranchContext'
+import { NESTED_IFTHEN_FEATURE_FLAG } from 'config/flags'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import client from 'graphql/client'
 import { CREATE_STEP } from 'graphql/mutations/create-step'
@@ -148,7 +149,7 @@ export function useIsIfThenSelectable({
     return false
   }
 
-  const canUseNestedBranch = ldFlags?.['feature_nested_if_then'] ?? false
+  const canUseNestedBranch = ldFlags?.[NESTED_IFTHEN_FEATURE_FLAG] ?? false
   if (canUseNestedBranch) {
     return true
   }

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -1,8 +1,11 @@
 import { ITableMetadata, ITableRow } from '@plumber/types'
 
-import { useParams } from 'react-router-dom'
+import { useContext } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Center, Flex, Spinner } from '@chakra-ui/react'
+import { TILES_FEATURE_FLAG } from 'config/flags'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 import { GET_ALL_ROWS } from 'graphql/queries/get-all-rows'
 import { GET_TABLE } from 'graphql/queries/get-table'
 
@@ -11,6 +14,9 @@ import TableBanner from './components/TableBanner'
 import { TableContextProvider } from './contexts/TableContext'
 
 export default function Tile(): JSX.Element {
+  const { flags, isLoading } = useContext(LaunchDarklyContext)
+  const navigate = useNavigate()
+
   const { tileId: tableId } = useParams<{ tileId: string }>()
 
   const { data: getTableData } = useQuery<{
@@ -29,6 +35,13 @@ export default function Tile(): JSX.Element {
     },
     fetchPolicy: 'network-only',
   })
+
+  /**
+   * Check if feature flag is enabled, otherwise redirect to 404
+   */
+  if (!isLoading && !flags?.[TILES_FEATURE_FLAG]) {
+    navigate('/404')
+  }
 
   if (!getTableData?.getTable || !getAllRowsData?.getAllRows) {
     return (

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -1,6 +1,10 @@
+import { useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 import Container from 'components/Container'
 import PageTitle from 'components/PageTitle'
+import { TILES_FEATURE_FLAG } from 'config/flags'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
 
 import CreateTileButton from './components/CreateTileButton'
 import TileList from './components/TileList'
@@ -8,6 +12,16 @@ import TileList from './components/TileList'
 const TILES_TITLE = 'Tiles'
 
 export default function Tiles(): JSX.Element {
+  /**
+   * Check if feature flag is enabled, otherwise redirect to 404
+   */
+  const { flags, isLoading } = useContext(LaunchDarklyContext)
+  const navigate = useNavigate()
+
+  if (!isLoading && !flags?.[TILES_FEATURE_FLAG]) {
+    navigate('/404')
+  }
+
   return (
     <Container py={7}>
       <Flex


### PR DESCRIPTION
## Problem

Currently, all the launch darkly flags are scattered around the codebase as arbitrary strings.

## Solution

1. Consolidate all these flag keys into a single config file for easier maintenance. 
2. Show `✨ Coming soon` badge for tiles with LD flag for internal testing

<img width="285" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/53d8f1c7-0dad-49ae-936a-a91e56d5acae">
