### PR TITLE
refactor(frontend): add data-test attribute for text input

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -198,7 +198,7 @@ const RichTextEditor = ({
 }: RichTextEditorProps) => {
   const { control } = useFormContext()
   return (
-    <FormControl style={{ flexGrow: 1 }}>
+    <FormControl style={{ flexGrow: 1 }} data-test="text-input-group">
       {label && (
         <FormLabel isRequired={required} description={description}>
           {label}


### PR DESCRIPTION
## Problem

There's no class-agnostic way of identifying text input group for our e2e test

## Solution

Add a div in between lib components for `data-test`

## Tests

- [x] All text input field visuals don't get affected
  - [x] plain text
  - [x] rich text
  - [x] text input with trash can

## Deploy Notes

N/A