### PR TITLE
PLU-255: disable publish button for incomplete flow

### DIFF
--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -12,7 +12,6 @@ const app: IApp = {
   primaryColor: '000000',
   actions,
   description: 'Perform calculations on numbers in your data',
-  isNewApp: true,
   substepLabels: {
     settingsStepLabel: 'Set up calculator',
   },

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -13,7 +13,6 @@ const app: IApp = {
   actions,
   description:
     'Manipulate your data, such as changing date formats or adding days to a date',
-  isNewApp: true,
   substepLabels: {
     settingsStepLabel: 'Set up formatter',
   },

--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -23,6 +23,7 @@ const app: IApp = {
   dynamicData,
   getTransferDetails,
   queue,
+  isNewApp: true,
   substepLabels: {
     connectionStepLabel: 'Connect to M365 Excel',
   },

--- a/packages/backend/src/apps/tiles/index.ts
+++ b/packages/backend/src/apps/tiles/index.ts
@@ -17,7 +17,6 @@ const app: IApp = {
   actions,
   dynamicData,
   getTransferDetails,
-  isNewApp: true,
 }
 
 export default app

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,6 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
-import { ReactElement, useCallback } from 'react'
+import { ReactElement, useCallback, useMemo } from 'react'
 import { BiChevronLeft, BiCog } from 'react-icons/bi'
 import { Link, useParams } from 'react-router-dom'
 import { ApolloError, useMutation, useQuery } from '@apollo/client'
@@ -109,6 +109,12 @@ export default function EditorLayout(): ReactElement {
     [flow?.id, flowId, updateFlowStatus],
   )
 
+  // disallow user from publishing pipe if any step is incomplete
+  const isFlowIncomplete = useMemo(
+    () => flow?.steps.some((step) => step.status === 'incomplete'),
+    [flow?.steps],
+  )
+
   // navigate user to not found page if flow does not belong to the user
   if (
     error instanceof ApolloError &&
@@ -177,13 +183,15 @@ export default function EditorLayout(): ReactElement {
           {/* Used a tooltip instead because the words take up too much space on mobile view */}
           <TouchableTooltip
             label={
-              hasFlowTransfer
+              isFlowIncomplete
+                ? 'Set up for all steps must be completed before you can publish your pipe'
+                : hasFlowTransfer
                 ? 'You cannot publish a pipe with a pending transfer'
                 : ''
             }
           >
             <Button
-              isDisabled={hasFlowTransfer}
+              isDisabled={isFlowIncomplete || hasFlowTransfer}
               isLoading={loading}
               spinner={<Spinner fontSize={24} />}
               size="md"

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -124,7 +124,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       />
       <Collapse in={expanded} unmountOnExit style={{ overflow: 'initial' }}>
         <Box p="1rem 1rem 1.5rem">
-          <Stack w="100%" spacing={2}>
+          <Stack w="100%" spacing={4}>
             {args?.map((argument) => (
               <InputCreator
                 key={argument.key}

--- a/packages/frontend/src/components/Layout/index.tsx
+++ b/packages/frontend/src/components/Layout/index.tsx
@@ -36,7 +36,6 @@ const drawerLinks = [
     Icon: BiLayer,
     text: 'Tiles',
     to: URLS.TILES,
-    badge: 'New feature',
   },
   {
     Icon: BiSolidGrid,


### PR DESCRIPTION
## Problem

We are seeing errors on datadog because users try to publish pipe without completing all the steps

## Solution

Disable the publish button if there is at least one incomplete step in the pipe.

## Tests
- [x] Pipes with all completed steps can be published and works
- [x] Pipes with a pending transfer cannot be published
- [x] Incomplete pipes cannot be published