### PR TITLE
PLU-258: Simplify phrasing for trigger and action

### DIFF
--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -101,7 +101,7 @@ export default function ExecutionStep({
 
             <Box>
               <Text textStyle="body-2">
-                {index === 0 && page === 1 ? 'Trigger' : 'Action'}
+                {index === 0 && page === 1 ? 'When' : 'Then'}
               </Text>
 
               <Text textStyle="h5">

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -207,6 +207,18 @@ export default function FlowStep(
     [deleteStep, step.id],
   )
 
+  // define caption description based on app and step
+  let caption = ''
+  if (app?.name) {
+    caption = `${step.position}. ${app.name}`
+  } else if (isTrigger) {
+    caption = 'This step starts your pipe'
+  } else if (step.position === 2) {
+    caption = 'This step happens after your pipe starts'
+  } else {
+    caption = 'This step happens after the previous step'
+  }
+
   if (!apps) {
     return <CircularProgress isIndeterminate my={2} />
   }
@@ -216,14 +228,7 @@ export default function FlowStep(
   return (
     <FlowStepHeader
       iconUrl={app?.iconUrl}
-      caption={
-        displayOverrides?.caption ??
-        (app?.name
-          ? `${step.position}. ${app.name}`
-          : isTrigger
-          ? 'This step starts your pipe'
-          : 'This step happens after your pipe starts')
-      }
+      caption={displayOverrides?.caption ?? caption}
       hintAboveCaption={
         displayOverrides?.hintAboveCaption ?? (isTrigger ? 'When' : 'Then')
       }

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -218,10 +218,14 @@ export default function FlowStep(
       iconUrl={app?.iconUrl}
       caption={
         displayOverrides?.caption ??
-        (app?.name ? `${step.position}. ${app.name}` : 'Choose an app')
+        (app?.name
+          ? `${step.position}. ${app.name}`
+          : isTrigger
+          ? 'This step starts your pipe'
+          : 'This step happens after your pipe starts')
       }
       hintAboveCaption={
-        displayOverrides?.hintAboveCaption ?? (isTrigger ? 'Trigger' : 'Action')
+        displayOverrides?.hintAboveCaption ?? (isTrigger ? 'When' : 'Then')
       }
       isCompleted={step.status === 'completed'}
       onDelete={isDeletable ? onDelete : undefined}

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -20,7 +20,7 @@ function getStepContent(steps: IStep[]): {
   if (isIfThenStep(mainStep)) {
     return {
       StepContent: IfThen,
-      hintAboveCaption: 'Action',
+      hintAboveCaption: 'Then',
       caption: 'If-then',
       isStepGroupCompleted: areAllIfThenBranchesCompleted(steps, 0),
     }


### PR DESCRIPTION
## Problem

We want to simplify the user experience for new Plumber users, to lead in to the new onboarding experiment.

## Details
- Replace `Trigger` with `When`
- Replace `Action` with `When`
- Replace `choose an app` with `This step starts your pipe` and `This step happens after your pipe starts`
- This is also replaced in the `Executions` page

## Screenshots
**Before**
<img width="938" alt="Screenshot 2024-05-24 at 2 52 18 PM" src="https://github.com/opengovsg/plumber/assets/65110268/3e227999-e363-4a3f-889d-9c41192cdf02">

**After**
<img width="999" alt="Screenshot 2024-05-24 at 2 40 24 PM" src="https://github.com/opengovsg/plumber/assets/65110268/cc313fdb-f929-403f-97c0-5051c6dc65b9">
