### PR TITLE
build(frontend): update prosemirror version for correct license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5372,47 +5372,9 @@
     },
     "node_modules/@remirror/core-constants": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ==",
       "peer": true
-    },
-    "node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/types/node_modules/type-fest": {
-      "version": "2.19.0",
-      "license": "(MIT OR CC0-1.0)",
-      "peer": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.6.2",
@@ -6819,16 +6781,6 @@
         "form-data": "^3.0.0"
       }
     },
-    "node_modules/@types/object.omit": {
-      "version": "3.0.2",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/object.pick": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/papaparse": {
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.14.tgz",
@@ -6936,11 +6888,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.7",
@@ -8117,17 +8064,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8871,11 +8807,6 @@
     "node_modules/csv-parse": {
       "version": "5.4.0",
       "license": "MIT"
-    },
-    "node_modules/dash-get": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dataloader": {
       "version": "2.1.0",
@@ -12314,6 +12245,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/markdown-it": {
@@ -14361,12 +14293,12 @@
       }
     },
     "node_modules/prosemirror-trailing-node": {
-      "version": "2.0.7",
-      "license": "MIT",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.8.tgz",
+      "integrity": "sha512-ujRYhSuhQb1Jsarh1IHqb2KoSnRiD7wAMDGucP35DN7j5af6X7B18PfdPIrbwsPTqIAj0fyOvxbuPsWhNvylmA==",
       "peer": true,
       "dependencies": {
         "@remirror/core-constants": "^2.0.2",
-        "@remirror/core-helpers": "^3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Problem

`promisemirror-trailing-node` is using ambiguous license in earlier version

## Solution

Updated to 2.0.8

## Tests

- [x] Input fields working

## Deploy Notes

N/A