### PR TITLE
[TILES] Allow import of empty column names

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -55,4 +55,10 @@ describe('create table mutation', () => {
     expect(table.name).toBe('Test Table')
     expect(table2.name).toBe('Test Table')
   })
+
+  it('should throw an error when table name is empty', async () => {
+    await expect(
+      createTable(null, { input: { name: '', isBlank: false } }, context),
+    ).rejects.toThrow()
+  })
 })

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -31,6 +31,11 @@ const createTable = async (
 ) => {
   const tableName = params.input.name
   const isBlankTable = params.input.isBlank
+
+  if (!tableName) {
+    throw new Error('Table name is required')
+  }
+
   const table = await context.currentUser.$relatedQuery('tables').insertGraph({
     name: tableName,
     role: 'owner',

--- a/packages/frontend/src/components/ThemeProvider/index.tsx
+++ b/packages/frontend/src/components/ThemeProvider/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { useRef } from 'react'
 import { Box } from '@chakra-ui/react'
 import {
   THEME_ID,
@@ -16,10 +16,20 @@ type ThemeProviderProps = {
 const ThemeProvider = ({
   children,
 }: ThemeProviderProps): React.ReactElement => {
+  // This is a workaround to fix the issue of toasts appearing behind modal overlays
+  const ref = useRef<HTMLDivElement>(null)
+
   return (
-    <ChakraThemeProvider theme={chakraTheme}>
+    <ChakraThemeProvider
+      theme={chakraTheme}
+      toastOptions={{
+        portalProps: {
+          containerRef: ref,
+        },
+      }}
+    >
       <MaterialThemeProvider theme={{ [THEME_ID]: materialTheme }}>
-        <Box display="flex" flexDir="column" minH="100vh">
+        <Box display="flex" flexDir="column" minH="100vh" ref={ref}>
           {children}
         </Box>
       </MaterialThemeProvider>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -115,7 +115,8 @@ export const ImportCsvModalContent = ({
     }
     setIsParsing(true)
     Papa.parse(file, {
-      transformHeader: (header) => header.trim(),
+      // transform empty headers to '(empty)'
+      transformHeader: (header) => header.trim() || '(empty)',
       header: true,
       skipEmptyLines: true,
       complete: (parseResult) => {
@@ -304,7 +305,7 @@ export const ImportCsvModalContent = ({
           </Box>
         )
       case 'error':
-        return <Text color="red.500">`Error: ${errorMsg}`</Text>
+        return <Text color="red.500">Error: {errorMsg}</Text>
     }
   }, [
     columnsToCreate,
@@ -396,6 +397,7 @@ const ImportCsvButton = (props: ButtonProps) => {
           closeOnOverlayClick={false}
           closeOnEsc={false}
           motionPreset="none"
+          isCentered
         >
           <ModalOverlay />
           <ModalContent>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -1,12 +1,12 @@
 import { ITableColumnMetadata, ITableMetadata } from '@plumber/types'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { BiImport } from 'react-icons/bi'
-import { BsCheckCircle, BsPlusCircleFill } from 'react-icons/bs'
+import { BiCheck, BiChevronDown, BiChevronUp, BiImport } from 'react-icons/bi'
 import { useLazyQuery, useMutation } from '@apollo/client'
 import {
   Box,
   Card,
+  Collapse,
   Flex,
   List,
   ListIcon,
@@ -20,6 +20,7 @@ import {
   ModalOverlay,
   Progress,
   Text,
+  useBoolean,
   useDisclosure,
 } from '@chakra-ui/react'
 import {
@@ -42,10 +43,89 @@ interface ValidParseResult extends ParseResult<Record<string, string>> {
   meta: SetRequired<ParseMeta, 'fields'>
 }
 
+type ImportStatusValue =
+  | 'ready'
+  | 'creating columns'
+  | 'importing'
+  | 'completed'
+  | 'error'
+
 // 2 MB in bytes
 const MAX_FILE_SIZE = 2 * 1000 * 1000
 // Add row chunk size
 const CHUNK_SIZE = 100
+
+const ImportStatus = ({
+  columnsToCreate,
+  errorMsg,
+  importStatus,
+  rowsImported,
+  rowsToImport,
+}: {
+  columnsToCreate: string[]
+  errorMsg: string | null
+  importStatus: ImportStatusValue
+  rowsImported: number
+  rowsToImport: number
+}) => {
+  const [isColumnDataExpanded, setIsColumnDataExpanded] = useBoolean(false)
+
+  switch (importStatus) {
+    case 'ready':
+      if (!columnsToCreate.length) {
+        return null
+      }
+      return (
+        <>
+          <Button
+            colorScheme="secondary"
+            variant="link"
+            onClick={setIsColumnDataExpanded.toggle}
+            rightIcon={
+              isColumnDataExpanded ? <BiChevronUp /> : <BiChevronDown />
+            }
+          >
+            {columnsToCreate.length} column(s) to create
+          </Button>
+          <Collapse in={isColumnDataExpanded}>
+            <List spacing={3} mt={4}>
+              {columnsToCreate.map((field, i) => {
+                return (
+                  <Flex key={i} alignItems="center">
+                    <ListIcon as={BiCheck} />
+                    <ListItem>{field}</ListItem>
+                  </Flex>
+                )
+              })}
+            </List>
+          </Collapse>
+        </>
+      )
+    case 'creating columns':
+      return (
+        <Box>
+          <Text>Creating Columns</Text>
+          <Progress mt={3} size="xs" isIndeterminate />
+        </Box>
+      )
+    case 'importing':
+      return (
+        <Box>
+          <Text>{`Importing rows ${rowsImported} of ${rowsToImport}`}</Text>
+          <Progress mt={3} size="xs" value={rowsImported} max={rowsToImport} />
+        </Box>
+      )
+    case 'completed':
+      return (
+        <Box>
+          <Text>{`${rowsToImport} rows imported`}</Text>
+          <Progress my={3} size="xs" value={100} />
+        </Box>
+      )
+    case 'error':
+      return <Text color="red.500">Error: {errorMsg}</Text>
+  }
+}
 
 export const ImportCsvModalContent = ({
   onClose,
@@ -75,9 +155,7 @@ export const ImportCsvModalContent = ({
     [tableColumns],
   )
 
-  const [importStatus, setImportStatus] = useState<
-    'ready' | 'creating columns' | 'importing' | 'completed' | 'error'
-  >('ready')
+  const [importStatus, setImportStatus] = useState<ImportStatusValue>('ready')
   const isImporting =
     importStatus === 'importing' || importStatus === 'creating columns'
   const [rowsToImport, setRowsToImport] = useState(0)
@@ -86,7 +164,6 @@ export const ImportCsvModalContent = ({
   const [isParsing, setIsParsing] = useState(false)
   const [result, setResult] = useState<ValidParseResult | null>(null)
   const [columnsToCreate, setColumnsToCreate] = useState<string[]>([])
-  const [matchedColumns, setMatchedColumns] = useState<string[]>([])
   // Used for new table creation via import
   // This is used to check if the import has already started, so it doesnt run on every render
   const importStartedRef = useRef(false)
@@ -126,9 +203,6 @@ export const ImportCsvModalContent = ({
           const columns = parseResult.meta.fields
           setColumnsToCreate(
             columns.filter((csvColumn) => !columnNamesSet.has(csvColumn)),
-          )
-          setMatchedColumns(
-            columns.filter((csvColumn) => columnNamesSet.has(csvColumn)),
           )
         }
       },
@@ -234,94 +308,15 @@ export const ImportCsvModalContent = ({
     }
   }, [onImport, onPreImport, tableId])
 
-  const importStatusComponent = useMemo(() => {
-    switch (importStatus) {
-      case 'ready':
-        if (!file) {
-          return null
-        }
-        return (
-          <>
-            {matchedColumns.length > 0 && (
-              <>
-                <Text color="green.600">
-                  {matchedColumns.length} columns matched
-                </Text>
-                <List spacing={3} my={2}>
-                  {matchedColumns.map((field, i) => {
-                    return (
-                      <Flex key={i} alignItems="center">
-                        <ListIcon as={BsCheckCircle} color={'green.500'} />
-                        <ListItem>{field}</ListItem>
-                      </Flex>
-                    )
-                  })}
-                </List>
-              </>
-            )}
-            {columnsToCreate.length > 0 && (
-              <>
-                <Text color="primary.600">
-                  {columnsToCreate.length} columns will be created
-                </Text>
-                <List spacing={3} my={2}>
-                  {columnsToCreate.map((field, i) => {
-                    return (
-                      <Flex key={i} alignItems="center">
-                        <ListIcon as={BsPlusCircleFill} color={'primary.500'} />
-                        <ListItem>{field}</ListItem>
-                      </Flex>
-                    )
-                  })}
-                </List>
-              </>
-            )}
-          </>
-        )
-      case 'creating columns':
-        return (
-          <Box>
-            <Text>Creating Columns</Text>
-            <Progress mt={3} size="xs" isIndeterminate />
-          </Box>
-        )
-      case 'importing':
-        return (
-          <Box>
-            <Text>{`Importing rows ${rowsImported} of ${rowsToImport}`}</Text>
-            <Progress
-              mt={3}
-              size="xs"
-              value={rowsImported}
-              max={rowsToImport}
-            />
-          </Box>
-        )
-      case 'completed':
-        return (
-          <Box>
-            <Text>{`${rowsToImport} rows imported`}</Text>
-            <Progress mt={3} size="xs" value={100} max={100} />
-          </Box>
-        )
-      case 'error':
-        return <Text color="red.500">Error: {errorMsg}</Text>
-    }
-  }, [
-    columnsToCreate,
-    errorMsg,
-    file,
-    importStatus,
-    matchedColumns,
-    rowsImported,
-    rowsToImport,
-  ])
-
   return (
     <>
       <ModalHeader>Import CSV</ModalHeader>
       {!isImporting && <ModalCloseButton />}
       <ModalBody>
+        <Text my={4}>
+          Any imported data will be appended as new cells and will not overwrite
+          existing values.
+        </Text>
         <Attachment
           maxSize={MAX_FILE_SIZE}
           onChange={setFile}
@@ -341,31 +336,36 @@ export const ImportCsvModalContent = ({
                 Parsing file...
               </Flex>
             ) : (
-              importStatusComponent
+              <ImportStatus
+                columnsToCreate={columnsToCreate}
+                errorMsg={errorMsg}
+                importStatus={importStatus}
+                rowsImported={rowsImported}
+                rowsToImport={rowsToImport}
+              />
             )}
           </Card>
         )}
       </ModalBody>
 
       <ModalFooter>
-        <Flex w="100%">
+        <Flex gap={4}>
           {onBack && importStatus === 'ready' && (
-            <Button variant="outline" onClick={onBack}>
+            <Button variant="clear" colorScheme="secondary" onClick={onBack}>
               Back
             </Button>
           )}
-          {result && importStatus === 'completed' && (
-            <Button ml="auto" isDisabled={!!onPreImport} onClick={onClose}>
+          {importStatus === 'completed' && (
+            <Button isDisabled={!!onPreImport} onClick={onClose}>
               {onPreImport ? 'Redirecting...' : 'Done'}
             </Button>
           )}
-          {result && importStatus !== 'completed' && (
+          {importStatus !== 'completed' && (
             <Button
-              ml="auto"
               isLoading={isImporting}
               onClick={onPreImport ? onPreImport : onImport}
             >
-              {`Import ${result.data.length} rows`}
+              Import {result ? `${result?.data.length} rows` : ''}
             </Button>
           )}
         </Flex>
@@ -397,7 +397,6 @@ const ImportCsvButton = (props: ButtonProps) => {
           closeOnOverlayClick={false}
           closeOnEsc={false}
           motionPreset="none"
-          isCentered
         >
           <ModalOverlay />
           <ModalContent>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -60,10 +60,8 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
     <Modal isOpen={true} onClose={onClose} motionPreset="none">
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
-          <Text textStyle="h6">Share tile</Text>
-          <ModalCloseButton />
-        </ModalHeader>
+        <ModalHeader>Share tile</ModalHeader>
+        <ModalCloseButton />
         <ModalBody mt={2}>
           <FormControl>
             <VStack spacing={2} alignItems="flex-start">

--- a/packages/frontend/src/pages/Tile/components/TableRow/TableCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableRow/TableCell.tsx
@@ -144,6 +144,7 @@ function TableCell({
             rowIndex,
             columnIndex,
             direction: 'up',
+            isViewMode,
           })
           break
         }
@@ -155,6 +156,7 @@ function TableCell({
             rowIndex,
             columnIndex,
             direction: 'down',
+            isViewMode,
           })
           break
         }
@@ -166,6 +168,7 @@ function TableCell({
             rowIndex,
             columnIndex,
             direction: 'left',
+            isViewMode,
           })
           break
         }
@@ -177,6 +180,7 @@ function TableCell({
             rowIndex,
             columnIndex,
             direction: 'right',
+            isViewMode,
           })
           break
         }

--- a/packages/frontend/src/pages/Tile/helpers/cell-navigation.ts
+++ b/packages/frontend/src/pages/Tile/helpers/cell-navigation.ts
@@ -8,6 +8,7 @@ export function moveCell({
   rowIndex,
   columnIndex,
   direction,
+  isViewMode = false, // add new column is hidden for view mode
   allowCrossBoundaries = false,
 }: {
   table: Table<GenericRowData>
@@ -15,6 +16,7 @@ export function moveCell({
   rowIndex: number
   columnIndex: number
   direction: 'up' | 'down' | 'left' | 'right'
+  isViewMode?: boolean
   allowCrossBoundaries?: boolean
 }) {
   const columnIds = table.getState().columnOrder
@@ -52,7 +54,7 @@ export function moveCell({
     }
     case 'right': {
       const nextActiveCell = row.getVisibleCells()[
-        Math.min(columnIndex + 1, columnIds.length - 2)
+        Math.min(columnIndex + 1, columnIds.length - (isViewMode ? 1 : 2))
       ] as CellType
       tableMeta?.setActiveCell(nextActiveCell)
       break


### PR DESCRIPTION
## Problem

There is an issue where importing csv with empty column name will throw an error.

## Solution
Replace all empty column names with `(empty)` and still import the columns