### PR TITLE
[TILES-COLLAB-3] PLU-238: add missing indices to table_collaborators

### DIFF
--- a/packages/backend/src/db/migrations/20240527081339_add-collaborator-indices.ts
+++ b/packages/backend/src/db/migrations/20240527081339_add-collaborator-indices.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('table_collaborators', (table) => {
+    table.index('user_id')
+    table.index('table_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('table_collaborators', (table) => {
+    table.dropIndex('user_id')
+    table.dropIndex('table_id')
+  })
+}


### PR DESCRIPTION
Add indicies to `table_collaborators` db for better future proofing.

## Migrations
- [ ] prod
- [x] staging
- [x] uat