### PR TITLE
PLU-261: [onboarding-demo-experiment-2]: add backend change to update flow config

### DIFF
--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -1,4 +1,8 @@
-import { IFlowErrorConfig } from '@plumber/types'
+import type {
+  IFlowConfig,
+  IFlowDemoConfig,
+  IFlowErrorConfig,
+} from '@plumber/types'
 
 import Context from '@/types/express/context'
 
@@ -6,6 +10,7 @@ type Params = {
   input: {
     id: string
     notificationFrequency: IFlowErrorConfig['notificationFrequency']
+    onFirstLoad: IFlowDemoConfig['onFirstLoad']
   }
 }
 
@@ -21,14 +26,26 @@ const updateFlowConfig = async (
     })
     .throwIfNotFound()
 
+  const newConfig: IFlowConfig = {
+    ...flow.config,
+  }
+
+  if (params.input.notificationFrequency !== undefined) {
+    newConfig.errorConfig = {
+      ...newConfig.errorConfig, // If ever undefined (should never be), it gets set to an empty object first
+      notificationFrequency: params.input.notificationFrequency,
+    }
+  }
+
+  if (params.input.onFirstLoad !== undefined) {
+    newConfig.demoConfig = {
+      ...newConfig.demoConfig, // If ever undefined (should never be), it gets set to an empty object first
+      onFirstLoad: params.input.onFirstLoad,
+    }
+  }
+
   return await flow.$query().patchAndFetch({
-    config: {
-      ...(flow.config ?? {}),
-      errorConfig: {
-        ...(flow.config?.errorConfig ?? {}),
-        notificationFrequency: params.input.notificationFrequency,
-      },
-    },
+    config: newConfig,
   })
 }
 

--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -10,7 +10,7 @@ type Params = {
   input: {
     id: string
     notificationFrequency: IFlowErrorConfig['notificationFrequency']
-    onFirstLoad: IFlowDemoConfig['onFirstLoad']
+    hasLoadedOnce: IFlowDemoConfig['hasLoadedOnce']
   }
 }
 
@@ -37,10 +37,10 @@ const updateFlowConfig = async (
     }
   }
 
-  if (params.input.onFirstLoad !== undefined) {
+  if (params.input.hasLoadedOnce !== undefined) {
     newConfig.demoConfig = {
       ...newConfig.demoConfig, // If ever undefined (should never be), it gets set to an empty object first
-      onFirstLoad: params.input.onFirstLoad,
+      hasLoadedOnce: params.input.hasLoadedOnce,
     }
   }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -333,8 +333,8 @@ type FlowErrorConfig {
 }
 
 type FlowDemoConfig {
-  onFirstLoad: Boolean!
-  isPreCreated: Boolean!
+  hasLoadedOnce: Boolean!
+  isAutoCreated: Boolean!
   videoId: String!
 }
 
@@ -413,7 +413,7 @@ enum NotificationFrequency {
 input UpdateFlowConfigInput {
   id: String!
   notificationFrequency: NotificationFrequency
-  onFirstLoad: Boolean
+  hasLoadedOnce: Boolean
 }
 
 input ExecuteFlowInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -412,7 +412,8 @@ enum NotificationFrequency {
 
 input UpdateFlowConfigInput {
   id: String!
-  notificationFrequency: NotificationFrequency!
+  notificationFrequency: NotificationFrequency
+  onFirstLoad: Boolean
 }
 
 input ExecuteFlowInput {

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -29,7 +29,7 @@ async function createFlowFromTemplate(
   trigger: AppEventKeyPair,
   actions: AppEventKeyPair[],
   user: User,
-  isPreCreated: boolean,
+  isAutoCreated: boolean,
   demoVideoId: string,
 ): Promise<Flow> {
   const { appKey: triggerAppKey, eventKey: triggerEventKey } = trigger
@@ -38,8 +38,8 @@ async function createFlowFromTemplate(
   return await Flow.transaction(async (trx) => {
     const flowConfig: FlowConfig = {
       demoConfig: {
-        onFirstLoad: true,
-        isPreCreated,
+        hasLoadedOnce: false,
+        isAutoCreated,
         videoId: demoVideoId,
       },
     }
@@ -74,7 +74,7 @@ async function createFlowFromTemplate(
       flowName: flow.name,
       trigger,
       actions,
-      isPreCreated,
+      isAutoCreated,
     })
 
     return flow

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -162,10 +162,17 @@ export interface IFlowConfig {
   rejectIfOverMaxQps?: boolean
   errorConfig?: IFlowErrorConfig
   duplicateCount?: number
+  demoConfig?: IFlowDemoConfig
 }
 
 export interface IFlowErrorConfig {
   notificationFrequency: 'once_per_day' | 'always'
+}
+
+export interface IFlowDemoConfig {
+  onFirstLoad: boolean
+  isPreCreated: boolean
+  videoId: string
 }
 
 export interface IFlow {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -170,8 +170,8 @@ export interface IFlowErrorConfig {
 }
 
 export interface IFlowDemoConfig {
-  onFirstLoad: boolean
-  isPreCreated: boolean
+  hasLoadedOnce: boolean
+  isAutoCreated: boolean
   videoId: string
 }
 
@@ -731,7 +731,7 @@ export type IGlobalVariable = {
   request?: IRequest
   flow?: {
     id: string
-    name: string,
+    name: string
     hasFileProcessingActions: boolean
     userId: string
     remoteWebhookId?: string
@@ -748,7 +748,9 @@ export type IGlobalVariable = {
     appKey: string
     parameters: IJSONObject
   }
-  getLastExecutionStep?: (options?: {sameExecution?: boolean}) => Promise<IExecutionStep | undefined>
+  getLastExecutionStep?: (options?: {
+    sameExecution?: boolean
+  }) => Promise<IExecutionStep | undefined>
   execution?: {
     id: string
     testRun: boolean


### PR DESCRIPTION
## Problem
New users are confused with how to get started on Plumber, so GGWP v1 is an onboarding demo flow we are experimenting with to provide more help for users to onboard with Plumber.

## Details
Backend
- Modify `updateFlowConfig` graphql query to allow `onFirstLoad` to be modified too

## Tests
- [x] Notification freq still can be updated properly
- [x] `onFirstLoad` can be updated using graphql