### PR TITLE
fix: wait for postgres to be healthy

### DIFF
--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -48,6 +48,8 @@ services:
     depends_on:
       minio:
         condition: service_healthy
+      postgres:
+        condition: service_healthy
     entrypoint: >
       /bin/bash -c "
       mc config host add plumber-minio http://minio:9000 minio-username minio-password &&


### PR DESCRIPTION
### Problem

Seed table script in `npm run setup` may fail when docker first starts. This is because pg might not be ready at that point of time. 

### Solution

Wait for pg to be healthy 