### PR TITLE
PLU-125: [EXCEL] Allow retrying redlock execution errors (due to quorum failure)

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/workbook-session.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/workbook-session.test.ts
@@ -1,0 +1,38 @@
+import { ExecutionError, ResourceLockedError } from 'redlock'
+import { describe, expect, it } from 'vitest'
+
+import { M365TenantInfo } from '@/config/app-env-vars/m365'
+import RetriableError from '@/errors/retriable-error'
+
+import { runWithLockElseRetryStep } from '../../common/workbook-session/redis'
+
+const SAMPLE_M365_TENANT: M365TenantInfo = {
+  label: 'sample',
+  id: 'sample-id',
+  sharePointSiteId: 'sample-sp-site-id',
+  clientId: 'sample-client-id',
+  clientThumbprint: 'sample-thumbprint',
+  clientPrivateKey: 'sample-private-key',
+  allowedSensitivityLabelGuids: new Set(['sample-guid']),
+}
+
+describe('Excel workbook session', () => {
+  describe('runWithLockElseRetryStep', () => {
+    it.each([ExecutionError, ResourceLockedError])(
+      'retries redlock failures',
+      async (RedlockError) => {
+        const testInvocation = async () =>
+          await runWithLockElseRetryStep(
+            SAMPLE_M365_TENANT,
+            'fake-file',
+            // Treat callback as a mock instead of mocking redlock (it feels like
+            // mocking redlock will make this test too fragile).
+            async () => {
+              throw new RedlockError('test error', [])
+            },
+          )
+        expect(testInvocation).rejects.toThrow(RetriableError)
+      },
+    )
+  })
+})

--- a/packages/backend/src/apps/m365-excel/common/workbook-session/redis.ts
+++ b/packages/backend/src/apps/m365-excel/common/workbook-session/redis.ts
@@ -75,7 +75,13 @@ export async function runWithLockElseRetryStep<T>(
       // Already locked by another server
       error instanceof ResourceLockedError ||
       // Redlock quorum failed; no harm retrying later.
-      error instanceof ExecutionError
+      (error instanceof ExecutionError &&
+        // Matching on string isn't the most robust, but redlock doesn't have
+        // error codes. Mitigating factor is that redlock isn't going frequently
+        // updated, and it's not the end of the world if they change the
+        // message.
+        error.message ===
+          'The operation was unable to achieve a quorum during its retry window.')
 
     if (isRetriableError) {
       throw new RetriableError({


### PR DESCRIPTION
## Problem
Occasionally, redlock fails to achieve a quorum from our redis cluster. These are transient errors, so we'll allow automatically retrying the step when we get this error.

## Solution
Redlock throws `ExecutionError` when it fails to reach a quorum, so make `workbookSession` catch this and re-throw as a `RetriableError`

## Tests
- New unit test
- Regression test: Check that I can still create excel table rows