### PR TITLE
fix: invalid private key for formsg connection

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -71,14 +71,12 @@ export async function decryptFormResponse(
 
   // Note: this could occur due to pipe transfer since connection becomes null
   if (!$.auth.data) {
-    logger.error(
-      'Form is not connected to any pipe after pipe is transferred',
-      {
-        flowId: $.flow.id,
-        stepId: $.step.id,
-        userId: $.user.id,
-      },
-    )
+    logger.warn('Form is not connected to any pipe after pipe is transferred', {
+      event: 'formsg-missing-connection',
+      flowId: $.flow.id,
+      stepId: $.step.id,
+      userId: $.user.id,
+    })
     return false
   }
 

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -69,6 +69,19 @@ export async function decryptFormResponse(
     return false
   }
 
+  // Note: this could occur due to pipe transfer since connection becomes null
+  if (!$.auth.data) {
+    logger.error(
+      'Form is not connected to any pipe after pipe is transferred',
+      {
+        flowId: $.flow.id,
+        stepId: $.step.id,
+        userId: $.user.id,
+      },
+    )
+    return false
+  }
+
   const formSecretKey = $.auth.data.privateKey as string
 
   const shouldStoreAttachments = $.flow.hasFileProcessingActions


### PR DESCRIPTION
## Problem

Our prod webhook experienced this error:
`TypeError: Cannot read properties of undefined (reading 'privateKey') at Object.decryptFormResponse [as verifyWebhook]`

Example: flow id `60e8d4f4-04b3-4997-a041-6bcee29ee3e5`

## Solution

Add an extra check to block the decryption if connection does not exist after the pipe is transferred but yet the formsg webhook is still connected to the pipe.

- [x] To check if to warn or error log?

## Repro steps
1. Connect your form to one of your pipes
2. Then nullify the connection by modifying in the DB, or just transfer the pipe to another user
3. Make a formsg submission and it should error out

## Tests
- [x] Pipes still work as intended as long as the connection is present
- [x] If the connection is removed, 401 error is thrown instead of 500