### PR TITLE
feat: support query params in webhook triggers

### DIFF
--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -111,6 +111,7 @@ export default async (request: IRequest, response: Response) => {
   // in case it's our built-in generic webhook trigger
   if (isWebhookApp) {
     payload = {
+      ...(request.query ? { _query: request.query } : {}),
       ...request.body,
     }
   }


### PR DESCRIPTION
## Problem

Some users want to send variable via query params.

## Solution

Include query params in data_out for webhook triggers

Things to note:
- All query params will be prefixed with `_query` key
- If a property with key `_query` exists in body, it will overried the query params


<img width="863" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/3bd18637-5f4d-4a79-adfe-d669a03a5175">
