### PR TITLE
PLU-212: Fix M365 users not being able to revoke permissions

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
@@ -1,0 +1,94 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createPlumberFolder } from '../../common/create-plumber-folder'
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(),
+  getM365TenantInfo: vi.fn(() => ({
+    label: 'test-tenant',
+    id: 'test-tenant-id',
+    sharePointSiteId: 'test-sharepoint-site-id',
+    clientId: 'abcd',
+    clientThumbprint: 'abcd',
+    clientPrivateKey: 'abcd',
+    allowedSensitivityLabelGuids: new Set(),
+  })),
+}))
+
+vi.mock('@/config/app-env-vars/m365', () => ({
+  getM365TenantInfo: mocks.getM365TenantInfo,
+}))
+
+describe('Create plumber folder', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      http: {
+        post: mocks.httpPost,
+      },
+      user: {
+        email: 'test@open.gov.sg',
+      },
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls the appropriate Graph API endpoints to create a folder and grants user access', async () => {
+    mocks.httpPost
+      // First call to create folder
+      .mockImplementationOnce(() => ({
+        data: { id: 'test-folder-id' },
+      }))
+      // 2nd call to grant access; no return value is needed but we mock to
+      // prevent outgoing call.
+      .mockImplementationOnce(() => {
+        // intentionally empty
+        return
+      })
+
+    await createPlumberFolder('local-dev', $)
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      1,
+      '/v1.0/sites/:sharePointSiteId/drive/root/children',
+      {
+        name: 'test@open.gov.sg',
+        folder: {},
+      },
+      {
+        urlPathParams: {
+          sharePointSiteId: 'test-sharepoint-site-id',
+        },
+      },
+    )
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      2,
+      '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
+      {
+        recipients: [{ email: 'test@open.gov.sg' }],
+        requireSignIn: true,
+        sendInvitation: false,
+        roles: ['sp.full control'],
+        retainInheritedPermissions: false,
+      },
+      {
+        urlPathParams: {
+          sharePointSiteId: 'test-sharepoint-site-id',
+          folderId: 'test-folder-id',
+        },
+      },
+    )
+  })
+
+  it("errors out if user's email is not set", async () => {
+    $.user.email = null
+    expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
+      'User email unavailable',
+    )
+  })
+})

--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -14,23 +14,34 @@ export async function createPlumberFolder(
 
   // Create folder
   const createFolderResult = await $.http.post<{ id: string }>(
-    `/v1.0/sites/${tenant.sharePointSiteId}/drive/root/children`,
+    '/v1.0/sites/:sharePointSiteId/drive/root/children',
     {
       name: $.user.email,
       folder: {},
     },
+    {
+      urlPathParams: {
+        sharePointSiteId: tenant.sharePointSiteId,
+      },
+    },
   )
   const folderId = createFolderResult.data.id
 
-  // Allow user R/W access to folder.
+  // Make user the folder owner.
   await $.http.post(
-    `/v1.0/sites/${tenant.sharePointSiteId}/drive/items/${folderId}/invite`,
+    '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
     {
       recipients: [{ email: $.user.email }],
       requireSignIn: true,
       sendInvitation: false,
-      roles: ['read', 'write'],
+      roles: ['sp.full control'],
       retainInheritedPermissions: false,
+    },
+    {
+      urlPathParams: {
+        sharePointSiteId: tenant.sharePointSiteId,
+        folderId,
+      },
     },
   )
 


### PR DESCRIPTION
## Problem
If an M365 user gives someone else access to documents in their Plumber folder, they cannot revoke this access later. This is because they're not officially their Plumber folder's owner (they're only given write access).

This is bad because we should always allow revoking access.

## Solution
Make each user owners of their Plumber folders by granting them the `sp.full control` role, instead of just the `read` and `write` roles.

_**Small detail**: Technically, the `owner` role is the right role to grant, but it looks like there is a long standing [bug](https://stackoverflow.com/questions/75038884/microsoft-graph-api-set-owner-role-for-file) with Microsoft Graph where `sp.full control` has to be used instead of `owner` for SharePoint folders. I've verified that `sp.full control` indeed maps to the `owner` role, by granting `sp.full control` to a folder and then reading back the folder's ACL in Graph API._ 

This is safe to do because the scope of this permission only applies to their folder, so the blast radius is contained (_e.g. they are still unable to view other M365 Plumber users's folders_).

Note that this introduces the risk of users doing funny things to their Plumber folder (_e.g. deleting it by accident_). But I think this should not be too much of an issue because we can always revert their changes via SharePoint recycle bin and/or SharePoint file versions.

**Note:** This only fixes permissions for new users. I'll run a script to retroactively make existing users owners of their Plumber folder.

## Tests
- New unit test
- Check that users can now revoke access to stuff in their Plumber folder
- [Just-in-case] Check that users cannot see other users' folders, nor modify them.
- [Just-in-case] Check that users cannot view or modify other parts of Plumber's SharePoint site.
- Regression test: check that M365 actions still work

