### PR TITLE
PLU-199: formsg checkbox field enhancement

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -403,6 +403,37 @@ describe('decrypt form response', () => {
         }),
       )
     })
+
+    describe('checkbox', () => {
+      beforeEach(() => {
+        mockDecryptedSubmission({
+          responses: [
+            {
+              _id: 'question1',
+              fieldType: 'checkbox',
+              question: 'Have you had your meals?',
+              answerArray: ['Breakfast', 'Lunch', 'Dinner', 'Supper'],
+            },
+          ],
+        })
+      })
+      it('checkbox question should include one additional combined answer response', async () => {
+        await expect(decryptFormResponse($)).resolves.toEqual(true)
+        expect($.request.body).toEqual(
+          expect.objectContaining({
+            fields: {
+              question1: {
+                order: 1,
+                fieldType: 'checkbox',
+                question: 'Have you had your meals?',
+                answerArray: ['Breakfast', 'Lunch', 'Dinner', 'Supper'],
+                answer: 'Breakfast, Lunch, Dinner, Supper',
+              },
+            },
+          }),
+        )
+      })
+    })
   })
 
   describe('attachments', () => {

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -104,6 +104,11 @@ export async function decryptFormResponse(
     for (const [index, formField] of submission.responses.entries()) {
       const { _id, ...rest } = formField
 
+      // for checkbox: keep answerArray for backward compatibility
+      if (rest.fieldType === 'checkbox') {
+        rest.answer = rest.answerArray.join(', ')
+      }
+
       if (rest.fieldType === 'nric' && !!rest.answer) {
         const filteredAnswer = filterNric($, rest.answer)
         if (!filteredAnswer) {

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -73,6 +73,7 @@ function buildAnswerArrayForCheckbox(
         ? `Response ${fieldData.order}, Selected Option ${i + 1}`
         : null,
       order: fieldData.order ? (fieldData.order as number) : null,
+      isHidden: true,
     })
   }
   return answerArray


### PR DESCRIPTION
## Problem

The FormSG test data currently returns the checkbox options that users selected only during the test submission. Some users complained that some options would be missing because the number of options selected per test submission may not match.

<img width="856" alt="Screenshot 2024-06-27 at 11 59 48 AM" src="https://github.com/opengovsg/plumber/assets/65110268/fd893d3f-2783-4ce5-8695-134940ec93c5">


## Solution

Concatenate the `answerArray` into an `answer` field and hide the `answerArray` fields in the metadata so that users cannot use the individual options but yet it won't break existing pipes (account for backwards compatibility issue)

Note: `Table` field is not changed because users still need to use the individual rows in different steps e.g. M365-excel when the user adds one row as one cell...

Possible extension: To include both individual options and combined option but for now, out of scope because no design yet and we don't want to overcomplicate and confuse users with both options available, therefore I chose this simple fix for now.

## Tests
- [x] Existing pipes with individual checkbox selected option still works
- [x] Combined selected options now appear as one response field (comma-separated) and can be used in subsequent steps e.g. postman