### PR TITLE
PLU-216: Allow blank values in LetterSG params

### DIFF
--- a/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
+++ b/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
@@ -167,4 +167,34 @@ describe('create letter from template', () => {
       'Please check that you have configured your step correctly',
     )
   })
+
+  it.each(['', '    '])(
+    'disallows empty or falsy fields in letter params',
+    async (field) => {
+      $.step.parameters.letterParams = [{ field, value: 'curry' }]
+
+      $.auth.data.apiKey = 'test_v1_123456'
+      expect(createLetterAction.run($)).rejects.toThrow(/field empty/)
+    },
+  )
+
+  it('disallows empty values in letter params', async () => {
+    $.step.parameters.letterParams = [{ field: 'name', value: '' }]
+
+    $.auth.data.apiKey = 'test_v1_123456'
+    expect(createLetterAction.run($)).rejects.toThrow(/value empty/)
+  })
+
+  it('allows values with whitespace in letter params', async () => {
+    $.step.parameters.letterParams = [{ field: 'name', value: '  ' }]
+
+    $.auth.data.apiKey = 'test_v1_123456'
+    await createLetterAction.run($)
+    expect(mocks.httpPost).toHaveBeenCalledWith('/v1/letters', {
+      templateId: 123,
+      letterParams: {
+        name: '  ',
+      },
+    })
+  })
 })

--- a/packages/backend/src/apps/lettersg/actions/create-letter/schema.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/schema.ts
@@ -12,34 +12,17 @@ export const requestSchema = z
           field: z
             .string()
             .trim()
-            .min(1, 'Please do not leave the field empty')
-            .nullish(),
+            .min(1, 'Please do not leave the field empty'),
           value: z
             .string()
-            .trim()
-            .min(1, 'Please do not leave the value empty')
-            .nullish(),
+            // Not trimming as we need to support whitespace
+            .min(1, 'Please do not leave the value empty'),
         }),
       )
       .transform((params, context) => {
         const result: Record<string, string> = Object.create(null)
         const seenFields = new Set<string>()
         for (const { field, value } of params) {
-          // no null fields or values are allowed
-          if (!field) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Please do not leave the field empty',
-            })
-            return z.NEVER
-          }
-          if (!value) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Please do not leave the value empty',
-            })
-            return z.NEVER
-          }
           // catch duplicate fields
           if (seenFields.has(field)) {
             context.addIssue({


### PR DESCRIPTION
## Problem
We currently block blank  (i.e. whitespace-only) values in letter params - e.g. `'  '`.

This blocks one of our user's use cases: blank unit numbers in addresses.

## Solution
Ideally, we can pass an empty string to LetterSG API, but this currently causes LetterSG to throw an error. The LetterSG team is unfortunately not aligned with supporting empty strings.

Luckily, any string with length >= 1 is accepted by the API. To unblock our user, we'll allow users to enter blank strings.

**NOTE:** I considered making `letterParams`' values optional, and then using zod to transform `null` values to a string with a single space... but that seems like bad UX. Users who expect an empty string would instead see an empty space in their generated letter. Better to not accidentally subvert the user's expectations, by forcing them to explicitly enter the space instead.

## Tests
- Updated unit test
- Check that I can enter "blank" values in letter params