### PR TITLE
test(e2e): add attributes for end2end tests

### DIFF
--- a/packages/frontend/src/components/FlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/FlowStepHeader/index.tsx
@@ -66,6 +66,7 @@ export default function FlowStepHeader(
       p={0}
       bg="white"
       boxShadow={collapsed ? undefined : 'base'}
+      data-test="flow-step" // adding to identify element for e2e testing
     >
       {/*
        * Top header

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -42,7 +42,7 @@ export default function VariablesList(props: VariablesListProps) {
   return (
     <List
       disablePadding
-      data-test="power-input-suggestion-group"
+      data-test="variable-suggestion-group"
       sx={{ maxHeight: listHeight, overflowY: 'auto' }}
     >
       {variables.map((variable) => {
@@ -51,7 +51,7 @@ export default function VariablesList(props: VariablesListProps) {
           <ListItemComponent
             sx={{ pl: 4 }}
             divider
-            data-test="power-input-suggestion-item"
+            data-test="variable-suggestion-item"
             key={`suggestion-${variable.name}`}
           >
             <ListItemText


### PR DESCRIPTION
## Problem

E2E test has no reliable way of identifying our elements as the class names are auto-generated

## Solution

Added `data-test` attributes to key components. Works in tandem with test cases from https://github.com/opengovsg/plumber-e2e

## Tests

- [x] Check component to have such attribs

## Deploy Notes

- N/A