### PR TITLE
Redact HttpError

### DIFF
--- a/packages/backend/src/errors/__tests__/http.test.ts
+++ b/packages/backend/src/errors/__tests__/http.test.ts
@@ -1,0 +1,39 @@
+import { AxiosError, AxiosHeaders } from 'axios'
+import { describe, expect, it } from 'vitest'
+
+import HttpError from '../http'
+
+describe('http error', () => {
+  it('removes non-allow-listed headers', () => {
+    const requestHeaders = new AxiosHeaders()
+    requestHeaders.set('content-type', 'application/json')
+    requestHeaders.set('authorization', 'Bearer 12345')
+
+    const responseHeaders = new AxiosHeaders()
+    responseHeaders.set('content-type', 'text/html')
+    responseHeaders.set('authorization', 'Bearer abcde')
+    responseHeaders.set('retry-after', '10')
+
+    const axiosError = new AxiosError(
+      'test error',
+      AxiosError.ERR_BAD_RESPONSE,
+      {
+        headers: requestHeaders,
+      },
+      'request data',
+      {
+        status: 429,
+        statusText: 'Too many requests',
+        data: '',
+        config: null,
+        headers: responseHeaders,
+      },
+    )
+
+    const httpError = new HttpError(axiosError)
+    expect(httpError.response.headers).toStrictEqual({
+      'retry-after': '10',
+    })
+    expect(httpError.response.config.headers).toBeUndefined()
+  })
+})

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -31,7 +31,10 @@ export default class HttpError extends BaseError {
         error.response?.headers?.['retry-after']
     }
 
-    // Get request headers from pipe config instead.
-    this.response.config.headers = undefined
+    // We can strip this completely; all relevant request headers should be in
+    // the pipe config.
+    if (this.response.config?.headers) {
+      this.response.config.headers = undefined
+    }
   }
 }

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -18,8 +18,20 @@ export default class HttpError extends BaseError {
       data: error.response?.data,
       status: error.response?.status,
       statusText: error.response?.statusText,
-      headers: error.response?.headers,
       config: error.config,
+      headers: {},
     }
+
+    //
+    // Only preserve selected headers to avoid storing sensitive data.
+    //
+
+    if (error.response?.headers?.['retry-after']) {
+      this.response.headers['retry-after'] =
+        error.response?.headers?.['retry-after']
+    }
+
+    // Get request headers from pipe config instead.
+    this.response.config.headers = undefined
   }
 }


### PR DESCRIPTION
## Problem
Our `HttpError` class does not strip headers, which risks us logging sensitive data.

## Solution
We will make `HttpError` strip all headers except for allow-listed ones.

## Tests
- New unit test
- Trigger a HTTP error, inspect dd console and check that headers are stripped.
- Regression test: Check that automatic retries due to 429 and 504 still work.
- **ADDITIONAL TEST**: verify in staging that headers are not logged in DD.