### PR TITLE
PLU-260: [STANDARDISE-DROPDOWNS-5] Allow user to explicitly choose free-solo item

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -258,6 +258,7 @@ function ChooseAppAndEventSubstep(
                   name="choose-app-option"
                   colorScheme="secondary"
                   isClearable={false}
+                  isRefreshLoading={isLoading}
                   isDisabled={isLoading || editorContext.readOnly}
                   // Don't display options until we can check feature flags!
                   items={isLoading ? [] : appOptions}

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -85,7 +85,7 @@ function ControlledAutocomplete(
   // for it yet and it makes things more complex.
   const freeSolo = useMemo(() => {
     if (
-      !options.length ||
+      options.length &&
       options.every((option) => typeof option.value !== 'string')
     ) {
       return false

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -84,7 +84,10 @@ function ControlledAutocomplete(
   // Do not support freeSolo if there are numerical options. Since no use case
   // for it yet and it makes things more complex.
   const freeSolo = useMemo(() => {
-    if (options.every((option) => typeof option.value !== 'string')) {
+    if (
+      !options.length ||
+      options.every((option) => typeof option.value !== 'string')
+    ) {
       return false
     }
     return rawFreeSolo
@@ -121,19 +124,14 @@ function ControlledAutocomplete(
                   colorScheme="secondary"
                   isClearable={!required}
                   items={items}
-                  onChange={(selectedOption) => {
-                    if (!selectedOption) {
-                      return
-                    }
-                    onChange(selectedOption)
-                  }}
+                  onChange={onChange}
                   value={fieldValue}
                   placeholder={placeholder}
                   ref={ref}
                   data-test={`${name}-autocomplete`}
                   onRefresh={onRefresh}
                   isRefreshLoading={loading}
-                  freeSolo={freeSolo ?? false}
+                  freeSolo={freeSolo}
                 />
               </Box>
             </Flex>

--- a/packages/frontend/src/components/SingleSelect/SelectContext.tsx
+++ b/packages/frontend/src/components/SingleSelect/SelectContext.tsx
@@ -27,6 +27,14 @@ export interface SharedSelectContextReturnProps<
   /** Item data used to render items in dropdown */
   items: Item[]
   size?: 'xs' | 'sm' | 'md' | 'lg'
+  /*
+   * SPECIAL CASES for Plumber
+   */
+  /** Allow dropdown options to reload upon clicking refresh. Defaults to false */
+  onRefresh?: (() => void) | null
+  isRefreshLoading?: boolean
+  /** Controls if user can add one arbitrary item of their choosing. */
+  freeSolo?: boolean
 }
 
 interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
@@ -52,14 +60,6 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   virtualListRef: RefObject<VirtuosoHandle>
   /** Height to assign to virtual list */
   virtualListHeight: number
-  /** SPECIAL CASE for Plumber:
-   * Allow dropdown options to reload upon clicking refresh */
-  onRefresh?: () => void
-  isRefreshLoading?: boolean
-  /** Allow custom dropdown option if freeSolo is enabled */
-  freeSolo?: boolean
-  /** Controlled selected value */
-  value: string
 }
 
 export const SelectContext = createContext<SelectContextReturn | undefined>(

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -110,8 +110,11 @@ export const SingleSelectProvider = ({
   )
 
   const getFilteredItems = useCallback(
-    (filterValue?: string) =>
-      filterValue != null ? filter(allItems, filterValue) : allItems,
+    (filterValue?: string) => {
+      const filtered =
+        filterValue != null ? filter(allItems, filterValue) : allItems
+      return [...filtered]
+    },
     [filter, allItems],
   )
   const [filteredItems, setFilteredItems] = useState(allItems)
@@ -135,8 +138,9 @@ export const SingleSelectProvider = ({
 
   const addFreeSoloItem = useCallback(
     (filteredItems: ComboboxItem<string>[], inputValue?: string) => {
-      if (inputValue != null && !getItemByValue(inputValue)) {
-        filteredItems.push(getFreeSoloItem(inputValue))
+      // freeSolo inputValue cannot be null or undefined or blank
+      if (inputValue?.trim() && !getItemByValue(inputValue)) {
+        return filteredItems.push(getFreeSoloItem(inputValue))
       }
     },
     [getItemByValue],

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ComboboxClearButton.tsx
@@ -20,11 +20,9 @@ export const ComboboxClearButton = (): JSX.Element | null => {
 
   const [announceClearedInput, setAnnounceClearedInput] = useState(false)
   const handleClearSelection = useCallback(() => {
-    // Need to focus before selecting null. I have no idea why, but it works
-    inputRef?.current?.focus()
     selectItem(null)
     setAnnounceClearedInput(true)
-  }, [inputRef, selectItem])
+  }, [selectItem])
 
   useEffect(() => {
     if (selectedItem) {

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -34,7 +34,6 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       inputRef,
       isClearable,
       size,
-      value,
     } = useSelectContext()
 
     const mergedInputRef = useMergeRefs(inputRef, ref)
@@ -81,12 +80,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            {/* To display custom value if it exists when freeSolo is enabled */}
-            <Flex w="100%" justifyContent="space-between">
-              <Text noOfLines={1}>
-                {selectedItemMeta.label !== '' ? selectedItemMeta.label : value}
-              </Text>
-            </Flex>
+            <Text noOfLines={1}>{selectedItemMeta.label}</Text>
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useMemo } from 'react'
+import { forwardRef, useCallback, useEffect, useMemo, useState } from 'react'
 import {
   Flex,
   Icon,
@@ -39,6 +39,15 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
 
     const mergedInputRef = useMergeRefs(inputRef, ref)
 
+    const [hasOptionsLoadedOnce, setHasOptionsLoadedOnce] = useState(false)
+    const isInitialLoading = !hasOptionsLoadedOnce && isRefreshLoading
+
+    useEffect(() => {
+      if (!isRefreshLoading) {
+        setHasOptionsLoadedOnce(true)
+      }
+    }, [isRefreshLoading])
+
     const selectedItemMeta = useMemo(
       () => ({
         icon: itemToIcon(selectedItem),
@@ -67,7 +76,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
           gridTemplateColumns="1fr"
         >
           <Stack
-            visibility={inputValue ? 'hidden' : 'initial'}
+            visibility={inputValue || isInitialLoading ? 'hidden' : 'initial'}
             direction="row"
             spacing="1rem"
             aria-disabled={isDisabled}
@@ -88,10 +97,10 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             isInvalid={isInvalid}
             isDisabled={isDisabled}
             placeholder={
-              selectedItem
-                ? undefined
-                : isRefreshLoading
+              isInitialLoading
                 ? 'Fetching options...'
+                : selectedItem
+                ? undefined
                 : placeholder
             }
             sx={styles.field}

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -29,6 +29,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       inputValue,
       isRequired,
       placeholder,
+      isRefreshLoading,
       isOpen,
       resetInputValue,
       inputRef,
@@ -86,7 +87,13 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             isReadOnly={!isSearchable || isReadOnly}
             isInvalid={isInvalid}
             isDisabled={isDisabled}
-            placeholder={selectedItem ? undefined : placeholder}
+            placeholder={
+              selectedItem
+                ? undefined
+                : isRefreshLoading
+                ? 'Fetching options...'
+                : placeholder
+            }
             sx={styles.field}
             {...getInputProps({
               onClick: handleToggleMenu,

--- a/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
@@ -4,7 +4,6 @@ import { List, ListItem, Portal } from '@chakra-ui/react'
 import { Button, Spinner } from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../SelectContext'
-import type { ComboboxItem } from '../types'
 import { itemToValue } from '../utils/itemUtils'
 
 import { DropdownItem } from './DropdownItem'
@@ -22,7 +21,6 @@ export const SelectMenu = (): JSX.Element => {
     onRefresh,
     isRefreshLoading,
     inputValue,
-    freeSolo,
   } = useSelectContext()
 
   const { floatingRef, floatingStyles } = useSelectPopover()
@@ -57,28 +55,10 @@ export const SelectMenu = (): JSX.Element => {
             }}
           />
         )}
-        {/* Freesolo enabled and non-empty input --> show new dropdown option
-         *  Freesolo disabled and no filtered input --> show nothing found label
-         */}
-        {isOpen && items.length === 0 ? (
-          freeSolo ? (
-            inputValue !== '' ? (
-              <DropdownItem
-                item={
-                  {
-                    label: inputValue,
-                    value: inputValue,
-                    description: inputValue,
-                  } as ComboboxItem
-                }
-                index={items.length}
-              />
-            ) : null
-          ) : (
-            <ListItem role="option" sx={styles.emptyItem}>
-              {nothingFoundLabel}
-            </ListItem>
-          )
+        {isOpen && items.length === 0 && inputValue?.length ? (
+          <ListItem role="option" sx={styles.emptyItem}>
+            {nothingFoundLabel}
+          </ListItem>
         ) : null}
         {/* Allow reload of dynamic data fields */}
         {isOpen && onRefresh && (

--- a/packages/frontend/src/components/SingleSelect/hooks/index.ts
+++ b/packages/frontend/src/components/SingleSelect/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useItems'
+export * from './useLookupItems'

--- a/packages/frontend/src/components/SingleSelect/hooks/useItems.ts
+++ b/packages/frontend/src/components/SingleSelect/hooks/useItems.ts
@@ -47,18 +47,6 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
     }, initialStore)
   }, [rawItems])
 
-  // UPDATE: used only if custom dropdown options are to be added
-  const addCustomItem = useCallback(
-    (newValue: string) => {
-      rawItems.push({
-        label: newValue,
-        value: newValue,
-        description: newValue,
-      } as Item)
-    },
-    [rawItems],
-  )
-
   const getItemByValue = useCallback(
     (value: string): ItemWithIndex<Item> | null => {
       return normalizedItems.byValue[value] ?? null
@@ -69,6 +57,5 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
   return {
     items: rawItems,
     getItemByValue,
-    addCustomItem,
   }
 }

--- a/packages/frontend/src/components/SingleSelect/hooks/useLookupItems.ts
+++ b/packages/frontend/src/components/SingleSelect/hooks/useLookupItems.ts
@@ -5,22 +5,20 @@ import { useCallback, useMemo } from 'react'
 import { ComboboxItem } from '../types'
 import { itemToValue } from '../utils/itemUtils'
 
-export type ItemWithIndex<Item extends ComboboxItem = ComboboxItem> = {
+type ItemWithIndex<Item extends ComboboxItem = ComboboxItem> = {
   item: Item
   index: number
 }
 
-export type UseItemsReturn<Item extends ComboboxItem = ComboboxItem> = {
+type UseItemsReturn<Item extends ComboboxItem = ComboboxItem> = {
   byValue: Record<string, ItemWithIndex<Item>>
 }
 
-interface UseItemProps<Item extends ComboboxItem = ComboboxItem> {
-  rawItems: Item[]
-}
-
-export const useItems = <Item extends ComboboxItem = ComboboxItem>({
+export const useLookupItems = <Item extends ComboboxItem = ComboboxItem>({
   rawItems,
-}: UseItemProps<Item>) => {
+}: {
+  rawItems: Item[]
+}) => {
   const normalizedItems = useMemo(() => {
     const initialStore: UseItemsReturn<Item> = {
       // Normalized store for filtering and retrieval of state
@@ -55,7 +53,6 @@ export const useItems = <Item extends ComboboxItem = ComboboxItem>({
   )
 
   return {
-    items: rawItems,
     getItemByValue,
   }
 }


### PR DESCRIPTION
## Problem
When we enable `freeSolo` in `ControlledAutocomplete`, search functionality is lost because it always sets the selected item to the search query (i.e. all input is considered free solo input).

## Solution
We will expose a "Use your custom option" for freeSolo `ControlledAutocomplete`, like the actual MUI `Autocomplete`.

Co-author: @dextertanyj
Thanks for your help!

<img width="800" alt="Screenshot 2024-06-11 at 7 48 23 PM" src="https://github.com/opengovsg/plumber/assets/135598754/bd3b4c68-6c82-4073-9576-e5ab118b67b8">

## Tests
- Check that when users select their freeSolo input, the input is updated in the form.
- Check that users can select predefined rows in freeSolo dropdowns even if they enter a search query.
- Regression test: check that searching in dropdowns without freeSolo will not show a "Use your custom option" item
- Regression test: check that I can still select items in dropdowns without freeSolo