### PR TITLE
PLU-198: Support FormSG payments data in FormSG trigger

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -137,9 +137,6 @@ export async function decryptFormResponse(
 
     $.request.body = {
       fields: parsedData,
-      ...(Object.keys(verifiedSubmitterInfo).length > 0 && {
-        verifiedSubmitterInfo,
-      }),
       submissionId: data.submissionId,
       // Forms gives us submission time as ISO 8601 UTC TZ, but our users
       // expect SGT time, so convert it to ISO 8601 SGT TZ (our Luxon is
@@ -147,6 +144,17 @@ export async function decryptFormResponse(
       // it internally does a TZ conversion).
       submissionTime: DateTime.fromISO(data.created).toISO(),
     }
+
+    if (Object.keys(verifiedSubmitterInfo).length > 0) {
+      $.request.body.verifiedSubmitterInfo = verifiedSubmitterInfo
+    }
+
+    // FormSG team has no plans to encrypt payment fields; they have told us to
+    // directly access the data in the body.
+    if (data.paymentContent && Object.keys(data.paymentContent).length > 0) {
+      $.request.body.paymentContent = data.paymentContent
+    }
+
     delete $.request.headers
     delete $.request.query
 


### PR DESCRIPTION
## Problem
We want to support FormSG payment data in our FormSG trigger

## Solution
Parse payment data if it's present in webhook.

<img width="500" alt="Screenshot 2024-02-06 at 5 33 47 PM" src="https://github.com/opengovsg/plumber/assets/135598754/122b207c-b7a9-4170-8a39-313993c95a47">

## Tests
- New unit test
- Create a FormSG payment and check that payment data is successfully parsed as variables
- Check that I can use formSG payment variables in other pipe steps.
- Regression test: Check that verified fields are still displayed.
- Regression test: Check that pipes still work with FormSGs without payments
- Regression test: Check that legacy FormSG pipes still work.
