### PR TITLE
PLU-251: throw step error for non-number comparison

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -2,6 +2,8 @@ import { type IGlobalVariable } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import StepError from '@/errors/step'
+
 import onlyContinueIfAction from '../../actions/only-continue-if'
 
 const mocks = vi.hoisted(() => ({
@@ -119,16 +121,14 @@ describe('Only continue if', () => {
     },
   )
 
-  // TODO (mal): uncomment after 1 week of monitoring
-  // it('should throw step error if a non-number is used for operator comparison', async () => {
-  //   $.step.parameters = {
-  //     field: 123,
-  //     is: 'is',
-  //     condition: 'gte',
-  //     text: '19 Nov 2021',
-  //   }
+  it('should throw step error if a non-number is used for operator comparison', async () => {
+    $.step.parameters = {
+      field: 123,
+      is: 'is',
+      condition: 'gte',
+      text: '19 Nov 2021',
+    }
 
-  //   // throw partial step error message
-  //   await expect(onlyContinueIfAction.run($)).rejects.toThrowError(StepError)
-  // })
+    await expect(onlyContinueIfAction.run($)).rejects.toThrowError(StepError)
+  })
 })

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -1,7 +1,5 @@
 import type { IJSONObject, IJSONValue } from '@plumber/types'
 
-import logger from '@/helpers/logger'
-
 function compareNumbers(
   field: IJSONValue,
   condition: 'gte' | 'gt' | 'lte' | 'lt',
@@ -9,14 +7,7 @@ function compareNumbers(
 ): boolean {
   // WARNING: can only compare safely up till Number.MAX_SAFE_INTEGER but BigInt cannot compare floats...
   if (isNaN(Number(field)) || isNaN(Number(value))) {
-    logger.info('Non-number comparison occurred', {
-      event: 'non-number-comparison',
-      field,
-      condition,
-      value,
-    })
-    // TODO (mal): uncomment after 1 week of monitoring
-    // throw new Error('Non-number used in field or value for comparison')
+    throw new Error('Non-number used in field or value for comparison')
   }
   switch (condition) {
     case 'gte':


### PR DESCRIPTION
## Problem

User tries to compare dates which give false info


## Solution

Throw step error if any operands are NaN in the comparison for numbers

## Tests
- [x] All comparison operators still work as intended (=, <, <=, >, >=, contains, empty)
- [x] Negation operator still work
- [x] Both only continue if and if-then pipe still work with the configuration
- [x] Throws step error when non-number comparison is made