### PR TITLE
PLU-259: Update privacy & terms of use

### DIFF
--- a/packages/frontend/src/components/Footer/index.tsx
+++ b/packages/frontend/src/components/Footer/index.tsx
@@ -1,6 +1,11 @@
 import { RestrictedFooter } from '@opengovsg/design-system-react'
 import appConfig from 'config/app'
-import { FEEDBACK_FORM_LINK, GUIDE_LINK } from 'config/urls'
+import {
+  FEEDBACK_FORM_LINK,
+  GUIDE_LINK,
+  PRIVACY_STATEMENT_LINK,
+  TERMS_OF_USE_LINK,
+} from 'config/urls'
 
 export const Footer = () => (
   <RestrictedFooter
@@ -17,11 +22,11 @@ export const Footer = () => (
       },
       {
         label: 'Privacy',
-        href: 'https://hack.gov.sg/2023/HFPGprivacy',
+        href: PRIVACY_STATEMENT_LINK,
       },
       {
         label: 'Terms of Use',
-        href: 'https://hack.gov.sg/2023/HFPGTC/',
+        href: TERMS_OF_USE_LINK,
       },
       {
         label: 'Report Vulnerability',

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -88,6 +88,10 @@ export const APP_ICON_URL = (appKey: string): string =>
 // external links
 export const OGP_HOMEPAGE = 'https://open.gov.sg'
 export const GUIDE_LINK = 'https://guide.plumber.gov.sg'
+export const PRIVACY_STATEMENT_LINK =
+  'https://guide.plumber.gov.sg/legal/government-agency-privacy-statement'
+export const TERMS_OF_USE_LINK =
+  'https://guide.plumber.gov.sg/legal/terms-of-use'
 export const FEEDBACK_FORM_LINK = 'https://go.gov.sg/plumber-feedback'
 export const STATUS_LINK = 'https://status.plumber.gov.sg/'
 export const SGID_CHECK_ELIGIBILITY_URL =


### PR DESCRIPTION
## Problem
We have an updated privacy statement and terms of use from legal.

## Solution
Put privacy statement and terms of use in our gitbook (similar to go.gov.sg). Putting them in a PDF seemed too scrappy, while putting them as a page in code seemed like too much eng effort.

## Tests
- Check that wording in gitbook is the same as legal's documents
- Check that footer links work