### PR TITLE
fix(frontend): fix empty line display on email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16117,7 +16117,6 @@
         "@plumber/types": "file:../types",
         "@tiptap/extension-image": "2.1.12",
         "@tiptap/extension-link": "2.1.12",
-        "@tiptap/extension-paragraph": "2.1.16",
         "@tiptap/extension-placeholder": "2.1.12",
         "@tiptap/extension-table": "2.1.12",
         "@tiptap/extension-table-cell": "2.1.12",

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -87,7 +87,12 @@ const action: IRawAction = {
     try {
       results = await sendTransactionalEmails($.http, recipients, {
         subject: result.data.subject,
-        body: result.data.body,
+        // this is to make sure there's at least some content for every new line
+        // so on the email client the new line will have some height and show up
+        body: result.data.body.replace(
+          /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
+          '<p style="margin: 0">&nbsp;</p>',
+        ),
         replyTo: result.data.replyTo,
         senderName: result.data.senderName,
         attachments: attachmentFiles,

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -23,7 +23,6 @@
     "@plumber/types": "file:../types",
     "@tiptap/extension-image": "2.1.12",
     "@tiptap/extension-link": "2.1.12",
-    "@tiptap/extension-paragraph": "2.1.16",
     "@tiptap/extension-placeholder": "2.1.12",
     "@tiptap/extension-table": "2.1.12",
     "@tiptap/extension-table-cell": "2.1.12",

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -107,13 +107,7 @@ const Editor = ({
         return
       }
 
-      const content = editor.getHTML()
-      const contentWithBreaks = content.replace(
-        /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
-        '<p style="margin: 0">&nbsp;</p>',
-      )
-
-      onChange(contentWithBreaks)
+      onChange(editor.getHTML())
     },
     editable,
   })

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -12,7 +12,6 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { ClickAwayListener, FormControl } from '@mui/material'
 import { FormLabel } from '@opengovsg/design-system-react'
 import Link from '@tiptap/extension-link'
-import Paragraph from '@tiptap/extension-paragraph'
 import Placeholder from '@tiptap/extension-placeholder'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
@@ -60,7 +59,11 @@ const Editor = ({
   }, [priorStepsWithExecutions])
 
   const extensions: Array<any> = [
-    StarterKit,
+    StarterKit.configure({
+      paragraph: {
+        HTMLAttributes: { style: 'margin: 0' },
+      },
+    }),
     Link.configure({
       HTMLAttributes: { rel: null, target: '_blank' },
     }),
@@ -86,11 +89,6 @@ const Editor = ({
       inline: true,
     }),
     StepVariable,
-    Paragraph.configure({
-      HTMLAttributes: {
-        style: 'margin: 0;min-height: 1em;',
-      },
-    }),
   ]
   let content = substituteOldTemplates(initialValue, varInfo) // back-ward compatibility with old values from PowerInput
 
@@ -101,8 +99,7 @@ const Editor = ({
     extensions,
     content,
     onUpdate: ({ editor }) => {
-      const content = editor.getHTML()
-      if (content === '<p></p>') {
+      if (editor.isEmpty) {
         // this is when content of the editor is empty
         // set controller value to empty string instead so the required rule can
         // work properly
@@ -110,7 +107,13 @@ const Editor = ({
         return
       }
 
-      onChange(content)
+      const content = editor.getHTML()
+      const contentWithBreaks = content.replace(
+        /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
+        '<p style="margin: 0">&nbsp;</p>',
+      )
+
+      onChange(contentWithBreaks)
     },
     editable,
   })


### PR DESCRIPTION
## Problem

Min-height approach from #405 doesn't work on some versions of Outlook

## Solution

Unset min-height for `<p />` and replace all (1) empty `<p />` tag pairs, (2) `<p />` tag pairs with empty spaces in between with `<p>&nbsp;</p>`

**Known drawbacks**
If user comes back to edit the transformed content after saving, they might notice there's a new non-breaking space character in their empty new lines

**Alternative considered**
To replace with `<p><br /></p>` instead. This approach will result in the number of empty new lines doubled when user come back to edit from previously saved content.

## Tests

- [x] Basic cases (1) new line (2) new line with empty spaces (3) consecutive new lines
Editor content
<img width="327" alt="Screenshot 2024-01-23 at 12 04 06 AM" src="https://github.com/opengovsg/plumber/assets/12974927/d39d68ec-a763-4998-9f0a-eb96d4be6b62">

Resulting HTML
<img width="758" alt="Screenshot 2024-01-23 at 12 03 58 AM" src="https://github.com/opengovsg/plumber/assets/12974927/f307b4bb-ea6d-4fcb-a2c7-dfa1933b93a9">

Email view
<img width="345" alt="Screenshot 2024-01-23 at 12 04 15 AM" src="https://github.com/opengovsg/plumber/assets/12974927/5fc16cc3-0f19-4f29-af32-3619b23f5d8d">

- [x] Content typing without any weird behaviours

https://github.com/opengovsg/plumber/assets/12974927/d93c3fb2-e408-43bd-9a5d-fb1e21276568

- [x] Email view on Outlook on GSIB

## Deploy Notes

N/A