### PR TITLE
PLU-245 [TILES] remove getAllRows types

### DIFF
--- a/gql-codegen.ts
+++ b/gql-codegen.ts
@@ -43,6 +43,12 @@ const config: CodegenConfig = {
             output: 'type-fest#JsonValue',
           },
         },
+        Any: {
+          type: {
+            input: 'any',
+            output: 'any',
+          },
+        },
       },
 
       typesPluginsConfig: {
@@ -112,6 +118,7 @@ const config: CodegenConfig = {
           // Use type-fest's JSON types in generated code, as they're nice.
           JSONObject: 'type-fest#JsonObject',
           JSON: 'type-fest#JsonValue',
+          Any: 'any',
         },
       },
     },

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -1,3 +1,5 @@
+import { ITableRow } from '@plumber/types'
+
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -66,7 +68,7 @@ describe('get all rows query', () => {
       },
       context,
     )
-    expect(rows.map((r) => r.rowId)).toEqual(rowIdsInserted)
+    expect(rows.map((r: ITableRow) => r.rowId)).toEqual(rowIdsInserted)
   })
 
   it('should fetch all rows even if more than 1MB', async () => {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -37,7 +37,7 @@ type Query {
   getTable(tableId: String!): TableMetadata!
   getTables: [TableMetadata!]!
   # Tiles rows
-  getAllRows(tableId: String!): [JSONObject!]!
+  getAllRows(tableId: String!): Any!
   getCurrentUser: User
   healthcheck: AppHealth
   getPlumberStats: Stats
@@ -425,6 +425,7 @@ input BulkRetryExecutionsInput {
 The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSONObject
+scalar Any
 
 input PreviousStepInput {
   id: String
@@ -651,7 +652,7 @@ input CreateTableRowInput {
 
 input CreateTableRowsInput {
   tableId: ID!
-  dataArray: [JSONObject!]!
+  dataArray: Any!
 }
 
 input UpdateTableRowInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -37,7 +37,7 @@ type Query {
   getTable(tableId: String!): TableMetadata!
   getTables: [TableMetadata!]!
   # Tiles rows
-  getAllRows(tableId: String!): [TileRow!]!
+  getAllRows(tableId: String!): [JSONObject!]!
   getCurrentUser: User
   healthcheck: AppHealth
   getPlumberStats: Stats
@@ -644,11 +644,6 @@ type TableMetadata {
 # End Tiles types
 
 # Start Tiles row types
-type TileRow {
-  rowId: ID!
-  data: JSONObject!
-}
-
 input CreateTableRowInput {
   tableId: ID!
   data: JSONObject!
@@ -669,7 +664,6 @@ input DeleteTableRowsInput {
   tableId: ID!
   rowIds: [ID!]!
 }
-
 # End Tiles row types
 
 type AppHealth {

--- a/packages/frontend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-all-rows.ts
@@ -2,9 +2,6 @@ import { gql } from '@apollo/client'
 
 export const GET_ALL_ROWS = gql`
   query GetAllRows($tableId: String!) {
-    getAllRows(tableId: $tableId) {
-      rowId
-      data
-    }
+    getAllRows(tableId: $tableId)
   }
 `


### PR DESCRIPTION
## Problem

Type checking on Apollo Server consumes too much CPU and memory for large response bodies. (aka getAllRows query)

## Solution

Relax type for GetAllRows output.

Full experiment found in this [notebook](https://ogp.datadoghq.com/notebook/8261235/tiles-cpu-and-memory-consumption)