### PR TITLE
PLU-283: [INLINE-TILES-6] allow creating of tile columns inline

### DIFF
--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -49,7 +49,7 @@ const action: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Column',
+          placeholder: 'Select a column or type to create one',
           key: 'columnId',
           type: 'dropdown' as const,
           required: true,

--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -56,7 +56,7 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
           }
           case 'tiles-createTileRow-columnId': {
             const tableId = parameters?.tableId
-            if (!tableId) {
+            if (!tableId || typeof tableId !== 'string') {
               return
             }
             const { data } = await updateTable({
@@ -67,9 +67,10 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
                 },
               },
             })
-            const newColumns = data?.updateTable?.columns
+            const newColumns = (data?.updateTable?.columns ??
+              []) as ITableColumnMetadata[]
             newValue = newColumns.find(
-              (column: ITableColumnMetadata) => column.name === inputValue,
+              (column) => column.name === inputValue,
             )?.id
             break
           }

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -47,7 +47,7 @@ const formComboboxOptions = (
 function ControlledAutocomplete(
   props: ControlledAutocompleteProps,
 ): React.ReactElement {
-  const { control } = useFormContext()
+  const { control, getValues } = useFormContext()
   const {
     name,
     label,
@@ -109,9 +109,24 @@ function ControlledAutocomplete(
   const onNewOptionModalSubmit = useCallback(
     (inputValue: string) => {
       onNewOptionModalClose()
-      createNewOption({ inputValue, addNewId: addNewOption?.id })
+      createNewOption({
+        inputValue,
+        addNewId: addNewOption?.id,
+        parameters: getValues('parameters'),
+      })
     },
-    [addNewOption?.id, createNewOption, onNewOptionModalClose],
+    [addNewOption?.id, createNewOption, getValues, onNewOptionModalClose],
+  )
+
+  const onNewOptionInlineSelected = useCallback(
+    (inputValue: string) => {
+      createNewOption({
+        inputValue,
+        addNewId: addNewOption?.id,
+        parameters: getValues('parameters'),
+      })
+    },
+    [createNewOption, getValues, addNewOption?.id],
   )
 
   return (
@@ -149,7 +164,10 @@ function ControlledAutocomplete(
                 ? {
                     type: addNewOption.type,
                     label: addNewOption.label,
-                    onSelected: onNewOptionModalOpen,
+                    onSelected:
+                      addNewOption?.type === 'modal'
+                        ? onNewOptionModalOpen
+                        : onNewOptionInlineSelected,
                     isCreating: isCreatingNewOption,
                   }
                 : undefined

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -159,6 +159,7 @@ function ControlledAutocomplete(
             onRefresh={onRefresh}
             isRefreshLoading={loading}
             freeSolo={freeSolo}
+            isReadOnly={isCreatingNewOption}
             addNew={
               addNewOption
                 ? {
@@ -176,6 +177,7 @@ function ControlledAutocomplete(
         </Box>
       </Flex>
       {isError && <FormErrorMessage>{error?.message}</FormErrorMessage>}
+      {/* the input state in the modal is reset on unmount */}
       {addNewOption?.type === 'modal' && isNewOptionModalOpen && (
         <AddNewOptionModal
           modalHeader={addNewOption.label}

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -1,4 +1,4 @@
-import { DropdownAddNewType } from '@plumber/types'
+import type { DropdownAddNewType } from '@plumber/types'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { VirtuosoHandle } from 'react-virtuoso'
@@ -12,7 +12,7 @@ import {
 import { BxPlus } from '@opengovsg/design-system-react'
 import {
   useCombobox,
-  UseComboboxProps,
+  type UseComboboxProps,
   type UseComboboxState,
   type UseComboboxStateChangeOptions,
 } from 'downshift'
@@ -26,7 +26,10 @@ import {
   itemToValue,
 } from './utils/itemUtils'
 import { VIRTUAL_LIST_ITEM_HEIGHT } from './constants'
-import { SelectContext, SharedSelectContextReturnProps } from './SelectContext'
+import {
+  SelectContext,
+  type SharedSelectContextReturnProps,
+} from './SelectContext'
 import type { ComboboxItem } from './types'
 
 export interface SingleSelectProviderProps<
@@ -55,7 +58,7 @@ export interface SingleSelectProviderProps<
   addNew?: {
     label: string
     type: DropdownAddNewType
-    onSelected: (value?: string) => void
+    onSelected: (value: string) => void
     isCreating: boolean
   }
 }
@@ -171,10 +174,25 @@ export const SingleSelectProvider = ({
     (filteredItems: ComboboxItem<string>[], inputValue?: string) => {
       // freeSolo inputValue cannot be null or undefined or blank
       if (inputValue?.trim() && !getItemByValue(inputValue)) {
-        return filteredItems.push(constructFreeSoloItem(inputValue))
+        filteredItems.push(constructFreeSoloItem(inputValue))
       }
     },
     [getItemByValue],
+  )
+
+  const addInlineNewOption = useCallback(
+    (filteredItems: ComboboxItem<string>[], inputValue?: string) => {
+      if (inputValue?.trim() && !getItemByValue(inputValue)) {
+        filteredItems.push({
+          value: '__ADD_NEW_PLACEHOLDER_VALUE__', // this is not referenced anywhere else
+          label: inputValue,
+          description: addNew?.label ?? 'Create new',
+          isAddNew: true,
+          icon: BxPlus,
+        })
+      }
+    },
+    [addNew?.label, getItemByValue],
   )
 
   const handleInputChange = useCallback(
@@ -183,9 +201,18 @@ export const SingleSelectProvider = ({
       if (freeSolo) {
         addFreeSoloItem(filteredItems, inputValue)
       }
+      if (addNew?.type === 'inline') {
+        addInlineNewOption(filteredItems, inputValue)
+      }
       setFilteredItems(filteredItems)
     },
-    [addFreeSoloItem, freeSolo, getFilteredItems],
+    [
+      addFreeSoloItem,
+      addInlineNewOption,
+      addNew?.type,
+      freeSolo,
+      getFilteredItems,
+    ],
   )
 
   const stateReducer = useCallback(

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -30,7 +30,7 @@ import {
   SelectContext,
   type SharedSelectContextReturnProps,
 } from './SelectContext'
-import type { ComboboxItem } from './types'
+import { ADD_NEW_PLACEHOLDER_VALUE, type ComboboxItem } from './types'
 
 export interface SingleSelectProviderProps<
   Item extends ComboboxItem = ComboboxItem,
@@ -118,7 +118,7 @@ export const SingleSelectProvider = ({
   const allItemsWithAddNewOption = useMemo(() => {
     if (addNew?.type === 'modal') {
       const addNewByModalItem = {
-        value: '__ADD_NEW_PLACEHOLDER_VALUE__', // this is not referenced anywhere else
+        value: ADD_NEW_PLACEHOLDER_VALUE, // this is not referenced anywhere else
         label: addNew.label,
         isAddNew: true,
         icon: BxPlus,
@@ -184,7 +184,7 @@ export const SingleSelectProvider = ({
     (filteredItems: ComboboxItem<string>[], inputValue?: string) => {
       if (inputValue?.trim() && !getItemByValue(inputValue)) {
         filteredItems.push({
-          value: '__ADD_NEW_PLACEHOLDER_VALUE__', // this is not referenced anywhere else
+          value: ADD_NEW_PLACEHOLDER_VALUE, // this is not referenced anywhere else
           label: inputValue,
           description: addNew?.label ?? 'Create new',
           isAddNew: true,

--- a/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/DropdownItem/DropdownItem.tsx
@@ -50,7 +50,7 @@ export const DropdownItem = ({
     >
       <Flex justifyContent="space-between" alignItems="center">
         <Flex flexDir="column">
-          <Flex gap={1.5}>
+          <Flex gap={1.5} alignItems="center">
             {icon ? <Icon as={icon} sx={styles.icon} /> : null}
             <Text
               minWidth={0}

--- a/packages/frontend/src/components/SingleSelect/types.ts
+++ b/packages/frontend/src/components/SingleSelect/types.ts
@@ -1,8 +1,13 @@
 import type { As } from '@chakra-ui/react'
 
+export const ADD_NEW_PLACEHOLDER_VALUE = '__ADD_NEW_PLACEHOLDER_VALUE__'
+
 export type ComboboxItem<T = string> =
   | {
-      /** Value to be passed to onChange */
+      /**
+       * Value to be passed to onChange
+       * Do not use `__ADD_NEW_PLACEHOLDER_VALUE__` as a value since it is reserved for add new
+       */
       value: T
       /** Label to render on input when selected. `value` will be used if this is not provided */
       label?: string

--- a/packages/frontend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/update-table.ts
@@ -4,6 +4,10 @@ export const UPDATE_TABLE = graphql(`
   mutation UpdateTable($input: UpdateTableInput!) {
     updateTable(input: $input) {
       id
+      columns {
+        id
+        name
+      }
     }
   }
 `)


### PR DESCRIPTION
## TL;DR
This PR allows the creation of new columns by directly typing in the dropdown field.

## Why?
Since creating of columns is more common, we dont wanna keep bringing up the modal as it's a bit distracting.

 ## What changed?
- Add new mutation `UpdateTable` to the useCreateNewOption hook. Also updates the hook to accept the current form field parameters.
- Modified `SingleSelectProvider` to add option to create the new column. This is similar to the `freeSolo` option except that it does not create the option immediately. Instead, it calls the `addNew?.onSelected()` callback.
- Fix minor styling issue with DropdownItem to vertically center the icon

## How to test?
- Optional: throttle network speed
- Using the Tile > Create row action, trying typing a new column name and select the `Create new column` option.
- You should see that it will show `Creating...` with a spinner and the new column is created and selected.

