### PR TITLE
chore: add yyyymmdd format

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -35,6 +35,8 @@ describe('convert date time', () => {
     { toFormat: 'dd/LL/yyyy', expectedResult: '01/04/2024' },
     { toFormat: 'dd LLL yyyy', expectedResult: '01 Apr 2024' },
     { toFormat: 'dd LLLL yyyy', expectedResult: '01 April 2024' },
+    { toFormat: 'yy/LL/dd', expectedResult: '24/04/01' },
+    { toFormat: 'yyyy/LL/dd', expectedResult: '2024/04/01' },
     { toFormat: 'hh:mm a', expectedResult: '12:05 pm' },
     { toFormat: 'hh:mm:ss a', expectedResult: '12:05:10 pm' },
     { toFormat: 'dd LLL yyyy hh:mm a', expectedResult: '01 Apr 2024 12:05 pm' },

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -9,6 +9,8 @@ const formatStringsEnum = z.enum([
   'dd/LL/yyyy',
   'dd LLL yyyy',
   'dd LLLL yyyy',
+  'yy/LL/dd',
+  'yyyy/LL/dd',
   'hh:mm a',
   'hh:mm:ss a',
   'dd LLL yyyy hh:mm a',
@@ -46,6 +48,16 @@ export const field = {
       label: 'DD MMMM YYYY',
       description: '02 January 2006',
       value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
+    },
+    {
+      label: 'YY/MM/DD',
+      description: '24/01/22',
+      value: ensureZodEnumValue(formatStringsEnum, 'yy/LL/dd'),
+    },
+    {
+      label: 'YYYY/MM/dd',
+      description: '2024/01/22',
+      value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
     },
     {
       label: 'HH:mm (am/pm)',

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -55,7 +55,7 @@ export const field = {
       value: ensureZodEnumValue(formatStringsEnum, 'yy/LL/dd'),
     },
     {
-      label: 'YYYY/MM/dd',
+      label: 'YYYY/MM/DD',
       description: '2024/01/22',
       value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
     },


### PR DESCRIPTION
## Problem
Users want to be able to format date starting with year instead of day.

## Solution
Discussed with stacey; instead of asking users to split (using our planned split string feature) our existing dd/mm/yyyy date, which makes the pipe more complex, we'll just add a new date formatter option.

<img width="500" alt="Screenshot 2024-05-28 at 6 29 58 PM" src="https://github.com/opengovsg/plumber/assets/135598754/a0482cc0-c983-48ca-926b-2849f30002bd">

## Tests
- Updated unit test
- Check that new date format works when chosen in a pipe