### PR TITLE
PLU-221: Calculator app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9127,6 +9127,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@types/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-e2cOW9YlVzFY2iScnGBBkplKsrn2CsObHQ2Hiw4V1sSyiGbgWL8IyqE3zFi1Pt5o1pdAtYkDAIsF3KKUPjdzaA==",
+      "dev": true
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "license": "MIT",
@@ -10616,6 +10622,18 @@
       "version": "0.14.5",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -22607,6 +22625,7 @@
         "ajv-formats": "^2.1.1",
         "async-mutex": "0.4.0",
         "axios": "1.6.2",
+        "big.js": "6.2.1",
         "cookie-parser": "1.4.6",
         "copyfiles": "^2.4.1",
         "cors": "^2.8.5",
@@ -22652,6 +22671,7 @@
       "devDependencies": {
         "@testcontainers/postgresql": "^10.2.1",
         "@types/bcrypt": "^5.0.0",
+        "@types/big.js": "6.2.2",
         "@types/bull": "^3.15.8",
         "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.12",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,7 @@
     "ajv-formats": "^2.1.1",
     "async-mutex": "0.4.0",
     "axios": "1.6.2",
+    "big.js": "6.2.1",
     "cookie-parser": "1.4.6",
     "copyfiles": "^2.4.1",
     "cors": "^2.8.5",
@@ -84,6 +85,7 @@
   "devDependencies": {
     "@testcontainers/postgresql": "^10.2.1",
     "@types/bcrypt": "^5.0.0",
+    "@types/big.js": "6.2.2",
     "@types/bull": "^3.15.8",
     "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.12",

--- a/packages/backend/src/apps/calculator/__tests__/perform-calculation.test.ts
+++ b/packages/backend/src/apps/calculator/__tests__/perform-calculation.test.ts
@@ -33,19 +33,19 @@ describe('perform calculation', () => {
   it.each([
     {
       params: { firstNumber: '3.25', op: 'add', secondNumber: '5' },
-      expectedResult: 8.25,
+      expectedResult: '8.25',
     },
     {
       params: { firstNumber: '3.25', op: 'subtract', secondNumber: '5' },
-      expectedResult: -1.75,
+      expectedResult: '-1.75',
     },
     {
       params: { firstNumber: '3.25', op: 'multiply', secondNumber: '1.5' },
-      expectedResult: 4.875,
+      expectedResult: '4.875',
     },
     {
       params: { firstNumber: '-108.375', op: 'divide', secondNumber: '8.5' },
-      expectedResult: -12.75,
+      expectedResult: '-12.75',
     },
   ])(
     'can $params.op $params.firstNumber with $params.secondNumber',
@@ -96,7 +96,9 @@ describe('perform calculation', () => {
           expect.unreachable()
         } else {
           expect(err.message).toEqual(
-            expect.stringContaining('did not yield a valid calculation'),
+            expect.stringContaining(
+              "Error performing calculation: 'Division by zero'",
+            ),
           )
         }
       }

--- a/packages/backend/src/apps/calculator/__tests__/perform-calculation.test.ts
+++ b/packages/backend/src/apps/calculator/__tests__/perform-calculation.test.ts
@@ -1,0 +1,105 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+
+import performCalculationAction from '../actions/perform-calculation'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('perform calculation', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      app: {
+        name: 'calculator',
+      },
+      step: {
+        position: 2,
+        parameters: {},
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    {
+      params: { firstNumber: '3.25', op: 'add', secondNumber: '5' },
+      expectedResult: 8.25,
+    },
+    {
+      params: { firstNumber: '3.25', op: 'subtract', secondNumber: '5' },
+      expectedResult: -1.75,
+    },
+    {
+      params: { firstNumber: '3.25', op: 'multiply', secondNumber: '1.5' },
+      expectedResult: 4.875,
+    },
+    {
+      params: { firstNumber: '-108.375', op: 'divide', secondNumber: '8.5' },
+      expectedResult: -12.75,
+    },
+  ])(
+    'can $params.op $params.firstNumber with $params.secondNumber',
+    async ({ params, expectedResult }) => {
+      $.step.parameters = params
+      await performCalculationAction.run($)
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { result: expectedResult },
+      })
+    },
+  )
+
+  it.each([
+    { firstNumber: 'not a number', op: 'divide', secondNumber: '8.5' },
+    { firstNumber: '850', op: 'invalid op', secondNumber: '8.5' },
+    { firstNumber: '850', op: 'add', secondNumber: '' },
+  ])(
+    'rejects bad parameters (firstNumber = $firstNumber, op = $op, secondNumber = $secondNumber)',
+    async (params) => {
+      $.step.parameters = params
+      try {
+        await performCalculationAction.run($)
+        expect.unreachable()
+      } catch (err) {
+        if (!(err instanceof StepError)) {
+          expect.unreachable()
+        } else {
+          expect(err.message).toEqual(
+            expect.stringContaining('Configuration problem: '),
+          )
+        }
+      }
+    },
+  )
+
+  it.each([
+    { firstNumber: '100', op: 'divide', secondNumber: '0' },
+    { firstNumber: '0', op: 'divide', secondNumber: '0' },
+  ])(
+    'errors on invalid calculation ($firstNumber $op $secondNumber)',
+    async (params) => {
+      $.step.parameters = params
+      try {
+        await performCalculationAction.run($)
+        expect.unreachable()
+      } catch (err) {
+        if (!(err instanceof StepError)) {
+          expect.unreachable()
+        } else {
+          expect(err.message).toEqual(
+            expect.stringContaining('did not yield a valid calculation'),
+          )
+        }
+      }
+    },
+  )
+})

--- a/packages/backend/src/apps/calculator/__tests__/round-to-decimal-places.test.ts
+++ b/packages/backend/src/apps/calculator/__tests__/round-to-decimal-places.test.ts
@@ -1,0 +1,147 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+
+import roundtoDecimalPlacesAction from '../actions/round-to-decimal-places'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+describe('perform calculation', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      app: {
+        name: 'formatter',
+      },
+      step: {
+        position: 2,
+        parameters: {},
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    // Round off
+    {
+      params: { value: '1.234', op: 'roundOff', toDecimalPlaces: '2' },
+      expectedResult: '1.23',
+    },
+    {
+      params: { value: '1.235', op: 'roundOff', toDecimalPlaces: '2' },
+      expectedResult: '1.24',
+    },
+    {
+      params: { value: '-1.235', op: 'roundOff', toDecimalPlaces: '2' },
+      expectedResult: '-1.24',
+    },
+    {
+      params: { value: '1.235', op: 'roundOff', toDecimalPlaces: '5' },
+      expectedResult: '1.23500',
+    },
+    {
+      params: { value: '1.235', op: 'roundOff', toDecimalPlaces: '0' },
+      expectedResult: '1',
+    },
+    {
+      params: { value: '2', op: 'roundOff', toDecimalPlaces: '0' },
+      expectedResult: '2',
+    },
+    // Round up
+    {
+      params: { value: '1.234', op: 'roundUp', toDecimalPlaces: '2' },
+      expectedResult: '1.24',
+    },
+    {
+      params: { value: '1.235', op: 'roundUp', toDecimalPlaces: '2' },
+      expectedResult: '1.24',
+    },
+    {
+      params: { value: '-1.235', op: 'roundUp', toDecimalPlaces: '2' },
+      expectedResult: '-1.24',
+    },
+    {
+      params: { value: '1.235', op: 'roundUp', toDecimalPlaces: '5' },
+      expectedResult: '1.23500',
+    },
+    {
+      params: { value: '1.235', op: 'roundUp', toDecimalPlaces: '0' },
+      expectedResult: '2',
+    },
+    {
+      params: { value: '2', op: 'roundUp', toDecimalPlaces: '0' },
+      expectedResult: '2',
+    },
+    // Round down
+    {
+      params: { value: '1.234', op: 'roundDown', toDecimalPlaces: '2' },
+      expectedResult: '1.23',
+    },
+    {
+      params: { value: '1.235', op: 'roundDown', toDecimalPlaces: '2' },
+      expectedResult: '1.23',
+    },
+    {
+      params: { value: '-1.235', op: 'roundDown', toDecimalPlaces: '2' },
+      expectedResult: '-1.23',
+    },
+    {
+      params: { value: '1.235', op: 'roundDown', toDecimalPlaces: '5' },
+      expectedResult: '1.23500',
+    },
+    {
+      params: { value: '1.235', op: 'roundDown', toDecimalPlaces: '0' },
+      expectedResult: '1',
+    },
+    {
+      params: { value: '2', op: 'roundDown', toDecimalPlaces: '0' },
+      expectedResult: '2',
+    },
+  ])(
+    'can $params.op $params.value to $params.toDecimalPlaces decimal places',
+    async ({ params, expectedResult }) => {
+      $.step.parameters = params
+      await roundtoDecimalPlacesAction.run($)
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { result: expectedResult },
+      })
+    },
+  )
+
+  it.each([
+    { value: 'not a number', op: 'roundUp', toDecimalPlaces: '2' },
+    { value: '', op: 'roundUp', toDecimalPlaces: '2' },
+    { value: '2.1234', op: 'not an op', toDecimalPlaces: '2' },
+    { value: '2.1234', op: '', toDecimalPlaces: '2' },
+    { value: '2.1234', op: 'roundOff', toDecimalPlaces: 'not a number' },
+    { value: '2.1234', op: 'roundOff', toDecimalPlaces: '-1' },
+    { value: '2.1234', op: 'roundOff', toDecimalPlaces: '2.6' },
+    { value: '2.1234', op: 'roundOff', toDecimalPlaces: '' },
+  ])(
+    'rejects bad parameters (value = $value, op = $op, toDecimalPlaces = $toDecimalPlaces)',
+    async (params) => {
+      $.step.parameters = params
+      try {
+        await roundtoDecimalPlacesAction.run($)
+        expect.unreachable()
+      } catch (err) {
+        if (!(err instanceof StepError)) {
+          expect.unreachable()
+        } else {
+          expect(err.message).toEqual(
+            expect.stringContaining('Configuration problem: '),
+          )
+        }
+      }
+    },
+  )
+})

--- a/packages/backend/src/apps/calculator/actions/index.ts
+++ b/packages/backend/src/apps/calculator/actions/index.ts
@@ -1,0 +1,4 @@
+import performCalculation from './perform-calculation'
+import roundToDecimalPlaces from './round-to-decimal-places'
+
+export default [performCalculation, roundToDecimalPlaces]

--- a/packages/backend/src/apps/calculator/actions/perform-calculation/fields.ts
+++ b/packages/backend/src/apps/calculator/actions/perform-calculation/fields.ts
@@ -1,0 +1,45 @@
+import type { IRawAction } from '@plumber/types'
+
+import { capitalize } from 'lodash'
+import z from 'zod'
+
+import { ensureZodObjectKey } from '@/helpers/zod-utils'
+
+import { numericStringSchema } from '../../common/numeric-string-schema'
+
+const opTypeEnum = z.enum(['add', 'subtract', 'multiply', 'divide'])
+
+export const fieldSchema = z.object({
+  firstNumber: numericStringSchema,
+  op: opTypeEnum,
+  secondNumber: numericStringSchema,
+})
+
+export const fields = [
+  {
+    label: 'Number to transform',
+    key: ensureZodObjectKey(fieldSchema, 'firstNumber'),
+    type: 'string' as const,
+    required: true,
+    variables: true,
+  },
+  {
+    label: 'Math operation to perform',
+    key: ensureZodObjectKey(fieldSchema, 'op'),
+    type: 'dropdown' as const,
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: opTypeEnum.options.map((op) => ({
+      label: capitalize(op),
+      value: op,
+    })),
+  },
+  {
+    placeholder: 'Value',
+    key: ensureZodObjectKey(fieldSchema, 'secondNumber'),
+    type: 'string' as const,
+    required: true,
+    variables: true,
+  },
+] satisfies IRawAction['arguments']

--- a/packages/backend/src/apps/calculator/actions/perform-calculation/index.ts
+++ b/packages/backend/src/apps/calculator/actions/perform-calculation/index.ts
@@ -1,0 +1,70 @@
+import type { IRawAction } from '@plumber/types'
+
+import { ZodError } from 'zod'
+
+import StepError, { GenericSolution } from '@/errors/step'
+import { firstZodParseError } from '@/helpers/zod-utils'
+
+import { fields, fieldSchema } from './fields'
+
+const action = {
+  name: 'Perform a calculation',
+  key: 'performCalculation',
+  description: 'Add, subtract, multiply or divide',
+  arguments: fields,
+
+  async run($) {
+    try {
+      const { firstNumber, op, secondNumber } = fieldSchema.parse(
+        $.step.parameters,
+      )
+
+      let result = 0
+      switch (op) {
+        case 'add':
+          result = firstNumber + secondNumber
+          break
+        case 'subtract':
+          result = firstNumber - secondNumber
+          break
+        case 'multiply':
+          result = firstNumber * secondNumber
+          break
+        case 'divide':
+          result = firstNumber / secondNumber
+          break
+      }
+
+      if (isNaN(result) || !isFinite(result)) {
+        // e.g. division by 0
+        throw new Error(
+          `${firstNumber} ${op} ${secondNumber} did not yield a valid calculation`,
+        )
+      }
+
+      $.setActionItem({
+        raw: {
+          result,
+        },
+      })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new StepError(
+          `Configuration problem: '${firstZodParseError(error)}'`,
+          GenericSolution.ReconfigureInvalidField,
+          $.step.position,
+          $.app.name,
+        )
+      } else {
+        throw new StepError(
+          `Error performing calculation: '${error.message}'`,
+          'Ensure that you have entered valid numbers.',
+          $.step.position,
+          $.app.name,
+        )
+      }
+    }
+  },
+} satisfies IRawAction
+
+export default action

--- a/packages/backend/src/apps/calculator/actions/round-to-decimal-places/fields.ts
+++ b/packages/backend/src/apps/calculator/actions/round-to-decimal-places/fields.ts
@@ -1,0 +1,59 @@
+import type { IRawAction } from '@plumber/types'
+
+import z from 'zod'
+
+import { ensureZodEnumValue, ensureZodObjectKey } from '@/helpers/zod-utils'
+
+import { numericStringSchema } from '../../common/numeric-string-schema'
+
+const opTypeEnum = z.enum(['roundDown', 'roundUp', 'roundOff'])
+
+export const fieldSchema = z.object({
+  value: numericStringSchema,
+  op: opTypeEnum,
+  toDecimalPlaces: numericStringSchema.pipe(
+    z
+      .number()
+      .int('Enter whole numbers without decimals')
+      .nonnegative('Enter a number greater than 0'),
+  ),
+})
+
+export const fields = [
+  {
+    label: 'Number to round',
+    key: ensureZodObjectKey(fieldSchema, 'value'),
+    type: 'string' as const,
+    required: true,
+    variables: true,
+  },
+  {
+    label: 'Rounding',
+    key: ensureZodObjectKey(fieldSchema, 'op'),
+    type: 'dropdown' as const,
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: [
+      {
+        label: 'Round Down',
+        value: ensureZodEnumValue(opTypeEnum, 'roundDown'),
+      },
+      {
+        label: 'Round Up',
+        value: ensureZodEnumValue(opTypeEnum, 'roundUp'),
+      },
+      {
+        label: 'Round Off',
+        value: ensureZodEnumValue(opTypeEnum, 'roundOff'),
+      },
+    ],
+  },
+  {
+    label: 'Decimal places',
+    key: ensureZodObjectKey(fieldSchema, 'toDecimalPlaces'),
+    type: 'string' as const,
+    required: true,
+    variables: true,
+  },
+] satisfies IRawAction['arguments']

--- a/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
+++ b/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
@@ -6,6 +6,8 @@ import { ZodError } from 'zod'
 import StepError, { GenericSolution } from '@/errors/step'
 import { firstZodParseError } from '@/helpers/zod-utils'
 
+import { formatBigJsErrorMessage } from '../../common/format-bigjs-error-message'
+
 import { fields, fieldSchema } from './fields'
 
 const action = {
@@ -46,9 +48,16 @@ const action = {
           $.step.position,
           $.app.name,
         )
+      } else if (error instanceof Error) {
+        throw new StepError(
+          `Error performing rounding: '${formatBigJsErrorMessage(error)}'`,
+          'Ensure that you have entered valid numbers.',
+          $.step.position,
+          $.app.name,
+        )
       } else {
         throw new StepError(
-          `Error performing rounding: '${error.message}'`,
+          `Error performing rounding`,
           'Ensure that you have entered valid numbers.',
           $.step.position,
           $.app.name,

--- a/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
+++ b/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
@@ -1,0 +1,61 @@
+import type { IRawAction } from '@plumber/types'
+
+import Big from 'big.js'
+import { ZodError } from 'zod'
+
+import StepError, { GenericSolution } from '@/errors/step'
+import { firstZodParseError } from '@/helpers/zod-utils'
+
+import { fields, fieldSchema } from './fields'
+
+const action = {
+  name: 'Round number',
+  key: 'roundToDecimalPlaces',
+  description: 'Round a number with a decimal down, up or off',
+  arguments: fields,
+
+  async run($) {
+    try {
+      const { value, op, toDecimalPlaces } = fieldSchema.parse(
+        $.step.parameters,
+      )
+
+      let result = ''
+      switch (op) {
+        case 'roundOff':
+          result = new Big(value).toFixed(toDecimalPlaces)
+          break
+        case 'roundUp':
+          result = new Big(value).toFixed(toDecimalPlaces, Big.roundUp)
+          break
+        case 'roundDown':
+          result = new Big(value).toFixed(toDecimalPlaces, Big.roundDown)
+          break
+      }
+
+      $.setActionItem({
+        raw: {
+          result,
+        },
+      })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        throw new StepError(
+          `Configuration problem: '${firstZodParseError(error)}'`,
+          GenericSolution.ReconfigureInvalidField,
+          $.step.position,
+          $.app.name,
+        )
+      } else {
+        throw new StepError(
+          `Error performing rounding: '${error.message}'`,
+          'Ensure that you have entered valid numbers.',
+          $.step.position,
+          $.app.name,
+        )
+      }
+    }
+  },
+} satisfies IRawAction
+
+export default action

--- a/packages/backend/src/apps/calculator/assets/favicon.svg
+++ b/packages/backend/src/apps/calculator/assets/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" style="fill: rgba(207, 26, 104, 1);transform: ;msFilter:;"><path d="M19 2H5c-1.103 0-2 .897-2 2v16c0 1.103.897 2 2 2h14c1.103 0 2-.897 2-2V4c0-1.103-.897-2-2-2zM5 20V4h14l.001 16H5z"></path><path d="M7 12h2v2H7zm0 4h2v2H7zm4-4h2v2h-2zM7 6h10v4H7zm4 10h2v2h-2zm4-4h2v6h-2z"></path></svg>

--- a/packages/backend/src/apps/calculator/common/format-bigjs-error-message.ts
+++ b/packages/backend/src/apps/calculator/common/format-bigjs-error-message.ts
@@ -1,0 +1,11 @@
+const BIG_JS_PREFIX = '[big.js] '
+
+// Big.js prefixes their errors with '[big.js] ', let's remove that to
+// prevent confusion.
+export function formatBigJsErrorMessage(error: Error): string {
+  if (!error.message.startsWith(BIG_JS_PREFIX)) {
+    return error.message
+  }
+
+  return error.message.substring(BIG_JS_PREFIX.length)
+}

--- a/packages/backend/src/apps/calculator/common/numeric-string-schema.ts
+++ b/packages/backend/src/apps/calculator/common/numeric-string-schema.ts
@@ -1,0 +1,10 @@
+import z from 'zod'
+
+export const numericStringSchema = z
+  .string({
+    required_error: 'No value found',
+  })
+  .trim()
+  .min(1, { message: 'No value found' })
+  .transform((amount) => Number(amount))
+  .pipe(z.number({ invalid_type_error: 'Enter a number' }))

--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -12,6 +12,7 @@ const app: IApp = {
   primaryColor: '000000',
   actions,
   description: 'Perform calculations on numbers in your data',
+  isNewApp: true,
 }
 
 export default app

--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -1,0 +1,17 @@
+import type { IApp } from '@plumber/types'
+
+import actions from './actions'
+
+const app: IApp = {
+  name: 'Calculator',
+  key: 'calculator',
+  iconUrl: '{BASE_URL}/apps/calculator/assets/favicon.svg',
+  authDocUrl: 'https://guide.plumber.gov.sg/user-guides/actions/calculator',
+  baseUrl: '',
+  apiBaseUrl: '',
+  primaryColor: '000000',
+  actions,
+  description: 'Perform calculations on numbers in your data',
+}
+
+export default app

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -13,6 +13,7 @@ const app: IApp = {
   actions,
   description:
     'Manipulate your data, such as changing date formats or adding days to a date',
+  isNewApp: true,
 }
 
 export default app

--- a/packages/backend/src/apps/index.ts
+++ b/packages/backend/src/apps/index.ts
@@ -1,5 +1,6 @@
-import { IApp } from '@plumber/types'
+import type { IApp } from '@plumber/types'
 
+import calculatorApp from './calculator'
 import customApiApp from './custom-api'
 import delayApp from './delay'
 import formatterApp from './formatter'
@@ -18,6 +19,7 @@ import vaultWorkspaceApp from './vault-workspace'
 import webhookApp from './webhook'
 
 const apps: Record<string, IApp> = {
+  [calculatorApp.key]: calculatorApp,
   [customApiApp.key]: customApiApp,
   [delayApp.key]: delayApp,
   [formatterApp.key]: formatterApp,

--- a/packages/backend/src/apps/tiles/index.ts
+++ b/packages/backend/src/apps/tiles/index.ts
@@ -17,6 +17,7 @@ const app: IApp = {
   actions,
   dynamicData,
   getTransferDetails,
+  isNewApp: true,
 }
 
 export default app

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -170,6 +170,7 @@ type App {
   actions: [Action]
   connections: [Connection]
   description: String
+  isNewApp: Boolean
 }
 
 type AppAuth {

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -33,14 +33,11 @@ type ChooseAppAndEventSubstepProps = {
   isLastStep: boolean
 }
 
-const optionGenerator = (app: {
-  name: string
-  key: string
-  description?: string
-}): { label: string; value: string; description: string } => ({
+const optionGenerator = (app: IApp) /* inferred return type */ => ({
   label: app.name as string,
   value: app.key as string,
   description: app?.description as string,
+  isNewApp: !!app?.isNewApp,
 })
 
 const eventOptionGenerator = (app: {
@@ -85,7 +82,7 @@ function ChooseAppAndEventSubstep(
   )
 
   apps?.sort((a, b) => {
-    if (a.description) {
+    if (a.isNewApp) {
       return -1
     }
     return a.name.localeCompare(b.name)
@@ -270,7 +267,7 @@ function ChooseAppAndEventSubstep(
                 <Flex py={1} flexDir="column">
                   <Flex gap={2} alignItems="center">
                     <Text>{option.label}</Text>
-                    {option.description && (
+                    {option.isNewApp && (
                       <Badge
                         bgColor="interaction.muted.main.active"
                         color="primary.600"
@@ -298,6 +295,7 @@ function ChooseAppAndEventSubstep(
                 label: '',
                 value: '',
                 description: '',
+                isNewApp: false,
               }
             }
             onChange={onAppChange}

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -80,8 +80,14 @@ function ChooseAppAndEventSubstep(
   )
 
   apps?.sort((a, b) => {
+    if (a.isNewApp && b.isNewApp) {
+      return a.name.localeCompare(b.name)
+    }
     if (a.isNewApp) {
       return -1
+    }
+    if (b.isNewApp) {
+      return 1
     }
     return a.name.localeCompare(b.name)
   })

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -4,12 +4,10 @@ import { type SyntheticEvent, useCallback, useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import { Flex, FormControl, Text } from '@chakra-ui/react'
 import Autocomplete from '@mui/material/Autocomplete'
-import Button from '@mui/material/Button'
-import Chip from '@mui/material/Chip'
 import Collapse from '@mui/material/Collapse'
 import ListItem from '@mui/material/ListItem'
 import TextField from '@mui/material/TextField'
-import { Badge, FormLabel } from '@opengovsg/design-system-react'
+import { Badge, Button, FormLabel } from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from 'config/flags'
 import { EditorContext } from 'contexts/Editor'
@@ -322,7 +320,14 @@ function ChooseAppAndEventSubstep(
                         ...params.InputProps,
                         endAdornment: (
                           <>
-                            {isWebhook && <Chip label="Instant" />}
+                            {isWebhook && (
+                              <Badge
+                                bgColor="interaction.muted.neutral.active"
+                                color="secondary.600"
+                              >
+                                Instant
+                              </Badge>
+                            )}
 
                             {params.InputProps.endAdornment}
                           </>
@@ -355,7 +360,12 @@ function ChooseAppAndEventSubstep(
                     </Flex>
 
                     {option.type === 'webhook' && (
-                      <Chip label="Instant" sx={{ mr: 3 }} />
+                      <Badge
+                        bgColor="interaction.muted.neutral.active"
+                        color="secondary.600"
+                      >
+                        Instant
+                      </Badge>
                     )}
                   </li>
                 )}
@@ -386,11 +396,10 @@ function ChooseAppAndEventSubstep(
           )}
 
           <Button
-            fullWidth
-            variant="contained"
+            isFullWidth
             onClick={onSubmit}
-            sx={{ mt: 2 }}
-            disabled={!valid || editorContext.readOnly}
+            mt={4}
+            isDisabled={!valid || editorContext.readOnly}
             data-test="flow-substep-continue-button"
           >
             Continue

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -19,6 +19,7 @@ export const GET_APPS = gql`
       primaryColor
       connectionCount
       description
+      isNewApp
       auth {
         connectionType
         connectionRegistrationType

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -349,6 +349,7 @@ export interface IApp {
   actions?: IAction[]
   connections?: IConnection[]
   description?: string
+  isNewApp?: boolean
 
   /**
    * A callback that is invoked if there's an error for any HTTP request this


### PR DESCRIPTION
## Problem
Our users need to perform calculations on numbers, such as converting dollars to cents and vice versa.

## Solution
We will introduce a new calculator app that can perform 2 functions:
- Basic math - add, subtract, multiply, divide
- Rounding decimals

We use `big.js` to deal with floating point [idiosyncracies](https://stackoverflow.com/questions/1458633/how-can-i-deal-with-floating-point-number-precision-in-javascript) in JS (_e.g. 12.34 + 456.789 breaks without big.js_)

This PR also introduces a new `isNewApp` flag, so that we can display the new badge independent of app description. And migrates some more stuff to chakra.

#### Calculator app
<img width="500" alt="Screenshot 2024-04-29 at 4 24 18 PM" src="https://github.com/opengovsg/plumber/assets/135598754/155e7496-3021-4424-b143-5341db134f97">

#### `isNewApp` flag
<img width="500" alt="Screenshot 2024-04-29 at 4 24 41 PM" src="https://github.com/opengovsg/plumber/assets/135598754/41c9a499-1671-4c1d-a6c4-c87040c52302">

## Tests
- New unit tests
- Check that add, subtract, minus and divide operations work as expected.
- Check that rounding works as expected
- Check that we get nice error messages if I input invalid numbers in rounding or calculations
- Regression test: check that I can still build other pipes.

## Deploy Notes
**New dependencies**:
- `big.js`: for dealing with javascript rounding idiosyncracies

