### PR TITLE
PLU-260: [STANDARDISE-DROPDOWNS-2] Choose app and event

### DIFF
--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -48,23 +48,11 @@ const action: IRawAction = {
     {
       label: 'Generate PDF',
       key: 'shouldGeneratePdf',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       required: true,
       description:
         'You will need to add an Email by Postman action after this step to send out the generated PDF.',
-      variables: false,
-      value: 'no',
-      showOptionValue: false,
-      options: [
-        {
-          label: 'No',
-          value: 'no',
-        },
-        {
-          label: 'Yes',
-          value: 'yes',
-        },
-      ],
+      value: false,
     },
     {
       label: 'Personalised fields',

--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -15,20 +15,18 @@ const trigger: IRawTrigger = {
     {
       label: 'Trigger on weekends?',
       key: 'triggersOnWeekend',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       description: 'Should this flow trigger on Saturday and Sunday?',
       required: true,
-      value: 'yes',
-      showOptionValue: false,
-      variables: false,
+      // flip the order of the default options
       options: [
         {
           label: 'Yes',
-          value: 'yes',
+          value: true,
         },
         {
           label: 'No',
-          value: 'no',
+          value: false,
         },
       ],
     },

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -15,20 +15,18 @@ const trigger: IRawTrigger = {
     {
       label: 'Trigger on weekends?',
       key: 'triggersOnWeekend',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       description: 'Should this flow trigger on Saturday and Sunday?',
       required: true,
-      value: 'yes',
-      showOptionValue: false,
-      variables: false,
+      // flip the order of the default options
       options: [
         {
           label: 'Yes',
-          value: 'yes',
+          value: true,
         },
         {
           label: 'No',
-          value: 'no',
+          value: false,
         },
       ],
     },
@@ -36,7 +34,7 @@ const trigger: IRawTrigger = {
   getDataOutMetadata,
 
   getInterval(parameters: IGlobalVariable['step']['parameters']) {
-    if (parameters.triggersOnWeekend) {
+    if (parameters.triggersOnWeekend as boolean) {
       return cronTimes.everyHour
     }
 

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -37,23 +37,11 @@ const action: IRawAction = {
     {
       label: 'Send as a bot?',
       key: 'sendAsBot',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       required: false,
-      value: 'no',
-      showOptionValue: false,
+      value: false,
       description:
         'If you choose no, this message will appear to come from you. Direct messages are always sent by bots.',
-      variables: false,
-      options: [
-        {
-          label: 'Yes',
-          value: 'yes',
-        },
-        {
-          label: 'No',
-          value: 'no',
-        },
-      ],
     },
     {
       label: 'Bot name',

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -41,23 +41,11 @@ const action: IRawAction = {
     {
       label: 'Disable notification?',
       key: 'disableNotification',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       required: false,
-      value: 'no',
-      showOptionValue: false,
+      value: false,
       description:
         'Sends the message silently. Users will receive a notification with no sound.',
-      variables: false,
-      options: [
-        {
-          label: 'Yes',
-          value: 'yes',
-        },
-        {
-          label: 'No',
-          value: 'no',
-        },
-      ],
     },
   ],
 

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -116,19 +116,17 @@ const action: IRawAction = {
     {
       label: 'Return most recent row instead?',
       key: 'returnLastRow',
-      type: 'dropdown' as const,
+      type: 'boolean-radio' as const,
       required: true,
-      variables: false,
-      value: 'no',
-      showOptionValue: false,
+      value: false,
       options: [
         {
           label: 'No (Returns oldest row)',
-          value: 'no',
+          value: false,
         },
         {
           label: 'Yes (Returns most recent row)',
-          value: 'yes',
+          value: true,
         },
       ],
     },

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -3,7 +3,7 @@ import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 import { useCallback, useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import { Box, Collapse, Flex, FormControl } from '@chakra-ui/react'
-import { Button, FormLabel } from '@opengovsg/design-system-react'
+import { Badge, Button, FormLabel } from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import { ComboboxItem, SingleSelect } from 'components/SingleSelect'
 import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from 'config/flags'
@@ -32,7 +32,15 @@ const formAppComboboxOption = (app: IApp): ComboboxItem => ({
   label: app.name as string,
   value: app.key as string,
   description: app?.description as string,
-  isAppNew: !!app?.isNewApp,
+  ...(app?.isNewApp
+    ? {
+        badge: (
+          <Badge bgColor="interaction.muted.main.active" color="primary.600">
+            New
+          </Badge>
+        ),
+      }
+    : {}),
 })
 
 const getSelectedOption = (
@@ -250,6 +258,7 @@ function ChooseAppAndEventSubstep(
                   name="choose-app-option"
                   colorScheme="secondary"
                   isClearable={false}
+                  isRefreshLoading={isLoading}
                   isDisabled={isLoading || editorContext.readOnly}
                   // Don't display options until we can check feature flags!
                   items={isLoading ? [] : appOptions}

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -139,7 +139,6 @@ function ChooseAppAndEventSubstep(
           : app.description,
         type: app.type, // webhook or polling
         disabled: isDisabled,
-        isEventInstant: app.type === 'webhook',
       }
     },
     [step.appKey, isIfThenSelectable],

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -1,14 +1,11 @@
 import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
-import { type SyntheticEvent, useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
-import { Flex, FormControl, Text } from '@chakra-ui/react'
-import Autocomplete from '@mui/material/Autocomplete'
-import Collapse from '@mui/material/Collapse'
-import ListItem from '@mui/material/ListItem'
-import TextField from '@mui/material/TextField'
-import { Badge, Button, FormLabel } from '@opengovsg/design-system-react'
+import { Box, Collapse, Flex, FormControl } from '@chakra-ui/react'
+import { Button, FormLabel } from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
+import { ComboboxItem, SingleSelect } from 'components/SingleSelect'
 import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from 'config/flags'
 import { EditorContext } from 'contexts/Editor'
 import { LaunchDarklyContext } from 'contexts/LaunchDarkly'
@@ -31,29 +28,28 @@ type ChooseAppAndEventSubstepProps = {
   isLastStep: boolean
 }
 
-const optionGenerator = (app: IApp) /* inferred return type */ => ({
+const formAppComboboxOption = (app: IApp): ComboboxItem => ({
   label: app.name as string,
   value: app.key as string,
   description: app?.description as string,
-  isNewApp: !!app?.isNewApp,
+  isAppNew: !!app?.isNewApp,
 })
 
-const eventOptionGenerator = (app: {
-  name: string
-  key: string
-  description: string
-  type?: string
-}): { label: string; value: string; type: string; description: string } => ({
-  label: app.name as string,
-  value: app.key as string,
-  type: app.type as string,
-  description: app.description,
-})
-
-const getOption = <T extends { value: string }>(
-  options: T[],
+const getSelectedOption = (
+  options: ComboboxItem[],
   selectedOptionValue?: string,
-) => options.find((option) => option.value === selectedOptionValue)
+): string => {
+  const foundOption = options.find((option: ComboboxItem) => {
+    if (typeof option !== 'string') {
+      return option?.value === selectedOptionValue
+    }
+    return option === selectedOptionValue
+  })
+  if (typeof foundOption === 'string') {
+    return foundOption
+  }
+  return foundOption?.value ?? ''
+}
 
 function ChooseAppAndEventSubstep(
   props: ChooseAppAndEventSubstepProps,
@@ -104,7 +100,7 @@ function ChooseAppAndEventSubstep(
           const ldAppFlag = getAppFlag(app.key)
           return launchDarkly.flags[ldAppFlag] ?? true
         })
-        ?.map((app) => optionGenerator(app)) ?? [],
+        ?.map((app) => formAppComboboxOption(app)) ?? [],
     [apps, launchDarkly.flags],
   )
 
@@ -114,6 +110,41 @@ function ChooseAppAndEventSubstep(
   )
 
   const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
+
+  // event option generator
+  const formEventComboboxOption = useCallback(
+    (app: {
+      name: string
+      key: string
+      description: string
+      type?: string
+    }): ComboboxItem => {
+      //
+      // ** EDGE CASE V2 **
+      // Check if option should be disabled: The if-then edge case demon again!
+      //
+      // To prevent user confusion, we want to show If-Then as a disabled option
+      // when we're not the last step.
+      //
+      const isDisabled =
+        step.appKey === TOOLBOX_APP_KEY &&
+        app.key === TOOLBOX_ACTIONS.IfThen &&
+        !isIfThenSelectable
+
+      return {
+        label: app.name,
+        value: app.key,
+        description: isDisabled
+          ? 'This can only be used in the last step'
+          : app.description,
+        type: app.type, // webhook or polling
+        disabled: isDisabled,
+        isEventInstant: app.type === 'webhook',
+      }
+    },
+    [step.appKey, isIfThenSelectable],
+  )
+
   const actionOrTriggerOptions = useMemo(
     () =>
       actionsOrTriggers
@@ -128,15 +159,15 @@ function ChooseAppAndEventSubstep(
           return launchDarkly.flags[launchDarklyKey] ?? true
         })
         //
-        .map((trigger) => eventOptionGenerator(trigger)),
-    [actionsOrTriggers, app?.key, launchDarkly.flags, isTrigger],
+        .map((trigger) => formEventComboboxOption(trigger)),
+    [
+      actionsOrTriggers,
+      app?.key,
+      launchDarkly.flags,
+      isTrigger,
+      formEventComboboxOption,
+    ],
   )
-  const selectedActionOrTrigger = actionsOrTriggers.find(
-    (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === step?.key,
-  )
-
-  const isWebhook =
-    isTrigger && (selectedActionOrTrigger as ITrigger)?.type === 'webhook'
 
   const { name } = substep
 
@@ -147,87 +178,54 @@ function ChooseAppAndEventSubstep(
   //
   const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
   const onEventChange = useCallback(
-    async (_event: SyntheticEvent, selectedOption: unknown) => {
-      if (typeof selectedOption === 'object') {
-        // TODO: try to simplify type casting below.
-        const typedSelectedOption = selectedOption as { value: string }
-        const option: { value: string } = typedSelectedOption
-        const eventKey = option?.value as string
+    async (eventKey: string) => {
+      // ** EDGE CASE **
+      // The if-then edge case demon here!
+      //
+      // If-then is weird in that we need to pre-populate with 2 branches
+      // upon initial selection (the only action that spawns 2 steps upon
+      // first selection), and we also need to update the first branch's
+      // parameters.
+      //
+      // Since there are a bunch of edge cases for If-then in this component
+      // already, let's localize the damage and continue adding edge cases
+      // here.
+      //
+      // Note that we don't need to check for inequality to the current
+      // step.key, since we don't display the action drop-down after someone
+      // selects If-then.
+      //
+      if (app?.key === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen) {
+        await initializeIfThen(step)
+        return
+      }
 
-        //
-        // ** EDGE CASE **
-        // The if-then edge case demon here!
-        //
-        // If-then is weird in that we need to pre-populate with 2 branches
-        // upon initial selection (the only action that spawns 2 steps upon
-        // first selection), and we also need to update the first branch's
-        // parameters.
-        //
-        // Since there are a bunch of edge cases for If-then in this component
-        // already, let's localize the damage and continue adding edge cases
-        // here.
-        //
-        // Note that we don't need to check for inequality to the current
-        // step.key, since we don't display the action drop-down after someone
-        // selects If-then.
-        //
-        if (
-          app?.key === TOOLBOX_APP_KEY &&
-          eventKey === TOOLBOX_ACTIONS.IfThen
-        ) {
-          await initializeIfThen(step)
-          return
-        }
-
-        if (step.key !== eventKey) {
-          onChange({
-            step: {
-              ...step,
-              key: eventKey,
-            },
-          })
-        }
+      if (step.key !== eventKey) {
+        onChange({
+          step: {
+            ...step,
+            key: eventKey,
+          },
+        })
       }
     },
     [app?.key, step, onChange, initializeIfThen],
   )
 
   const onAppChange = useCallback(
-    (_event: SyntheticEvent, selectedOption: unknown) => {
-      if (typeof selectedOption === 'object') {
-        // TODO: try to simplify type casting below.
-        const typedSelectedOption = selectedOption as { value: string }
-        const option: { value: string } = typedSelectedOption
-        const appKey = option?.value as string
-
-        if (step.appKey !== appKey) {
-          onChange({
-            step: {
-              ...step,
-              key: '',
-              appKey,
-              parameters: {},
-            },
-          })
-        }
+    (appKey: string) => {
+      if (step.appKey !== appKey) {
+        onChange({
+          step: {
+            ...step,
+            key: '',
+            appKey,
+            parameters: {},
+          },
+        })
       }
     },
     [step, onChange],
-  )
-
-  //
-  // ** EDGE CASE V2 **
-  // The if-then edge case demon again!
-  //
-  // To prevent user confusion, we want to show If-Then as a disabled option
-  // when we're not the last step.
-  //
-  const getIsIfThenDisabled = useCallback(
-    ({ value: actionKey }: ReturnType<typeof eventOptionGenerator>) =>
-      step.appKey === TOOLBOX_APP_KEY &&
-      actionKey === TOOLBOX_ACTIONS.IfThen &&
-      !isIfThenSelectable,
-    [step.appKey, isIfThenSelectable],
   )
 
   const onToggle = expanded ? onCollapse : onExpand
@@ -243,162 +241,55 @@ function ChooseAppAndEventSubstep(
         valid={valid}
       />
 
-      <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <ListItem
-          sx={{
-            pt: 2,
-            pb: 3,
-            flexDirection: 'column',
-            alignItems: 'flex-start',
-          }}
-        >
-          <Autocomplete
-            fullWidth
-            disablePortal
-            disableClearable
-            disabled={isLoading || editorContext.readOnly}
-            loading={isLoading}
-            // Don't display options until we can check feature flags!
-            options={launchDarkly.isLoading ? [] : appOptions}
-            renderOption={(optionProps, option) => (
-              <li
-                {...optionProps}
-                key={option.value.toString()}
-                style={{
-                  flexDirection: 'row',
-                }}
-              >
-                <Flex py={1} flexDir="column">
-                  <Flex gap={2} alignItems="center">
-                    <Text>{option.label}</Text>
-                    {option.isNewApp && (
-                      <Badge
-                        bgColor="interaction.muted.main.active"
-                        color="primary.600"
-                        px={2}
-                        py={1}
-                      >
-                        New
-                      </Badge>
-                    )}
-                  </Flex>
-                  <Text textStyle="body-2" color="base.content.medium">
-                    {option.description}
-                  </Text>
-                </Flex>
-              </li>
-            )}
-            renderInput={(params) => (
-              <FormControl>
-                <FormLabel isRequired>Choose an app</FormLabel>
-                <TextField {...params} />
-              </FormControl>
-            )}
-            value={
-              getOption(appOptions, step.appKey) ?? {
-                label: '',
-                value: '',
-                description: '',
-                isNewApp: false,
-              }
-            }
-            onChange={onAppChange}
-            data-test="choose-app-autocomplete"
-          />
+      <Collapse in={expanded} unmountOnExit>
+        <Box w="100%" p="1rem 1rem 1.5rem">
+          <Flex width="full" flexDir="column">
+            <FormControl>
+              <FormLabel isRequired>Choose an app</FormLabel>
+              <Box>
+                <SingleSelect
+                  name="choose-app-option"
+                  colorScheme="secondary"
+                  isClearable={false}
+                  isDisabled={isLoading || editorContext.readOnly}
+                  // Don't display options until we can check feature flags!
+                  items={isLoading ? [] : appOptions}
+                  onChange={(selectedOption) => {
+                    const option = getSelectedOption(appOptions, selectedOption)
+                    onAppChange(option)
+                  }}
+                  value={getSelectedOption(appOptions, step.appKey)}
+                  data-test="choose-app-autocomplete"
+                />
+              </Box>
+            </FormControl>
+          </Flex>
 
           {step.appKey && (
             <Flex width="full" pt={4} flexDir="column">
-              <Autocomplete
-                fullWidth
-                disablePortal
-                disableClearable
-                disabled={isLoading || editorContext.readOnly}
-                loading={isLoading}
-                // Don't display options until we can check feature flags!
-                options={isLoading ? [] : actionOrTriggerOptions}
-                getOptionDisabled={getIsIfThenDisabled}
-                renderInput={(params) => (
-                  <FormControl>
-                    <FormLabel isRequired>Choose an event</FormLabel>
-                    <TextField
-                      {...params}
-                      InputProps={{
-                        ...params.InputProps,
-                        endAdornment: (
-                          <>
-                            {isWebhook && (
-                              <Badge
-                                bgColor="interaction.muted.neutral.active"
-                                color="secondary.600"
-                              >
-                                Instant
-                              </Badge>
-                            )}
-
-                            {params.InputProps.endAdornment}
-                          </>
-                        ),
-                      }}
-                    />
-                  </FormControl>
-                )}
-                renderOption={(optionProps, option) => (
-                  <li
-                    {...optionProps}
-                    key={option.value.toString()}
-                    style={{
-                      flexDirection: 'row',
-                      justifyContent: 'space-between',
+              <FormControl>
+                <FormLabel isRequired>Choose an event</FormLabel>
+                <Box>
+                  <SingleSelect
+                    name="choose-event-option"
+                    colorScheme="secondary"
+                    isClearable={false}
+                    isDisabled={isLoading || editorContext.readOnly}
+                    // Don't display options until we can check feature flags!
+                    items={isLoading ? [] : actionOrTriggerOptions}
+                    onChange={(selectedOption) => {
+                      const option = getSelectedOption(
+                        actionOrTriggerOptions,
+                        selectedOption,
+                      )
+                      onEventChange(option)
                     }}
-                  >
-                    <Flex flexDir="column">
-                      <Text>{option.label}</Text>
-                      <Text
-                        fontSize="xs"
-                        color={
-                          getIsIfThenDisabled(option) ? 'red.500' : 'inherit'
-                        }
-                      >
-                        {getIsIfThenDisabled(option)
-                          ? 'This can only be used in the last step'
-                          : option.description}
-                      </Text>
-                    </Flex>
-
-                    {option.type === 'webhook' && (
-                      <Badge
-                        bgColor="interaction.muted.neutral.active"
-                        color="secondary.600"
-                      >
-                        Instant
-                      </Badge>
-                    )}
-                  </li>
-                )}
-                value={
-                  getOption(actionOrTriggerOptions, step.key) ?? {
-                    label: '',
-                    value: '',
-                    type: '',
-                    description: '',
-                  }
-                }
-                onChange={onEventChange}
-                data-test="choose-event-autocomplete"
-              />
+                    value={getSelectedOption(actionOrTriggerOptions, step.key)}
+                    data-test="choose-event-autocomplete"
+                  />
+                </Box>
+              </FormControl>
             </Flex>
-          )}
-
-          {isTrigger && (selectedActionOrTrigger as ITrigger)?.pollInterval && (
-            <TextField
-              label="Poll interval"
-              value={`Every ${
-                (selectedActionOrTrigger as ITrigger)?.pollInterval
-              } minutes`}
-              sx={{ mt: 2 }}
-              fullWidth
-              disabled
-            />
           )}
 
           <Button
@@ -410,7 +301,7 @@ function ChooseAppAndEventSubstep(
           >
             Continue
           </Button>
-        </ListItem>
+        </Box>
       </Collapse>
     </>
   )

--- a/packages/frontend/src/components/ChooseConnectionDropdown/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionDropdown/index.tsx
@@ -2,8 +2,9 @@ import { IApp } from '@plumber/types'
 
 import { useCallback, useState } from 'react'
 import { FormControl } from '@chakra-ui/react'
-import { BxPlus, FormLabel, SingleSelect } from '@opengovsg/design-system-react'
+import { BxPlus, FormLabel } from '@opengovsg/design-system-react'
 import AddAppConnection from 'components/AddAppConnection'
+import { SingleSelect } from 'components/SingleSelect'
 
 type ConnectionDropdownOption = {
   label: string
@@ -69,6 +70,7 @@ function ChooseConnectionDropdown({
         <FormLabel isRequired>Choose connection</FormLabel>
         <SingleSelect
           name="choose-connection"
+          colorScheme="secondary"
           isRequired={true}
           isClearable={false}
           isDisabled={isDisabled}

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -8,8 +8,7 @@ import type {
 
 import { useCallback, useContext, useMemo } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
-import Collapse from '@mui/material/Collapse'
-import ListItem from '@mui/material/ListItem'
+import { Collapse, Flex } from '@chakra-ui/react'
 import ChooseConnectionDropdown from 'components/ChooseConnectionDropdown'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import SetConnectionButton from 'components/SetConnectionButton'
@@ -154,16 +153,8 @@ function ChooseConnectionSubstep(
         title={name}
         valid={isTestStepValid}
       />
-      <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <ListItem
-          sx={{
-            pt: 2,
-            pb: 3,
-            flexDirection: 'column',
-            alignItems: 'flex-start',
-            gap: 2,
-          }}
-        >
+      <Collapse in={expanded} unmountOnExit>
+        <Flex w="100%" p="1rem 1rem 1.5rem" flexDir="column" gap={4}>
           <ChooseConnectionDropdown
             isDisabled={editorContext.readOnly || loading}
             connectionOptions={connectionOptions}
@@ -180,7 +171,7 @@ function ChooseConnectionSubstep(
             testResultLoading={testResultLoading}
             registerConnectionLoading={registerConnectionLoading}
           />
-        </ListItem>
+        </Flex>
       </Collapse>
     </>
   )

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -1,6 +1,6 @@
 import type { IFieldDropdownOption } from '@plumber/types'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import Markdown from 'react-markdown'
 import { Box, Flex, FormControl } from '@chakra-ui/react'
@@ -29,29 +29,17 @@ const formComboboxOptions = (
   const result: ComboboxItem[] = []
   for (const option of options) {
     const item = {
-      value: option['value'],
+      value: option['value']?.toString(),
       // Display value if label does not exist
       label: option['label'] ?? (option.value?.toString() || ''),
       // Always hide value if description is availble.
       description:
-        option['description'] ?? (showOptionValue ? option['value'] : ''),
-    } as ComboboxItem
+        option['description'] ??
+        (showOptionValue ? option['value'].toString() : ''),
+    } satisfies ComboboxItem
     result.push(item)
   }
   return result
-}
-
-const getSingleSelectOption = (
-  options: readonly IFieldDropdownOption[],
-  value: string,
-  freeSolo?: boolean,
-): string => {
-  const foundOption = options.find((option) => option.value === value)
-  // If allowArbitrary is true, return the value as the option
-  if (freeSolo) {
-    return value
-  }
-  return foundOption?.value.toString() ?? ''
 }
 
 function ControlledAutocomplete(
@@ -66,7 +54,7 @@ function ControlledAutocomplete(
     options = [],
     dependsOn = [],
     showOptionValue,
-    freeSolo,
+    freeSolo: rawFreeSolo,
     onRefresh,
     loading,
     required,
@@ -77,10 +65,6 @@ function ControlledAutocomplete(
     () => (dependsOn?.length ? watch(dependsOn) : []),
     [dependsOn, watch],
   )
-
-  // This is added to add custom dropdown options when freeSolo is enabled
-  const [sessionOptions, setSessionOptions] = useState(options)
-
   useEffect(() => {
     const hasDependencies = dependsOnValues.length
     const allDepsSatisfied = dependsOnValues.every(Boolean)
@@ -90,27 +74,24 @@ function ControlledAutocomplete(
       setValue(name, null)
       resetField(name)
     }
+  }, [dependsOnValues, name, resetField, setValue, options])
 
-    if (freeSolo) {
-      // allow for custom fields to be added temporarily when allowArbitrary is set to true
-      if (sessionOptions.length === 0) {
-        setSessionOptions(options)
-      }
-    } else {
-      // dynamically update and refresh the next set of fields
-      if (sessionOptions !== options) {
-        setSessionOptions(options)
-      }
+  const items = useMemo(
+    () => formComboboxOptions(options, showOptionValue),
+    [options, showOptionValue],
+  )
+
+  // Do not support freeSolo if there are numerical options. Since no use case
+  // for it yet and it makes things more complex.
+  const freeSolo = useMemo(() => {
+    if (
+      options.length &&
+      options.every((option) => typeof option.value !== 'string')
+    ) {
+      return false
     }
-  }, [
-    dependsOnValues,
-    name,
-    resetField,
-    setValue,
-    options,
-    sessionOptions,
-    freeSolo,
-  ])
+    return rawFreeSolo
+  }, [options, rawFreeSolo])
 
   return (
     <Controller
@@ -118,7 +99,7 @@ function ControlledAutocomplete(
       name={name}
       defaultValue={defaultValue ?? ''}
       control={control}
-      render={({ field: { ref, onChange, ...field }, fieldState }) => {
+      render={({ field: { ref, onChange, value: fieldValue }, fieldState }) => {
         const isError = Boolean(fieldState.isTouched && fieldState.error)
 
         return (
@@ -142,29 +123,15 @@ function ControlledAutocomplete(
                   name="choose-dropdown-option"
                   colorScheme="secondary"
                   isClearable={!required}
-                  items={formComboboxOptions(sessionOptions, showOptionValue)}
-                  onChange={(selectedOption) => onChange(selectedOption)}
-                  value={getSingleSelectOption(
-                    sessionOptions,
-                    field.value,
-                    freeSolo,
-                  )}
+                  items={items}
+                  onChange={onChange}
+                  value={fieldValue}
                   placeholder={placeholder}
                   ref={ref}
                   data-test={`${name}-autocomplete`}
                   onRefresh={onRefresh}
                   isRefreshLoading={loading}
                   freeSolo={freeSolo}
-                  addCustomOption={(selectedOption) => {
-                    setSessionOptions([
-                      ...sessionOptions,
-                      {
-                        label: selectedOption,
-                        value: selectedOption,
-                        description: selectedOption,
-                      },
-                    ])
-                  }}
                 />
               </Box>
             </Flex>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -131,7 +131,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
             alignItems: 'flex-start',
           }}
         >
-          <Stack width="100%" spacing={2}>
+          <Stack width="100%" spacing={3}>
             {args?.map((argument) => (
               <InputCreator
                 key={argument.key}

--- a/packages/frontend/src/components/InputCreator/BooleanRadio.tsx
+++ b/packages/frontend/src/components/InputCreator/BooleanRadio.tsx
@@ -1,0 +1,117 @@
+import type { IFieldBooleanRadioOptions } from '@plumber/types'
+
+import { Controller, useFormContext } from 'react-hook-form'
+import Markdown from 'react-markdown'
+import { FormControl, RadioGroup, Stack } from '@chakra-ui/react'
+import {
+  FormErrorMessage,
+  FormLabel,
+  Radio,
+} from '@opengovsg/design-system-react'
+
+interface BooleanRadioProps {
+  name: string
+  label?: string
+  description?: string
+  required?: boolean
+  defaultValue?: boolean
+  options?: IFieldBooleanRadioOptions
+}
+
+function convertBooleanToString(value: boolean | null): string {
+  if (value === null) {
+    return ''
+  }
+  return value ? 'yes' : 'no'
+}
+
+function convertStringToBoolean(value: string): boolean | null {
+  if (value === '') {
+    return null
+  }
+  return value === 'yes'
+}
+
+// show no then yes by default
+const defaultLabelOptions: IFieldBooleanRadioOptions = [
+  {
+    label: 'No',
+    value: false,
+  },
+  {
+    label: 'Yes',
+    value: true,
+  },
+]
+
+export default function BooleanRadio(props: BooleanRadioProps) {
+  const {
+    name,
+    label,
+    required = false,
+    defaultValue,
+    description,
+    options,
+  } = props
+  const { control } = useFormContext()
+  const [firstOption, secondOption] = options ?? defaultLabelOptions
+
+  return (
+    <Controller
+      name={name}
+      rules={{ required }}
+      control={control}
+      defaultValue={defaultValue}
+      render={({
+        field: { onChange, value },
+        fieldState: { isTouched, error },
+      }) => {
+        const isError = Boolean(isTouched && !!error)
+
+        return (
+          <FormControl isInvalid={isError}>
+            {label && (
+              <FormLabel
+                isRequired={required}
+                description={
+                  description && (
+                    <Markdown linkTarget="_blank">{description}</Markdown>
+                  )
+                }
+              >
+                {label}
+              </FormLabel>
+            )}
+
+            <RadioGroup
+              onChange={
+                (selectedValue) =>
+                  onChange(convertStringToBoolean(selectedValue)) // store null in db for backwards compat
+              }
+              // value will be empty if not provided on backend, null if user did not select
+              value={value === '' ? value : convertBooleanToString(value)}
+              colorScheme="secondary"
+            >
+              <Stack spacing={0}>
+                <Radio
+                  allowDeselect={!required}
+                  value={convertBooleanToString(firstOption.value)}
+                >
+                  {firstOption.label}
+                </Radio>
+                <Radio
+                  allowDeselect={!required}
+                  value={convertBooleanToString(secondOption.value)}
+                >
+                  {secondOption.label}
+                </Radio>
+              </Stack>
+            </RadioGroup>
+
+            {isError && <FormErrorMessage>{error?.message}</FormErrorMessage>}
+          </FormControl>
+        )
+      }}
+    />
+  )
+}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -9,6 +9,8 @@ import TextField from 'components/TextField'
 import { isFieldHidden } from 'helpers/isFieldHidden'
 import useDynamicData from 'hooks/useDynamicData'
 
+import BooleanRadio from './BooleanRadio'
+
 export type InputCreatorProps = {
   schema: IField
   namePrefix?: string
@@ -58,6 +60,19 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
   const isHidden = useIsFieldHidden(namePrefix, schema)
   if (isHidden) {
     return <></>
+  }
+
+  if (type === 'boolean-radio') {
+    return (
+      <BooleanRadio
+        name={computedName}
+        label={label}
+        description={description}
+        required={required}
+        defaultValue={value as boolean}
+        options={schema?.options}
+      />
+    )
   }
 
   if (type === 'dropdown') {

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -140,7 +140,6 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               onClick={handleAddRow}
               isDisabled={isEditorReadOnly}
               maxW="fit-content"
-              mb={4}
             >
               And
             </Button>

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -34,6 +34,9 @@ import { SuggestionsPopper } from './SuggestionPopper'
 import { genVariableInfoMap, substituteOldTemplates } from './utils'
 
 const RICH_TEXT_EXTENSIONS = [
+  Document.configure({
+    HTMLAttributes: { style: 'min-height: 9rem' },
+  }),
   StarterKit.configure({
     paragraph: {
       HTMLAttributes: { style: 'margin: 0' },
@@ -137,6 +140,11 @@ const Editor = ({
       onChange(isRich ? editor.getHTML() : editor.getText())
     },
     editable,
+    // To simulate textarea and coordinate with dropdown input size
+    onCreate: ({ editor }) => {
+      const editorElement = editor.view.dom as HTMLElement
+      editorElement.style.minHeight = isRich ? '9rem' : '2.625rem' // Set initial minHeight directly
+    },
   })
   useEffect(() => {
     // have to listen to editable as this element might not re-render upon
@@ -171,9 +179,6 @@ const Editor = ({
             className="editor__content"
             editor={editor}
             onFocus={() => setShowVarSuggestions(true)}
-            style={{
-              minHeight: isRich ? '9rem' : '2.625rem', // to simulate textarea and coordinate with dropdown input size
-            }}
           />
           {variablesEnabled && (
             <SuggestionsPopper

--- a/packages/frontend/src/components/SingleSelect/SelectContext.tsx
+++ b/packages/frontend/src/components/SingleSelect/SelectContext.tsx
@@ -27,6 +27,14 @@ export interface SharedSelectContextReturnProps<
   /** Item data used to render items in dropdown */
   items: Item[]
   size?: 'xs' | 'sm' | 'md' | 'lg'
+  /*
+   * SPECIAL CASES for Plumber
+   */
+  /** Allow dropdown options to reload upon clicking refresh. Defaults to false */
+  onRefresh?: (() => void) | null
+  isRefreshLoading?: boolean
+  /** Controls if user can add one arbitrary item of their choosing. */
+  freeSolo?: boolean
 }
 
 interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
@@ -52,14 +60,6 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   virtualListRef: RefObject<VirtuosoHandle>
   /** Height to assign to virtual list */
   virtualListHeight: number
-  /** SPECIAL CASE for Plumber:
-   * Allow dropdown options to reload upon clicking refresh */
-  onRefresh?: () => void
-  isRefreshLoading?: boolean
-  /** Allow custom dropdown option if freeSolo is enabled */
-  freeSolo?: boolean
-  /** Controlled selected value */
-  value: string
 }
 
 export const SelectContext = createContext<SelectContextReturn | undefined>(

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -7,9 +7,14 @@ import {
   useMultiStyleConfig,
   useTheme,
 } from '@chakra-ui/react'
-import { useCombobox, UseComboboxProps } from 'downshift'
+import {
+  useCombobox,
+  UseComboboxProps,
+  type UseComboboxState,
+  type UseComboboxStateChangeOptions,
+} from 'downshift'
 
-import { useItems } from './hooks/useItems'
+import { useLookupItems } from './hooks/useLookupItems'
 import { defaultFilter } from './utils/defaultFilter'
 import {
   isItemDisabled,
@@ -18,7 +23,15 @@ import {
 } from './utils/itemUtils'
 import { VIRTUAL_LIST_ITEM_HEIGHT } from './constants'
 import { SelectContext, SharedSelectContextReturnProps } from './SelectContext'
-import { ComboboxItem } from './types'
+import type { ComboboxItem } from './types'
+
+function getFreeSoloItem(freeSoloValue: string) {
+  return {
+    value: freeSoloValue,
+    label: freeSoloValue,
+    description: 'Use this custom value',
+  }
+}
 
 export interface SingleSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
@@ -43,22 +56,16 @@ export interface SingleSelectProviderProps<
   /** Color scheme of component */
   colorScheme?: ThemingProps<'SingleSelect'>['colorScheme']
   fixedItemHeight?: number
-  /** SPECIAL CASE for Plumber:
-   * Allow dropdown options to reload upon clicking refresh */
-  onRefresh?: () => void
-  isRefreshLoading?: boolean
-  /** Allow custom dropdown option if freeSolo is enabled */
-  freeSolo?: boolean
-  addCustomOption?: (newValue: string) => void
 }
+
 export const SingleSelectProvider = ({
-  items: rawItems,
+  items: allItems,
   value,
   onChange,
   name,
   filter = defaultFilter,
   nothingFoundLabel = 'No matching results',
-  placeholder: placeholderProp,
+  placeholder = 'Select an option',
   clearButtonLabel = 'Clear selection',
   isClearable = true,
   isSearchable = true,
@@ -73,10 +80,9 @@ export const SingleSelectProvider = ({
   size: _size,
   comboboxProps = {},
   fixedItemHeight,
-  onRefresh,
-  isRefreshLoading,
-  freeSolo,
-  addCustomOption,
+  onRefresh = null,
+  isRefreshLoading = false,
+  freeSolo = false,
 }: SingleSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -90,7 +96,8 @@ export const SingleSelectProvider = ({
     [_size, theme?.components?.SingleSelect?.defaultProps?.size],
   )
 
-  const { items, getItemByValue, addCustomItem } = useItems({ rawItems })
+  const { getItemByValue } = useLookupItems({ rawItems: allItems })
+
   const [isFocused, setIsFocused] = useState(false)
 
   const { isInvalid, isDisabled, isReadOnly, isRequired } = useFormControlProps(
@@ -102,88 +109,59 @@ export const SingleSelectProvider = ({
     },
   )
 
-  const placeholder = useMemo(() => {
-    if (placeholderProp === null) {
-      return ''
-    }
-    return placeholderProp ?? 'Select an option'
-  }, [placeholderProp])
-
   const getFilteredItems = useCallback(
-    (filterValue?: string) =>
-      filterValue ? filter(items, filterValue) : items,
-    [filter, items],
+    (filterValue?: string) => {
+      const filtered =
+        filterValue != null ? filter(allItems, filterValue) : allItems
+      return [...filtered]
+    },
+    [filter, allItems],
   )
-  const [filteredItems, setFilteredItems] = useState(
-    getFilteredItems(
-      comboboxProps.initialInputValue ?? comboboxProps.inputValue,
-    ),
-  )
+  const [filteredItems, setFilteredItems] = useState(allItems)
 
   const memoizedSelectedItem = useMemo(() => {
-    return getItemByValue(value)?.item ?? null
-  }, [getItemByValue, value])
+    const fromItems = getItemByValue(value)
+    if (fromItems) {
+      return fromItems.item
+    }
 
-  const resetItems = useCallback(
-    () => setFilteredItems(getFilteredItems()),
-    [getFilteredItems],
-  )
+    const selectedItem = freeSolo && value ? getFreeSoloItem(value) : null
+    return selectedItem
+  }, [getItemByValue, freeSolo, value])
+
+  useEffect(() => {
+    setFilteredItems(allItems)
+  }, [allItems])
 
   const virtualListRef = useRef<VirtuosoHandle>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const {
-    toggleMenu,
-    closeMenu,
-    isOpen,
-    getLabelProps,
-    getMenuProps,
-    getInputProps,
-    getItemProps,
-    getToggleButtonProps,
-    highlightedIndex,
-    selectItem,
-    selectedItem,
-    inputValue,
-    setInputValue,
-  } = useCombobox({
-    labelId: `${name}-label`,
-    inputId: name,
-    defaultInputValue: '',
-    defaultHighlightedIndex: 0,
-    items: filteredItems,
-    initialIsOpen,
-    selectedItem: memoizedSelectedItem,
-    itemToString: itemToValue,
-    onSelectedItemChange: ({ selectedItem }) => {
-      if (!selectedItem || !isItemDisabled(selectedItem)) {
-        onChange(itemToValue(selectedItem))
+  const addFreeSoloItem = useCallback(
+    (filteredItems: ComboboxItem<string>[], inputValue?: string) => {
+      // freeSolo inputValue cannot be null or undefined or blank
+      if (inputValue?.trim() && !getItemByValue(inputValue)) {
+        return filteredItems.push(getFreeSoloItem(inputValue))
       }
     },
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    scrollIntoView: () => {},
-    onHighlightedIndexChange: ({ highlightedIndex }) => {
-      if (
-        highlightedIndex !== undefined &&
-        highlightedIndex >= 0 &&
-        virtualListRef.current
-      ) {
-        virtualListRef.current.scrollIntoView({
-          index: highlightedIndex,
-        })
+    [getItemByValue],
+  )
+
+  const handleInputChange = useCallback(
+    (inputValue: string | undefined) => {
+      const filteredItems = getFilteredItems(inputValue)
+      if (freeSolo) {
+        addFreeSoloItem(filteredItems, inputValue)
       }
+      setFilteredItems(filteredItems)
     },
-    onStateChange: ({ inputValue, type }) => {
-      switch (type) {
-        case useCombobox.stateChangeTypes.FunctionSetInputValue:
-        case useCombobox.stateChangeTypes.InputChange:
-          setFilteredItems(getFilteredItems(inputValue))
-          break
-        default:
-          return
-      }
-    },
-    stateReducer: (state, { changes, type }) => {
+    [addFreeSoloItem, freeSolo, getFilteredItems],
+  )
+
+  const stateReducer = useCallback(
+    (
+      state: UseComboboxState<ComboboxItem>,
+      { changes, type }: UseComboboxStateChangeOptions<ComboboxItem>,
+    ) => {
       switch (type) {
         // Handle controlled `value` prop changes.
         case useCombobox.stateChangeTypes.ControlledPropUpdatedSelectedItem:
@@ -208,23 +186,10 @@ export const SingleSelectProvider = ({
             selectedItem: state.selectedItem,
           }
         }
+        case useCombobox.stateChangeTypes.FunctionSelectItem:
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.InputBlur:
         case useCombobox.stateChangeTypes.ItemClick: {
-          resetItems()
-
-          // UPDATE: to add custom dropdown options
-          if (freeSolo) {
-            if (inputValue !== '' && getItemByValue(inputValue) === null) {
-              // Sanity check: if freeSolo is enabled, the addCustomOption function must come together
-              if (addCustomOption) {
-                addCustomOption(inputValue) // To update the items array to be re-rendered
-                // To render the option immediately
-                addCustomItem(inputValue)
-                selectItem(items[items.length - 1])
-              }
-            }
-          }
           return {
             ...changes,
             // Clear inputValue on item selection
@@ -237,22 +202,72 @@ export const SingleSelectProvider = ({
             ...changes,
             isOpen: false, // keep the menu closed when input gets focused.
           }
-        case useCombobox.stateChangeTypes.ToggleButtonClick:
-          return {
-            ...changes,
-            isOpen: !state.isOpen,
-          }
         default:
           return changes
       }
     },
+    [isClearable],
+  )
+
+  const {
+    toggleMenu,
+    closeMenu,
+    isOpen,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+    getToggleButtonProps,
+    highlightedIndex,
+    selectItem,
+    selectedItem,
+    inputValue,
+    setInputValue,
+  } = useCombobox({
+    labelId: `${name}-label`,
+    inputId: name,
+    defaultInputValue: '',
+    defaultHighlightedIndex: 0,
+    items: filteredItems,
+    initialIsOpen,
+    selectedItem: memoizedSelectedItem,
+    itemToString: itemToValue,
+    onIsOpenChange: ({ isOpen }) => {
+      if (!isOpen) {
+        reset()
+      }
+    },
+    onHighlightedIndexChange: ({ highlightedIndex }) => {
+      if (
+        highlightedIndex !== undefined &&
+        highlightedIndex >= 0 &&
+        virtualListRef.current
+      ) {
+        virtualListRef.current.scrollIntoView({
+          index: highlightedIndex,
+        })
+      }
+    },
+    onSelectedItemChange: ({ selectedItem }) => {
+      if (!selectedItem) {
+        onChange('')
+      } else if (!isItemDisabled(selectedItem)) {
+        onChange(itemToValue(selectedItem))
+      }
+    },
+    onStateChange: ({ inputValue, type }) => {
+      switch (type) {
+        case useCombobox.stateChangeTypes.FunctionSetInputValue:
+        case useCombobox.stateChangeTypes.InputChange:
+          handleInputChange(inputValue)
+          break
+        default:
+          return
+      }
+    },
+    stateReducer,
     ...comboboxProps,
   })
-
-  /** Effect to update filtered items whenever items prop changes. */
-  useEffect(() => {
-    setFilteredItems(getFilteredItems(inputValue))
-  }, [getFilteredItems, inputValue, items])
 
   const isItemSelected = useCallback(
     (item: ComboboxItem) => {
@@ -261,7 +276,10 @@ export const SingleSelectProvider = ({
     [selectedItem],
   )
 
-  const resetInputValue = useCallback(() => setInputValue(''), [setInputValue])
+  const reset = useCallback(() => {
+    setFilteredItems(allItems)
+    setInputValue('')
+  }, [allItems, setInputValue])
 
   const styles = useMultiStyleConfig('SingleSelect', {
     size,
@@ -270,16 +288,14 @@ export const SingleSelectProvider = ({
   })
 
   const virtualListHeight = useMemo(() => {
-    // UPDATE: allow proper rendering of dropdown with both label and description
-    let updatedSize = size
-    for (const item of filteredItems) {
-      if (itemToDescriptionString(item)) {
-        updatedSize = 'lg'
-        break
-      }
-    }
+    // Size needs to be larger if we have items with descriptions
+    const itemsHaveDescription = filteredItems.some((item) =>
+      itemToDescriptionString(item),
+    )
+    const itemHeight =
+      fixedItemHeight ??
+      VIRTUAL_LIST_ITEM_HEIGHT[itemsHaveDescription ? 'lg' : size]
 
-    const itemHeight = fixedItemHeight ?? VIRTUAL_LIST_ITEM_HEIGHT[updatedSize]
     // If the total height is less than the max height, just return the total height.
     // Otherwise, return the max height.
     return Math.min(filteredItems.length, 4) * itemHeight
@@ -316,7 +332,7 @@ export const SingleSelectProvider = ({
         styles,
         isFocused,
         setIsFocused,
-        resetInputValue,
+        resetInputValue: reset,
         inputAria,
         inputRef,
         virtualListRef,
@@ -324,7 +340,6 @@ export const SingleSelectProvider = ({
         onRefresh,
         isRefreshLoading,
         freeSolo,
-        value,
       }}
     >
       {children}

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react'
 import { Flex, Icon, ListItem, Text } from '@chakra-ui/react'
 import { dataAttr } from '@chakra-ui/utils'
+import { Badge } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../../SelectContext'
 import { ComboboxItem } from '../../types'
 import {
   isItemDisabled,
-  itemToBadge,
+  isItemInstant,
+  isItemNew,
   itemToDescriptionString,
   itemToIcon,
   itemToLabelString,
@@ -18,6 +20,12 @@ export interface DropdownItemProps {
   item: ComboboxItem
   index: number
 }
+
+/**
+ * Note: This is customised just for Plumber.
+ * A new badge is to indicate that the app is new.
+ * An instant badge is to indicate that the event is a webhook trigger.
+ */
 
 export const DropdownItem = ({
   item,
@@ -36,14 +44,23 @@ export const DropdownItem = ({
     setIsHovered(false)
   }
 
-  const { icon, badge, label, description, isDisabled, isActive } = useMemo(
+  const {
+    icon,
+    label,
+    description,
+    isDisabled,
+    isActive,
+    isAppNew,
+    isEventInstant,
+  } = useMemo(
     () => ({
       icon: itemToIcon(item),
-      badge: itemToBadge(item),
       label: itemToLabelString(item),
       description: itemToDescriptionString(item),
       isDisabled: isItemDisabled(item),
       isActive: isItemSelected(item),
+      isAppNew: isItemNew(item),
+      isEventInstant: isItemInstant(item),
     }),
     [isItemSelected, item],
   )
@@ -61,7 +78,7 @@ export const DropdownItem = ({
         isHovered
           ? {
               backgroundColor: '#f8f9fa',
-              cursor: 'pointer',
+              cursor: isDisabled ? 'not-allowed' : 'pointer',
             }
           : isActive
           ? {
@@ -73,29 +90,48 @@ export const DropdownItem = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <Flex flexDir="column">
-        <Flex gap={1.5}>
-          {icon ? <Icon as={icon} sx={styles.icon} /> : null}
-          <Text
-            minWidth={0}
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-            overflowX="hidden"
-          >
-            <DropdownItemTextHighlighter
-              inputValue={inputValue ?? ''}
-              textToHighlight={label}
-            />
-          </Text>
-          {badge}
+      <Flex justifyContent="space-between" alignItems="center">
+        <Flex flexDir="column">
+          <Flex gap={1.5}>
+            {icon ? <Icon as={icon} sx={styles.icon} /> : null}
+            <Text
+              minWidth={0}
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+              overflowX="hidden"
+            >
+              <DropdownItemTextHighlighter
+                inputValue={inputValue ?? ''}
+                textToHighlight={label}
+              />
+            </Text>
+            {isAppNew && (
+              <Badge
+                bgColor="interaction.muted.main.active"
+                color="primary.600"
+              >
+                New
+              </Badge>
+            )}
+          </Flex>
+          {description && (
+            <Text
+              sx={{
+                ...styles.itemDescription,
+                ...(isDisabled ? { color: 'red.500' } : {}),
+              }}
+            >
+              <DropdownItemTextHighlighter
+                inputValue={inputValue ?? ''}
+                textToHighlight={description}
+              />
+            </Text>
+          )}
         </Flex>
-        {description && (
-          <Text sx={styles.itemDescription}>
-            <DropdownItemTextHighlighter
-              inputValue={inputValue ?? ''}
-              textToHighlight={description}
-            />
-          </Text>
+        {isEventInstant && (
+          <Badge bgColor="interaction.muted.main.active" color="primary.600">
+            Instant
+          </Badge>
         )}
       </Flex>
     </ListItem>

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -1,14 +1,12 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { Flex, Icon, ListItem, Text } from '@chakra-ui/react'
 import { dataAttr } from '@chakra-ui/utils'
-import { Badge } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../../SelectContext'
 import { ComboboxItem } from '../../types'
 import {
   isItemDisabled,
-  isItemInstant,
-  isItemNew,
+  itemToBadge,
   itemToDescriptionString,
   itemToIcon,
   itemToLabelString,
@@ -21,12 +19,6 @@ export interface DropdownItemProps {
   index: number
 }
 
-/**
- * Note: This is customised just for Plumber.
- * A new badge is to indicate that the app is new.
- * An instant badge is to indicate that the event is a webhook trigger.
- */
-
 export const DropdownItem = ({
   item,
   index,
@@ -34,33 +26,14 @@ export const DropdownItem = ({
   const { getItemProps, isItemSelected, inputValue, styles } =
     useSelectContext()
 
-  // add this for hover detection
-  const [isHovered, setIsHovered] = useState(false)
-  const handleMouseEnter = () => {
-    setIsHovered(true)
-  }
-
-  const handleMouseLeave = () => {
-    setIsHovered(false)
-  }
-
-  const {
-    icon,
-    label,
-    description,
-    isDisabled,
-    isActive,
-    isAppNew,
-    isEventInstant,
-  } = useMemo(
+  const { icon, label, description, isDisabled, isActive, badge } = useMemo(
     () => ({
       icon: itemToIcon(item),
       label: itemToLabelString(item),
       description: itemToDescriptionString(item),
       isDisabled: isItemDisabled(item),
       isActive: isItemSelected(item),
-      isAppNew: isItemNew(item),
-      isEventInstant: isItemInstant(item),
+      badge: itemToBadge(item),
     }),
     [isItemSelected, item],
   )
@@ -74,21 +47,6 @@ export const DropdownItem = ({
         index,
         disabled: isDisabled,
       })}
-      style={
-        isHovered
-          ? {
-              backgroundColor: '#f8f9fa',
-              cursor: isDisabled ? 'not-allowed' : 'pointer',
-            }
-          : isActive
-          ? {
-              backgroundColor: '#e9eaee',
-              cursor: 'pointer',
-            }
-          : undefined
-      }
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
     >
       <Flex justifyContent="space-between" alignItems="center">
         <Flex flexDir="column">
@@ -105,14 +63,7 @@ export const DropdownItem = ({
                 textToHighlight={label}
               />
             </Text>
-            {isAppNew && (
-              <Badge
-                bgColor="interaction.muted.main.active"
-                color="primary.600"
-              >
-                New
-              </Badge>
-            )}
+            {badge}
           </Flex>
           {description && (
             <Text
@@ -128,11 +79,6 @@ export const DropdownItem = ({
             </Text>
           )}
         </Flex>
-        {isEventInstant && (
-          <Badge bgColor="interaction.muted.main.active" color="primary.600">
-            Instant
-          </Badge>
-        )}
       </Flex>
     </ListItem>
   )

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
@@ -20,11 +20,9 @@ export const ComboboxClearButton = (): JSX.Element | null => {
 
   const [announceClearedInput, setAnnounceClearedInput] = useState(false)
   const handleClearSelection = useCallback(() => {
-    // Need to focus before selecting null. I have no idea why, but it works
-    inputRef?.current?.focus()
     selectItem(null)
     setAnnounceClearedInput(true)
-  }, [inputRef, selectItem])
+  }, [selectItem])
 
   useEffect(() => {
     if (selectedItem) {

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -7,10 +7,14 @@ import {
   Text,
   useMergeRefs,
 } from '@chakra-ui/react'
-import { Input } from '@opengovsg/design-system-react'
+import { Badge, Input } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../../SelectContext'
-import { itemToIcon, itemToLabelString } from '../../utils/itemUtils'
+import {
+  isItemInstant,
+  itemToIcon,
+  itemToLabelString,
+} from '../../utils/itemUtils'
 
 import { ComboboxClearButton } from './ComboboxClearButton'
 import { ToggleChevron } from './ToggleChevron'
@@ -82,9 +86,19 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
               />
             ) : null}
             {/* To display custom value if it exists when freeSolo is enabled */}
-            <Text noOfLines={1}>
-              {selectedItemMeta.label !== '' ? selectedItemMeta.label : value}
-            </Text>
+            <Flex w="100%" justifyContent="space-between">
+              <Text noOfLines={1}>
+                {selectedItemMeta.label !== '' ? selectedItemMeta.label : value}
+              </Text>
+              {isItemInstant(selectedItem) && (
+                <Badge
+                  bgColor="interaction.muted.main.active"
+                  color="primary.600"
+                >
+                  Instant
+                </Badge>
+              )}
+            </Flex>
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo } from 'react'
+import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Flex,
   Icon,
@@ -7,14 +7,10 @@ import {
   Text,
   useMergeRefs,
 } from '@chakra-ui/react'
-import { Badge, Input } from '@opengovsg/design-system-react'
+import { Input } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../../SelectContext'
-import {
-  isItemInstant,
-  itemToIcon,
-  itemToLabelString,
-} from '../../utils/itemUtils'
+import { itemToIcon, itemToLabelString } from '../../utils/itemUtils'
 
 import { ComboboxClearButton } from './ComboboxClearButton'
 import { ToggleChevron } from './ToggleChevron'
@@ -33,15 +29,24 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       inputValue,
       isRequired,
       placeholder,
+      isRefreshLoading,
       isOpen,
       resetInputValue,
       inputRef,
       isClearable,
       size,
-      value,
     } = useSelectContext()
 
     const mergedInputRef = useMergeRefs(inputRef, ref)
+
+    const [hasOptionsLoadedOnce, setHasOptionsLoadedOnce] = useState(false)
+    const isInitialLoading = !hasOptionsLoadedOnce && isRefreshLoading
+
+    useEffect(() => {
+      if (!isRefreshLoading) {
+        setHasOptionsLoadedOnce(true)
+      }
+    }, [isRefreshLoading])
 
     const selectedItemMeta = useMemo(
       () => ({
@@ -71,7 +76,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
           gridTemplateColumns="1fr"
         >
           <Stack
-            visibility={inputValue ? 'hidden' : 'initial'}
+            visibility={inputValue || isInitialLoading ? 'hidden' : 'initial'}
             direction="row"
             spacing="1rem"
             aria-disabled={isDisabled}
@@ -85,26 +90,19 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            {/* To display custom value if it exists when freeSolo is enabled */}
-            <Flex w="100%" justifyContent="space-between">
-              <Text noOfLines={1}>
-                {selectedItemMeta.label !== '' ? selectedItemMeta.label : value}
-              </Text>
-              {isItemInstant(selectedItem) && (
-                <Badge
-                  bgColor="interaction.muted.main.active"
-                  color="primary.600"
-                >
-                  Instant
-                </Badge>
-              )}
-            </Flex>
+            <Text noOfLines={1}>{selectedItemMeta.label}</Text>
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}
             isInvalid={isInvalid}
             isDisabled={isDisabled}
-            placeholder={selectedItem ? undefined : placeholder}
+            placeholder={
+              isInitialLoading
+                ? 'Fetching options...'
+                : selectedItem
+                ? undefined
+                : placeholder
+            }
             sx={styles.field}
             {...getInputProps({
               onClick: handleToggleMenu,

--- a/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
@@ -4,7 +4,6 @@ import { List, ListItem, Portal } from '@chakra-ui/react'
 import { Button, Spinner } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../SelectContext'
-import type { ComboboxItem } from '../types'
 import { itemToValue } from '../utils/itemUtils'
 
 import { DropdownItem } from './DropdownItem'
@@ -22,7 +21,6 @@ export const SelectMenu = (): JSX.Element => {
     onRefresh,
     isRefreshLoading,
     inputValue,
-    freeSolo,
   } = useSelectContext()
 
   const { floatingRef, floatingStyles } = useSelectPopover()
@@ -57,28 +55,10 @@ export const SelectMenu = (): JSX.Element => {
             }}
           />
         )}
-        {/* Freesolo enabled and non-empty input --> show new dropdown option
-         *  Freesolo disabled and no filtered input --> show nothing found label
-         */}
-        {isOpen && items.length === 0 ? (
-          freeSolo ? (
-            inputValue !== '' ? (
-              <DropdownItem
-                item={
-                  {
-                    label: inputValue,
-                    value: inputValue,
-                    description: inputValue,
-                  } as ComboboxItem
-                }
-                index={items.length}
-              />
-            ) : null
-          ) : (
-            <ListItem role="option" sx={styles.emptyItem}>
-              {nothingFoundLabel}
-            </ListItem>
-          )
+        {isOpen && items.length === 0 && inputValue?.length ? (
+          <ListItem role="option" sx={styles.emptyItem}>
+            {nothingFoundLabel}
+          </ListItem>
         ) : null}
         {/* Allow reload of dynamic data fields */}
         {isOpen && onRefresh && (

--- a/packages/frontend/src/components/SingleSelect/hooks/index.ts
+++ b/packages/frontend/src/components/SingleSelect/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useItems'
+export * from './useLookupItems'

--- a/packages/frontend/src/components/SingleSelect/hooks/useLookupItems.ts
+++ b/packages/frontend/src/components/SingleSelect/hooks/useLookupItems.ts
@@ -5,22 +5,20 @@ import { useCallback, useMemo } from 'react'
 import { ComboboxItem } from '../types'
 import { itemToValue } from '../utils/itemUtils'
 
-export type ItemWithIndex<Item extends ComboboxItem = ComboboxItem> = {
+type ItemWithIndex<Item extends ComboboxItem = ComboboxItem> = {
   item: Item
   index: number
 }
 
-export type UseItemsReturn<Item extends ComboboxItem = ComboboxItem> = {
+type UseItemsReturn<Item extends ComboboxItem = ComboboxItem> = {
   byValue: Record<string, ItemWithIndex<Item>>
 }
 
-interface UseItemProps<Item extends ComboboxItem = ComboboxItem> {
-  rawItems: Item[]
-}
-
-export const useItems = <Item extends ComboboxItem = ComboboxItem>({
+export const useLookupItems = <Item extends ComboboxItem = ComboboxItem>({
   rawItems,
-}: UseItemProps<Item>) => {
+}: {
+  rawItems: Item[]
+}) => {
   const normalizedItems = useMemo(() => {
     const initialStore: UseItemsReturn<Item> = {
       // Normalized store for filtering and retrieval of state
@@ -47,18 +45,6 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
     }, initialStore)
   }, [rawItems])
 
-  // UPDATE: used only if custom dropdown options are to be added
-  const addCustomItem = useCallback(
-    (newValue: string) => {
-      rawItems.push({
-        label: newValue,
-        value: newValue,
-        description: newValue,
-      } as Item)
-    },
-    [rawItems],
-  )
-
   const getItemByValue = useCallback(
     (value: string): ItemWithIndex<Item> | null => {
       return normalizedItems.byValue[value] ?? null
@@ -67,8 +53,6 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
   )
 
   return {
-    items: rawItems,
     getItemByValue,
-    addCustomItem,
   }
 }

--- a/packages/frontend/src/components/SingleSelect/types.ts
+++ b/packages/frontend/src/components/SingleSelect/types.ts
@@ -12,8 +12,9 @@ export type ComboboxItem<T = string> =
       disabled?: boolean
       /** Icon to display in input field when item is selected, if available */
       icon?: As
-      /** Badge to display for label, if available */
-      badge?: JSX.Element
+      /** Badges to display for Plumber apps and events, if available */
+      isAppNew?: boolean // new apps
+      isEventInstant?: boolean // webhook events
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       [key: string]: any
     }

--- a/packages/frontend/src/components/SingleSelect/types.ts
+++ b/packages/frontend/src/components/SingleSelect/types.ts
@@ -12,9 +12,8 @@ export type ComboboxItem<T = string> =
       disabled?: boolean
       /** Icon to display in input field when item is selected, if available */
       icon?: As
-      /** Badges to display for Plumber apps and events, if available */
-      isAppNew?: boolean // new apps
-      isEventInstant?: boolean // webhook events
+      /** Badge to display on the right of the label, if available */
+      badge?: JSX.Element
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       [key: string]: any
     }

--- a/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
+++ b/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
@@ -35,13 +35,6 @@ export const itemToIcon = <Item extends ComboboxItem>(item?: Item) => {
   return item.icon
 }
 
-export const itemToBadge = <Item extends ComboboxItem>(item?: Item) => {
-  if (!item || !itemIsObject(item)) {
-    return undefined
-  }
-  return item.badge
-}
-
 export const isItemDisabled = <Item extends ComboboxItem>(
   item: Item,
 ): boolean => {
@@ -52,4 +45,14 @@ export const itemToDescriptionString = <Item extends ComboboxItem>(
   item: Item,
 ): string | undefined => {
   return itemIsObject(item) ? item.description : undefined
+}
+
+export const isItemNew = <Item extends ComboboxItem>(item: Item): boolean => {
+  return itemIsObject(item) && !!item.isAppNew
+}
+
+export const isItemInstant = <Item extends ComboboxItem>(
+  item: Item,
+): boolean => {
+  return itemIsObject(item) && !!item.isEventInstant
 }

--- a/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
+++ b/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
@@ -35,6 +35,13 @@ export const itemToIcon = <Item extends ComboboxItem>(item?: Item) => {
   return item.icon
 }
 
+export const itemToBadge = <Item extends ComboboxItem>(item?: Item) => {
+  if (!item || !itemIsObject(item)) {
+    return undefined
+  }
+  return item.badge
+}
+
 export const isItemDisabled = <Item extends ComboboxItem>(
   item: Item,
 ): boolean => {
@@ -45,14 +52,4 @@ export const itemToDescriptionString = <Item extends ComboboxItem>(
   item: Item,
 ): string | undefined => {
   return itemIsObject(item) ? item.description : undefined
-}
-
-export const isItemNew = <Item extends ComboboxItem>(item: Item): boolean => {
-  return itemIsObject(item) && !!item.isAppNew
-}
-
-export const isItemInstant = <Item extends ComboboxItem>(
-  item: Item,
-): boolean => {
-  return itemIsObject(item) && !!item.isEventInstant
 }

--- a/packages/frontend/src/theme/components/Radio.ts
+++ b/packages/frontend/src/theme/components/Radio.ts
@@ -1,0 +1,19 @@
+import { radioAnatomy } from '@chakra-ui/anatomy'
+import { createMultiStyleConfigHelpers } from '@chakra-ui/react'
+
+const { defineMultiStyleConfig } = createMultiStyleConfigHelpers(
+  radioAnatomy.keys,
+)
+
+export const Radio = defineMultiStyleConfig({
+  baseStyle: {
+    container: {
+      _hover: {
+        bg: 'interaction.muted.neutral.hover',
+      },
+      _focusWithin: {
+        outline: 0,
+      },
+    },
+  },
+})

--- a/packages/frontend/src/theme/components/SingleSelect.ts
+++ b/packages/frontend/src/theme/components/SingleSelect.ts
@@ -1,0 +1,38 @@
+import { createMultiStyleConfigHelpers, defineStyle } from '@chakra-ui/react'
+import { anatomy } from '@chakra-ui/theme-tools'
+
+export const comboboxParts = anatomy('combobox').parts('item')
+
+export const parts = anatomy('singleselect')
+  .parts(...comboboxParts.keys)
+  .extend('field', 'selected')
+
+const { definePartsStyle, defineMultiStyleConfig } =
+  createMultiStyleConfigHelpers(parts.keys)
+
+const itemBaseStyle = defineStyle((props) => {
+  // follow 50, 100 instead of 100, 200 just for Plumber
+  const { colorScheme: c } = props
+  return {
+    _selected: {
+      bg: `${c}.50`,
+    },
+    _hover: {
+      bg: `${c}.50`,
+    },
+    _active: {
+      bg: `${c}.100 !important`, // to override the hover state
+    },
+  }
+})
+
+const baseStyle = definePartsStyle((props) => {
+  const itemStyle = itemBaseStyle(props)
+  return {
+    item: itemStyle,
+  }
+})
+
+export const SingleSelect = defineMultiStyleConfig({
+  baseStyle,
+})

--- a/packages/frontend/src/theme/components/index.ts
+++ b/packages/frontend/src/theme/components/index.ts
@@ -4,6 +4,8 @@ import { FormLabel } from './FormLabel'
 import { Infobox } from './Infobox'
 import { Link } from './Link'
 import { Modal } from './Modal'
+import { Radio } from './Radio'
+import { SingleSelect } from './SingleSelect'
 import { Text } from './Text'
 
 export const components = {
@@ -14,4 +16,6 @@ export const components = {
   Link,
   Infobox,
   Text,
+  SingleSelect,
+  Radio,
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -309,6 +309,22 @@ export interface IFieldRichText extends IBaseField {
   value?: string
 }
 
+export interface IFieldBooleanRadio extends IBaseField {
+  type: 'boolean-radio'
+  value?: boolean // will default to null if not provided
+  options?: IFieldBooleanRadioOptions // only can provide 2 OPTIONS if label is not yes/no
+}
+
+export type IFieldBooleanRadioOptions = [
+  IFieldBooleanRadioOption,
+  IFieldBooleanRadioOption,
+]
+
+export interface IFieldBooleanRadioOption {
+  label: string
+  value: boolean
+}
+
 export type IField =
   | IFieldDropdown
   | IFieldText
@@ -316,6 +332,7 @@ export type IField =
   | IFieldMultiSelect
   | IFieldMultiRow
   | IFieldRichText
+  | IFieldBooleanRadio
 
 export interface IAuthenticationStepField {
   name: string


### PR DESCRIPTION
## Problem
Need to migrate from MUI Autocomplete component to our own DS SingleSelect component for "choose app and event dropdown"

## Details
- Add isEventNew boolean to check whether to display new events in dropdown item
- Add isEventInstant boolean to check whether to display webhook events in dropdown item
- Add disabled text and color
- Removed code regarding polling since it is not used for now

## Tests
- [x] Old pipes still work
- [x] New apps have the badge to display
- [x] If-then is disabled if not at the last step or in nested
- [x] Webhook triggers **CAN** (formsg and raw webhook) have `instant` badge in the form label and dropdown option
