### PR TITLE
chore: add stricter checks for lettersg action

### DIFF
--- a/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
+++ b/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
@@ -145,7 +145,7 @@ describe('create letter from template', () => {
     mocks.httpPost.mockRejectedValueOnce(httpError)
     // throw partial step error
     await expect(createLetterAction.run($)).rejects.toThrowError(
-      'Missing pair of field/value for letter template',
+      'Missing field(s) for letter template',
     )
   })
 

--- a/packages/backend/src/apps/lettersg/common/add-auth-header.ts
+++ b/packages/backend/src/apps/lettersg/common/add-auth-header.ts
@@ -10,10 +10,10 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
   if (typeof apiKey !== 'string') {
     logger.error({
       event: 'auth-header-apikey-error',
-      error: 'LetterSG: API key must be set',
+      error: `[LetterSG] Unexpected API key type: ${typeof apiKey}`,
       flowId: $.flow.id,
     })
-    throw new Error('Missing API key')
+    throw new Error('[LetterSG] Missing API key')
   }
 
   const baseUrl = getApiBaseUrl(apiKey)
@@ -21,10 +21,10 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
   if (!baseUrl) {
     logger.error({
       event: 'auth-header-baseurl-error',
-      error: 'LetterSG: No base URL obtained from API key',
+      error: '[LetterSG] No base URL obtained from API key',
       flowId: $.flow.id,
     })
-    throw new Error('No base URL obtained from API key')
+    throw new Error('[LetterSG] No base URL obtained from API key')
   }
 
   // request config has headers by default already

--- a/packages/backend/src/apps/lettersg/common/add-auth-header.ts
+++ b/packages/backend/src/apps/lettersg/common/add-auth-header.ts
@@ -1,12 +1,34 @@
 import { TBeforeRequest } from '@plumber/types'
 
+import logger from '@/helpers/logger'
+
 import { getApiBaseUrl } from './api'
 
 const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
-  const apiKey = $.auth.data.apiKey as string
+  const apiKey = $.auth.data.apiKey
+
+  if (typeof apiKey !== 'string') {
+    logger.error({
+      event: 'auth-header-apikey-error',
+      error: 'LetterSG: API key must be set',
+      flowId: $.flow.id,
+    })
+    throw new Error('Missing API key')
+  }
+
   const baseUrl = getApiBaseUrl(apiKey)
+
+  if (!baseUrl) {
+    logger.error({
+      event: 'auth-header-baseurl-error',
+      error: 'LetterSG: No base URL obtained from API key',
+      flowId: $.flow.id,
+    })
+    throw new Error('No base URL obtained from API key')
+  }
+
   // request config has headers by default already
-  requestConfig.headers['Authorization'] = `Bearer ${apiKey}`
+  requestConfig.headers.set('Authorization', `Bearer ${apiKey}`)
   requestConfig.baseURL = baseUrl
   return requestConfig
 }

--- a/packages/backend/src/apps/lettersg/common/api.ts
+++ b/packages/backend/src/apps/lettersg/common/api.ts
@@ -6,7 +6,6 @@ export enum LetterSgEnvironment {
 const STAGING_ENV_API_KEY_PREFIX = 'test_'
 const STAGING_ENV_BASE_URL = 'https://staging.letters.gov.sg/api'
 
-// TODO (mal): test this when prod api is out
 const PROD_ENV_API_KEY_PREFIX = 'live_'
 const PROD_ENV_BASE_URL = 'https://letters.gov.sg/api'
 

--- a/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
@@ -16,7 +16,11 @@ const dynamicData: IDynamicData = {
     }
 
     try {
-      const { data } = await $.http.get(`/v1/templates/${templateId}`)
+      const { data } = await $.http.get('/v1/templates/:templateId', {
+        urlPathParams: {
+          templateId,
+        },
+      })
 
       if (!data?.fields) {
         return {

--- a/packages/backend/src/apps/lettersg/dynamic-data/get-template-ids.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/get-template-ids.ts
@@ -4,6 +4,7 @@ import {
   IGlobalVariable,
 } from '@plumber/types'
 
+import { templateSchema } from './schema'
 import { type Template } from './types'
 
 const dynamicData: IDynamicData = {
@@ -21,10 +22,9 @@ const dynamicData: IDynamicData = {
 
       // map to dynamic data format which is { name: string; value: string }
       return {
-        data: data.templates.map((template: Template) => ({
-          name: template.name,
-          value: template.templateId.toString(),
-        })),
+        data: data.templates.map((template: Template) =>
+          templateSchema.parse(template),
+        ),
       }
     } catch (error) {
       return {

--- a/packages/backend/src/apps/lettersg/dynamic-data/schema.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const templateSchema = z
+  .object({
+    templateId: z.number(),
+    fields: z.array(z.string()),
+    name: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+  })
+  .transform((data) => ({
+    name: data.name,
+    value: data.templateId.toString(),
+  }))

--- a/packages/backend/src/apps/lettersg/dynamic-data/types.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/types.ts
@@ -1,5 +1,4 @@
 // Reference: https://guide.letters.gov.sg/developer-guide/upcoming-api-documentation
-// TODO (mal): Perform zod validation on this
 export type Template = {
   templateId: string
   fields: string[]

--- a/packages/backend/src/apps/lettersg/helpers/process-missing-fields.ts
+++ b/packages/backend/src/apps/lettersg/helpers/process-missing-fields.ts
@@ -1,0 +1,34 @@
+import { IGlobalVariable } from '@plumber/types'
+
+export async function processMissingFields(
+  $: IGlobalVariable,
+): Promise<string[]> {
+  try {
+    const templateId = $.step.parameters.templateId as string
+    const { data } = await $.http.get('/v1/templates/:templateId', {
+      urlPathParams: {
+        templateId,
+      },
+    })
+
+    if (!data?.fields) {
+      return []
+    }
+    const allTemplateFields: string[] = data.fields
+    // follows subfield format for letterParams which is { field: string, value: string }
+    const inputTemplateFields = $.step.parameters.letterParams as Record<
+      string,
+      string
+    >[]
+
+    // perform filter for fields that don't exist
+    const inputFieldsSet: Set<string> = new Set()
+    for (const param of inputTemplateFields) {
+      inputFieldsSet.add(param['field'])
+    }
+    return allTemplateFields.filter((field) => !inputFieldsSet.has(field))
+  } catch (err) {
+    // not crucial so we don't alarm the user and return an empty array for the missing fields instead
+    return []
+  }
+}

--- a/packages/backend/src/apps/paysg/common/add-auth-header.ts
+++ b/packages/backend/src/apps/paysg/common/add-auth-header.ts
@@ -9,7 +9,8 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
 
   if (typeof apiKey !== 'string' || typeof paymentServiceId !== 'string') {
     logger.error({
-      erorr: 'API key and payment service ID must be set',
+      event: 'auth-header-apikey-error',
+      error: 'PaySG: API key and payment service ID must be set',
       flowId: $.flow.id,
     })
     throw new Error('Missing API key or payment service ID')
@@ -19,7 +20,8 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
 
   if (!baseUrl) {
     logger.error({
-      error: 'No base URL obtained from API key',
+      event: 'auth-header-baseurl-error',
+      error: 'PaySG: No base URL obtained from API key',
       flowId: $.flow.id,
     })
     throw new Error('No base URL obtained from API key')

--- a/packages/backend/src/apps/paysg/common/add-auth-header.ts
+++ b/packages/backend/src/apps/paysg/common/add-auth-header.ts
@@ -10,10 +10,10 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
   if (typeof apiKey !== 'string' || typeof paymentServiceId !== 'string') {
     logger.error({
       event: 'auth-header-apikey-error',
-      error: 'PaySG: API key and payment service ID must be set',
+      error: `[PaySG] Unexpected API key type: ${typeof apiKey} and payment service ID type: ${typeof paymentServiceId}`,
       flowId: $.flow.id,
     })
-    throw new Error('Missing API key or payment service ID')
+    throw new Error('[PaySG] Missing API key or payment service ID')
   }
 
   const baseUrl = getApiBaseUrl(apiKey)
@@ -21,10 +21,10 @@ const addAuthHeader: TBeforeRequest = async ($, requestConfig) => {
   if (!baseUrl) {
     logger.error({
       event: 'auth-header-baseurl-error',
-      error: 'PaySG: No base URL obtained from API key',
+      error: '[PaySG] No base URL obtained from API key',
       flowId: $.flow.id,
     })
-    throw new Error('No base URL obtained from API key')
+    throw new Error('[PaySG] No base URL obtained from API key')
   }
 
   requestConfig.baseURL = baseUrl


### PR DESCRIPTION
## Improvements
- Add error logging if api key and base url is not set properly in `add-auth-header`
- Use urlPathParams to populate url paths for existing API calls
- Add zod validation for `getTemplate` API call
- Add check to process and return missing fields for user (improve step error explanation)

## Tests
- Letter still can be created and sent as an attachment
- Correct missing fields show when user messes up
- No missing field is shown if the API call gives an error