### PR TITLE
PLU-283: [INLINE-TILES-3] add new property addNewOption for IDropdownAction

### DIFF
--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -22,6 +22,11 @@ const action: IRawAction = {
       required: true,
       variables: false,
       showOptionValue: false,
+      addNewOption: {
+        id: 'tiles-createTileRow-tableId',
+        type: 'modal',
+        label: 'Create a new tile',
+      },
       source: {
         type: 'query' as const,
         name: 'getDynamicData' as const,
@@ -50,6 +55,11 @@ const action: IRawAction = {
           required: true,
           variables: false,
           showOptionValue: false,
+          addNewOption: {
+            id: 'tiles-createTileRow-columnId',
+            type: 'inline',
+            label: 'Create a new column',
+          },
           source: {
             type: 'query' as const,
             name: 'getDynamicData' as const,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -145,6 +145,17 @@ type ActionSubstep {
   arguments: [ActionSubstepArgument]
 }
 
+enum DropdownAddNewOptionType {
+  modal
+  inline
+}
+
+type DropdownAddNewOption {
+  id: String!
+  type: DropdownAddNewOptionType!
+  label: String!
+}
+
 type ActionSubstepArgument {
   label: String
   key: String
@@ -160,6 +171,9 @@ type ActionSubstepArgument {
   value: JSONObject
   source: ActionSubstepArgumentSource
   hiddenIf: FieldVisibilityCondition
+
+  # Only for dropdown
+  addNewOption: DropdownAddNewOption
 
   # Only for multirow
   subFields: [ActionSubstepArgument]

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -208,6 +208,11 @@ export const GET_APPS = gql`
               fieldValue
               op
             }
+            addNewOption {
+              id
+              label
+              type
+            }
             # Only for multi-row
             subFields {
               label
@@ -224,6 +229,11 @@ export const GET_APPS = gql`
                 fieldKey
                 fieldValue
                 op
+              }
+              addNewOption {
+                id
+                label
+                type
               }
               options {
                 label

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -263,14 +263,23 @@ export interface IBaseField {
   hiddenIf?: IFieldVisibilityCondition
 }
 
+export type DropdownAddNewType = 'modal' | 'inline'
+
 export interface IFieldDropdown extends IBaseField {
   type: 'dropdown'
   showOptionValue?: boolean
   allowArbitrary?: boolean
+  addNewOption?: {
+    id: DropdownAddNewId // identifier when add new option is selected
+    type: DropdownAddNewType
+    label: string
+  }
   value?: string // for true/false dropdown, use boolean-radio
   options?: IFieldDropdownOption[]
   source?: IFieldDropdownSource
 }
+
+export type DropdownAddNewId = 'tiles-createTileRow-tableId' | 'tiles-createTileRow-columnId'
 
 export interface IFieldDropdownSource {
   type: string


### PR DESCRIPTION
### TL;DR

Added support for to `Add new` in action dropdowns to allow creation of new tiles and columns directly from the dropdown menu.

### What changed?

- Updated backend to support 'add new' options for dropdowns in the action creation process (addNewOption)
- Modified GraphQL schema to include new enum and type for 'add new' options
- Updated frontend GraphQL queries to fetch new data
- Updated TypeScript interfaces to include new properties

### How to test?

1. Create a pipe with action create new row for Tiles
2. Under setup substep, check that the graphql response includes the new `addNewOption` property

### Why make this change?

This change is in preparation for the next PR shows a new option `+ Create new Tile` and opens a new modal on click