### PR TITLE
PLU-230: Block Multi-Respondent Form connections

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/verify-credentials.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/verify-credentials.test.ts
@@ -166,5 +166,24 @@ describe('verify credentials', () => {
         ),
       ).rejects.toThrowError('Invalid secret key')
     })
+
+    it('should throw an error if form is multirespondent', async () => {
+      $.http.get = vi.fn().mockResolvedValueOnce({
+        data: {
+          form: {
+            responseMode: 'multirespondent',
+          },
+        },
+      })
+      await expect(
+        verifyFormCreds(
+          $,
+          $.auth.data.formId as string,
+          $.auth.data.privateKey as string,
+        ),
+      ).rejects.toThrowError(
+        'Multi-Respondent Forms cannot be connected to Plumber yet.',
+      )
+    })
   })
 })

--- a/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
@@ -185,5 +185,16 @@ describe('formsg webhook registration', () => {
         FORMSG_WEBHOOK_REGISTRATION_MESSAGE.UNAUTHORIZED,
       )
     })
+
+    it('should error if trying to connect to a multirespondent form', async () => {
+      $.http.post = vi.fn().mockResolvedValueOnce({
+        data: {
+          responseMode: 'multirespondent',
+        },
+      })
+      await expect(registerWebhookUrl($)).rejects.toThrowError(
+        'Multi-Respondent Forms cannot be connected to Plumber yet.',
+      )
+    })
   })
 })

--- a/packages/backend/src/apps/formsg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/formsg/auth/verify-credentials.ts
@@ -16,10 +16,12 @@ export const verifyFormCreds = async (
 ) => {
   let formTitle = ''
   let publicKey = ''
+  let responseMode = ''
   try {
     const { data } = await $.http.get(`/v3/forms/${formId}`)
     formTitle = get(data, 'form.title')
     publicKey = get(data, 'form.publicKey')
+    responseMode = get(data, 'form.responseMode')
   } catch (error) {
     if (error.response?.status === 404) {
       if (error.response.data?.isPageFound) {
@@ -28,6 +30,12 @@ export const verifyFormCreds = async (
       }
     }
     throw new Error('Form not found')
+  }
+
+  if (responseMode === 'multirespondent') {
+    throw new Error(
+      'Multi-Respondent Forms cannot be connected to Plumber yet.',
+    )
   }
 
   if (!formTitle) {

--- a/packages/backend/src/apps/formsg/common/webhook-settings.ts
+++ b/packages/backend/src/apps/formsg/common/webhook-settings.ts
@@ -70,7 +70,7 @@ async function validateFormIsNotMultiRespondent(
     },
   )
 
-  if (settings.data.responseMode === 'multirespondent') {
+  if (settings?.data?.responseMode === 'multirespondent') {
     throw new Error(
       'Multi-Respondent Forms cannot be connected to Plumber yet.',
     )


### PR DESCRIPTION
## Problem
We have high user frustration signals from them trying to connect to multi respondent forms, which are not supported.

## Solution
We'll block creating MRF connections. This is scrappy because this is temporary; MRF will support webhooks later on.

![Screenshot 2024-04-12 at 7 43 57 PM](https://github.com/opengovsg/plumber/assets/135598754/7245e4c2-2d3f-4cbf-a2a5-210b0a6385e1)

## Tests
- Check that MRF forms cannot be added.
- Regression test: check that I can still add normal forms