### PR TITLE
[HOTPATCH] Executions status stuck at null after maximal automated retries

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -153,6 +153,10 @@
     {
       "name": "M365_SG_GOVT_ALLOWED_SENSITIVITY_LABEL_GUIDS_CSV",
       "valueFrom": "plumber-<ENVIRONMENT>-m365-sg-govt-allowed-sensitivity-label-guids-csv"
+    },
+    {
+      "name": "M365_STEPS_LIMIT_PER_SEC",
+      "valueFrom": "plumber-<ENVIRONMENT>-m365-steps-limit-per-sec"
     }
   ]
 }

--- a/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
+++ b/packages/backend/src/apps/m365-excel/common/rate-limiter.ts
@@ -7,7 +7,10 @@ import {
   RateLimiterUnion,
 } from 'rate-limiter-flexible'
 
-import { M365TenantKey } from '@/config/app-env-vars/m365'
+import {
+  M365_STEPS_LIMIT_PER_SEC,
+  M365TenantKey,
+} from '@/config/app-env-vars/m365'
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import RetriableError from '@/errors/retriable-error'
 import logger from '@/helpers/logger'
@@ -73,7 +76,7 @@ const excelLimiter = new RateLimiterRedis({
 // than 1 excel step. For published pipes, it's not an issue because of
 // auto-retry.
 const perFileStepLimiter = new RateLimiterRedis({
-  points: 1,
+  points: M365_STEPS_LIMIT_PER_SEC,
   duration: 1,
   keyPrefix: 'm365-per-file-step-limiter',
   storeClient: redisClient,

--- a/packages/backend/src/config/app-env-vars/m365.ts
+++ b/packages/backend/src/config/app-env-vars/m365.ts
@@ -2,6 +2,10 @@ import z from 'zod'
 
 import appConfig from '../app'
 
+export const M365_STEPS_LIMIT_PER_SEC = Number(
+  process.env.M365_STEPS_LIMIT_PER_SEC ?? 1,
+)
+
 if (!appConfig) {
   throw new Error('Cyclic import of appConfig from app-env-vars')
 }

--- a/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
@@ -118,6 +118,7 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
           event: 'bulk-retry-step-job-getstate-error',
           oldJobData: job.data,
           oldJobId: job.id,
+          error,
         })
 
         throw error

--- a/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-executions.ts
@@ -54,17 +54,15 @@ const bulkRetryExecutions: MutationResolvers['bulkRetryExecutions'] = async (
   let latestFailedExecutionSteps: ExecutionStep[] = []
   // Admin usage only
   if (context.currentUser.email === 'plumber@open.gov.sg') {
-    if (params.input.executionId) {
-      latestFailedExecutionSteps.push(
-        await ExecutionStep.query()
-          .findById(params.input.executionId)
-          .orderBy([
-            { column: 'execution_id' },
-            { column: 'created_at', order: 'desc' },
-          ])
-          .distinctOn('execution_id')
-          .select('id', 'execution_id', 'status', 'job_id'),
-      )
+    if (params.input.executionIds) {
+      latestFailedExecutionSteps = await ExecutionStep.query()
+        .findByIds(params.input.executionIds)
+        .orderBy([
+          { column: 'execution_id' },
+          { column: 'created_at', order: 'desc' },
+        ])
+        .distinctOn('execution_id')
+        .select('id', 'execution_id', 'status', 'job_id')
     } else if (params.input.flowId) {
       latestFailedExecutionSteps = await getAllFailedExecutionSteps(
         Execution.query(),

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -412,7 +412,7 @@ input RetryExecutionStepInput {
 }
 
 input BulkRetryExecutionsInput {
-  flowId: String!
+  flowId: String
   executionId: String
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -413,6 +413,7 @@ input RetryExecutionStepInput {
 
 input BulkRetryExecutionsInput {
   flowId: String!
+  executionId: String
 }
 
 """

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -412,7 +412,7 @@ input RetryExecutionStepInput {
 }
 
 input BulkRetryExecutionsInput {
-  flowId: String
+  flowId: String!
   executionIds: [String!]
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -413,7 +413,7 @@ input RetryExecutionStepInput {
 
 input BulkRetryExecutionsInput {
   flowId: String
-  executionId: String
+  executionIds: [String!]
 }
 
 """

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -78,13 +78,14 @@ export const worker = new WorkerPro(
             !(e instanceof UnrecoverableError) &&
             job.attemptsMade < MAXIMUM_JOB_ATTEMPTS - 1
 
+          logger.info('Failed execution', {
+            event: 'failed-execution-job-info',
+            ...jobData,
+          })
           if (!isRetriable) {
-            logger.info('Failing execution due to non-retriable error.', {
-              event: 'failing-non-retriable-execution',
-              ...jobData,
-            })
             await Execution.setStatus(executionId, 'failure')
           }
+
           throw e
         }
       }

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -71,7 +71,6 @@ export const worker = new WorkerPro(
       if (executionStep.isFailed) {
         // Properly fixed in https://github.com/opengovsg/plumber/pull/548
         try {
-          await Execution.setStatus(executionId, 'failure')
           return handleErrorAndThrow(executionStep.errorDetails, executionError)
         } catch (e) {
           const isRetriable =

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -65,7 +65,7 @@ export default function ExecutionStep({
   }
 
   const isStepSuccessful = executionStep.status === 'success'
-  const hasExecutionFailed = execution.status === 'failure'
+  const hasExecutionFailed = execution.status !== 'success' // Account for NULL execution status.
 
   const hasError = !!executionStep.errorDetails
 

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -65,7 +65,7 @@ export default function ExecutionStep({
   }
 
   const isStepSuccessful = executionStep.status === 'success'
-  const hasExecutionFailed = execution.status !== 'success' // Account for NULL execution status.
+  const hasExecutionFailed = execution.status === 'failure'
 
   const hasError = !!executionStep.errorDetails
 


### PR DESCRIPTION
## Problem
#553 made it so that execution statuses are not set to `failure` until we are no longer going to retry. Unfortunately, due to an off by one error in `attemptsMade`, we always think that we will retry.

Furthermore, `job.retry()` does not reset `attemptsMade`, so retried jobs will never auto retry. This is unexpected behaviour, so we will fix this.

## Solution
1. Allow admins to retry "stuck" executions
2. Instead of calling `job.retry()`, we will remove the old job and enqueue a new job, to refresh `attemptsMade`.

## Tests
- Check that executions correctly fail after max automated attempts
- Check that retried jobs still go through automated retries.
- Check that only failed jobs are re-enqueued as a new job during a retry
- Check that retried executions are updated with the correct status