### PR TITLE
PLU-211: Normalize some punctuation in PaySG names and addresses

### DIFF
--- a/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
@@ -170,7 +170,14 @@ describe('create payment', () => {
       expectedPayerName: 'a--b-c-d--e',
       expectedPayerAddress: `"'top"' - '"kek'"`,
     },
-    // Check that normal dashes and quotes are not impacted
+    // Check that it handles halfwidth and fullwidth conversion
+    {
+      payerName: '\uff21\uff22\uff23\uff44\uff45\uff46',
+      payerAddress: '#\uff10\uff12\uff0d\uff18\uff15',
+      expectedPayerName: 'ABCdef',
+      expectedPayerAddress: `#02-85`,
+    },
+    // Check that latin characters are not impacted
     {
       payerName: 'a--b\u2010c-d--e',
       payerAddress: `"\u2018top\u201C' \u2012 '\u201Dkek\u2019"`,

--- a/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
@@ -158,17 +158,17 @@ describe('create payment', () => {
   it.each([
     {
       payerName: 'a\u2010b\u2011c\u2012d\u2014e\u2015f',
-      payerAddress: '\u2018top\u2019 \u201Ckek\u201D',
+      payerAddress: '\u2018topkek\u2019',
       expectedPayerName: 'a-b-c-d-e-f',
-      expectedPayerAddress: `'top' "kek"`,
+      expectedPayerAddress: `'topkek'`,
     },
     // Check that it replaces _all_ occurances.
     {
       payerName: 'a\u2010\u2010b\u2010c\u2012d\u2012\u2012e',
       payerAddress:
-        '\u201C\u2018top\u201C\u2018 \u2012 \u2019\u201Dkek\u2019\u201D',
+        '\u2018\u2018top\u2019\u2019 \u2012 \u2019\u2018kek\u2018\u2019',
       expectedPayerName: 'a--b-c-d--e',
-      expectedPayerAddress: `"'top"' - '"kek'"`,
+      expectedPayerAddress: `''top'' - ''kek''`,
     },
     // Check that it handles halfwidth and fullwidth conversion
     {
@@ -180,9 +180,9 @@ describe('create payment', () => {
     // Check that latin characters are not impacted
     {
       payerName: 'a--b\u2010c-d--e',
-      payerAddress: `"\u2018top\u201C' \u2012 '\u201Dkek\u2019"`,
+      payerAddress: `\u2018top' \u2012 'kek\u2019`,
       expectedPayerName: 'a--b-c-d--e',
-      expectedPayerAddress: `"'top"' - '"kek'"`,
+      expectedPayerAddress: `'top' - 'kek'`,
     },
   ])(
     'normalizes special characters',

--- a/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
@@ -21,7 +21,7 @@ describe('create payment', () => {
       auth: {
         set: vi.fn(),
         data: {
-          apiKey: 'sample-api-key',
+          apiKey: 'paysg_stag_abcd',
           paymentServiceId: 'sample-payment-service-id',
         },
       },
@@ -81,7 +81,6 @@ describe('create payment', () => {
       { key: 'test-key-2', value: 'test-value-2' },
     ]
 
-    $.auth.data.apiKey = 'paysg_stag_abcd'
     await createPaymentAction.run($)
 
     expect(mocks.httpPost).toHaveBeenCalledWith(
@@ -113,7 +112,6 @@ describe('create payment', () => {
       { key: 'test-key-2', value: 'test-value-2' },
     ]
 
-    $.auth.data.apiKey = 'paysg_stag_abcd'
     await createPaymentAction.run($)
     expect($.setActionItem).toBeCalledWith({
       raw: {
@@ -136,8 +134,6 @@ describe('create payment', () => {
       { key: 'test-key-2', value: 'test-value-2' },
     ]
 
-    $.auth.data.apiKey = 'paysg_stag_abcd'
-
     mocks.httpPost.mockReturnValueOnce({
       data: {
         ...MOCK_PAYMENT,
@@ -158,4 +154,49 @@ describe('create payment', () => {
       },
     })
   })
+
+  it.each([
+    {
+      payerName: 'a\u2010b\u2011c\u2012d\u2014e\u2015f',
+      payerAddress: '\u2018top\u2019 \u201Ckek\u201D',
+      expectedPayerName: 'a-b-c-d-e-f',
+      expectedPayerAddress: `'top' "kek"`,
+    },
+    // Check that it replaces _all_ occurances.
+    {
+      payerName: 'a\u2010\u2010b\u2010c\u2012d\u2012\u2012e',
+      payerAddress:
+        '\u201C\u2018top\u201C\u2018 \u2012 \u2019\u201Dkek\u2019\u201D',
+      expectedPayerName: 'a--b-c-d--e',
+      expectedPayerAddress: `"'top"' - '"kek'"`,
+    },
+    // Check that normal dashes and quotes are not impacted
+    {
+      payerName: 'a--b\u2010c-d--e',
+      payerAddress: `"\u2018top\u201C' \u2012 '\u201Dkek\u2019"`,
+      expectedPayerName: 'a--b-c-d--e',
+      expectedPayerAddress: `"'top"' - '"kek'"`,
+    },
+  ])(
+    'normalizes special characters',
+    async ({
+      payerName,
+      payerAddress,
+      expectedPayerName,
+      expectedPayerAddress,
+    }) => {
+      $.step.parameters.payerName = payerName
+      $.step.parameters.payerAddress = payerAddress
+      await createPaymentAction.run($)
+
+      expect(mocks.httpPost).toBeCalledWith(
+        '/v1/payment-services/sample-payment-service-id/payments',
+        expect.objectContaining({
+          payer_name: expectedPayerName,
+          payer_address: expectedPayerAddress,
+        }),
+        expect.anything(),
+      )
+    },
+  )
 })

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -23,9 +23,9 @@ const UNICODE_TO_ASCII_MAP: Record<number, string> = {
   //
   0x201c: `"`, // General Punctuation
   0x201d: `"`,
-  0x301d: `"`, // CJK
+  0x3003: `"`, // CJK
+  0x301d: `"`,
   0x301e: `"`,
-  0x3003: `"`,
 
   //
   // Commas

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -1,11 +1,59 @@
-// Taken from Unicode general punctuation range
-const DASHES = /[\u2010-\u2015]/g
-const SINGLE_QUOTES = /[\u2018\u2019]/g
-const DOUBLE_QUOTES = /[\u201C\u201D]/g
+//
+// Small, best effort mapping.
+//
+const UNICODE_TO_ASCII_MAP: Record<number, string> = {
+  //
+  // Dashes
+  //
+  0x2010: `-`, // General Punctuation
+  0x2011: `-`,
+  0x2012: `-`,
+  0x2013: `-`,
+  0x2014: `-`,
+  0x2015: `-`,
+
+  //
+  // Single Quotes
+  //
+  0x2018: `'`, // General Punctuation
+  0x2019: `'`,
+
+  //
+  // Double Quotes
+  //
+  0x201c: `"`, // General Punctuation
+  0x201d: `"`,
+  0x301d: `"`, // CJK
+  0x301e: `"`,
+  0x3003: `"`,
+
+  //
+  // Commas
+  //
+  0x3001: `,`, // CJK
+  0xff64: `,`, // Halfwidth and fullwidth
+
+  //
+  // Dots
+  //
+  0x3002: `.`, // CJK
+  0xff61: `.`, // Halfwidth and fullwidth
+}
+
+function replacer(inputChar: string): string {
+  const codePoint = inputChar.codePointAt(0)
+
+  // Edge case: Latin range of halfwidth and fullwidth can be converted
+  // mathematically.
+  if (0xff01 <= codePoint && codePoint <= 0xff5e) {
+    return String.fromCodePoint(codePoint + 0x20 - 0xff00)
+  }
+
+  const replacementChar = UNICODE_TO_ASCII_MAP[codePoint]
+  return replacementChar ?? inputChar
+}
 
 export function normalizeSpecialChars(input: string): string {
-  return input
-    .replaceAll(DASHES, '-')
-    .replaceAll(SINGLE_QUOTES, "'")
-    .replaceAll(DOUBLE_QUOTES, '"')
+  // Process all non-latin characters.
+  return input.replaceAll(/[^\u0020-\u007F]/g, replacer)
 }

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -1,0 +1,11 @@
+// Taken from Unicode general punctuation range
+const DASHES = /[\u2010-\u2015]/g
+const SINGLE_QUOTES = /[\u2018\u2019]/g
+const DOUBLE_QUOTES = /[\u201C\u201D]/g
+
+export function normalizeSpecialChars(input: string): string {
+  return input
+    .replaceAll(DASHES, '-')
+    .replaceAll(SINGLE_QUOTES, "'")
+    .replaceAll(DOUBLE_QUOTES, '"')
+}

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -1,6 +1,11 @@
 //
 // Small, best effort mapping.
 //
+// If this gets too unwieldy, we can consider moving to something like
+// unidecode-plus. Decided not to use it for now due to weird licensing (hybrid
+// MIT and Perl), and that validating _all_ its replacements is too time
+// consuming.
+//
 const UNICODE_TO_ASCII_MAP: Record<number, string> = {
   //
   // Dashes

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -55,5 +55,5 @@ function replacer(inputChar: string): string {
 
 export function normalizeSpecialChars(input: string): string {
   // Process all non-latin characters.
-  return input.replaceAll(/[^\u0020-\u007F]/g, replacer)
+  return input.replaceAll(/[^\u{0020}-\u{007F}]/gu, replacer)
 }

--- a/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/normalize-special-chars.ts
@@ -19,15 +19,6 @@ const UNICODE_TO_ASCII_MAP: Record<number, string> = {
   0x2019: `'`,
 
   //
-  // Double Quotes
-  //
-  0x201c: `"`, // General Punctuation
-  0x201d: `"`,
-  0x3003: `"`, // CJK
-  0x301d: `"`,
-  0x301e: `"`,
-
-  //
   // Commas
   //
   0x3001: `,`, // CJK

--- a/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 
 import { zodParser as plumberDate } from '@/helpers/internal-date-format'
 
+import { normalizeSpecialChars } from './normalize-special-chars'
+
 export const requestSchema = z
   .object({
     referenceId: z
@@ -147,8 +149,8 @@ export const requestSchema = z
   // After parsing, convert to PaySG format.
   .transform((data) => ({
     reference_id: data.referenceId,
-    payer_name: data.payerName,
-    payer_address: data.payerAddress,
+    payer_name: normalizeSpecialChars(data.payerName),
+    payer_address: normalizeSpecialChars(data.payerAddress),
     payer_identifier: data.payerIdentifier,
     payer_email: data.payerEmail,
     description: data.description,


### PR DESCRIPTION
## Problem
We are constantly getting pipe failures due to PaySG rejecting punctuation like `'` or `"`; this is because PaySG only accepts ASCII. It turns out these are entered by end users who use iPhones or non-english keyboards. In particular, iPhones allow users to choose open / closed quotation marks with long press.

As this is quite a common use case (mobile users), we should support what we can instead of erroring out.

## Solution
For now, we will convert selected punctuation into their ASCII equivalents. Specifically, we will convert the following chars from the unicode [general punctuation](https://symbl.cc/en/unicode/blocks/general-punctuation/) range:
1. All dashes to `-`
2. Left and right single quotation marks to `'`.
3. CJK full stop to `.`.
4. CJK commas to `,`.
5. Halfwidth and fullwidth characters to their latin equivalents.

I've verified that iPhone uses characters from this range in the default keyboard.

Note that this will not 100% solve the problem; there may be other homoglyphs that we do not know about. If this happens, we'll update the function to normalize them if possible.

## Tests
- New unit test
- Check that I can create a PaySG payment with special punctuation in payer name and address
- Regression test: check that I can create a PaySG payment without special punctuation