### PR TITLE
[RFC][ADMIN-PANEL-1] Support admin queries in GraphQL

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -209,6 +209,10 @@
     {
       "name": "M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS",
       "valueFrom": "plumber-<ENVIRONMENT>-m365-excel-interval-between-actions-ms"
+    },
+    {
+      "name": "ADMIN_JWT_SECRET_KEY",
+      "valueFrom": "plumber-<ENVIRONMENT>-admin-jwt-secret-key"
     }
   ]
 }

--- a/packages/backend/.env-example
+++ b/packages/backend/.env-example
@@ -11,6 +11,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_ENABLE_SSL=false
 ENCRYPTION_KEY=sample-encryption-key
 SESSION_SECRET_KEY=sample-app-secret-key
+ADMIN_JWT_SECRET_KEY=sample-admin-secret-key
 REDIS_PORT=6379
 REDIS_HOST=localhost
 REDIS_USERNAME=

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -20,6 +20,7 @@ type AppConfig = {
   baseUrl: string
   encryptionKey: string
   sessionSecretKey: string
+  adminJwtSecretKey: string
   serveWebAppSeparately: boolean
   redisHost: string
   redisPort: number
@@ -72,6 +73,7 @@ const appConfig: AppConfig = {
   postgresEnableSsl: process.env.POSTGRES_ENABLE_SSL === 'true',
   encryptionKey: process.env.ENCRYPTION_KEY || '',
   sessionSecretKey: process.env.SESSION_SECRET_KEY || '',
+  adminJwtSecretKey: process.env.ADMIN_JWT_SECRET_KEY || '',
   serveWebAppSeparately: process.env.SERVE_WEB_APP_SEPARATELY === 'true',
   redisHost: process.env.REDIS_HOST || '127.0.0.1',
   redisPort: parseInt(process.env.REDIS_PORT || '6379'),
@@ -110,6 +112,10 @@ if (!appConfig.encryptionKey) {
 
 if (!appConfig.sessionSecretKey) {
   throw new Error('SESSION_SECRET_KEY environment variable needs to be set!')
+}
+
+if (!appConfig.adminJwtSecretKey) {
+  throw new Error('ADMIN_JWT_SECRET_KEY environment variable needs to be set!')
 }
 
 if (!appConfig.postman.apiKey) {

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
@@ -11,6 +11,7 @@ export async function generateMockContext(): Promise<Context> {
     req: null,
     res: null,
     currentUser: await User.query().findOne({ email: 'tester@open.gov.sg' }),
+    isAdminOperation: false,
   }
 }
 

--- a/packages/backend/src/helpers/__tests__/auth.test.ts
+++ b/packages/backend/src/helpers/__tests__/auth.test.ts
@@ -1,0 +1,72 @@
+import jwt from 'jsonwebtoken'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import appConfig from '@/config/app'
+
+import { getAdminTokenUser, parseAdminToken } from '../auth'
+
+const mocks = vi.hoisted(() => ({
+  whereUser: vi.fn(() => ({
+    first: vi.fn(() => ({
+      throwIfNotFound: vi.fn(() => ({ id: 'test-user-id' })),
+    })),
+  })),
+}))
+
+vi.mock('@/models/user', () => ({
+  default: {
+    query: vi.fn(() => ({
+      where: mocks.whereUser,
+    })),
+  },
+}))
+
+describe('Auth helpers', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('parseAdminToken', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('01 June 2024 00:00:00 GMT+8'))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('can parse valid admin tokens', () => {
+      const token = jwt.sign(
+        { userEmail: 'coffee@plumber.local' },
+        appConfig.adminJwtSecretKey,
+        {
+          expiresIn: 60,
+        },
+      )
+      const result = parseAdminToken(token)
+      expect(result.userEmail).toEqual('coffee@plumber.local')
+    })
+
+    it('does not accept tokens past a certain age', () => {
+      const token = jwt.sign(
+        { userEmail: 'coffee@plumber.local' },
+        appConfig.adminJwtSecretKey,
+      )
+
+      vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24)
+      expect(parseAdminToken(token)).toBeNull()
+    })
+  })
+
+  describe('getAdminTokenUser', () => {
+    it('queries for the user with the email in the token', async () => {
+      const result = await getAdminTokenUser({
+        userEmail: 'coffee@plumber.local',
+      })
+
+      expect(mocks.whereUser).toBeCalledWith('email', 'coffee@plumber.local')
+      expect(result.id).toEqual('test-user-id')
+    })
+  })
+})

--- a/packages/backend/src/helpers/__tests__/authentication.test.ts
+++ b/packages/backend/src/helpers/__tests__/authentication.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { setCurrentUserContext } from '../authentication'
+
+const mocks = vi.hoisted(() => ({
+  getAdminTokenUser: vi.fn(),
+  getLoggedInUser: vi.fn(),
+  parseAdminToken: vi.fn(),
+}))
+
+vi.mock('@/helpers/auth', () => ({
+  getAdminTokenUser: mocks.getAdminTokenUser,
+  getLoggedInUser: mocks.getLoggedInUser,
+  parseAdminToken: mocks.parseAdminToken,
+}))
+
+describe('GraphQL Authentication', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('setCurrentUserContext', () => {
+    it('parses admin token if available', async () => {
+      mocks.parseAdminToken.mockReturnValueOnce({
+        userEmail: 'test@plumber.local',
+      })
+      mocks.getAdminTokenUser.mockReturnValueOnce({
+        id: 'test-user-id',
+      })
+
+      const result = await setCurrentUserContext({
+        req: {
+          headers: {
+            'x-plumber-admin-token': 'test-token',
+          },
+        },
+      } as unknown as any)
+      expect(mocks.parseAdminToken).toBeCalled()
+      expect(mocks.getAdminTokenUser).toBeCalled()
+      expect(result.currentUser.id).toEqual('test-user-id')
+    })
+
+    it('does not invoke admin-related functions if admin header not set', async () => {
+      await setCurrentUserContext({ req: { headers: {} } } as unknown as any)
+      expect(mocks.parseAdminToken).not.toBeCalled()
+      expect(mocks.getAdminTokenUser).not.toBeCalled()
+    })
+  })
+})

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -1,9 +1,13 @@
 import { Request, Response } from 'express'
 import { createRateLimitRule, RedisStore } from 'graphql-rate-limit'
-import { allow, rule, shield } from 'graphql-shield'
+import { allow, and, not, or, rule, shield } from 'graphql-shield'
 
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
-import { getLoggedInUser } from '@/helpers/auth'
+import {
+  getAdminTokenUser,
+  getLoggedInUser,
+  parseAdminToken,
+} from '@/helpers/auth'
 import { UnauthenticatedContext } from '@/types/express/context'
 
 export const setCurrentUserContext = async ({
@@ -13,12 +17,30 @@ export const setCurrentUserContext = async ({
   req: Request
   res: Response
 }): Promise<UnauthenticatedContext> => {
-  const context: UnauthenticatedContext = { req, res, currentUser: null }
+  const context: UnauthenticatedContext = {
+    req,
+    res,
+    currentUser: null,
+    isAdminOperation: false,
+  }
 
   // Get tiles view key from headers
   context.tilesViewKey = req.headers['x-tiles-view-key'] as string | undefined
 
-  context.currentUser = await getLoggedInUser(req)
+  if (typeof req.headers['x-plumber-admin-token'] === 'string') {
+    const adminToken = parseAdminToken(req.headers['x-plumber-admin-token'])
+    if (!adminToken) {
+      // If admin token is specified but it's invalid, something's really wrong
+      // so we abort immediately instead of falling back to getLoggedInUser.
+      return context
+    }
+
+    context.currentUser = await getAdminTokenUser(adminToken)
+    context.isAdminOperation = true
+  } else {
+    context.currentUser = await getLoggedInUser(req)
+  }
+
   return context
 }
 
@@ -28,9 +50,15 @@ const isAuthenticated = rule()(
   },
 )
 
-const isAuthenticatedOrViewKey = rule()(
+const isViewKey = rule()(
   async (_parent, _args, ctx: UnauthenticatedContext) => {
-    return ctx.currentUser != null || ctx.tilesViewKey != null
+    return ctx.tilesViewKey != null
+  },
+)
+
+const isAdminOperation = rule()(
+  async (_parent, _args, ctx: UnauthenticatedContext) => {
+    return ctx.isAdminOperation
   },
 )
 
@@ -50,15 +78,18 @@ const rateLimitRule = createRateLimitRule({
 const authentication = shield(
   {
     Query: {
-      '*': isAuthenticated,
-      getTable: isAuthenticatedOrViewKey,
-      getAllRows: isAuthenticatedOrViewKey,
+      '*': or(isAuthenticated, isAdminOperation),
+      getTable: or(isAuthenticated, isAdminOperation, isViewKey),
+      getAllRows: or(isAuthenticated, isAdminOperation, isViewKey),
       healthcheck: allow,
       getCurrentUser: allow,
       getPlumberStats: allow,
     },
     Mutation: {
-      '*': isAuthenticated,
+      '*': and(
+        isAuthenticated,
+        not(isAdminOperation), // Limiting admins to read-only for now.
+      ),
       requestOtp: rateLimitRule({ window: '1s', max: 5 }),
       verifyOtp: rateLimitRule({ window: '1s', max: 5 }),
       // Not OTP, but no real reason to be looser than OTP.

--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -21,11 +21,21 @@ function ApolloServerPluginUserTracer(): ApolloServerPlugin<AuthenticatedContext
     async requestDidStart(requestContext) {
       // Add the tag right before we reply the user.
       // https://www.apollographql.com/docs/apollo-server/integrations/plugins#request-lifecycle-event-flow
+      const isAdminOperation = requestContext.contextValue?.isAdminOperation
+        ? 'true'
+        : 'false'
+      tracer.scope().active()?.addTags({
+        isAdminOperation,
+      })
+
       const currentUser = requestContext.contextValue?.currentUser
       if (currentUser) {
         tracer.setUser({
           id: currentUser.id,
           email: currentUser.email,
+
+          // For convenience
+          isAdminOperation,
         })
       }
     },

--- a/packages/backend/src/types/express/context.ts
+++ b/packages/backend/src/types/express/context.ts
@@ -6,6 +6,7 @@ export interface UnauthenticatedContext {
   req: Request
   res: Response
   currentUser: User | null
+  isAdminOperation: boolean
   tilesViewKey?: string
 }
 


### PR DESCRIPTION
# Problem
We want to support admin-level queries for troubleshooting.

# Solution
We will allow specifying an alternate JWT which replaces our auth cookie in the `x-plumber-admin-token` in our headers.

This PR also refactors our GraphQL shield rules a little bit to use logic primitives.

# Tests
- Check that I can perform queries even if I'm not logged in as a user, if a valid `x-plumber-admin-token` is set.
- Check that I cannot run mutations if `x-plumber-admin-token` is set.
- Check that I get an error if `x-plumber-admin-token` is not signed with the right key.
- **TODO ON STAGING**: Check that `isAdminQuery` is logged if a valid `x-plumber-admin-token` is provided.
- Regression test: check that I can make queries and mutations as a logged in user.
- Regression test: check that I cannot make queries and mutations if (I am not logged in and I have not provided a valid `x-plumber-admin-token`).
- Regression test: check that I can still view appropriate tiles if I have the corresponding view key
- Regression test: check that I cannot view tiles if I don't any view key.

# Deploy Notes
**New env vars**
- `PLUMBER_ADMIN_JWT_SECRET_KEY`: Self-explanatory