### PR TITLE
PLU-261: [onboarding-demo-experiment-1]: add backend code for creating flow template

### DIFF
--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -2,9 +2,9 @@ import type { MutationResolvers } from './__generated__/types.generated'
 import bulkRetryExecutions from './mutations/bulk-retry-executions'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
-import createFlowTemplate from './mutations/create-flow-template'
 import createFlowTransfer from './mutations/create-flow-transfer'
 import createStep from './mutations/create-step'
+import createTemplatedFlow from './mutations/create-templated-flow'
 import deleteConnection from './mutations/delete-connection'
 import deleteFlow from './mutations/delete-flow'
 import deleteStep from './mutations/delete-step'
@@ -56,7 +56,7 @@ export default {
   deleteConnection,
   registerConnection,
   createFlow,
-  createFlowTemplate,
+  createTemplatedFlow,
   updateFlow,
   updateFlowStatus,
   updateFlowConfig,

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -2,6 +2,7 @@ import type { MutationResolvers } from './__generated__/types.generated'
 import bulkRetryExecutions from './mutations/bulk-retry-executions'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
+import createFlowTemplate from './mutations/create-flow-template'
 import createFlowTransfer from './mutations/create-flow-transfer'
 import createStep from './mutations/create-step'
 import deleteConnection from './mutations/delete-connection'
@@ -55,6 +56,7 @@ export default {
   deleteConnection,
   registerConnection,
   createFlow,
+  createFlowTemplate,
   updateFlow,
   updateFlowStatus,
   updateFlowConfig,

--- a/packages/backend/src/graphql/mutations/create-flow-template.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-template.ts
@@ -1,4 +1,4 @@
-import makeFlowTemplate from '@/helpers/flow-templates'
+import createFlowFromTemplate from '@/helpers/flow-templates'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -7,14 +7,14 @@ const createFlowTemplate: MutationResolvers['createFlowTemplate'] = async (
   params,
   context,
 ) => {
-  const { flowName, trigger, actions, demoVideoDetails } = params.input
-  return makeFlowTemplate(
+  const { flowName, trigger, actions, demoVideoId } = params.input
+  return createFlowFromTemplate(
     flowName,
     trigger,
     actions,
     context.currentUser,
     false,
-    demoVideoDetails,
+    demoVideoId,
   )
 }
 

--- a/packages/backend/src/graphql/mutations/create-flow-template.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-template.ts
@@ -1,0 +1,21 @@
+import makeFlowTemplate from '@/helpers/flow-templates'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const createFlowTemplate: MutationResolvers['createFlowTemplate'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { flowName, trigger, actions, demoVideoDetails } = params.input
+  return makeFlowTemplate(
+    flowName,
+    trigger,
+    actions,
+    context.currentUser,
+    false,
+    demoVideoDetails,
+  )
+}
+
+export default createFlowTemplate

--- a/packages/backend/src/graphql/mutations/create-templated-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-templated-flow.ts
@@ -2,7 +2,7 @@ import createFlowFromTemplate from '@/helpers/flow-templates'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
-const createFlowTemplate: MutationResolvers['createFlowTemplate'] = async (
+const createTemplatedFlow: MutationResolvers['createTemplatedFlow'] = async (
   _parent,
   params,
   context,
@@ -18,4 +18,4 @@ const createFlowTemplate: MutationResolvers['createFlowTemplate'] = async (
   )
 }
 
-export default createFlowTemplate
+export default createTemplatedFlow

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -335,7 +335,7 @@ type FlowErrorConfig {
 type FlowDemoConfig {
   onFirstLoad: Boolean!
   isPreCreated: Boolean!
-  videoDetails: DemoVideoDetails!
+  videoId: String!
 }
 
 type Execution {
@@ -392,7 +392,7 @@ input CreateFlowTemplateInput {
   flowName: String!
   trigger: AppEventKeyPair!
   actions: [AppEventKeyPair!]!
-  demoVideoDetails: DemoVideoDetailsInput!
+  demoVideoId: String!
 }
 
 input UpdateFlowInput {
@@ -522,11 +522,6 @@ type Step {
 input AppEventKeyPair {
   appKey: String!
   eventKey: String!
-}
-
-input DemoVideoDetailsInput {
-  url: String!
-  title: String!
 }
 
 input StepConnectionInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -56,6 +56,7 @@ type Mutation {
   registerConnection(input: RegisterConnectionInput): Boolean
   # Flows
   createFlow(input: CreateFlowInput): Flow
+  createFlowTemplate(input: CreateFlowTemplateInput): Flow
   updateFlow(input: UpdateFlowInput): Flow
   updateFlowStatus(input: UpdateFlowStatusInput): Flow
   updateFlowConfig(input: UpdateFlowConfigInput): Flow
@@ -195,6 +196,11 @@ type App {
   setupMessage: SetupMessage
 }
 
+type DemoVideoDetails {
+  url: String!
+  title: String!
+}
+
 type StepLabel {
   connectionStepLabel: String
   settingsStepLabel: String
@@ -319,10 +325,17 @@ type Flow {
 type FlowConfig {
   errorConfig: FlowErrorConfig
   duplicateCount: Int
+  demoConfig: FlowDemoConfig
 }
 
 type FlowErrorConfig {
   notificationFrequency: NotificationFrequency!
+}
+
+type FlowDemoConfig {
+  onFirstLoad: Boolean!
+  isPreCreated: Boolean!
+  videoDetails: DemoVideoDetails!
 }
 
 type Execution {
@@ -373,6 +386,13 @@ input RegisterConnectionInput {
 input CreateFlowInput {
   triggerAppKey: String
   connectionId: String
+}
+
+input CreateFlowTemplateInput {
+  flowName: String!
+  trigger: AppEventKeyPair!
+  actions: [AppEventKeyPair!]!
+  demoVideoDetails: DemoVideoDetailsInput!
 }
 
 input UpdateFlowInput {
@@ -497,6 +517,16 @@ type Step {
   position: Int
   status: String
   executionSteps: [ExecutionStep]
+}
+
+input AppEventKeyPair {
+  appKey: String!
+  eventKey: String!
+}
+
+input DemoVideoDetailsInput {
+  url: String!
+  title: String!
 }
 
 input StepConnectionInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -56,7 +56,7 @@ type Mutation {
   registerConnection(input: RegisterConnectionInput): Boolean
   # Flows
   createFlow(input: CreateFlowInput): Flow
-  createFlowTemplate(input: CreateFlowTemplateInput): Flow
+  createTemplatedFlow(input: CreateTemplatedFlowInput): Flow
   updateFlow(input: UpdateFlowInput): Flow
   updateFlowStatus(input: UpdateFlowStatusInput): Flow
   updateFlowConfig(input: UpdateFlowConfigInput): Flow
@@ -388,7 +388,7 @@ input CreateFlowInput {
   connectionId: String
 }
 
-input CreateFlowTemplateInput {
+input CreateTemplatedFlowInput {
   flowName: String!
   trigger: AppEventKeyPair!
   actions: [AppEventKeyPair!]!

--- a/packages/backend/src/helpers/auth.ts
+++ b/packages/backend/src/helpers/auth.ts
@@ -4,7 +4,7 @@ import jwt from 'jsonwebtoken'
 import appConfig from '@/config/app'
 import User from '@/models/user'
 
-import makeFlowTemplate, { DEFAULT_FLOW_TEMPLATE } from './flow-templates'
+import createFlowFromTemplate, { DEFAULT_FLOW_TEMPLATE } from './flow-templates'
 
 const AUTH_COOKIE_NAME = 'plumber.sid'
 // 3 days expiry
@@ -58,9 +58,8 @@ export async function getOrCreateUser(email: string): Promise<User> {
   let user = await User.query().findOne({ email })
   if (!user) {
     user = await User.query().insertAndFetch({ email })
-    const { flowName, trigger, actions, demoVideoDetails } =
-      DEFAULT_FLOW_TEMPLATE
-    makeFlowTemplate(flowName, trigger, actions, user, true, demoVideoDetails)
+    const { flowName, trigger, actions, demoVideoId } = DEFAULT_FLOW_TEMPLATE
+    createFlowFromTemplate(flowName, trigger, actions, user, true, demoVideoId)
   }
 
   return user

--- a/packages/backend/src/helpers/auth.ts
+++ b/packages/backend/src/helpers/auth.ts
@@ -4,6 +4,8 @@ import jwt from 'jsonwebtoken'
 import appConfig from '@/config/app'
 import User from '@/models/user'
 
+import makeFlowTemplate, { DEFAULT_FLOW_TEMPLATE } from './flow-templates'
+
 const AUTH_COOKIE_NAME = 'plumber.sid'
 // 3 days expiry
 const TOKEN_EXPIRES_IN_SEC = 3 * 24 * 60 * 60
@@ -56,6 +58,9 @@ export async function getOrCreateUser(email: string): Promise<User> {
   let user = await User.query().findOne({ email })
   if (!user) {
     user = await User.query().insertAndFetch({ email })
+    const { flowName, trigger, actions, demoVideoDetails } =
+      DEFAULT_FLOW_TEMPLATE
+    makeFlowTemplate(flowName, trigger, actions, user, true, demoVideoDetails)
   }
 
   return user

--- a/packages/backend/src/helpers/auth.ts
+++ b/packages/backend/src/helpers/auth.ts
@@ -59,7 +59,14 @@ export async function getOrCreateUser(email: string): Promise<User> {
   if (!user) {
     user = await User.query().insertAndFetch({ email })
     const { flowName, trigger, actions, demoVideoId } = DEFAULT_FLOW_TEMPLATE
-    createFlowFromTemplate(flowName, trigger, actions, user, true, demoVideoId)
+    await createFlowFromTemplate(
+      flowName,
+      trigger,
+      actions,
+      user,
+      true,
+      demoVideoId,
+    )
   }
 
   return user

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -2,7 +2,6 @@ import type { AppEventKeyPair } from '@plumber/types'
 
 import type {
   CreateFlowTemplateInput,
-  DemoVideoDetails,
   FlowConfig,
 } from '@/graphql/__generated__/types.generated'
 import Flow from '@/models/flow'
@@ -22,19 +21,16 @@ export const DEFAULT_FLOW_TEMPLATE: CreateFlowTemplateInput = {
       eventKey: 'sendTransactionalEmail',
     },
   ],
-  demoVideoDetails: {
-    url: 'https://demo.arcade.software/FzpL1zCmibw0oXR6HUJi?embed&show_copy_link=true',
-    title: 'Send notifications',
-  },
+  demoVideoId: 'formsg-postman',
 }
 
-async function makeFlowTemplate(
+async function createFlowFromTemplate(
   flowName: string,
   trigger: AppEventKeyPair,
   actions: AppEventKeyPair[],
   user: User,
   isPreCreated: boolean,
-  demoVideoDetails: DemoVideoDetails,
+  demoVideoId: string,
 ): Promise<Flow> {
   const { appKey: triggerAppKey, eventKey: triggerEventKey } = trigger
 
@@ -44,7 +40,7 @@ async function makeFlowTemplate(
       demoConfig: {
         onFirstLoad: true,
         isPreCreated,
-        videoDetails: demoVideoDetails,
+        videoId: demoVideoId,
       },
     }
     // insert flow
@@ -85,4 +81,4 @@ async function makeFlowTemplate(
   })
 }
 
-export default makeFlowTemplate
+export default createFlowFromTemplate

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -1,7 +1,7 @@
 import type { AppEventKeyPair } from '@plumber/types'
 
 import type {
-  CreateFlowTemplateInput,
+  CreateTemplatedFlowInput,
   FlowConfig,
 } from '@/graphql/__generated__/types.generated'
 import Flow from '@/models/flow'
@@ -9,7 +9,7 @@ import User from '@/models/user'
 
 import logger from './logger'
 
-export const DEFAULT_FLOW_TEMPLATE: CreateFlowTemplateInput = {
+export const DEFAULT_FLOW_TEMPLATE: CreateTemplatedFlowInput = {
   flowName: 'Send notifications',
   trigger: {
     appKey: 'formsg',

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -1,0 +1,88 @@
+import type { AppEventKeyPair } from '@plumber/types'
+
+import type {
+  CreateFlowTemplateInput,
+  DemoVideoDetails,
+  FlowConfig,
+} from '@/graphql/__generated__/types.generated'
+import Flow from '@/models/flow'
+import User from '@/models/user'
+
+import logger from './logger'
+
+export const DEFAULT_FLOW_TEMPLATE: CreateFlowTemplateInput = {
+  flowName: 'Send notifications',
+  trigger: {
+    appKey: 'formsg',
+    eventKey: 'newSubmission',
+  },
+  actions: [
+    {
+      appKey: 'postman',
+      eventKey: 'sendTransactionalEmail',
+    },
+  ],
+  demoVideoDetails: {
+    url: 'https://demo.arcade.software/FzpL1zCmibw0oXR6HUJi?embed&show_copy_link=true',
+    title: 'Send notifications',
+  },
+}
+
+async function makeFlowTemplate(
+  flowName: string,
+  trigger: AppEventKeyPair,
+  actions: AppEventKeyPair[],
+  user: User,
+  isPreCreated: boolean,
+  demoVideoDetails: DemoVideoDetails,
+): Promise<Flow> {
+  const { appKey: triggerAppKey, eventKey: triggerEventKey } = trigger
+
+  // transaction will insert flow and steps
+  return await Flow.transaction(async (trx) => {
+    const flowConfig: FlowConfig = {
+      demoConfig: {
+        onFirstLoad: true,
+        isPreCreated,
+        videoDetails: demoVideoDetails,
+      },
+    }
+    // insert flow
+    const flow = await user.$relatedQuery('flows', trx).insert({
+      name: `[DEMO] ${flowName}`,
+      config: flowConfig,
+    })
+
+    // insert trigger step
+    await flow.$relatedQuery('steps', trx).insert({
+      type: 'trigger',
+      position: 1,
+      appKey: triggerAppKey,
+      key: triggerEventKey,
+    })
+
+    // insert action steps
+    for (let i = 0; i < actions.length; i++) {
+      const { appKey: actionAppKey, eventKey: actionEventKey } = actions[i]
+      await flow.$relatedQuery('steps', trx).insert({
+        type: 'action',
+        position: i + 2, // start at position 2
+        appKey: actionAppKey,
+        key: actionEventKey,
+      })
+    }
+
+    logger.info('Demo flow created', {
+      event: 'demo-flow-request',
+      flowId: flow.id,
+      flowName: flow.name,
+      trigger,
+      actions,
+      isPreCreated,
+    })
+
+    return flow
+  })
+}
+
+export default makeFlowTemplate

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -152,6 +152,11 @@ export interface IStep {
   jobId?: string
 }
 
+export type AppEventKeyPair = {
+  appKey: string
+  eventKey: string
+}
+
 export interface IFlowConfig {
   maxQps?: number
   rejectIfOverMaxQps?: boolean


### PR DESCRIPTION
## Problem
New users are confused with how to get started on Plumber, so GGWP v1 is an onboarding demo flow we are experimenting with to provide more help for users to onboard with Plumber.

## Details
Backend
- Create a demo flow first with the `demoConfig`: `onFirstLoad` (used to display modal and tooltip later on), `isPreCreated` (to determine which modal to display later) and `videoUrl` and `videoTitle` to display the demo video later
- Add creation of the demo flow by default for new users

## Tests
- [x] New user will have a demo pipe instantiated
- [x] Can create flow templates using graphql, confirm later with frontend code added