### PR TITLE
fix: preserve variable labels in text fields

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -39,13 +39,15 @@ function substituteTemplateStringWithSpan(
   const searchRegex = /({{[^{}]+}})/
   const nodes = s.split(searchRegex)
   for (const i in nodes) {
-    if (!searchRegex.test(nodes[i])) {
+    const node = nodes[i]
+    if (!searchRegex.test(node)) {
       continue
     }
-    const id = nodes[i].replace('{{', '').replace('}}', '')
+    const id = node.replace('{{', '').replace('}}', '')
     const idComponents = id.split('.')
-    const label = idComponents[idComponents.length - 1]
-    const value = varInfo.get(nodes[i])?.testRunValue || ''
+    const varInfoForNode = varInfo.get(node)
+    const value = varInfoForNode?.testRunValue || ''
+    const label = varInfoForNode?.label || idComponents[idComponents.length - 1]
     nodes[
       i
     ] = `<span data-type="variable" data-id="${id}" data-label="${label}" data-value="${value}">${nodes[i]}</span>`


### PR DESCRIPTION
## Problem

Variable labels disappear after re-render
![Screenshot 2024-04-30 at 6 17 04 PM](https://github.com/opengovsg/plumber/assets/10072985/6c5c82cc-6c69-4b1d-a702-e3be7f5370f7)


## Solution

Properly set variable labels on render.
![Screenshot 2024-04-30 at 6 15 49 PM](https://github.com/opengovsg/plumber/assets/10072985/64076859-fbea-41af-88fd-282f14444497)

