### PR TITLE
PLU-307: chore: remove redirect restriction for custom api

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -2,7 +2,6 @@ import { IRawAction } from '@plumber/types'
 
 import { URL } from 'url'
 
-import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 
 import { isUrlAllowed } from '../../common/ip-resolver'
@@ -95,10 +94,7 @@ const action: IRawAction = {
 
       $.setActionItem({ raw: { data: responseData } })
     } catch (err) {
-      if (
-        !(err instanceof HttpError) &&
-        err.message === RECURSIVE_WEBHOOK_ERROR_NAME
-      ) {
+      if (err.message === RECURSIVE_WEBHOOK_ERROR_NAME) {
         throw new StepError(
           RECURSIVE_WEBHOOK_ERROR_NAME,
           RECURSIVE_WEBHOOK_ERROR_SOLUTION,


### PR DESCRIPTION
## Problem

Users want to be able to add a redirect URL when using the `custom-api` action.

## Solution

- Removed the `maxRedirects: 0` check but added in a check to not allow redirects to plumber urls.
- Updated error to stepError for recursive invoking of plumber webhooks
- Added unit tests

## Tests
- [x] Custom-api still works for 200 status codes
- [x] Only redirects to plumber.gov.sg will cause a `stepError`
- [x] Redirects are now allowed: used opentunnel.io to test
- [x] Recursive invoking of plumber webhooks throw `stepError` instead

