### PR TITLE
[TILES] chore: allow column resizing even in readonly mode

### DIFF
--- a/packages/frontend/src/pages/Tile/components/TableHeader/ColumnHeaderCell.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableHeader/ColumnHeaderCell.tsx
@@ -191,7 +191,7 @@ function ColumnHeaderCell({
           )}
         </PopoverContent>
       </Popover>
-      {isEditMode && <ColumnResizer header={header} />}
+      <ColumnResizer header={header} />
       {isDeletionModalOpen && (
         <DeletionModal
           columnId={column.id}

--- a/packages/frontend/src/pages/Tile/components/TableHeader/ColumnResizer.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableHeader/ColumnResizer.tsx
@@ -3,6 +3,7 @@ import { Box } from '@chakra-ui/react'
 import { Header } from '@tanstack/react-table'
 
 import { HEADER_COLOR } from '../../constants'
+import { useTableContext } from '../../contexts/TableContext'
 import { useUpdateTable } from '../../hooks/useUpdateTable'
 import { GenericRowData } from '../../types'
 
@@ -12,6 +13,8 @@ interface ColumnResizerProps {
 
 export default function ColumnResizer({ header }: ColumnResizerProps) {
   const { updateColumns } = useUpdateTable()
+  const { mode } = useTableContext()
+  const isEditMode = mode === 'edit'
 
   const onMouseUp = useCallback(() => {
     const newSize = header.getSize()
@@ -25,10 +28,12 @@ export default function ColumnResizer({ header }: ColumnResizerProps) {
   const onResizeStart = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {
       // this is necessary because mouse up outside of the element will not be registered otherwise
-      document.addEventListener('mouseup', onMouseUp, { once: true })
+      if (isEditMode) {
+        document.addEventListener('mouseup', onMouseUp, { once: true })
+      }
       return resizeHandler(e)
     },
-    [onMouseUp, resizeHandler],
+    [isEditMode, onMouseUp, resizeHandler],
   )
 
   return (


### PR DESCRIPTION
## Problem
Users cannot resize columns in view-only mode for tiles.

## Solution
Allow resizing in view-only mode but do **not** save the new width in db.

## Tests
- [ ] Users can resize columns in edit mode
- [ ] Users can resize columns in view mode
- [ ] In view mode, column width resets on refresh (i.e. is not persisted in db)