### PR TITLE
chore: bump server memory capacity for tiles usage surge

### DIFF
--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "server",
-      "cpu": 512,
+      "cpu": 1024,
       "command": ["npm", "run", "start"],
       "environment": [{
         "name": "NODE_OPTIONS",

--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -4,6 +4,10 @@
       "name": "server",
       "cpu": 512,
       "command": ["npm", "run", "start"],
+      "environment": [{
+        "name": "NODE_OPTIONS",
+        "value": "--max-old-space-size=3072"
+      }],
       "portMappings": [
         {
           "containerPort": 8080,
@@ -102,5 +106,5 @@
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
   "cpu": "2048",
-  "memory": "4096"
+  "memory": "5120"
 }


### PR DESCRIPTION
## Problem

<img width="1474" alt="image" src="https://github.com/opengovsg/plumber/assets/10072985/1e79894d-87d8-49c3-b00c-c4693493f684">
CPU and memory maxing out due to surges in CSV imports for tiles.

## Solution (Interim)

- Bump heap size to 3GB to hopefully prevent/reduce frequency of GC
- Bump reserved CPU to 1GB to ensure sufficient CPU capacity for GC if needed

## Testing
- [x] Test on UAT