### PR TITLE
[PLU-244] fix: prevent marshalling of unsafe values, handle neg values

### DIFF
--- a/packages/backend/src/models/dynamodb/__tests__/helper.test.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/helper.test.ts
@@ -14,8 +14,13 @@ describe('dynamodb helpers', () => {
       const rawValue = {
         text: 'abc',
         int: '123',
+        negativeInt: '-123',
         float: '12.444',
+        negativeFloat: '-12.444',
         invalidFloat: '12.444.444',
+        invalidNegativeFloat: '--12.444',
+        numberExceedingMaxSafe: '9007199254740992',
+        numberUnderMinSafe: '-9007199254740992',
         exponential: '1e+3',
         mixed: '123abc',
       }
@@ -23,8 +28,13 @@ describe('dynamodb helpers', () => {
       expect(autoMarshallDataObj(rawValue)).toEqual({
         text: 'abc',
         int: 123,
+        negativeInt: -123,
         float: 12.444,
+        negativeFloat: -12.444,
         invalidFloat: '12.444.444',
+        invalidNegativeFloat: '--12.444',
+        numberExceedingMaxSafe: '9007199254740992',
+        numberUnderMinSafe: '-9007199254740992',
         exponential: '1e+3',
         mixed: '123abc',
       })

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -34,10 +34,15 @@ export function autoMarshallNumberStrings(value: string): string | number {
   // only accepts string that contains only numbers and a single decimal point
   if (
     typeof value === 'string' &&
-    /^\d+(\.\d+)?$/.test(value) &&
+    /^-{0,1}\d+(\.\d+)?$/.test(value) &&
     !isNaN(+value)
   ) {
-    return +value
+    if (
+      +value <= Number.MAX_SAFE_INTEGER &&
+      +value >= Number.MIN_SAFE_INTEGER
+    ) {
+      return +value
+    }
   }
   return value
 }


### PR DESCRIPTION
## Problem

DynamoDB error when trying to store integers above MAX_SAFE_INTEGER

## Solution

- Prevent marshalling of values > MAX_SAFE_INTEGER and < MIN_SAFE_INTEGER
- Also properly marshalls negative values