### PR TITLE
PLU-174: allow space in parameters

### DIFF
--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -7,7 +7,8 @@ import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
-const variableRegExp = /({{step\.[\da-zA-Z-]+(?:\.[\da-zA-Z-_]+)+}})/g
+const variableRegExp =
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
 
 function findAndSubstituteVariables(
   // i.e. the `key` corresponding to this variable's form field in defineAction


### PR DESCRIPTION
## Problem
Custom API with space in the JSON keys will not be usable in subsequent steps.

## Solution
- Allow space (not tabs, newlines or other whitespaces) in REGEX
- Make step id regex more stringent (i.e. UUID v4)
- Add unit tests

## Tests
- Existing pipes should still work as expected
- New pipes will now support keys like ` h e l l o `, `he   llo`, `h      `, etc...