### PR TITLE
fix: add catch error for blacklisted email

### DIFF
--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -124,12 +124,13 @@ worker.on('failed', async (job, err) => {
       job: job.data,
     },
   )
-  const isEmailSent = await checkErrorEmail(job.data.flowId)
-  if (isEmailSent) {
-    return
-  }
 
   try {
+    const isEmailSent = await checkErrorEmail(job.data.flowId)
+    if (isEmailSent) {
+      return
+    }
+
     if (
       err instanceof UnrecoverableError ||
       job.attemptsMade === MAXIMUM_JOB_ATTEMPTS

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -128,17 +128,24 @@ worker.on('failed', async (job, err) => {
   if (isEmailSent) {
     return
   }
-  if (
-    err instanceof UnrecoverableError ||
-    job.attemptsMade === MAXIMUM_JOB_ATTEMPTS
-  ) {
-    const flow = await Flow.query()
-      .findById(job.data.flowId)
-      .withGraphFetched('user')
-      .throwIfNotFound()
-    const emailErrorDetails = await sendErrorEmail(flow)
-    logger.info(`Sent error email for FLOW ID: ${job.data.flowId}`, {
-      errorDetails: { ...emailErrorDetails, ...job.data },
+
+  try {
+    if (
+      err instanceof UnrecoverableError ||
+      job.attemptsMade === MAXIMUM_JOB_ATTEMPTS
+    ) {
+      const flow = await Flow.query()
+        .findById(job.data.flowId)
+        .withGraphFetched('user')
+        .throwIfNotFound()
+      const emailErrorDetails = await sendErrorEmail(flow)
+      logger.info(`Sent error email for FLOW ID: ${job.data.flowId}`, {
+        errorDetails: { ...emailErrorDetails, ...job.data },
+      })
+    }
+  } catch (err) {
+    logger.error(`Could not send error email for FLOW ID: ${job.data.flowId}`, {
+      errorDetails: { ...job.data, err: err.stack },
     })
   }
 })


### PR DESCRIPTION
## Problem

Blacklisted pipe owner cannot receive emails, hence triggering an error on our `send-email` function and it is uncaught, causing the worker to be killed

## Solution

Add a try catch to log the error

## Tests
Tested that blacklisted pipe owner will not cause the worker to die because the error is caught and logged
![image](https://github.com/opengovsg/plumber/assets/65110268/f32d9c37-e117-4703-a961-91b199d25e8b)



