### PR TITLE
PLU-190: [pipe-transfer-8] fix: add ux change

### DIFF
--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -156,8 +156,8 @@ export default function EditorLayout(): React.ReactElement {
           <TouchableTooltip
             label={
               hasFlowTransfer
-                ? ''
-                : 'You cannot publish a pipe with a pending transfer'
+                ? 'You cannot publish a pipe with a pending transfer'
+                : ''
             }
           >
             <Button


### PR DESCRIPTION
## Problem

User needs to transfer pipe using our UI

## Details
- Add ux update to set the steps with connections or tiles to be `incomplete` to cause less confusion for the user when they receive the new pipe and just publish it
- Fix logging for flow transfer request
- Fix logic for tooltip for publish button when a request has been created

## Tests
- Tooltip appears for the publish button in the editor
- Logging for flow transfer is correct now
- Flow transfer without connections can immediately be published without "test step"
- Flow transfer with connections cannot be published (must test step)
- Flow transfer with tiles action cannot be published (must test step) 