### PR TITLE
PLU-203: fix: editor layout mobile view

### DIFF
--- a/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
@@ -22,11 +22,12 @@ export default function EditorSnackbar(props: EditorSnackbarProps) {
       borderRadius="0.25rem"
       boxShadow="0px 0px 10px 0px rgba(191, 191, 191, 0.50)"
       display={isOpen ? 'block' : 'none'}
+      minW="22rem"
     >
-      <Flex justifyContent="center" alignItems="center" gap={2}>
+      <Flex justifyContent="center" alignItems="center" gap={4}>
         <Text textStyle={{ sm: 'body-2', md: 'body-1' }}>{snackbarText}</Text>
         <Button
-          variant="clear"
+          variant="outline"
           colorScheme="inverse"
           onClick={handleUnpublish}
           size={{ sm: 'sm', md: 'md' }}

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -93,7 +93,7 @@ export default function EditorLayout(): React.ReactElement {
                 variant="body1"
                 onConfirm={onFlowNameUpdate}
                 noWrap
-                sx={{ display: 'flex', flex: 1, maxWidth: '50vw', ml: 1 }}
+                sx={{ display: 'flex', flex: 1, maxWidth: '30vw', ml: 1 }}
               >
                 {flow?.name}
               </EditableTypography>


### PR DESCRIPTION
**Simple fix** 
- editor layout view for mobile
- unpublish button for editor snackbar

**Before**

https://github.com/opengovsg/plumber/assets/65110268/dde0a8dc-b79d-4952-966b-0fb8317643ee

**After**

https://github.com/opengovsg/plumber/assets/65110268/21c392ee-291f-4b62-8b07-592112e90921



**Tests**
- check that unpublish button still works