### PR TITLE
HOTFIX: Variables popper stealing focus

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
+++ b/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
@@ -1,15 +1,16 @@
 import { useState } from 'react'
 import { Box, Collapse, Divider, Flex, Text } from '@chakra-ui/react'
+import type { VariableClickCallback } from 'components/VariablesList'
 import VariablesList from 'components/VariablesList'
-import { StepWithVariables, Variable } from 'helpers/variables'
+import type { StepWithVariables } from 'helpers/variables'
 
 interface SuggestionsProps {
   data: StepWithVariables[]
-  onSuggestionClick: (variable: Variable) => void
+  onSuggestionClick?: VariableClickCallback
 }
 
 export default function Suggestions(props: SuggestionsProps) {
-  const { data, onSuggestionClick = () => null } = props
+  const { data, onSuggestionClick } = props
   const [current, setCurrent] = useState<number>(0)
 
   const isEmpty = data.reduce(

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -24,8 +24,9 @@ import Text from '@tiptap/extension-text'
 import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import { VariableClickCallback } from 'components/VariablesList'
 import { StepExecutionsContext } from 'contexts/StepExecutions'
-import { extractVariables, filterVariables, Variable } from 'helpers/variables'
+import { extractVariables, filterVariables } from 'helpers/variables'
 
 import { MenuBar } from './MenuBar'
 import ImageResize from './ResizableImageExtension'
@@ -150,8 +151,12 @@ const Editor = ({
     editor?.setOptions({ editable })
   }, [editable, editor])
 
-  const handleVariableClick = useCallback(
-    (variable: Variable) => {
+  const handleVariableClick = useCallback<VariableClickCallback>(
+    (variable, mouseEvent) => {
+      // Prevent default here to let focus stay in the editor instead of going
+      // to the popper when clicking.
+      mouseEvent.preventDefault()
+
       editor?.commands.insertContent({
         type: StepVariable.name,
         attrs: {
@@ -164,7 +169,6 @@ const Editor = ({
     },
     [editor],
   )
-
   const {
     isOpen: isSuggestionsOpen,
     onOpen: openSuggestions,
@@ -173,24 +177,24 @@ const Editor = ({
 
   return (
     <Popover
-      autoFocus={false}
       gutter={0}
       matchWidth={true}
       isOpen={isSuggestionsOpen}
+      autoFocus={false}
     >
       <div
         className="editor"
         onClick={openSuggestions}
-        onBlur={(e) => {
+        onFocus={openSuggestions}
+        onBlur={(event) => {
           // Focus might shift to menu bar or other children, where we do _not_
           // want to close our popper.
-          if (e.currentTarget.contains(e.relatedTarget)) {
+          if (event.currentTarget.contains(event.relatedTarget)) {
             return
           }
 
           closeSuggestions()
         }}
-        onFocus={openSuggestions}
       >
         <PopoverTrigger>
           <Box>

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -8,6 +8,7 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { FormLabel } from '@opengovsg/design-system-react'
 import Document from '@tiptap/extension-document'
@@ -164,9 +165,33 @@ const Editor = ({
     [editor],
   )
 
+  const {
+    isOpen: isSuggestionsOpen,
+    onOpen: openSuggestions,
+    onClose: closeSuggestions,
+  } = useDisclosure()
+
   return (
-    <Popover gutter={0} matchWidth={true}>
-      <div className="editor">
+    <Popover
+      autoFocus={false}
+      gutter={0}
+      matchWidth={true}
+      isOpen={isSuggestionsOpen}
+    >
+      <div
+        className="editor"
+        onClick={openSuggestions}
+        onBlur={(e) => {
+          // Focus might shift to menu bar or other children, where we do _not_
+          // want to close our popper.
+          if (e.currentTarget.contains(e.relatedTarget)) {
+            return
+          }
+
+          closeSuggestions()
+        }}
+        onFocus={openSuggestions}
+      >
         <PopoverTrigger>
           <Box>
             {isRich && <MenuBar editor={editor} />}

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -1,9 +1,15 @@
+import type { MouseEvent } from 'react'
 import { Box, Text } from '@chakra-ui/react'
 import { type Variable } from 'helpers/variables'
 
+export type VariableClickCallback = (
+  variable: Variable,
+  mouseEvent: MouseEvent<HTMLDivElement>,
+) => void
+
 function makeVariableComponent(
   variable: Variable,
-  onClick?: (variable: Variable) => void,
+  onClick?: VariableClickCallback,
 ): JSX.Element {
   return (
     <Box
@@ -30,8 +36,8 @@ function makeVariableComponent(
       // onClick doesn't work sometimes due to latency between mousedown and immediate mouseup event after
       onMouseDown={
         onClick
-          ? () => {
-              onClick(variable)
+          ? (event) => {
+              onClick(variable, event)
             }
           : undefined
       }
@@ -48,7 +54,7 @@ function makeVariableComponent(
 
 interface VariablesListProps {
   variables: Variable[]
-  onClick?: (variable: Variable) => void
+  onClick?: VariableClickCallback
 }
 
 export default function VariablesList(props: VariablesListProps) {


### PR DESCRIPTION
## Problem
The new variable popper steals focus when it pops up, which makes it very irritating to compose emails (since you typically want to type something first, then click on a variable). Clicking on variables also causes focus to be stolen.

## Solution
Make popper's open state controlled, and inject `onClick`, `onBlur` and `onFocus` handlers into the editor to manipulate popper status. We also invoke `preventDefault` on variable click to prevent focus from going into the popper.

**Before**
https://github.com/opengovsg/plumber/assets/135598754/9277bab2-5a0a-4ebc-bad7-e48a867cf44a

**After**
https://github.com/opengovsg/plumber/assets/135598754/b305accb-bbcf-4262-9f50-bb4823abf92e

## Tests
- Check that focus is no longer stolen by the popper on opening, and that typing will cause text to appear in the input field instead.
- Regression test: check that clicking away closes the popper
- Regression test: check that clicking on a variables does not set focus on the popper
- Regression test: check that tabbing around fields closes the previous popper and opens the next popper.