### PR TITLE
chore: add paysg validation

### DIFF
--- a/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/create-payment.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import app from '../..'
 import createPaymentAction from '../../actions/create-payment'
-import { getApiBaseUrl } from '../../common/api'
 import { MOCK_PAYMENT } from '../utils'
 
 const mocks = vi.hoisted(() => ({
@@ -53,22 +52,20 @@ describe('create payment', () => {
   })
 
   it.each(['paysg_stag_abcd, paysg_live_abcd'])(
-    'invokes the correct URL based on the API key',
+    'invokes the correct url with urlPathParams',
     async (apiKey) => {
       $.auth.data.apiKey = apiKey
-      const expectedBaseUrl = getApiBaseUrl($.auth.data.apiKey)
 
       await createPaymentAction.run($)
 
       expect(mocks.httpPost).toHaveBeenCalledWith(
-        '/v1/payment-services/sample-payment-service-id/payments',
+        '/v1/payment-services/:paymentServiceId/payments',
         expect.anything(),
-        expect.objectContaining({
-          baseURL: expectedBaseUrl,
-          headers: {
-            'x-api-key': $.auth.data.apiKey,
+        {
+          urlPathParams: {
+            paymentServiceId: 'sample-payment-service-id',
           },
-        }),
+        },
       )
     },
   )
@@ -84,7 +81,7 @@ describe('create payment', () => {
     await createPaymentAction.run($)
 
     expect(mocks.httpPost).toHaveBeenCalledWith(
-      '/v1/payment-services/sample-payment-service-id/payments',
+      '/v1/payment-services/:paymentServiceId/payments',
       {
         reference_id: 'test-reference-id',
         payer_name: 'test-name',
@@ -100,7 +97,11 @@ describe('create payment', () => {
           'test-key-2': 'test-value-2',
         },
       },
-      expect.anything(),
+      {
+        urlPathParams: {
+          paymentServiceId: 'sample-payment-service-id',
+        },
+      },
     )
   })
 
@@ -197,12 +198,16 @@ describe('create payment', () => {
       await createPaymentAction.run($)
 
       expect(mocks.httpPost).toBeCalledWith(
-        '/v1/payment-services/sample-payment-service-id/payments',
+        '/v1/payment-services/:paymentServiceId/payments',
         expect.objectContaining({
           payer_name: expectedPayerName,
           payer_address: expectedPayerAddress,
         }),
-        expect.anything(),
+        {
+          urlPathParams: {
+            paymentServiceId: 'sample-payment-service-id',
+          },
+        },
       )
     },
   )

--- a/packages/backend/src/apps/paysg/__tests__/actions/get-payment.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/get-payment.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import app from '../..'
 import getPaymentAction from '../../actions/get-payment'
-import { getApiBaseUrl } from '../../common/api'
 import { MOCK_PAYMENT } from '../utils'
 
 const mocks = vi.hoisted(() => ({
@@ -50,18 +49,16 @@ describe('get payment', () => {
     'invokes the correct URL based on the API key and payment ID',
     async (apiKey) => {
       $.auth.data.apiKey = apiKey
-      const expectedBaseUrl = getApiBaseUrl($.auth.data.apiKey)
-
       await getPaymentAction.run($)
 
       expect(mocks.httpGet).toHaveBeenCalledWith(
-        '/v1/payment-services/sample-payment-service-id/payments/sample-payment-id',
-        expect.objectContaining({
-          baseURL: expectedBaseUrl,
-          headers: {
-            'x-api-key': $.auth.data.apiKey,
+        '/v1/payment-services/:paymentServiceId/payments/:paymentId',
+        {
+          urlPathParams: {
+            paymentServiceId: 'sample-payment-service-id',
+            paymentId: 'sample-payment-id',
           },
-        }),
+        },
       )
     },
   )

--- a/packages/backend/src/apps/paysg/__tests__/actions/send-email.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/actions/send-email.test.ts
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import app from '../..'
 import sendEmailAction from '../../actions/send-email'
-import { getApiBaseUrl } from '../../common/api'
 
 const mocks = vi.hoisted(() => ({
   httpPost: vi.fn(() => ({})),
@@ -44,22 +43,21 @@ describe('send payment email', () => {
   })
 
   it.each(['paysg_stag_abcd, paysg_live_abcd'])(
-    'invokes the correct URL based on the API key and payment ID',
+    'invokes the correct URL with urlPathParams',
     async (apiKey) => {
       $.auth.data.apiKey = apiKey
-      const expectedBaseUrl = getApiBaseUrl($.auth.data.apiKey)
 
       await sendEmailAction.run($)
 
       expect(mocks.httpPost).toHaveBeenCalledWith(
-        '/v1/payment-services/sample-payment-service-id/payments/sample-payment-id/send-email',
+        '/v1/payment-services/:paymentServiceId/payments/:paymentId/send-email',
         {},
-        expect.objectContaining({
-          baseURL: expectedBaseUrl,
-          headers: {
-            'x-api-key': $.auth.data.apiKey,
+        {
+          urlPathParams: {
+            paymentServiceId: 'sample-payment-service-id',
+            paymentId: 'sample-payment-id',
           },
-        }),
+        },
       )
     },
   )

--- a/packages/backend/src/apps/paysg/__tests__/auth/verify-credentials.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/auth/verify-credentials.test.ts
@@ -1,0 +1,67 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import app from '../..'
+import verifyCredentials from '../../auth/verify-credentials'
+
+const mocks = vi.hoisted(() => ({
+  httpGet: vi.fn(),
+}))
+
+describe('Verify credentials', () => {
+  let $: IGlobalVariable
+  beforeEach(() => {
+    $ = {
+      auth: {
+        set: vi.fn(),
+        data: {
+          apiKey: 'paysg_stag_abcd',
+          paymentServiceId: 'sample-payment-service-id',
+          screenName: 'my screen name',
+        },
+      },
+      http: {
+        get: mocks.httpGet,
+      } as unknown as IGlobalVariable['http'],
+      app,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should throw an error if the API key is not set', async () => {
+    $.auth.data.apiKey = ''
+    await expect(verifyCredentials($)).rejects.toThrow()
+  })
+
+  it('should throw an error if payment service id is not set', async () => {
+    $.auth.data.paymentServiceId = ''
+    await expect(verifyCredentials($)).rejects.toThrow()
+  })
+
+  it('should throw an error if test api returns a 401 or 403', async () => {
+    mocks.httpGet.mockRejectedValue({ response: { status: 401 } })
+    await expect(verifyCredentials($)).rejects.toThrow('Invalid credentials')
+    mocks.httpGet.mockRejectedValue({ response: { status: 403 } })
+    await expect(verifyCredentials($)).rejects.toThrow('Invalid credentials')
+  })
+
+  it('should throw an error if test api returns a different error', async () => {
+    mocks.httpGet.mockRejectedValue({ response: { status: 404 } })
+    await expect(verifyCredentials($)).rejects.toThrow(
+      'Unable to validate payment service id and api key',
+    )
+  })
+
+  it('should set the screen name and env', async () => {
+    mocks.httpGet.mockResolvedValue({})
+    await verifyCredentials($)
+    expect($.auth.set).toHaveBeenCalledWith({
+      screenName: 'my screen name [STAGING]',
+      env: 'staging',
+    })
+  })
+})

--- a/packages/backend/src/apps/paysg/__tests__/common/add-auth-header.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/common/add-auth-header.test.ts
@@ -48,7 +48,7 @@ describe('Add auth headers', async () => {
       },
     } as unknown as IGlobalVariable
 
-    await expect(() => addAuthHeader($, {} as any)).rejects.toThrowError(
+    await expect(addAuthHeader($, {} as any)).rejects.toThrowError(
       'Missing API key or payment service ID',
     )
   })
@@ -66,7 +66,7 @@ describe('Add auth headers', async () => {
       },
     } as unknown as IGlobalVariable
 
-    await expect(() => addAuthHeader($, {} as any)).rejects.toThrowError(
+    await expect(addAuthHeader($, {} as any)).rejects.toThrowError(
       'Missing API key or payment service ID',
     )
   })
@@ -91,7 +91,7 @@ describe('Add auth headers', async () => {
       },
     } as unknown as InternalAxiosRequestConfig<any> // cant be bothered casting
 
-    await expect(() => addAuthHeader($, requestConfig)).rejects.toThrowError(
+    await expect(addAuthHeader($, requestConfig)).rejects.toThrowError(
       'API key has unrecognized prefix!',
     )
   })

--- a/packages/backend/src/apps/paysg/__tests__/common/add-auth-header.test.ts
+++ b/packages/backend/src/apps/paysg/__tests__/common/add-auth-header.test.ts
@@ -1,0 +1,98 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { InternalAxiosRequestConfig } from 'axios'
+import { describe, expect, it, vi } from 'vitest'
+
+import addAuthHeader from '../../common/add-auth-header'
+import { getApiBaseUrl } from '../../common/api'
+
+describe('Add auth headers', async () => {
+  it('should correctly set the api key and base url', async () => {
+    const $ = {
+      auth: {
+        data: {
+          apiKey: 'paysg_stag_abcd',
+          paymentServiceId: 'sample-payment-service-id',
+        },
+        set: vi.fn(),
+      },
+      flow: {
+        id: 'hihi',
+      },
+    } as unknown as IGlobalVariable
+    const requestConfig = {
+      headers: {
+        set: vi.fn(),
+      },
+    } as unknown as InternalAxiosRequestConfig<any> // cant be bothered casting
+
+    const actual = await addAuthHeader($, requestConfig)
+
+    expect(actual.baseURL === getApiBaseUrl($.auth.data.apiKey as string))
+    expect(requestConfig.headers.set).toBeCalledWith(
+      'x-api-key',
+      $.auth.data.apiKey,
+    )
+  })
+
+  it('should throw an error if api key is missing', async () => {
+    const $ = {
+      auth: {
+        data: {
+          paymentServiceId: 'sample-payment-service-id',
+        },
+        set: vi.fn(),
+      },
+      flow: {
+        id: 'hihi',
+      },
+    } as unknown as IGlobalVariable
+
+    await expect(() => addAuthHeader($, {} as any)).rejects.toThrowError(
+      'Missing API key or payment service ID',
+    )
+  })
+
+  it('should throw an error if payment service id is missing', async () => {
+    const $ = {
+      auth: {
+        data: {
+          apiKey: 'paysg_stag_abcd',
+        },
+        set: vi.fn(),
+      },
+      flow: {
+        id: 'hihi',
+      },
+    } as unknown as IGlobalVariable
+
+    await expect(() => addAuthHeader($, {} as any)).rejects.toThrowError(
+      'Missing API key or payment service ID',
+    )
+  })
+
+  it('should throw an error is no base url is obtained from the api key', async () => {
+    const $ = {
+      auth: {
+        data: {
+          apiKey: 'invalid_key',
+          paymentServiceId: 'sample-payment-service-id',
+        },
+        set: vi.fn(),
+      },
+      flow: {
+        id: 'hihi',
+      },
+    } as unknown as IGlobalVariable
+
+    const requestConfig = {
+      headers: {
+        set: vi.fn(),
+      },
+    } as unknown as InternalAxiosRequestConfig<any> // cant be bothered casting
+
+    await expect(() => addAuthHeader($, requestConfig)).rejects.toThrowError(
+      'API key has unrecognized prefix!',
+    )
+  })
+})

--- a/packages/backend/src/apps/paysg/actions/create-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/index.ts
@@ -5,8 +5,6 @@ import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { getApiBaseUrl } from '../../common/api'
-
 import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
@@ -105,20 +103,17 @@ const action: IRawAction = {
   ],
 
   async run($) {
-    const apiKey = $.auth.data.apiKey as string
-    const baseUrl = getApiBaseUrl(apiKey)
     const paymentServiceId = $.auth.data.paymentServiceId as string
 
     try {
       const payload = requestSchema.parse($.step.parameters)
 
       const rawResponse = await $.http.post(
-        `/v1/payment-services/${paymentServiceId}/payments`,
+        `/v1/payment-services/:paymentServiceId/payments`,
         payload,
         {
-          baseURL: baseUrl,
-          headers: {
-            'x-api-key': apiKey,
+          urlPathParams: {
+            paymentServiceId,
           },
         },
       )

--- a/packages/backend/src/apps/paysg/actions/get-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/get-payment/index.ts
@@ -5,8 +5,6 @@ import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { getApiBaseUrl } from '../../common/api'
-
 import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
@@ -24,19 +22,17 @@ const action: IRawAction = {
   ],
 
   async run($) {
-    const apiKey = $.auth.data.apiKey as string
-    const baseUrl = getApiBaseUrl(apiKey)
     const paymentServiceId = $.auth.data.paymentServiceId as string
 
     try {
       const { paymentId } = requestSchema.parse($.step.parameters)
 
       const rawResponse = await $.http.get(
-        `/v1/payment-services/${paymentServiceId}/payments/${paymentId}`,
+        `/v1/payment-services/:paymentServiceId/payments/:paymentId`,
         {
-          baseURL: baseUrl,
-          headers: {
-            'x-api-key': apiKey,
+          urlPathParams: {
+            paymentServiceId,
+            paymentId,
           },
         },
       )

--- a/packages/backend/src/apps/paysg/actions/send-email/index.ts
+++ b/packages/backend/src/apps/paysg/actions/send-email/index.ts
@@ -5,8 +5,6 @@ import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { getApiBaseUrl } from '../../common/api'
-
 import { requestSchema } from './schema'
 
 const action: IRawAction = {
@@ -25,8 +23,6 @@ const action: IRawAction = {
   ],
 
   async run($) {
-    const apiKey = $.auth.data.apiKey as string
-    const baseUrl = getApiBaseUrl(apiKey)
     const paymentServiceId = $.auth.data.paymentServiceId as string
 
     try {
@@ -34,12 +30,12 @@ const action: IRawAction = {
 
       // Empty response body expected, so just set a placeholder.
       await $.http.post(
-        `/v1/payment-services/${paymentServiceId}/payments/${paymentId}/send-email`,
+        `/v1/payment-services/:paymentServiceId/payments/:paymentId/send-email`,
         {}, // No need for request body.
         {
-          baseURL: baseUrl,
-          headers: {
-            'x-api-key': apiKey,
+          urlPathParams: {
+            paymentServiceId,
+            paymentId,
           },
         },
       )

--- a/packages/backend/src/apps/paysg/auth/is-still-verified.ts
+++ b/packages/backend/src/apps/paysg/auth/is-still-verified.ts
@@ -1,19 +1,14 @@
 import type { IGlobalVariable } from '@plumber/types'
 
-import { getEnvironmentFromApiKey } from '../common/api'
+import verifyCredentials from './verify-credentials'
 
 export default async function isStillVerified(
   $: IGlobalVariable,
 ): Promise<boolean> {
-  const authData = $.auth.data
-
-  if (!authData || !authData.apiKey) {
-    throw new Error('Invalid PaySG API key')
+  try {
+    await verifyCredentials($)
+    return true
+  } catch (e) {
+    return false
   }
-
-  // If we can get the env, we're good for now.
-  // TODO (ogp-weeloong): verify properly via paysg healthcheck api
-  getEnvironmentFromApiKey(authData.apiKey as string)
-
-  return true
 }

--- a/packages/backend/src/apps/paysg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/paysg/auth/verify-credentials.ts
@@ -28,7 +28,7 @@ export default async function verifyCredentials(
     )
   } catch (e) {
     if (e.response?.status === 401 || e.response?.status === 403) {
-      throw new Error('Invalid Payment Service ID')
+      throw new Error('Invalid credentials')
     }
     throw new Error('Unable to validate payment service id and api key')
   }

--- a/packages/backend/src/apps/paysg/common/add-auth-header.ts
+++ b/packages/backend/src/apps/paysg/common/add-auth-header.ts
@@ -1,0 +1,34 @@
+import { TBeforeRequest } from '@plumber/types'
+
+import logger from '@/helpers/logger'
+
+import { getApiBaseUrl } from './api'
+
+const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
+  const { apiKey, paymentServiceId } = $.auth.data
+
+  if (typeof apiKey !== 'string' || typeof paymentServiceId !== 'string') {
+    logger.error({
+      erorr: 'API key and payment service ID must be set',
+      flowId: $.flow.id,
+    })
+    throw new Error('Missing API key or payment service ID')
+  }
+
+  const baseUrl = getApiBaseUrl(apiKey)
+
+  if (!baseUrl) {
+    logger.error({
+      error: 'No base URL obtained from API key',
+      flowId: $.flow.id,
+    })
+    throw new Error('No base URL obtained from API key')
+  }
+
+  requestConfig.baseURL = baseUrl
+  requestConfig.headers.set('x-api-key', apiKey)
+
+  return requestConfig
+}
+
+export default addAuthHeader

--- a/packages/backend/src/apps/paysg/index.ts
+++ b/packages/backend/src/apps/paysg/index.ts
@@ -1,5 +1,6 @@
 import type { IApp } from '@plumber/types'
 
+import addAuthHeader from './common/add-auth-header'
 import actions from './actions'
 import auth from './auth'
 
@@ -12,6 +13,7 @@ const app: IApp = {
   baseUrl: '',
   apiBaseUrl: '',
   primaryColor: '000000',
+  beforeRequest: [addAuthHeader],
   auth,
   actions,
 }


### PR DESCRIPTION
## Improvements
- Move setting of api key and base url to a shared before request callback
- Use urlPathParams to populate url paths (as requested by @ogp-weeloong)
- Verify credentials by making a get request to list all payments

## Fixes
- Testing of connection in the My Apps page not reflecting the correct test result

## Tests
- Fix tests
- Add tests for verify connection

## How to test this PR
- [x] Existing api calls should work
- [x] Adding an invalid connection should fail