### PR TITLE
PLU-215: Enable automatic retries for 503s from M365

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/interceptors.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/interceptors.test.ts
@@ -1,0 +1,143 @@
+// Avoid cyclic imports when importing m365ExcelApp
+import '@/apps'
+
+import type { IGlobalVariable } from '@plumber/types'
+
+import {
+  AxiosError,
+  type AxiosPromise,
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+} from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
+import RetriableError from '@/errors/retriable-error'
+import createHttpClient, { type IHttpClient } from '@/helpers/http-client'
+
+import m365ExcelApp from '../'
+
+function mockAxiosAdapterToThrowOnce(
+  status: AxiosResponse['status'],
+  headers?: AxiosResponse['headers'],
+): void {
+  mocks.axiosAdapter.mockImplementationOnce((config) => {
+    throw new AxiosError(
+      'Request failed',
+      AxiosError.ERR_BAD_RESPONSE,
+      config,
+      null,
+      {
+        status,
+        headers,
+        config,
+      } as unknown as AxiosResponse,
+    )
+  })
+}
+
+const mocks = vi.hoisted(() => ({
+  axiosAdapter: vi.fn(
+    async (config: InternalAxiosRequestConfig): AxiosPromise => ({
+      data: 'test-data',
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    }),
+  ),
+  logError: vi.fn(),
+}))
+
+vi.mock('axios', async (importOriginal) => {
+  const actualAxios = await importOriginal<typeof import('axios')>()
+  const mockCreate: typeof actualAxios.default.create = (createConfig) =>
+    actualAxios.default.create({
+      ...createConfig,
+      adapter: mocks.axiosAdapter,
+    })
+
+  return {
+    ...actualAxios,
+    default: {
+      ...actualAxios.default,
+      create: mockCreate,
+    },
+  }
+})
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.logError,
+  },
+}))
+
+describe('M365 interceptors', () => {
+  let http: IHttpClient
+
+  beforeEach(() => {
+    const $ = {
+      auth: {
+        data: {
+          tenantKey: 'test-tenant',
+        },
+      },
+    } as unknown as IGlobalVariable
+    http = createHttpClient({
+      $,
+      baseURL: 'http://localhost/mock-m365-graph-api',
+      beforeRequest: [],
+      requestErrorHandler: m365ExcelApp.requestErrorHandler,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Request error handlers', () => {
+    it('throws a retriable error on 503 with default delay, if response does not have retry-after', async () => {
+      mockAxiosAdapterToThrowOnce(503)
+      await http
+        .get('/test-url')
+        .then(() => {
+          expect.unreachable()
+        })
+        .catch((error): void => {
+          expect(error).toBeInstanceOf(RetriableError)
+          expect(error.delayInMs).toEqual('default')
+        })
+    })
+
+    it('throws a retriable error on 503 with delay set to retry-after', async () => {
+      mockAxiosAdapterToThrowOnce(503, { 'retry-after': 123 })
+      await http
+        .get('/test-url')
+        .then(() => {
+          expect.unreachable()
+        })
+        .catch((error): void => {
+          expect(error).toBeInstanceOf(RetriableError)
+          expect(error.delayInMs).toEqual(123000)
+        })
+    })
+
+    it('throws a normal error on 429', async () => {
+      mockAxiosAdapterToThrowOnce(429, { 'retry-after': 123 })
+      expect(http.get('/test-url')).rejects.toThrowError(
+        'Rate limited by Microsoft Graph',
+      )
+    })
+
+    it('throws HTTP error on other non-successful codes', async () => {
+      mockAxiosAdapterToThrowOnce(500, { 'retry-after': 123 })
+      expect(http.get('/test-url')).rejects.toThrow(HttpError)
+    })
+
+    it('does not throw error if response is success', async () => {
+      expect(http.get('/test-url')).resolves.toEqual(
+        expect.objectContaining({ data: 'test-data', status: 200 }),
+      )
+    })
+  })
+})

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -32,7 +32,7 @@ const handle429: ThrowingHandler = ($, error) => {
 //
 const handle503: ThrowingHandler = function ($, error) {
   // Log to monitor spikes, just in case
-  logger.error('Received HTTP 503 from MS Graph', {
+  logger.warn('Received HTTP 503 from MS Graph', {
     event: 'm365-http-503',
     tenant: $.auth?.data?.tenantKey as string,
     baseUrl: error.response.config.baseURL,
@@ -43,22 +43,39 @@ const handle503: ThrowingHandler = function ($, error) {
   })
 
   // Microsoft _sometimes_ specifies a Retry-After when it returns 503.
-  const retryAfterMs = Number(error.response?.headers?.['retry-after'] ?? null)
+  const retryAfterMs = Number(error.response?.headers?.['retry-after']) * 1000
   throw new RetriableError({
     error: 'Encountered HTTP 503 from MS',
-    delayInMs:
-      isNaN(retryAfterMs) || retryAfterMs === 0
-        ? 'default'
-        : retryAfterMs * 1000,
+    delayInMs: isNaN(retryAfterMs) ? 'default' : retryAfterMs,
   })
+}
+
+//
+// Handle exceeding bandwidth limit
+//
+const handle509: ThrowingHandler = function ($, error) {
+  logger.error('Received HTTP 509 from MS Graph', {
+    event: 'm365-http-509',
+    tenant: $.auth?.data?.tenantKey as string,
+    baseUrl: error.response.config.baseURL,
+    url: error.response.config.url,
+    flowId: $.flow?.id,
+    stepId: $.step?.id,
+    executionId: $.execution?.id,
+  })
+
+  // We don't want to retry 509s from M365, so convert it into a non-HttpError.
+  throw new Error('Bandwidth limited by Microsoft Graph.')
 }
 
 const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
   switch (error.response.status) {
-    case 429:
+    case 429: // Rate limited
       return handle429($, error)
-    case 503:
+    case 503: // Transient error
       return handle503($, error)
+    case 509: // Bandwidth limit reached
+      return handle509($, error)
   }
 }
 

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -1,12 +1,16 @@
 import type { IApp } from '@plumber/types'
 
+import RetriableError from '@/errors/retriable-error'
 import logger from '@/helpers/logger'
 
-const http429Handler: IApp['requestErrorHandler'] = async function ($, error) {
-  if (error.response.status !== 429) {
-    return
-  }
+type ThrowingHandler = (
+  ...args: Parameters<IApp['requestErrorHandler']>
+) => never
 
+//
+// Handle MS rate limiting us
+//
+const handle429: ThrowingHandler = ($, error) => {
   // A 429 response is considered a SEV-2+ incident for some tenants; log it
   // explicitly so that we can easily trigger incident creation from DD.
   logger.error('Received HTTP 429 from MS Graph', {
@@ -23,4 +27,39 @@ const http429Handler: IApp['requestErrorHandler'] = async function ($, error) {
   throw new Error('Rate limited by Microsoft Graph.')
 }
 
-export default http429Handler
+//
+// Retry failures due to flakey M365 servers
+//
+const handle503: ThrowingHandler = function ($, error) {
+  // Log to monitor spikes, just in case
+  logger.error('Received HTTP 503 from MS Graph', {
+    event: 'm365-http-503',
+    tenant: $.auth?.data?.tenantKey as string,
+    baseUrl: error.response.config.baseURL,
+    url: error.response.config.url,
+    flowId: $.flow?.id,
+    stepId: $.step?.id,
+    executionId: $.execution?.id,
+  })
+
+  // Microsoft _sometimes_ specifies a Retry-After when it returns 503.
+  const retryAfterMs = Number(error.response?.headers?.['retry-after'] ?? null)
+  throw new RetriableError({
+    error: 'Encountered HTTP 503 from MS',
+    delayInMs:
+      isNaN(retryAfterMs) || retryAfterMs === 0
+        ? 'default'
+        : retryAfterMs * 1000,
+  })
+}
+
+const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
+  switch (error.response.status) {
+    case 429:
+      return handle429($, error)
+    case 503:
+      return handle503($, error)
+  }
+}
+
+export default errorHandler


### PR DESCRIPTION
## Problem
We are not retrying 503s from Graph API when that is Microsoft's official [recommendation](https://learn.microsoft.com/en-us/graph/errors#http-status-codes).

This forces our users to manually retry, and also causes confusion.

## Solution
Make Plumber retry the M365 request if we get a 503.

## Tests
- New unit test
- Mock a 503 response from MS Graph, and check that it's retried.
- Regression test: Mock a 429 response from MS Graph, and check that we're not retrying.
- Regression test: check that M365 excel operations (create row, get row) still work