### PR TITLE
PLU-178: TILES - backend auth for public view

### DIFF
--- a/packages/backend/src/errors/invalid-tile-view-key.ts
+++ b/packages/backend/src/errors/invalid-tile-view-key.ts
@@ -1,0 +1,9 @@
+export default class InvalidTileViewKeyError extends Error {
+  tableId: string
+  viewOnlyKey: string
+  constructor(tableId: string, viewOnlyKey: string) {
+    super('Invalid tile view only key')
+    this.tableId = tableId
+    this.viewOnlyKey = viewOnlyKey
+  }
+}

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -1,4 +1,8 @@
+import { NotFoundError } from 'objection'
+
+import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import { getTableRows, TableRowItem } from '@/models/dynamodb/table-row'
+import TableMetadata from '@/models/table-metadata'
 import Context from '@/types/express/context'
 
 type Params = {
@@ -11,17 +15,40 @@ const getAllRows = async (
   context: Context,
 ): Promise<Pick<TableRowItem, 'rowId' | 'data'>[]> => {
   const { tableId } = params
-  const table = await context.currentUser
-    .$relatedQuery('tables')
-    .withGraphJoined('columns')
-    .findById(tableId)
-    .throwIfNotFound()
-  // update last accessed at for collaborator/table
-  await table.$relatedQuery('collaborators').patch({
-    lastAccessedAt: new Date().toISOString(),
-  })
-  const columnIds = table.columns.map((column) => column.id)
-  return getTableRows({ tableId, columnIds })
+
+  try {
+    const table = context.tilesViewKey
+      ? await TableMetadata.query()
+          .withGraphFetched('columns')
+          .findOne({
+            id: tableId,
+            view_only_key: context.tilesViewKey,
+          })
+          .throwIfNotFound()
+      : await context.currentUser
+          .$relatedQuery('tables')
+          .withGraphFetched('columns')
+          .findById(tableId)
+          .throwIfNotFound()
+
+    // update last accessed at for collaborator/table
+    if (!context.tilesViewKey) {
+      await table.$relatedQuery('collaborators').patch({
+        lastAccessedAt: new Date().toISOString(),
+      })
+    }
+
+    const columnIds = table.columns.map((column) => column.id)
+    return getTableRows({ tableId, columnIds })
+  } catch (e) {
+    if (e instanceof NotFoundError) {
+      if (context.tilesViewKey) {
+        throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
+      }
+      throw new Error('Table not found')
+    }
+    throw new Error('Error fetching rows')
+  }
 }
 
 export default getAllRows

--- a/packages/backend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table.ts
@@ -1,6 +1,6 @@
 import { NotFoundError } from 'objection'
-import { SetRequired } from 'type-fest'
 
+import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import TableMetadata from '@/models/table-metadata'
 import Context from '@/types/express/context'
 
@@ -12,18 +12,28 @@ const getTable = async (
   _parent: unknown,
   params: Params,
   context: Context,
-): Promise<SetRequired<TableMetadata, 'columns'>> => {
+): Promise<TableMetadata> => {
   const { tableId } = params
 
   try {
-    const table = await context.currentUser
-      .$relatedQuery('tables')
-      .findById(tableId)
-      .throwIfNotFound()
+    const table = context.tilesViewKey
+      ? await TableMetadata.query()
+          .findOne({
+            id: tableId,
+            view_only_key: context.tilesViewKey,
+          })
+          .throwIfNotFound()
+      : await context.currentUser
+          .$relatedQuery('tables')
+          .findById(tableId)
+          .throwIfNotFound()
 
     return table
   } catch (e) {
     if (e instanceof NotFoundError) {
+      if (context.tilesViewKey) {
+        throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
+      }
       throw new Error('Table not found')
     }
     throw new Error('Error fetching table')

--- a/packages/backend/src/types/express/context.ts
+++ b/packages/backend/src/types/express/context.ts
@@ -6,6 +6,7 @@ export interface UnauthenticatedContext {
   req: Request
   res: Response
   currentUser: User | null
+  tilesViewKey?: string
 }
 
 interface Context extends UnauthenticatedContext {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -589,6 +589,7 @@ export interface ITableMetadata {
   name: string
   columns: ITableColumnMetadata[]
   lastAccessedAt: string
+  viewOnlyKey?: string
 }
 
 export interface ITableRow {


### PR DESCRIPTION
## Modify auth for backend queries `getTable` and `getAllRows`

Context object now has an additional optional field called `tilesViewKey`. This allows unauthenticated users to call these queries with the `viewOnlyKey`. 