### PR TITLE
PLU-228: [M365-GA] Allow retrying plumber folder creation

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/create-plumber-folder.test.ts
@@ -1,11 +1,15 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import { AxiosError } from 'axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
 
 import { createPlumberFolder } from '../../common/create-plumber-folder'
 
 const mocks = vi.hoisted(() => ({
   httpPost: vi.fn(),
+  httpGet: vi.fn(),
   getM365TenantInfo: vi.fn(() => ({
     label: 'test-tenant',
     id: 'test-tenant-id',
@@ -28,6 +32,7 @@ describe('Create plumber folder', () => {
     $ = {
       http: {
         post: mocks.httpPost,
+        get: mocks.httpGet,
       },
       user: {
         email: 'test@open.gov.sg',
@@ -87,8 +92,129 @@ describe('Create plumber folder', () => {
 
   it("errors out if user's email is not set", async () => {
     $.user.email = null
-    expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
+    await expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
       'User email unavailable',
+    )
+  })
+
+  it('proceeds with permission granting if folder already exists', async () => {
+    mocks.httpPost
+      // First call to error out with "folder already exists"
+      .mockRejectedValueOnce(
+        new HttpError({
+          response: {
+            data: {
+              error: {
+                code: 'nameAlreadyExists',
+                message: '',
+              },
+            },
+          },
+        } as unknown as AxiosError),
+      )
+      // 2nd call to grant access; no return value is needed but we mock to
+      // prevent outgoing call.
+      .mockImplementationOnce(() => {
+        // intentionally empty
+        return
+      })
+    mocks.httpGet
+      // Mock get folder API to return null ID
+      .mockResolvedValueOnce({
+        data: {
+          value: [{ id: 'existing-folder-id' }],
+        },
+      })
+
+    await createPlumberFolder('local-dev', $)
+
+    expect(mocks.httpPost).toHaveBeenNthCalledWith(
+      2,
+      '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
+      {
+        recipients: [{ email: 'test@open.gov.sg' }],
+        requireSignIn: true,
+        sendInvitation: false,
+        roles: ['sp.full control'],
+        retainInheritedPermissions: false,
+      },
+      {
+        urlPathParams: {
+          sharePointSiteId: 'test-sharepoint-site-id',
+          folderId: 'existing-folder-id',
+        },
+      },
+    )
+  })
+
+  it('errors out if create folder failed and reason was not due to folder existing', async () => {
+    mocks.httpPost
+      // First call to error out some random error message
+      .mockRejectedValueOnce(
+        new HttpError({
+          response: {
+            data: {
+              error: {
+                code: 'transientFailure',
+              },
+            },
+          },
+        } as unknown as AxiosError),
+      )
+      // 2nd call to grant access; no return value is needed but we mock to
+      // prevent outgoing call.
+      .mockImplementationOnce(() => {
+        // intentionally empty
+        return
+      })
+
+    try {
+      await createPlumberFolder('local-dev', $)
+    } catch (error) {
+      if (!(error instanceof HttpError)) {
+        expect.unreachable()
+      }
+      expect(error.response.data.error.code === 'transientFailure')
+    }
+  })
+
+  it('errors out if folder ID is null after creating folder', async () => {
+    mocks.httpPost
+      // Make create folder API return null
+      .mockImplementationOnce(() => ({
+        data: { id: null },
+      }))
+
+    await expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
+      /a problem creating your folder/,
+    )
+  })
+
+  it("errors out if folder ID is null after trying to grab existing folder's ID", async () => {
+    mocks.httpPost
+      // Mock create folder API to error out with "folder already exists"
+      .mockRejectedValueOnce(
+        new HttpError({
+          response: {
+            data: {
+              error: {
+                code: 'nameAlreadyExists',
+                message: '',
+              },
+            },
+          },
+        } as unknown as AxiosError),
+      )
+    mocks.httpGet
+      // Mock get folder API to return null ID
+      .mockResolvedValueOnce({
+        data: {
+          value: [{ id: null }],
+        },
+      })
+
+    await expect(createPlumberFolder('local-dev', $)).rejects.toThrowError(
+      /a problem creating your folder/,
     )
   })
 })

--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -1,6 +1,30 @@
 import type { IGlobalVariable } from '@plumber/types'
 
-import { getM365TenantInfo } from '@/config/app-env-vars/m365'
+import { getM365TenantInfo, M365TenantInfo } from '@/config/app-env-vars/m365'
+import HttpError from '@/errors/http'
+
+import { tryParseGraphApiError } from './parse-graph-api-error'
+
+async function checkForExistingFolder(
+  $: IGlobalVariable,
+  tenant: M365TenantInfo,
+): Promise<string> {
+  const filterQueryParams = new URLSearchParams({
+    filter: `name eq '${$.user.email}'`,
+    select: 'id',
+  }).toString()
+
+  const getFolderIdResult = await $.http.get<{ value: { id: string }[] }>(
+    `/v1.0/sites/:sharePointSiteId/drive/root/children?${filterQueryParams}`,
+    {
+      urlPathParams: {
+        sharePointSiteId: tenant.sharePointSiteId,
+      },
+    },
+  )
+
+  return getFolderIdResult.data?.value?.[0]?.id
+}
 
 export async function createPlumberFolder(
   tenantKey: string,
@@ -13,21 +37,40 @@ export async function createPlumberFolder(
   const tenant = getM365TenantInfo(tenantKey)
 
   // Create folder
-  const createFolderResult = await $.http.post<{ id: string }>(
-    '/v1.0/sites/:sharePointSiteId/drive/root/children',
-    {
-      name: $.user.email,
-      folder: {},
-    },
-    {
-      urlPathParams: {
-        sharePointSiteId: tenant.sharePointSiteId,
+  let folderId = ''
+  try {
+    const createFolderResult = await $.http.post<{ id: string }>(
+      '/v1.0/sites/:sharePointSiteId/drive/root/children',
+      {
+        name: $.user.email,
+        folder: {},
       },
-    },
-  )
-  const folderId = createFolderResult.data.id
+      {
+        urlPathParams: {
+          sharePointSiteId: tenant.sharePointSiteId,
+        },
+      },
+    )
+    folderId = createFolderResult.data.id
+  } catch (error) {
+    const folderAlreadyExists =
+      error instanceof HttpError &&
+      tryParseGraphApiError(error)?.code === 'nameAlreadyExists'
+    if (!folderAlreadyExists) {
+      throw error
+    }
+
+    folderId = await checkForExistingFolder($, tenant)
+  }
+
+  if (!folderId) {
+    throw new Error(
+      'There was a problem creating your folder. Please contact support@plumber.gov.sg for assistance.',
+    )
+  }
 
   // Make user the folder owner.
+  // NOTE: If they already have an existing folder, then this becomes a no-op.
   await $.http.post(
     '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
     {

--- a/packages/backend/src/apps/m365-excel/common/parse-graph-api-error.ts
+++ b/packages/backend/src/apps/m365-excel/common/parse-graph-api-error.ts
@@ -4,13 +4,13 @@ import type HttpError from '@/errors/http'
 
 const graphApiErrorSchema = z.object({
   code: z.string().trim(),
-  message: z.string().trim(),
+  message: z.string().trim().optional(),
   innerError: z
     .object({
-      code: z.string().trim(),
-      message: z.string().trim(),
+      code: z.string().trim().optional(),
+      message: z.string().trim().optional(),
     })
-    .nullish(),
+    .optional(),
 })
 
 /**


### PR DESCRIPTION
# Problem
While connecting, if Microsoft's permission grant API errors out after the user's plumber folder has been created, the user is blocked until they contact us. This is because the connection row is not inserted until permission API succeeds.

Root cause is due to us not handling the case where a folder with the same name already exists.

# Solution
If a plumber folder with the user's email already exists, then allow connection creation to proceed.

One concern might be that this allows a malicious person with access to the user's email to take over their plumber folder. But this doesn't make our security posture worse, since email takeover is complete compromise of that user's account, and we consider that out of scope of our threat model (e.g. the malicious person could have used the user's email to make a support / change request to many different govt entities already).

# Tests
- Updated unit tests
- Delete my plumber connection (which is linked to an existing folder) and check that I can still re-connect and re-use my existing files.