### PR TITLE
[TILES-COLLAB-2] PLU-238 edit collaborators endpoints

### DIFF
--- a/packages/backend/src/errors/graphql-errors/bad-user-input.ts
+++ b/packages/backend/src/errors/graphql-errors/bad-user-input.ts
@@ -1,0 +1,16 @@
+import { ApolloServerErrorCode } from '@apollo/server/errors'
+import { GraphQLError } from 'graphql/error'
+
+export class BadUserInputError extends GraphQLError {
+  constructor(message: string) {
+    super(message, {
+      extensions: {
+        code: ApolloServerErrorCode.BAD_USER_INPUT,
+        message,
+        http: {
+          status: 400,
+        },
+      },
+    })
+  }
+}

--- a/packages/backend/src/errors/graphql-errors/index.ts
+++ b/packages/backend/src/errors/graphql-errors/index.ts
@@ -1,0 +1,1 @@
+export * from './bad-user-input'

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import TableMetadata from '@/models/table-metadata'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import deleteTableCollaborator from '../../../mutations/tiles/delete-table-collaborator'
+
+import { generateMockContext, generateMockTable } from './table.mock'
+
+describe('delete table collaborators', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+  let editor: User
+  let owner: User
+  let viewer: User
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    const mockTable = await generateMockTable({
+      userId: context.currentUser.id,
+    })
+    dummyTable = mockTable.table
+    editor = mockTable.editor
+    owner = mockTable.owner
+    viewer = mockTable.viewer
+  })
+
+  it('should be able to delete collaborators', async () => {
+    await deleteTableCollaborator(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+          email: viewer.email,
+        },
+      },
+      context,
+    )
+    const collaborators = await dummyTable
+      .$relatedQuery('collaborators')
+      .select('email', 'role', 'table_collaborators.deleted_at')
+      .where('table_collaborators.deleted_at', null)
+    expect(collaborators).toHaveLength(2)
+    const addedCollaborator = collaborators.find(
+      (col) => col.email === viewer.email,
+    )
+    expect(addedCollaborator).toBeUndefined()
+  })
+
+  it('should throw an error if collaborator is not found', async () => {
+    await expect(
+      deleteTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: 'viewer2@open.gov.sg',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('should not delete owner role', async () => {
+    context.currentUser = editor
+    await deleteTableCollaborator(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+          email: owner.email,
+        },
+      },
+      context,
+    )
+    const collaborators = await dummyTable
+      .$relatedQuery('collaborators')
+      .where('table_collaborators.deleted_at', null)
+    expect(collaborators).toHaveLength(3)
+  })
+
+  it('should not allow deleting of oneself', async () => {
+    context.currentUser = editor
+    await expect(
+      deleteTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: editor.email,
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
@@ -39,7 +39,9 @@ describe('update table collaborators', () => {
       },
       context,
     )
-    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    const collaborators = await dummyTable
+      .$relatedQuery('collaborators')
+      .where('table_collaborators.deleted_at', null)
     expect(collaborators).toHaveLength(4)
     const addedCollaborator = collaborators.find(
       (col) => col.email === 'viewer2@open.gov.sg',
@@ -59,7 +61,9 @@ describe('update table collaborators', () => {
       },
       context,
     )
-    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    const collaborators = await dummyTable
+      .$relatedQuery('collaborators')
+      .where('table_collaborators.deleted_at', null)
     expect(collaborators).toHaveLength(4)
     const addedCollaborator = collaborators.find(
       (col) => col.email === 'editor2@open.gov.sg',
@@ -79,7 +83,9 @@ describe('update table collaborators', () => {
       },
       context,
     )
-    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    const collaborators = await dummyTable
+      .$relatedQuery('collaborators')
+      .where('table_collaborators.deleted_at', null)
     expect(collaborators).toHaveLength(3)
     const addedCollaborator = collaborators.find(
       (col) => col.email === 'editor@open.gov.sg',

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import TableMetadata from '@/models/table-metadata'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import upsertTableCollaborator from '../../../mutations/tiles/upsert-table-collaborator'
+
+import { generateMockContext, generateMockTable } from './table.mock'
+
+describe('update table collaborators', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+  let editor: User
+  let owner: User
+  let viewer: User
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    const mockTable = await generateMockTable({
+      userId: context.currentUser.id,
+    })
+    dummyTable = mockTable.table
+    editor = mockTable.editor
+    owner = mockTable.owner
+    viewer = mockTable.viewer
+  })
+
+  it('should be able to add new viewers', async () => {
+    await upsertTableCollaborator(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+          email: 'viewer2@open.gov.sg',
+          role: 'viewer',
+        },
+      },
+      context,
+    )
+    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    expect(collaborators).toHaveLength(4)
+    const addedCollaborator = collaborators.find(
+      (col) => col.email === 'viewer2@open.gov.sg',
+    )
+    expect(addedCollaborator).toHaveProperty('role', 'viewer')
+  })
+
+  it('should be able to add new editors', async () => {
+    await upsertTableCollaborator(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+          email: 'editor2@open.gov.sg',
+          role: 'editor',
+        },
+      },
+      context,
+    )
+    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    expect(collaborators).toHaveLength(4)
+    const addedCollaborator = collaborators.find(
+      (col) => col.email === 'editor2@open.gov.sg',
+    )
+    expect(addedCollaborator).toHaveProperty('role', 'editor')
+  })
+
+  it('should be able to update roles', async () => {
+    await upsertTableCollaborator(
+      null,
+      {
+        input: {
+          tableId: dummyTable.id,
+          email: 'editor@open.gov.sg',
+          role: 'viewer',
+        },
+      },
+      context,
+    )
+    const collaborators = await dummyTable.$relatedQuery('collaborators')
+    expect(collaborators).toHaveLength(3)
+    const addedCollaborator = collaborators.find(
+      (col) => col.email === 'editor@open.gov.sg',
+    )
+    expect(addedCollaborator).toHaveProperty('role', 'viewer')
+  })
+
+  it('should not allow adding of owner role', async () => {
+    await expect(
+      upsertTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: 'owner2@open.gov.sg',
+            role: 'owner',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrowError('Cannot set collaborator role as owner')
+  })
+
+  it('should not allow editing role of owner', async () => {
+    context.currentUser = editor
+    await expect(
+      upsertTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: owner.email,
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow()
+  })
+
+  it('should not allow editing of own role', async () => {
+    context.currentUser = editor
+    await expect(
+      upsertTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: context.currentUser.email,
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('Cannot change own role')
+  })
+  it('should not allow editing of own role', async () => {
+    context.currentUser = editor
+    await expect(
+      upsertTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: context.currentUser.email,
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('Cannot change own role')
+  })
+
+  it('should only not allow viewers to modify collaborators', async () => {
+    context.currentUser = viewer
+    await expect(
+      upsertTableCollaborator(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            email: 'tester33@open.gov.sg',
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow('You do not have access to this tile')
+  })
+})

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import getAllRows from '@/graphql/queries/tiles/get-all-rows'
 import { createTableRow } from '@/models/dynamodb/table-row'
+import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -153,5 +154,22 @@ describe('get all rows query', () => {
         context,
       ),
     ).resolves.toBeDefined()
+  })
+
+  it('should throw an error if collaborator does not exist or is soft deleted', async () => {
+    context.currentUser = editor
+    await TableCollaborator.query()
+      .delete()
+      .where('table_id', dummyTable.id)
+      .andWhere('user_id', editor.id)
+    await expect(
+      getAllRows(
+        null,
+        {
+          tableId: dummyTable.id,
+        },
+        context,
+      ),
+    ).rejects.toThrow('Table not found')
   })
 })

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import TableMetadataResolver from '@/graphql/custom-resolvers/table-metadata'
 import getTable from '@/graphql/queries/tiles/get-table'
+import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -73,6 +74,23 @@ describe('get single table query', () => {
         null,
         {
           tableId: randomUUID(),
+        },
+        context,
+      ),
+    ).rejects.toThrow('Table not found')
+  })
+
+  it('should throw an error if collaborator does not exist or is soft deleted', async () => {
+    context.currentUser = editor
+    await TableCollaborator.query()
+      .delete()
+      .where('table_id', dummyTable.id)
+      .andWhere('user_id', editor.id)
+    await expect(
+      getTable(
+        null,
+        {
+          tableId: dummyTable.id,
         },
         context,
       ),

--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -19,6 +19,7 @@ const collaborators: TableMetadataResolver['collaborators'] = async (
     .$relatedQuery('collaborators')
     .select('email', 'role')
     .orderBy('role', 'desc')
+    .where('table_collaborators.deleted_at', null)
   return sortBy(
     collaborators,
     [

--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -18,7 +18,6 @@ const collaborators: TableMetadataResolver['collaborators'] = async (
   const collaborators = await parent
     .$relatedQuery('collaborators')
     .select('email', 'role')
-    .orderBy('role', 'desc')
     .where('table_collaborators.deleted_at', null)
   return sortBy(
     collaborators,

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
@@ -20,12 +20,10 @@ const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
       .throwIfNotFound()
 
     try {
-      await TableCollaborator.query()
-        .where({
-          tableId,
-          userId: collaboratorUser.id,
-        })
-        .delete()
+      await TableCollaborator.query().delete().where({
+        table_id: tableId,
+        user_id: collaboratorUser.id,
+      })
     } catch (e) {
       logger.error({
         message: 'Failed to delete collaborator',
@@ -34,6 +32,7 @@ const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
           email,
         },
         userId: context.currentUser.id,
+        error: e,
       })
       throw new Error('Failed to delete collaborator')
     }

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
@@ -13,8 +13,6 @@ const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
       email: string
     }
 
-    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
-
     const validatedEmail = await validateAndParseEmail(email)
     if (!validatedEmail) {
       throw new BadUserInputError('Invalid collaborator email')
@@ -23,6 +21,8 @@ const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
     if (validatedEmail === context.currentUser.email) {
       throw new BadUserInputError('Cannot remove yourself')
     }
+
+    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
     const user = await User.query()
       .findOne({

--- a/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-collaborator.ts
@@ -1,0 +1,44 @@
+import logger from '@/helpers/logger'
+import TableCollaborator from '@/models/table-collaborators'
+import User from '@/models/user'
+
+import type { MutationResolvers } from '../../__generated__/types.generated'
+
+const deleteTableCollaborator: MutationResolvers['deleteTableCollaborator'] =
+  async (_parent, params, context) => {
+    const { tableId, email } = params.input as {
+      tableId: string
+      email: string
+    }
+
+    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+
+    const collaboratorUser = await User.query()
+      .findOne({
+        email,
+      })
+      .throwIfNotFound()
+
+    try {
+      await TableCollaborator.query()
+        .where({
+          tableId,
+          userId: collaboratorUser.id,
+        })
+        .delete()
+    } catch (e) {
+      logger.error({
+        message: 'Failed to delete collaborator',
+        data: {
+          tableId,
+          email,
+        },
+        userId: context.currentUser.id,
+      })
+      throw new Error('Failed to delete collaborator')
+    }
+
+    return true
+  }
+
+export default deleteTableCollaborator

--- a/packages/backend/src/graphql/mutations/tiles/index.ts
+++ b/packages/backend/src/graphql/mutations/tiles/index.ts
@@ -6,8 +6,10 @@ import createTable from './create-table'
 import createShareableTableLink from './create-table-shareable-link'
 import deleteRows from './delete-rows'
 import deleteTable from './delete-table'
+import deleteTableCollaborator from './delete-table-collaborator'
 import updateRow from './update-row'
 import updateTable from './update-table'
+import upsertTableCollaborator from './upsert-table-collaborator'
 
 export default {
   createTable,
@@ -18,4 +20,6 @@ export default {
   updateRow,
   deleteRows,
   createShareableTableLink,
+  deleteTableCollaborator,
+  upsertTableCollaborator,
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
@@ -1,0 +1,56 @@
+import { ITableCollabRole } from '@plumber/types'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { getOrCreateUser } from '@/helpers/auth'
+import { validateAndParseEmail } from '@/helpers/email-validator'
+import logger from '@/helpers/logger'
+import TableCollaborator from '@/models/table-collaborators'
+
+import type { MutationResolvers } from '../../__generated__/types.generated'
+
+const upsertTableCollaborator: MutationResolvers['upsertTableCollaborator'] =
+  async (_parent, params, context) => {
+    const { tableId, email, role } = params.input as {
+      tableId: string
+      email: string
+      role: ITableCollabRole
+    }
+
+    await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+
+    const validatedEmail = await validateAndParseEmail(email)
+
+    if (!validatedEmail) {
+      throw new BadUserInputError('Invalid collaborator email')
+    }
+
+    const collaboratorUser = await getOrCreateUser(validatedEmail)
+
+    try {
+      await TableCollaborator.query()
+        .insert({
+          tableId,
+          userId: collaboratorUser.id,
+          role,
+        })
+        .onConflict(['tableId', 'userId'])
+        .update({
+          role,
+        })
+    } catch (e) {
+      logger.error({
+        message: 'Failed to upsert collaborator',
+        data: {
+          tableId,
+          email,
+          role,
+        },
+        userId: context.currentUser.id,
+      })
+      throw new Error('Failed to upsert collaborator')
+    }
+
+    return true
+  }
+
+export default upsertTableCollaborator

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -26,7 +26,6 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
       : await context.currentUser
           .$relatedQuery('tables')
           .withGraphFetched('columns')
-          .whereNull('table_collaborators.deleted_at')
           .findById(tableId)
           .throwIfNotFound()
 

--- a/packages/backend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from 'objection'
 
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
+import logger from '@/helpers/logger'
 import TableMetadata from '@/models/table-metadata'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
@@ -27,6 +28,7 @@ const getTable: QueryResolvers['getTable'] = async (
 
     return table
   } catch (e) {
+    logger.error(e)
     if (e instanceof NotFoundError) {
       if (context.tilesViewKey) {
         throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -648,13 +648,13 @@ type TableCollaborator {
   role: String!
 }
 
-type TableCollaboratorInput {
+input TableCollaboratorInput {
   tableId: ID!
   email: String!
   role: String!
 }
 
-type DeleteTableCollaboratorInput {
+input DeleteTableCollaboratorInput {
   tableId: ID!
   email: String!
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -86,6 +86,9 @@ type Mutation {
   createRows(input: CreateTableRowsInput!): Boolean
   updateRow(input: UpdateTableRowInput!): ID!
   deleteRows(input: DeleteTableRowsInput!): [ID!]!
+  # Tiles collaborators
+  upsertTableCollaborator(input: TableCollaboratorInput!): Boolean!
+  deleteTableCollaborator(input: DeleteTableCollaboratorInput!): Boolean!
   # Flow transfers
   createFlowTransfer(input: CreateFlowTransferInput!): FlowTransfer!
   updateFlowTransferStatus(input: UpdateFlowTransferStatusInput): FlowTransfer!
@@ -643,6 +646,17 @@ type TableColumnMetadata {
 type TableCollaborator {
   email: String!
   role: String!
+}
+
+type TableCollaboratorInput {
+  tableId: ID!
+  email: String!
+  role: String!
+}
+
+type DeleteTableCollaboratorInput {
+  tableId: ID!
+  email: String!
 }
 
 type TableMetadata {

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -23,7 +23,6 @@ class TableCollaborator extends Base {
       tableId: { type: 'string', format: 'uuid' },
       name: { type: 'string', format: 'uuid' },
       role: { type: 'string', enum: ['owner', 'editor', 'viewer'] },
-      deletedAt: { type: 'null' }, // disallow soft deletes
       lastAccessedAt: { type: 'string', format: 'date-time' },
     },
   }

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,7 +1,7 @@
 import { ITableCollabRole } from '@plumber/types'
 
 import crypto from 'crypto'
-import { ModelOptions, QueryContext } from 'objection'
+import { AnyQueryBuilder, ModelOptions, QueryContext } from 'objection'
 
 import Base from './base'
 import Connection from './connection'
@@ -99,6 +99,8 @@ class User extends Base {
         },
         to: `${TableMetadata.tableName}.id`,
       },
+      filter: (query: AnyQueryBuilder) =>
+        query.whereNull(`${TableCollaborator.tableName}.deleted_at`),
     },
     sentFlowTransfers: {
       relation: Base.HasManyRelation,


### PR DESCRIPTION
## Edit tile collaborator 
- Upsert
- Delete


  | Owner | Editor | Viewer | Shareable link
-- | -- | -- | -- | --
Can view tile | ✅ | ✅ | ✅ | ✅
Can view collaborators | ✅ | ✅ | ✅ |  ✅
Can view shareable link | ✅ | ✅ | ✅ |  ✅
Can edit data | ✅ | ✅ |   |  
Can rename pipe | ✅ | ✅ |   |  
Can adjust/edit columns | ✅ | ✅ |   |  
Can modify collaborators | ✅ | ✅ |   |  
Can regen shareable link | ✅ | ✅ |   |  
Can use in pipe | ✅ |   |   |  
Can delete table | ✅ |   |   |  



## Testing
- Unit tests added
- To manually test, use /graphql endpoint to manually insert, update and delete