### PR TITLE
fix: remove richness from normal text fields

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -183,6 +183,10 @@
   &:focus-visible {
     outline: none;
   }
+
+  .node-variable.ProseMirror-selectednode .chakra-badge {
+    box-shadow: 0 0 0 1px var(--chakra-colors-primary-600);
+  }
 }
 
 .editor {

--- a/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
+++ b/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
@@ -19,7 +19,7 @@ export const StepVariable = Node.create<VariableOptions>({
   },
   group: 'inline',
   inline: true,
-  selectable: false,
+  selectable: true,
   atom: true,
   addAttributes() {
     // attributes equivalent of

--- a/packages/frontend/src/components/RichTextEditor/SuggestionPopper.tsx
+++ b/packages/frontend/src/components/RichTextEditor/SuggestionPopper.tsx
@@ -26,6 +26,11 @@ export default function Suggestions(props: SuggestionsProps) {
   const [current, setCurrent] = useState<number | null>(0)
   const [listLength, setListLength] = useState<number>(SHORT_LIST_LENGTH)
 
+  const isEmpty = data.reduce(
+    (acc, step) => acc && step.output.length === 0,
+    true,
+  )
+
   const expandList = () => {
     setListLength(Infinity)
   }
@@ -40,8 +45,8 @@ export default function Suggestions(props: SuggestionsProps) {
 
   return (
     <Paper elevation={5} sx={{ width: '100%' }}>
-      <Typography variant="subtitle2" sx={{ p: 2 }}>
-        Variables
+      <Typography variant="subtitle2" sx={{ p: 2, opacity: isEmpty ? 0.5 : 1 }}>
+        {isEmpty ? 'No variables available' : 'Variables'}
       </Typography>
       <List disablePadding>
         {data.map((option, index) => (

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -5,7 +5,14 @@ import { NodeViewWrapper } from '@tiptap/react'
 export const VariableBadge = ({ node }: { node: Node }) => {
   return (
     <NodeViewWrapper>
-      <Badge maxW="full" variant="solid" bg="primary.100" borderRadius="50px">
+      <Badge
+        maxW="full"
+        variant="solid"
+        bg="primary.100"
+        borderRadius="50px"
+        mx={0.5}
+        cursor="default"
+      >
         <Text isTruncated color="base.content.strong" mr={1}>
           {node.attrs.label}
         </Text>

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -11,13 +11,16 @@ import {
 import { Controller, useFormContext } from 'react-hook-form'
 import { ClickAwayListener, FormControl } from '@mui/material'
 import { FormLabel } from '@opengovsg/design-system-react'
+import Document from '@tiptap/extension-document'
 import Hardbreak from '@tiptap/extension-hard-break'
 import Link from '@tiptap/extension-link'
+import Paragraph from '@tiptap/extension-paragraph'
 import Placeholder from '@tiptap/extension-placeholder'
 import Table from '@tiptap/extension-table'
 import TableCell from '@tiptap/extension-table-cell'
 import TableHeader from '@tiptap/extension-table-header'
 import TableRow from '@tiptap/extension-table-row'
+import Text from '@tiptap/extension-text'
 import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
@@ -29,6 +32,35 @@ import ImageResize from './ResizableImageExtension'
 import { StepVariable } from './StepVariablePlugin'
 import { SuggestionsPopper } from './SuggestionPopper'
 import { genVariableInfoMap, substituteOldTemplates } from './utils'
+
+const RICH_TEXT_EXTENSIONS = [
+  StarterKit.configure({
+    paragraph: {
+      HTMLAttributes: { style: 'margin: 0px' },
+    },
+  }),
+  Link.configure({
+    HTMLAttributes: { rel: null, target: '_blank' },
+  }),
+  Underline,
+  Table.configure({
+    resizable: false,
+    HTMLAttributes: {
+      style: 'border-collapse:collapse;',
+    },
+  }),
+  TableRow,
+  TableHeader,
+  TableCell.configure({
+    HTMLAttributes: {
+      style:
+        'border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;',
+    },
+  }),
+  ImageResize.configure({
+    inline: true,
+  }),
+]
 
 interface EditorProps {
   onChange: (...event: any[]) => void
@@ -60,34 +92,8 @@ const Editor = ({
   }, [priorStepsWithExecutions])
 
   const extensions: Array<any> = [
-    StarterKit.configure({
-      paragraph: {
-        HTMLAttributes: { style: 'margin: 0' },
-      },
-    }),
-    Link.configure({
-      HTMLAttributes: { rel: null, target: '_blank' },
-    }),
-    Underline,
-    Table.configure({
-      resizable: false,
-      HTMLAttributes: {
-        style: 'border-collapse:collapse;',
-      },
-    }),
-    TableRow,
-    TableHeader,
-    TableCell.configure({
-      HTMLAttributes: {
-        style:
-          'border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;',
-      },
-    }),
     Placeholder.configure({
       placeholder,
-    }),
-    ImageResize.configure({
-      inline: true,
     }),
     StepVariable,
   ]
@@ -95,10 +101,17 @@ const Editor = ({
 
   // convert new line character into br elem so tiptap can load the content correctly
   content = content.replaceAll('\n', '<br>')
-  if (!isRich) {
+  if (isRich) {
+    extensions.push(...RICH_TEXT_EXTENSIONS)
+  } else {
     // this extension is to have <br /> as new line instead of new paragraph
     // as new paragraph will translate to a double \n\n instead of \n when getText
     extensions.push(
+      Document,
+      Text,
+      Paragraph.configure({
+        HTMLAttributes: { style: 'margin: 0px' },
+      }),
       Hardbreak.extend({
         addKeyboardShortcuts() {
           return {
@@ -157,7 +170,6 @@ const Editor = ({
           <EditorContent
             className="editor__content"
             editor={editor}
-            placeholder="Hello world"
             onFocus={() => setShowVarSuggestions(true)}
           />
           {variablesEnabled && (


### PR DESCRIPTION
## Problem
Normal text fields show rich text properties such as linkifying text, bolding, italics, bullet points, etc. This is a problem because it causes unintended input from users.

## Solution
- Remove rich text extensions from normal text fields.
- Show highlight border around variable pill on select
- Show greyed-out "no variables available" if there are no variables to select

## Before
<img width="846" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/ad0b9645-9073-46d9-a531-828e14919381">
## After

![image](https://github.com/opengovsg/plumber/assets/10072985/ed3132e6-8cdb-468f-8196-6a4a61fb13f6)
<img width="846" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/f92094cb-fdb1-4551-94b0-33e762066e5e">

