### PR TITLE
feat(frontend): connect mockable step test with backend

### DIFF
--- a/packages/frontend/src/graphql/mutations/mock-execute-flow.ts
+++ b/packages/frontend/src/graphql/mutations/mock-execute-flow.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client'
+
+export const MOCK_EXECUTE_FLOW = gql`
+  mutation MockExecuteFlow($input: ExecuteFlowInput) {
+    mockExecuteFlow(input: $input) {
+      step {
+        id
+        status
+        appKey
+        executionSteps {
+          id
+          executionId
+          stepId
+          status
+          dataOut
+          dataOutMetadata
+        }
+      }
+      data
+    }
+  }
+`

--- a/packages/frontend/src/graphql/queries/get-app.ts
+++ b/packages/frontend/src/graphql/queries/get-app.ts
@@ -65,6 +65,7 @@ export const GET_APP = gql`
         type
         pollInterval
         description
+        mockAvailable
         substeps {
           name
         }
@@ -73,6 +74,7 @@ export const GET_APP = gql`
         name
         key
         description
+        mockAvailable
         substeps {
           name
         }

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -72,6 +72,7 @@ export const GET_APPS = gql`
         type
         pollInterval
         description
+        mockAvailable
         webhookTriggerInstructions {
           beforeUrlMsg
           afterUrlMsg
@@ -150,6 +151,7 @@ export const GET_APPS = gql`
         key
         description
         groupsLaterSteps
+        mockAvailable
         substeps {
           key
           name

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -128,6 +128,7 @@ export interface IStep {
   appData?: IApp
   retryable?: boolean
   jobId?: string
+  mockAvailable?: boolean
 }
 
 export interface IFlowConfig {


### PR DESCRIPTION
## Problem

Implement frontend for testing with mock data

## Solution

- Check for `mockAvailable` flag from https://github.com/opengovsg/plumber/pull/487 to render `Test with Mock Data` button
- Once that button is clicked, backend will generate a mock record and return
- "Test again" for form will return latest execution record hence the mock data still

## Tests

- [x] Create a new pipe with form trigger
- [x] Use this button on an existing pipe with form trigger

## Deploy Notes

N/A