### PR TITLE
fix: handle multer error properly to prevent 500

### DIFF
--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -19,16 +19,20 @@ router.use((req, res, next) => {
   uploadNone(req, res, (err) => {
     // file upload is not supported
     // handle error to prevent http 500 error
-    logger.error({
-      req,
-      err,
-      msg: 'Invalid request: multer error',
-    })
     if (err instanceof multer.MulterError) {
-      res.status(400).send('Invalid request, file upload is not supported.')
-    } else {
-      next(err)
+      logger.error({
+        req: {
+          body: req.body,
+          headers: req.headers,
+          url: req.url,
+        },
+        err,
+        msg: 'Invalid request: multer error',
+      })
+      res.status(415).send('Invalid request, file upload is not supported.')
+      return
     }
+    next(err)
   })
 })
 

--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -13,9 +13,24 @@ import webhookHandler from '@/controllers/webhooks/handler'
 import logger from '@/helpers/logger'
 
 const router = Router()
-const upload = multer()
+const uploadNone = multer().none()
 
-router.use(upload.none())
+router.use((req, res, next) => {
+  uploadNone(req, res, (err) => {
+    // file upload is not supported
+    // handle error to prevent http 500 error
+    logger.error({
+      req,
+      err,
+      msg: 'Invalid request: multer error',
+    })
+    if (err instanceof multer.MulterError) {
+      res.status(400).send('Invalid request, file upload is not supported.')
+    } else {
+      next(err)
+    }
+  })
+})
 
 router.use(
   express.text({


### PR DESCRIPTION
## Problem

Our webhook handler prevents file upload via our webhook trigger. Sending a non-text multipart request will result in a 500 error being thrown.

## Solution

Handle this error properly and return a 400 instead.