### PR TITLE
PLU-293: modify checkbox option for mock data

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -13,6 +13,9 @@ type FormField = {
   columns?: Array<{
     _id: string
   }>
+  fieldType: string
+  fieldOptions?: string[]
+  othersRadioButton?: boolean
 }
 
 const MOCK_ATTACHMENT_FILE_PATH = `s3:${COMMON_S3_BUCKET}:mock/plumber-logo.jpg`
@@ -54,6 +57,16 @@ async function getMockData($: IGlobalVariable) {
     const formFields = formDetails.form.form_fields as Array<FormField>
     for (let i = 0; i < formFields.length; i++) {
       if (data.responses[formFields[i]._id]) {
+        // forcefully include all checkbox options in the correct order
+        if (data.responses[formFields[i]._id].fieldType === 'checkbox') {
+          data.responses[formFields[i]._id].answerArray =
+            formFields[i].fieldOptions
+          // include the others option if available
+          if (formFields[i].othersRadioButton) {
+            data.responses[formFields[i]._id].answerArray.push('Others')
+          }
+        }
+
         if (data.responses[formFields[i]._id].fieldType === 'attachment') {
           data.responses[formFields[i]._id].answer = MOCK_ATTACHMENT_FILE_PATH
         }

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -63,7 +63,9 @@ async function getMockData($: IGlobalVariable) {
             formFields[i].fieldOptions
           // include the others option if available
           if (formFields[i].othersRadioButton) {
-            data.responses[formFields[i]._id].answerArray.push('Others')
+            data.responses[formFields[i]._id].answerArray.push(
+              'Others: Sample Input',
+            )
           }
         }
 


### PR DESCRIPTION
**NOTE**: the short form for date field is fixed with a formsg [PR](https://github.com/opengovsg/FormSG/pull/7442) instead
## Problem

Right now, formsg sample form submission randomises the checkbox options which is not the best experience for users since they may want to use every option.

## Solution

Formsg wanted the idea of randomising the options since it is a sample submission so I have forcefully included all checkbox options (including others option) on our end when we return the mock data.

## Tests
- [x] Mock data with checkbox will give all options regardless of whether optional field or not
- [x] Normal test data with a form submission still returns as intended
