### PR TITLE
PLU-20: [BUAY-TAHAN-3] RFC: Typed GraphQL - Typed GraphQL mutations

### DIFF
--- a/gql-codegen.ts
+++ b/gql-codegen.ts
@@ -49,10 +49,14 @@ const config: CodegenConfig = {
         // Add some stricter type checking. See
         // https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-resolvers
         // for more info.
+        //
+        // NOTE: immutableTypes is not enabled here as the libraries we use
+        // (e.g. objectionjs) have not marked their function params as
+        // readonly; enabling this will cause too much friction for not that
+        // much gain.
         defaultScalarType: 'unknown',
         strictScalars: true,
         useTypeImports: true,
-        immutableTypes: true,
 
         // In addition to normal functions, resolvers can also be objects with a
         //  `resolve` function. Due to this, the generated types for resolvers

--- a/packages/backend/src/graphql/__generated__/types.generated.ts
+++ b/packages/backend/src/graphql/__generated__/types.generated.ts
@@ -23,83 +23,83 @@ export type Scalars = {
 };
 
 export type Action = {
-  readonly __typename?: 'Action';
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly groupsLaterSteps?: Maybe<Scalars['Boolean']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly substeps?: Maybe<ReadonlyArray<Maybe<ActionSubstep>>>;
+  __typename?: 'Action';
+  description?: Maybe<Scalars['String']['output']>;
+  groupsLaterSteps?: Maybe<Scalars['Boolean']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  substeps?: Maybe<Array<Maybe<ActionSubstep>>>;
 };
 
 export type ActionSubstep = {
-  readonly __typename?: 'ActionSubstep';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<ActionSubstepArgument>>>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ActionSubstep';
+  arguments?: Maybe<Array<Maybe<ActionSubstepArgument>>>;
+  key?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type ActionSubstepArgument = {
-  readonly __typename?: 'ActionSubstepArgument';
-  readonly allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
-  readonly dependsOn?: Maybe<ReadonlyArray<Maybe<Scalars['String']['output']>>>;
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly hidden?: Maybe<Scalars['Boolean']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly label?: Maybe<Scalars['String']['output']>;
-  readonly options?: Maybe<ReadonlyArray<Maybe<ArgumentOption>>>;
-  readonly placeholder?: Maybe<Scalars['String']['output']>;
-  readonly required?: Maybe<Scalars['Boolean']['output']>;
-  readonly showOptionValue?: Maybe<Scalars['Boolean']['output']>;
-  readonly source?: Maybe<ActionSubstepArgumentSource>;
-  readonly subFields?: Maybe<ReadonlyArray<Maybe<ActionSubstepArgument>>>;
-  readonly type?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['JSONObject']['output']>;
-  readonly variableTypes?: Maybe<ReadonlyArray<Maybe<Scalars['String']['output']>>>;
-  readonly variables?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'ActionSubstepArgument';
+  allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
+  dependsOn?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  description?: Maybe<Scalars['String']['output']>;
+  hidden?: Maybe<Scalars['Boolean']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  options?: Maybe<Array<Maybe<ArgumentOption>>>;
+  placeholder?: Maybe<Scalars['String']['output']>;
+  required?: Maybe<Scalars['Boolean']['output']>;
+  showOptionValue?: Maybe<Scalars['Boolean']['output']>;
+  source?: Maybe<ActionSubstepArgumentSource>;
+  subFields?: Maybe<Array<Maybe<ActionSubstepArgument>>>;
+  type?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['JSONObject']['output']>;
+  variableTypes?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  variables?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type ActionSubstepArgumentSource = {
-  readonly __typename?: 'ActionSubstepArgumentSource';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<ActionSubstepArgumentSourceArgument>>>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly type?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ActionSubstepArgumentSource';
+  arguments?: Maybe<Array<Maybe<ActionSubstepArgumentSourceArgument>>>;
+  name?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type ActionSubstepArgumentSourceArgument = {
-  readonly __typename?: 'ActionSubstepArgumentSourceArgument';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ActionSubstepArgumentSourceArgument';
+  name?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type App = {
-  readonly __typename?: 'App';
-  readonly actions?: Maybe<ReadonlyArray<Maybe<Action>>>;
-  readonly auth?: Maybe<AppAuth>;
-  readonly authDocUrl?: Maybe<Scalars['String']['output']>;
-  readonly connectionCount?: Maybe<Scalars['Int']['output']>;
-  readonly connections?: Maybe<ReadonlyArray<Maybe<Connection>>>;
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly docUrl?: Maybe<Scalars['String']['output']>;
-  readonly flowCount?: Maybe<Scalars['Int']['output']>;
-  readonly iconUrl?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly primaryColor?: Maybe<Scalars['String']['output']>;
-  readonly triggers?: Maybe<ReadonlyArray<Maybe<Trigger>>>;
+  __typename?: 'App';
+  actions?: Maybe<Array<Maybe<Action>>>;
+  auth?: Maybe<AppAuth>;
+  authDocUrl?: Maybe<Scalars['String']['output']>;
+  connectionCount?: Maybe<Scalars['Int']['output']>;
+  connections?: Maybe<Array<Maybe<Connection>>>;
+  description?: Maybe<Scalars['String']['output']>;
+  docUrl?: Maybe<Scalars['String']['output']>;
+  flowCount?: Maybe<Scalars['Int']['output']>;
+  iconUrl?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  primaryColor?: Maybe<Scalars['String']['output']>;
+  triggers?: Maybe<Array<Maybe<Trigger>>>;
 };
 
 export type AppAuth = {
-  readonly __typename?: 'AppAuth';
-  readonly authenticationSteps?: Maybe<ReadonlyArray<Maybe<AuthenticationStep>>>;
-  readonly connectionRegistrationType?: Maybe<Scalars['String']['output']>;
-  readonly connectionType: Scalars['String']['output'];
-  readonly fields?: Maybe<ReadonlyArray<Maybe<Field>>>;
-  readonly reconnectionSteps?: Maybe<ReadonlyArray<Maybe<ReconnectionStep>>>;
+  __typename?: 'AppAuth';
+  authenticationSteps?: Maybe<Array<Maybe<AuthenticationStep>>>;
+  connectionRegistrationType?: Maybe<Scalars['String']['output']>;
+  connectionType: Scalars['String']['output'];
+  fields?: Maybe<Array<Maybe<Field>>>;
+  reconnectionSteps?: Maybe<Array<Maybe<ReconnectionStep>>>;
 };
 
 export type AppHealth = {
-  readonly __typename?: 'AppHealth';
-  readonly version?: Maybe<Scalars['String']['output']>;
+  __typename?: 'AppHealth';
+  version?: Maybe<Scalars['String']['output']>;
 };
 
 export type ArgumentEnumType =
@@ -107,262 +107,262 @@ export type ArgumentEnumType =
   | 'string';
 
 export type ArgumentOption = {
-  readonly __typename?: 'ArgumentOption';
-  readonly label?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['JSONObject']['output']>;
+  __typename?: 'ArgumentOption';
+  label?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['JSONObject']['output']>;
 };
 
 export type AuthLink = {
-  readonly __typename?: 'AuthLink';
-  readonly url?: Maybe<Scalars['String']['output']>;
+  __typename?: 'AuthLink';
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 export type AuthenticationStep = {
-  readonly __typename?: 'AuthenticationStep';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<AuthenticationStepArgument>>>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly type?: Maybe<Scalars['String']['output']>;
+  __typename?: 'AuthenticationStep';
+  arguments?: Maybe<Array<Maybe<AuthenticationStepArgument>>>;
+  name?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type AuthenticationStepArgument = {
-  readonly __typename?: 'AuthenticationStepArgument';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly properties?: Maybe<ReadonlyArray<Maybe<AuthenticationStepProperty>>>;
-  readonly type?: Maybe<ArgumentEnumType>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'AuthenticationStepArgument';
+  name?: Maybe<Scalars['String']['output']>;
+  properties?: Maybe<Array<Maybe<AuthenticationStepProperty>>>;
+  type?: Maybe<ArgumentEnumType>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type AuthenticationStepProperty = {
-  readonly __typename?: 'AuthenticationStepProperty';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'AuthenticationStepProperty';
+  name?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type Connection = {
-  readonly __typename?: 'Connection';
-  readonly app?: Maybe<App>;
-  readonly createdAt?: Maybe<Scalars['String']['output']>;
-  readonly flowCount?: Maybe<Scalars['Int']['output']>;
-  readonly formattedData?: Maybe<ConnectionData>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly verified?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'Connection';
+  app?: Maybe<App>;
+  createdAt?: Maybe<Scalars['String']['output']>;
+  flowCount?: Maybe<Scalars['Int']['output']>;
+  formattedData?: Maybe<ConnectionData>;
+  id?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  verified?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type ConnectionData = {
-  readonly __typename?: 'ConnectionData';
-  readonly screenName?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ConnectionData';
+  screenName?: Maybe<Scalars['String']['output']>;
 };
 
 export type CreateConnectionInput = {
-  readonly formattedData: Scalars['JSONObject']['input'];
-  readonly key: Scalars['String']['input'];
+  formattedData: Scalars['JSONObject']['input'];
+  key: Scalars['String']['input'];
 };
 
 export type CreateFlowInput = {
-  readonly connectionId?: InputMaybe<Scalars['String']['input']>;
-  readonly triggerAppKey?: InputMaybe<Scalars['String']['input']>;
+  connectionId?: InputMaybe<Scalars['String']['input']>;
+  triggerAppKey?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateStepInput = {
-  readonly appKey?: InputMaybe<Scalars['String']['input']>;
-  readonly connection?: InputMaybe<StepConnectionInput>;
-  readonly flow?: InputMaybe<StepFlowInput>;
-  readonly id?: InputMaybe<Scalars['String']['input']>;
-  readonly key?: InputMaybe<Scalars['String']['input']>;
-  readonly parameters?: InputMaybe<Scalars['JSONObject']['input']>;
-  readonly previousStep?: InputMaybe<PreviousStepInput>;
-  readonly previousStepId?: InputMaybe<Scalars['String']['input']>;
+  appKey?: InputMaybe<Scalars['String']['input']>;
+  connection?: InputMaybe<StepConnectionInput>;
+  flow?: InputMaybe<StepFlowInput>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  key?: InputMaybe<Scalars['String']['input']>;
+  parameters?: InputMaybe<Scalars['JSONObject']['input']>;
+  previousStep?: InputMaybe<PreviousStepInput>;
+  previousStepId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type CreateTableInput = {
-  readonly name: Scalars['String']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type CreateTableRowInput = {
-  readonly data: Scalars['JSONObject']['input'];
-  readonly tableId: Scalars['ID']['input'];
+  data: Scalars['JSONObject']['input'];
+  tableId: Scalars['ID']['input'];
 };
 
 export type CreateTableRowsInput = {
-  readonly dataArray: ReadonlyArray<Scalars['JSONObject']['input']>;
-  readonly tableId: Scalars['ID']['input'];
+  dataArray: Array<Scalars['JSONObject']['input']>;
+  tableId: Scalars['ID']['input'];
 };
 
 export type DeleteConnectionInput = {
-  readonly id: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type DeleteFlowInput = {
-  readonly id: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type DeleteStepInput = {
-  readonly ids: ReadonlyArray<Scalars['String']['input']>;
+  ids: Array<Scalars['String']['input']>;
 };
 
 export type DeleteTableInput = {
-  readonly id: Scalars['ID']['input'];
+  id: Scalars['ID']['input'];
 };
 
 export type DeleteTableRowsInput = {
-  readonly rowIds: ReadonlyArray<Scalars['ID']['input']>;
-  readonly tableId: Scalars['ID']['input'];
+  rowIds: Array<Scalars['ID']['input']>;
+  tableId: Scalars['ID']['input'];
 };
 
 export type ExecuteFlowInput = {
-  readonly stepId: Scalars['String']['input'];
+  stepId: Scalars['String']['input'];
 };
 
 export type ExecuteFlowType = {
-  readonly __typename?: 'ExecuteFlowType';
-  readonly data?: Maybe<Scalars['JSONObject']['output']>;
-  readonly step?: Maybe<Step>;
+  __typename?: 'ExecuteFlowType';
+  data?: Maybe<Scalars['JSONObject']['output']>;
+  step?: Maybe<Step>;
 };
 
 export type Execution = {
-  readonly __typename?: 'Execution';
-  readonly createdAt?: Maybe<Scalars['String']['output']>;
-  readonly flow?: Maybe<Flow>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly status?: Maybe<Scalars['String']['output']>;
-  readonly testRun?: Maybe<Scalars['Boolean']['output']>;
-  readonly updatedAt?: Maybe<Scalars['String']['output']>;
+  __typename?: 'Execution';
+  createdAt?: Maybe<Scalars['String']['output']>;
+  flow?: Maybe<Flow>;
+  id?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  testRun?: Maybe<Scalars['Boolean']['output']>;
+  updatedAt?: Maybe<Scalars['String']['output']>;
 };
 
 export type ExecutionConnection = {
-  readonly __typename?: 'ExecutionConnection';
-  readonly edges?: Maybe<ReadonlyArray<Maybe<ExecutionEdge>>>;
-  readonly pageInfo?: Maybe<PageInfo>;
+  __typename?: 'ExecutionConnection';
+  edges?: Maybe<Array<Maybe<ExecutionEdge>>>;
+  pageInfo?: Maybe<PageInfo>;
 };
 
 export type ExecutionEdge = {
-  readonly __typename?: 'ExecutionEdge';
-  readonly node?: Maybe<Execution>;
+  __typename?: 'ExecutionEdge';
+  node?: Maybe<Execution>;
 };
 
 export type ExecutionStep = {
-  readonly __typename?: 'ExecutionStep';
-  readonly appKey?: Maybe<Scalars['String']['output']>;
-  readonly createdAt?: Maybe<Scalars['String']['output']>;
-  readonly dataIn?: Maybe<Scalars['JSONObject']['output']>;
-  readonly dataOut?: Maybe<Scalars['JSONObject']['output']>;
-  readonly dataOutMetadata?: Maybe<Scalars['JSONObject']['output']>;
-  readonly errorDetails?: Maybe<Scalars['JSONObject']['output']>;
-  readonly executionId?: Maybe<Scalars['String']['output']>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly jobId?: Maybe<Scalars['String']['output']>;
-  readonly status?: Maybe<Scalars['String']['output']>;
-  readonly step?: Maybe<Step>;
-  readonly stepId?: Maybe<Scalars['String']['output']>;
-  readonly updatedAt?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ExecutionStep';
+  appKey?: Maybe<Scalars['String']['output']>;
+  createdAt?: Maybe<Scalars['String']['output']>;
+  dataIn?: Maybe<Scalars['JSONObject']['output']>;
+  dataOut?: Maybe<Scalars['JSONObject']['output']>;
+  dataOutMetadata?: Maybe<Scalars['JSONObject']['output']>;
+  errorDetails?: Maybe<Scalars['JSONObject']['output']>;
+  executionId?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  jobId?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  step?: Maybe<Step>;
+  stepId?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['String']['output']>;
 };
 
 export type ExecutionStepConnection = {
-  readonly __typename?: 'ExecutionStepConnection';
-  readonly edges?: Maybe<ReadonlyArray<Maybe<ExecutionStepEdge>>>;
-  readonly pageInfo?: Maybe<PageInfo>;
+  __typename?: 'ExecutionStepConnection';
+  edges?: Maybe<Array<Maybe<ExecutionStepEdge>>>;
+  pageInfo?: Maybe<PageInfo>;
 };
 
 export type ExecutionStepEdge = {
-  readonly __typename?: 'ExecutionStepEdge';
-  readonly node?: Maybe<ExecutionStep>;
+  __typename?: 'ExecutionStepEdge';
+  node?: Maybe<ExecutionStep>;
 };
 
 export type Field = {
-  readonly __typename?: 'Field';
-  readonly allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
-  readonly autoComplete?: Maybe<Scalars['String']['output']>;
-  readonly clickToCopy?: Maybe<Scalars['Boolean']['output']>;
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly docUrl?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly label?: Maybe<Scalars['String']['output']>;
-  readonly options?: Maybe<ReadonlyArray<Maybe<ArgumentOption>>>;
-  readonly placeholder?: Maybe<Scalars['String']['output']>;
-  readonly readOnly?: Maybe<Scalars['Boolean']['output']>;
-  readonly required?: Maybe<Scalars['Boolean']['output']>;
-  readonly showOptionValue?: Maybe<Scalars['Boolean']['output']>;
-  readonly type?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'Field';
+  allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
+  autoComplete?: Maybe<Scalars['String']['output']>;
+  clickToCopy?: Maybe<Scalars['Boolean']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  docUrl?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  options?: Maybe<Array<Maybe<ArgumentOption>>>;
+  placeholder?: Maybe<Scalars['String']['output']>;
+  readOnly?: Maybe<Scalars['Boolean']['output']>;
+  required?: Maybe<Scalars['Boolean']['output']>;
+  showOptionValue?: Maybe<Scalars['Boolean']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type Flow = {
-  readonly __typename?: 'Flow';
-  readonly active?: Maybe<Scalars['Boolean']['output']>;
-  readonly createdAt?: Maybe<Scalars['String']['output']>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly steps?: Maybe<ReadonlyArray<Maybe<Step>>>;
-  readonly updatedAt?: Maybe<Scalars['String']['output']>;
+  __typename?: 'Flow';
+  active?: Maybe<Scalars['Boolean']['output']>;
+  createdAt?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  steps?: Maybe<Array<Maybe<Step>>>;
+  updatedAt?: Maybe<Scalars['String']['output']>;
 };
 
 export type FlowConnection = {
-  readonly __typename?: 'FlowConnection';
-  readonly edges?: Maybe<ReadonlyArray<Maybe<FlowEdge>>>;
-  readonly pageInfo?: Maybe<PageInfo>;
+  __typename?: 'FlowConnection';
+  edges?: Maybe<Array<Maybe<FlowEdge>>>;
+  pageInfo?: Maybe<PageInfo>;
 };
 
 export type FlowEdge = {
-  readonly __typename?: 'FlowEdge';
-  readonly node?: Maybe<Flow>;
+  __typename?: 'FlowEdge';
+  node?: Maybe<Flow>;
 };
 
 export type GenerateAuthUrlInput = {
-  readonly id: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type LoginWithSelectedSgidInput = {
-  readonly workEmail: Scalars['String']['input'];
+  workEmail: Scalars['String']['input'];
 };
 
 export type LoginWithSelectedSgidResult = {
-  readonly __typename?: 'LoginWithSelectedSgidResult';
-  readonly success: Scalars['Boolean']['output'];
+  __typename?: 'LoginWithSelectedSgidResult';
+  success: Scalars['Boolean']['output'];
 };
 
 export type LoginWithSgidInput = {
-  readonly authCode: Scalars['String']['input'];
-  readonly nonce: Scalars['String']['input'];
-  readonly verifier: Scalars['String']['input'];
+  authCode: Scalars['String']['input'];
+  nonce: Scalars['String']['input'];
+  verifier: Scalars['String']['input'];
 };
 
 export type LoginWithSgidResult = {
-  readonly __typename?: 'LoginWithSgidResult';
-  readonly publicOfficerEmployments: ReadonlyArray<SgidPublicOfficerEmployment>;
+  __typename?: 'LoginWithSgidResult';
+  publicOfficerEmployments: Array<SgidPublicOfficerEmployment>;
 };
 
 export type Mutation = {
-  readonly __typename?: 'Mutation';
-  readonly createConnection?: Maybe<Connection>;
-  readonly createFlow?: Maybe<Flow>;
-  readonly createRow: Scalars['ID']['output'];
-  readonly createRows?: Maybe<Scalars['Boolean']['output']>;
-  readonly createShareableTableLink: Scalars['String']['output'];
-  readonly createStep?: Maybe<Step>;
-  readonly createTable: TableMetadata;
-  readonly deleteConnection?: Maybe<Scalars['Boolean']['output']>;
-  readonly deleteFlow?: Maybe<Scalars['Boolean']['output']>;
-  readonly deleteRows: ReadonlyArray<Scalars['ID']['output']>;
-  readonly deleteStep?: Maybe<Flow>;
-  readonly deleteTable: Scalars['Boolean']['output'];
-  readonly executeFlow?: Maybe<ExecuteFlowType>;
-  readonly generateAuthUrl?: Maybe<AuthLink>;
-  readonly loginWithSelectedSgid: LoginWithSelectedSgidResult;
-  readonly loginWithSgid: LoginWithSgidResult;
-  readonly logout?: Maybe<Scalars['Boolean']['output']>;
-  readonly registerConnection?: Maybe<Scalars['Boolean']['output']>;
-  readonly requestOtp?: Maybe<Scalars['Boolean']['output']>;
-  readonly resetConnection?: Maybe<Connection>;
-  readonly retryExecutionStep?: Maybe<Scalars['Boolean']['output']>;
-  readonly updateConnection?: Maybe<Connection>;
-  readonly updateFlow?: Maybe<Flow>;
-  readonly updateFlowStatus?: Maybe<Flow>;
-  readonly updateRow: Scalars['ID']['output'];
-  readonly updateStep?: Maybe<Step>;
-  readonly updateTable: TableMetadata;
-  readonly verifyConnection?: Maybe<Connection>;
-  readonly verifyOtp?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'Mutation';
+  createConnection?: Maybe<Connection>;
+  createFlow?: Maybe<Flow>;
+  createRow: Scalars['ID']['output'];
+  createRows?: Maybe<Scalars['Boolean']['output']>;
+  createShareableTableLink: Scalars['String']['output'];
+  createStep?: Maybe<Step>;
+  createTable: TableMetadata;
+  deleteConnection?: Maybe<Scalars['Boolean']['output']>;
+  deleteFlow?: Maybe<Scalars['Boolean']['output']>;
+  deleteRows: Array<Scalars['ID']['output']>;
+  deleteStep?: Maybe<Flow>;
+  deleteTable: Scalars['Boolean']['output'];
+  executeFlow?: Maybe<ExecuteFlowType>;
+  generateAuthUrl?: Maybe<AuthLink>;
+  loginWithSelectedSgid: LoginWithSelectedSgidResult;
+  loginWithSgid: LoginWithSgidResult;
+  logout?: Maybe<Scalars['Boolean']['output']>;
+  registerConnection?: Maybe<Scalars['Boolean']['output']>;
+  requestOtp?: Maybe<Scalars['Boolean']['output']>;
+  resetConnection?: Maybe<Connection>;
+  retryExecutionStep?: Maybe<Scalars['Boolean']['output']>;
+  updateConnection?: Maybe<Connection>;
+  updateFlow?: Maybe<Flow>;
+  updateFlowStatus?: Maybe<Flow>;
+  updateRow: Scalars['ID']['output'];
+  updateStep?: Maybe<Step>;
+  updateTable: TableMetadata;
+  verifyConnection?: Maybe<Connection>;
+  verifyOtp?: Maybe<Scalars['Boolean']['output']>;
 };
 
 
@@ -506,33 +506,33 @@ export type MutationverifyOtpArgs = {
 };
 
 export type PageInfo = {
-  readonly __typename?: 'PageInfo';
-  readonly currentPage: Scalars['Int']['output'];
-  readonly totalCount: Scalars['Int']['output'];
+  __typename?: 'PageInfo';
+  currentPage: Scalars['Int']['output'];
+  totalCount: Scalars['Int']['output'];
 };
 
 export type PreviousStepInput = {
-  readonly id?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Query = {
-  readonly __typename?: 'Query';
-  readonly getAllRows: ReadonlyArray<TileRow>;
-  readonly getApp?: Maybe<App>;
-  readonly getApps?: Maybe<ReadonlyArray<Maybe<App>>>;
-  readonly getConnectedApps?: Maybe<ReadonlyArray<Maybe<App>>>;
-  readonly getCurrentUser?: Maybe<User>;
-  readonly getDynamicData?: Maybe<ReadonlyArray<Maybe<Scalars['JSONObject']['output']>>>;
-  readonly getExecution?: Maybe<Execution>;
-  readonly getExecutionSteps?: Maybe<ExecutionStepConnection>;
-  readonly getExecutions?: Maybe<ExecutionConnection>;
-  readonly getFlow?: Maybe<Flow>;
-  readonly getFlows?: Maybe<FlowConnection>;
-  readonly getStepWithTestExecutions?: Maybe<ReadonlyArray<Maybe<Step>>>;
-  readonly getTable: TableMetadata;
-  readonly getTables: ReadonlyArray<TableMetadata>;
-  readonly healthcheck?: Maybe<AppHealth>;
-  readonly testConnection?: Maybe<TestConnectionResult>;
+  __typename?: 'Query';
+  getAllRows: Array<TileRow>;
+  getApp?: Maybe<App>;
+  getApps?: Maybe<Array<Maybe<App>>>;
+  getConnectedApps?: Maybe<Array<Maybe<App>>>;
+  getCurrentUser?: Maybe<User>;
+  getDynamicData?: Maybe<Array<Maybe<Scalars['JSONObject']['output']>>>;
+  getExecution?: Maybe<Execution>;
+  getExecutionSteps?: Maybe<ExecutionStepConnection>;
+  getExecutions?: Maybe<ExecutionConnection>;
+  getFlow?: Maybe<Flow>;
+  getFlows?: Maybe<FlowConnection>;
+  getStepWithTestExecutions?: Maybe<Array<Maybe<Step>>>;
+  getTable: TableMetadata;
+  getTables: Array<TableMetadata>;
+  healthcheck?: Maybe<AppHealth>;
+  testConnection?: Maybe<TestConnectionResult>;
 };
 
 
@@ -615,71 +615,71 @@ export type QuerytestConnectionArgs = {
 };
 
 export type ReconnectionStep = {
-  readonly __typename?: 'ReconnectionStep';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<ReconnectionStepArgument>>>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly type?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ReconnectionStep';
+  arguments?: Maybe<Array<Maybe<ReconnectionStepArgument>>>;
+  name?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type ReconnectionStepArgument = {
-  readonly __typename?: 'ReconnectionStepArgument';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly properties?: Maybe<ReadonlyArray<Maybe<ReconnectionStepProperty>>>;
-  readonly type?: Maybe<ArgumentEnumType>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ReconnectionStepArgument';
+  name?: Maybe<Scalars['String']['output']>;
+  properties?: Maybe<Array<Maybe<ReconnectionStepProperty>>>;
+  type?: Maybe<ArgumentEnumType>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type ReconnectionStepProperty = {
-  readonly __typename?: 'ReconnectionStepProperty';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ReconnectionStepProperty';
+  name?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type RegisterConnectionInput = {
-  readonly connectionId: Scalars['String']['input'];
-  readonly stepId?: InputMaybe<Scalars['String']['input']>;
+  connectionId: Scalars['String']['input'];
+  stepId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type RequestOtpInput = {
-  readonly email: Scalars['String']['input'];
+  email: Scalars['String']['input'];
 };
 
 export type ResetConnectionInput = {
-  readonly id: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type RetryExecutionStepInput = {
-  readonly executionStepId: Scalars['String']['input'];
+  executionStepId: Scalars['String']['input'];
 };
 
 export type SgidPublicOfficerEmployment = {
-  readonly __typename?: 'SgidPublicOfficerEmployment';
-  readonly agencyName?: Maybe<Scalars['String']['output']>;
-  readonly departmentName?: Maybe<Scalars['String']['output']>;
-  readonly employmentTitle?: Maybe<Scalars['String']['output']>;
-  readonly employmentType?: Maybe<Scalars['String']['output']>;
-  readonly workEmail?: Maybe<Scalars['String']['output']>;
+  __typename?: 'SgidPublicOfficerEmployment';
+  agencyName?: Maybe<Scalars['String']['output']>;
+  departmentName?: Maybe<Scalars['String']['output']>;
+  employmentTitle?: Maybe<Scalars['String']['output']>;
+  employmentType?: Maybe<Scalars['String']['output']>;
+  workEmail?: Maybe<Scalars['String']['output']>;
 };
 
 export type Step = {
-  readonly __typename?: 'Step';
-  readonly appKey?: Maybe<Scalars['String']['output']>;
-  readonly connection?: Maybe<Connection>;
-  readonly executionSteps?: Maybe<ReadonlyArray<Maybe<ExecutionStep>>>;
-  readonly flow?: Maybe<Flow>;
-  readonly iconUrl?: Maybe<Scalars['String']['output']>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly parameters?: Maybe<Scalars['JSONObject']['output']>;
-  readonly position?: Maybe<Scalars['Int']['output']>;
-  readonly previousStepId?: Maybe<Scalars['String']['output']>;
-  readonly status?: Maybe<Scalars['String']['output']>;
-  readonly type?: Maybe<StepEnumType>;
-  readonly webhookUrl?: Maybe<Scalars['String']['output']>;
+  __typename?: 'Step';
+  appKey?: Maybe<Scalars['String']['output']>;
+  connection?: Maybe<Connection>;
+  executionSteps?: Maybe<Array<Maybe<ExecutionStep>>>;
+  flow?: Maybe<Flow>;
+  iconUrl?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  parameters?: Maybe<Scalars['JSONObject']['output']>;
+  position?: Maybe<Scalars['Int']['output']>;
+  previousStepId?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<StepEnumType>;
+  webhookUrl?: Maybe<Scalars['String']['output']>;
 };
 
 export type StepConnectionInput = {
-  readonly id?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type StepEnumType =
@@ -687,179 +687,179 @@ export type StepEnumType =
   | 'trigger';
 
 export type StepFlowInput = {
-  readonly id?: InputMaybe<Scalars['String']['input']>;
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type StepInput = {
-  readonly appKey?: InputMaybe<Scalars['String']['input']>;
-  readonly connection?: InputMaybe<StepConnectionInput>;
-  readonly flow?: InputMaybe<StepFlowInput>;
-  readonly id?: InputMaybe<Scalars['String']['input']>;
-  readonly key?: InputMaybe<Scalars['String']['input']>;
-  readonly parameters?: InputMaybe<Scalars['JSONObject']['input']>;
-  readonly previousStep?: InputMaybe<PreviousStepInput>;
-  readonly previousStepId?: InputMaybe<Scalars['String']['input']>;
+  appKey?: InputMaybe<Scalars['String']['input']>;
+  connection?: InputMaybe<StepConnectionInput>;
+  flow?: InputMaybe<StepFlowInput>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  key?: InputMaybe<Scalars['String']['input']>;
+  parameters?: InputMaybe<Scalars['JSONObject']['input']>;
+  previousStep?: InputMaybe<PreviousStepInput>;
+  previousStepId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type TableColumnConfig = {
-  readonly __typename?: 'TableColumnConfig';
-  readonly width?: Maybe<Scalars['Int']['output']>;
+  __typename?: 'TableColumnConfig';
+  width?: Maybe<Scalars['Int']['output']>;
 };
 
 export type TableColumnConfigInput = {
-  readonly width?: InputMaybe<Scalars['Int']['input']>;
+  width?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type TableColumnMetadata = {
-  readonly __typename?: 'TableColumnMetadata';
-  readonly config: TableColumnConfig;
-  readonly id: Scalars['ID']['output'];
-  readonly name: Scalars['String']['output'];
-  readonly position: Scalars['Int']['output'];
+  __typename?: 'TableColumnMetadata';
+  config: TableColumnConfig;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  position: Scalars['Int']['output'];
 };
 
 export type TableColumnMetadataInput = {
-  readonly config?: InputMaybe<TableColumnConfigInput>;
-  readonly id: Scalars['ID']['input'];
-  readonly name?: InputMaybe<Scalars['String']['input']>;
-  readonly position?: InputMaybe<Scalars['Int']['input']>;
+  config?: InputMaybe<TableColumnConfigInput>;
+  id: Scalars['ID']['input'];
+  name?: InputMaybe<Scalars['String']['input']>;
+  position?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type TableMetadata = {
-  readonly __typename?: 'TableMetadata';
-  readonly columns?: Maybe<ReadonlyArray<TableColumnMetadata>>;
-  readonly id: Scalars['ID']['output'];
-  readonly lastAccessedAt: Scalars['String']['output'];
-  readonly name: Scalars['String']['output'];
-  readonly viewOnlyKey?: Maybe<Scalars['String']['output']>;
+  __typename?: 'TableMetadata';
+  columns?: Maybe<Array<TableColumnMetadata>>;
+  id: Scalars['ID']['output'];
+  lastAccessedAt: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  viewOnlyKey?: Maybe<Scalars['String']['output']>;
 };
 
 export type TestConnectionResult = {
-  readonly __typename?: 'TestConnectionResult';
-  readonly connectionVerified: Scalars['Boolean']['output'];
-  readonly message?: Maybe<Scalars['String']['output']>;
-  readonly registrationVerified?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'TestConnectionResult';
+  connectionVerified: Scalars['Boolean']['output'];
+  message?: Maybe<Scalars['String']['output']>;
+  registrationVerified?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type TileRow = {
-  readonly __typename?: 'TileRow';
-  readonly data: Scalars['JSONObject']['output'];
-  readonly rowId: Scalars['ID']['output'];
+  __typename?: 'TileRow';
+  data: Scalars['JSONObject']['output'];
+  rowId: Scalars['ID']['output'];
 };
 
 export type Trigger = {
-  readonly __typename?: 'Trigger';
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly pollInterval?: Maybe<Scalars['Int']['output']>;
-  readonly substeps?: Maybe<ReadonlyArray<Maybe<TriggerSubstep>>>;
-  readonly type?: Maybe<Scalars['String']['output']>;
-  readonly webhookTriggerInstructions?: Maybe<TriggerInstructions>;
+  __typename?: 'Trigger';
+  description?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  pollInterval?: Maybe<Scalars['Int']['output']>;
+  substeps?: Maybe<Array<Maybe<TriggerSubstep>>>;
+  type?: Maybe<Scalars['String']['output']>;
+  webhookTriggerInstructions?: Maybe<TriggerInstructions>;
 };
 
 export type TriggerInstructions = {
-  readonly __typename?: 'TriggerInstructions';
-  readonly afterUrlMsg?: Maybe<Scalars['String']['output']>;
-  readonly beforeUrlMsg?: Maybe<Scalars['String']['output']>;
-  readonly errorMsg?: Maybe<Scalars['String']['output']>;
-  readonly hideWebhookUrl?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'TriggerInstructions';
+  afterUrlMsg?: Maybe<Scalars['String']['output']>;
+  beforeUrlMsg?: Maybe<Scalars['String']['output']>;
+  errorMsg?: Maybe<Scalars['String']['output']>;
+  hideWebhookUrl?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type TriggerSubstep = {
-  readonly __typename?: 'TriggerSubstep';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<TriggerSubstepArgument>>>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly name?: Maybe<Scalars['String']['output']>;
+  __typename?: 'TriggerSubstep';
+  arguments?: Maybe<Array<Maybe<TriggerSubstepArgument>>>;
+  key?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type TriggerSubstepArgument = {
-  readonly __typename?: 'TriggerSubstepArgument';
-  readonly allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
-  readonly dependsOn?: Maybe<ReadonlyArray<Maybe<Scalars['String']['output']>>>;
-  readonly description?: Maybe<Scalars['String']['output']>;
-  readonly key?: Maybe<Scalars['String']['output']>;
-  readonly label?: Maybe<Scalars['String']['output']>;
-  readonly options?: Maybe<ReadonlyArray<Maybe<ArgumentOption>>>;
-  readonly placeholder?: Maybe<Scalars['String']['output']>;
-  readonly required?: Maybe<Scalars['Boolean']['output']>;
-  readonly showOptionValue?: Maybe<Scalars['Boolean']['output']>;
-  readonly source?: Maybe<TriggerSubstepArgumentSource>;
-  readonly subFields?: Maybe<ReadonlyArray<Maybe<TriggerSubstepArgument>>>;
-  readonly type?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['JSONObject']['output']>;
-  readonly variableTypes?: Maybe<ReadonlyArray<Maybe<Scalars['String']['output']>>>;
-  readonly variables?: Maybe<Scalars['Boolean']['output']>;
+  __typename?: 'TriggerSubstepArgument';
+  allowArbitrary?: Maybe<Scalars['Boolean']['output']>;
+  dependsOn?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  description?: Maybe<Scalars['String']['output']>;
+  key?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  options?: Maybe<Array<Maybe<ArgumentOption>>>;
+  placeholder?: Maybe<Scalars['String']['output']>;
+  required?: Maybe<Scalars['Boolean']['output']>;
+  showOptionValue?: Maybe<Scalars['Boolean']['output']>;
+  source?: Maybe<TriggerSubstepArgumentSource>;
+  subFields?: Maybe<Array<Maybe<TriggerSubstepArgument>>>;
+  type?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['JSONObject']['output']>;
+  variableTypes?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  variables?: Maybe<Scalars['Boolean']['output']>;
 };
 
 export type TriggerSubstepArgumentSource = {
-  readonly __typename?: 'TriggerSubstepArgumentSource';
-  readonly arguments?: Maybe<ReadonlyArray<Maybe<TriggerSubstepArgumentSourceArgument>>>;
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly type?: Maybe<Scalars['String']['output']>;
+  __typename?: 'TriggerSubstepArgumentSource';
+  arguments?: Maybe<Array<Maybe<TriggerSubstepArgumentSourceArgument>>>;
+  name?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
 };
 
 export type TriggerSubstepArgumentSourceArgument = {
-  readonly __typename?: 'TriggerSubstepArgumentSourceArgument';
-  readonly name?: Maybe<Scalars['String']['output']>;
-  readonly value?: Maybe<Scalars['String']['output']>;
+  __typename?: 'TriggerSubstepArgumentSourceArgument';
+  name?: Maybe<Scalars['String']['output']>;
+  value?: Maybe<Scalars['String']['output']>;
 };
 
 export type UpdateConnectionInput = {
-  readonly formattedData: Scalars['JSONObject']['input'];
-  readonly id: Scalars['String']['input'];
+  formattedData: Scalars['JSONObject']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type UpdateFlowInput = {
-  readonly id: Scalars['String']['input'];
-  readonly name: Scalars['String']['input'];
+  id: Scalars['String']['input'];
+  name: Scalars['String']['input'];
 };
 
 export type UpdateFlowStatusInput = {
-  readonly active: Scalars['Boolean']['input'];
-  readonly id: Scalars['String']['input'];
+  active: Scalars['Boolean']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type UpdateStepInput = {
-  readonly appKey?: InputMaybe<Scalars['String']['input']>;
-  readonly connection?: InputMaybe<StepConnectionInput>;
-  readonly flow?: InputMaybe<StepFlowInput>;
-  readonly id?: InputMaybe<Scalars['String']['input']>;
-  readonly key?: InputMaybe<Scalars['String']['input']>;
-  readonly parameters?: InputMaybe<Scalars['JSONObject']['input']>;
-  readonly previousStep?: InputMaybe<PreviousStepInput>;
-  readonly previousStepId?: InputMaybe<Scalars['String']['input']>;
+  appKey?: InputMaybe<Scalars['String']['input']>;
+  connection?: InputMaybe<StepConnectionInput>;
+  flow?: InputMaybe<StepFlowInput>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  key?: InputMaybe<Scalars['String']['input']>;
+  parameters?: InputMaybe<Scalars['JSONObject']['input']>;
+  previousStep?: InputMaybe<PreviousStepInput>;
+  previousStepId?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateTableInput = {
-  readonly addedColumns?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
-  readonly deletedColumns?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
-  readonly id: Scalars['ID']['input'];
-  readonly modifiedColumns?: InputMaybe<ReadonlyArray<TableColumnMetadataInput>>;
-  readonly name?: InputMaybe<Scalars['String']['input']>;
+  addedColumns?: InputMaybe<Array<Scalars['String']['input']>>;
+  deletedColumns?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id: Scalars['ID']['input'];
+  modifiedColumns?: InputMaybe<Array<TableColumnMetadataInput>>;
+  name?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateTableRowInput = {
-  readonly data: Scalars['JSONObject']['input'];
-  readonly rowId: Scalars['ID']['input'];
-  readonly tableId: Scalars['ID']['input'];
+  data: Scalars['JSONObject']['input'];
+  rowId: Scalars['ID']['input'];
+  tableId: Scalars['ID']['input'];
 };
 
 export type User = {
-  readonly __typename?: 'User';
-  readonly createdAt?: Maybe<Scalars['String']['output']>;
-  readonly email?: Maybe<Scalars['String']['output']>;
-  readonly id?: Maybe<Scalars['String']['output']>;
-  readonly updatedAt?: Maybe<Scalars['String']['output']>;
+  __typename?: 'User';
+  createdAt?: Maybe<Scalars['String']['output']>;
+  email?: Maybe<Scalars['String']['output']>;
+  id?: Maybe<Scalars['String']['output']>;
+  updatedAt?: Maybe<Scalars['String']['output']>;
 };
 
 export type VerifyConnectionInput = {
-  readonly id: Scalars['String']['input'];
+  id: Scalars['String']['input'];
 };
 
 export type VerifyOtpInput = {
-  readonly email: Scalars['String']['input'];
-  readonly otp: Scalars['String']['input'];
+  email: Scalars['String']['input'];
+  otp: Scalars['String']['input'];
 };
 
 
@@ -969,7 +969,7 @@ export type ResolversTypes = {
   ExecutionStepConnection: ResolverTypeWrapper<ExecutionStepConnectionGraphQLType>;
   ExecutionStepEdge: ResolverTypeWrapper<Omit<ExecutionStepEdge, 'node'> & { node?: Maybe<ResolversTypes['ExecutionStep']> }>;
   Field: ResolverTypeWrapper<Field>;
-  Flow: ResolverTypeWrapper<Omit<Flow, 'steps'> & { steps?: Maybe<ReadonlyArray<Maybe<ResolversTypes['Step']>>> }>;
+  Flow: ResolverTypeWrapper<Omit<Flow, 'steps'> & { steps?: Maybe<Array<Maybe<ResolversTypes['Step']>>> }>;
   FlowConnection: ResolverTypeWrapper<FlowConnectionGraphQLType>;
   FlowEdge: ResolverTypeWrapper<Omit<FlowEdge, 'node'> & { node?: Maybe<ResolversTypes['Flow']> }>;
   GenerateAuthUrlInput: GenerateAuthUrlInput;
@@ -990,7 +990,7 @@ export type ResolversTypes = {
   ResetConnectionInput: ResetConnectionInput;
   RetryExecutionStepInput: RetryExecutionStepInput;
   SgidPublicOfficerEmployment: ResolverTypeWrapper<SgidPublicOfficerEmployment>;
-  Step: ResolverTypeWrapper<Omit<Step, 'connection' | 'executionSteps' | 'flow'> & { connection?: Maybe<ResolversTypes['Connection']>, executionSteps?: Maybe<ReadonlyArray<Maybe<ResolversTypes['ExecutionStep']>>>, flow?: Maybe<ResolversTypes['Flow']> }>;
+  Step: ResolverTypeWrapper<Omit<Step, 'connection' | 'executionSteps' | 'flow'> & { connection?: Maybe<ResolversTypes['Connection']>, executionSteps?: Maybe<Array<Maybe<ResolversTypes['ExecutionStep']>>>, flow?: Maybe<ResolversTypes['Flow']> }>;
   StepConnectionInput: StepConnectionInput;
   StepEnumType: StepEnumType;
   StepFlowInput: StepFlowInput;
@@ -1060,7 +1060,7 @@ export type ResolversParentTypes = {
   ExecutionStepConnection: ExecutionStepConnectionGraphQLType;
   ExecutionStepEdge: Omit<ExecutionStepEdge, 'node'> & { node?: Maybe<ResolversParentTypes['ExecutionStep']> };
   Field: Field;
-  Flow: Omit<Flow, 'steps'> & { steps?: Maybe<ReadonlyArray<Maybe<ResolversParentTypes['Step']>>> };
+  Flow: Omit<Flow, 'steps'> & { steps?: Maybe<Array<Maybe<ResolversParentTypes['Step']>>> };
   FlowConnection: FlowConnectionGraphQLType;
   FlowEdge: Omit<FlowEdge, 'node'> & { node?: Maybe<ResolversParentTypes['Flow']> };
   GenerateAuthUrlInput: GenerateAuthUrlInput;
@@ -1081,7 +1081,7 @@ export type ResolversParentTypes = {
   ResetConnectionInput: ResetConnectionInput;
   RetryExecutionStepInput: RetryExecutionStepInput;
   SgidPublicOfficerEmployment: SgidPublicOfficerEmployment;
-  Step: Omit<Step, 'connection' | 'executionSteps' | 'flow'> & { connection?: Maybe<ResolversParentTypes['Connection']>, executionSteps?: Maybe<ReadonlyArray<Maybe<ResolversParentTypes['ExecutionStep']>>>, flow?: Maybe<ResolversParentTypes['Flow']> };
+  Step: Omit<Step, 'connection' | 'executionSteps' | 'flow'> & { connection?: Maybe<ResolversParentTypes['Connection']>, executionSteps?: Maybe<Array<Maybe<ResolversParentTypes['ExecutionStep']>>>, flow?: Maybe<ResolversParentTypes['Flow']> };
   StepConnectionInput: StepConnectionInput;
   StepFlowInput: StepFlowInput;
   StepInput: StepInput;
@@ -1114,12 +1114,12 @@ export type ActionResolvers<ContextType = AuthenticatedGraphQLContext, ParentTyp
   groupsLaterSteps?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  substeps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ActionSubstep']>>>, ParentType, ContextType>;
+  substeps?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionSubstep']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type ActionSubstepResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ActionSubstep'] = ResolversParentTypes['ActionSubstep']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ActionSubstepArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionSubstepArgument']>>>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1127,26 +1127,26 @@ export type ActionSubstepResolvers<ContextType = AuthenticatedGraphQLContext, Pa
 
 export type ActionSubstepArgumentResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ActionSubstepArgument'] = ResolversParentTypes['ActionSubstepArgument']> = {
   allowArbitrary?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  dependsOn?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  dependsOn?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   hidden?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  options?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
+  options?: Resolver<Maybe<Array<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
   placeholder?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   showOptionValue?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['ActionSubstepArgumentSource']>, ParentType, ContextType>;
-  subFields?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ActionSubstepArgument']>>>, ParentType, ContextType>;
+  subFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionSubstepArgument']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
-  variableTypes?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  variableTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   variables?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type ActionSubstepArgumentSourceResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ActionSubstepArgumentSource'] = ResolversParentTypes['ActionSubstepArgumentSource']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ActionSubstepArgumentSourceArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionSubstepArgumentSourceArgument']>>>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1159,11 +1159,11 @@ export type ActionSubstepArgumentSourceArgumentResolvers<ContextType = Authentic
 };
 
 export type AppResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['App'] = ResolversParentTypes['App']> = {
-  actions?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Action']>>>, ParentType, ContextType>;
+  actions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Action']>>>, ParentType, ContextType>;
   auth?: Resolver<Maybe<ResolversTypes['AppAuth']>, ParentType, ContextType>;
   authDocUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   connectionCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  connections?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Connection']>>>, ParentType, ContextType>;
+  connections?: Resolver<Maybe<Array<Maybe<ResolversTypes['Connection']>>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   flowCount?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -1171,16 +1171,16 @@ export type AppResolvers<ContextType = AuthenticatedGraphQLContext, ParentType e
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   primaryColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  triggers?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Trigger']>>>, ParentType, ContextType>;
+  triggers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Trigger']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type AppAuthResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['AppAuth'] = ResolversParentTypes['AppAuth']> = {
-  authenticationSteps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['AuthenticationStep']>>>, ParentType, ContextType>;
+  authenticationSteps?: Resolver<Maybe<Array<Maybe<ResolversTypes['AuthenticationStep']>>>, ParentType, ContextType>;
   connectionRegistrationType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   connectionType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  fields?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Field']>>>, ParentType, ContextType>;
-  reconnectionSteps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ReconnectionStep']>>>, ParentType, ContextType>;
+  fields?: Resolver<Maybe<Array<Maybe<ResolversTypes['Field']>>>, ParentType, ContextType>;
+  reconnectionSteps?: Resolver<Maybe<Array<Maybe<ResolversTypes['ReconnectionStep']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1201,7 +1201,7 @@ export type AuthLinkResolvers<ContextType = AuthenticatedGraphQLContext, ParentT
 };
 
 export type AuthenticationStepResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['AuthenticationStep'] = ResolversParentTypes['AuthenticationStep']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['AuthenticationStepArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['AuthenticationStepArgument']>>>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1209,7 +1209,7 @@ export type AuthenticationStepResolvers<ContextType = AuthenticatedGraphQLContex
 
 export type AuthenticationStepArgumentResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['AuthenticationStepArgument'] = ResolversParentTypes['AuthenticationStepArgument']> = {
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  properties?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['AuthenticationStepProperty']>>>, ParentType, ContextType>;
+  properties?: Resolver<Maybe<Array<Maybe<ResolversTypes['AuthenticationStepProperty']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['ArgumentEnumType']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1254,7 +1254,7 @@ export type ExecutionResolvers<ContextType = AuthenticatedGraphQLContext, Parent
 };
 
 export type ExecutionConnectionResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ExecutionConnection'] = ResolversParentTypes['ExecutionConnection']> = {
-  edges?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ExecutionEdge']>>>, ParentType, ContextType>;
+  edges?: Resolver<Maybe<Array<Maybe<ResolversTypes['ExecutionEdge']>>>, ParentType, ContextType>;
   pageInfo?: Resolver<Maybe<ResolversTypes['PageInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1282,7 +1282,7 @@ export type ExecutionStepResolvers<ContextType = AuthenticatedGraphQLContext, Pa
 };
 
 export type ExecutionStepConnectionResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ExecutionStepConnection'] = ResolversParentTypes['ExecutionStepConnection']> = {
-  edges?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ExecutionStepEdge']>>>, ParentType, ContextType>;
+  edges?: Resolver<Maybe<Array<Maybe<ResolversTypes['ExecutionStepEdge']>>>, ParentType, ContextType>;
   pageInfo?: Resolver<Maybe<ResolversTypes['PageInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1300,7 +1300,7 @@ export type FieldResolvers<ContextType = AuthenticatedGraphQLContext, ParentType
   docUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  options?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
+  options?: Resolver<Maybe<Array<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
   placeholder?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   readOnly?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
@@ -1315,13 +1315,13 @@ export type FlowResolvers<ContextType = AuthenticatedGraphQLContext, ParentType 
   createdAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  steps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Step']>>>, ParentType, ContextType>;
+  steps?: Resolver<Maybe<Array<Maybe<ResolversTypes['Step']>>>, ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type FlowConnectionResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['FlowConnection'] = ResolversParentTypes['FlowConnection']> = {
-  edges?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['FlowEdge']>>>, ParentType, ContextType>;
+  edges?: Resolver<Maybe<Array<Maybe<ResolversTypes['FlowEdge']>>>, ParentType, ContextType>;
   pageInfo?: Resolver<Maybe<ResolversTypes['PageInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -1341,7 +1341,7 @@ export type LoginWithSelectedSgidResultResolvers<ContextType = AuthenticatedGrap
 };
 
 export type LoginWithSgidResultResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['LoginWithSgidResult'] = ResolversParentTypes['LoginWithSgidResult']> = {
-  publicOfficerEmployments?: Resolver<ReadonlyArray<ResolversTypes['SgidPublicOfficerEmployment']>, ParentType, ContextType>;
+  publicOfficerEmployments?: Resolver<Array<ResolversTypes['SgidPublicOfficerEmployment']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1355,7 +1355,7 @@ export type MutationResolvers<ContextType = AuthenticatedGraphQLContext, ParentT
   createTable?: Resolver<ResolversTypes['TableMetadata'], ParentType, ContextType, RequireFields<MutationcreateTableArgs, 'input'>>;
   deleteConnection?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, Partial<MutationdeleteConnectionArgs>>;
   deleteFlow?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType, Partial<MutationdeleteFlowArgs>>;
-  deleteRows?: Resolver<ReadonlyArray<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationdeleteRowsArgs, 'input'>>;
+  deleteRows?: Resolver<Array<ResolversTypes['ID']>, ParentType, ContextType, RequireFields<MutationdeleteRowsArgs, 'input'>>;
   deleteStep?: Resolver<Maybe<ResolversTypes['Flow']>, ParentType, ContextType, Partial<MutationdeleteStepArgs>>;
   deleteTable?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType, RequireFields<MutationdeleteTableArgs, 'input'>>;
   executeFlow?: Resolver<Maybe<ResolversTypes['ExecuteFlowType']>, ParentType, ContextType, Partial<MutationexecuteFlowArgs>>;
@@ -1384,26 +1384,26 @@ export type PageInfoResolvers<ContextType = AuthenticatedGraphQLContext, ParentT
 };
 
 export type QueryResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  getAllRows?: Resolver<ReadonlyArray<ResolversTypes['TileRow']>, ParentType, ContextType, RequireFields<QuerygetAllRowsArgs, 'tableId'>>;
+  getAllRows?: Resolver<Array<ResolversTypes['TileRow']>, ParentType, ContextType, RequireFields<QuerygetAllRowsArgs, 'tableId'>>;
   getApp?: Resolver<Maybe<ResolversTypes['App']>, ParentType, ContextType, RequireFields<QuerygetAppArgs, 'key'>>;
-  getApps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['App']>>>, ParentType, ContextType, Partial<QuerygetAppsArgs>>;
-  getConnectedApps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['App']>>>, ParentType, ContextType, Partial<QuerygetConnectedAppsArgs>>;
+  getApps?: Resolver<Maybe<Array<Maybe<ResolversTypes['App']>>>, ParentType, ContextType, Partial<QuerygetAppsArgs>>;
+  getConnectedApps?: Resolver<Maybe<Array<Maybe<ResolversTypes['App']>>>, ParentType, ContextType, Partial<QuerygetConnectedAppsArgs>>;
   getCurrentUser?: Resolver<Maybe<ResolversTypes['User']>, ParentType, UnauthenticatedGraphQLContext>;
-  getDynamicData?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['JSONObject']>>>, ParentType, ContextType, RequireFields<QuerygetDynamicDataArgs, 'key' | 'stepId'>>;
+  getDynamicData?: Resolver<Maybe<Array<Maybe<ResolversTypes['JSONObject']>>>, ParentType, ContextType, RequireFields<QuerygetDynamicDataArgs, 'key' | 'stepId'>>;
   getExecution?: Resolver<Maybe<ResolversTypes['Execution']>, ParentType, ContextType, RequireFields<QuerygetExecutionArgs, 'executionId'>>;
   getExecutionSteps?: Resolver<Maybe<ResolversTypes['ExecutionStepConnection']>, ParentType, ContextType, RequireFields<QuerygetExecutionStepsArgs, 'executionId' | 'limit' | 'offset'>>;
   getExecutions?: Resolver<Maybe<ResolversTypes['ExecutionConnection']>, ParentType, ContextType, RequireFields<QuerygetExecutionsArgs, 'limit' | 'offset'>>;
   getFlow?: Resolver<Maybe<ResolversTypes['Flow']>, ParentType, ContextType, RequireFields<QuerygetFlowArgs, 'id'>>;
   getFlows?: Resolver<Maybe<ResolversTypes['FlowConnection']>, ParentType, ContextType, RequireFields<QuerygetFlowsArgs, 'limit' | 'offset'>>;
-  getStepWithTestExecutions?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['Step']>>>, ParentType, ContextType, RequireFields<QuerygetStepWithTestExecutionsArgs, 'stepId'>>;
+  getStepWithTestExecutions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Step']>>>, ParentType, ContextType, RequireFields<QuerygetStepWithTestExecutionsArgs, 'stepId'>>;
   getTable?: Resolver<ResolversTypes['TableMetadata'], ParentType, ContextType, RequireFields<QuerygetTableArgs, 'tableId'>>;
-  getTables?: Resolver<ReadonlyArray<ResolversTypes['TableMetadata']>, ParentType, ContextType>;
+  getTables?: Resolver<Array<ResolversTypes['TableMetadata']>, ParentType, ContextType>;
   healthcheck?: Resolver<Maybe<ResolversTypes['AppHealth']>, ParentType, ContextType>;
   testConnection?: Resolver<Maybe<ResolversTypes['TestConnectionResult']>, ParentType, ContextType, RequireFields<QuerytestConnectionArgs, 'connectionId'>>;
 };
 
 export type ReconnectionStepResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ReconnectionStep'] = ResolversParentTypes['ReconnectionStep']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ReconnectionStepArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['ReconnectionStepArgument']>>>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1411,7 +1411,7 @@ export type ReconnectionStepResolvers<ContextType = AuthenticatedGraphQLContext,
 
 export type ReconnectionStepArgumentResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['ReconnectionStepArgument'] = ResolversParentTypes['ReconnectionStepArgument']> = {
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  properties?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ReconnectionStepProperty']>>>, ParentType, ContextType>;
+  properties?: Resolver<Maybe<Array<Maybe<ResolversTypes['ReconnectionStepProperty']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['ArgumentEnumType']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1435,7 +1435,7 @@ export type SgidPublicOfficerEmploymentResolvers<ContextType = AuthenticatedGrap
 export type StepResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['Step'] = ResolversParentTypes['Step']> = {
   appKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   connection?: Resolver<Maybe<ResolversTypes['Connection']>, ParentType, ContextType>;
-  executionSteps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ExecutionStep']>>>, ParentType, ContextType>;
+  executionSteps?: Resolver<Maybe<Array<Maybe<ResolversTypes['ExecutionStep']>>>, ParentType, ContextType>;
   flow?: Resolver<Maybe<ResolversTypes['Flow']>, ParentType, ContextType>;
   iconUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -1463,7 +1463,7 @@ export type TableColumnMetadataResolvers<ContextType = AuthenticatedGraphQLConte
 };
 
 export type TableMetadataResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['TableMetadata'] = ResolversParentTypes['TableMetadata']> = {
-  columns?: Resolver<Maybe<ReadonlyArray<ResolversTypes['TableColumnMetadata']>>, ParentType, ContextType>;
+  columns?: Resolver<Maybe<Array<ResolversTypes['TableColumnMetadata']>>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   lastAccessedAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -1489,7 +1489,7 @@ export type TriggerResolvers<ContextType = AuthenticatedGraphQLContext, ParentTy
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   pollInterval?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  substeps?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['TriggerSubstep']>>>, ParentType, ContextType>;
+  substeps?: Resolver<Maybe<Array<Maybe<ResolversTypes['TriggerSubstep']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   webhookTriggerInstructions?: Resolver<Maybe<ResolversTypes['TriggerInstructions']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1504,7 +1504,7 @@ export type TriggerInstructionsResolvers<ContextType = AuthenticatedGraphQLConte
 };
 
 export type TriggerSubstepResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['TriggerSubstep'] = ResolversParentTypes['TriggerSubstep']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['TriggerSubstepArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['TriggerSubstepArgument']>>>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -1512,25 +1512,25 @@ export type TriggerSubstepResolvers<ContextType = AuthenticatedGraphQLContext, P
 
 export type TriggerSubstepArgumentResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['TriggerSubstepArgument'] = ResolversParentTypes['TriggerSubstepArgument']> = {
   allowArbitrary?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
-  dependsOn?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  dependsOn?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  options?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
+  options?: Resolver<Maybe<Array<Maybe<ResolversTypes['ArgumentOption']>>>, ParentType, ContextType>;
   placeholder?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   showOptionValue?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['TriggerSubstepArgumentSource']>, ParentType, ContextType>;
-  subFields?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['TriggerSubstepArgument']>>>, ParentType, ContextType>;
+  subFields?: Resolver<Maybe<Array<Maybe<ResolversTypes['TriggerSubstepArgument']>>>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes['JSONObject']>, ParentType, ContextType>;
-  variableTypes?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
+  variableTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   variables?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type TriggerSubstepArgumentSourceResolvers<ContextType = AuthenticatedGraphQLContext, ParentType extends ResolversParentTypes['TriggerSubstepArgumentSource'] = ResolversParentTypes['TriggerSubstepArgumentSource']> = {
-  arguments?: Resolver<Maybe<ReadonlyArray<Maybe<ResolversTypes['TriggerSubstepArgumentSourceArgument']>>>, ParentType, ContextType>;
+  arguments?: Resolver<Maybe<Array<Maybe<ResolversTypes['TriggerSubstepArgumentSourceArgument']>>>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -1,3 +1,4 @@
+import type { MutationResolvers } from './__generated__/types.generated'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
 import createStep from './mutations/create-step'
@@ -27,7 +28,7 @@ import verifyOtp from './mutations/verify-otp'
  * be sure to redact it in the morgan middleware. See /backend/src/helpers/morgan.ts.
  */
 
-const mutationResolvers = {
+export default {
   createConnection,
   generateAuthUrl,
   updateConnection,
@@ -50,6 +51,4 @@ const mutationResolvers = {
   loginWithSgid,
   loginWithSelectedSgid,
   ...tilesMutationResolvers,
-}
-
-export default mutationResolvers
+} satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -1,21 +1,13 @@
-import { IJSONObject } from '@plumber/types'
-
 import App from '@/models/app'
-import Context from '@/types/express/context'
 
-// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data Scanner
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-type Params = {
-  input: {
-    key: string
-    formattedData: IJSONObject
-  }
-}
-const createConnection = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive
+// Data Scanner
+
+const createConnection: NonNullable<
+  MutationResolvers['createConnection']
+> = async (_parent, params, context) => {
   await App.findOneByKey(params.input.key)
 
   return await context.currentUser.$relatedQuery('connections').insert({

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -5,9 +5,11 @@ import type { MutationResolvers } from '../__generated__/types.generated'
 // Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive
 // Data Scanner
 
-const createConnection: NonNullable<
-  MutationResolvers['createConnection']
-> = async (_parent, params, context) => {
+const createConnection: MutationResolvers['createConnection'] = async (
+  _parent,
+  params,
+  context,
+) => {
   await App.findOneByKey(params.input.key)
 
   return await context.currentUser.$relatedQuery('connections').insert({

--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -1,6 +1,6 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createFlow: NonNullable<MutationResolvers['createFlow']> = async (
+const createFlow: MutationResolvers['createFlow'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -1,16 +1,9 @@
-import Context from '@/types/express/context'
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-type Params = {
-  input: {
-    triggerAppKey: string
-    connectionId: string
-  }
-}
-
-const createFlow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const createFlow: NonNullable<MutationResolvers['createFlow']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const connectionId = params?.input?.connectionId
   const appKey = params?.input?.triggerAppKey

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,29 +1,11 @@
-import { type IJSONObject } from '@plumber/types'
-
 import Step from '@/models/step'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    key: string
-    appKey: string
-    flow: {
-      id: string
-    }
-    connection: {
-      id: string
-    }
-    previousStep: {
-      id: string
-    }
-    parameters: IJSONObject
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createStep = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const createStep: NonNullable<MutationResolvers['createStep']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const { input } = params
 

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,7 +2,7 @@ import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createStep: NonNullable<MutationResolvers['createStep']> = async (
+const createStep: MutationResolvers['createStep'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/delete-connection.ts
+++ b/packages/backend/src/graphql/mutations/delete-connection.ts
@@ -1,16 +1,8 @@
-import Context from '@/types/express/context'
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
-
-const deleteConnection = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const deleteConnection: NonNullable<
+  MutationResolvers['deleteConnection']
+> = async (_parent, params, context) => {
   await context.currentUser
     .$relatedQuery('connections')
     .delete()
@@ -19,7 +11,7 @@ const deleteConnection = async (
     })
     .throwIfNotFound()
 
-  return
+  return true
 }
 
 export default deleteConnection

--- a/packages/backend/src/graphql/mutations/delete-connection.ts
+++ b/packages/backend/src/graphql/mutations/delete-connection.ts
@@ -1,8 +1,10 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteConnection: NonNullable<
-  MutationResolvers['deleteConnection']
-> = async (_parent, params, context) => {
+const deleteConnection: MutationResolvers['deleteConnection'] = async (
+  _parent,
+  params,
+  context,
+) => {
   await context.currentUser
     .$relatedQuery('connections')
     .delete()

--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -1,17 +1,12 @@
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteFlow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const deleteFlow: NonNullable<MutationResolvers['deleteFlow']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const flow = await context.currentUser
     .$relatedQuery('flows')
@@ -30,7 +25,7 @@ const deleteFlow = async (
   await flow.$relatedQuery('steps').delete()
   await flow.$query().delete()
 
-  return
+  return true
 }
 
 export default deleteFlow

--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -3,7 +3,7 @@ import ExecutionStep from '@/models/execution-step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteFlow: NonNullable<MutationResolvers['deleteFlow']> = async (
+const deleteFlow: MutationResolvers['deleteFlow'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -1,18 +1,13 @@
 import { raw } from 'objection'
 
 import Step from '@/models/step'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    ids: string[]
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteStep = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const deleteStep: NonNullable<MutationResolvers['deleteStep']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   if (params.input.ids.length === 0) {
     throw new Error('Nothing to delete')

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -4,7 +4,7 @@ import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const deleteStep: NonNullable<MutationResolvers['deleteStep']> = async (
+const deleteStep: MutationResolvers['deleteStep'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -1,16 +1,11 @@
 import testRun from '@/services/test-run'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    stepId: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const executeFlow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const executeFlow: NonNullable<MutationResolvers['executeFlow']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const { stepId } = params.input
 

--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -2,7 +2,7 @@ import testRun from '@/services/test-run'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const executeFlow: NonNullable<MutationResolvers['executeFlow']> = async (
+const executeFlow: MutationResolvers['executeFlow'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/backend/src/graphql/mutations/generate-auth-url.ts
@@ -6,9 +6,11 @@ import App from '@/models/app'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const generateAuthUrl: NonNullable<
-  MutationResolvers['generateAuthUrl']
-> = async (_parent, params, context) => {
+const generateAuthUrl: MutationResolvers['generateAuthUrl'] = async (
+  _parent,
+  params,
+  context,
+) => {
   const connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/backend/src/graphql/mutations/generate-auth-url.ts
@@ -3,19 +3,12 @@ import axios from 'axios'
 import GenerateAuthUrlError from '@/errors/generate-auth-url'
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const generateAuthUrl = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const generateAuthUrl: NonNullable<
+  MutationResolvers['generateAuthUrl']
+> = async (_parent, params, context) => {
   const connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
@@ -8,7 +8,8 @@ import {
   type PublicOfficerEmployment,
   SGID_MULTI_HAT_COOKIE_NAME,
 } from '@/helpers/sgid'
-import type Context from '@/types/express/context'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
 
 function readEmploymentsFromCookie(req: Request): PublicOfficerEmployment[] {
   const token = req.cookies[SGID_MULTI_HAT_COOKIE_NAME]
@@ -27,19 +28,9 @@ function readEmploymentsFromCookie(req: Request): PublicOfficerEmployment[] {
   }
 }
 
-interface LoginWithSelectedSgidParams {
-  input: { workEmail: string }
-}
-
-interface LoginWithSelectedSgidResult {
-  success: boolean
-}
-
-export default async function loginWithSelectedSgid(
-  _parent: unknown,
-  params: LoginWithSelectedSgidParams,
-  context: Context,
-): Promise<LoginWithSelectedSgidResult> {
+const loginWithSelectedSgid: NonNullable<
+  MutationResolvers['loginWithSelectedSgid']
+> = async (_parent, params, context) => {
   const employments = readEmploymentsFromCookie(context.req)
   context.res.clearCookie(SGID_MULTI_HAT_COOKIE_NAME)
 
@@ -60,3 +51,5 @@ export default async function loginWithSelectedSgid(
     success: true,
   }
 }
+
+export default loginWithSelectedSgid

--- a/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-selected-sgid.ts
@@ -28,28 +28,27 @@ function readEmploymentsFromCookie(req: Request): PublicOfficerEmployment[] {
   }
 }
 
-const loginWithSelectedSgid: NonNullable<
-  MutationResolvers['loginWithSelectedSgid']
-> = async (_parent, params, context) => {
-  const employments = readEmploymentsFromCookie(context.req)
-  context.res.clearCookie(SGID_MULTI_HAT_COOKIE_NAME)
+const loginWithSelectedSgid: MutationResolvers['loginWithSelectedSgid'] =
+  async (_parent, params, context) => {
+    const employments = readEmploymentsFromCookie(context.req)
+    context.res.clearCookie(SGID_MULTI_HAT_COOKIE_NAME)
 
-  const workEmail = params.input.workEmail
+    const workEmail = params.input.workEmail
 
-  const employment = employments.find(
-    (employment) => employment.workEmail === workEmail,
-  )
+    const employment = employments.find(
+      (employment) => employment.workEmail === workEmail,
+    )
 
-  if (!employment) {
-    throw new Error('Invalid work email')
+    if (!employment) {
+      throw new Error('Invalid work email')
+    }
+
+    const user = await getOrCreateUser(workEmail)
+    setAuthCookie(context.res, { userId: user.id })
+
+    return {
+      success: true,
+    }
   }
-
-  const user = await getOrCreateUser(workEmail)
-  setAuthCookie(context.res, { userId: user.id })
-
-  return {
-    success: true,
-  }
-}
 
 export default loginWithSelectedSgid

--- a/packages/backend/src/graphql/mutations/login-with-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-sgid.ts
@@ -12,7 +12,8 @@ import {
   SGID_MULTI_HAT_COOKIE_TTL_SECONDS,
   sgidClient,
 } from '@/helpers/sgid'
-import type Context from '@/types/express/context'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
 
 function setSignedCookie<T extends object>(res: Response, data: T): void {
   const token = signJwt(data, appConfig.sessionSecretKey)
@@ -74,26 +75,19 @@ async function parsePocdexData(
   return result.filter((_, index) => validResults[index])
 }
 
-interface LoginWithSgidParams {
-  input: { authCode: string; nonce: string; verifier: string }
-}
-
-interface LoginWithSgidResult {
-  /**
-   * Success or failure can be determined by the length of this array.
-   * - Length = 0: Login failed, we could not find any valid POCDEX data.
-   * - Length = 1: Login success, we will return the POCDEX entry used to login.
-   * - Length > 1: Multi-hat user; we need the user to select which work email
-   *               to login.
-   */
-  publicOfficerEmployments: PublicOfficerEmployment[]
-}
-
-export default async function loginWithSgid(
-  _parent: unknown,
-  params: LoginWithSgidParams,
-  context: Context,
-): Promise<LoginWithSgidResult> {
+/**
+ * Success or failure of the login can be determined by the length of the
+ * returned publicOfficerEmployments array.
+ * - Length = 0: Login failed, we could not find any valid POCDEX data.
+ * - Length = 1: Login success, we will return the POCDEX entry used to login.
+ * - Length > 1: Multi-hat user; we need the user to select which work email
+ *               to login.
+ */
+const loginWithSgid: NonNullable<MutationResolvers['loginWithSgid']> = async (
+  _parent,
+  params,
+  context,
+) => {
   const { authCode, nonce, verifier } = params.input
 
   let userInfo: SgidUserInfoReturn | null = null
@@ -148,3 +142,5 @@ export default async function loginWithSgid(
     publicOfficerEmployments,
   }
 }
+
+export default loginWithSgid

--- a/packages/backend/src/graphql/mutations/login-with-sgid.ts
+++ b/packages/backend/src/graphql/mutations/login-with-sgid.ts
@@ -83,7 +83,7 @@ async function parsePocdexData(
  * - Length > 1: Multi-hat user; we need the user to select which work email
  *               to login.
  */
-const loginWithSgid: NonNullable<MutationResolvers['loginWithSgid']> = async (
+const loginWithSgid: MutationResolvers['loginWithSgid'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/logout.ts
+++ b/packages/backend/src/graphql/mutations/logout.ts
@@ -1,10 +1,11 @@
 import { deleteAuthCookie } from '@/helpers/auth'
-import Context from '@/types/express/context'
 
-const logout = async (
-  _parent: unknown,
-  _params: unknown,
-  context: Context,
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const logout: NonNullable<MutationResolvers['logout']> = async (
+  _parent,
+  _params,
+  context,
 ): Promise<boolean> => {
   deleteAuthCookie(context.res)
   return true

--- a/packages/backend/src/graphql/mutations/logout.ts
+++ b/packages/backend/src/graphql/mutations/logout.ts
@@ -2,11 +2,11 @@ import { deleteAuthCookie } from '@/helpers/auth'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const logout: NonNullable<MutationResolvers['logout']> = async (
+const logout: MutationResolvers['logout'] = async (
   _parent,
   _params,
   context,
-): Promise<boolean> => {
+) => {
   deleteAuthCookie(context.res)
   return true
 }

--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -17,10 +17,7 @@ const OTP_RESEND_TIMEOUT_IN_MS = 1 * 30 * 1000
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const requestOtp: NonNullable<MutationResolvers['requestOtp']> = async (
-  _parent,
-  params,
-): Promise<boolean> => {
+const requestOtp: MutationResolvers['requestOtp'] = async (_parent, params) => {
   const email = await validateAndParseEmail(params.input.email)
   // validate email
   if (!email) {

--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -6,11 +6,7 @@ import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import { sendEmail } from '@/helpers/send-email'
 
-type Params = {
-  input: {
-    email: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
 const OTP_LENGTH = 6
 const OTP_ALLOWED_CHARS = '23456789ABCDEFGHJKLMNPQRSTUVWXYZ'
@@ -21,9 +17,9 @@ const OTP_RESEND_TIMEOUT_IN_MS = 1 * 30 * 1000
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const requestOtp = async (
-  _parent: unknown,
-  params: Params,
+const requestOtp: NonNullable<MutationResolvers['requestOtp']> = async (
+  _parent,
+  params,
 ): Promise<boolean> => {
   const email = await validateAndParseEmail(params.input.email)
   // validate email

--- a/packages/backend/src/graphql/mutations/reset-connection.ts
+++ b/packages/backend/src/graphql/mutations/reset-connection.ts
@@ -1,8 +1,10 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const resetConnection: NonNullable<
-  MutationResolvers['resetConnection']
-> = async (_parent, params, context) => {
+const resetConnection: MutationResolvers['resetConnection'] = async (
+  _parent,
+  params,
+  context,
+) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/reset-connection.ts
+++ b/packages/backend/src/graphql/mutations/reset-connection.ts
@@ -1,16 +1,8 @@
-import Context from '@/types/express/context'
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
-
-const resetConnection = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const resetConnection: NonNullable<
+  MutationResolvers['resetConnection']
+> = async (_parent, params, context) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -3,19 +3,12 @@ import { ref } from 'objection'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import actionQueue from '@/queues/action'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    executionStepId: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const retryExecutionStep = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const retryExecutionStep: NonNullable<
+  MutationResolvers['retryExecutionStep']
+> = async (_parent, params, context) => {
   const executionStep = await ExecutionStep.query()
     .findById(params.input.executionStepId)
     .whereNotNull('job_id')

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -6,9 +6,11 @@ import actionQueue from '@/queues/action'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const retryExecutionStep: NonNullable<
-  MutationResolvers['retryExecutionStep']
-> = async (_parent, params, context) => {
+const retryExecutionStep: MutationResolvers['retryExecutionStep'] = async (
+  _parent,
+  params,
+  context,
+) => {
   const executionStep = await ExecutionStep.query()
     .findById(params.input.executionStepId)
     .whereNotNull('job_id')

--- a/packages/backend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-row.ts
@@ -1,14 +1,11 @@
-import { CreateRowInput, createTableRow } from '@/models/dynamodb/table-row'
-import Context from '@/types/express/context'
+import { createTableRow } from '@/models/dynamodb/table-row'
 
-type Params = {
-  input: CreateRowInput
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const createRow: NonNullable<MutationResolvers['createRow']> = async (
+  _parent,
+  params,
+  context,
 ): Promise<string> => {
   const { tableId, data } = params.input
   const table = await context.currentUser

--- a/packages/backend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-row.ts
@@ -2,11 +2,11 @@ import { createTableRow } from '@/models/dynamodb/table-row'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRow: NonNullable<MutationResolvers['createRow']> = async (
+const createRow: MutationResolvers['createRow'] = async (
   _parent,
   params,
   context,
-): Promise<string> => {
+) => {
   const { tableId, data } = params.input
   const table = await context.currentUser
     .$relatedQuery('tables')

--- a/packages/backend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-rows.ts
@@ -1,14 +1,11 @@
-import { CreateRowsInput, createTableRows } from '@/models/dynamodb/table-row'
-import Context from '@/types/express/context'
+import { createTableRows } from '@/models/dynamodb/table-row'
 
-type Params = {
-  input: CreateRowsInput
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRows = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const createRows: NonNullable<MutationResolvers['createRows']> = async (
+  _parent,
+  params,
+  context,
 ): Promise<boolean> => {
   const { tableId, dataArray } = params.input
   const table = await context.currentUser

--- a/packages/backend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-rows.ts
@@ -2,11 +2,11 @@ import { createTableRows } from '@/models/dynamodb/table-row'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createRows: NonNullable<MutationResolvers['createRows']> = async (
+const createRows: MutationResolvers['createRows'] = async (
   _parent,
   params,
   context,
-): Promise<boolean> => {
+) => {
   const { tableId, dataArray } = params.input
   const table = await context.currentUser
     .$relatedQuery('tables')

--- a/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
@@ -2,24 +2,23 @@ import { randomUUID } from 'crypto'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createShareableTableLink: NonNullable<
-  MutationResolvers['createShareableTableLink']
-> = async (_parent, params, context) => {
-  const tableId = params.tableId
+const createShareableTableLink: MutationResolvers['createShareableTableLink'] =
+  async (_parent, params, context) => {
+    const tableId = params.tableId
 
-  // TODO: when implementing collaborators, only allow owner or editor
-  const table = await await context.currentUser
-    .$relatedQuery('tables')
-    .findById(tableId)
-    .throwIfNotFound()
+    // TODO: when implementing collaborators, only allow owner or editor
+    const table = await await context.currentUser
+      .$relatedQuery('tables')
+      .findById(tableId)
+      .throwIfNotFound()
 
-  const newViewOnlyKey = randomUUID()
+    const newViewOnlyKey = randomUUID()
 
-  await table.$query().patch({
-    viewOnlyKey: newViewOnlyKey,
-  })
+    await table.$query().patch({
+      viewOnlyKey: newViewOnlyKey,
+    })
 
-  return newViewOnlyKey
-}
+    return newViewOnlyKey
+  }
 
 export default createShareableTableLink

--- a/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table-shareable-link.ts
@@ -1,16 +1,10 @@
 import { randomUUID } from 'crypto'
 
-import Context from '@/types/express/context'
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-type Params = {
-  tableId: string
-}
-
-const createShareableTableLink = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const createShareableTableLink: NonNullable<
+  MutationResolvers['createShareableTableLink']
+> = async (_parent, params, context) => {
   const tableId = params.tableId
 
   // TODO: when implementing collaborators, only allow owner or editor

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -2,7 +2,7 @@ import { createTableRows } from '@/models/dynamodb/table-row'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createTable: NonNullable<MutationResolvers['createTable']> = async (
+const createTable: MutationResolvers['createTable'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -1,16 +1,11 @@
 import { createTableRows } from '@/models/dynamodb/table-row'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    name: string
-  }
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const createTable = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const createTable: NonNullable<MutationResolvers['createTable']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const tableName = params.input.name
 

--- a/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
@@ -2,7 +2,7 @@ import { deleteTableRows } from '@/models/dynamodb/table-row'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteRows: NonNullable<MutationResolvers['deleteRows']> = async (
+const deleteRows: MutationResolvers['deleteRows'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
@@ -1,14 +1,11 @@
-import { DeleteRowsInput, deleteTableRows } from '@/models/dynamodb/table-row'
-import Context from '@/types/express/context'
+import { deleteTableRows } from '@/models/dynamodb/table-row'
 
-type Params = {
-  input: DeleteRowsInput
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteRows = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const deleteRows: NonNullable<MutationResolvers['deleteRows']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const { tableId, rowIds } = params.input
 

--- a/packages/backend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table.ts
@@ -2,7 +2,7 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteTable: NonNullable<MutationResolvers['deleteTable']> = async (
+const deleteTable: MutationResolvers['deleteTable'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table.ts
@@ -1,16 +1,11 @@
 import TableMetadata from '@/models/table-metadata'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteTable = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const deleteTable: NonNullable<MutationResolvers['deleteTable']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   await TableMetadata.transaction(async (trx) => {
     const table = await context.currentUser

--- a/packages/backend/src/graphql/mutations/tiles/index.ts
+++ b/packages/backend/src/graphql/mutations/tiles/index.ts
@@ -1,3 +1,5 @@
+import type { MutationResolvers } from '../../__generated__/types.generated'
+
 import createRow from './create-row'
 import createRows from './create-rows'
 import createTable from './create-table'
@@ -16,4 +18,4 @@ export default {
   updateRow,
   deleteRows,
   createShareableTableLink,
-}
+} satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -1,14 +1,11 @@
-import { UpdateRowInput, updateTableRow } from '@/models/dynamodb/table-row'
-import Context from '@/types/express/context'
+import { updateTableRow } from '@/models/dynamodb/table-row'
 
-type Params = {
-  input: UpdateRowInput
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const updateRow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const updateRow: NonNullable<MutationResolvers['updateRow']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const { tableId, rowId, data } = params.input
 

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -2,7 +2,7 @@ import { updateTableRow } from '@/models/dynamodb/table-row'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const updateRow: NonNullable<MutationResolvers['updateRow']> = async (
+const updateRow: MutationResolvers['updateRow'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -1,25 +1,9 @@
-import { ITableColumnConfig } from '@plumber/types'
-
 import pLimit from 'p-limit'
 import { z } from 'zod'
 
 import TableColumnMetadata from '@/models/table-column-metadata'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-    name?: string
-    addedColumns?: string[]
-    modifiedColumns?: {
-      id: string
-      name?: string
-      position?: number
-      config?: ITableColumnConfig
-    }[]
-    deletedColumns?: string[]
-  }
-}
+import type { MutationResolvers } from '../../__generated__/types.generated'
 
 export const updateTableSchema = z.object({
   id: z.string().uuid(),
@@ -42,10 +26,10 @@ export const updateTableSchema = z.object({
   deletedColumns: z.array(z.string().uuid()).optional(),
 })
 
-const updateTable = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const updateTable: NonNullable<MutationResolvers['updateTable']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const {
     id: tableId,

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -26,7 +26,7 @@ export const updateTableSchema = z.object({
   deletedColumns: z.array(z.string().uuid()).optional(),
 })
 
-const updateTable: NonNullable<MutationResolvers['updateTable']> = async (
+const updateTable: MutationResolvers['updateTable'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -1,21 +1,11 @@
-import { IJSONObject } from '@plumber/types'
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-import Context from '@/types/express/context'
+// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data
+// Scanner
 
-// Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data Scanner
-
-type Params = {
-  input: {
-    id: string
-    formattedData: IJSONObject
-  }
-}
-
-const updateConnection = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const updateConnection: NonNullable<
+  MutationResolvers['updateConnection']
+> = async (_parent, params, context) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -3,9 +3,11 @@ import type { MutationResolvers } from '../__generated__/types.generated'
 // Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data
 // Scanner
 
-const updateConnection: NonNullable<
-  MutationResolvers['updateConnection']
-> = async (_parent, params, context) => {
+const updateConnection: MutationResolvers['updateConnection'] = async (
+  _parent,
+  params,
+  context,
+) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -3,23 +3,15 @@ import {
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
 import flowQueue from '@/queues/flow'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-    active: boolean
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
 const JOB_NAME = 'flow'
 const EVERY_15_MINUTES_CRON = '*/15 * * * *'
 
-const updateFlowStatus = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const updateFlowStatus: NonNullable<
+  MutationResolvers['updateFlowStatus']
+> = async (_parent, params, context) => {
   let flow = await context.currentUser
     .$relatedQuery('flows')
     .findOne({

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -9,9 +9,11 @@ import type { MutationResolvers } from '../__generated__/types.generated'
 const JOB_NAME = 'flow'
 const EVERY_15_MINUTES_CRON = '*/15 * * * *'
 
-const updateFlowStatus: NonNullable<
-  MutationResolvers['updateFlowStatus']
-> = async (_parent, params, context) => {
+const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
+  _parent,
+  params,
+  context,
+) => {
   let flow = await context.currentUser
     .$relatedQuery('flows')
     .findOne({

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -1,16 +1,9 @@
-import Context from '@/types/express/context'
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-type Params = {
-  input: {
-    id: string
-    name: string
-  }
-}
-
-const updateFlow = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const updateFlow: NonNullable<MutationResolvers['updateFlow']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   let flow = await context.currentUser
     .$relatedQuery('flows')

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -1,6 +1,6 @@
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateFlow: NonNullable<MutationResolvers['updateFlow']> = async (
+const updateFlow: MutationResolvers['updateFlow'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,27 +1,11 @@
-import { IJSONObject } from '@plumber/types'
-
 import Step from '@/models/step'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-    key: string
-    appKey: string
-    parameters: IJSONObject
-    flow: {
-      id: string
-    }
-    connection: {
-      id: string
-    }
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateStep = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const updateStep: NonNullable<MutationResolvers['updateStep']> = async (
+  _parent,
+  params,
+  context,
 ) => {
   const { input } = params
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -2,7 +2,7 @@ import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const updateStep: NonNullable<MutationResolvers['updateStep']> = async (
+const updateStep: MutationResolvers['updateStep'] = async (
   _parent,
   params,
   context,

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -4,19 +4,12 @@
 
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    id: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
-const verifyConnection = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
-) => {
+const verifyConnection: NonNullable<
+  MutationResolvers['verifyConnection']
+> = async (_parent, params, context) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -7,9 +7,11 @@ import App from '@/models/app'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const verifyConnection: NonNullable<
-  MutationResolvers['verifyConnection']
-> = async (_parent, params, context) => {
+const verifyConnection: MutationResolvers['verifyConnection'] = async (
+  _parent,
+  params,
+  context,
+) => {
   let connection = await context.currentUser
     .$relatedQuery('connections')
     .findOne({

--- a/packages/backend/src/graphql/mutations/verify-otp.ts
+++ b/packages/backend/src/graphql/mutations/verify-otp.ts
@@ -4,23 +4,17 @@ import BaseError from '@/errors/base'
 import { setAuthCookie } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import User from '@/models/user'
-import Context from '@/types/express/context'
 
-type Params = {
-  input: {
-    email: string
-    otp: string
-  }
-}
+import type { MutationResolvers } from '../__generated__/types.generated'
 
 const MAX_OTP_ATTEMPTS = 5
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const verifyOtp = async (
-  _parent: unknown,
-  params: Params,
-  context: Context,
+const verifyOtp: NonNullable<MutationResolvers['verifyOtp']> = async (
+  _parent,
+  params,
+  context,
 ): Promise<boolean> => {
   const { otp, email: emailRaw } = params.input
   // validate email

--- a/packages/backend/src/graphql/mutations/verify-otp.ts
+++ b/packages/backend/src/graphql/mutations/verify-otp.ts
@@ -11,11 +11,11 @@ const MAX_OTP_ATTEMPTS = 5
 // 15 minutes in milliseconds
 const OTP_VALIDITY_IN_MS = 15 * 60 * 1000
 
-const verifyOtp: NonNullable<MutationResolvers['verifyOtp']> = async (
+const verifyOtp: MutationResolvers['verifyOtp'] = async (
   _parent,
   params,
   context,
-): Promise<boolean> => {
+) => {
   const { otp, email: emailRaw } = params.input
   // validate email
   const email = await validateAndParseEmail(emailRaw)

--- a/packages/backend/src/graphql/resolvers.ts
+++ b/packages/backend/src/graphql/resolvers.ts
@@ -1,11 +1,10 @@
+import type { Resolvers } from './__generated__/types.generated'
 import customResolvers from './custom-resolvers'
 import mutationResolvers from './mutation-resolvers'
 import queryResolvers from './query-resolvers'
 
-const resolvers = {
+export default {
   Query: queryResolvers,
   Mutation: mutationResolvers,
   ...customResolvers,
-}
-
-export default resolvers
+} satisfies Resolvers

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -6,7 +6,7 @@ export type TableRowItem = CreateEntityItem<typeof TableRow>
 export type CreateRowInput = Pick<TableRowItem, 'tableId' | 'data'>
 export type CreateRowsInput = {
   tableId: string
-  dataArray: Record<string, string>[]
+  dataArray: Array<TableRowItem['data']>
 }
 export type UpdateRowInput = Pick<TableRowItem, 'tableId' | 'data' | 'rowId'>
 export interface DeleteRowsInput {


### PR DESCRIPTION
## Problem
We are adding more and more GraphQL operations with questionable type safety practices (e.g. manual typing and casting). This is likely going to create footguns for us in the future.

## Solution
Bite the bullet and migrate to using [graphql codegen](https://the-guild.dev/graphql/codegen) to generate typed GraphQL operations.

This PR builds on top of #452 and adds typing for GraphQL mutations.

### Exhaustive GraphQL testing to be done if team ok with this approach.
#### Queries
- [ ] getApps
- [ ] getApp
- [ ] getConnectedApps
- [ ] testConnection
- [ ] getFlow
- [ ] getFlows
- [ ] getStepWithTestExecutions
- [ ] getExecution
- [ ] getExecutions
- [ ] getExecutionSteps
- [ ] getDynamicData
- [ ] getCurrentUser
- [ ] healthcheck
- [ ] getTable
- [ ] getTables
- [ ] getAllRows

#### Mutations
- [ ] createConnection
- [ ] generateAuthUrl
- [ ] updateConnection
- [ ] resetConnection
- [ ] verifyConnection
- [ ] deleteConnection
- [ ] registerConnection
- [ ] createFlow
- [ ] updateFlow
- [ ] updateFlowStatus
- [ ] executeFlow
- [ ] deleteFlow
- [ ] createStep
- [ ] updateStep
- [ ] deleteStep
- [ ] requestOtp
- [ ] verifyOtp
- [ ] retryExecutionStep
- [ ] logout
- [ ] loginWithSgid
- [ ] loginWithSelectedSgid
- [ ] createTable
- [ ] deleteTable
- [ ] updateTable
- [ ] createRow
- [ ] createRows
- [ ] updateRow
- [ ] deleteRows
- [ ] createShareableTableLink

## Tests
- Check that unit tests still pass
- Sanity check that editing pipes still work.
- Exhaustive GraphQL testing in this PR once team is OK with backend approach.