### PR TITLE
PLU-228: [M365-GA] Add time in action queue to span tags

### DIFF
--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -115,6 +115,8 @@ export function makeActionWorker(
           actionKey: currStep?.key,
           appKey: currStep?.appKey,
           jobId,
+          jobCreationTime: job.timestamp,
+          timeInJobQueue: Date.now() - job.timestamp,
           workerVersion: appConfig.version,
         })
 


### PR DESCRIPTION
## Problem
I want to track the amount of time an action spends in the queue, as that's one of my SLOs for excel (<= 30 min in queue)

## Solution
Add the SLO (time in queue) metric to our span tags, and make DD monitors and dashboard which query these tags.

## Tests
- Push to staging and check that the `jobCreationTime` and `timeInJobQueue` span tags are available in worker.action DD traces.