### PR TITLE
PLU-179: slack channel dropdown not showing all public channels

### DIFF
--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -11,6 +11,7 @@ const action: IRawAction = {
       label: 'Channel',
       key: 'channel',
       type: 'dropdown' as const,
+      allowArbitrary: true,
       required: true,
       description: 'Pick a channel to send the message to.',
       variables: false,

--- a/packages/backend/src/apps/slack/dynamic-data/list-channels/index.ts
+++ b/packages/backend/src/apps/slack/dynamic-data/list-channels/index.ts
@@ -2,39 +2,78 @@ import {
   DynamicDataOutput,
   IDynamicData,
   IGlobalVariable,
-  IJSONObject,
 } from '@plumber/types'
+
+import logger from '@/helpers/logger'
+
+interface SlackConversation {
+  id: string
+  name: string
+  is_channel: boolean
+  is_archived: boolean
+}
+
+interface ListChannelResponse {
+  ok: boolean
+  channels: Array<SlackConversation>
+  response_metadata?: {
+    next_cursor: string
+  }
+}
+
+// we want to limit the number of pages the API traverses to prevent rate limits or timeouts
+const MAX_PAGES = 4
 
 const dynamicData: IDynamicData = {
   name: 'List channels',
   key: 'listChannels',
 
   async run($: IGlobalVariable): Promise<DynamicDataOutput> {
-    const channels: DynamicDataOutput = {
+    const result: DynamicDataOutput = {
       data: [],
       error: null,
     }
 
-    const response = await $.http.get('/conversations.list', {
-      params: {
-        exclude_archived: true,
-        types: 'public_channel',
-        limit: 1000,
-      },
-    })
+    let cursor: string | undefined
+    let pages = 0
 
-    if (response.data.ok === false) {
-      throw new Error(response.data)
-    }
+    do {
+      const { data } = await $.http
+        .get<ListChannelResponse>('/conversations.list', {
+          params: {
+            exclude_archived: true,
+            // do not add private_channel to this list as it will return a lot of channels
+            // and cause this dynamic data api to timeout. instead, we allow the user to
+            // manually enter the private channel ID
+            types: 'public_channel',
+            limit: 1000,
+            cursor,
+          },
+        })
+        .catch((error) => {
+          logger.error(error)
+          throw new Error('Failed to list channels')
+        })
 
-    channels.data = response.data.channels.map((channel: IJSONObject) => {
-      return {
-        value: channel.id,
-        name: channel.name,
+      if (data.ok === false) {
+        logger.error(data)
+        throw new Error('Failed to list channels')
       }
-    })
 
-    return channels
+      cursor = data.response_metadata?.next_cursor
+
+      const channels = data.channels.map((channel) => {
+        return {
+          value: channel.id,
+          name: channel.name,
+        }
+      })
+
+      result.data.push(...channels)
+      pages++
+    } while (cursor && pages < MAX_PAGES)
+
+    return result
   },
 }
 


### PR DESCRIPTION
## Problem

Slack action not showing all public channels. This is due to the API limiting only 1000 channels to be searched.

## Solution

Paginate the conversations.list API using the provided cursor. but also limiting the max number of pages it can traverse to prevent timeouts and rate-limits.

**Improvements**:

**Allow arbitrary channel IDs to be used.** 
The benefits of this is two-fold. It allows for users to send a message to private channels and to circumvent the issue of not all public channels being returned.

<img width="908" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/d622f94c-1740-45a2-b9ed-fdea80f3f5e9">

The guide has been updated with instructions on how to retrieve the channel ID.  
see: https://guide.plumber.gov.sg/user-guides/actions/slack#channel

## What to test?
1. Create a new public channel and see that the channel is not displayed in the dropdown list.
2. Send to a private channel using the guide
3. Proof-read the newly added section of the guide
