### PR TITLE
PLU-178: TILES - View only mode frontend

### DIFF
--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -66,6 +66,7 @@ export const FLOW_PATTERN = '/flows/:flowId'
 export const TILES = '/tiles'
 export const TILE = (tableId: string): string => `/tiles/${tableId}`
 export const TILE_PATTERN = '/tiles/:tileId'
+export const PUBLIC_TILE_PATTERN = '/tiles/:tileId/:viewOnlyKey'
 
 export const DASHBOARD = FLOWS
 

--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -207,9 +207,9 @@ export default function Table(): JSX.Element {
         position="relative"
         // prevent active element from being hidden by footer
         scrollBehavior="smooth"
-        scrollPaddingBottom={
-          editingCell?.row.id === NEW_ROW_ID ? 0 : ROW_HEIGHT.FOOTER
-        }
+        // so that search bar results dont get blocked by header or footer
+        scrollPaddingTop={ROW_HEIGHT.HEADER + 'px'}
+        scrollPaddingBottom={ROW_HEIGHT.FOOTER + ROW_HEIGHT.DEFAULT + 'px'}
         // so highlighted element doesnt get blocked by checkbox column
         scrollPaddingLeft={60}
         onClick={onBlurClick}

--- a/packages/frontend/src/pages/Tile/components/TableBanner/EditMode.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/EditMode.tsx
@@ -30,7 +30,7 @@ const MODES: ModeOption[] = [
 ]
 
 const EditMode = () => {
-  const { mode, setMode } = useTableContext()
+  const { mode, setMode, hasEditPermission } = useTableContext()
 
   const selectedModeOption = useMemo(
     () => MODES.find((m) => m.value === mode) ?? MODES[0],
@@ -43,19 +43,23 @@ const EditMode = () => {
         as={Button}
         variant="outline"
         size="xs"
+        border="none"
+        bg={`${selectedModeOption.colorScheme}.100`}
         colorScheme={selectedModeOption.colorScheme}
         leftIcon={selectedModeOption.icon}
-        rightIcon={<BiChevronDown />}
+        rightIcon={hasEditPermission ? <BiChevronDown /> : undefined}
       >
         {selectedModeOption.label}
       </MenuButton>
 
       <MenuList borderRadius="md">
-        {MODES.map(({ label, icon, value }) => (
+        {MODES.map(({ label, icon, value, colorScheme }) => (
           <MenuItem
             fontSize="sm"
             icon={icon}
             key={value}
+            color={`${colorScheme}.600`}
+            isDisabled={!hasEditPermission && value === 'edit'}
             onClick={() => setMode(value)}
           >
             {label}

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
@@ -1,17 +1,21 @@
 import { Flex } from '@chakra-ui/react'
 
+import { useTableContext } from '../../contexts/TableContext'
+
 import EditMode from './EditMode'
 import ExportCsvButton from './ExportCsvButton'
 import ImportCsvButton from './ImportCsvButton'
 import ShareButton from './ShareButton'
 
 const ImportExportToolbar = (): JSX.Element => {
+  const { hasEditPermission } = useTableContext()
+
   return (
     <Flex justifyContent="center" alignItems="center">
       <EditMode />
-      <ImportCsvButton />
+      {hasEditPermission && <ImportCsvButton />}
       <ExportCsvButton />
-      <ShareButton />
+      {hasEditPermission && <ShareButton />}
     </Flex>
   )
 }

--- a/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsButton.tsx
@@ -11,6 +11,7 @@ import {
 } from '@chakra-ui/react'
 import { ROW_HEIGHT } from 'pages/Tile/constants'
 
+import { useTableContext } from '../../contexts/TableContext'
 import { useDeleteRows } from '../../hooks/useDeleteRows'
 
 interface DeleteRowsButtonProps {
@@ -22,6 +23,9 @@ export default function DeleteRowsButton({
   rowSelection,
   removeRows,
 }: DeleteRowsButtonProps) {
+  const { mode } = useTableContext()
+  const isViewMode = mode === 'view'
+
   const rowsSelected = Object.keys(rowSelection)
   const cancelRef = useRef(null)
   const { deleteRows, rowsDeleting } = useDeleteRows()
@@ -33,6 +37,10 @@ export default function DeleteRowsButton({
     removeRows(rowsSelected)
     setIsDialogOpen(false)
   }, [deleteRows, removeRows, rowsSelected])
+
+  if (isViewMode) {
+    return null
+  }
 
   return (
     <div

--- a/packages/frontend/src/pages/Tile/components/TableHeader/ColumnHeaderCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableHeader/ColumnHeaderCell.tsx
@@ -25,6 +25,7 @@ import {
   HEADER_COLOR,
   POPOVER_MOTION_PROPS,
 } from '../../constants'
+import { useTableContext } from '../../contexts/TableContext'
 import { GenericRowData } from '../../types'
 
 import { ColumnFilter } from './ColumnFilter'
@@ -48,6 +49,7 @@ function ColumnHeaderCell({
   sortDir,
   isFiltered,
 }: ColumnHeaderCellProps) {
+  const { mode } = useTableContext()
   const { id } = header
   const { isOpen, onClose, onOpen } = useDisclosure()
   const [isDeletionModalOpen, setIsDeletionModalOpen] = useState(false)
@@ -66,6 +68,8 @@ function ColumnHeaderCell({
     transform: CSS.Translate.toString(transform),
     transition,
   }
+
+  const isEditMode = mode === 'edit'
 
   return (
     <Flex
@@ -106,7 +110,7 @@ function ColumnHeaderCell({
               outline: 'none',
             }}
             {...attributes}
-            {...listeners}
+            {...(isEditMode ? listeners : {})}
           >
             <Text
               overflow="hidden"
@@ -159,30 +163,34 @@ function ColumnHeaderCell({
           motionProps={POPOVER_MOTION_PROPS}
         >
           <PopoverArrow />
-          <PopoverHeader px={4}>
-            <EditColumnName id={id} columnName={columnName} />
-          </PopoverHeader>
+          {isEditMode && (
+            <PopoverHeader px={4}>
+              <EditColumnName id={id} columnName={columnName} />
+            </PopoverHeader>
+          )}
           <PopoverBody px={4}>
             <ColumnSort column={column} />
             <ColumnFilter column={column} />
           </PopoverBody>
-          <PopoverFooter justifyContent="flex-start" display="flex" px={4}>
-            <Button
-              leftIcon={<BsTrash />}
-              variant="link"
-              py={2}
-              color="utility.feedback.critical"
-              _hover={{
-                color: 'red.400',
-              }}
-              onClick={() => setIsDeletionModalOpen(true)}
-            >
-              Delete column
-            </Button>
-          </PopoverFooter>
+          {isEditMode && (
+            <PopoverFooter justifyContent="flex-start" display={'flex'} px={4}>
+              <Button
+                leftIcon={<BsTrash />}
+                variant="link"
+                py={2}
+                color="utility.feedback.critical"
+                _hover={{
+                  color: 'red.400',
+                }}
+                onClick={() => setIsDeletionModalOpen(true)}
+              >
+                Delete column
+              </Button>
+            </PopoverFooter>
+          )}
         </PopoverContent>
       </Popover>
-      <ColumnResizer header={header} />
+      {isEditMode && <ColumnResizer header={header} />}
       {isDeletionModalOpen && (
         <DeletionModal
           columnId={column.id}

--- a/packages/frontend/src/pages/Tile/components/TableHeader/NewColumnHeaderCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableHeader/NewColumnHeaderCell.tsx
@@ -22,11 +22,15 @@ import { HeaderContext } from '@tanstack/react-table'
 import { GenericRowData } from 'pages/Tile/types'
 
 import { HEADER_COLOR, POPOVER_MOTION_PROPS } from '../../constants'
+import { useTableContext } from '../../contexts/TableContext'
 import { useUpdateTable } from '../../hooks/useUpdateTable'
 
 export default function NewColumnHeaderCell({
   column,
 }: HeaderContext<GenericRowData, unknown>) {
+  const { mode } = useTableContext()
+  const isViewMode = mode === 'view'
+
   const { isOpen, onClose, onOpen } = useDisclosure()
   const { createColumns, isCreatingColumns } = useUpdateTable()
   const [newColumnName, setNewColumnName] = useState('')
@@ -43,6 +47,10 @@ export default function NewColumnHeaderCell({
     },
     [createColumns, newColumnName, onClose],
   )
+
+  if (isViewMode) {
+    return null
+  }
 
   return (
     <Popover

--- a/packages/frontend/src/pages/Tile/components/TableRow/TableCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableRow/TableCell.tsx
@@ -227,7 +227,7 @@ function TableCell({
 
   const hasMatchingSearch =
     tableMeta?.searchString !== '' &&
-    value?.toLowerCase().includes(tableMeta?.searchString)
+    value?.toString().toLowerCase().includes(tableMeta?.searchString)
 
   return (
     <div

--- a/packages/frontend/src/pages/Tile/layouts/TileLayout.tsx
+++ b/packages/frontend/src/pages/Tile/layouts/TileLayout.tsx
@@ -1,0 +1,23 @@
+import { Navigate } from 'react-router-dom'
+import * as URLS from 'config/urls'
+import useAuthentication from 'hooks/useAuthentication'
+
+type TileLayoutProps = {
+  publicLayout?: boolean
+  children: React.ReactNode
+}
+
+export default function TileLayout({ children }: TileLayoutProps): JSX.Element {
+  const { currentUser } = useAuthentication()
+
+  if (!currentUser) {
+    const redirectQueryParam = window.location.pathname + window.location.search
+    return (
+      <Navigate
+        to={URLS.ADD_REDIRECT_TO_LOGIN(encodeURIComponent(redirectQueryParam))}
+      />
+    )
+  }
+
+  return <>{children}</>
+}

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -12,6 +12,7 @@ import Flow from 'pages/Flow'
 import Flows from 'pages/Flows'
 import Login from 'pages/Login'
 import SgidCallback from 'pages/SgidCallback'
+import TileLayout from 'pages/Tile/layouts/TileLayout'
 import Tiles from 'pages/Tiles'
 
 const Landing = lazy(() => import('pages/Landing'))
@@ -95,6 +96,17 @@ export default createRoutesFromElements(
 
     <Route
       path={URLS.TILE_PATTERN}
+      element={
+        <TileLayout>
+          <Suspense fallback={<></>}>
+            <Tile />
+          </Suspense>
+        </TileLayout>
+      }
+    />
+
+    <Route
+      path={URLS.PUBLIC_TILE_PATTERN}
       element={
         <Suspense fallback={<></>}>
           <Tile />


### PR DESCRIPTION
## Implement view only mode on frontend

Most of view only mode have already been implemented. This PR just hides all the other "mutating" features on the frontend in view mode.

<img width="1512" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/f477316e-ee55-4062-82df-9fd61e8291d3">
<img width="343" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/06ee3b2c-fb7e-4a4d-a06b-06327dc57358">


Changes
- Remove `Import` and `Share` Toolbar buttons
- Remove resizing and resorting of columns
- Remove add new column
- Remove delete rows butoton
- Remove delete /rename column
- Remove breadcrumb on top