### PR TITLE
[TILES] feat: add context menu to allow right-click deletion of rows

### DIFF
--- a/packages/frontend/src/pages/Tile/components/Table.tsx
+++ b/packages/frontend/src/pages/Tile/components/Table.tsx
@@ -27,6 +27,7 @@ import {
   TEMP_ROW_ID_PREFIX,
   Z_INDEX,
 } from '../constants'
+import { ContextMenuContextProvider } from '../contexts/ContextMenuContext'
 import { useTableContext } from '../contexts/TableContext'
 import { generateColumns } from '../helpers/columns-helper'
 import { scrollToBottom } from '../helpers/scroll-helper'
@@ -248,21 +249,29 @@ export default function Table(): JSX.Element {
               tableState={table.getState()}
             />
           </Flex>
-          <Box h={rowVirtualizer.getTotalSize()} ref={childRef}>
-            {virtualRows.map((virtualRow) => {
-              const row = rows[virtualRow.index] as Row<GenericRowData>
-              if (row) {
-                return (
-                  <TableRow
-                    key={row.id}
-                    row={row}
-                    tableMeta={table.options.meta as TableMeta<GenericRowData>}
-                    virtualRow={virtualRow}
-                  />
-                )
-              }
-            })}
-          </Box>
+          <ContextMenuContextProvider
+            removeRows={removeRows}
+            rowSelection={rowSelection}
+            clearRowSelection={() => setRowSelection({})}
+          >
+            <Box h={rowVirtualizer.getTotalSize()} ref={childRef}>
+              {virtualRows.map((virtualRow) => {
+                const row = rows[virtualRow.index] as Row<GenericRowData>
+                if (row) {
+                  return (
+                    <TableRow
+                      key={row.id}
+                      row={row}
+                      tableMeta={
+                        table.options.meta as TableMeta<GenericRowData>
+                      }
+                      virtualRow={virtualRow}
+                    />
+                  )
+                }
+              })}
+            </Box>
+          </ContextMenuContextProvider>
         </Flex>
         {mode === 'edit' && (
           <TableRow

--- a/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsButton.tsx
@@ -1,23 +1,11 @@
-import { useCallback, useRef, useState } from 'react'
+import { useState } from 'react'
 import { BsTrash } from 'react-icons/bs'
-import {
-  AlertDialog,
-  AlertDialogBody,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogOverlay,
-  Button,
-  Progress,
-  Text,
-} from '@chakra-ui/react'
-import { chunk } from 'lodash'
+import { Button } from '@chakra-ui/react'
 import { ROW_HEIGHT } from 'pages/Tile/constants'
 
 import { useTableContext } from '../../contexts/TableContext'
-import { useDeleteRows } from '../../hooks/useDeleteRows'
 
-const CHUNK_SIZE = 100
+import DeleteRowsModal from './DeleteRowsModal'
 
 interface DeleteRowsButtonProps {
   rowSelection: Record<string, boolean>
@@ -32,33 +20,8 @@ export default function DeleteRowsButton({
   const isViewMode = mode === 'view'
 
   const rowsSelected = Object.keys(rowSelection)
-  const cancelRef = useRef(null)
-  const { deleteRows, rowsDeleting } = useDeleteRows()
-  const [numDeletedRows, setNumDeletedRows] = useState(0)
-  const [numRowsToDelete, setNumRowsToDelete] = useState(0)
-  const [isDeletingRows, setIsDeletingRows] = useState(false)
 
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-
-  const onDelete = useCallback(async () => {
-    setIsDeletingRows(true)
-    const chunks = chunk(rowsSelected, CHUNK_SIZE)
-    for (const chunk of chunks) {
-      await deleteRows(chunk)
-      setNumDeletedRows((prev) => prev + chunk.length)
-      removeRows(chunk)
-    }
-    setTimeout(() => {
-      setIsDialogOpen(false)
-    }, 1000)
-  }, [deleteRows, removeRows, rowsSelected])
-
-  const onOpen = useCallback(() => {
-    setIsDeletingRows(false)
-    setNumDeletedRows(0)
-    setNumRowsToDelete(rowsSelected.length)
-    setIsDialogOpen(true)
-  }, [rowsSelected.length])
 
   if (isViewMode) {
     return null
@@ -78,70 +41,17 @@ export default function DeleteRowsButton({
         size="xs"
         h="100%"
         leftIcon={<BsTrash />}
-        onClick={onOpen}
+        onClick={() => setIsDialogOpen(true)}
       >
         Delete
       </Button>
       {/* lazy load the dialog */}
       {isDialogOpen && (
-        <AlertDialog
-          motionPreset="none"
-          isOpen={true}
-          leastDestructiveRef={cancelRef}
-          trapFocus={false}
-          closeOnOverlayClick={!isDeletingRows}
+        <DeleteRowsModal
+          rowIdsToDelete={rowsSelected}
+          removeRows={removeRows}
           onClose={() => setIsDialogOpen(false)}
-        >
-          <AlertDialogOverlay>
-            <AlertDialogContent>
-              <AlertDialogHeader fontSize="lg" fontWeight="bold">
-                Delete rows
-              </AlertDialogHeader>
-
-              <AlertDialogBody>
-                {isDeletingRows ? (
-                  <>
-                    <Text>
-                      Deleting rows ({numDeletedRows} / {numRowsToDelete})
-                    </Text>
-                    <Progress
-                      value={numDeletedRows}
-                      max={numRowsToDelete}
-                      mt={4}
-                    />
-                  </>
-                ) : (
-                  <Text>
-                    Are you sure you want to <b>{numRowsToDelete}</b> row
-                    {numRowsToDelete > 1 ? 's' : ''}?
-                  </Text>
-                )}
-              </AlertDialogBody>
-
-              <AlertDialogFooter>
-                {!isDeletingRows && (
-                  <Button
-                    colorScheme="secondary"
-                    variant="clear"
-                    ref={cancelRef}
-                    onClick={() => setIsDialogOpen(false)}
-                  >
-                    Cancel
-                  </Button>
-                )}
-                <Button
-                  colorScheme="red"
-                  onClick={onDelete}
-                  ml={3}
-                  isDisabled={isDeletingRows}
-                  isLoading={!!rowsDeleting}
-                >
-                  {isDeletingRows ? 'Done' : 'Delete'}
-                </Button>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialogOverlay>
-        </AlertDialog>
+        />
       )}
     </div>
   )

--- a/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsModal.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsModal.tsx
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+  Progress,
+  Text,
+} from '@chakra-ui/react'
+import { chunk } from 'lodash'
+
+import { useTableContext } from '../../contexts/TableContext'
+import { useDeleteRows } from '../../hooks/useDeleteRows'
+
+const CHUNK_SIZE = 100
+
+interface DeleteRowsModalProps {
+  rowIdsToDelete: string[]
+  removeRows: (rowIds: string[]) => void
+  onClose: () => void
+}
+
+export default function DeleteRowsModal({
+  rowIdsToDelete,
+  removeRows,
+  onClose,
+}: DeleteRowsModalProps) {
+  const { mode } = useTableContext()
+  const isViewMode = mode === 'view'
+
+  const cancelRef = useRef(null)
+  const { deleteRows, rowsDeleting } = useDeleteRows()
+  const [numDeletedRows, setNumDeletedRows] = useState(0)
+  const [numRowsToDelete, setNumRowsToDelete] = useState(0)
+  const [isDeletingRows, setIsDeletingRows] = useState(false)
+
+  const onDelete = useCallback(async () => {
+    setIsDeletingRows(true)
+    const chunks = chunk(rowIdsToDelete, CHUNK_SIZE)
+    for (const chunk of chunks) {
+      await deleteRows(chunk)
+      setNumDeletedRows((prev) => prev + chunk.length)
+      removeRows(chunk)
+    }
+    setTimeout(() => {
+      onClose()
+    }, 1000)
+  }, [deleteRows, onClose, removeRows, rowIdsToDelete])
+
+  useEffect(() => {
+    setIsDeletingRows(false)
+    setNumDeletedRows(0)
+    setNumRowsToDelete(rowIdsToDelete.length)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (isViewMode) {
+    return null
+  }
+
+  return (
+    <AlertDialog
+      motionPreset="none"
+      isOpen={true}
+      leastDestructiveRef={cancelRef}
+      trapFocus={false}
+      closeOnOverlayClick={!isDeletingRows}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Delete rows
+          </AlertDialogHeader>
+
+          <AlertDialogBody>
+            {isDeletingRows ? (
+              <>
+                <Text>
+                  Deleting rows ({numDeletedRows} / {numRowsToDelete})
+                </Text>
+                <Progress value={numDeletedRows} max={numRowsToDelete} mt={4} />
+              </>
+            ) : (
+              <Text>
+                Are you sure you want to <b>{numRowsToDelete}</b> row
+                {numRowsToDelete > 1 ? 's' : ''}?
+              </Text>
+            )}
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            {!isDeletingRows && (
+              <Button
+                colorScheme="secondary"
+                variant="clear"
+                ref={cancelRef}
+                onClick={onClose}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button
+              colorScheme="red"
+              onClick={onDelete}
+              ml={3}
+              isDisabled={isDeletingRows}
+              isLoading={!!rowsDeleting}
+            >
+              {isDeletingRows ? 'Done' : 'Delete'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  )
+}

--- a/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsModal.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter/DeleteRowsModal.tsx
@@ -86,7 +86,7 @@ export default function DeleteRowsModal({
               </>
             ) : (
               <Text>
-                Are you sure you want to <b>{numRowsToDelete}</b> row
+                Are you sure you want to delete <b>{numRowsToDelete}</b> row
                 {numRowsToDelete > 1 ? 's' : ''}?
               </Text>
             )}

--- a/packages/frontend/src/pages/Tile/components/TableRow/index.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableRow/index.tsx
@@ -50,15 +50,17 @@ export default function TableRow({
     [tableMeta.highlightedCell?.row.id, row.id],
   )
   const isRowSelected = row.getIsSelected()
+  const isEditingRow = tableMeta.activeCell?.row.id === row.id
 
   const backgroundColor = useMemo(() => {
     if (isRowSelected) {
       return ROW_COLOR.SELECTED
     }
+    if (isEditingRow) {
+      return ROW_COLOR.EDITING
+    }
     return (virtualRow?.index ?? 0) % 2 ? ROW_COLOR.EVEN : ROW_COLOR.ODD
-  }, [isRowSelected, virtualRow?.index])
-
-  const isEditingRow = tableMeta.activeCell?.row.id === row.id
+  }, [isEditingRow, isRowSelected, virtualRow?.index])
 
   return (
     <RowContextProvider

--- a/packages/frontend/src/pages/Tile/constants.ts
+++ b/packages/frontend/src/pages/Tile/constants.ts
@@ -39,6 +39,7 @@ export const ROW_COLOR = {
   EVEN: 'var(--chakra-colors-secondary-50)',
   ODD: 'white',
   SELECTED: 'var(--chakra-colors-primary-50)',
+  EDITING: 'var(--chakra-colors-primary-100)',
 }
 
 export const HEADER_COLOR = {
@@ -49,6 +50,11 @@ export const HEADER_COLOR = {
 export const BORDER_COLOR = {
   DEFAULT: 'var(--chakra-colors-secondary-100)',
   ACTIVE: 'var(--chakra-colors-secondary-200)',
+}
+
+export const CELL_BOX_SHADOW = {
+  ACTIVE: '0 0 0 2px var(--chakra-colors-primary-400)',
+  HOVER: '0 0 0 1px var(--chakra-colors-primary-400)',
 }
 
 // to reduce transition effects

--- a/packages/frontend/src/pages/Tile/contexts/ContextMenuContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/ContextMenuContext.tsx
@@ -1,0 +1,107 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from 'react'
+import { BsTrash } from 'react-icons/bs'
+import { Menu, MenuButton, MenuItem, MenuList, Portal } from '@chakra-ui/react'
+
+import DeleteRowsModal from '../components/TableFooter/DeleteRowsModal'
+
+interface ContextMenuContextProps {
+  onRightClick: (rowId: string, pos: [number, number]) => void
+  onDeleteRows: (rowIdsToDelete: string[]) => void
+}
+
+const ContextMenuContext = createContext<ContextMenuContextProps | null>(null)
+
+export const useContextMenuContext = () => {
+  const context = useContext(ContextMenuContext)
+  if (!context) {
+    return {} as ContextMenuContextProps
+  }
+  return context
+}
+
+interface ContextMenuContextProviderProps {
+  clearRowSelection: () => void
+  rowSelection: Record<string, boolean>
+  removeRows: (rowIds: string[]) => void
+  children: ReactNode
+}
+
+export const ContextMenuContextProvider = ({
+  rowSelection,
+  clearRowSelection,
+  removeRows,
+  children,
+}: ContextMenuContextProviderProps) => {
+  const [position, setPosition] = useState<[number, number] | null>(null)
+  const [rowIdsToDelete, setRowIdsToDelete] = useState<string[]>([])
+
+  const rowsSelected = Object.keys(rowSelection)
+
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+  const onRightClick = useCallback(
+    (rowId: string, pos: [number, number]) => {
+      setPosition(pos)
+      if (!rowsSelected.includes(rowId)) {
+        clearRowSelection()
+        setRowIdsToDelete([rowId])
+      } else {
+        setRowIdsToDelete(rowsSelected)
+      }
+    },
+    [clearRowSelection, rowsSelected],
+  )
+
+  return (
+    <ContextMenuContext.Provider
+      value={{
+        onRightClick,
+        onDeleteRows: () => setIsDeleteModalOpen(true),
+      }}
+    >
+      {children}
+      <Portal>
+        {position && (
+          <Menu
+            isOpen
+            isLazy
+            gutter={0}
+            closeOnBlur
+            onClose={() => setPosition(null)}
+          >
+            <MenuButton
+              aria-hidden={true}
+              w={0}
+              h={0}
+              position="absolute"
+              left={position[0]}
+              top={position[1]}
+            />
+            <MenuList m={0}>
+              <MenuItem
+                icon={<BsTrash />}
+                color="red.500"
+                onClick={() => setIsDeleteModalOpen(true)}
+              >
+                {rowsSelected.length ? 'Delete selected rows' : 'Delete row'}
+              </MenuItem>
+            </MenuList>
+          </Menu>
+        )}
+      </Portal>
+      {isDeleteModalOpen && (
+        <DeleteRowsModal
+          removeRows={removeRows}
+          onClose={() => setIsDeleteModalOpen(false)}
+          rowIdsToDelete={rowIdsToDelete}
+        />
+      )}
+    </ContextMenuContext.Provider>
+  )
+}


### PR DESCRIPTION
## Problem

Tiles users cannot find the delete button.

## Solution

- Implement context menu to allow deletion by right click

### Multi-row deletion
![Screenshot 2024-04-18 at 3 41 04 PM](https://github.com/opengovsg/plumber/assets/10072985/be939f89-60e8-450a-a380-5f3e88769da8)

### Single-row deletion
<img width="705" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/771d3180-fc33-4c1d-a335-fffb906f7c40">
