### PR TITLE
[PLU-224] HOTFIX - further lower M365 spikes rate limiter

### DIFF
--- a/packages/backend/src/apps/m365-excel/common/interceptors/before-request.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/before-request.ts
@@ -8,7 +8,10 @@ import logger from '@/helpers/logger'
 
 import { MS_GRAPH_OAUTH_BASE_URL } from '../constants'
 import { getAccessToken } from '../oauth/token-cache'
-import { consumeOrThrowLimiterWithLongestDelay } from '../rate-limiter'
+import {
+  consumeOrThrowLimiterWithLongestDelay,
+  throttleSpikesForPublishedPipes,
+} from '../rate-limiter'
 
 // This explicitly overcounts - e.g we will log if the request times out, even
 // we can't confirm that it reached Microsoft. The intent is to assume the worst
@@ -63,6 +66,9 @@ const rateLimitCheck: TBeforeRequest = async function ($, requestConfig) {
   }
 
   try {
+    // FIXME (ogp-weeloong): throttle spiky published pipes only.
+    await throttleSpikesForPublishedPipes($, tenantKey)
+
     await consumeOrThrowLimiterWithLongestDelay($, tenantKey, 1)
   } catch (error) {
     if (!(error instanceof RateLimiterRes)) {

--- a/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
+++ b/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
@@ -67,7 +67,9 @@ const excelLimiter = new RateLimiterRedis({
 // within rate limits). This is a workaround to stop spikes until we get
 // BullMQ pro in.
 const spikePreventer = new RateLimiterRedis({
-  // Numbers obtained via trial and error from user reports. We
+  // Numbers obtained via trial and error from user reports, plus some
+  // reasoning: we make ~2 queries per excel step, and we want to allow 3 steps
+  // to progress each time window,
   points: 6,
   duration: 3,
   keyPrefix: 'm365-spike-preventer',
@@ -75,7 +77,7 @@ const spikePreventer = new RateLimiterRedis({
 })
 
 // FIXME (ogp-weeloong): we don't throttle test runs because this limit is too
-// low; at 5 queries per 3 seconds, users can't test pipes with more than 1
+// low; at 6 queries per 3 seconds, users can't test pipes with more than 1
 // excel step. For publisehd pipes, it's not an issue because of auto-retry.
 export async function throttleSpikesForPublishedPipes(
   $: IGlobalVariable,

--- a/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
+++ b/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
@@ -67,8 +67,8 @@ const excelLimiter = new RateLimiterRedis({
 // within rate limits). This is a workaround to stop spikes until we get
 // BullMQ pro in.
 const spikePreventer = new RateLimiterRedis({
-  // Numbers obtained via trial and error from user reports.
-  points: 5,
+  // Numbers obtained via trial and error from user reports. We
+  points: 6,
   duration: 3,
   keyPrefix: 'm365-spike-preventer',
   storeClient: redisClient,

--- a/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
+++ b/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
@@ -67,9 +67,9 @@ const excelLimiter = new RateLimiterRedis({
 // within rate limits). This is a workaround to stop spikes until we get
 // BullMQ pro in.
 const spikePreventer = new RateLimiterRedis({
-  // Analyzing logs over month of March, ~7 QPS is our error-free QPS.
-  points: 7,
-  duration: 1,
+  // Numbers obtained via trial and error from user reports.
+  points: 5,
+  duration: 3,
   keyPrefix: 'm365-spike-preventer',
   storeClient: redisClient,
 })

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -10,7 +10,7 @@ export const REMOVE_AFTER_7_DAYS_OR_50_JOBS = {
 }
 
 export const DEFAULT_JOB_DELAY_DURATION = 0
-export const MAXIMUM_JOB_ATTEMPTS = 6
+export const MAXIMUM_JOB_ATTEMPTS = 20 // FIXME (ogp-weeloong): high number to handle expected increased retries from M465. Revert back to 6 once BullMQ Pro is in.
 
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -10,7 +10,18 @@ export const REMOVE_AFTER_7_DAYS_OR_50_JOBS = {
 }
 
 export const DEFAULT_JOB_DELAY_DURATION = 0
-export const MAXIMUM_JOB_ATTEMPTS = 20 // FIXME (ogp-weeloong): high number to handle expected increased retries from M465. Revert back to 6 once BullMQ Pro is in.
+
+// FIXME (ogp-weeloong): high number to handle expected increased retries from
+// M465. Revert back to 6 once BullMQ Pro is in.
+//
+// Number chosen as follows:
+// - Excel rate limit is 6 per 3 seconds
+// - Excel pipes tend to spike at ~100 submissions per 3 second window
+// - Each excel step takes 2 queries = ~3 excel steps progresses per window,
+//   others get retried. Under high concurrency, we may half this number as all
+//   steps share the same limiter.
+// - So in the worst case, a step may need to be retried 100 / 1.5 ~= 60 times.
+export const MAXIMUM_JOB_ATTEMPTS = 60
 
 export const DEFAULT_JOB_OPTIONS: JobsOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,


### PR DESCRIPTION
## Problem
Users with spiky form submissions (e.g. events) are still facing 429s from Excel. We attempted to hotfix this by rate limiting excel to 7 QPS (#504), but looks like that is still too high.

## Solution
Lower rate limit to 6 per 3 seconds. See comments for reasoning

## Tests
- Test that rate limit works on published pipes
- Regression test: check that a single user can configure and test excel steps on front end no problems.