### PR TITLE
PLU-20: [BUAY-TAHAN-5] Add graphql-codegen types to easy frontend queries

### DIFF
--- a/packages/frontend/src/graphql/mutations/create-connection.ts
+++ b/packages/frontend/src/graphql/mutations/create-connection.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const CREATE_CONNECTION = gql`
+export const CREATE_CONNECTION = graphql(`
   mutation CreateConnection($input: CreateConnectionInput) {
     createConnection(input: $input) {
       id
@@ -11,4 +11,4 @@ export const CREATE_CONNECTION = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/delete-connection.ts
+++ b/packages/frontend/src/graphql/mutations/delete-connection.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_CONNECTION = gql`
+export const DELETE_CONNECTION = graphql(`
   mutation DeleteConnection($input: DeleteConnectionInput) {
     deleteConnection(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/delete-flow.ts
+++ b/packages/frontend/src/graphql/mutations/delete-flow.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_FLOW = gql`
+export const DELETE_FLOW = graphql(`
   mutation DeleteFlow($input: DeleteFlowInput) {
     deleteFlow(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/delete-step.ts
+++ b/packages/frontend/src/graphql/mutations/delete-step.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_STEP = gql`
+export const DELETE_STEP = graphql(`
   mutation DeleteStep($input: DeleteStepInput) {
     deleteStep(input: $input) {
       id
@@ -9,4 +9,4 @@ export const DELETE_STEP = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/frontend/src/graphql/mutations/generate-auth-url.ts
@@ -1,9 +1,9 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const GENERATE_AUTH_URL = gql`
+export const GENERATE_AUTH_URL = graphql(`
   mutation generateAuthUrl($input: GenerateAuthUrlInput) {
     generateAuthUrl(input: $input) {
       url
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/login-with-selected-sgid.ts
+++ b/packages/frontend/src/graphql/mutations/login-with-selected-sgid.ts
@@ -1,9 +1,9 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const LOGIN_WITH_SELECTED_SGID = gql`
+export const LOGIN_WITH_SELECTED_SGID = graphql(`
   mutation LoginWithSelectedSgid($input: LoginWithSelectedSgidInput!) {
     loginWithSelectedSgid(input: $input) {
       success
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/login-with-sgid.ts
+++ b/packages/frontend/src/graphql/mutations/login-with-sgid.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const LOGIN_WITH_SGID = gql`
+export const LOGIN_WITH_SGID = graphql(`
   mutation LoginWithSgid($input: LoginWithSgidInput!) {
     loginWithSgid(input: $input) {
       publicOfficerEmployments {
@@ -11,4 +11,4 @@ export const LOGIN_WITH_SGID = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/register-connection.ts
+++ b/packages/frontend/src/graphql/mutations/register-connection.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const REGISTER_CONNECTION = gql`
+export const REGISTER_CONNECTION = graphql(`
   mutation RegisterConnection($input: RegisterConnectionInput) {
     registerConnection(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/request-otp.ts
+++ b/packages/frontend/src/graphql/mutations/request-otp.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const REQUEST_OTP = gql`
+export const REQUEST_OTP = graphql(`
   mutation RequestOtp($input: RequestOtpInput) {
     requestOtp(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/reset-connection.ts
+++ b/packages/frontend/src/graphql/mutations/reset-connection.ts
@@ -1,9 +1,9 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const RESET_CONNECTION = gql`
+export const RESET_CONNECTION = graphql(`
   mutation ResetConnection($input: ResetConnectionInput) {
     resetConnection(input: $input) {
       id
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/frontend/src/graphql/mutations/retry-execution-step.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const RETRY_EXECUTION_STEP = gql`
+export const RETRY_EXECUTION_STEP = graphql(`
   mutation RetryExecutionStep($input: RetryExecutionStepInput) {
     retryExecutionStep(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/create-row.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const CREATE_ROW = gql`
+export const CREATE_ROW = graphql(`
   mutation CreateRow($input: CreateTableRowInput!) {
     createRow(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/create-rows.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const CREATE_ROWS = gql`
+export const CREATE_ROWS = graphql(`
   mutation CreateRows($input: CreateTableRowsInput!) {
     createRows(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/create-shareable-link.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/create-shareable-link.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const CREATE_SHAREABLE_TABLE_LINK = gql`
+export const CREATE_SHAREABLE_TABLE_LINK = graphql(`
   mutation CreateShareableTableLink($tableId: ID!) {
     createShareableTableLink(tableId: $tableId)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/create-table.ts
@@ -1,10 +1,10 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const CREATE_TABLE = gql`
+export const CREATE_TABLE = graphql(`
   mutation CreateTable($input: CreateTableInput!) {
     createTable(input: $input) {
       id
       name
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/delete-rows.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/delete-rows.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_ROWS = gql`
+export const DELETE_ROWS = graphql(`
   mutation DeleteRows($input: DeleteTableRowsInput!) {
     deleteRows(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/delete-table-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/delete-table-collaborator.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_TABLE_COLLABORATOR = gql`
+export const DELETE_TABLE_COLLABORATOR = graphql(`
   mutation DeleteTableCollaborator($input: DeleteTableCollaboratorInput!) {
     deleteTableCollaborator(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/delete-table.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const DELETE_TABLE = gql`
+export const DELETE_TABLE = graphql(`
   mutation DeleteTable($input: DeleteTableInput!) {
     deleteTable(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/update-row.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const UPDATE_ROW = gql`
+export const UPDATE_ROW = graphql(`
   mutation UpdateRow($input: UpdateTableRowInput!) {
     updateRow(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/update-table.ts
@@ -1,9 +1,9 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const UPDATE_TABLE = gql`
+export const UPDATE_TABLE = graphql(`
   mutation UpdateTable($input: UpdateTableInput!) {
     updateTable(input: $input) {
       id
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/upsert-table-collaborator.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const UPSERT_TABLE_COLLABORATOR = gql`
+export const UPSERT_TABLE_COLLABORATOR = graphql(`
   mutation UpsertTableCollaborator($input: TableCollaboratorInput!) {
     upsertTableCollaborator(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/update-connection.ts
+++ b/packages/frontend/src/graphql/mutations/update-connection.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from '../__generated__/gql'
 
-export const UPDATE_CONNECTION = gql`
+export const UPDATE_CONNECTION = graphql(`
   mutation UpdateConnection($input: UpdateConnectionInput) {
     updateConnection(input: $input) {
       id
@@ -11,4 +11,4 @@ export const UPDATE_CONNECTION = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const UPDATE_STEP = gql`
+export const UPDATE_STEP = graphql(`
   mutation UpdateStep($input: UpdateStepInput) {
     updateStep(input: $input) {
       id
@@ -15,4 +15,4 @@ export const UPDATE_STEP = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/verify-connection.ts
+++ b/packages/frontend/src/graphql/mutations/verify-connection.ts
@@ -1,6 +1,6 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const VERIFY_CONNECTION = gql`
+export const VERIFY_CONNECTION = graphql(`
   mutation VerifyConnection($input: VerifyConnectionInput) {
     verifyConnection(input: $input) {
       id
@@ -15,4 +15,4 @@ export const VERIFY_CONNECTION = gql`
       }
     }
   }
-`
+`)

--- a/packages/frontend/src/graphql/mutations/verify-otp.ts
+++ b/packages/frontend/src/graphql/mutations/verify-otp.ts
@@ -1,7 +1,7 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const VERIFY_OTP = gql`
+export const VERIFY_OTP = graphql(`
   mutation VerifyOtp($input: VerifyOtpInput) {
     verifyOtp(input: $input)
   }
-`
+`)

--- a/packages/frontend/src/graphql/queries/healthcheck.ts
+++ b/packages/frontend/src/graphql/queries/healthcheck.ts
@@ -1,9 +1,9 @@
-import { gql } from '@apollo/client'
+import { graphql } from 'graphql/__generated__'
 
-export const HEALTHCHECK = gql`
+export const HEALTHCHECK = graphql(`
   query Healthcheck {
     healthcheck {
       version
     }
   }
-`
+`)


### PR DESCRIPTION
## Problem
GraphQL on our frontend is not typed, even though we have already implemented graphql-codegen.

## Solution
It's harder to migrate frontend GraphQL because of coupling with `@plumber/types`: types from graphql-codegen may not be immediately compatible with our existing types from `@plumber/types`, but our props and variables are all typed with the latter.

This PR adds graphql-codegen types to the "easy to add" GraphQL operations on our friend. By "easy", I mean operations whose graphql-codegen types don't conflict with our existing `@plumber/types`.

## Tests
- All typescript, so just check that `npm build` works
- E2E test