### PR TITLE
Release v1.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17246,7 +17246,7 @@
       }
     },
     "packages/backend": {
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@apollo/server": "4.9.4",
         "@aws-sdk/client-dynamodb": "3.460.0",
@@ -17356,7 +17356,7 @@
       }
     },
     "packages/frontend": {
-      "version": "1.13.0",
+      "version": "1.13.1",
       "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "3.8.7",
@@ -17555,7 +17555,7 @@
     },
     "packages/types": {
       "name": "@plumber/types",
-      "version": "1.13.0"
+      "version": "1.13.1"
     }
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -103,5 +103,5 @@
     "tsc-alias": "^1.8.6",
     "tsconfig-paths": "^4.2.0"
   },
-  "version": "1.13.0"
+  "version": "1.13.1"
 }

--- a/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
@@ -1,0 +1,94 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createPlumberFolder } from '../../common/create-plumber-folder'
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(),
+  getM365TenantInfo: vi.fn(() => ({
+    label: 'test-tenant',
+    id: 'test-tenant-id',
+    sharePointSiteId: 'test-sharepoint-site-id',
+    clientId: 'abcd',
+    clientThumbprint: 'abcd',
+    clientPrivateKey: 'abcd',
+    allowedSensitivityLabelGuids: new Set(),
+  })),
+}))
+
+vi.mock('@/config/app-env-vars/m365', () => ({
+  getM365TenantInfo: mocks.getM365TenantInfo,
+}))
+
+describe('Create plumber folder', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      http: {
+        post: mocks.httpPost,
+      },
+      user: {
+        email: 'test@open.gov.sg',
+      },
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('calls the appropriate Graph API endpoints to create a folder and grants user access', async () => {
+    mocks.httpPost
+      // First call to create folder
+      .mockImplementationOnce(() => ({
+        data: { id: 'test-folder-id' },
+      }))
+      // 2nd call to grant access; no return value is needed but we mock to
+      // prevent outgoing call.
+      .mockImplementationOnce(() => {
+        // intentionally empty
+        return
+      })
+
+    await createPlumberFolder('local-dev', $)
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      1,
+      '/v1.0/sites/:sharePointSiteId/drive/root/children',
+      {
+        name: 'test@open.gov.sg',
+        folder: {},
+      },
+      {
+        urlPathParams: {
+          sharePointSiteId: 'test-sharepoint-site-id',
+        },
+      },
+    )
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      2,
+      '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
+      {
+        recipients: [{ email: 'test@open.gov.sg' }],
+        requireSignIn: true,
+        sendInvitation: false,
+        roles: ['sp.full control'],
+        retainInheritedPermissions: false,
+      },
+      {
+        urlPathParams: {
+          sharePointSiteId: 'test-sharepoint-site-id',
+          folderId: 'test-folder-id',
+        },
+      },
+    )
+  })
+
+  it("errors out if user's email is not set", async () => {
+    $.user.email = null
+    expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
+      'User email unavailable',
+    )
+  })
+})

--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -14,23 +14,34 @@ export async function createPlumberFolder(
 
   // Create folder
   const createFolderResult = await $.http.post<{ id: string }>(
-    `/v1.0/sites/${tenant.sharePointSiteId}/drive/root/children`,
+    '/v1.0/sites/:sharePointSiteId/drive/root/children',
     {
       name: $.user.email,
       folder: {},
     },
+    {
+      urlPathParams: {
+        sharePointSiteId: tenant.sharePointSiteId,
+      },
+    },
   )
   const folderId = createFolderResult.data.id
 
-  // Allow user R/W access to folder.
+  // Make user the folder owner.
   await $.http.post(
-    `/v1.0/sites/${tenant.sharePointSiteId}/drive/items/${folderId}/invite`,
+    '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
     {
       recipients: [{ email: $.user.email }],
       requireSignIn: true,
       sendInvitation: false,
-      roles: ['read', 'write'],
+      roles: ['sp.full control'],
       retainInheritedPermissions: false,
+    },
+    {
+      urlPathParams: {
+        sharePointSiteId: tenant.sharePointSiteId,
+        folderId,
+      },
     },
   )
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "scripts": {
     "dev": "vite --host --force",
     "build": "tsc && vite build --mode=${VITE_MODE:-prod}",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,5 +2,5 @@
   "name": "@plumber/types",
   "description": "Shared types for plumber",
   "types": "./index.d.ts",
-  "version": "1.13.0"
+  "version": "1.13.1"
 }


### PR DESCRIPTION
# Features
* Make M365 Excel users full owners of their SharePoint plumber folder (#478)

Releasing as there are a few more straggling users and I don't want to backfill for them.

Note: backfill script for existing users will be done in a later PR; not urgent to backfill for now.

# To Test
- [x] M365 should work as normal
- [x] New M365 users are owners of their Plumber folder
