### PR TITLE
PLU-275: [BTN-MIGRATION-1] Fix url path params interceptor order

### DIFF
--- a/packages/backend/src/helpers/http-client/process-url-path-params.ts
+++ b/packages/backend/src/helpers/http-client/process-url-path-params.ts
@@ -1,9 +1,5 @@
-import type { Axios } from 'axios'
+import type { InternalAxiosRequestConfig } from 'axios'
 import { type ParamMap as UrlPathParams, subst } from 'urlcat'
-
-type AxiosRequestInterceptor = Parameters<
-  Axios['interceptors']['request']['use']
->[0]
 
 declare module 'axios' {
   interface AxiosRequestConfig {
@@ -12,9 +8,9 @@ declare module 'axios' {
 }
 
 /**
- * An interceptor to enable safe URL path building
+ * A function to enable safe URL path building
  * -----
- * This interceptor provides "SQL prepared statements"-esque functionality to
+ * This provides "SQL prepared statements"-esque functionality to
  * construct URL paths.
  *
  * With this, instead of using JS template literals:
@@ -50,7 +46,9 @@ declare module 'axios' {
  * ```
  * will yield a GET request to `/1/durian%20pics/details`.
  */
-export const urlPathParamsInterceptor: AxiosRequestInterceptor = (config) => {
+export function processUrlPathParams<T>(
+  config: InternalAxiosRequestConfig<T>,
+): InternalAxiosRequestConfig<T> {
   const { url, urlPathParams } = config
   if (!urlPathParams) {
     return config


### PR DESCRIPTION
## Problem
When using URL path params, we see params _before replacement_ in DD logs. 

**Example (in DD)**
```
{
  url: 'http://test.local/:user-id'
}
```

**Expected**
```
{
  url: 'http://test.local/1234'
}
```

## Solution
These logs occur because there is a `beforeRequest` callback which logs to DD. As axios request interceptors are processed in a LIFO order, and we add our path params interceptor added _before_ our `beforeRequest` interceptors, `beforeRequest` callbacks do not see the processed URL.

We will fix this by making using only 1 request interceptor do everything.

## Tests
- Updated unit test
- Check that `beforeRequest` callbacks see the URL _after_ path params replacement