### PR TITLE
[PLU-238] TILES-COLLAB: List only

### DIFF
--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -1,3 +1,5 @@
+import sortBy from 'lodash/sortBy'
+
 import type { Resolvers } from '../__generated__/types.generated'
 
 type TableMetadataResolver = Resolvers['TableMetadata']
@@ -10,6 +12,25 @@ const columns: TableMetadataResolver['columns'] = async (parent) => {
   return columns
 }
 
+const collaborators: TableMetadataResolver['collaborators'] = async (
+  parent,
+) => {
+  const collaborators = await parent
+    .$relatedQuery('collaborators')
+    .select('email', 'role')
+    .orderBy('role', 'desc')
+  return sortBy(
+    collaborators,
+    [
+      (collab) => {
+        return ['owner', 'editor', 'viewer'].indexOf(collab.role)
+      },
+    ],
+    (collab) => collab.email,
+  ) as { email: string; role: string }[]
+}
+
 export default {
   columns,
+  collaborators,
 } satisfies TableMetadataResolver

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -640,12 +640,18 @@ type TableColumnMetadata {
   config: TableColumnConfig!
 }
 
+type TableCollaborator {
+  email: String!
+  role: String!
+}
+
 type TableMetadata {
   id: ID!
   name: String!
   columns: [TableColumnMetadata!]
   lastAccessedAt: String!
   viewOnlyKey: String
+  collaborators: [TableCollaborator!]
 }
 
 # End Tiles types

--- a/packages/frontend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table.ts
@@ -14,6 +14,10 @@ export const GET_TABLE = gql`
           width
         }
       }
+      collaborators {
+        email
+        role
+      }
     }
   }
 `

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { BiCopy, BiShareAlt } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import {
+  Divider,
   Flex,
   FormControl,
   InputGroup,
@@ -113,6 +114,7 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
                 </FormHelperText>
               )}
             </VStack>
+            <Divider my={6} />
             <TableCollaborators />
           </FormControl>
         </ModalBody>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -31,6 +31,8 @@ import { GET_TABLE } from 'graphql/queries/tiles/get-table'
 
 import { useTableContext } from '../../contexts/TableContext'
 
+import TableCollaborators from './TableCollaborators'
+
 const ShareModal = ({ onClose }: { onClose: () => void }) => {
   const { tableId, viewOnlyKey } = useTableContext()
   const [isNewLink, setIsNewLink] = useState(false)
@@ -111,6 +113,7 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
                 </FormHelperText>
               )}
             </VStack>
+            <TableCollaborators />
           </FormControl>
         </ModalBody>
         <ModalFooter></ModalFooter>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -1,0 +1,166 @@
+import { ITableCollaborator, ITableCollabRole } from '@plumber/types'
+
+import { FormEventHandler, useContext, useState } from 'react'
+import { BiChevronDown, BiTrash } from 'react-icons/bi'
+import {
+  Divider,
+  Flex,
+  FormControl,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  Button,
+  ButtonProps,
+  IconButton,
+  Input,
+  Menu,
+} from '@opengovsg/design-system-react'
+import { AuthenticationContext } from 'contexts/Authentication'
+import { useTableContext } from 'pages/Tile/contexts/TableContext'
+
+const TableCollabRoleSelect = ({
+  value,
+  onChange,
+  isEditable,
+  variant = 'outline',
+}: {
+  value: ITableCollabRole
+  onChange: (val: ITableCollabRole) => void
+  isEditable: boolean
+  variant?: ButtonProps['variant']
+}) => {
+  return (
+    <Menu gutter={0}>
+      <MenuButton
+        as={Button}
+        pointerEvents={isEditable ? 'auto' : 'none'}
+        colorScheme="secondary"
+        variant={variant}
+        w={32}
+        px={6}
+        textTransform="capitalize"
+        rightIcon={isEditable ? <BiChevronDown /> : undefined}
+        textAlign={variant === 'clear' ? 'left' : 'center'}
+      >
+        {value}
+      </MenuButton>
+      <MenuList w={32}>
+        <MenuItem onClick={() => onChange('editor')}>Editor</MenuItem>
+        <MenuItem onClick={() => onChange('viewer')}>Viewer</MenuItem>
+      </MenuList>
+    </Menu>
+  )
+}
+
+const AddNewCollaborator = () => {
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<ITableCollabRole>('editor')
+  const [isAdding, setIsAdding] = useState(false)
+
+  const onAdd: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
+    setIsAdding(true)
+    console.log('Adding collaborator', email, role)
+    setIsAdding(false)
+    setEmail('')
+    setRole('editor')
+  }
+
+  return (
+    <form
+      style={{
+        width: '100%',
+      }}
+      onSubmit={onAdd}
+    >
+      <FormControl>
+        <VStack spacing={2} alignItems="flex-start">
+          <Text textStyle="subhead-3">People with access</Text>
+          <Flex alignSelf="stretch" gap={2}>
+            <Input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <TableCollabRoleSelect
+              value={role}
+              onChange={setRole}
+              isEditable={true}
+            />
+          </Flex>
+          <Button
+            colorScheme="primary"
+            variant="outline"
+            type="submit"
+            isLoading={isAdding}
+          >
+            Add collaborator
+          </Button>
+        </VStack>
+      </FormControl>
+    </form>
+  )
+}
+
+const CollaboratorListRow = ({
+  collaborator,
+  onRoleChange,
+  onDelete,
+}: {
+  collaborator: ITableCollaborator
+  onRoleChange: (role: ITableCollabRole) => void
+  onDelete: () => void
+}) => {
+  const { currentUser } = useContext(AuthenticationContext)
+  const isEditable =
+    collaborator.role !== 'owner' && collaborator.email !== currentUser?.email
+
+  return (
+    <Flex alignItems="center" w="100%" py={1} px={4}>
+      <Text flex={1}>{collaborator.email}</Text>
+      <TableCollabRoleSelect
+        value={collaborator.role}
+        onChange={onRoleChange}
+        variant="clear"
+        isEditable={isEditable}
+      />
+      <IconButton
+        colorScheme="red"
+        isDisabled={!isEditable}
+        onClick={onDelete}
+        aria-label={'remove collaborator'}
+        variant="clear"
+        icon={<BiTrash />}
+      />
+    </Flex>
+  )
+}
+
+const TableCollaborators = () => {
+  const { collaborators } = useTableContext()
+
+  if (!collaborators) {
+    return null
+  }
+  return (
+    <VStack mt={5} gap={2}>
+      <AddNewCollaborator />
+      <VStack w="100%" divider={<Divider />}>
+        {collaborators.map((collab) => (
+          <CollaboratorListRow
+            key={collab.email}
+            collaborator={collab}
+            onRoleChange={() => null}
+            onDelete={() => null}
+          />
+        ))}
+      </VStack>
+    </VStack>
+  )
+}
+
+export default TableCollaborators

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -79,7 +79,7 @@ const AddNewCollaborator = () => {
     >
       <FormControl>
         <VStack spacing={2} alignItems="flex-start">
-          <Text textStyle="subhead-3">People with access</Text>
+          <Text textStyle="subhead-3">Collaborators</Text>
           <Flex alignSelf="stretch" gap={2}>
             <Input
               type="email"
@@ -122,20 +122,23 @@ const CollaboratorListRow = ({
   return (
     <Flex alignItems="center" w="100%" py={1} px={4}>
       <Text flex={1}>{collaborator.email}</Text>
-      <TableCollabRoleSelect
-        value={collaborator.role}
-        onChange={onRoleChange}
-        variant="clear"
-        isEditable={isEditable}
-      />
-      <IconButton
-        colorScheme="red"
-        isDisabled={!isEditable}
-        onClick={onDelete}
-        aria-label={'remove collaborator'}
-        variant="clear"
-        icon={<BiTrash />}
-      />
+      <Flex w={44}>
+        <TableCollabRoleSelect
+          value={collaborator.role}
+          onChange={onRoleChange}
+          variant="clear"
+          isEditable={isEditable}
+        />
+        {isEditable && (
+          <IconButton
+            colorScheme="red"
+            onClick={onDelete}
+            aria-label={'remove collaborator'}
+            variant="clear"
+            icon={<BiTrash />}
+          />
+        )}
+      </Flex>
     </Flex>
   )
 }
@@ -147,7 +150,7 @@ const TableCollaborators = () => {
     return null
   }
   return (
-    <VStack mt={5} gap={2}>
+    <VStack gap={2}>
       <AddNewCollaborator />
       <VStack w="100%" divider={<Divider />}>
         {collaborators.map((collab) => (

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -1,4 +1,8 @@
-import { ITableColumnMetadata, ITableRow } from '@plumber/types'
+import {
+  ITableCollaborator,
+  ITableColumnMetadata,
+  ITableRow,
+} from '@plumber/types'
 
 import React, {
   createContext,
@@ -23,6 +27,7 @@ interface TableContextProps {
   setMode: (mode: EditMode) => void
   hasEditPermission: boolean
   viewOnlyKey?: string
+  collaborators?: ITableCollaborator[]
 }
 
 const TableContext = createContext<TableContextProps | undefined>(undefined)
@@ -45,6 +50,7 @@ interface TableContextProviderProps {
   children: React.ReactNode
   hasEditPermission: boolean
   viewOnlyKey?: string
+  collaborators?: ITableCollaborator[]
 }
 
 export const TableContextProvider = ({
@@ -55,6 +61,7 @@ export const TableContextProvider = ({
   children,
   hasEditPermission,
   viewOnlyKey,
+  collaborators,
 }: TableContextProviderProps) => {
   const flattenedData = useMemo(() => flattenRows(tableRows), [tableRows])
   const filteredDataRef = useRef<GenericRowData[]>([])
@@ -75,6 +82,7 @@ export const TableContextProvider = ({
         setMode,
         hasEditPermission,
         viewOnlyKey,
+        collaborators,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -54,7 +54,8 @@ export default function Tile(): JSX.Element {
     )
   }
 
-  const { id, name, columns, viewOnlyKey } = getTableData.getTable
+  const { id, name, columns, viewOnlyKey, collaborators } =
+    getTableData.getTable
   const rows = getAllRowsData.getAllRows
 
   return (
@@ -65,6 +66,7 @@ export default function Tile(): JSX.Element {
       tableRows={rows}
       hasEditPermission={!isReadOnly}
       viewOnlyKey={viewOnlyKey}
+      collaborators={collaborators}
     >
       <Flex
         flexDir={{ base: 'column' }}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -754,6 +754,12 @@ export interface ITableMetadata {
   columns: ITableColumnMetadata[]
   lastAccessedAt: string
   viewOnlyKey?: string
+  collaborators?: ITableCollaborator[]
+}
+
+export interface ITableCollaborator {
+  email: string
+  role: ITableCollabRole
 }
 
 export interface ITableRow {


### PR DESCRIPTION
### Changes

1. Expose collaborators in GetTable query
2. Modify Share Modal to display list of collaborators (frontend only! buttons do not work!)

![Screenshot 2024-05-14 at 10 33 26 PM](https://github.com/opengovsg/plumber/assets/10072985/e07cc418-314c-4d8b-93c0-30b76677ce6d)

### Testing

- You need to manually seed rows into the `table_collaborators` table for testing

For example: 
| user_id                              | table_id                             | role   | created_at                    | updated_at                 | deleted_at | last_accessed_at           |
|--------------------------------------|--------------------------------------|--------|-------------------------------|----------------------------|------------|----------------------------|
| 49c2a3e8-6a55-4fcf-a7b4-5d3afe0c1b8a | 783ed27a-cf0b-487d-ac27-44ac34ac5502 | editor | 2024-05-14 14:27:40.689352+00 | 2024-05-14 14:47:11.661+00 |            | 2024-05-14 14:47:11.656+00 |
| fdc3205d-6362-48b4-9336-173d366ec9d9 | 783ed27a-cf0b-487d-ac27-44ac34ac5502 | owner  | 2024-05-09 07:36:17.059+00    | 2024-05-14 14:47:11.661+00 |            | 2024-05-14 14:47:11.656+00 |
| 3db7f844-dee8-447c-b05e-8ffc92ca514d | 783ed27a-cf0b-487d-ac27-44ac34ac5502 | viewer | 2024-05-14 14:27:40.689352+00 | 2024-05-14 14:47:11.661+00 |            | 2024-05-14 14:47:11.656+00 |