### PR TITLE
PLU-263: add connection label for choose connection dropdown

### DIFF
--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -13,7 +13,9 @@ const app: IApp = {
   actions,
   description: 'Perform calculations on numbers in your data',
   isNewApp: true,
-  settingsStepLabel: 'Set up calculator',
+  substepLabels: {
+    settingsStepLabel: 'Set up calculator',
+  },
 }
 
 export default app

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -14,7 +14,9 @@ const app: IApp = {
   description:
     'Manipulate your data, such as changing date formats or adding days to a date',
   isNewApp: true,
-  settingsStepLabel: 'Set up formatter',
+  substepLabels: {
+    settingsStepLabel: 'Set up formatter',
+  },
 }
 
 export default app

--- a/packages/backend/src/apps/formsg/index.ts
+++ b/packages/backend/src/apps/formsg/index.ts
@@ -15,8 +15,11 @@ const app: IApp = {
   auth,
   triggers,
   actions: [],
-  connectionStepLabel: 'Connect your form',
-  settingsStepLabel: 'Other settings',
+  substepLabels: {
+    connectionStepLabel: 'Connect your form',
+    settingsStepLabel: 'Other settings',
+    addConnectionLabel: 'Add new form',
+  },
 }
 
 export default app

--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -23,7 +23,9 @@ const app: IApp = {
   dynamicData,
   getTransferDetails,
   queue,
-  connectionStepLabel: 'Connect to M365 Excel',
+  substepLabels: {
+    connectionStepLabel: 'Connect to M365 Excel',
+  },
 }
 
 export default app

--- a/packages/backend/src/apps/postman/index.ts
+++ b/packages/backend/src/apps/postman/index.ts
@@ -11,7 +11,9 @@ const app: IApp = {
   apiBaseUrl: 'https://api.postman.gov.sg',
   primaryColor: '000000',
   actions,
-  settingsStepLabel: 'Set up email',
+  substepLabels: {
+    settingsStepLabel: 'Set up email',
+  },
 }
 
 export default app

--- a/packages/backend/src/apps/scheduler/index.ts
+++ b/packages/backend/src/apps/scheduler/index.ts
@@ -12,7 +12,9 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '0059F7',
   triggers,
-  settingsStepLabel: 'Set up scheduler',
+  substepLabels: {
+    settingsStepLabel: 'Set up scheduler',
+  },
 }
 
 export default app

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -179,8 +179,13 @@ type App {
   connections: [Connection]
   description: String
   isNewApp: Boolean
+  substepLabels: StepLabel
+}
+
+type StepLabel {
   connectionStepLabel: String
   settingsStepLabel: String
+  addConnectionLabel: String
 }
 
 type AppAuth {

--- a/packages/frontend/src/components/ChooseConnectionDropdown/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionDropdown/index.tsx
@@ -19,10 +19,14 @@ interface ChooseConnectionDropdownProps {
 }
 
 const ADD_CONNECTION_VALUE = 'ADD_CONNECTION'
-const ADD_NEW_CONNECTION_OPTION: ConnectionDropdownOption = {
-  label: 'Add new connection',
-  icon: BxPlus,
-  value: ADD_CONNECTION_VALUE,
+const ADD_NEW_CONNECTION_OPTION = (
+  label?: string,
+): ConnectionDropdownOption => {
+  return {
+    label: label ?? 'Add new connection',
+    icon: BxPlus,
+    value: ADD_CONNECTION_VALUE,
+  }
 }
 
 function ChooseConnectionDropdown({
@@ -60,7 +64,9 @@ function ChooseConnectionDropdown({
 
   const items = [...connectionOptions]
   if (application?.auth?.connectionType === 'user-added') {
-    items.push(ADD_NEW_CONNECTION_OPTION)
+    items.unshift(
+      ADD_NEW_CONNECTION_OPTION(application?.substepLabels?.addConnectionLabel),
+    )
   }
 
   return (

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -151,7 +151,7 @@ function ChooseConnectionSubstep(
       <FlowSubstepTitle
         expanded={expanded}
         onClick={onToggle}
-        title={application?.connectionStepLabel ?? name}
+        title={application?.substepLabels?.connectionStepLabel ?? name}
         valid={isTestStepValid}
       />
       <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -305,7 +305,7 @@ export default function FlowStep(
                       step={step}
                       settingsLabel={
                         selectedActionOrTrigger?.settingsStepLabel ??
-                        app?.settingsStepLabel
+                        app?.substepLabels?.settingsStepLabel
                       }
                     />
                   )}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -20,8 +20,11 @@ export const GET_APPS = gql`
       connectionCount
       description
       isNewApp
-      connectionStepLabel
-      settingsStepLabel
+      substepLabels {
+        connectionStepLabel
+        settingsStepLabel
+        addConnectionLabel
+      }
       auth {
         connectionType
         connectionRegistrationType

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -408,8 +408,11 @@ export interface IApp {
   connections?: IConnection[]
   description?: string
   isNewApp?: boolean
-  connectionStepLabel?: string // for step accordion label
-  settingsStepLabel?: string // for step accordion label: app level
+  substepLabels?: {
+    connectionStepLabel?: string // for step accordion label
+    settingsStepLabel?: string // for step accordion label: app level
+    addConnectionLabel?: string // for adding connection in choose connection dropdown
+  }
 
   /**
    * A callback that is invoked if there's an error for any HTTP request this


### PR DESCRIPTION
## Problem

Currently, the `add new connection` option in the choose connection dropdown is at the bottom, which is not accessible if a user has many connections.

## Solution

- Shift it up to the top
- Add custom label for formsg (add new form)

## Tests
- [x] Existing pipes still work
- [x] Only formsg label changes
- [x] Can still add connection