### PR TITLE
PLU-283: [INLINE-TILES-4] create new tile from dropdown

### DIFF
--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -1,0 +1,111 @@
+import { IFieldDropdown } from '@plumber/types'
+
+import { FormEvent, useCallback, useState } from 'react'
+import { useMutation } from '@apollo/client'
+import {
+  FormControl,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react'
+import { Button, FormLabel, Input } from '@opengovsg/design-system-react'
+import client from 'graphql/client'
+import { CREATE_TABLE } from 'graphql/mutations/tiles/create-table'
+import { GET_DYNAMIC_DATA } from 'graphql/queries/get-dynamic-data'
+
+interface AddNewOptionalModalProps {
+  addNewOption: NonNullable<IFieldDropdown['addNewOption']>
+  onSubmit: (newValue: string) => void
+  onClose: () => void
+}
+
+function AddNewOptionalModal({
+  addNewOption: { id: addNewId, label },
+  onClose,
+  onSubmit,
+}: AddNewOptionalModalProps) {
+  const [createTable] = useMutation(CREATE_TABLE)
+  const [isMutatingLoading, setIsMutationLoading] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const trimmedInputValue = inputValue.trim()
+
+  const onFormSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!trimmedInputValue) {
+        return
+      }
+      setIsMutationLoading(true)
+      try {
+        let newValue: string | undefined
+        switch (addNewId) {
+          case 'tiles-createTileRow-tableId': {
+            const { data } = await createTable({
+              variables: {
+                input: {
+                  name: trimmedInputValue,
+                  isBlank: true,
+                },
+              },
+            })
+            newValue = data?.createTable.id
+            break
+          }
+          default:
+            break
+        }
+        await client.refetchQueries({ include: [GET_DYNAMIC_DATA] })
+        if (newValue) {
+          onSubmit(newValue)
+        }
+        onClose()
+      } finally {
+        setIsMutationLoading(false)
+      }
+    },
+    [addNewId, createTable, onClose, onSubmit, trimmedInputValue],
+  )
+
+  return (
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      size="md"
+      closeOnEsc={false}
+      motionPreset="none"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <form onSubmit={onFormSubmit}>
+          <ModalHeader>{label}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={8}>
+            <FormControl display="flex" flexDir="column" gap={2}>
+              <FormLabel isRequired>Name your tile</FormLabel>
+              <Input
+                autoFocus
+                onChange={(e) => setInputValue(e.target.value)}
+                value={inputValue}
+                isDisabled={isMutatingLoading}
+              />
+              <Button
+                mt={2}
+                type="submit"
+                isDisabled={!trimmedInputValue}
+                isLoading={isMutatingLoading}
+                alignSelf="flex-end"
+              >
+                Create
+              </Button>
+            </FormControl>
+          </ModalBody>
+        </form>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default AddNewOptionalModal

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -1,13 +1,19 @@
-import type { IFieldDropdownOption } from '@plumber/types'
+import type { IFieldDropdown, IFieldDropdownOption } from '@plumber/types'
 
-import { useMemo } from 'react'
-import { Controller, useFormContext } from 'react-hook-form'
+import { useCallback, useMemo } from 'react'
+import { useController, useFormContext } from 'react-hook-form'
 import Markdown from 'react-markdown'
-import { Box, Flex, FormControl } from '@chakra-ui/react'
-import { FormErrorMessage, FormLabel } from '@opengovsg/design-system-react'
+import { Box, Flex, FormControl, useDisclosure } from '@chakra-ui/react'
+import {
+  BxPlus,
+  FormErrorMessage,
+  FormLabel,
+} from '@opengovsg/design-system-react'
 import { ComboboxItem, SingleSelect } from 'components/SingleSelect'
 
-interface ControlledAutocompleteProps {
+import AddNewOptionModal from './AddNewOptionModal'
+
+export interface ControlledAutocompleteProps {
   options: IFieldDropdownOption[]
   defaultValue?: string
   loading: boolean
@@ -19,13 +25,24 @@ interface ControlledAutocompleteProps {
   onRefresh?: () => void
   required?: boolean
   placeholder?: string
+  addNewOption?: IFieldDropdown['addNewOption']
 }
+
+const ADD_NEW_MODAL_VALUE = 'ADD_NEW_MODAL_VALUE'
 
 const formComboboxOptions = (
   options: readonly IFieldDropdownOption[],
   showOptionValue?: boolean,
+  addNewLabel?: string,
 ) => {
   const result: ComboboxItem[] = []
+  if (addNewLabel) {
+    result.push({
+      value: ADD_NEW_MODAL_VALUE,
+      label: addNewLabel,
+      icon: BxPlus,
+    })
+  }
   for (const option of options) {
     const item = {
       value: option['value']?.toString(),
@@ -57,11 +74,17 @@ function ControlledAutocomplete(
     loading,
     required,
     placeholder,
+    addNewOption,
   } = props
 
   const items = useMemo(
-    () => formComboboxOptions(options, showOptionValue),
-    [options, showOptionValue],
+    () =>
+      formComboboxOptions(
+        options,
+        showOptionValue,
+        addNewOption?.type === 'modal' ? addNewOption?.label : undefined,
+      ),
+    [addNewOption, options, showOptionValue],
   )
 
   // Do not support freeSolo if there are numerical options. Since no use case
@@ -76,55 +99,82 @@ function ControlledAutocomplete(
     return rawFreeSolo
   }, [options, rawFreeSolo])
 
-  return (
-    <Controller
-      rules={{ required }}
-      name={name}
-      defaultValue={defaultValue ?? ''}
-      control={control}
-      render={({ field: { ref, onChange, value: fieldValue }, fieldState }) => {
-        const isError = Boolean(fieldState.isTouched && fieldState.error)
+  /**
+   * useController is used here instead of the Controller component
+   * so that we could wrap the onChange handler
+   */
+  const {
+    field: { value: fieldValue, onChange: fieldOnChange, ref },
+    fieldState: { isTouched, error },
+  } = useController({
+    name,
+    control,
+    rules: { required },
+    defaultValue: defaultValue ?? '',
+  })
 
-        return (
-          <FormControl isInvalid={isError}>
-            {label && (
-              <FormLabel
-                isRequired={required}
-                description={
-                  description && (
-                    <Markdown linkTarget="_blank">{description}</Markdown>
-                  )
-                }
-              >
-                {label}
-              </FormLabel>
-            )}
-            {/* Dropdown row option content */}
-            <Flex>
-              <Box flexGrow={1}>
-                <SingleSelect
-                  name="choose-dropdown-option"
-                  colorScheme="secondary"
-                  isClearable={!required}
-                  items={items}
-                  onChange={onChange}
-                  value={fieldValue}
-                  placeholder={placeholder}
-                  ref={ref}
-                  data-test={`${name}-autocomplete`}
-                  onRefresh={onRefresh}
-                  isRefreshLoading={loading}
-                  freeSolo={freeSolo}
-                />
-              </Box>
-            </Flex>
-            {isError && (
-              <FormErrorMessage>{fieldState.error?.message}</FormErrorMessage>
-            )}
-          </FormControl>
-        )
-      }}
-    />
+  const isError = Boolean(isTouched && error)
+
+  // Control add new option modal
+  const {
+    onClose: onNewOptionModalClose,
+    onOpen: onNewOptionModalOpen,
+    isOpen: isNewOptionModalOpen,
+  } = useDisclosure()
+
+  const onChange = useCallback(
+    (newValue?: string) => {
+      if (addNewOption && newValue === ADD_NEW_MODAL_VALUE) {
+        onNewOptionModalOpen()
+        return
+      }
+      fieldOnChange(newValue)
+    },
+    [addNewOption, fieldOnChange, onNewOptionModalOpen],
+  )
+
+  return (
+    <FormControl isInvalid={isError}>
+      {label && (
+        <FormLabel
+          isRequired={required}
+          description={
+            description && (
+              <Markdown linkTarget="_blank">{description}</Markdown>
+            )
+          }
+        >
+          {label}
+        </FormLabel>
+      )}
+      {/* Dropdown row option content */}
+      <Flex>
+        <Box flexGrow={1}>
+          <SingleSelect
+            name="choose-dropdown-option"
+            colorScheme="secondary"
+            isClearable={!required}
+            items={items}
+            onChange={onChange}
+            value={fieldValue}
+            placeholder={placeholder}
+            ref={ref}
+            data-test={`${name}-autocomplete`}
+            onRefresh={onRefresh}
+            isRefreshLoading={loading}
+            freeSolo={freeSolo}
+          />
+        </Box>
+      </Flex>
+      {isError && <FormErrorMessage>{error?.message}</FormErrorMessage>}
+      {addNewOption?.type === 'modal' && isNewOptionModalOpen && (
+        <AddNewOptionModal
+          addNewOption={addNewOption}
+          onClose={onNewOptionModalClose}
+          onSubmit={fieldOnChange}
+        />
+      )}
+    </FormControl>
   )
 }
 

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -1,12 +1,11 @@
 import type { IField, IFieldDropdownOption } from '@plumber/types'
 
-import { useFormContext } from 'react-hook-form'
 import ControlledAutocomplete from 'components/ControlledAutocomplete'
 import MultiRow from 'components/MultiRow'
 import MultiSelect from 'components/MultiSelect'
 import RichTextEditor from 'components/RichTextEditor'
 import TextField from 'components/TextField'
-import { isFieldHidden } from 'helpers/isFieldHidden'
+import { useIsFieldHidden } from 'helpers/isFieldHidden'
 import useDynamicData from 'hooks/useDynamicData'
 
 import BooleanRadio from './BooleanRadio'
@@ -25,15 +24,6 @@ type RawOption = {
 
 const optionGenerator = (options: RawOption[]): IFieldDropdownOption[] =>
   options?.map(({ name, value }) => ({ label: name as string, value: value }))
-
-function useIsFieldHidden(
-  namePrefix: string | undefined | null,
-  field: IField,
-): boolean {
-  const { getValues } = useFormContext()
-  const siblingParams = namePrefix ? getValues(namePrefix) : getValues()
-  return isFieldHidden(field.hiddenIf, siblingParams)
-}
 
 export default function InputCreator(props: InputCreatorProps): JSX.Element {
   const { schema, namePrefix, stepId, disabled } = props
@@ -88,6 +78,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         // if schema source is defined, dynamic data is supported
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
+        addNewOption={schema.addNewOption}
         label={label}
         placeholder={placeholder}
       />

--- a/packages/frontend/src/components/SingleSelect/SelectContext.tsx
+++ b/packages/frontend/src/components/SingleSelect/SelectContext.tsx
@@ -60,6 +60,8 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   virtualListRef: RefObject<VirtuosoHandle>
   /** Height to assign to virtual list */
   virtualListHeight: number
+  /** Whether new option is being created */
+  isCreatingNewOption?: boolean
 }
 
 export const SelectContext = createContext<SelectContextReturn | undefined>(

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -248,7 +248,10 @@ export const SingleSelectProvider = ({
         })
       }
     },
-    onSelectedItemChange: ({ selectedItem }) => {
+    onSelectedItemChange: ({ selectedItem, type }) => {
+      if (type === useCombobox.stateChangeTypes.InputBlur) {
+        return
+      }
       if (!selectedItem) {
         onChange('')
       } else if (!isItemDisabled(selectedItem)) {

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -50,7 +50,7 @@ export const DropdownItem = ({
     >
       <Flex justifyContent="space-between" alignItems="center">
         <Flex flexDir="column">
-          <Flex gap={1.5}>
+          <Flex gap={1.5} alignItems="center">
             {icon ? <Icon as={icon} sx={styles.icon} /> : null}
             <Text
               minWidth={0}

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -50,7 +50,7 @@ export const DropdownItem = ({
     >
       <Flex justifyContent="space-between" alignItems="center">
         <Flex flexDir="column">
-          <Flex gap={1.5} alignItems="center">
+          <Flex gap={1.5}>
             {icon ? <Icon as={icon} sx={styles.icon} /> : null}
             <Text
               minWidth={0}

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -30,6 +30,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       isRequired,
       placeholder,
       isRefreshLoading,
+      isCreatingNewOption,
       isOpen,
       resetInputValue,
       inputRef,
@@ -63,6 +64,24 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       return toggleMenu()
     }, [isDisabled, isReadOnly, toggleMenu])
 
+    const textToDisplay = useMemo(() => {
+      if (isInitialLoading) {
+        return 'Fetching options...'
+      }
+      if (isCreatingNewOption) {
+        return 'Creating...'
+      }
+      if (selectedItem) {
+        return selectedItemMeta.label
+      }
+      return ''
+    }, [
+      isCreatingNewOption,
+      isInitialLoading,
+      selectedItem,
+      selectedItemMeta.label,
+    ])
+
     return (
       <Flex>
         <InputGroup
@@ -90,19 +109,13 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            <Text noOfLines={1}>{selectedItemMeta.label}</Text>
+            <Text noOfLines={1}>{textToDisplay}</Text>
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}
             isInvalid={isInvalid}
             isDisabled={isDisabled}
-            placeholder={
-              isInitialLoading
-                ? 'Fetching options...'
-                : selectedItem
-                ? undefined
-                : placeholder
-            }
+            placeholder={textToDisplay ? '' : placeholder}
             sx={styles.field}
             {...getInputProps({
               onClick: handleToggleMenu,

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ToggleChevron.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/ToggleChevron.tsx
@@ -1,11 +1,22 @@
 import { Icon, InputRightElement } from '@chakra-ui/react'
-import { BxsChevronDown, BxsChevronUp } from '@opengovsg/design-system-react'
+import {
+  BxsChevronDown,
+  BxsChevronUp,
+  Spinner,
+} from '@opengovsg/design-system-react'
 
 import { useSelectContext } from '../../SelectContext'
 
 export const ToggleChevron = (): JSX.Element => {
-  const { isOpen, getToggleButtonProps, isDisabled, isReadOnly, styles } =
-    useSelectContext()
+  const {
+    isOpen,
+    getToggleButtonProps,
+    isDisabled,
+    isReadOnly,
+    styles,
+    isRefreshLoading,
+    isCreatingNewOption,
+  } = useSelectContext()
 
   return (
     <InputRightElement
@@ -22,11 +33,15 @@ export const ToggleChevron = (): JSX.Element => {
         tabIndex: 0,
       })}
     >
-      <Icon
-        sx={styles.icon}
-        as={isOpen ? BxsChevronUp : BxsChevronDown}
-        aria-disabled={isDisabled || isReadOnly}
-      />
+      {isRefreshLoading || isCreatingNewOption ? (
+        <Spinner color="primary.600" />
+      ) : (
+        <Icon
+          sx={styles.icon}
+          as={isOpen ? BxsChevronUp : BxsChevronDown}
+          aria-disabled={isDisabled || isReadOnly}
+        />
+      )}
     </InputRightElement>
   )
 }

--- a/packages/frontend/src/components/SingleSelect/types.ts
+++ b/packages/frontend/src/components/SingleSelect/types.ts
@@ -14,6 +14,8 @@ export type ComboboxItem<T = string> =
       icon?: As
       /** Badge to display on the right of the label, if available */
       badge?: JSX.Element
+      /** Whether this is an option to add new */
+      isAddNew?: boolean
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       [key: string]: any
     }

--- a/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
+++ b/packages/frontend/src/components/SingleSelect/utils/itemUtils.ts
@@ -16,6 +16,12 @@ export const itemToValue = <Item extends ComboboxItem>(item?: Item): string => {
   return item.value
 }
 
+export const isItemAddNew = <Item extends ComboboxItem>(
+  item: Item,
+): boolean => {
+  return itemIsObject(item) && !!item.isAddNew
+}
+
 export const itemToLabelString = <Item extends ComboboxItem>(
   item?: Item,
 ): string => {

--- a/packages/frontend/src/helpers/isFieldHidden.ts
+++ b/packages/frontend/src/helpers/isFieldHidden.ts
@@ -1,5 +1,6 @@
 import type { IField, IJSONObject } from '@plumber/types'
 
+import { useFormContext } from 'react-hook-form'
 import get from 'lodash.get'
 
 export function isFieldHidden(
@@ -36,4 +37,13 @@ export function isFieldHidden(
           !fieldVal
     }
   }
+}
+
+export function useIsFieldHidden(
+  namePrefix: string | undefined | null,
+  field: IField,
+): boolean {
+  const { getValues } = useFormContext()
+  const siblingParams = namePrefix ? getValues(namePrefix) : getValues()
+  return isFieldHidden(field.hiddenIf, siblingParams)
 }


### PR DESCRIPTION

### TL;DR
This PR introduces the feature to create a new option via a modal to support creation of new tiles via the dropdown.

### What changed?
- A new component `AddNewOptionalModal` is added. This brings up the modal with an input field for the new option. The text in the modal is now hardcoded specifically for tile creation and can be extended in future. Also exposes a hook to call the mutation that corresponds to the `AddNewId` lives.
- Updated `ControlledAutocomplete` to render and manage the state for `AddNewOptionModal`. It handles the callbacks when the `create new option` is selected.
- Modified `SingleSelectProvider` to add 'Add New Option' button to the list of items.
- Moved `useIsFieldHidden` hook to `isFieldHidden` helper file
- Modified `SelectCombobox` and `ToggleChevron` to display `creating...` state

### How to test?
1. Create a pipe that uses Tiles -> Create Row action.
2. Optional: Open dev tools and throttle network speed to Slow 3G
3. In setup substep, select the `+ Create new Tile` option. This should bring up a modal to name the tile.
4. After submitting, you should see that the `Creating...` text and spinner.
5. The new tile should be created and submitted.
6. Also test that tabbing thru the input fields should not bring up the modal. (This was the previous incorrect behaviour for Add new connection)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/8798d6f7-1daf-478a-851c-4e0acd856fac.png)