### PR TITLE
PLU-219: [FORMATTER-3] Date converter

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -1,0 +1,85 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { Settings as LuxonSettings } from 'luxon'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { spec } from '../actions/date-time/transforms/convert-date-time'
+
+// TZ formatting replicated here (see appConfig) as tests don't load the app
+// config module.
+LuxonSettings.defaultZone = 'Asia/Singapore'
+LuxonSettings.defaultLocale = 'en-SG'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('convert date time', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      step: {
+        parameters: {},
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    { toFormat: 'dd/LL/yy', expectedResult: '01/04/24' },
+    { toFormat: 'dd/LL/yyyy', expectedResult: '01/04/2024' },
+    { toFormat: 'dd LLL yyyy', expectedResult: '01 Apr 2024' },
+    { toFormat: 'dd LLLL yyyy', expectedResult: '01 April 2024' },
+    { toFormat: 'hh:mm a', expectedResult: '12:05 pm' },
+    { toFormat: 'hh:mm:ss a', expectedResult: '12:05:10 pm' },
+    { toFormat: 'dd LLL yyyy hh:mm a', expectedResult: '01 Apr 2024 12:05 pm' },
+    {
+      toFormat: 'dd LLL yyyy hh:mm:ss a',
+      expectedResult: '01 Apr 2024 12:05:10 pm',
+    },
+  ])(
+    'formats input to the selected format correctly',
+    ({ toFormat, expectedResult }) => {
+      $.step.parameters = {
+        dateTimeFormat: 'formsgSubmissionTime',
+        formatDateTimeToFormat: toFormat,
+      }
+      spec.transformData($, '2024-04-01T12:05:10.000+08:00')
+
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { result: expectedResult },
+      })
+    },
+  )
+
+  it.each([
+    {
+      inputFormat: 'formsgSubmissionTime',
+      inputValue: '2024-04-01T23:45:08.000+08:00',
+      toFormat: 'dd LLL yyyy hh:mm a',
+      expectedResult: '01 Apr 2024 11:45 pm',
+    },
+    {
+      inputFormat: 'formsgDateField',
+      inputValue: '01 Apr 2024',
+      toFormat: 'dd/LL/yy',
+      expectedResult: '01/04/24',
+    },
+  ])('can handle all supported input formats', (testParams) => {
+    const { inputFormat, inputValue, toFormat, expectedResult } = testParams
+    $.step.parameters = {
+      dateTimeFormat: inputFormat,
+      formatDateTimeToFormat: toFormat,
+    }
+    spec.transformData($, inputValue)
+
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: expectedResult },
+    })
+  })
+})

--- a/packages/backend/src/apps/formatter/actions/date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/index.ts
@@ -5,6 +5,7 @@ import { setUpActionFields } from '../../common/set-up-action-fields'
 
 import { field as dateFormatField } from './common/date-time-format'
 import { spec as addSubtractDateTime } from './transforms/add-subtract-date-time'
+import { spec as convertDateTime } from './transforms/convert-date-time'
 
 const action: IRawAction = {
   name: 'Date / Time',
@@ -12,7 +13,7 @@ const action: IRawAction = {
   description: 'Format date and time values',
   arguments: setUpActionFields({
     commonFields: [dateFormatField],
-    transforms: [addSubtractDateTime],
+    transforms: [addSubtractDateTime, convertDateTime],
   }),
 
   async run($) {
@@ -23,6 +24,8 @@ const action: IRawAction = {
     switch (transformId) {
       case addSubtractDateTime.id:
         return addSubtractDateTime.transformData($, valueToTransform)
+      case convertDateTime.id:
+        return convertDateTime.transformData($, valueToTransform)
       default:
         throw new Error(`Unknown Date/Time transform: '${transformId}'`)
     }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -1,0 +1,71 @@
+import type { IFieldDropdown } from '@plumber/types'
+
+import z from 'zod'
+
+import { ensureZodEnumValue, ensureZodObjectKey } from '@/helpers/zod-utils'
+
+const formatStringsEnum = z.enum([
+  'dd/LL/yy',
+  'dd/LL/yyyy',
+  'dd LLL yyyy',
+  'dd LLLL yyyy',
+  'hh:mm a',
+  'hh:mm:ss a',
+  'dd LLL yyyy hh:mm a',
+  'dd LLL yyyy hh:mm:ss a',
+])
+
+export const fieldSchema = z.object({
+  formatDateTimeToFormat: formatStringsEnum,
+})
+
+export const field = {
+  key: ensureZodObjectKey(fieldSchema, 'formatDateTimeToFormat'),
+  label: 'What format do you want to transform value to?',
+  type: 'dropdown' as const,
+  required: true,
+  variables: false,
+  showOptionValue: false,
+  options: [
+    {
+      label: 'DD/MM/YY',
+      description: '02/01/24',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yy'),
+    },
+    {
+      label: 'DD/MM/YYYY',
+      description: '02/01/2024',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yyyy'),
+    },
+    {
+      label: 'DD MMM YYYY',
+      description: '02 Jan 2006',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy'),
+    },
+    {
+      label: 'DD MMMM YYYY',
+      description: '02 January 2006',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
+    },
+    {
+      label: 'HH:mm (am/pm)',
+      description: '12:04 PM',
+      value: ensureZodEnumValue(formatStringsEnum, 'hh:mm a'),
+    },
+    {
+      label: 'HH:mm:ss (am/pm)',
+      description: '12:04:05 pm',
+      value: ensureZodEnumValue(formatStringsEnum, 'hh:mm:ss a'),
+    },
+    {
+      label: 'DD MMMM YYYY HH:mm (am/pm)',
+      description: '02 Jan 2006 12:04 pm',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm a'),
+    },
+    {
+      label: 'DD MMMM YYYY HH:mm:ss (am/pm)',
+      description: '02 Jan 2006 23:04:05 pm',
+      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
+    },
+  ],
+} satisfies IFieldDropdown

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -58,12 +58,12 @@ export const field = {
       value: ensureZodEnumValue(formatStringsEnum, 'hh:mm:ss a'),
     },
     {
-      label: 'DD MMMM YYYY HH:mm (am/pm)',
+      label: 'DD MMM YYYY HH:mm (am/pm)',
       description: '02 Jan 2006 12:04 pm',
       value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm a'),
     },
     {
-      label: 'DD MMMM YYYY HH:mm:ss (am/pm)',
+      label: 'DD MMM YYYY HH:mm:ss (am/pm)',
       description: '02 Jan 2006 23:04:05 pm',
       value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
     },

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -64,7 +64,7 @@ export const field = {
     },
     {
       label: 'DD MMM YYYY HH:mm:ss (am/pm)',
-      description: '02 Jan 2006 23:04:05 pm',
+      description: '02 Jan 2006 12:04:05 pm',
       value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
     },
   ],

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -1,0 +1,28 @@
+import type { TransformSpec } from '../../../../common/transform-spec'
+import {
+  fieldSchema as dateTimeFormatSchema,
+  parseDateTime,
+} from '../../common/date-time-format'
+
+import { field, fieldSchema } from './fields'
+
+export const spec = {
+  id: 'formatDateTime',
+
+  dropdownConfig: {
+    label: 'Format',
+    description: 'Change a date or time to a new format style',
+  },
+
+  fields: [field],
+
+  transformData: ($, valueToTransform) => {
+    const { dateTimeFormat } = dateTimeFormatSchema.parse($.step.parameters)
+    const { formatDateTimeToFormat: formatString } = fieldSchema.parse(
+      $.step.parameters,
+    )
+
+    const dateTime = parseDateTime(dateTimeFormat, valueToTransform)
+    $.setActionItem({ raw: { result: dateTime.toFormat(formatString) } })
+  },
+} satisfies TransformSpec

--- a/packages/backend/src/helpers/zod-utils.ts
+++ b/packages/backend/src/helpers/zod-utils.ts
@@ -9,3 +9,13 @@ export function ensureZodObjectKey<
 >(_schema: TZodObject, key: TKey): TKey {
   return key
 }
+
+/**
+ * Helper to ensure that `value` one of the values the `enum` Zod enum.
+ */
+export function ensureZodEnumValue<
+  TZodEnum extends z.ZodEnum<any>,
+  TValue extends z.infer<TZodEnum>,
+>(_enum: TZodEnum, value: TValue): TValue {
+  return value
+}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -40,6 +40,7 @@ type FlowStepProps = {
   onContinue?: () => void
 }
 
+// FIXME (ogp-weeloong): remove this; not needed since we already do validation in FlowSubstep.
 function generateValidationSchema(substeps: ISubstep[]) {
   const fieldValidations = substeps?.reduce(
     (allValidations, { arguments: args }) => {
@@ -50,7 +51,7 @@ function generateValidationSchema(substeps: ISubstep[]) {
       const substepArgumentValidations: Record<string, BaseSchema> = {}
 
       for (const arg of args) {
-        const { key, required, dependsOn } = arg
+        const { key, required, dependsOn, hiddenIf } = arg
 
         // base validation for the field if not exists
         if (!substepArgumentValidations[key]) {
@@ -58,8 +59,9 @@ function generateValidationSchema(substeps: ISubstep[]) {
         }
 
         if (typeof substepArgumentValidations[key] === 'object') {
-          // if the field is required, add the required validation
-          if (required) {
+          // if the field is required and not conditionally hidden, add the
+          // required validation
+          if (required && !hiddenIf) {
             substepArgumentValidations[key] = substepArgumentValidations[
               key
             ].required(`${key} is required.`)


### PR DESCRIPTION
## Problem
Our users need to be able to convert between various date formats.

## Solution
Implement a formatter transform to convert between dates.

**NOTE**: This also disables yup validation for conditionally hidden fields; this validation was blocking submission for required fields which were hidden. It's possible to fix the validation, but I didn't bother as this yup validation is extraneous.

<img width="500" alt="Screenshot 2024-04-02 at 7 01 19 PM" src="https://github.com/opengovsg/plumber/assets/135598754/5c9b0621-ef9f-4b2a-b0e2-7aca3cdc937c">

## Tests
- New unit test
- Check that formatting works