### PR TITLE
[TILES-COLLAB-1] PLU-238 GetTable return collaborators

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -102,4 +102,24 @@ describe('get single table query', () => {
       ),
     ).resolves.toBeDefined()
   })
+
+  it('should return all collaborators ordered by roles', async () => {
+    const table = await getTable(
+      null,
+      {
+        tableId: dummyTable.id,
+      },
+      context,
+    )
+    const collaborators = await TableMetadataResolver.collaborators(
+      table,
+      {},
+      null,
+    )
+    expect(collaborators).toEqual([
+      { email: context.currentUser.email, role: 'owner' },
+      { email: editor.email, role: 'editor' },
+      { email: viewer.email, role: 'viewer' },
+    ])
+  })
 })

--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -1,3 +1,5 @@
+import sortBy from 'lodash/sortBy'
+
 import type { Resolvers } from '../__generated__/types.generated'
 
 type TableMetadataResolver = Resolvers['TableMetadata']
@@ -10,6 +12,25 @@ const columns: TableMetadataResolver['columns'] = async (parent) => {
   return columns
 }
 
+const collaborators: TableMetadataResolver['collaborators'] = async (
+  parent,
+) => {
+  const collaborators = await parent
+    .$relatedQuery('collaborators')
+    .select('email', 'role')
+    .orderBy('role', 'desc')
+  return sortBy(
+    collaborators,
+    [
+      (collab) => {
+        return ['owner', 'editor', 'viewer'].indexOf(collab.role)
+      },
+    ],
+    (collab) => collab.email,
+  ) as { email: string; role: string }[]
+}
+
 export default {
   columns,
+  collaborators,
 } satisfies TableMetadataResolver

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -640,12 +640,18 @@ type TableColumnMetadata {
   config: TableColumnConfig!
 }
 
+type TableCollaborator {
+  email: String!
+  role: String!
+}
+
 type TableMetadata {
   id: ID!
   name: String!
   columns: [TableColumnMetadata!]
   lastAccessedAt: String!
   viewOnlyKey: String
+  collaborators: [TableCollaborator!]
 }
 
 # End Tiles types

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -754,6 +754,12 @@ export interface ITableMetadata {
   columns: ITableColumnMetadata[]
   lastAccessedAt: string
   viewOnlyKey?: string
+  collaborators?: ITableCollaborator[]
+}
+
+export interface ITableCollaborator {
+  email: string
+  role: ITableCollabRole
 }
 
 export interface ITableRow {


### PR DESCRIPTION
## Get collaborators (backend only)
This adds the collaborators property for the getTable query.
Order is sorted by owner -> editors -> viewers and alphabetically in between.

## Testing
- Unit test covered
- Can also manually call getTable endpoint with `collaborators` property to inspect