### PR TITLE
PLU-283: [INLINE-TILES-7] reset fields when prerequisite fields change

### DIFF
--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -41,8 +41,12 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     placeholder,
   } = schema
 
-  const { data, loading, refetch } = useDynamicData(stepId, schema)
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
+  const { data, loading, refetch } = useDynamicData(
+    stepId,
+    schema,
+    computedName,
+  )
 
   // NOTE: we handle visibility in InputCreator instead of in FlowSubStep
   // because MultiRow recursively renders InputCreator.

--- a/packages/frontend/src/hooks/useDynamicData.ts
+++ b/packages/frontend/src/hooks/useDynamicData.ts
@@ -55,9 +55,14 @@ function getWatchedFormFieldValues(
  *
  * @param stepId - the id of the step
  * @param schema - the field that needs the dynamic data
+ * @
  */
-function useDynamicData(stepId: string | undefined, schema: IField) {
-  const { getValues, watch } = useFormContext()
+function useDynamicData(
+  stepId: string | undefined,
+  schema: IField,
+  fieldName: string,
+) {
+  const { getValues, watch, setValue } = useFormContext()
   const { nonFormFieldArgs, watchedFormFields } = useMemo(() => {
     if (schema.type !== 'dropdown' || !schema.source) {
       return {
@@ -108,6 +113,10 @@ function useDynamicData(stepId: string | undefined, schema: IField) {
           return
         }
 
+        // we set the field to null if the parameter(s) to dynamic data query have changed
+        // resetField function resets it to the last saved value which is wrong
+        setValue(fieldName, null)
+
         refetch({
           ...getWatchedFormFieldValues(watchedFormFields, newFieldValues),
         })
@@ -115,7 +124,7 @@ function useDynamicData(stepId: string | undefined, schema: IField) {
     )
 
     return () => watchSubscription.unsubscribe()
-  }, [refetch, watch, watchedFormFields])
+  }, [fieldName, refetch, setValue, watch, watchedFormFields])
 
   return {
     called,


### PR DESCRIPTION
## Problem
Since we removed the unused `dependsOn` property, there's no way to clear values when the prereq field changes. 

## Solution
Instead of introducing a new property on IRawField, we rely on useDynamicData hook to determine if fields should be set to `null` when prereq fields change. 

Under the `watch` callback in useDynamicData hook, we reset the values there. 

## To test
1. Add a console.log in the watch callback in useDynamicData.ts (after L.106)
2. Use an action that relies whose fields rely on dynamic data with parameters, e.g. tiles, m365
3. For example in create-row for tiles, select a tile then select a column.
4. Try changing the tile and the columnIds should reset in rowData