### PR TITLE
PLU-275: [BTN-MIGRATION-3] Introduce info message for Postman SMS

### DIFF
--- a/packages/backend/src/apps/postman-sms/index.ts
+++ b/packages/backend/src/apps/postman-sms/index.ts
@@ -18,6 +18,11 @@ const app: IApp = {
   actions,
   queue,
   isNewApp: true,
+  setupMessage: {
+    variant: 'info',
+    messageBody:
+      'This service is free until **May 2025**. Find out more [here](https://guide.plumber.gov.sg/user-guides/actions/postman-sms).',
+  },
 }
 
 export default app

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -117,12 +117,23 @@ type FieldVisibilityCondition {
   fieldValue: String
 }
 
+enum SetupMessageVariant {
+  info
+  warning
+}
+
+type SetupMessage {
+  variant: SetupMessageVariant!
+  messageBody: String!
+}
+
 type Action {
   name: String
   key: String
   description: String
   settingsStepLabel: String
   groupsLaterSteps: Boolean
+  setupMessage: SetupMessage
   substeps: [ActionSubstep]
 }
 
@@ -180,6 +191,7 @@ type App {
   description: String
   isNewApp: Boolean
   substepLabels: StepLabel
+  setupMessage: SetupMessage
 }
 
 type StepLabel {
@@ -512,6 +524,7 @@ type Trigger {
   description: String
   pollInterval: Int
   type: String
+  setupMessage: SetupMessage
   webhookTriggerInstructions: TriggerInstructions
   settingsStepLabel: String
   substeps: [TriggerSubstep]

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -2,9 +2,16 @@ import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import { useCallback, useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
-import { Box, Collapse, Flex, FormControl } from '@chakra-ui/react'
-import { Badge, Button, FormLabel } from '@opengovsg/design-system-react'
+import { Box, chakra, Collapse, Flex, FormControl } from '@chakra-ui/react'
+import {
+  Badge,
+  Button,
+  FormLabel,
+  Infobox,
+  Link,
+} from '@opengovsg/design-system-react'
 import FlowSubstepTitle from 'components/FlowSubstepTitle'
+import MarkdownRenderer from 'components/MarkdownRenderer'
 import { ComboboxItem, SingleSelect } from 'components/SingleSelect'
 import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from 'config/flags'
 import { EditorContext } from 'contexts/Editor'
@@ -235,6 +242,14 @@ function ChooseAppAndEventSubstep(
     [step, onChange],
   )
 
+  const setupMessage = useMemo(() => {
+    const selectedEvent = actionsOrTriggers.find(
+      (actionOrTrigger: IAction | ITrigger) =>
+        actionOrTrigger.key === step?.key,
+    )
+    return selectedEvent?.setupMessage ?? app?.setupMessage ?? null
+  }, [actionsOrTriggers, app, step?.key])
+
   const onToggle = expanded ? onCollapse : onExpand
 
   const isLoading = launchDarkly.isLoading || isInitializingIfThen
@@ -297,6 +312,28 @@ function ChooseAppAndEventSubstep(
                 </Box>
               </FormControl>
             </Flex>
+          )}
+
+          {setupMessage && (
+            <Infobox mt={4} width="full" variant={setupMessage.variant}>
+              <MarkdownRenderer
+                source={setupMessage.messageBody}
+                components={{
+                  // Force all links in our message to be opened in a new tab.
+                  a: ({ ...props }) => (
+                    <Link
+                      isExternal
+                      color="interaction.links.neutral-default"
+                      _hover={{ color: 'interaction.links.neutral-hover' }}
+                      {...props}
+                    />
+                  ),
+                  // react-markdown wraps everything in a <Text> by default,
+                  // which mucks up styling for infoboxes with variants.
+                  p: ({ ...props }) => <chakra.p {...props} />,
+                }}
+              />
+            </Infobox>
           )}
 
           <Button

--- a/packages/frontend/src/components/MarkdownRenderer/index.tsx
+++ b/packages/frontend/src/components/MarkdownRenderer/index.tsx
@@ -27,7 +27,7 @@ interface MarkdownRendererProps {
 }
 
 export default function MarkdownRenderer(props: MarkdownRendererProps) {
-  const { allowMultilineBreaks = true, source } = props
+  const { allowMultilineBreaks = true, source, components = {} } = props
   const processedSource = useMemo(() => {
     if (allowMultilineBreaks) {
       return source.replace(/\n/gi, '&nbsp; \n')
@@ -109,7 +109,10 @@ export default function MarkdownRenderer(props: MarkdownRendererProps) {
   return (
     <Box>
       <ReactMarkdown
-        components={mdComponents}
+        components={{
+          ...mdComponents,
+          ...components,
+        }}
         remarkPlugins={[remarkBreaks, remarkGfm]}
       >
         {processedSource}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -25,6 +25,10 @@ export const GET_APPS = gql`
         settingsStepLabel
         addConnectionLabel
       }
+      setupMessage {
+        variant
+        messageBody
+      }
       auth {
         connectionType
         connectionRegistrationType
@@ -79,6 +83,10 @@ export const GET_APPS = gql`
         pollInterval
         description
         settingsStepLabel
+        setupMessage {
+          variant
+          messageBody
+        }
         webhookTriggerInstructions {
           beforeUrlMsg
           afterUrlMsg
@@ -160,6 +168,10 @@ export const GET_APPS = gql`
         key
         description
         settingsStepLabel
+        setupMessage {
+          variant
+          messageBody
+        }
         groupsLaterSteps
         substeps {
           key

--- a/packages/frontend/src/theme/foundations/colors.ts
+++ b/packages/frontend/src/theme/foundations/colors.ts
@@ -52,6 +52,11 @@ const bbBearColors = {
       hover: '#E2B73E',
       active: '#C4992A',
     },
+    'warning-subtle': {
+      default: '#fffae1',
+      hover: '#FFDA68',
+      active: '#E2B73E',
+    },
     critical: {
       default: '#c03434',
       hover: '#992a2a',
@@ -70,6 +75,12 @@ const bbBearColors = {
     },
     'main-subtle': {
       default: '#FFF0F7',
+    },
+    links: {
+      default: '#cf1a68',
+      hover: '#aa004b',
+      'neutral-default': '#454953',
+      'neutral-hover': '#2C2E34',
     },
   },
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -22,6 +22,19 @@ export interface IJSONObject extends JsonObject {
   [x: string]: IJSONValue
 }
 
+export interface SetupMessage {
+  /**
+   * Synced with SetupMessageVariant GraphQL enum. Loosely based off Design
+   * System's InfoBox variants
+   */
+  variant: 'info' | 'warning'
+
+  /**
+   * Supports markdown
+   */
+  messageBody: string
+}
+
 export interface IConnection {
   id: string
   key: string
@@ -451,6 +464,17 @@ export interface IApp {
    * Apps specify this if they need their own dedicated action queue.
    */
   queue?: IAppQueue
+
+  /**
+   * Apps specify this if they want to display an additional informative
+   * message to the user during pipe setup / config, when the user selects the
+   * app in the "choose app and event" substep.
+   *
+   * Note that the apps' own triggers / actions may also specify their own
+   * setupMessage. In this case, the triggers' / actions' info message takes
+   * precedence.
+   */
+  setupMessage?: SetupMessage
 }
 
 export type TBeforeRequest = (
@@ -557,6 +581,12 @@ export interface IBaseTrigger {
    * @param executionStep The execution step to get metadata for.
    */
   getDataOutMetadata?(executionStep: IExecutionStep): Promise<IDataOutMetadata>
+
+  /**
+   * Triggers specify this if they want to display an additional informative
+   * message to the user during pipe setup / config.
+   */
+  setupMessage?: SetupMessage
 }
 
 export interface IRawTrigger extends IBaseTrigger {
@@ -648,6 +678,12 @@ export interface IBaseAction {
    * action.
    */
   groupsLaterSteps?: boolean
+
+  /**
+   * Actions specify this if they want to display an additional informative
+   * message to the user during pipe setup / config.
+   */
+  setupMessage?: SetupMessage
 }
 
 export interface IRawAction extends IBaseAction {


### PR DESCRIPTION
# Problem
We want to make it clear to users that our SMS action is only free until a certain date.

# Solution
Users may not read our guidebook, so we will put this message inside our UI (where there is a higher chance of being read)

This PR introduces a new "setup message" attribute to display such messages.

![Screenshot 2024-06-03 at 5.00.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/52yORk4WhOvpiff9IQU6/ee00635a-43da-4f6e-a977-da233b5f3691.png)

# Tests
- Check that info message shows up when Postman SMS is selected
- Regression test: check that info message does not show up for other apps.