### PR TITLE
PLU-254, PLU-265: add customisations for flow step

### DIFF
--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -13,6 +13,7 @@ const app: IApp = {
   actions,
   description: 'Perform calculations on numbers in your data',
   isNewApp: true,
+  settingsStepLabel: 'Set up calculator',
 }
 
 export default app

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -9,7 +9,7 @@ import { isUrlAllowed } from '../../common/ip-resolver'
 type TMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
 
 const action: IRawAction = {
-  name: 'Make a HTTP Request',
+  name: 'Make a HTTP request',
   key: 'httpRequest',
   description: 'Makes a custom HTTP request of any method and body',
   arguments: [

--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -3,7 +3,7 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 
 const action: IRawAction = {
-  name: 'Delay For',
+  name: 'Delay for',
   key: 'delayFor',
   description:
     'Delays the execution of the next action by a specified amount of time',

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -7,7 +7,7 @@ import StepError from '@/errors/step'
 import generateTimestamp from '../../helpers/generate-timestamp'
 
 const action: IRawAction = {
-  name: 'Delay Until',
+  name: 'Delay until',
   key: 'delayUntil',
   description: 'Delays the execution of the next action until a specified date',
   arguments: [

--- a/packages/backend/src/apps/formatter/actions/date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/index.ts
@@ -8,7 +8,7 @@ import { spec as addSubtractDateTime } from './transforms/add-subtract-date-time
 import { spec as convertDateTime } from './transforms/convert-date-time'
 
 const action: IRawAction = {
-  name: 'Date / Time',
+  name: 'Format date / time',
   key: 'dateTime',
   description: 'Format date and time values',
   arguments: setUpActionFields({

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -14,6 +14,7 @@ const app: IApp = {
   description:
     'Manipulate your data, such as changing date formats or adding days to a date',
   isNewApp: true,
+  settingsStepLabel: 'Set up formatter',
 }
 
 export default app

--- a/packages/backend/src/apps/formsg/index.ts
+++ b/packages/backend/src/apps/formsg/index.ts
@@ -15,6 +15,8 @@ const app: IApp = {
   auth,
   triggers,
   actions: [],
+  connectionStepLabel: 'Connect your form',
+  settingsStepLabel: 'Other settings',
 }
 
 export default app

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -15,10 +15,10 @@ export const NricFilter = {
 }
 
 const trigger: IRawTrigger = {
-  name: 'New form submission',
+  name: 'New form response',
   key: 'newSubmission',
   type: 'webhook',
-  description: 'Triggers when a new form submission is received',
+  description: 'Triggers when a new form response is received',
   webhookTriggerInstructions: {
     hideWebhookUrl: true,
     errorMsg:

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -20,7 +20,7 @@ type LettersApiFieldErrorData = {
 }
 
 const action: IRawAction = {
-  name: 'Create Letter',
+  name: 'Create letter',
   key: 'createLetter',
   description: 'Create a new letter based on the template id input',
   arguments: [

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -36,6 +36,7 @@ const action: IRawAction = {
   name: 'Create row',
   key: 'createTableRow',
   description: 'Creates a new row in your Excel table',
+  settingsStepLabel: 'Set up row to create',
   arguments: [
     {
       key: 'fileId',

--- a/packages/backend/src/apps/m365-excel/actions/get-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-cell-values/index.ts
@@ -11,6 +11,7 @@ const action: IRawAction = {
   name: 'Get cell values',
   key: 'getCellValues',
   description: 'Gets cell value(s) in your Excel spreadsheet',
+  settingsStepLabel: 'Set up cell(s) to get',
   arguments: [
     {
       key: 'fileId',

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -17,6 +17,7 @@ const action: IRawAction = {
   name: 'Get table row',
   key: 'getTableRow',
   description: 'Gets a single row of data from your Excel table.',
+  settingsStepLabel: 'Set up row to get',
   arguments: [
     {
       key: 'fileId',

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -25,6 +25,7 @@ const action: IRawAction = {
   name: 'Update table row',
   key: 'updateTableRow',
   description: 'Updates a single row of data in your Excel table',
+  settingsStepLabel: 'Set up row to update',
   arguments: [
     // We're doing an update based on results of our getTableRow action, so just
     // re-use its arguments.

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
@@ -10,6 +10,7 @@ const action: IRawAction = {
   name: 'Write cell values',
   key: 'writeCellValues',
   description: "Write values into your Excel worksheet's cells",
+  settingsStepLabel: 'Set up cell(s) to update',
   arguments: [
     {
       key: 'fileId',

--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -23,6 +23,7 @@ const app: IApp = {
   dynamicData,
   getTransferDetails,
   queue,
+  connectionStepLabel: 'Connect to M365 Excel',
 }
 
 export default app

--- a/packages/backend/src/apps/paysg/actions/create-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/index.ts
@@ -8,7 +8,7 @@ import StepError, { GenericSolution } from '@/errors/step'
 import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
-  name: 'Create Payment',
+  name: 'Create payment',
   key: 'createPayment',
   description: 'Create a new PaySG payment',
   arguments: [

--- a/packages/backend/src/apps/paysg/actions/get-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/get-payment/index.ts
@@ -8,7 +8,7 @@ import StepError, { GenericSolution } from '@/errors/step'
 import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
-  name: 'Get Payment',
+  name: 'Get payment',
   key: 'getPayment',
   description: 'Get details of a payment that has previously been created',
   arguments: [

--- a/packages/backend/src/apps/paysg/actions/send-email/index.ts
+++ b/packages/backend/src/apps/paysg/actions/send-email/index.ts
@@ -8,7 +8,7 @@ import StepError, { GenericSolution } from '@/errors/step'
 import { requestSchema } from './schema'
 
 const action: IRawAction = {
-  name: 'Send Payment Email',
+  name: 'Send payment email',
   key: 'sendEmail',
   description:
     'Send email to payee for a payment that has previously been created',

--- a/packages/backend/src/apps/postman/index.ts
+++ b/packages/backend/src/apps/postman/index.ts
@@ -11,6 +11,7 @@ const app: IApp = {
   apiBaseUrl: 'https://api.postman.gov.sg',
   primaryColor: '000000',
   actions,
+  settingsStepLabel: 'Set up email',
 }
 
 export default app

--- a/packages/backend/src/apps/scheduler/index.ts
+++ b/packages/backend/src/apps/scheduler/index.ts
@@ -12,6 +12,7 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '0059F7',
   triggers,
+  settingsStepLabel: 'Set up scheduler',
 }
 
 export default app

--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -8,7 +8,7 @@ import getNextCronDateTime from '../../common/get-next-cron-date-time'
 import getDataOutMetadata from '../get-data-out-metadata'
 
 const trigger: IRawTrigger = {
-  name: 'Daily',
+  name: 'Schedule daily',
   key: 'everyDay',
   description: 'Triggers every day, choose a specific hour',
   arguments: [

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -8,7 +8,7 @@ import getNextCronDateTime from '../../common/get-next-cron-date-time'
 import getDataOutMetadata from '../get-data-out-metadata'
 
 const trigger: IRawTrigger = {
-  name: 'Hourly',
+  name: 'Schedule hourly',
   key: 'everyHour',
   description: 'Triggers every hour',
   arguments: [

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -8,7 +8,7 @@ import getNextCronDateTime from '../../common/get-next-cron-date-time'
 import getDataOutMetadata from '../get-data-out-metadata'
 
 const trigger: IRawTrigger = {
-  name: 'Monthly',
+  name: 'Schedule monthly',
   key: 'everyMonth',
   description:
     'Triggers every month, choose a specific day and hour of the month',

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -8,7 +8,7 @@ import getNextCronDateTime from '../../common/get-next-cron-date-time'
 import getDataOutMetadata from '../get-data-out-metadata'
 
 const trigger: IRawTrigger = {
-  name: 'Weekly',
+  name: 'Schedule weekly',
   key: 'everyWeek',
   description:
     'Triggers every week, choose a specific day and hour of the week',

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -13,6 +13,7 @@ const action: IRawAction = {
   name: 'Create row',
   key: 'createTileRow',
   description: 'Creates a new row in your tile',
+  settingsStepLabel: 'Set up row to create',
   arguments: [
     {
       label: 'Select Tile',

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -20,6 +20,7 @@ const action: IRawAction = {
   name: 'Find single row',
   key: 'findSingleRow',
   description: 'Gets data of a single row from your tile',
+  settingsStepLabel: 'Set up row to find',
   arguments: [
     {
       label: 'Select Tile',

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -14,6 +14,7 @@ const action: IRawAction = {
   name: 'Update single row',
   key: 'updateSingleRow',
   description: 'Updates a single row in your tile',
+  settingsStepLabel: 'Set up row to update',
   arguments: [
     {
       label: 'Select Tile',

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -118,6 +118,7 @@ type Action {
   name: String
   key: String
   description: String
+  settingsStepLabel: String
   groupsLaterSteps: Boolean
   substeps: [ActionSubstep]
 }
@@ -175,6 +176,8 @@ type App {
   connections: [Connection]
   description: String
   isNewApp: Boolean
+  connectionStepLabel: String
+  settingsStepLabel: String
 }
 
 type AppAuth {
@@ -502,6 +505,7 @@ type Trigger {
   pollInterval: Int
   type: String
   webhookTriggerInstructions: TriggerInstructions
+  settingsStepLabel: String
   substeps: [TriggerSubstep]
 }
 

--- a/packages/backend/src/helpers/get-app.ts
+++ b/packages/backend/src/helpers/get-app.ts
@@ -40,16 +40,16 @@ const getApp = (appKey: string, stripFuncs = true) => {
   return appData
 }
 
-const chooseConnectionStep = {
-  key: 'chooseConnection',
-  name: 'Choose connection',
+const chooseConnectionStep = (connectionStepLabel?: string) => {
+  return {
+    key: 'chooseConnection',
+    name: connectionStepLabel ?? 'Choose connection',
+  }
 }
 
-const testStep = (stepType: 'trigger' | 'action') => {
-  return {
-    key: 'testStep',
-    name: stepType === 'trigger' ? 'Test trigger' : 'Test action',
-  }
+const testStep = {
+  key: 'testStep',
+  name: 'Test step',
 }
 
 function addStaticSubsteps(
@@ -72,18 +72,20 @@ function addStaticSubsteps(
   computedStep.substeps = []
 
   if (appData.auth) {
-    computedStep.substeps.push(chooseConnectionStep)
+    computedStep.substeps.push(
+      chooseConnectionStep(appData?.connectionStepLabel),
+    )
   }
 
   if (step.arguments) {
     computedStep.substeps.push({
-      key: 'chooseTrigger',
-      name: stepType === 'trigger' ? 'Set up a trigger' : 'Set up action',
+      key: stepType === 'trigger' ? 'setUpTrigger' : 'setUpAction',
+      name: appData.settingsStepLabel ?? 'Set up step',
       arguments: step.arguments,
     })
   }
 
-  computedStep.substeps.push(testStep(stepType))
+  computedStep.substeps.push(testStep)
 
   return computedStep
 }

--- a/packages/backend/src/helpers/get-app.ts
+++ b/packages/backend/src/helpers/get-app.ts
@@ -40,11 +40,9 @@ const getApp = (appKey: string, stripFuncs = true) => {
   return appData
 }
 
-const chooseConnectionStep = (connectionStepLabel?: string) => {
-  return {
-    key: 'chooseConnection',
-    name: connectionStepLabel ?? 'Choose connection',
-  }
+const chooseConnectionStep = {
+  key: 'chooseConnection',
+  name: 'Choose connection',
 }
 
 const testStep = {
@@ -72,15 +70,13 @@ function addStaticSubsteps(
   computedStep.substeps = []
 
   if (appData.auth) {
-    computedStep.substeps.push(
-      chooseConnectionStep(appData?.connectionStepLabel),
-    )
+    computedStep.substeps.push(chooseConnectionStep)
   }
 
   if (step.arguments) {
     computedStep.substeps.push({
       key: stepType === 'trigger' ? 'setUpTrigger' : 'setUpAction',
-      name: appData.settingsStepLabel ?? 'Set up step',
+      name: 'Set up step',
       arguments: step.arguments,
     })
   }

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -151,7 +151,7 @@ function ChooseConnectionSubstep(
       <FlowSubstepTitle
         expanded={expanded}
         onClick={onToggle}
-        title={name}
+        title={application?.connectionStepLabel ?? name}
         valid={isTestStepValid}
       />
       <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -303,7 +303,10 @@ export default function FlowStep(
                       onSubmit={expandNextStep}
                       onChange={handleChange}
                       step={step}
-                      settingsLabel={selectedActionOrTrigger?.settingsStepLabel}
+                      settingsLabel={
+                        selectedActionOrTrigger?.settingsStepLabel ??
+                        app?.settingsStepLabel
+                      }
                     />
                   )}
               </Fragment>

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -209,7 +209,9 @@ export default function FlowStep(
 
   // define caption description based on app and step
   let caption = ''
-  if (app?.name) {
+  if (selectedActionOrTrigger?.name) {
+    caption = `${step.position}. ${selectedActionOrTrigger?.name}`
+  } else if (app?.name) {
     caption = `${step.position}. ${app.name}`
   } else if (isTrigger) {
     caption = 'This step starts your pipe'
@@ -301,6 +303,7 @@ export default function FlowStep(
                       onSubmit={expandNextStep}
                       onChange={handleChange}
                       step={step}
+                      settingsLabel={selectedActionOrTrigger?.settingsStepLabel}
                     />
                   )}
               </Fragment>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -25,6 +25,7 @@ type FlowSubstepProps = {
   onChange: ({ step }: { step: IStep }) => void
   onSubmit: () => void
   step: IStep
+  settingsLabel?: string
 }
 
 function isValidArgValue(value: IJSONValue): boolean {
@@ -92,6 +93,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     onCollapse,
     onSubmit,
     step,
+    settingsLabel,
   } = props
 
   const { name, arguments: args } = substep
@@ -119,7 +121,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       <FlowSubstepTitle
         expanded={expanded}
         onClick={onToggle}
-        title={name}
+        title={settingsLabel ?? name}
         valid={validationStatus}
       />
       <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -20,6 +20,8 @@ export const GET_APPS = gql`
       connectionCount
       description
       isNewApp
+      connectionStepLabel
+      settingsStepLabel
       auth {
         connectionType
         connectionRegistrationType
@@ -73,6 +75,7 @@ export const GET_APPS = gql`
         type
         pollInterval
         description
+        settingsStepLabel
         webhookTriggerInstructions {
           beforeUrlMsg
           afterUrlMsg
@@ -153,6 +156,7 @@ export const GET_APPS = gql`
         name
         key
         description
+        settingsStepLabel
         groupsLaterSteps
         substeps {
           key

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -408,6 +408,8 @@ export interface IApp {
   connections?: IConnection[]
   description?: string
   isNewApp?: boolean
+  connectionStepLabel?: string // for step accordion label
+  settingsStepLabel?: string // for step accordion label: app level
 
   /**
    * A callback that is invoked if there's an error for any HTTP request this
@@ -520,6 +522,7 @@ export interface IBaseTrigger {
   pollInterval?: number
   description: string
   webhookTriggerInstructions?: ITriggerInstructions
+  settingsStepLabel?: string // for step accordion label: event level
   getInterval?(parameters: IStep['parameters']): string
   run?($: IGlobalVariable): Promise<void>
   testRun?($: IGlobalVariable): Promise<void>
@@ -584,6 +587,7 @@ export interface IBaseAction {
   name: string
   key: string
   description: string
+  settingsStepLabel?: string // for step accordion label: event level
   run?(
     $: IGlobalVariable,
     metadata?: NextStepMetadata,


### PR DESCRIPTION
## Problem

The flow step content is not too intuitive and cannot be customised.
<img width="910" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/10f39832-4c31-4ebe-a95a-c4a7f209d6ec">


## Solution

1. Display event name instead of app name to give more context to users, this will be the default state in the future, in which we will be implementing functionality to edit the step name.
2. Each step's accordion label should be different, only `ChooseConnectionSubstep` and `FlowSubstep` require customisable labels now.

Updated example:
<img width="911" alt="image" src="https://github.com/opengovsg/plumber/assets/65110268/c96f8844-34bc-4feb-bf30-229eb74c2e4f">


## Tests
- [x] Existing pipes still work
- [x] If no label is given for the connection step or settings step, fallback to default states
