### PR TITLE
PLU-178: TILES - Shareable links

### DIFF
--- a/packages/backend/src/db/migrations/20240129115425_table-view-only-key.ts
+++ b/packages/backend/src/db/migrations/20240129115425_table-view-only-key.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.table('table_metadata', (table) => {
-    table.timestamp('view_only_key').notNullable().defaultTo(knex.fn.now())
+    table.string('view_only_key').nullable()
   })
 }
 

--- a/packages/backend/src/db/migrations/20240129115425_table-view-only-key.ts
+++ b/packages/backend/src/db/migrations/20240129115425_table-view-only-key.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('table_metadata', (table) => {
+    table.timestamp('view_only_key').notNullable().defaultTo(knex.fn.now())
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('table_metadata', (table) => {
+    table.dropColumn('view_only_key')
+  })
+}

--- a/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'crypto'
+
+import Context from '@/types/express/context'
+
+type Params = {
+  tableId: string
+}
+
+const createShareableTableLink = async (
+  _parent: unknown,
+  params: Params,
+  context: Context,
+) => {
+  const tableId = params.tableId
+
+  // TODO: when implementing collaborators, only allow owner or editor
+  const table = await await context.currentUser
+    .$relatedQuery('tables')
+    .findById(tableId)
+    .throwIfNotFound()
+
+  const newViewOnlyKey = randomUUID()
+
+  await table.$query().patch({
+    viewOnlyKey: newViewOnlyKey,
+  })
+
+  return newViewOnlyKey
+}
+
+export default createShareableTableLink

--- a/packages/backend/src/graphql/mutations/tiles/index.ts
+++ b/packages/backend/src/graphql/mutations/tiles/index.ts
@@ -1,6 +1,7 @@
 import createRow from './create-row'
 import createRows from './create-rows'
 import createTable from './create-table'
+import createShareableTableLink from './create-table-shareable-link'
 import deleteRows from './delete-rows'
 import deleteTable from './delete-table'
 import updateRow from './update-row'
@@ -14,4 +15,5 @@ export default {
   createRows,
   updateRow,
   deleteRows,
+  createShareableTableLink,
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -561,6 +561,7 @@ type TableMetadata {
   name: String!
   columns: [TableColumnMetadata!]
   lastAccessedAt: String!
+  viewOnlyKey: String
 }
 
 # End Tiles types

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -68,6 +68,7 @@ type Mutation {
   ): LoginWithSelectedSgidResult!
   # Tiles
   createTable(input: CreateTableInput!): TableMetadata!
+  createShareableTableLink(tableId: ID!): String!
   updateTable(input: UpdateTableInput!): TableMetadata!
   deleteTable(input: DeleteTableInput!): Boolean!
   # Tiles rows

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -10,6 +10,7 @@ class TableMetadata extends Base {
   name: string
   collaborators!: User[]
   columns: TableColumnMetadata[]
+  viewOnlyKey?: string
 
   /**
    * for typescript support when creating TableCollaborator row in insertGraph
@@ -24,6 +25,7 @@ class TableMetadata extends Base {
     properties: {
       id: { type: 'string', format: 'uuid' },
       name: { type: 'string' },
+      viewOnlyKey: { type: 'string' },
     },
   }
 

--- a/packages/frontend/src/graphql/mutations/create-shareable-link.ts
+++ b/packages/frontend/src/graphql/mutations/create-shareable-link.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client'
+
+export const CREATE_SHAREABLE_TABLE_LINK = gql`
+  mutation CreateShareableTableLink($tableId: ID!) {
+    createShareableTableLink(tableId: $tableId)
+  }
+`

--- a/packages/frontend/src/graphql/queries/get-table.ts
+++ b/packages/frontend/src/graphql/queries/get-table.ts
@@ -5,6 +5,7 @@ export const GET_TABLE = gql`
     getTable(tableId: $tableId) {
       id
       name
+      viewOnlyKey
       columns {
         id
         name

--- a/packages/frontend/src/pages/Tile/components/TableBanner/BreadCrumb.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/BreadCrumb.tsx
@@ -1,0 +1,114 @@
+import { KeyboardEvent, useCallback, useState } from 'react'
+import { FaCheck, FaChevronRight, FaPencilAlt, FaTimes } from 'react-icons/fa'
+import { Link } from 'react-router-dom'
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Flex,
+  Icon,
+} from '@chakra-ui/react'
+import { IconButton, Input } from '@opengovsg/design-system-react'
+import * as URLS from 'config/urls'
+
+import { useTableContext } from '../../contexts/TableContext'
+import { useUpdateTable } from '../../hooks/useUpdateTable'
+
+function BreadCrumb() {
+  const { tableName: initialTableName } = useTableContext()
+  const [isEditingTableName, setIsEditingTableName] = useState(false)
+  const [tableName, setTableName] = useState(initialTableName)
+  const { updateTableName, isUpdatingTableName } = useUpdateTable()
+
+  const resetField = useCallback(() => {
+    setTableName(initialTableName)
+    setIsEditingTableName(false)
+  }, [initialTableName])
+
+  const onSave = useCallback(async () => {
+    await updateTableName(tableName)
+    setIsEditingTableName(false)
+  }, [tableName, updateTableName])
+
+  const onEnter = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        onSave()
+      }
+      if (e.key === 'Escape') {
+        resetField()
+      }
+    },
+    [onSave, resetField],
+  )
+
+  return (
+    <Breadcrumb
+      spacing={4}
+      separator={<Icon as={FaChevronRight} color="secondary.300" h={3} />}
+    >
+      <BreadcrumbItem>
+        <BreadcrumbLink as={Link} to={URLS.TILES}>
+          Tiles
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+      <BreadcrumbItem isCurrentPage>
+        {isEditingTableName ? (
+          <Flex alignItems="center" maxW="100%">
+            <Input
+              autoFocus
+              w="500px"
+              maxLength={64}
+              variant="flushed"
+              value={tableName}
+              onKeyDown={onEnter}
+              onChange={(e) => setTableName(e.target.value)}
+            />
+            <IconButton
+              ml={3}
+              icon={<FaCheck size={14} />}
+              aria-label="Save"
+              isLoading={isUpdatingTableName}
+              onClick={onSave}
+              variant="clear"
+              size="xs"
+            />
+            <IconButton
+              icon={<FaTimes size={14} />}
+              aria-label="Cancel"
+              isDisabled={isUpdatingTableName}
+              onClick={resetField}
+              size="xs"
+              variant="clear"
+              colorScheme="secondary"
+            />
+          </Flex>
+        ) : (
+          <BreadcrumbLink
+            onClick={() => setIsEditingTableName(true)}
+            gap={3}
+            overflow="hidden"
+            alignItems="center"
+            cursor="pointer"
+            display="flex"
+            role="group"
+          >
+            {initialTableName}
+            <IconButton
+              icon={<FaPencilAlt size={14} />}
+              aria-label="Edit"
+              size="xs"
+              variant="clear"
+              display="none"
+              _groupHover={{
+                display: 'flex',
+              }}
+            />
+          </BreadcrumbLink>
+        )}
+      </BreadcrumbItem>
+    </Breadcrumb>
+  )
+}
+
+export default BreadCrumb

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ExportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ExportCsvButton.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, useCallback } from 'react'
 import { BiExport } from 'react-icons/bi'
 import {
-  Flex,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -65,17 +64,19 @@ const ExportCsvModal = ({ onClose }: { onClose: () => void }) => {
         </ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <Flex mt={4} gap={4}>
-            <Button onClick={() => onExport({ filtered: false })}>
-              Export all rows
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => onExport({ filtered: true })}
-            >
-              Export current view
-            </Button>
-          </Flex>
+          <Text mb={2}>Export all data in this table</Text>
+          <Button onClick={() => onExport({ filtered: false })}>
+            Export all
+          </Button>
+          <Text mt={4} mb={2}>
+            Export rows based on current filter(s)
+          </Text>
+          <Button
+            variant="outline"
+            onClick={() => onExport({ filtered: true })}
+          >
+            Export filtered rows
+          </Button>
         </ModalBody>
 
         <ModalFooter></ModalFooter>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
@@ -3,6 +3,7 @@ import { Flex } from '@chakra-ui/react'
 import EditMode from './EditMode'
 import ExportCsvButton from './ExportCsvButton'
 import ImportCsvButton from './ImportCsvButton'
+import ShareButton from './ShareButton'
 
 const ImportExportToolbar = (): JSX.Element => {
   return (
@@ -10,6 +11,7 @@ const ImportExportToolbar = (): JSX.Element => {
       <EditMode />
       <ImportCsvButton />
       <ExportCsvButton />
+      <ShareButton />
     </Flex>
   )
 }

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -1,0 +1,112 @@
+import { forwardRef } from 'react'
+import { BiCopy, BiRefresh, BiShareAlt } from 'react-icons/bi'
+import {
+  Flex,
+  FormControl,
+  InputGroup,
+  InputRightAddon,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  Button,
+  FormHelperText,
+  FormLabel,
+  IconButton,
+  Input,
+} from '@opengovsg/design-system-react'
+import copy from 'clipboard-copy'
+
+import { useTableContext } from '../../contexts/TableContext'
+
+const ShareModal = ({ onClose }: { onClose: () => void }) => {
+  const { hasEditPermission, shareableLink } = useTableContext()
+
+  return (
+    <Modal isOpen={true} onClose={onClose} motionPreset="none">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Text textStyle="h6">Share tile</Text>
+          <ModalCloseButton />
+        </ModalHeader>
+        <ModalBody>
+          <FormControl>
+            <VStack spacing={2} alignItems="flex-start">
+              <Text textStyle="subhead-3">Public Access</Text>
+              <Text textStyle="body-1">
+                Generate a shareable link to allow viewing and exporting only.
+                No login required.
+              </Text>
+              <Flex alignSelf="stretch" gap={2}>
+                {shareableLink && (
+                  <InputGroup borderColor="primary.200">
+                    <Input
+                      value={shareableLink}
+                      borderRightWidth={0}
+                      isReadOnly
+                      _focusVisible={{
+                        boxShadow: 'none',
+                      }}
+                    />
+                    <InputRightAddon
+                      padding={0}
+                      background="white"
+                      borderColor="secondary.200"
+                    >
+                      <IconButton
+                        icon={<BiCopy />}
+                        colorScheme="secondary"
+                        variant="clear"
+                        isDisabled={!shareableLink}
+                        aria-label={'Copy'}
+                        onClick={() => copy(shareableLink ?? '')}
+                      />
+                    </InputRightAddon>
+                  </InputGroup>
+                )}
+                <Button variant="outline">Generate new link</Button>
+              </Flex>
+              {shareableLink && (
+                <FormHelperText>
+                  Generating a new link will invalidate the previous link.
+                </FormHelperText>
+              )}
+            </VStack>
+          </FormControl>
+        </ModalBody>
+        <ModalFooter></ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+const ExportCsvButton = forwardRef<HTMLButtonElement>((_, ref) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  return (
+    <>
+      <Button
+        ref={ref}
+        variant="clear"
+        colorScheme="secondary"
+        size="xs"
+        onClick={onOpen}
+        leftIcon={<BiShareAlt />}
+      >
+        Share
+      </Button>
+      {/* unmount component when closed to reset all state */}
+      {isOpen && <ShareModal onClose={onClose} />}
+    </>
+  )
+})
+
+export default ExportCsvButton

--- a/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
@@ -3,7 +3,7 @@ import { Flex, Text } from '@chakra-ui/react'
 import { TABLE_BANNER_HEIGHT } from '../../constants'
 import { useTableContext } from '../../contexts/TableContext'
 
-import BreadCrumb from './Breadcrumb'
+import BreadCrumb from './BreadCrumb'
 import ImportExportToolbar from './ImportExportToolbar'
 
 function TableBanner() {

--- a/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
@@ -1,49 +1,13 @@
-import { KeyboardEvent, useCallback, useState } from 'react'
-import { FaCheck, FaChevronRight, FaPencilAlt, FaTimes } from 'react-icons/fa'
-import { Link } from 'react-router-dom'
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  Flex,
-  Icon,
-} from '@chakra-ui/react'
-import { IconButton, Input } from '@opengovsg/design-system-react'
-import * as URLS from 'config/urls'
+import { Flex, Text } from '@chakra-ui/react'
 
 import { TABLE_BANNER_HEIGHT } from '../../constants'
 import { useTableContext } from '../../contexts/TableContext'
-import { useUpdateTable } from '../../hooks/useUpdateTable'
 
+import BreadCrumb from './Breadcrumb'
 import ImportExportToolbar from './ImportExportToolbar'
 
 function TableBanner() {
-  const { tableName: initialTableName } = useTableContext()
-  const [isEditingTableName, setIsEditingTableName] = useState(false)
-  const [tableName, setTableName] = useState(initialTableName)
-  const { updateTableName, isUpdatingTableName } = useUpdateTable()
-
-  const resetField = useCallback(() => {
-    setTableName(initialTableName)
-    setIsEditingTableName(false)
-  }, [initialTableName])
-
-  const onSave = useCallback(async () => {
-    await updateTableName(tableName)
-    setIsEditingTableName(false)
-  }, [tableName, updateTableName])
-
-  const onEnter = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        onSave()
-      }
-      if (e.key === 'Escape') {
-        resetField()
-      }
-    },
-    [onSave, resetField],
-  )
+  const { tableName, hasEditPermission } = useTableContext()
 
   return (
     <Flex
@@ -54,71 +18,11 @@ function TableBanner() {
       overflow="hidden"
       zIndex={10}
     >
-      <Breadcrumb
-        spacing={4}
-        separator={<Icon as={FaChevronRight} color="secondary.300" h={3} />}
-      >
-        <BreadcrumbItem>
-          <BreadcrumbLink as={Link} to={URLS.TILES}>
-            Tiles
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbItem isCurrentPage>
-          {isEditingTableName ? (
-            <Flex alignItems="center" maxW="100%">
-              <Input
-                autoFocus
-                w="500px"
-                maxLength={64}
-                variant="flushed"
-                value={tableName}
-                onKeyDown={onEnter}
-                onChange={(e) => setTableName(e.target.value)}
-              />
-              <IconButton
-                ml={3}
-                icon={<FaCheck size={14} />}
-                aria-label="Save"
-                isLoading={isUpdatingTableName}
-                onClick={onSave}
-                variant="clear"
-                size="xs"
-              />
-              <IconButton
-                icon={<FaTimes size={14} />}
-                aria-label="Cancel"
-                isDisabled={isUpdatingTableName}
-                onClick={resetField}
-                size="xs"
-                variant="clear"
-                colorScheme="secondary"
-              />
-            </Flex>
-          ) : (
-            <BreadcrumbLink
-              onClick={() => setIsEditingTableName(true)}
-              gap={3}
-              overflow="hidden"
-              alignItems="center"
-              cursor="pointer"
-              display="flex"
-              role="group"
-            >
-              {initialTableName}
-              <IconButton
-                icon={<FaPencilAlt size={14} />}
-                aria-label="Edit"
-                size="xs"
-                variant="clear"
-                display="none"
-                _groupHover={{
-                  display: 'flex',
-                }}
-              />
-            </BreadcrumbLink>
-          )}
-        </BreadcrumbItem>
-      </Breadcrumb>
+      {hasEditPermission ? (
+        <BreadCrumb />
+      ) : (
+        <Text textStyle="subhead-1">{tableName}</Text>
+      )}
       <ImportExportToolbar />
     </Flex>
   )

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -21,6 +21,7 @@ interface TableContextProps {
   mode: EditMode
   setMode: (mode: EditMode) => void
   hasEditPermission: boolean
+  shareableLink?: string
 }
 
 const TableContext = createContext<TableContextProps | undefined>(undefined)
@@ -42,6 +43,7 @@ interface TableContextProviderProps {
   tableRows: ITableRow[]
   children: React.ReactNode
   hasEditPermission: boolean
+  shareableLink?: string
 }
 
 export const TableContextProvider = ({
@@ -51,10 +53,13 @@ export const TableContextProvider = ({
   tableRows,
   children,
   hasEditPermission,
+  shareableLink,
 }: TableContextProviderProps) => {
   const flattenedData = useMemo(() => flattenRows(tableRows), [tableRows])
   const filteredDataRef = useRef<GenericRowData[]>([])
-  const [mode, setMode] = useState<EditMode>('view')
+  const [mode, setMode] = useState<EditMode>(
+    hasEditPermission ? 'edit' : 'view',
+  )
   return (
     <TableContext.Provider
       value={{
@@ -66,6 +71,7 @@ export const TableContextProvider = ({
         mode,
         setMode,
         hasEditPermission,
+        shareableLink,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -21,7 +21,7 @@ interface TableContextProps {
   mode: EditMode
   setMode: (mode: EditMode) => void
   hasEditPermission: boolean
-  shareableLink?: string
+  viewOnlyKey?: string
 }
 
 const TableContext = createContext<TableContextProps | undefined>(undefined)
@@ -43,7 +43,7 @@ interface TableContextProviderProps {
   tableRows: ITableRow[]
   children: React.ReactNode
   hasEditPermission: boolean
-  shareableLink?: string
+  viewOnlyKey?: string
 }
 
 export const TableContextProvider = ({
@@ -53,7 +53,7 @@ export const TableContextProvider = ({
   tableRows,
   children,
   hasEditPermission,
-  shareableLink,
+  viewOnlyKey,
 }: TableContextProviderProps) => {
   const flattenedData = useMemo(() => flattenRows(tableRows), [tableRows])
   const filteredDataRef = useRef<GenericRowData[]>([])
@@ -71,7 +71,7 @@ export const TableContextProvider = ({
         mode,
         setMode,
         hasEditPermission,
-        shareableLink,
+        viewOnlyKey,
       }}
     >
       {children}


### PR DESCRIPTION
## Show shareable link on tiles
Links will be generated as such `/tiles/<TILE_ID>/<UNIQUE_VIEW_ONLY_KEY>`

<img width="732" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/2fbf1e51-0fd4-47c2-a897-a448e1a691cd">

## What this PR does
- Frontend components for link generation
- DB migration to add new column to `table_metadata` called `view_only_key`
- Backend graphql mutation for this