### PR TITLE
[PARTIAL-5] send blacklist notification email

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -83,6 +83,7 @@ describe('decrypt form response', () => {
         id: 'flowid',
         userId: 'userid',
         hasFileProcessingActions: false,
+        name: 'test flow',
       },
       app,
     }

--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -32,6 +32,7 @@ vi.mock('../../common/parameters-helper', () => ({
 
 vi.mock('../../common/send-blacklist-email', () => ({
   sendBlacklistEmail: mocks.sendBlacklistEmail,
+  createRequestBlacklistFormLink: vi.fn(),
 }))
 
 describe('send transactional email', () => {

--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -12,6 +12,7 @@ import sendTransactionalEmail from '../../actions/send-transactional-email'
 const mocks = vi.hoisted(() => ({
   getObjectFromS3Id: vi.fn(),
   getDefaultReplyTo: vi.fn(() => 'replyTo@open.gov.sg'),
+  sendBlacklistEmail: vi.fn(),
 }))
 
 vi.mock('@/helpers/s3', async () => {
@@ -27,6 +28,10 @@ vi.mock('@/helpers/s3', async () => {
 
 vi.mock('../../common/parameters-helper', () => ({
   getDefaultReplyTo: mocks.getDefaultReplyTo,
+}))
+
+vi.mock('../../common/send-blacklist-email', () => ({
+  sendBlacklistEmail: mocks.sendBlacklistEmail,
 }))
 
 describe('send transactional email', () => {
@@ -65,6 +70,13 @@ describe('send transactional email', () => {
       },
       flow: {
         id: '123',
+        name: 'Test Flow',
+      },
+      execution: {
+        testRun: false,
+      },
+      user: {
+        email: 'tester@open.gov.sg',
       },
       getLastExecutionStep: vi.fn(),
     } as unknown as IGlobalVariable
@@ -251,6 +263,13 @@ describe('send transactional email', () => {
         reply_to: 'replyTo@open.gov.sg',
       },
     })
+    expect(mocks.sendBlacklistEmail).toHaveBeenCalledWith({
+      flowName: $.flow.name,
+      flowId: $.flow.id,
+      userEmail: $.user.email,
+      executionId: $.execution.id,
+      blacklistedRecipients: [recipients[1]],
+    })
   })
 
   it('should fail as long as rate limit error is thrown', async () => {
@@ -307,9 +326,17 @@ describe('send transactional email', () => {
         reply_to: 'replyTo@open.gov.sg',
       },
     })
+
+    expect(mocks.sendBlacklistEmail).toHaveBeenCalledWith({
+      flowName: $.flow.name,
+      flowId: $.flow.id,
+      userEmail: $.user.email,
+      executionId: $.execution.id,
+      blacklistedRecipients: [recipients[1]],
+    })
   })
 
-  it('should fail as long as rate limit error is thrown', async () => {
+  it('should only retry to non-accepted emails', async () => {
     const recipients = [
       'recipient1@open.gov.sg',
       'recipient2@open.gov.sg',
@@ -337,5 +364,6 @@ describe('send transactional email', () => {
         reply_to: 'replyTo@open.gov.sg',
       },
     })
+    expect(mocks.sendBlacklistEmail).not.toHaveBeenCalled()
   })
 })

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -168,6 +168,7 @@ const action: IRawAction = {
           blacklistedRecipients,
         })
       } catch (e) {
+        logger.error(e)
         logger.error({
           message: 'Error sending blacklist email',
           flowId: $.flow.id,
@@ -183,9 +184,8 @@ const action: IRawAction = {
      */
     if (error && errorStatus) {
       throwPostmanStepError({
+        $,
         status: errorStatus,
-        position: $.step.position,
-        appName: $.app.name,
         error,
         isPartialSuccess: hasAtLeastOneSuccess,
         blacklistedRecipients,

--- a/packages/backend/src/apps/postman/common/send-blacklist-email.ts
+++ b/packages/backend/src/apps/postman/common/send-blacklist-email.ts
@@ -23,6 +23,8 @@ interface BlacklistEmailProps {
   blacklistedRecipients: string[]
 }
 
+type BlacklistEmailFormProps = Omit<BlacklistEmailProps, 'flowName'>
+
 const blacklistRedisKey = (flowId: string, email: string) =>
   `blacklist-alert:${flowId}:${email}`
 
@@ -32,11 +34,11 @@ function truncateFlowName(flowName: string) {
     : flowName
 }
 
-function createRequestBlacklistFormLink({
+export function createRequestBlacklistFormLink({
   userEmail,
   executionId,
   blacklistedRecipients,
-}: BlacklistEmailProps) {
+}: BlacklistEmailFormProps) {
   const queryParams = new URLSearchParams({
     '666190bbfdd7e4abe8973b76': blacklistedRecipients.join(','),
     '666190371ace7810ab47cf65': executionId,

--- a/packages/backend/src/apps/postman/common/send-blacklist-email.ts
+++ b/packages/backend/src/apps/postman/common/send-blacklist-email.ts
@@ -1,0 +1,140 @@
+import { DateTime } from 'luxon'
+
+import appConfig from '@/config/app'
+import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
+import { sendEmail } from '@/helpers/send-email'
+
+const MAX_LENGTH = 80
+const BLACKLIST_REQUEST_FORM_URL =
+  'https://form.gov.sg/6661900c502545e6788fa3c4'
+const redisClient = createRedisClient(REDIS_DB_INDEX.PIPE_ERRORS)
+
+interface SendBlacklistEmailProps {
+  flowName: string
+  flowId: string
+  userEmail: string
+  executionId: string
+  blacklistedRecipients: string[]
+}
+
+interface BlacklistEmailProps {
+  flowName: string
+  userEmail: string
+  executionId: string
+  blacklistedRecipients: string[]
+}
+
+const blacklistRedisKey = (flowId: string, email: string) =>
+  `blacklist-alert:${flowId}:${email}`
+
+function truncateFlowName(flowName: string) {
+  return flowName.length > MAX_LENGTH
+    ? flowName.slice(0, MAX_LENGTH) + '...'
+    : flowName
+}
+
+function createRequestBlacklistFormLink({
+  userEmail,
+  executionId,
+  blacklistedRecipients,
+}: BlacklistEmailProps) {
+  const queryParams = new URLSearchParams({
+    '666190bbfdd7e4abe8973b76': blacklistedRecipients.join(','),
+    '666190371ace7810ab47cf65': executionId,
+    '666191476a8b859f7f792a63': userEmail,
+  })
+  return BLACKLIST_REQUEST_FORM_URL + '?' + queryParams.toString()
+}
+
+function createBodyErrorMessage(props: BlacklistEmailProps): string {
+  const { flowName, executionId, blacklistedRecipients } = props
+  const appPrefixUrl = appConfig.isDev ? appConfig.webAppUrl : appConfig.baseUrl
+  const redirectUrl = `/executions/${executionId}`
+  const formattedUrl = `${appPrefixUrl}${redirectUrl}`
+
+  const formLink = createRequestBlacklistFormLink(props)
+
+  const bodyMessage = `
+    Dear fellow plumber,
+    <br>
+    <br>
+    We have detected that your pipe: <strong>${flowName}</strong> has attempted to send an email to one or more blacklisted email addresses:
+    <ul>
+      ${blacklistedRecipients.map((email) => `<li>${email}</li>`).join('\n')}
+    </ul>
+    Emails could be blacklisted for one of the following reasons:
+    <ul>
+      <li>The email address is invalid.</li>
+      <li>The email address was temporarily deactivated (e.g. due to personnel movement across agencies).</li>
+    </ul>
+    <p>What should you do if you have verified that the email addresses are valid?</p>
+    <ol>
+      <li>Submit this form to request for the email addresses to be removed from the blacklist: <a href="${formLink}">Request to remove email from blacklist</a></li>
+      <li>Wait for confirmation from us that the email adddress(es) have been removed from the blacklist successfully</li>
+      <li>Retry sending the emails by clicking on <strong>Resend to blacklisted recipients</strong> on the failed execution page: ${formattedUrl}</li>
+    </ol>
+    <br>
+    Regards,
+    <br>
+    Plumber team
+  `
+  return bodyMessage
+}
+
+async function filterNotifiedEmails(
+  flowId: string,
+  emails: string[],
+): Promise<string[]> {
+  const blacklistKeys = emails.map((email) => blacklistRedisKey(flowId, email))
+  const isNotified = await redisClient.mget(blacklistKeys)
+  return emails.filter((_, i) => isNotified[i] !== '1')
+}
+
+async function addBlacklistedEmailToRedis(
+  flowId: string,
+  emails: string[],
+): Promise<void> {
+  await Promise.all(
+    emails.map(async (email) => {
+      const errorKey = blacklistRedisKey(flowId, email)
+      await redisClient
+        .multi()
+        .set(errorKey, '1')
+        .pexpireat(errorKey, DateTime.now().endOf('week').toMillis())
+        .exec()
+    }),
+  )
+  return
+}
+
+export async function sendBlacklistEmail({
+  flowName,
+  flowId,
+  userEmail,
+  executionId,
+  blacklistedRecipients,
+}: SendBlacklistEmailProps) {
+  const truncatedFlowName = truncateFlowName(flowName)
+  const filteredBlacklist = await filterNotifiedEmails(
+    flowId,
+    blacklistedRecipients,
+  )
+
+  if (filteredBlacklist.length === 0) {
+    return
+  }
+
+  await addBlacklistedEmailToRedis(flowId, filteredBlacklist)
+
+  await sendEmail({
+    subject: `Plumber: Blacklisted email detected on ${truncatedFlowName}`,
+    body: createBodyErrorMessage({
+      flowName,
+      userEmail,
+      executionId,
+      blacklistedRecipients: filteredBlacklist,
+    }),
+    recipient: userEmail,
+    replyTo: 'support@plumber.gov.sg',
+  })
+}

--- a/packages/backend/src/apps/postman/common/send-blacklist-email.ts
+++ b/packages/backend/src/apps/postman/common/send-blacklist-email.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 
-import appConfig from '@/config/app'
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import { sendEmail } from '@/helpers/send-email'
 
@@ -47,10 +46,7 @@ function createRequestBlacklistFormLink({
 }
 
 function createBodyErrorMessage(props: BlacklistEmailProps): string {
-  const { flowName, executionId, blacklistedRecipients } = props
-  const appPrefixUrl = appConfig.isDev ? appConfig.webAppUrl : appConfig.baseUrl
-  const redirectUrl = `/executions/${executionId}`
-  const formattedUrl = `${appPrefixUrl}${redirectUrl}`
+  const { flowName, blacklistedRecipients } = props
 
   const formLink = createRequestBlacklistFormLink(props)
 
@@ -58,7 +54,7 @@ function createBodyErrorMessage(props: BlacklistEmailProps): string {
     Dear fellow plumber,
     <br>
     <br>
-    We have detected that your pipe: <strong>${flowName}</strong> has attempted to send an email to one or more blacklisted email addresses:
+    We have detected that your pipe <strong>${flowName}</strong> has attempted to send an email to one or more blacklisted email addresses:
     <ul>
       ${blacklistedRecipients.map((email) => `<li>${email}</li>`).join('\n')}
     </ul>
@@ -67,11 +63,11 @@ function createBodyErrorMessage(props: BlacklistEmailProps): string {
       <li>The email address is invalid.</li>
       <li>The email address was temporarily deactivated (e.g. due to personnel movement across agencies).</li>
     </ul>
-    <p>What should you do if you have verified that the email addresses are valid?</p>
+    <p>What should you do?</p>
     <ol>
-      <li>Submit this form to request for the email addresses to be removed from the blacklist: <a href="${formLink}">Request to remove email from blacklist</a></li>
-      <li>Wait for confirmation from us that the email adddress(es) have been removed from the blacklist successfully</li>
-      <li>Retry sending the emails by clicking on <strong>Resend to blacklisted recipients</strong> on the failed execution page: ${formattedUrl}</li>
+      <li>Verify that the emails are valid by checking with the recipient.</li>
+      <li>Submit <a href="${formLink}">this form</a> to request for the email addresses to be removed from the blacklist.</li>
+      <li>Wait for an email confirmation from us (1-2 working days) for further instructions.</li>
     </ol>
     <br>
     Regards,

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -66,6 +66,7 @@ const globalVariable = async (
     app: app,
     flow: {
       id: flow?.id,
+      name: flow?.name,
       userId: flow?.userId,
       hasFileProcessingActions:
         (await flow?.containsFileProcessingActions()) ?? false,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -723,6 +723,7 @@ export type IGlobalVariable = {
   request?: IRequest
   flow?: {
     id: string
+    name: string,
     hasFileProcessingActions: boolean
     userId: string
     remoteWebhookId?: string


### PR DESCRIPTION

## Problem
Since PartialStepErrors are not failures, user will not be notified of such errors.

## Solution
Send an email to them about the blacklisted recipients and provide a pre-filled [form](https://go.gov.sg/plumber-blacklist-removal) to request for whitelist.  

## Next steps
Alert #plumber-ops on Slack when such emails are submitted.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/60817499-2f16-44cf-8d98-262379038fe5.png)

![Screenshot 2024-06-06 at 7.52.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/ca1dc0a2-95e5-4a11-815c-e01f05d0f92d.png)

