### PR TITLE
PLU-268: reorder app dropdown options

### DIFF
--- a/packages/backend/src/apps/calculator/index.ts
+++ b/packages/backend/src/apps/calculator/index.ts
@@ -15,6 +15,7 @@ const app: IApp = {
   substepLabels: {
     settingsStepLabel: 'Set up calculator',
   },
+  priority: 6,
 }
 
 export default app

--- a/packages/backend/src/apps/custom-api/index.ts
+++ b/packages/backend/src/apps/custom-api/index.ts
@@ -15,6 +15,7 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '0059F7',
   actions,
+  priority: 13,
 }
 
 export default app

--- a/packages/backend/src/apps/delay/index.ts
+++ b/packages/backend/src/apps/delay/index.ts
@@ -11,6 +11,7 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '001F52',
   actions,
+  priority: 7,
 }
 
 export default app

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -16,6 +16,7 @@ const app: IApp = {
   substepLabels: {
     settingsStepLabel: 'Set up formatter',
   },
+  priority: 5,
 }
 
 export default app

--- a/packages/backend/src/apps/formsg/index.ts
+++ b/packages/backend/src/apps/formsg/index.ts
@@ -24,6 +24,7 @@ const app: IApp = {
     url: 'https://demo.arcade.software/6cWULLTHkTH4XsSB1rs1?embed&show_copy_link=true',
     title: 'Setting up FormSG',
   },
+  priority: 1,
 }
 
 export default app

--- a/packages/backend/src/apps/lettersg/index.ts
+++ b/packages/backend/src/apps/lettersg/index.ts
@@ -17,6 +17,7 @@ const app: IApp = {
   auth,
   actions,
   dynamicData,
+  priority: 9,
 }
 
 export default app

--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -32,6 +32,7 @@ const app: IApp = {
     messageBody:
       'There is a cap on total disk space and Excel actions across all Plumber users. To prevent disruption to your workflow, contact us if you have large files or need more than 100 Excel actions per hour.\n\nRead [our guide](https://guide.plumber.gov.sg/user-guides/actions/m365-excel) for more information.',
   },
+  priority: 3,
 }
 
 export default app

--- a/packages/backend/src/apps/paysg/index.ts
+++ b/packages/backend/src/apps/paysg/index.ts
@@ -15,6 +15,7 @@ const app: IApp = {
   beforeRequest: [addAuthHeader],
   auth,
   actions,
+  priority: 8,
 }
 
 export default app

--- a/packages/backend/src/apps/postman-sms/index.ts
+++ b/packages/backend/src/apps/postman-sms/index.ts
@@ -21,6 +21,7 @@ const app: IApp = {
   actions,
   queue,
   isNewApp: true,
+  priority: 10,
 }
 
 export default app

--- a/packages/backend/src/apps/postman/index.ts
+++ b/packages/backend/src/apps/postman/index.ts
@@ -18,6 +18,7 @@ const app: IApp = {
     url: 'https://demo.arcade.software/VppMAbGKfFXFEsKxnKiw?embed&show_copy_link=true',
     title: 'Setting up Email by Postman',
   },
+  priority: 1,
 }
 
 export default app

--- a/packages/backend/src/apps/scheduler/index.ts
+++ b/packages/backend/src/apps/scheduler/index.ts
@@ -15,6 +15,7 @@ const app: IApp = {
   substepLabels: {
     settingsStepLabel: 'Set up scheduler',
   },
+  priority: 2,
 }
 
 export default app

--- a/packages/backend/src/apps/slack/index.ts
+++ b/packages/backend/src/apps/slack/index.ts
@@ -17,6 +17,7 @@ const app: IApp = {
   auth,
   actions,
   dynamicData,
+  priority: 12,
 }
 
 export default app

--- a/packages/backend/src/apps/telegram-bot/index.ts
+++ b/packages/backend/src/apps/telegram-bot/index.ts
@@ -19,6 +19,7 @@ const app: IApp = {
   dynamicData,
   auth,
   actions,
+  priority: 11,
 }
 
 export default app

--- a/packages/backend/src/apps/tiles/index.ts
+++ b/packages/backend/src/apps/tiles/index.ts
@@ -17,6 +17,7 @@ const app: IApp = {
   actions,
   dynamicData,
   getTransferDetails,
+  priority: 2,
 }
 
 export default app

--- a/packages/backend/src/apps/toolbox/index.ts
+++ b/packages/backend/src/apps/toolbox/index.ts
@@ -13,6 +13,7 @@ const app: IApp = {
   actions,
   description:
     "Use Plumber's built in tools like If-then and Only continue if to add more functionality to your pipes",
+  priority: 4,
 }
 
 export default app

--- a/packages/backend/src/apps/twilio/index.ts
+++ b/packages/backend/src/apps/twilio/index.ts
@@ -15,6 +15,7 @@ const app: IApp = {
   beforeRequest: [addAuthHeader],
   auth,
   actions,
+  priority: 15,
 }
 
 export default app

--- a/packages/backend/src/apps/vault-workspace/index.ts
+++ b/packages/backend/src/apps/vault-workspace/index.ts
@@ -22,6 +22,7 @@ const app: IApp = {
   actions,
   // disabling triggers from vault workspace
   dynamicData,
+  priority: 14,
 }
 
 export default app

--- a/packages/backend/src/apps/webhook/index.ts
+++ b/packages/backend/src/apps/webhook/index.ts
@@ -11,6 +11,7 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '0059F7',
   triggers,
+  priority: 3,
 }
 
 export default app

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -195,6 +195,7 @@ type App {
   substepLabels: StepLabel
   setupMessage: SetupMessage
   demoVideoDetails: DemoVideoDetails
+  priority: Int
 }
 
 type DemoVideoDetails {

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -92,7 +92,7 @@ function ChooseAppAndEventSubstep(
 
   apps?.sort((a, b) => {
     if (a.isNewApp && b.isNewApp) {
-      return a.name.localeCompare(b.name)
+      return a.priority - b.priority
     }
     if (a.isNewApp) {
       return -1
@@ -100,7 +100,7 @@ function ChooseAppAndEventSubstep(
     if (b.isNewApp) {
       return 1
     }
-    return a.name.localeCompare(b.name)
+    return a.priority - b.priority
   })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -33,6 +33,7 @@ export const GET_APPS = gql`
         url
         title
       }
+      priority
       auth {
         connectionType
         connectionRegistrationType

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -459,6 +459,14 @@ export interface IApp {
     url: string
     title: string
   }
+  /**
+   * to determine which app dropdown option appears first
+   * Note that triggers and actions have separate rankings
+   * Triggers: formsg, scheduler, webhook
+   * Actions: email by postman, tiles, m365, toolbox, formatter, calculator, delay,
+   * paysg, lettersg, sms by postman, telegram, slack, custom-api, vault, twilio
+   */
+  priority: number
 
   /**
    * A callback that is invoked if there's an error for any HTTP request this


### PR DESCRIPTION
## Problem

Apps are now ordered alphabetically, the more popular apps not as "accessible" to users.

## Solution

Simplest solution I can come up with is to assign a priority to each app and then sort by the priority.
Ordering system is separate for triggers and actions.
Triggers: formsg, scheduler, webhook
Actions: email by postman, tiles, m365, toolbox, formatter, calculator, delay, paysg, lettersg, sms by postman, telegram, slack, custom-api, vault, twilio
New apps: m365 and sms by postman

## Tests
- [x] New apps show first
- [x] App still can be selected and pipe execution works as expected
