### PR TITLE
[TILES-COLLAB-6] PLU-238: return role for each tile when fetching tableMetadata

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -53,6 +53,17 @@ describe('get single table query', () => {
     expect(columns.map((c) => c.id)).toEqual(dummyColumnIds)
   })
 
+  it('should return table metadata with role', async () => {
+    const table = await getTable(
+      null,
+      {
+        tableId: dummyTable.id,
+      },
+      context,
+    )
+    expect(table.role).toBe('owner')
+  })
+
   it('should return empty array of columns if no columns exist', async () => {
     const { table: insertedTable } = await generateMockTable({
       userId: context.currentUser.id,

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
@@ -45,4 +45,14 @@ describe('get tables query', () => {
       numTables - 1,
     )
   })
+  it('should return the corresponding roles of each user', async () => {
+    const numTables = 5
+    for (let i = 0; i < numTables; i++) {
+      await generateMockTable({ userId: context.currentUser.id })
+    }
+    const tables = await getTables(null, null, context)
+    for (const table of tables) {
+      expect(table.role).toBe('owner')
+    }
+  })
 })

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -666,6 +666,7 @@ type TableMetadata {
   lastAccessedAt: String!
   viewOnlyKey: String
   collaborators: [TableCollaborator!]
+  role: String
 }
 
 # End Tiles types

--- a/packages/frontend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table.ts
@@ -18,6 +18,7 @@ export const GET_TABLE = gql`
         email
         role
       }
+      role
     }
   }
 `

--- a/packages/frontend/src/graphql/queries/tiles/get-tables.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-tables.ts
@@ -6,6 +6,7 @@ export const GET_TABLES = gql`
       id
       name
       lastAccessedAt
+      role
     }
   }
 `

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -755,6 +755,7 @@ export interface ITableMetadata {
   lastAccessedAt: string
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
+  role?: ITableCollabRole
 }
 
 export interface ITableCollaborator {


### PR DESCRIPTION
## Changes
GetTable and GetTables should now return the `role` of the current user in `TableMetadata`.
Although you could also get the current user's role for the tile by searching through the collaborators array, i think it's cleaner this way since the role is already returned in the db query.

This role is used to determine which frontend functions should be disabled.
