### PR TITLE
fix: enforce lowercase input for pipe transfer

### DIFF
--- a/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
@@ -102,7 +102,7 @@ export default function FlowTransfer() {
               autoFocus={true}
               {...register('email', {
                 onChange: (event) => {
-                  setNewOwnerEmail(event.target.value)
+                  setNewOwnerEmail(event.target.value.toLowerCase())
                 },
               })}
             />


### PR DESCRIPTION
## Problem

User can type capital letters but email is supposed to be case-insensitive.

## Solution

Make the input lowercase...

## Tests
- [x] Pipe transfer still works!