### PR TITLE
chore: add user email to graphql traces

### DIFF
--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -18,18 +18,15 @@ import type AuthenticatedContext from '@/types/express/context'
 // Adds the logged in user's email (if available) as a span tag to each query.
 function ApolloServerPluginUserTracer(): ApolloServerPlugin<AuthenticatedContext> {
   return {
-    async requestDidStart() {
-      return {
-        // Add the tag right before we reply the user.
-        // https://www.apollographql.com/docs/apollo-server/integrations/plugins#request-lifecycle-event-flow
-        async willSendResponse(requestContext) {
-          const span = tracer.scope().active()
-          span?.addTags({
-            user:
-              requestContext.contextValue?.currentUser?.email ??
-              'unauthenticated',
-          })
-        },
+    async requestDidStart(requestContext) {
+      // Add the tag right before we reply the user.
+      // https://www.apollographql.com/docs/apollo-server/integrations/plugins#request-lifecycle-event-flow
+      const currentUser = requestContext.contextValue?.currentUser
+      if (currentUser) {
+        tracer.setUser({
+          id: currentUser.id,
+          email: currentUser.email,
+        })
       }
     },
   }

--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -12,9 +12,8 @@ import resolvers from '@/graphql/resolvers'
 import authentication, { setCurrentUserContext } from '@/helpers/authentication'
 import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
-import AuthenticatedContext, {
-  UnauthenticatedContext,
-} from '@/types/express/context'
+import type { UnauthenticatedContext } from '@/types/express/context'
+import type AuthenticatedContext from '@/types/express/context'
 
 // Adds the logged in user's email (if available) as a span tag to each query.
 function ApolloServerPluginUserTracer(): ApolloServerPlugin<AuthenticatedContext> {


### PR DESCRIPTION
## Problem
We can't attribute GraphQL operations to a user, which makes troubleshooting hard.

## Solution
Add a Apollo server plugin to add a `username` tag to our GraphQL traces. For logged-out contexts, the username tag will be set to 'unauthenticated'.

#### NOTE
As I implemented this with an Apollo plugin, this tag shows up in the `graphQLRouteHandler` span, instead of the actual GraphQL operation span (i.e. the spans with names like `getPlumberStats:Stats`...).

I _believe_ that if we want to make this tag show up in the GraphQL operation span, we will need to wrap all our GraphQL resolvers. I think that approach is either more error prone (e.g. need to remember to manually wrap) or more complexity to implement (e.g. implement a codegen plugin to do this) Since this is not critical, I decided to take the least-effort route instead <.<

## Tests
- Check that actual username shows up in the `graphQLRouteHandler` for authenticated GraphQL operations.
- Check that `unauthenticated` shows up in the `graphQLRouteHandler` for unauthenticated GraphQL operations like `getPlumberStats`.
- Regression test: sanity check that GraphQL still works (e.g. queries - get pipes / executions; mutations - create pipe, update step)