### PR TITLE
PLU-227: Support "is empty" check in toolbox

### DIFF
--- a/packages/backend/src/apps/formatter/assets/favicon.svg
+++ b/packages/backend/src/apps/formatter/assets/favicon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" style="fill: rgba(0, 0, 0, 1);transform: ;msFilter:;"><path d="m16 2.012 3 3L16.713 7.3l-3-3zM4 14v3h3l8.299-8.287-3-3zm0 6h16v2H4z"></path></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" style="fill: rgba(207, 26, 104, 1);transform: ;msFilter:;"><path d="m16 2.012 3 3L16.713 7.3l-3-3zM4 14v3h3l8.299-8.287-3-3zm0 6h16v2H4z"></path></svg>

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -3,7 +3,7 @@ import { IApp } from '@plumber/types'
 import actions from './actions'
 
 const app: IApp = {
-  name: 'Formatter (Pilot)',
+  name: 'Formatter',
   key: 'formatter',
   iconUrl: '{BASE_URL}/apps/formatter/assets/favicon.svg',
   authDocUrl: 'https://guide.plumber.gov.sg/user-guides/actions/formatter',

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -114,19 +114,26 @@ describe('Condition is true', () => {
     { field: null, expectedResult: true },
     { field: undefined, expectedResult: true },
 
-    // Non string values are always not-empty, even if they're falsey.
+    { field: '     ', expectedResult: false },
+    { field: '\n', expectedResult: false },
+    { field: '\t', expectedResult: false },
     { field: 'hello', expectedResult: false },
+
+    // Non string values are always not-empty, even if they're falsey.
     { field: 0, expectedResult: false },
     { field: {}, expectedResult: false },
-  ])('is_empty is $expectedResult for $field', ({ field, expectedResult }) => {
-    const result = conditionIsTrue({
-      field,
-      is: 'is',
-      condition: 'is_empty',
-      text: null,
-    })
-    expect(result).toEqual(expectedResult)
-  })
+  ])(
+    'supports empty ($expectedResult for $field)',
+    ({ field, expectedResult }) => {
+      const result = conditionIsTrue({
+        field,
+        is: 'is',
+        condition: 'empty',
+        text: null,
+      })
+      expect(result).toEqual(expectedResult)
+    },
+  )
 
   it('throws an error for unsupported conditions', () => {
     expect(() =>

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -115,8 +115,8 @@ describe('Condition is true', () => {
     { field: undefined, expectedResult: true },
 
     { field: '     ', expectedResult: false },
-    { field: '\n', expectedResult: false },
-    { field: '\t', expectedResult: false },
+    { field: `\n`, expectedResult: false },
+    { field: `\t`, expectedResult: false },
     { field: 'hello', expectedResult: false },
 
     // Non string values are always not-empty, even if they're falsey.

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -109,6 +109,25 @@ describe('Condition is true', () => {
     expect(result).toEqual(expectedResult)
   })
 
+  it.each([
+    { field: '', expectedResult: true },
+    { field: null, expectedResult: true },
+    { field: undefined, expectedResult: true },
+
+    // Non string values are always not-empty, even if they're falsey.
+    { field: 'hello', expectedResult: false },
+    { field: 0, expectedResult: false },
+    { field: {}, expectedResult: false },
+  ])('is_empty is $expectedResult for $field', ({ field, expectedResult }) => {
+    const result = conditionIsTrue({
+      field,
+      is: 'is',
+      condition: 'is_empty',
+      text: null,
+    })
+    expect(result).toEqual(expectedResult)
+  })
+
   it('throws an error for unsupported conditions', () => {
     expect(() =>
       conditionIsTrue({

--- a/packages/backend/src/apps/toolbox/__tests__/common/get-condition-args.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-condition-args.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import getConditionArgs from '../../common/get-condition-args'
+
+describe('Get condition args', () => {
+  it('hides the value field if "is_empty" is chosen', () => {
+    const args = getConditionArgs({ usePlaceholders: false })
+    expect(args.find((a) => a.key === 'text').hiddenIf).toEqual({
+      fieldKey: 'condition',
+      op: 'equals',
+      fieldValue: 'is_empty',
+    })
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/common/get-condition-args.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-condition-args.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest'
 import getConditionArgs from '../../common/get-condition-args'
 
 describe('Get condition args', () => {
-  it('hides the value field if "is_empty" is chosen', () => {
+  it('hides the value field if "empty" condition is chosen', () => {
     const args = getConditionArgs({ usePlaceholders: false })
     expect(args.find((a) => a.key === 'text').hiddenIf).toEqual({
       fieldKey: 'condition',
       op: 'equals',
-      fieldValue: 'is_empty',
+      fieldValue: 'empty',
     })
   })
 })

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -24,18 +24,20 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
     case 'contains':
       result = field.toString().includes(value.toString())
       break
-    case 'is_empty':
+    case 'empty':
       // `field` and `value` are a bit of a misnomer. They're both form fields
-      // that the user inputs data into.  For "is_empty", the `value` field is
-      // hidden from the user, so we only need to check `field` field.
+      // that the user inputs data into.  The "empty" condition is unary, so the
+      // `value` field is hidden from the user. Thus we only need to check
+      // `field` field.
       if (typeof field === 'string') {
         // Strings are empty if they are falsey.
-        return !field
+        result = !field
       } else {
         // All other types (e.g. 0, {}) are considered non-empty unless they are
         // null or undefined
-        return field === null || field === undefined
+        result = field === null || field === undefined
       }
+      break
     default:
       throw new Error(
         `Conditional logic block contains an unknown operator: ${condition}`,

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -24,6 +24,18 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
     case 'contains':
       result = field.toString().includes(value.toString())
       break
+    case 'is_empty':
+      // `field` and `value` are a bit of a misnomer. They're both form fields
+      // that the user inputs data into.  For "is_empty", the `value` field is
+      // hidden from the user, so we only need to check `field` field.
+      if (typeof field === 'string') {
+        // Strings are empty if they are falsey.
+        return !field
+      } else {
+        // All other types (e.g. 0, {}) are considered non-empty unless they are
+        // null or undefined
+        return field === null || field === undefined
+      }
     default:
       throw new Error(
         `Conditional logic block contains an unknown operator: ${condition}`,

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -29,14 +29,11 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
       // that the user inputs data into.  The "empty" condition is unary, so the
       // `value` field is hidden from the user. Thus we only need to check
       // `field` field.
-      if (typeof field === 'string') {
-        // Strings are empty if they are falsey.
-        result = !field
-      } else {
-        // All other types (e.g. 0, {}) are considered non-empty unless they are
-        // null or undefined
-        result = field === null || field === undefined
-      }
+
+      // Strings are empty if they are falsey.
+      // All other types (e.g. 0, {}) are considered non-empty unless they are
+      // null or undefined
+      result = field === null || field === undefined || field === ''
       break
     default:
       throw new Error(

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -45,7 +45,7 @@ export default function getConditionArgs({
         { label: 'Less than', value: 'lt' },
         { label: 'Less than or equals to', value: 'lte' },
         { label: 'Contains', value: 'contains' },
-        { label: 'Is Empty', value: 'is_empty' },
+        { label: 'Empty', value: 'empty' },
       ],
     },
     {
@@ -57,7 +57,7 @@ export default function getConditionArgs({
       hiddenIf: {
         fieldKey: 'condition',
         op: 'equals',
-        fieldValue: 'is_empty',
+        fieldValue: 'empty',
       },
     },
   ]

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -45,6 +45,7 @@ export default function getConditionArgs({
         { label: 'Less than', value: 'lt' },
         { label: 'Less than or equals to', value: 'lte' },
         { label: 'Contains', value: 'contains' },
+        { label: 'Is Empty', value: 'is_empty' },
       ],
     },
     {
@@ -53,6 +54,11 @@ export default function getConditionArgs({
       type: 'string' as const,
       required: true,
       variables: true,
+      hiddenIf: {
+        fieldKey: 'condition',
+        op: 'equals',
+        fieldValue: 'is_empty',
+      },
     },
   ]
 }

--- a/packages/backend/src/apps/toolbox/index.ts
+++ b/packages/backend/src/apps/toolbox/index.ts
@@ -11,6 +11,8 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '000000',
   actions,
+  description:
+    "Use Plumber's built in tools like If-then and Only continue if to add more functionality to your pipes",
 }
 
 export default app


### PR DESCRIPTION
## Problem
Our users need to check if a variable is empty (E.g. empty form field, empty excel value etc)

## Solution
Add a new "empty" condition.

<img width="500" alt="Screenshot 2024-04-08 at 2 24 17 PM" src="https://github.com/opengovsg/plumber/assets/135598754/b95b9bf1-4c67-4097-afad-13d28464dad9">

## Tests
- New unit test
- Check that it returns true for empty strings
- Check that it returns false for non empty strings
- Check that it returns false for 0.
- Check that if "is not" is set, the result is negated
- Check that it works on optional FormSG short answer fields
- Regression test: check that other conditions in if-then still work
