### PR TITLE
[PARTIAL-6] add partial retry mutation

### DIFF
--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -158,12 +158,12 @@ export async function sendTransactionalEmails(
   /**
    * Since we can only return one error per postman step, we have to select in terms of priority
    * 1. RATE-LIMITED (so we can auto-retry)
-   * 2. BLACKLISTED (so they can manual-retry)
-   * 3. INVALID-ATTACHMENT (probably all recipients should fail)
-   * 4. ERROR (same as above, probably all recipients should fail)
+   * 2. INVALID-ATTACHMENT (probably all recipients should fail)
+   * 3. ERROR (same as above, probably all recipients should fail)
+   * 4. BLACKLISTED (blacklisted errors are returned even if there are other errors like invalid attachment)
    */
   const sortedErrors = sortBy(errors, (error) =>
-    ['RATE-LIMITED', 'BLACKLISTED', 'INVALID-ATTACHMENT', 'ERROR'].indexOf(
+    ['RATE-LIMITED', 'INVALID-ATTACHMENT', 'ERROR', 'BLACKLISTED'].indexOf(
       error.status,
     ),
   )

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -17,6 +17,7 @@ import registerConnection from './mutations/register-connection'
 import requestOtp from './mutations/request-otp'
 import resetConnection from './mutations/reset-connection'
 import retryExecutionStep from './mutations/retry-execution-step'
+import retryPartialStep from './mutations/retry-partial-step'
 import tilesMutationResolvers from './mutations/tiles'
 import updateConnection from './mutations/update-connection'
 import updateFlow from './mutations/update-flow'
@@ -65,6 +66,7 @@ export default {
   requestOtp,
   verifyOtp,
   retryExecutionStep,
+  retryPartialStep,
   logout,
   loginWithSgid,
   loginWithSelectedSgid,

--- a/packages/backend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-partial-step.ts
@@ -1,0 +1,45 @@
+import { ref } from 'objection'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import ExecutionStep from '@/models/execution-step'
+import { processAction } from '@/services/action'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const retryPartialStep: MutationResolvers['retryPartialStep'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const executionStep = await ExecutionStep.query()
+    .findById(params.input.executionStepId)
+    .withGraphJoined('execution')
+    .whereExists(
+      context.currentUser
+        .$relatedQuery('executions')
+        .select(1)
+        .where('executions.id', ref('execution_steps.execution_id')),
+    )
+
+  if (!executionStep) {
+    throw new BadUserInputError('Execution step not found')
+  }
+
+  if (executionStep.status !== 'success' || !executionStep.errorDetails) {
+    throw new BadUserInputError('Execution step not partially retriable')
+  }
+
+  try {
+    await processAction({
+      executionId: executionStep.executionId,
+      flowId: executionStep.execution.flowId,
+      stepId: executionStep.stepId,
+    })
+  } catch (e) {
+    throw new Error('Failed to retry partial step')
+  }
+
+  return true
+}
+
+export default retryPartialStep

--- a/packages/backend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-execution-steps.ts
@@ -20,7 +20,11 @@ const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
     .$relatedQuery('executionSteps')
     .with('latest_steps', (builder) => {
       builder
-        .select('step_id', raw('max(created_at) as max_created_at'))
+        .select(
+          'step_id',
+          raw('max(created_at) as max_created_at'),
+          raw('min(created_at) as min_created_at'),
+        )
         .from('execution_steps')
         .groupBy('step_id')
         .where('execution_id', '=', execution.id)
@@ -30,8 +34,9 @@ const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
         .on('execution_steps.step_id', '=', 'latest_steps.step_id')
         .andOn('execution_steps.created_at', '=', 'latest_steps.max_created_at')
     })
+    .select('execution_steps.*', 'min_created_at')
     .withSoftDeleted()
-    .orderBy('created_at', 'asc')
+    .orderBy('min_created_at', 'asc')
 
   return paginate(executionSteps, params.limit, params.offset)
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -67,7 +67,7 @@ type Mutation {
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
   retryExecutionStep(input: RetryExecutionStepInput): Boolean
-  retryPartialStep(input: RetryPartialStepInput): Boolean
+  retryPartialStep(input: RetryPartialStepInput!): Boolean
   bulkRetryExecutions(
     input: BulkRetryExecutionsInput
   ): BulkRetryExecutionsResult!

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -67,6 +67,7 @@ type Mutation {
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
   retryExecutionStep(input: RetryExecutionStepInput): Boolean
+  retryPartialStep(input: RetryPartialStepInput): Boolean
   bulkRetryExecutions(
     input: BulkRetryExecutionsInput
   ): BulkRetryExecutionsResult!
@@ -442,6 +443,10 @@ input VerifyOtpInput {
 }
 
 input RetryExecutionStepInput {
+  executionStepId: String!
+}
+
+input RetryPartialStepInput {
   executionStepId: String!
 }
 

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -16,6 +16,7 @@ class ExecutionStep extends Base {
   jobId: string
   step: Step
   metadata: IExecutionStepMetadata
+  execution?: Execution
 
   static tableName = 'execution_steps'
 

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -2,26 +2,55 @@ import { IStepError } from '@plumber/types'
 
 import { useCallback, useState } from 'react'
 import Markdown from 'react-markdown'
+import { useMutation } from '@apollo/client'
 import { Box, Collapse, Text } from '@chakra-ui/react'
-import { Badge, Button, Infobox } from '@opengovsg/design-system-react'
+import {
+  Badge,
+  Button,
+  Infobox,
+  useToast,
+} from '@opengovsg/design-system-react'
 import JSONViewer from 'components/JSONViewer'
+import { RETRY_PARTIAL_STEP } from 'graphql/mutations/retry-partial-step'
+import { GET_EXECUTION_STEPS } from 'graphql/queries/get-execution-steps'
 
 interface SpecificErrorResultProps {
   errorDetails: IStepError
   isTestRun: boolean
+  executionStepId?: string
 }
 
 const contactPlumberMessage =
   'If this error still persists, contact us at support@plumber.gov.sg.'
 
 export default function SpecificErrorResult(props: SpecificErrorResultProps) {
-  const { errorDetails, isTestRun } = props
+  const { errorDetails, isTestRun, executionStepId } = props
   const { name, solution, position, appName, details, partialRetry } =
     errorDetails
   const [isOpen, setIsOpen] = useState(false)
   const toggleDropdown = useCallback(() => {
     setIsOpen((value) => !value)
   }, [])
+
+  const toast = useToast()
+
+  const [retryPartialStep, { loading }] = useMutation(RETRY_PARTIAL_STEP, {
+    variables: {
+      input: {
+        executionStepId,
+      },
+    },
+    onCompleted: () => {
+      toast({
+        title: 'Step has been retried successfully',
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+        position: 'top',
+      })
+    },
+    refetchQueries: [GET_EXECUTION_STEPS],
+  })
 
   return (
     <Infobox variant="error">
@@ -65,8 +94,14 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
             </>
           )}
 
-          {!isTestRun && partialRetry && (
-            <Button variant="link" textDecoration="underline" mt={4}>
+          {!isTestRun && partialRetry && executionStepId && (
+            <Button
+              variant="link"
+              textDecoration="underline"
+              mt={4}
+              isLoading={loading}
+              onClick={() => retryPartialStep()}
+            >
               {partialRetry.buttonMessage}
             </Button>
           )}

--- a/packages/frontend/src/components/ErrorResult/index.tsx
+++ b/packages/frontend/src/components/ErrorResult/index.tsx
@@ -18,12 +18,17 @@ const isStepError = (value: IStepError | IJSONObject): value is IStepError => {
 interface ErrorResultProps {
   errorDetails: IStepError | IJSONObject
   isTestRun: boolean
+  executionStepId?: string
 }
 
 export default function ErrorResult(props: ErrorResultProps) {
-  const { errorDetails, isTestRun } = props
+  const { errorDetails, isTestRun, executionStepId } = props
   return isStepError(errorDetails) ? (
-    <SpecificErrorResult errorDetails={errorDetails} isTestRun={isTestRun} />
+    <SpecificErrorResult
+      executionStepId={executionStepId}
+      errorDetails={errorDetails}
+      isTestRun={isTestRun}
+    />
   ) : (
     <GenericErrorResult errorDetails={errorDetails} isTestRun={isTestRun} />
   )

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -171,6 +171,7 @@ export default function ExecutionStep({
               {hasError && (
                 <TabPanel>
                   <ErrorResult
+                    executionStepId={executionStep.id}
                     errorDetails={executionStep.errorDetails}
                     isTestRun={false}
                   />

--- a/packages/frontend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/frontend/src/graphql/mutations/retry-partial-step.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client'
+
+export const RETRY_PARTIAL_STEP = gql`
+  mutation RetryPartialStep($input: RetryPartialStepInput) {
+    retryPartialStep(input: $input)
+  }
+`

--- a/packages/frontend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/frontend/src/graphql/mutations/retry-partial-step.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const RETRY_PARTIAL_STEP = gql`
-  mutation RetryPartialStep($input: RetryPartialStepInput) {
+  mutation RetryPartialStep($input: RetryPartialStepInput!) {
     retryPartialStep(input: $input)
   }
 `

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -597,12 +597,8 @@ export interface ITrigger extends IBaseTrigger {
   substeps?: ISubstep[]
 }
 
-interface PostmanSendEmailMetadata {
-  type: 'postman-send-email'
-  progress?: number
-}
 // Can add more type in this union later for different action types
-export type NextStepMetadata = PostmanSendEmailMetadata
+export type NextStepMetadata = Record<string, any>
 
 export interface IActionJobData {
   flowId: string


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/75285d21-ee51-440e-b162-bcd27a96f9ee.png)

## Changes
**Partial Retry Mutation**
This button will call the retryPartialStep mutation which runs processAction.

**Get Execution Steps Query**
Modify get-execution-steps to sort by min_created_at rather than max_created_at since retrying of partial steps will cause the execution steps to go out of order.

**Refactor**
Because postman action can only show 1 error, we need to prioritise which error to show in the event of multiple errors. Since postman will return blacklist errors over other errors such as invalid attachments, we will deprioritise blacklist errors over other errors as it's more relevant.
Also, removing type for NextStepMetadata cos not used any more.