### PR TITLE
feat(backend): disable tracking pixel in OTP emails

### DIFF
--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -27,6 +27,7 @@ export async function sendEmail({
         recipient,
         from: `Plumber <${appConfig.postman.fromAddress}>`,
         ...(replyTo && { reply_to: replyTo }),
+        disable_tracking: true,
       },
       {
         headers: {


### PR DESCRIPTION
## Problem

Tracking pixels show up in OTP emails unnecessarily 

## Solution

Disable tracking pixel for OTP email sending

## Tests

- [x] Test in local
- [x] Test in staging

## Deploy Notes

N/A