### PR TITLE
PLU-228: [M365-GA] Add release-period rate limit to guard against thundering herd

### DIFF
--- a/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
+++ b/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
@@ -1,20 +1,30 @@
+import type { IGlobalVariable } from '@plumber/types'
+
 import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible'
 
-import { M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS } from '@/config/app-env-vars/m365'
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
+import StepError from '@/errors/step'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 
 const redisClient = createRedisClient(REDIS_DB_INDEX.RATE_LIMIT)
 
-// Rough numbers for release only.
-// Instead of rate limiting per second, we allow spikes in 30 second windows to
-// make the UX not _as_ bad.
+// Rate limiter to control potential thundering herd during release period
+// --
+// This applies a rate limit on users doing test steps in our UI. This is needed
+// because we don't queue frontend actions, but there's a risk many users will
+// explore this feature at release time and overload M365 backend.
 //
-// (e.g. thundering herd spams tests within the 1st 10 seconds and use up all
-// quota allocated for 30s, but they don't complain since they're busy
-// publishing or thinking about why they had an error)
-const ACTIONS_PER_SECOND = 1000 / M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS
-const DURATION_SECONDS = 30
-const ACTIONS_PER_DURATION = Math.floor(ACTIONS_PER_SECOND * DURATION_SECONDS)
+// We're currently allocated ~4 excel actions per second, and we'll allocate ~3
+// actions per second to our frontend.
+//
+// Note that instead of rate limiting per second, we allow spikes in ~10 second
+// windows to make the UX not _as_ bad (e.g. thundering herd spams tests within
+// the 1st 5 seconds and use up all quota allocated for 10s, but they don't
+// complain since they're busy publishing or thinking about why they had an
+// error).
+
+const DURATION_SECONDS = 10
+const ACTIONS_PER_DURATION = 30 // 3 actions per second, for 10 seconds.
 
 const rateLimiter = new RateLimiterRedis({
   points: ACTIONS_PER_DURATION,
@@ -23,16 +33,50 @@ const rateLimiter = new RateLimiterRedis({
   storeClient: redisClient,
 })
 
-export async function RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024() {
+function throwError($?: IGlobalVariable): never {
+  if ($) {
+    throw new StepError(
+      'Excel has reached its limit',
+      'There are too many users testing Excel at this moment. Try testing your step again later.',
+      $.step.position,
+      $.app.name,
+    )
+  } else {
+    throw new Error(
+      'There are too many users testing Excel at this moment. Try again later.',
+    )
+  }
+}
+
+const LD_FLAG_RATE_LIMIT_TYPE = 'm365-excel-release-rate-limit-type'
+const RATE_LIMIT_TYPE_RATE_LIMITED = 'rate-limited'
+const RATE_LIMIT_TYPE_NOT_RATE_LIMITED = 'not-rate-limited'
+const RATE_LIMIT_TYPE_BANNED = 'banned'
+
+export async function RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024(
+  userEmail: string,
+  $?: IGlobalVariable,
+) {
+  const rateLimitType = await getLdFlagValue<string>(
+    LD_FLAG_RATE_LIMIT_TYPE,
+    userEmail,
+    RATE_LIMIT_TYPE_RATE_LIMITED,
+  )
+
+  if (rateLimitType === RATE_LIMIT_TYPE_NOT_RATE_LIMITED) {
+    return
+  }
+
+  if (rateLimitType === RATE_LIMIT_TYPE_BANNED) {
+    return throwError($)
+  }
+
   try {
-    await rateLimiter.consume(1)
+    await rateLimiter.consume('global-rate-limit', 1)
   } catch (error) {
     if (!(error instanceof RateLimiterRes)) {
       throw error
     }
-
-    throw new Error(
-      'Excel has reached its limit. There are too many users on Excel at this moment. Try testing your step again later.',
-    )
+    throwError($)
   }
 }

--- a/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
+++ b/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
@@ -1,0 +1,38 @@
+import { RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible'
+
+import { M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS } from '@/config/app-env-vars/m365'
+import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
+
+const redisClient = createRedisClient(REDIS_DB_INDEX.RATE_LIMIT)
+
+// Rough numbers for release only.
+// Instead of rate limiting per second, we allow spikes in 30 second windows to
+// make the UX not _as_ bad.
+//
+// (e.g. thundering herd spams tests within the 1st 10 seconds and use up all
+// quota allocated for 30s, but they don't complain since they're busy
+// publishing or thinking about why they had an error)
+const ACTIONS_PER_SECOND = 1000 / M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS
+const DURATION_SECONDS = 30
+const ACTIONS_PER_DURATION = Math.floor(ACTIONS_PER_SECOND * DURATION_SECONDS)
+
+const rateLimiter = new RateLimiterRedis({
+  points: ACTIONS_PER_DURATION,
+  duration: DURATION_SECONDS,
+  keyPrefix: 'm365-release-limiter',
+  storeClient: redisClient,
+})
+
+export async function RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024() {
+  try {
+    await rateLimiter.consume(1)
+  } catch (error) {
+    if (!(error instanceof RateLimiterRes)) {
+      throw error
+    }
+
+    throw new Error(
+      'Excel has reached its limit. There are too many users on Excel at this moment. Try testing your step again later.',
+    )
+  }
+}

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -4,6 +4,7 @@ import StepError from '@/errors/step'
 
 import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
+import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
 
 import getDataOutMetadata from './get-data-out-metadata'
 
@@ -127,6 +128,11 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    if ($.execution.testRun) {
+      // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+    }
+
     const { fileId, tableId } = $.step.parameters
     const columnValues = ($.step.parameters.columnValues as IJSONObject[]) ?? []
     if (columnValues.length === 0) {

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -130,7 +130,7 @@ const action: IRawAction = {
   async run($) {
     if ($.execution.testRun) {
       // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
     }
 
     const { fileId, tableId } = $.step.parameters

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -6,6 +6,7 @@ import StepError from '@/errors/step'
 
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
+import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
 
 import getDataOutMetadata from './get-data-out-metadata'
 import getTableRowImpl, { MAX_ROWS } from './implementation'
@@ -109,6 +110,11 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
+    if ($.execution.testRun) {
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+    }
+
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)
 
     if (parametersParseResult.success === false) {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -112,7 +112,7 @@ const action: IRawAction = {
   async run($) {
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -81,7 +81,7 @@ const action: IRawAction = {
   async run($) {
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
-      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -9,6 +9,7 @@ import {
   convertRowToHexEncodedRowRecord,
 } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
+import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
 import getTableRowAction from '../get-table-row'
 import getTableRowImpl from '../get-table-row/implementation'
 
@@ -78,6 +79,11 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
+    if ($.execution.testRun) {
+      await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+    }
+
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)
 
     if (parametersParseResult.success === false) {

--- a/packages/backend/src/apps/m365-excel/auth/register-connection.ts
+++ b/packages/backend/src/apps/m365-excel/auth/register-connection.ts
@@ -2,6 +2,7 @@ import type { IAuth } from '@plumber/types'
 
 import type { AuthData } from '../common//auth-data'
 import { createPlumberFolder } from '../common/create-plumber-folder'
+import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../FOR_RELEASE_PERIOD_ONLY'
 
 const registerConnection: NonNullable<IAuth['registerConnection']> =
   async function ($) {
@@ -11,6 +12,9 @@ const registerConnection: NonNullable<IAuth['registerConnection']> =
       // No-op, folder already created
       return
     }
+
+    // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
+    await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
 
     const folderId = await createPlumberFolder(authData.tenantKey, $)
     $.auth.set({

--- a/packages/backend/src/apps/m365-excel/auth/register-connection.ts
+++ b/packages/backend/src/apps/m365-excel/auth/register-connection.ts
@@ -14,7 +14,7 @@ const registerConnection: NonNullable<IAuth['registerConnection']> =
     }
 
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
-    await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024()
+    await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email)
 
     const folderId = await createPlumberFolder(authData.tenantKey, $)
     $.auth.set({


### PR DESCRIPTION
# Problem
We might face a thundering herd when we first release Excel. This is bad for GovTech.

# Solution
Add a rate limit for plumber folder creation and test runs. 

### Error toast during plumber folder creation
![Screenshot 2024-06-21 at 2.45.02 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/52yORk4WhOvpiff9IQU6/9b48000e-7ef8-4b84-85ca-73b730d63b12.png)

### Step error during test step
![Screenshot 2024-06-21 at 2.44.30 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/52yORk4WhOvpiff9IQU6/277b1c71-8e8b-4770-b256-4f1d16760738.png)

# Tests
- Check that rate limit error shows up for both "Connect" and "Test step"
- Regression test: check that published pipes are not impacted