### PR TITLE
feat(tracing): add will_retry tag for action execution

### DIFF
--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -99,10 +99,10 @@ export const worker = new Worker(
         !(e instanceof UnrecoverableError) &&
         job.attemptsMade < MAXIMUM_JOB_ATTEMPTS
 
+      span?.addTags({
+        willRetry: isRetriable ? 'true' : 'false',
+      })
       if (isRetriable) {
-        span?.addTags({
-          will_retry: 'true',
-        })
         logger.info(`Will retry flow: ${job.data.flowId}`, {
           job: job.data,
           error: e,


### PR DESCRIPTION
## Problem

Right now our traces of step executions don't have a way for us to differentiate between whether they will be retried or not

## Solution

Added `will_retry` tag to the span if the step is going to be retried

## Tests

- [x] Force an error inside postman action and execute
- [x] Tested in staging using [this monitor](https://ogp.datadoghq.com/monitors/140442358?view=spans)

## Deploy Notes

- [x] Delete the [staging monitor](https://ogp.datadoghq.com/monitors/140442358?view=spans) and apply the same change to the prod one