### PR TITLE
[TILES-COLLAB-7] PLU-238: hide/show certain functions depending on role

### DIFF
--- a/packages/frontend/src/pages/Tile/components/TableBanner/BreadCrumb.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/BreadCrumb.tsx
@@ -16,7 +16,7 @@ import { useTableContext } from '../../contexts/TableContext'
 import { useUpdateTable } from '../../hooks/useUpdateTable'
 
 function BreadCrumb() {
-  const { tableName: initialTableName } = useTableContext()
+  const { tableName: initialTableName, hasEditPermission } = useTableContext()
   const [isEditingTableName, setIsEditingTableName] = useState(false)
   const [tableName, setTableName] = useState(initialTableName)
   const { updateTableName, isUpdatingTableName } = useUpdateTable()
@@ -96,6 +96,7 @@ function BreadCrumb() {
         ) : (
           <BreadcrumbLink
             onClick={() => setIsEditingTableName(true)}
+            pointerEvents={hasEditPermission ? 'auto' : 'none'}
             gap={3}
             overflow="hidden"
             alignItems="center"
@@ -104,16 +105,18 @@ function BreadCrumb() {
             role="group"
           >
             {initialTableName}
-            <IconButton
-              icon={<MdOutlineModeEdit size={14} />}
-              aria-label="Edit"
-              size="xs"
-              variant="clear"
-              display="none"
-              _groupHover={{
-                display: 'flex',
-              }}
-            />
+            {hasEditPermission && (
+              <IconButton
+                icon={<MdOutlineModeEdit size={14} />}
+                aria-label="Edit"
+                size="xs"
+                variant="clear"
+                display="none"
+                _groupHover={{
+                  display: 'flex',
+                }}
+              />
+            )}
           </BreadcrumbLink>
         )}
       </BreadcrumbItem>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/EditMode.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/EditMode.tsx
@@ -36,14 +36,14 @@ const EditMode = () => {
     [mode],
   )
 
-  if (mode === 'edit') {
+  if (hasEditPermission) {
     return null
   }
 
   return (
     <Menu gutter={0} colorScheme="secondary">
-      <MenuButton
-        as={Badge}
+      <Badge
+        as={MenuButton}
         /**
          * Prevent the button from being clicked, as it is only used to display the current mode
          * remove this prop to allow selection of view/edit mode
@@ -62,7 +62,7 @@ const EditMode = () => {
             {selectedModeOption.label}
           </Text>
         </Flex>
-      </MenuButton>
+      </Badge>
 
       <MenuList borderRadius="md">
         {MODES.map(({ label, icon, value, colorScheme }) => (

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportExportToolbar.tsx
@@ -23,7 +23,7 @@ const ImportExportToolbar = (): JSX.Element => {
         <Flex justifyContent="center" alignItems="center">
           {hasEditPermission && <ImportCsvButton />}
           <ExportCsvButton />
-          {hasEditPermission && <ShareButton />}
+          <ShareButton />
         </Flex>
       </Show>
       <Hide above="md">
@@ -37,7 +37,7 @@ const ImportExportToolbar = (): JSX.Element => {
           <MenuList display="flex" flexDir="column" borderRadius="md">
             {hasEditPermission && <ImportCsvButton {...MENU_ITEM_PROPS} />}
             <ExportCsvButton {...MENU_ITEM_PROPS} />
-            {hasEditPermission && <ShareButton {...MENU_ITEM_PROPS} />}
+            <ShareButton {...MENU_ITEM_PROPS} />
           </MenuList>
         </Menu>
       </Hide>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -35,7 +35,7 @@ import { useTableContext } from '../../contexts/TableContext'
 import TableCollaborators from './TableCollaborators'
 
 const ShareModal = ({ onClose }: { onClose: () => void }) => {
-  const { tableId, viewOnlyKey } = useTableContext()
+  const { tableId, viewOnlyKey, hasEditPermission } = useTableContext()
   const [isNewLink, setIsNewLink] = useState(false)
 
   const shareableLink = viewOnlyKey
@@ -98,15 +98,17 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
                     </InputRightAddon>
                   </InputGroup>
                 )}
-                <Button
-                  variant="outline"
-                  isLoading={loading}
-                  onClick={onGenerate}
-                >
-                  Generate new link
-                </Button>
+                {hasEditPermission && (
+                  <Button
+                    variant="outline"
+                    isLoading={loading}
+                    onClick={onGenerate}
+                  >
+                    Generate new link
+                  </Button>
+                )}
               </Flex>
-              {viewOnlyKey && (
+              {viewOnlyKey && hasEditPermission && (
                 <FormHelperText variant={isNewLink ? 'success' : undefined}>
                   {isNewLink
                     ? 'New link generated!'

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -67,56 +67,63 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
         <ModalCloseButton />
         <ModalBody mt={2}>
           <FormControl>
-            <VStack spacing={2} alignItems="flex-start">
-              <Text textStyle="subhead-3">General Access</Text>
-              <Text textStyle="body-1">
-                Generate a shareable link to allow viewing and exporting only.
-                No login required.
-              </Text>
-              <Flex alignSelf="stretch" gap={2}>
-                {viewOnlyKey && (
-                  <InputGroup borderWidth={0}>
-                    <Input
-                      value={shareableLink}
-                      borderRightWidth={0}
-                      borderColor={inputBorderColor}
-                      _focusVisible={{ borderColor: inputBorderColor }}
-                      isReadOnly
-                    />
-                    <InputRightAddon
-                      padding={0}
-                      background="white"
-                      borderColor={inputBorderColor}
-                    >
-                      <IconButton
-                        icon={<BiCopy />}
-                        colorScheme="secondary"
-                        variant="clear"
-                        aria-label={'Copy'}
-                        onClick={() => copy(shareableLink ?? '')}
-                      />
-                    </InputRightAddon>
-                  </InputGroup>
-                )}
-                {hasEditPermission && (
-                  <Button
-                    variant="outline"
-                    isLoading={loading}
-                    onClick={onGenerate}
-                  >
-                    Generate new link
-                  </Button>
-                )}
-              </Flex>
-              {viewOnlyKey && hasEditPermission && (
-                <FormHelperText variant={isNewLink ? 'success' : undefined}>
-                  {isNewLink
-                    ? 'New link generated!'
-                    : 'By generating a new link, your previous link will not work anymore.'}
-                </FormHelperText>
-              )}
-            </VStack>
-            <Divider my={6} />
+            {(viewOnlyKey || hasEditPermission) && (
+              <>
+                <VStack spacing={2} alignItems="flex-start">
+                  <Text textStyle="subhead-3">General Access</Text>
+                  <Text textStyle="body-1">
+                    {hasEditPermission
+                      ? 'Generate a shareable link to allow'
+                      : 'This shareable link allows'}{' '}
+                    viewing and exporting only. No login required.
+                  </Text>
+                  <Flex alignSelf="stretch" gap={2}>
+                    {viewOnlyKey && (
+                      <InputGroup borderWidth={0}>
+                        <Input
+                          value={shareableLink}
+                          borderRightWidth={0}
+                          paddingRight={0}
+                          borderColor={inputBorderColor}
+                          _focusVisible={{ borderColor: inputBorderColor }}
+                          isReadOnly
+                        />
+                        <InputRightAddon
+                          padding={0}
+                          background="white"
+                          borderColor={inputBorderColor}
+                        >
+                          <IconButton
+                            icon={<BiCopy />}
+                            colorScheme="secondary"
+                            variant="clear"
+                            aria-label={'Copy'}
+                            onClick={() => copy(shareableLink ?? '')}
+                          />
+                        </InputRightAddon>
+                      </InputGroup>
+                    )}
+                    {hasEditPermission && (
+                      <Button
+                        variant="outline"
+                        isLoading={loading}
+                        onClick={onGenerate}
+                      >
+                        Generate new link
+                      </Button>
+                    )}
+                  </Flex>
+                  {viewOnlyKey && hasEditPermission && (
+                    <FormHelperText variant={isNewLink ? 'success' : undefined}>
+                      {isNewLink
+                        ? 'New link generated!'
+                        : 'By generating a new link, your previous link will not work anymore.'}
+                    </FormHelperText>
+                  )}
+                </VStack>
+                <Divider my={6} />
+              </>
+            )}
             <TableCollaborators />
           </FormControl>
         </ModalBody>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -93,7 +93,6 @@ const AddNewCollaborator = ({
     >
       <FormControl>
         <VStack spacing={2} alignItems="flex-start">
-          <Text textStyle="subhead-3">Collaborators</Text>
           <Flex alignSelf="stretch" gap={2}>
             <Input
               type="email"
@@ -119,15 +118,17 @@ const CollaboratorListRow = ({
   collaborator,
   onRoleChange,
   onDelete,
+  isEditable,
 }: {
   collaborator: ITableCollaborator
   onRoleChange: (role: ITableCollabRole) => void
   onDelete: () => void
+  isEditable: boolean
 }) => {
   const { currentUser } = useContext(AuthenticationContext)
   const [isDeleting, setIsDeleting] = useState(false)
-  const isEditable =
-    collaborator.role !== 'owner' && collaborator.email !== currentUser?.email
+  const isOwnerOrSelf =
+    collaborator.role === 'owner' || collaborator.email === currentUser?.email
 
   const onDeleteHandler = useCallback(async () => {
     setIsDeleting(true)
@@ -143,9 +144,9 @@ const CollaboratorListRow = ({
           value={collaborator.role}
           onChange={onRoleChange}
           variant="clear"
-          isEditable={isEditable}
+          isEditable={!isOwnerOrSelf && isEditable}
         />
-        {isEditable && (
+        {!isOwnerOrSelf && isEditable && (
           <IconButton
             colorScheme="critical"
             onClick={onDeleteHandler}
@@ -161,7 +162,7 @@ const CollaboratorListRow = ({
 }
 
 const TableCollaborators = () => {
-  const { collaborators, tableId } = useTableContext()
+  const { collaborators, tableId, hasEditPermission } = useTableContext()
   const toast = useToast({
     status: 'success',
     duration: 3000,
@@ -222,8 +223,11 @@ const TableCollaborators = () => {
   }
 
   return (
-    <VStack gap={2}>
-      <AddNewCollaborator onAdd={upsertCollaboratorHandler} />
+    <VStack gap={2} alignItems="flex-start">
+      <Text textStyle="subhead-3">Collaborators</Text>
+      {hasEditPermission && (
+        <AddNewCollaborator onAdd={upsertCollaboratorHandler} />
+      )}
       <VStack w="100%" divider={<Divider />}>
         {collaborators.map((collab) => (
           <CollaboratorListRow
@@ -233,6 +237,7 @@ const TableCollaborators = () => {
               upsertCollaboratorHandler(collab.email, role, true)
             }
             onDelete={() => deleteCollaboratorHandler(collab.email)}
+            isEditable={hasEditPermission}
           />
         ))}
       </VStack>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -73,7 +73,7 @@ const AddNewCollaborator = ({
   const onSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     async (e) => {
       try {
-        e.stopPropagation()
+        e.preventDefault()
         setIsAdding(true)
         await onAdd(email, role)
         setEmail('')

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -73,7 +73,7 @@ const AddNewCollaborator = ({
   const onSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     async (e) => {
       try {
-        e.preventDefault()
+        e.stopPropagation()
         setIsAdding(true)
         await onAdd(email, role)
         setEmail('')
@@ -97,6 +97,7 @@ const AddNewCollaborator = ({
             <Input
               type="email"
               value={email}
+              isRequired
               onChange={(e) => setEmail(e.target.value)}
             />
             <TableCollabRoleSelect

--- a/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
@@ -8,7 +8,7 @@ import EditMode from './EditMode'
 import ImportExportToolbar from './ImportExportToolbar'
 
 function TableBanner() {
-  const { tableName, hasEditPermission } = useTableContext()
+  const { tableName, role } = useTableContext()
 
   return (
     <Flex
@@ -20,11 +20,7 @@ function TableBanner() {
       zIndex={10}
     >
       <Flex alignItems="center" gap={4}>
-        {hasEditPermission ? (
-          <BreadCrumb />
-        ) : (
-          <Text textStyle="subhead-1">{tableName}</Text>
-        )}
+        {role ? <BreadCrumb /> : <Text textStyle="subhead-1">{tableName}</Text>}
         <EditMode />
       </Flex>
       <ImportExportToolbar />

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -28,6 +28,7 @@ interface TableContextProps {
   hasEditPermission: boolean
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
+  role?: string
 }
 
 const TableContext = createContext<TableContextProps | undefined>(undefined)
@@ -48,9 +49,10 @@ interface TableContextProviderProps {
   tableColumns: ITableColumnMetadata[]
   tableRows: ITableRow[]
   children: React.ReactNode
-  hasEditPermission: boolean
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
+  // If null, the tile is accessed by a shareable link
+  role?: string
 }
 
 export const TableContextProvider = ({
@@ -59,13 +61,14 @@ export const TableContextProvider = ({
   tableColumns,
   tableRows,
   children,
-  hasEditPermission,
   viewOnlyKey,
   collaborators,
+  role,
 }: TableContextProviderProps) => {
   const flattenedData = useMemo(() => flattenRows(tableRows), [tableRows])
   const filteredDataRef = useRef<GenericRowData[]>([])
   const allDataRef = useRef<GenericRowData[]>(flattenedData)
+  const hasEditPermission = role === 'editor' || role === 'owner'
   const [mode, setMode] = useState<EditMode>(
     hasEditPermission ? 'edit' : 'view',
   )
@@ -83,6 +86,7 @@ export const TableContextProvider = ({
         hasEditPermission,
         viewOnlyKey,
         collaborators,
+        role,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -16,20 +16,19 @@ export default function Tile(): JSX.Element {
     viewOnlyKey?: string
   }>()
 
-  const isReadOnly = !!urlViewOnlyKey
-
   const { data: getTableData } = useQuery<{
     getTable: ITableMetadata
   }>(GET_TABLE, {
     variables: {
       tableId,
     },
-    context: isReadOnly
+    context: urlViewOnlyKey
       ? {
           headers: { 'x-tiles-view-key': urlViewOnlyKey },
         }
       : undefined,
   })
+  const ownRole = getTableData?.getTable?.role
 
   const { data: getAllRowsData } = useQuery<{
     getAllRows: ITableRow[]
@@ -38,7 +37,7 @@ export default function Tile(): JSX.Element {
       tableId,
       viewOnlyKey: urlViewOnlyKey,
     },
-    context: isReadOnly
+    context: urlViewOnlyKey
       ? {
           headers: { 'x-tiles-view-key': urlViewOnlyKey },
         }
@@ -64,9 +63,9 @@ export default function Tile(): JSX.Element {
       tableId={id}
       tableColumns={columns}
       tableRows={rows}
-      hasEditPermission={!isReadOnly}
       viewOnlyKey={viewOnlyKey}
       collaborators={collaborators}
+      role={ownRole}
     >
       <Flex
         flexDir={{ base: 'column' }}

--- a/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
+++ b/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
@@ -158,7 +158,6 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
             tableId={tableData ? tableData.id : ''}
             tableColumns={[]}
             tableRows={[]}
-            hasEditPermission={true}
           >
             <ImportCsvModalContent
               onPreImport={() => createTable({ isBlank: true })}

--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -23,7 +23,13 @@ import {
   useDisclosure,
   VStack,
 } from '@chakra-ui/react'
-import { Button, IconButton } from '@opengovsg/design-system-react'
+import {
+  Button,
+  IconButton,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
+} from '@opengovsg/design-system-react'
 import * as URLS from 'config/urls'
 import { DELETE_TABLE } from 'graphql/mutations/tiles/delete-table'
 import { GET_TABLES } from 'graphql/queries/tiles/get-tables'
@@ -86,34 +92,51 @@ const TileListItem = ({ table }: { table: ITableMetadata }): JSX.Element => {
             Last opened {toPrettyDateString(+table.lastAccessedAt)}
           </Text>
         </Box>
-        <Menu onClose={onMenuClose} isOpen={isMenuOpen} gutter={0}>
-          <MenuButton
-            as={IconButton}
-            colorScheme="secondary"
-            variant="clear"
-            icon={<BsThreeDots />}
-            aria-label="options"
-            onClick={(event) => {
-              event.preventDefault()
-              onMenuToggle()
-            }}
-          />
-          <MenuList>
-            <MenuItem
-              icon={<MdOutlineRemoveRedEye />}
-              onClick={() => navigate(URLS.TILE(table.id))}
+        <Flex alignItems="center" gap={4}>
+          {table.role === 'viewer' && (
+            <Tag
+              colorScheme="secondary"
+              size="xs"
+              variant="subtle"
+              py={2}
+              gap={1}
+              pointerEvents="none"
             >
-              View
-            </MenuItem>
-            <MenuItem
-              icon={<BsTrash />}
-              color="red.500"
-              onClick={onDeleteButtonClick}
-            >
-              Delete
-            </MenuItem>
-          </MenuList>
-        </Menu>
+              <TagLeftIcon as={MdOutlineRemoveRedEye} />
+              <TagLabel>View only</TagLabel>
+            </Tag>
+          )}
+          <Menu onClose={onMenuClose} isOpen={isMenuOpen} gutter={0}>
+            <MenuButton
+              as={IconButton}
+              colorScheme="secondary"
+              variant="clear"
+              icon={<BsThreeDots />}
+              aria-label="options"
+              onClick={(event) => {
+                event.preventDefault()
+                onMenuToggle()
+              }}
+            />
+            <MenuList>
+              <MenuItem
+                icon={<MdOutlineRemoveRedEye />}
+                onClick={() => navigate(URLS.TILE(table.id))}
+              >
+                View
+              </MenuItem>
+              {table.role === 'owner' && (
+                <MenuItem
+                  icon={<BsTrash />}
+                  color="red.500"
+                  onClick={onDeleteButtonClick}
+                >
+                  Delete
+                </MenuItem>
+              )}
+            </MenuList>
+          </Menu>
+        </Flex>
       </Flex>
       <AlertDialog
         isOpen={isDialogOpen}


### PR DESCRIPTION
## Changes

Referencing this: https://www.notion.so/opengov/Tiles-Collaborator-50eba0b1019b4b5c8de1355bf97d7784?pvs=4

  | Owner | Editor | Viewer | Shareable link
-- | -- | -- | -- | --
Can view tile | ✅ | ✅ | ✅ | ✅
Can view collaborators | ✅ | ✅ | ✅ | ✅
Can view shareable link | ✅ | ✅ | ✅ | ✅
Can edit data | ✅ | ✅ |   |  
Can adjust/edit columns | ✅ | ✅ |   |  
Can modify collaborators | ✅ | ✅ |   |  
Can regenerate shareable link | ✅ | ✅ |   |  
Can use in pipe | ✅ |   |   |  
Can delete table | ✅ |   |   |  

This PR hides/disables certain features based on this permission matrix