### PR TITLE
PLU-268: reorder the app dropdown options

### DIFF
--- a/packages/backend/src/apps/__tests__/index.test.ts
+++ b/packages/backend/src/apps/__tests__/index.test.ts
@@ -3,6 +3,10 @@ import { join } from 'path'
 import { describe, expect, it } from 'vitest'
 
 import exportedApps from '@/apps'
+import {
+  ACTION_APPS_RANKING_MAP,
+  TRIGGER_APPS_RANKING_MAP,
+} from '@/graphql/queries/get-apps'
 
 describe('index.ts', () => {
   it('should export all apps keys that also match their folder names', () => {
@@ -18,5 +22,16 @@ describe('index.ts', () => {
     // Set comparison
     expect(exportedAppNames.length).toEqual(appFolderNames.length)
     expect(exportedAppNames.sort()).toEqual(appFolderNames.sort())
+  })
+})
+
+describe('get-apps query', () => {
+  it('number of apps in ranking maps should match with the number of apps we have', () => {
+    const exportedAppNamesSet = new Set(Object.keys(exportedApps))
+    const rankingMapAppsSet = new Set([
+      ...Object.keys(TRIGGER_APPS_RANKING_MAP),
+      ...Object.keys(ACTION_APPS_RANKING_MAP),
+    ])
+    expect(exportedAppNamesSet).toEqual(rankingMapAppsSet)
   })
 })

--- a/packages/backend/src/apps/__tests__/index.test.ts
+++ b/packages/backend/src/apps/__tests__/index.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import exportedApps from '@/apps'
 import {
-  ACTION_APPS_RANKING_MAP,
-  TRIGGER_APPS_RANKING_MAP,
+  ACTION_APPS_RANKING,
+  TRIGGER_APPS_RANKING,
 } from '@/graphql/queries/get-apps'
 
 describe('index.ts', () => {
@@ -29,8 +29,8 @@ describe('get-apps query', () => {
   it('number of apps in ranking maps should match with the number of apps we have', () => {
     const exportedAppNamesSet = new Set(Object.keys(exportedApps))
     const rankingMapAppsSet = new Set([
-      ...Object.keys(TRIGGER_APPS_RANKING_MAP),
-      ...Object.keys(ACTION_APPS_RANKING_MAP),
+      ...TRIGGER_APPS_RANKING,
+      ...ACTION_APPS_RANKING,
     ])
     expect(exportedAppNamesSet).toEqual(rankingMapAppsSet)
   })

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -1,9 +1,85 @@
+import type { IApp } from '@plumber/types'
+
+import calculatorApp from '@/apps/calculator'
+import customApiApp from '@/apps/custom-api'
+import delayApp from '@/apps/delay'
+import formatterApp from '@/apps/formatter'
+import formsgApp from '@/apps/formsg/'
+import lettersgApp from '@/apps/lettersg'
+import m365ExcelApp from '@/apps/m365-excel'
+import paysgApp from '@/apps/paysg'
+import postmanApp from '@/apps/postman'
+import postmanSmsApp from '@/apps/postman-sms'
+import schedulerApp from '@/apps/scheduler'
+import slackApp from '@/apps/slack'
+import telegramBotApp from '@/apps/telegram-bot'
+import tilesApp from '@/apps/tiles'
+import toolboxApp from '@/apps/toolbox'
+import twilioApp from '@/apps/twilio'
+import vaultWorkspaceApp from '@/apps/vault-workspace'
+import webhookApp from '@/apps/webhook'
 import App from '@/models/app'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
+/**
+ * Note: Remember to add the priority of the app here whenever a new app
+ * is created, this is to determine which app dropdown option appears first.
+ * Note that triggers and actions have separate rankings!
+ * Triggers: formsg, scheduler, webhook
+ * Actions: email by postman, tiles, m365, toolbox, formatter, calculator, delay,
+ * paysg, lettersg, sms by postman, telegram, slack, custom-api, vault, twilio
+ */
+
+export const TRIGGER_APPS_RANKING_MAP: Record<string, number> = {
+  [formsgApp.key]: 1,
+  [schedulerApp.key]: 2,
+  [webhookApp.key]: 3,
+}
+
+export const ACTION_APPS_RANKING_MAP: Record<string, number> = {
+  [postmanApp.key]: 1,
+  [tilesApp.key]: 2,
+  [m365ExcelApp.key]: 3,
+  [toolboxApp.key]: 4,
+  [formatterApp.key]: 5,
+  [calculatorApp.key]: 6,
+  [delayApp.key]: 7,
+  [paysgApp.key]: 8,
+  [lettersgApp.key]: 9,
+  [postmanSmsApp.key]: 10,
+  [telegramBotApp.key]: 11,
+  [slackApp.key]: 12,
+  [customApiApp.key]: 13,
+  [vaultWorkspaceApp.key]: 14,
+  [twilioApp.key]: 15,
+}
+
+function sortApps(apps: IApp[]): IApp[] {
+  return apps.sort((a, b) => {
+    const firstPriority = a.triggers
+      ? TRIGGER_APPS_RANKING_MAP[a.key]
+      : ACTION_APPS_RANKING_MAP[a.key]
+    const secondPriority = b.triggers
+      ? TRIGGER_APPS_RANKING_MAP[b.key]
+      : ACTION_APPS_RANKING_MAP[b.key]
+
+    // sort by newApp flag, followed by priority
+    if (a.isNewApp && b.isNewApp) {
+      return firstPriority - secondPriority
+    }
+    if (a.isNewApp) {
+      return -1
+    }
+    if (b.isNewApp) {
+      return 1
+    }
+    return firstPriority - secondPriority
+  })
+}
+
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {
-  const apps = await App.findAll(params.name)
+  const apps = sortApps(await App.findAll(params.name))
 
   if (params.onlyWithTriggers) {
     return apps.filter((app) => app.triggers?.length)

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -31,38 +31,38 @@ import type { QueryResolvers } from '../__generated__/types.generated'
  * paysg, lettersg, sms by postman, telegram, slack, custom-api, vault, twilio
  */
 
-export const TRIGGER_APPS_RANKING_MAP: Record<string, number> = {
-  [formsgApp.key]: 1,
-  [schedulerApp.key]: 2,
-  [webhookApp.key]: 3,
-}
-
-export const ACTION_APPS_RANKING_MAP: Record<string, number> = {
-  [postmanApp.key]: 1,
-  [tilesApp.key]: 2,
-  [m365ExcelApp.key]: 3,
-  [toolboxApp.key]: 4,
-  [formatterApp.key]: 5,
-  [calculatorApp.key]: 6,
-  [delayApp.key]: 7,
-  [paysgApp.key]: 8,
-  [lettersgApp.key]: 9,
-  [postmanSmsApp.key]: 10,
-  [telegramBotApp.key]: 11,
-  [slackApp.key]: 12,
-  [customApiApp.key]: 13,
-  [vaultWorkspaceApp.key]: 14,
-  [twilioApp.key]: 15,
-}
+export const TRIGGER_APPS_RANKING = [
+  formsgApp.key,
+  schedulerApp.key,
+  webhookApp.key,
+]
+export const ACTION_APPS_RANKING = [
+  postmanApp.key,
+  tilesApp.key,
+  m365ExcelApp.key,
+  toolboxApp.key,
+  formatterApp.key,
+  calculatorApp.key,
+  delayApp.key,
+  paysgApp.key,
+  lettersgApp.key,
+  postmanSmsApp.key,
+  telegramBotApp.key,
+  slackApp.key,
+  customApiApp.key,
+  vaultWorkspaceApp.key,
+  twilioApp.key,
+]
 
 function sortApps(apps: IApp[]): IApp[] {
+  // trade off for increased time complexity but easier to add a new app to the ranking
   return apps.sort((a, b) => {
     const firstPriority = a.triggers
-      ? TRIGGER_APPS_RANKING_MAP[a.key]
-      : ACTION_APPS_RANKING_MAP[a.key]
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
     const secondPriority = b.triggers
-      ? TRIGGER_APPS_RANKING_MAP[b.key]
-      : ACTION_APPS_RANKING_MAP[b.key]
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
 
     // sort by newApp flag, followed by priority
     if (a.isNewApp && b.isNewApp) {
@@ -80,7 +80,6 @@ function sortApps(apps: IApp[]): IApp[] {
 
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {
   const apps = sortApps(await App.findAll(params.name))
-
   if (params.onlyWithTriggers) {
     return apps.filter((app) => app.triggers?.length)
   }

--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -90,18 +90,6 @@ function ChooseAppAndEventSubstep(
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
 
-  apps?.sort((a, b) => {
-    if (a.isNewApp && b.isNewApp) {
-      return a.name.localeCompare(b.name)
-    }
-    if (a.isNewApp) {
-      return -1
-    }
-    if (b.isNewApp) {
-      return 1
-    }
-    return a.name.localeCompare(b.name)
-  })
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)
 
   const appOptions = useMemo(


### PR DESCRIPTION
## Problem

Apps are now ordered alphabetically, the more popular apps not as "accessible" to users.

## Solution

- Cleanest solution I can come up with is to assign a priority to each app and then sort by the priority. 
- This ranking map will be in the `getApps` query and I added a unit test to ensure that when you add a new app, you must add it to the ranking map, if not, the test will not pass.
- Ordering system is separate for triggers and actions.
  - Triggers: formsg, scheduler, webhook
  - Actions: email by postman, tiles, m365, toolbox, formatter, calculator, delay, paysg, lettersg, sms by postman, telegram, slack, custom-api, vault, twilio
  - New apps: m365 and sms by postman

## Tests
- [x] New apps show first
- [x] App still can be selected and pipe execution works as expected
- [x] Add connection will have the apps reordered the same way as well
