### PR TITLE
Release v1.8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "plumber",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plumber",
+      "version": "0.0.1",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^18.15.11",
@@ -16003,7 +16005,7 @@
       }
     },
     "packages/backend": {
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dependencies": {
         "@apollo/server": "4.9.4",
         "@aws-sdk/client-s3": "3.369.0",
@@ -16099,7 +16101,7 @@
       }
     },
     "packages/frontend": {
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dependencies": {
         "@apollo/client": "3.8.7",
         "@chakra-ui/react": "2.6.1",
@@ -16285,7 +16287,7 @@
     },
     "packages/types": {
       "name": "@plumber/types",
-      "version": "1.8.5"
+      "version": "1.8.6"
     }
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -93,5 +93,5 @@
     "tsc-alias": "^1.8.6",
     "tsconfig-paths": "^4.2.0"
   },
-  "version": "1.8.5"
+  "version": "1.8.6"
 }

--- a/packages/backend/src/errors/__tests__/http.test.ts
+++ b/packages/backend/src/errors/__tests__/http.test.ts
@@ -1,0 +1,39 @@
+import { AxiosError, AxiosHeaders } from 'axios'
+import { describe, expect, it } from 'vitest'
+
+import HttpError from '../http'
+
+describe('http error', () => {
+  it('removes non-allow-listed headers', () => {
+    const requestHeaders = new AxiosHeaders()
+    requestHeaders.set('content-type', 'application/json')
+    requestHeaders.set('authorization', 'Bearer 12345')
+
+    const responseHeaders = new AxiosHeaders()
+    responseHeaders.set('content-type', 'text/html')
+    responseHeaders.set('authorization', 'Bearer abcde')
+    responseHeaders.set('retry-after', '10')
+
+    const axiosError = new AxiosError(
+      'test error',
+      AxiosError.ERR_BAD_RESPONSE,
+      {
+        headers: requestHeaders,
+      },
+      'request data',
+      {
+        status: 429,
+        statusText: 'Too many requests',
+        data: '',
+        config: null,
+        headers: responseHeaders,
+      },
+    )
+
+    const httpError = new HttpError(axiosError)
+    expect(httpError.response.headers).toStrictEqual({
+      'retry-after': '10',
+    })
+    expect(httpError.response.config.headers).toBeUndefined()
+  })
+})

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -18,8 +18,23 @@ export default class HttpError extends BaseError {
       data: error.response?.data,
       status: error.response?.status,
       statusText: error.response?.statusText,
-      headers: error.response?.headers,
       config: error.config,
+      headers: {},
+    }
+
+    //
+    // Only preserve selected headers to avoid storing sensitive data.
+    //
+
+    if (error.response?.headers?.['retry-after']) {
+      this.response.headers['retry-after'] =
+        error.response?.headers?.['retry-after']
+    }
+
+    // We can strip this completely; all relevant request headers should be in
+    // the pipe config.
+    if (this.response.config?.headers) {
+      this.response.config.headers = undefined
     }
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "scripts": {
     "dev": "vite --host --force",
     "build": "tsc && vite build --mode=${VITE_MODE:-prod}",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,5 +2,5 @@
   "name": "@plumber/types",
   "description": "Shared types for plumber",
   "types": "./index.d.ts",
-  "version": "1.8.5"
+  "version": "1.8.6"
 }


### PR DESCRIPTION
# Fixes
1. Redact `HttpError` headers.

# Tests
- [x] Check that non-allow-listed headers do not appear in DD logs
- [x] Regression test: check that auto-retry still works.