### PR TITLE
feat(backend): add flag on step to signify mockRun availability

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -110,6 +110,7 @@ type Action {
   description: String
   groupsLaterSteps: Boolean
   substeps: [ActionSubstep]
+  mockAvailable: Boolean
 }
 
 type ActionSubstep {
@@ -469,6 +470,7 @@ type Trigger {
   type: String
   webhookTriggerInstructions: TriggerInstructions
   substeps: [TriggerSubstep]
+  mockAvailable: Boolean
 }
 
 type TriggerInstructions {

--- a/packages/backend/src/helpers/get-app.ts
+++ b/packages/backend/src/helpers/get-app.ts
@@ -75,6 +75,10 @@ function addStaticSubsteps(
     computedStep.substeps.push(chooseConnectionStep)
   }
 
+  if (step.mockRun) {
+    computedStep.mockAvailable = true
+  }
+
   if (step.arguments) {
     computedStep.substeps.push({
       key: 'chooseTrigger',

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -444,6 +444,7 @@ export interface IRawTrigger extends IBaseTrigger {
 
 export interface ITrigger extends IBaseTrigger {
   substeps?: ISubstep[]
+  mockAvailable?: boolean
 }
 
 interface PostmanSendEmailMetadata {
@@ -487,6 +488,7 @@ export interface IBaseAction {
     $: IGlobalVariable,
     metadata?: NextStepMetadata,
   ): Promise<IActionRunResult | void>
+  mockRun?($: IGlobalVariable): Promise<Record<string, any>>
 
   /**
    * Gets metadata for the `dataOut` of this action's execution step.
@@ -527,6 +529,7 @@ export interface IRawAction extends IBaseAction {
 
 export interface IAction extends IBaseAction {
   substeps?: ISubstep[]
+  mockAvailable?: boolean
 }
 
 export interface IAuthentication {


### PR DESCRIPTION
## Problem

There's no way for frontend to tell whether to render a `Test with mock data` button

## Solution

Add `mockAvailable` field to step returned data 

## Deploy Notes
N/A