### PR TITLE
PLU-229: Add connection check for formsg after pipe transfer

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -61,7 +61,7 @@ const trigger: IRawTrigger = {
     if (!$.auth.data) {
       throw new StepError(
         'Missing FormSG connection',
-        'Click on choose connection and connect your FormSG connection.',
+        'Click on choose connection and set up your form credentials.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -2,6 +2,8 @@ import { IGlobalVariable, IRawTrigger } from '@plumber/types'
 
 import isEmpty from 'lodash/isEmpty'
 
+import StepError from '@/errors/step'
+
 import getDataOutMetadata from './get-data-out-metadata'
 
 export const NricFilter = {
@@ -56,6 +58,15 @@ const trigger: IRawTrigger = {
   getDataOutMetadata,
 
   async testRun($: IGlobalVariable) {
+    if (!$.auth.data) {
+      throw new StepError(
+        'Missing FormSG connection',
+        'Click on choose connection and connect your FormSG connection.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
     const lastExecutionStep = await $.getLastExecutionStep()
     if (!isEmpty(lastExecutionStep?.dataOut)) {
       await $.pushTriggerItem({

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -118,6 +118,17 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
             alignItems: 'flex-start',
           }}
         >
+          {step.webhookUrl && (
+            <WebhookUrlInfo
+              webhookUrl={step.webhookUrl}
+              webhookTriggerInstructions={
+                (selectedActionOrTrigger as IBaseTrigger)
+                  .webhookTriggerInstructions || defaultTriggerInstructions
+              }
+              sx={{ mb: 2 }}
+            />
+          )}
+
           {!!error?.graphQLErrors?.length && (
             <Box w="100%">
               {serializeErrors(error.graphQLErrors).map(
@@ -130,16 +141,6 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
                 ),
               )}
             </Box>
-          )}
-          {step.webhookUrl && (
-            <WebhookUrlInfo
-              webhookUrl={step.webhookUrl}
-              webhookTriggerInstructions={
-                (selectedActionOrTrigger as IBaseTrigger)
-                  .webhookTriggerInstructions || defaultTriggerInstructions
-              }
-              sx={{ mb: 2 }}
-            />
           )}
 
           <TestResult


### PR DESCRIPTION
## Problem

After pipe is transferred, connection is nullified for formsg but user can still test step without it being configured because it uses the `lastExecutionStep`.

## Solution

- Add a auth check and return a step error if the connection is not configured for formsg
- Modify the UI when trigger has an error

## Screenshots
After
![image](https://github.com/opengovsg/plumber/assets/65110268/f661ffe0-bd00-4f84-a8f3-87d04944e3de)


## Tests
- Connections still can be configured for formsg successfully
- StepError is shown when no connection is selected
- If pipe owner is not an editor/owner, formsg step will still be incomplete as intended