### PR TITLE
(BETA) Bulk retry execution failures

### DIFF
--- a/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
+++ b/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
@@ -66,19 +66,15 @@ const excelLimiter = new RateLimiterRedis({
 // FIXME (ogp-weeloong): it turns out MS Graph cannot tolerate 10 QPS spikes
 // and will reply with HTTP 429 if we do that (even though it's technically
 // within rate limits). This is a workaround to stop these spikes until we get
-// BullMQ pro in, by choking ourselves to at most 1 step per 3 seconds per
+// BullMQ pro in, by choking ourselves to at most 1 step per 1 second per
 // file (hypothesis is that Excel can't handle bursts to the same file)
-//
-// 3 seconds was chosen as that was the P90 of excel API calls over past 2
-// weeks.
 //
 // Note that we don't throttle test runs to enable users to test pipes with more
 // than 1 excel step. For published pipes, it's not an issue because of
 // auto-retry.
-const P90_EXCEL_API_RTT_SECONDS = 3
 const perFileStepLimiter = new RateLimiterRedis({
   points: 1,
-  duration: P90_EXCEL_API_RTT_SECONDS,
+  duration: 1,
   keyPrefix: 'm365-per-file-step-limiter',
   storeClient: redisClient,
 })
@@ -99,10 +95,7 @@ export async function throttleStepsForPublishedPipes(
 
     throw new RetriableError({
       error: 'Reached M365 step limit',
-      // If we're rate limited, we're probably facing a spike of steps for that
-      // file, so spread out retries over a wider time period (2x) to reduce the
-      // size of the retry thundering herd at any point in time.
-      delayInMs: P90_EXCEL_API_RTT_SECONDS * 1000 * 2,
+      delayInMs: 'default',
     })
   }
 }

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -1,4 +1,5 @@
 import type { MutationResolvers } from './__generated__/types.generated'
+import bulkRetryExecutions from './mutations/bulk-retry-executions'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
 import createFlowTransfer from './mutations/create-flow-transfer'
@@ -43,6 +44,7 @@ import verifyOtp from './mutations/verify-otp'
  */
 
 export default {
+  bulkRetryExecutions,
   createConnection,
   generateAuthUrl,
   updateConnection,

--- a/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
@@ -5,6 +5,8 @@ import actionQueue from '@/queues/action'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
+const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000
+
 const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
   _parent,
   params,
@@ -18,8 +20,12 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
     .where('executions.flow_id', params.input.flowId)
     .where('executions.test_run', false)
     .where('executions.status', 'failure')
+    .where(
+      'executions.created_at',
+      '>=',
+      new Date(Date.now() - SEVEN_DAYS_IN_MS).toISOString(),
+    )
     .select('executions.id')
-    .limit(500)
   let latestFailedExecutionSteps = await ExecutionStep.query()
     .whereIn(
       'execution_id',
@@ -32,10 +38,11 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
     .distinctOn('execution_id')
     .select('execution_id', 'status', 'job_id')
 
-  // Double check that latest steps for each failed execution is a failure.
+  // Double check that latest steps for each failed execution is a failure and
+  // has a valid job ID.
   latestFailedExecutionSteps = latestFailedExecutionSteps.filter(
     (executionStep) => {
-      const { id: executionStepId, executionId, status } = executionStep
+      const { id: executionStepId, executionId, status, jobId } = executionStep
       if (status !== 'failure') {
         logger.error(
           'Latest execution step is not failed for a failed execution',
@@ -45,6 +52,15 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
             executionStepId: executionStepId,
           },
         )
+        return false
+      }
+      if (jobId === null || jobId === undefined) {
+        // For fresh per-app queues, job ID can be 0.
+        logger.error('Latest execution step does not have a job ID', {
+          event: 'bulk-retry-step-no-job-id',
+          executionId: executionId,
+          executionStepId: executionStepId,
+        })
         return false
       }
       return true
@@ -86,6 +102,7 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
   const allSuccessfullyRetried = !retryAttempts.find(
     (attempt) => attempt.status === 'rejected',
   )
+
   if (!allSuccessfullyRetried) {
     // Actually we can do some more processing to see which IDs failed but nvm.
     logger.warn('Some attempts in bulk execution retry failed', {

--- a/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
@@ -1,0 +1,84 @@
+import logger from '@/helpers/logger'
+import actionQueue from '@/queues/action'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  // Fetch failed executions along with their latest execution step. Since we
+  // run steps serially, latest execution step in a failed execution has to be
+  // the one that failed.
+  const failedExecutions = await context.currentUser
+    .$relatedQuery('executions')
+    .where('flow_id', params.input.flowId)
+    .where('test_run', false)
+    .where('executions.status', 'failure')
+    .withGraphJoined({ executionSteps: true })
+    .orderBy([
+      { column: 'executions.id' },
+      { column: 'executionSteps:created_at', order: 'desc' },
+    ])
+    .distinctOn('executions.id')
+
+  // For each failed execution, retry the latest step (if its a failure).
+  const promises = failedExecutions.map(async (execution) => {
+    const executionStep = execution.executionSteps[0]
+    const { jobId, status } = executionStep
+
+    // Sanity check
+    if (status !== 'failure') {
+      logger.error(
+        'Latest execution step is not failed for a failed execution',
+        {
+          event: 'bulk-retry-step-status-mismatch',
+          executionId: execution.id,
+          executionStepId: executionStep.id,
+        },
+      )
+
+      return null
+    } else {
+      logger.info('Bulk retrying execution step', {
+        event: 'bulk-retry-step-start',
+        executionId: execution.id,
+        executionStepId: executionStep.id,
+      })
+    }
+
+    const job = await actionQueue.getJob(jobId)
+    if (!job) {
+      // if job cannot be found anymore, remove the job id from the execution step so it cannot be retried again
+      await executionStep.$query().patch({ jobId: null })
+      throw new Error(
+        `Job for ${execution.id}-${executionStep.id} not found or has expired`,
+      )
+    }
+
+    await job.retry()
+    await execution.$query().patch({ status: null })
+  })
+
+  const retryAttempts = await Promise.allSettled(promises)
+
+  const allSuccessfullyRetried = !retryAttempts.find(
+    (attempt) => attempt.status === 'rejected',
+  )
+
+  // Actually we can do some more processing to see which IDs failed but nvm.
+  if (!allSuccessfullyRetried) {
+    logger.warn('Some attempts in bulk execution retry failed', {
+      event: 'bulk-retry-some-attempts-failed',
+      flowId: params.input.flowId,
+    })
+  }
+
+  return {
+    numFailedExecutions: failedExecutions.length,
+    allSuccessfullyRetried,
+  }
+}
+
+export default bulkRetryExecutions

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -67,6 +67,9 @@ type Mutation {
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
   retryExecutionStep(input: RetryExecutionStepInput): Boolean
+  bulkRetryExecutions(
+    input: BulkRetryExecutionsInput
+  ): BulkRetryExecutionsResult!
   logout: Boolean
   loginWithSgid(input: LoginWithSgidInput!): LoginWithSgidResult!
   loginWithSelectedSgid(
@@ -300,6 +303,11 @@ type Execution {
   flow: Flow
 }
 
+type BulkRetryExecutionsResult {
+  numFailedExecutions: Int!
+  allSuccessfullyRetried: Boolean!
+}
+
 input CreateConnectionInput {
   key: String!
   formattedData: JSONObject!
@@ -401,6 +409,10 @@ input VerifyOtpInput {
 
 input RetryExecutionStepInput {
   executionStepId: String!
+}
+
+input BulkRetryExecutionsInput {
+  flowId: String!
 }
 
 """

--- a/packages/frontend/src/components/ExecutionStep/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/RetryAllButton.tsx
@@ -1,0 +1,72 @@
+import { IExecution } from '@plumber/types'
+
+import { useCallback, useContext, useState } from 'react'
+import { TbArrowForwardUpDouble } from 'react-icons/tb'
+import { useMutation } from '@apollo/client'
+import { Icon } from '@chakra-ui/react'
+import { Button, Spinner, useToast } from '@opengovsg/design-system-react'
+import { BULK_RETRY_EXECUTIONS_FLAG } from 'config/flags'
+import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
+import { BULK_RETRY_EXECUTIONS } from 'graphql/mutations/bulk-retry-executions'
+
+interface RetryAllButtonProps {
+  execution: IExecution
+}
+
+export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
+  const flowId = execution.flow?.id
+  const { flags } = useContext(LaunchDarklyContext)
+  const toast = useToast()
+  const [isBulkRetrying, setIsBulkRetrying] = useState(false)
+  const [hasBulkRetried, setHasBulkRetried] = useState(false)
+  const [bulkRetryExecutions] = useMutation(BULK_RETRY_EXECUTIONS)
+  const onBulkRetryExecutions = useCallback(async () => {
+    setIsBulkRetrying(true)
+    try {
+      const result = await bulkRetryExecutions({
+        variables: {
+          input: {
+            flowId: flowId ?? '',
+          },
+        },
+      })
+      let message =
+        'Plumber has started retrying all failures for this pipe. Please check the executions page after a while to see updated status.'
+      if (result.data?.bulkRetryExecutions?.numFailedExecutions === 0) {
+        message = 'Plumber did not find any failed executions to retry.'
+      } else if (!result.data?.bulkRetryExecutions?.allSuccessfullyRetried) {
+        message =
+          'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
+      }
+
+      toast({
+        title: message,
+        status: 'info',
+        duration: 3000,
+        isClosable: true,
+        position: 'top',
+      })
+    } finally {
+      setIsBulkRetrying(false)
+      setHasBulkRetried(true)
+    }
+  }, [flowId, bulkRetryExecutions, toast])
+
+  if (!flags?.[BULK_RETRY_EXECUTIONS_FLAG]) {
+    return null
+  }
+
+  return (
+    <Button
+      variant="clear"
+      leftIcon={<Icon boxSize={6} as={TbArrowForwardUpDouble} />}
+      isLoading={isBulkRetrying}
+      isDisabled={hasBulkRetried}
+      spinner={<Spinner fontSize={24} />}
+      size="md"
+      onClick={onBulkRetryExecutions}
+    >
+      Retry all failures for this pipe
+    </Button>
+  )
+}

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -1,6 +1,5 @@
-import type { IApp, IExecutionStep } from '@plumber/types'
+import type { IApp, IExecution, IExecutionStep } from '@plumber/types'
 
-import * as React from 'react'
 import { BiSolidCheckCircle, BiSolidErrorCircle } from 'react-icons/bi'
 import { useQuery } from '@apollo/client'
 import {
@@ -21,11 +20,13 @@ import JSONViewer from 'components/JSONViewer'
 import { GET_APP } from 'graphql/queries/get-app'
 import { EXECUTION_STEP_PER_PAGE } from 'pages/Execution'
 
+import { RetryAllButton } from './RetryAllButton'
 import RetryButton from './RetryButton'
 
 type ExecutionStepProps = {
   index: number
   page: number
+  execution: IExecution
   executionStep: IExecutionStep
 }
 
@@ -50,6 +51,7 @@ const getStepPosition = (page: number, index: number) => {
 export default function ExecutionStep({
   index,
   page,
+  execution,
   executionStep,
 }: ExecutionStepProps): React.ReactElement | null {
   const { data } = useQuery(GET_APP, {
@@ -63,10 +65,12 @@ export default function ExecutionStep({
   }
 
   const isStepSuccessful = executionStep.status === 'success'
+  const hasExecutionFailed = execution.status === 'failure'
 
   const hasError = !!executionStep.errorDetails
 
-  const canRetry = !isStepSuccessful && !!executionStep.jobId
+  const canRetry =
+    !isStepSuccessful && !!executionStep.jobId && hasExecutionFailed
 
   return (
     <Card boxShadow="none" border="1px solid" borderColor="base.divider.medium">
@@ -105,7 +109,10 @@ export default function ExecutionStep({
               </Text>
             </Box>
           </HStack>
-          {canRetry && <RetryButton executionStepId={executionStep.id} />}
+          <HStack>
+            {canRetry && <RetryAllButton execution={execution} />}
+            {canRetry && <RetryButton executionStepId={executionStep.id} />}
+          </HStack>
         </HStack>
 
         {/* bottom half: data in, data out and error */}

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -9,6 +9,7 @@ export const BANNER_TEXT_FLAG = 'banner_display'
 /**
  * Feature flags
  */
+export const BULK_RETRY_EXECUTIONS_FLAG = 'bulk-retry-failed-executions-v1'
 export const SGID_FEATURE_FLAG = 'sgid-login'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
 

--- a/packages/frontend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/frontend/src/graphql/mutations/bulk-retry-executions.ts
@@ -1,0 +1,10 @@
+import { graphql } from '../__generated__/gql'
+
+export const BULK_RETRY_EXECUTIONS = graphql(`
+  mutation BulkRetryExecutions($input: BulkRetryExecutionsInput) {
+    bulkRetryExecutions(input: $input) {
+      numFailedExecutions
+      allSuccessfullyRetried
+    }
+  }
+`)

--- a/packages/frontend/src/graphql/queries/get-execution.ts
+++ b/packages/frontend/src/graphql/queries/get-execution.ts
@@ -12,6 +12,7 @@ export const GET_EXECUTION = gql`
         name
         active
       }
+      status
     }
   }
 `

--- a/packages/frontend/src/pages/Execution/index.tsx
+++ b/packages/frontend/src/pages/Execution/index.tsx
@@ -1,16 +1,12 @@
 import type { IExecutionStep } from '@plumber/types'
 
-import { useCallback, useContext, useState } from 'react'
 import { useParams, useSearchParams } from 'react-router-dom'
-import { useMutation, useQuery } from '@apollo/client'
-import { Box, Button, Flex, Grid, Text, useToast } from '@chakra-ui/react'
+import { useQuery } from '@apollo/client'
+import { Box, Flex, Grid, Text } from '@chakra-ui/react'
 import { Infobox, Pagination, Spinner } from '@opengovsg/design-system-react'
 import Container from 'components/Container'
 import ExecutionHeader from 'components/ExecutionHeader'
 import ExecutionStep from 'components/ExecutionStep'
-import { BULK_RETRY_EXECUTIONS_FLAG } from 'config/flags'
-import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
-import { BULK_RETRY_EXECUTIONS } from 'graphql/mutations/bulk-retry-executions'
 import { GET_EXECUTION } from 'graphql/queries/get-execution'
 import { GET_EXECUTION_STEPS } from 'graphql/queries/get-execution-steps'
 
@@ -25,11 +21,11 @@ const getLimitAndOffset = (page: number) => ({
   offset: (page - 1) * EXECUTION_STEP_PER_PAGE,
 })
 
-export default function Execution(): React.ReactElement {
+export default function Execution() {
   const { executionId } = useParams() as ExecutionParams
   const [searchParams, setSearchParams] = useSearchParams()
   const page = parseInt(searchParams.get('page') || '', 10) || 1
-  const { data: execution } = useQuery(GET_EXECUTION, {
+  const { data: executionData } = useQuery(GET_EXECUTION, {
     variables: { executionId },
   })
   const { data, loading } = useQuery(GET_EXECUTION_STEPS, {
@@ -41,59 +37,15 @@ export default function Execution(): React.ReactElement {
     (edge: { node: IExecutionStep }) => edge.node,
   )
 
-  // FIXME (ogp-weeloong: move this elsewhere and spruce up looks.)
-  const flowId = execution?.getExecution?.flow?.id
-  const { flags } = useContext(LaunchDarklyContext)
-  const toast = useToast()
-  const [isBulkRetrying, setIsBulkRetrying] = useState(false)
-  const [bulkRetryExecutions] = useMutation(BULK_RETRY_EXECUTIONS)
-  const onBulkRetryExecutions = useCallback(async () => {
-    setIsBulkRetrying(true)
-    try {
-      const result = await bulkRetryExecutions({
-        variables: {
-          input: {
-            flowId: flowId ?? '',
-          },
-        },
-      })
-      let message =
-        'Plumber has started retrying all failures for this pipe. Please check the executions page after a while to see updated status.'
-      if (result.data?.bulkRetryExecutions?.numFailedExecutions === 0) {
-        message = 'Plumber did not find any failed executions to retry.'
-      } else if (!result.data?.bulkRetryExecutions?.allSuccessfullyRetried) {
-        message =
-          'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
-      }
+  const execution = executionData?.getExecution
 
-      toast({
-        title: message,
-        status: 'info',
-        duration: 3000,
-        isClosable: true,
-        position: 'top',
-      })
-    } finally {
-      setIsBulkRetrying(false)
-    }
-  }, [flowId, bulkRetryExecutions, toast])
+  if (!execution) {
+    return <Spinner fontSize={36} margin="auto" />
+  }
 
   return (
     <Container sx={{ py: 3 }}>
-      <ExecutionHeader execution={execution?.getExecution} />
-
-      {flags?.[BULK_RETRY_EXECUTIONS_FLAG] && (
-        <Button
-          variant="outline"
-          isDisabled={loading}
-          isLoading={isBulkRetrying}
-          spinner={<Spinner fontSize={24} />}
-          size="md"
-          onClick={onBulkRetryExecutions}
-        >
-          Retry all failed executions for this pipe (BETA)
-        </Button>
-      )}
+      <ExecutionHeader execution={execution} />
 
       <Grid mt={4} mb={{ base: '16px', sm: '40px' }} rowGap={6}>
         {!loading && !executionSteps?.length && (
@@ -115,6 +67,7 @@ export default function Execution(): React.ReactElement {
         {executionSteps?.map((executionStep, i) => (
           <ExecutionStep
             key={executionStep.id}
+            execution={execution}
             executionStep={executionStep}
             index={i}
             page={page}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -103,7 +103,7 @@ export interface IExecution {
   flowId: string
   flow: IFlow
   testRun: boolean
-  status: 'success' | 'failure'
+  status: 'success' | 'failure' | null
   executionSteps: IExecutionStep[]
   updatedAt: string
   createdAt: string


### PR DESCRIPTION
## Problem
One of our power users has to retry ~200+ failed pipes due to Excel failures.

## Solution
We will provide give him a button that retries all failed executions for a particular pipe. This is scrappy as we will gate the feature to him only.

## Tests
- Check that it retries all failed executions
- Check that it does not retry successful executions