### PR TITLE
PLU-247: chore: log invalid number comparison

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -121,15 +121,16 @@ describe('Only continue if', () => {
     },
   )
 
-  it('should throw step error if a non-number is used for operator comparison', async () => {
-    $.step.parameters = {
-      field: 123,
-      is: 'is',
-      condition: 'gte',
-      text: '19 Nov 2021',
-    }
+  // TODO (mal): uncomment after 1 week of monitoring
+  // it('should throw step error if a non-number is used for operator comparison', async () => {
+  //   $.step.parameters = {
+  //     field: 123,
+  //     is: 'is',
+  //     condition: 'gte',
+  //     text: '19 Nov 2021',
+  //   }
 
-    // throw partial step error message
-    await expect(onlyContinueIfAction.run($)).rejects.toThrowError(StepError)
-  })
+  //   // throw partial step error message
+  //   await expect(onlyContinueIfAction.run($)).rejects.toThrowError(StepError)
+  // })
 })

--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -2,8 +2,6 @@ import { type IGlobalVariable } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import StepError from '@/errors/step'
-
 import onlyContinueIfAction from '../../actions/only-continue-if'
 
 const mocks = vi.hoisted(() => ({

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -2,7 +2,7 @@ import type { IJSONObject, IJSONValue } from '@plumber/types'
 
 function compareNumbers(
   field: IJSONValue,
-  condition: IJSONValue,
+  condition: 'gte' | 'gt' | 'lte' | 'lt',
   value: IJSONValue,
 ): boolean {
   // WARNING: can only compare safely up till Number.MAX_SAFE_INTEGER but BigInt cannot compare floats...
@@ -18,10 +18,6 @@ function compareNumbers(
       return Number(field) <= Number(value)
     case 'lt':
       return Number(field) < Number(value)
-    default:
-      throw new Error(
-        `Conditional logic block contains an unknown operator: ${condition}`,
-      )
   }
 }
 
@@ -33,6 +29,12 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
   switch (condition) {
     case 'equals':
       result = field === value
+      break
+    case 'gte':
+    case 'gt':
+    case 'lte':
+    case 'lt':
+      result = compareNumbers(field, condition, value)
       break
     case 'contains':
       result = field.toString().includes(value.toString())
@@ -49,7 +51,9 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
       result = field === null || field === undefined || field === ''
       break
     default:
-      result = compareNumbers(field, condition, value)
+      throw new Error(
+        `Conditional logic block contains an unknown operator: ${condition}`,
+      )
   }
 
   if (is === 'not') {

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -1,4 +1,29 @@
-import type { IJSONObject } from '@plumber/types'
+import type { IJSONObject, IJSONValue } from '@plumber/types'
+
+function compareNumbers(
+  field: IJSONValue,
+  condition: IJSONValue,
+  value: IJSONValue,
+): boolean {
+  // WARNING: can only compare safely up till Number.MAX_SAFE_INTEGER but BigInt cannot compare floats...
+  if (isNaN(Number(field)) || isNaN(Number(value))) {
+    throw new Error('Non-number used in field or value for comparison')
+  }
+  switch (condition) {
+    case 'gte':
+      return Number(field) >= Number(value)
+    case 'gt':
+      return Number(field) > Number(value)
+    case 'lte':
+      return Number(field) <= Number(value)
+    case 'lt':
+      return Number(field) < Number(value)
+    default:
+      throw new Error(
+        `Conditional logic block contains an unknown operator: ${condition}`,
+      )
+  }
+}
 
 export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
   // `value` is named `text` for legacy reasons.
@@ -8,18 +33,6 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
   switch (condition) {
     case 'equals':
       result = field === value
-      break
-    case 'gte':
-      result = Number(field) >= Number(value)
-      break
-    case 'gt':
-      result = Number(field) > Number(value)
-      break
-    case 'lte':
-      result = Number(field) <= Number(value)
-      break
-    case 'lt':
-      result = Number(field) < Number(value)
       break
     case 'contains':
       result = field.toString().includes(value.toString())
@@ -36,9 +49,7 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
       result = field === null || field === undefined || field === ''
       break
     default:
-      throw new Error(
-        `Conditional logic block contains an unknown operator: ${condition}`,
-      )
+      result = compareNumbers(field, condition, value)
   }
 
   if (is === 'not') {

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -1,5 +1,7 @@
 import type { IJSONObject, IJSONValue } from '@plumber/types'
 
+import logger from '@/helpers/logger'
+
 function compareNumbers(
   field: IJSONValue,
   condition: 'gte' | 'gt' | 'lte' | 'lt',
@@ -7,7 +9,14 @@ function compareNumbers(
 ): boolean {
   // WARNING: can only compare safely up till Number.MAX_SAFE_INTEGER but BigInt cannot compare floats...
   if (isNaN(Number(field)) || isNaN(Number(value))) {
-    throw new Error('Non-number used in field or value for comparison')
+    logger.info('Non-number comparison occurred', {
+      event: 'non-number-comparison',
+      field,
+      condition,
+      value,
+    })
+    // TODO (mal): uncomment after 1 week of monitoring
+    // throw new Error('Non-number used in field or value for comparison')
   }
   switch (condition) {
     case 'gte':


### PR DESCRIPTION
## Problem
User tries to compare dates which give false info

![image](https://github.com/opengovsg/plumber/assets/65110268/e7b828c4-0bcf-405c-902e-888d45656a2e)
![image](https://github.com/opengovsg/plumber/assets/65110268/d3943594-5a3b-4995-b467-bbd0b54c1439)

## Solution
- Log if any operands are NaN in the comparison for numbers: we will monitor for a week on datadog for the event: `non-number-comparison` before throwing step error
- Add unit tests to cover all the comparison operators as well

## Tests
- [x] All comparison operators still work as intended (=, <, <=, >, >=, contains, empty)
- [x] Negation operator still work
- [x] Both only continue if and if-then pipe still work with the configuration