### PR TITLE
fix: prevent sensitive graphql variables from being logged

### DIFF
--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -21,6 +21,12 @@ import updateStep from './mutations/update-step'
 import verifyConnection from './mutations/verify-connection'
 import verifyOtp from './mutations/verify-otp'
 
+/**
+ * Important:
+ * When adding NEW mutations that involve sensitive data like api keys and private keys,
+ * be sure to redact it in the morgan middleware. See /backend/src/helpers/morgan.ts.
+ */
+
 const mutationResolvers = {
   createConnection,
   generateAuthUrl,

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -3,6 +3,8 @@ import { IJSONObject } from '@plumber/types'
 import App from '@/models/app'
 import Context from '@/types/express/context'
 
+// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data Scanner
+
 type Params = {
   input: {
     key: string

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -2,6 +2,8 @@ import { IJSONObject } from '@plumber/types'
 
 import Context from '@/types/express/context'
 
+// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data Scanner
+
 type Params = {
   input: {
     id: string

--- a/packages/backend/src/helpers/morgan.ts
+++ b/packages/backend/src/helpers/morgan.ts
@@ -26,15 +26,28 @@ morgan.token('cf-connecting-ip', (req: Request) => {
   }
 })
 morgan.token('graphql-query', (req: Request) => {
-  if (req.body.query) {
+  if (typeof req.body.query === 'string') {
     return req.body.query
       .replace(/\s+/g, ' ')
       .replace(/\n/g, '')
       .replace(/"/g, "'")
   }
 })
+
+const SENSITIVE_MUTATIONS = ['createConnection', 'updateConnection']
+
 morgan.token('graphql-variables', (req: Request) => {
   if (req.body.variables) {
+    // redact sensitive graphql variables related to connections
+    if (typeof req.body.query === 'string') {
+      if (
+        SENSITIVE_MUTATIONS.some((mutation) =>
+          req.body.query.includes(mutation),
+        )
+      ) {
+        return '[redacted]'
+      }
+    }
     return JSON.stringify(req.body.variables).replace(/"/g, "'")
   }
 })


### PR DESCRIPTION
Adds a filter in morgan logger to prevent certain graphql variables from being logged.

![image](https://github.com/opengovsg/plumber/assets/10072985/21ed4642-557d-47fb-80ee-3c9363911c88)
