### PR TITLE
PLU-206: add automatic fix for telegram supergroup chat error

### DIFF
--- a/packages/backend/src/apps/telegram-bot/__tests__/actions/send-message.test.ts
+++ b/packages/backend/src/apps/telegram-bot/__tests__/actions/send-message.test.ts
@@ -22,7 +22,6 @@ vi.mock('@/models/step', () => ({
       })),
     })),
   },
-  SHOULD_UPDATE_STEP_PARAMS: 'shouldUpdateStepParams',
 }))
 
 describe('send message', () => {

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -91,7 +91,7 @@ const action: IRawAction = {
         raw: response.data,
       })
     } catch (err) {
-      throwSendMessageError(err, $.step.position, $.app.name)
+      await throwSendMessageError(err, $.step.position, $.app.name, $)
     }
   },
 }

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -91,7 +91,7 @@ const action: IRawAction = {
         raw: response.data,
       })
     } catch (err) {
-      await throwSendMessageError(err, $.step.position, $.app.name, $)
+      await throwSendMessageError(err, $.step, $.app.name, $.execution.testRun)
     }
   },
 }

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -11,6 +11,7 @@ import Connection from './connection'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
 
+export const SHOULD_UPDATE_STEP_PARAMS = 'shouldUpdateStepParams'
 class Step extends Base {
   id!: string
   flowId!: string
@@ -158,6 +159,11 @@ class Step extends Base {
 
   static async beforeUpdate(args: StaticHookArguments<Step>): Promise<void> {
     await super.beforeUpdate(args)
+
+    // bypass check when step error can be rectified by just updating the step parameters
+    if (args.context[SHOULD_UPDATE_STEP_PARAMS] === true) {
+      return
+    }
 
     // We _have_ to use asFindQuery here instead of iterating through
     // args.inputItems (like in beforeInsert), because patch queries don't

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -11,7 +11,10 @@ import Connection from './connection'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
 
-export const SHOULD_UPDATE_STEP_PARAMS = 'shouldUpdateStepParams'
+export interface StepContext {
+  shouldBypassBeforeUpdateHook?: boolean
+}
+
 class Step extends Base {
   id!: string
   flowId!: string
@@ -161,7 +164,8 @@ class Step extends Base {
     await super.beforeUpdate(args)
 
     // bypass check when step error can be rectified by just updating the step parameters
-    if (args.context[SHOULD_UPDATE_STEP_PARAMS] === true) {
+    const queryContext = args.context as StepContext
+    if (queryContext.shouldBypassBeforeUpdateHook) {
       return
     }
 


### PR DESCRIPTION
## Problem

Telegram supergroup chat upgrade would cause errors for published pipes, and we can directly change it for them since the error shows the new chat id.

Example of error:
`data: { ok: false,
        error_code: 400,
        description: 'Bad Request: group chat was upgraded to a supergroup chat',
        parameters: { migrate_to_chat_id: -123 }
    },`

## Solution

- ONLY for published pipes, update the step parameters for the chat id directly after getting the error and send a new `RetriableError`
- Had to add a `context` to the update query since we added a strict check to not allow updating of steps for published pipes
Note: This would fix the subsequent executions but user still has to manually change it on the frontend eventually under set up action.

## Tests
- To recreate the error: 
  - Created a telegram bot group that is a normal group first: get the chat id so you can use it to test for the upgrade (check for chat id using: [https://api.telegram.org/bot[bot_token]/getUpdates](https://api.telegram.org/bot%5Bbot_token%5D/getUpdates))
  - Upgrade to public group then its a supergroup: use the API above to get the chat id or just look at the step error when testing step
  - Then, just publish the pipe with the old chat id still there, observe that a `RetriableError` is thrown and then the execution should be successful after
  - Tested with multiple consecutive executions and it will still work because the step parameter will just be updated to the new chat id
- Check that other pipes still work
- Check that the step cannot be mutated without the `context` set

