### PR TITLE
PLU-226: fix: add delay until past timestamp catch

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-for.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-for.test.ts
@@ -2,6 +2,8 @@ import { type IGlobalVariable } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import StepError from '@/errors/step'
+
 import delayForAction from '../actions/delay-for'
 import delayApp from '../index'
 
@@ -59,8 +61,6 @@ describe('Delay for action', () => {
     }
 
     // throw partial step error message
-    await expect(delayForAction.run($)).rejects.toThrowError(
-      'Invalid delay for value entered',
-    )
+    await expect(delayForAction.run($)).rejects.toThrowError(StepError)
   })
 })

--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -2,10 +2,13 @@ import { type IGlobalVariable } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import StepError from '@/errors/step'
+
 import delayUntilAction from '../actions/delay-until'
 import delayApp from '../index'
 
-const VALID_DATE = '2023-11-08'
+const PAST_DATE = '2023-11-08'
+const VALID_DATE = '2025-12-31' // long long time later
 const VALID_TIME = '12:00'
 const DEFAULT_TIME = '00:00'
 const INVALID_TIME = '25:00'
@@ -79,15 +82,23 @@ describe('Delay until action', () => {
     })
   })
 
+  it('throws step error if delay until has a past timestamp', async () => {
+    $.step.parameters = {
+      delayUntil: PAST_DATE,
+      delayUntilTime: DEFAULT_TIME,
+    }
+
+    // throw step error
+    await expect(delayUntilAction.run($)).rejects.toThrowError(StepError)
+  })
+
   it('throws step error if delay until has an invalid configuration', async () => {
     $.step.parameters = {
       delayUntil: VALID_DATE,
       delayUntilTime: INVALID_TIME,
     }
 
-    // throw partial step error message
-    await expect(delayUntilAction.run($)).rejects.toThrowError(
-      'Invalid timestamp entered',
-    )
+    // throw step error
+    await expect(delayUntilAction.run($)).rejects.toThrowError(StepError)
   })
 })

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -56,7 +56,7 @@ const action: IRawAction = {
     if (delayTimestamp < DateTime.now().toMillis()) {
       throw new StepError(
         'Delay until timestamp entered is in the past',
-        'Click on set up action and check that the date and time entered is of a future timestamp.',
+        'Click on set up action and check that the date and time entered is not in the past.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -1,5 +1,7 @@
 import { IRawAction } from '@plumber/types'
 
+import { DateTime } from 'luxon'
+
 import StepError from '@/errors/step'
 
 import generateTimestamp from '../../helpers/generate-timestamp'
@@ -46,6 +48,15 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid timestamp entered',
         'Click on set up action and check that the date or time entered is of a valid format.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    if (delayTimestamp < DateTime.now().toMillis()) {
+      throw new StepError(
+        'Delay until timestamp entered is in the past',
+        'Click on set up action and check that the date and time entered is of a future timestamp.',
         $.step.position,
         $.app.name,
       )


### PR DESCRIPTION
## Problem

Jackson brought up that it seems unintuitive that user can select a "past" delay until timestamp and the delay still works.

## Solution

- Add a check if the delay until timestamp is before the current timestamp
- Fix unit tests

**RFC**
- Should we indicate a dropdown to allow uses to "bypass" and let past timestamps through because with this fix, more errors may appear because this input could most probably be a date field from formsg and "uncontrollable" by the pipe owner.
  - Dropdown may cause more confusion to the user but could provide more flexibility for the user...
  - My stand is don't need to complicate things.

## Screenshots
After:
![image](https://github.com/opengovsg/plumber/assets/65110268/2e6c6653-747d-4c3b-ab5c-983a33d9eeba)


## Tests
- [x] Current pipe with delay until future timestamp still works
- [x] Current pipe with delay until past timestamp won't work anymore