### PR TITLE
fix(postman): remove tracking pixel by default

### DIFF
--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -63,6 +63,7 @@ export async function sendTransactionalEmails(
       'from',
       `${email.senderName} <${appConfig.postman.fromAddress}>`,
     )
+    requestData.append('disable_tracking', 'true')
 
     if (email.replyTo) {
       requestData.append('reply_to', email.replyTo)


### PR DESCRIPTION
## Problem

Postman by default sends a tracking pixel hosted on AWS server to track the email open status, but it doesn't render on GSIB machine due to firewall rule

## Solution

Disable tracking pixel

## Before & After Screenshots

**BEFORE**:

<img width="678" alt="Screenshot 2024-01-25 at 4 06 23 PM" src="https://github.com/opengovsg/plumber/assets/12974927/48c50d0a-6694-4b7d-bf6d-8d6675d2daa6">

**AFTER**:

<img width="677" alt="Screenshot 2024-01-25 at 4 06 28 PM" src="https://github.com/opengovsg/plumber/assets/12974927/40dba319-bcd8-4b00-aea7-47fbd2ffd235">


## Deploy Notes

N/A