### PR TITLE
PLU-199: formsg checkbox field enhancement

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -302,95 +302,14 @@ describe('new submission trigger for answer array fields', () => {
       expect(metadata.fields.textFieldId1.question.label).toEqual('Question 1')
     })
 
-    it('Checkbox type: changes the answerArray label to a group of selected responses', async () => {
+    it('Checkbox type: changes the answerArray label to a single response', async () => {
       const metadata = await trigger.getDataOutMetadata(executionStep)
       const array = metadata.fields.textFieldId1.answerArray
-
-      for (let i = 0; i < array.length; i++) {
-        expect(array[i].label).toEqual(`Response 1, Selected Option ${i + 1}`)
-      }
-    })
-
-    it('changes the question label to "Question 2"', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-
-      expect(metadata.fields.textFieldId2.question.label).toEqual('Question 2')
-    })
-
-    it('Table type: changes the answerArray label to a group of rows and columns', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-      const array = metadata.fields.textFieldId2.answerArray
-
-      for (let i = 0; i < array.length; i++) {
-        const nestedArray = array[i]
-        for (let j = 0; j < array.length; j++) {
-          expect(nestedArray[j].label).toEqual(
-            `Response 2, Row ${i + 1} Column ${j + 1}`,
-          )
-        }
-      }
-    })
-
-    it('changes the question label to "Question 3"', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-
-      expect(metadata.fields.textFieldId3.question.label).toEqual('Question 3')
-    })
-
-    it('Unknown type: answerArray label should be undefined', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-      expect(metadata.fields.textFieldId3.answerArray).toBeUndefined()
-    })
-  })
-})
-
-describe('new submission trigger for answer array fields', () => {
-  let executionStep: IExecutionStep
-
-  beforeEach(() => {
-    executionStep = {
-      dataOut: {
-        fields: {
-          textFieldId1: {
-            question: 'Have you had your meals?',
-            fieldType: 'checkbox',
-            order: 1,
-            answerArray: ['lunch', 'dinner'],
-          },
-          textFieldId2: {
-            question: 'What are your hobbies? When do you do them?',
-            fieldType: 'table',
-            order: 2,
-            answerArray: [
-              ['sleeping', 'night'],
-              ['eating', 'all day'],
-            ],
-          },
-          textFieldId3: {
-            question: 'Unknown question',
-            fieldType: 'unknown',
-            order: 3,
-            answerArray: ['weird', 'strange'],
-          },
-        },
-      },
-    } as unknown as IExecutionStep
-  })
-
-  describe('dataOut metadata', () => {
-    it('changes the question label to "Question 1"', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-
-      expect(metadata.fields.textFieldId1.question.label).toEqual('Question 1')
-    })
-
-    it('Checkbox type: changes the answerArray label to a group of selected responses', async () => {
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-      const array = metadata.fields.textFieldId1.answerArray
-
-      for (let i = 0; i < array.length; i++) {
-        expect(array[i].label).toEqual(`Response 1, Selected Option ${i + 1}`)
-      }
+      expect(array).toEqual({
+        type: 'text',
+        label: 'Response 1',
+        order: 1.1,
+      })
     })
 
     it('changes the question label to "Question 2"', async () => {

--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -305,8 +305,9 @@ describe('new submission trigger for answer array fields', () => {
     it('Checkbox type: changes the answerArray label to a single response', async () => {
       const metadata = await trigger.getDataOutMetadata(executionStep)
       const array = metadata.fields.textFieldId1.answerArray
+      // type will be array instead of text!
       expect(array).toEqual({
-        type: 'text',
+        type: 'array',
         label: 'Response 1',
         order: 1.1,
       })

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -67,7 +67,7 @@ function buildAnswerArrayForCheckbox(
   // NOTE: checkbox answerArray will not be further splitted,
   // handled specifically in variables.ts and compute-parameters.ts
   return {
-    type: 'text',
+    type: 'array',
     label: `Response ${fieldData.order}`,
     order: fieldData.order ? (fieldData.order as number) + 0.1 : null,
   }

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -63,19 +63,14 @@ function isAnswerArrayValid(fieldData: IJSONObject): boolean {
 
 function buildAnswerArrayForCheckbox(
   fieldData: IJSONObject,
-): IDataOutMetadatum[] {
-  const answerArray = [] as IDataOutMetadatum[]
-  const array = fieldData.answerArray as IJSONArray
-  for (let i = 0; i < array.length; i++) {
-    answerArray.push({
-      type: 'text',
-      label: fieldData.order
-        ? `Response ${fieldData.order}, Selected Option ${i + 1}`
-        : null,
-      order: fieldData.order ? (fieldData.order as number) : null,
-    })
+): IDataOutMetadatum {
+  // NOTE: checkbox answerArray will not be further splitted,
+  // handled specifically in variables.ts and compute-parameters.ts
+  return {
+    type: 'text',
+    label: `Response ${fieldData.order}`,
+    order: fieldData.order ? (fieldData.order as number) + 0.1 : null,
   }
-  return answerArray
 }
 
 function buildAnswerArrayForTable(
@@ -105,7 +100,7 @@ function buildAnswerArrayMetadatum(
   fieldData: IJSONObject,
   stepId: string,
   submissionId: IJSONValue,
-): IDataOutMetadatum[] | IDataOutMetadatum[][] {
+): IDataOutMetadatum | IDataOutMetadatum[][] {
   // there should only be checkbox and table fieldtypes that contain answer array
   const fieldType = fieldData.fieldType
   switch (fieldType) {

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -15,6 +15,7 @@ const executionSteps = [
       stringProp: 'string value',
       numberProp: 123,
       'space separated prop': 'space separated value',
+      arrayProp: ['array value 1', 'hehe', 'array value 3'], // for-each intro
     },
   } as unknown as ExecutionStep,
 ]
@@ -82,6 +83,9 @@ describe('compute parameters', () => {
           {
             key1: `object 3 - {{step.${randomStepID}.space separated prop}}`,
           },
+          {
+            key1: `object 4 - {{step.${randomStepID}.arrayProp}}`,
+          },
         ],
       },
       expected: {
@@ -89,6 +93,7 @@ describe('compute parameters', () => {
           { key1: 'object 1 - string value' },
           { key1: 'object 2 - 123' },
           { key1: 'object 3 - space separated value' },
+          { key1: 'object 4 - array value 1, hehe, array value 3' },
         ],
       },
     },
@@ -123,6 +128,25 @@ describe('compute parameters', () => {
       expected: {
         objectParam: {
           key1: ['123', 'string value', 'space separated value'],
+        },
+      },
+    },
+    {
+      testDescription: 'nested objects with an array prop',
+      params: {
+        objectParam: {
+          subObject: {
+            key1: `{{step.${randomStepID}.numberProp}}`,
+            key2: `{{step.${randomStepID}.arrayProp}} and more...`,
+          },
+        },
+      },
+      expected: {
+        objectParam: {
+          subObject: {
+            key1: '123',
+            key2: 'array value 1, hehe, array value 3 and more...',
+          },
         },
       },
     },
@@ -254,7 +278,7 @@ describe('compute parameters', () => {
       ],
     })
   })
-  it('can compute on  templates with non-hex-encoded param keys using new vault WS objects whose keys hex-encoded', () => {
+  it('can compute on templates with non-hex-encoded param keys using new vault WS objects whose keys hex-encoded', () => {
     const vaultWSExecutionStep = [
       {
         stepId: randomStepID,

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -62,7 +62,7 @@ function findAndSubstituteVariables(
         })
         const data = executionStep?.dataOut
 
-        const keyPath = keyPaths.join('.')
+        const keyPath = keyPaths.join('.') // for lodash get to work
         let dataValue = get(data, keyPath)
         // custom logic to deal with backward compatibility of key encoding for
         // data from vault. Under the new logic, data from vault will always have
@@ -81,8 +81,12 @@ function findAndSubstituteVariables(
           ).toString('hex')
           dataValue = get(data, keyPaths.join('.'))
         }
+        // NOTE: dataValue could be an array if it is not processed on variables.ts
+        // which is the case for formSG checkbox only, this is to deal with forEach next time
         return preprocessVariable
           ? preprocessVariable(parameterKey, dataValue)
+          : Array.isArray(dataValue)
+          ? dataValue.join(', ')
           : dataValue
       }
 

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -25,7 +25,12 @@ import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { StepExecutionsContext } from 'contexts/StepExecutions'
-import { extractVariables, filterVariables, Variable } from 'helpers/variables'
+import {
+  extractVariables,
+  filterVariables,
+  Variable,
+  VISIBLE_VARIABLE_TYPES,
+} from 'helpers/variables'
 import { POPOVER_MOTION_PROPS } from 'theme/constants'
 
 import { MenuBar } from './MenuBar'
@@ -87,7 +92,10 @@ const Editor = ({
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
       extractVariables(priorStepsWithExecutions),
-      (variable) => (variable.type ?? 'text') === 'text',
+      (variable) => {
+        const variableType = variable.type ?? 'text'
+        return VISIBLE_VARIABLE_TYPES.includes(variableType)
+      },
     )
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -16,7 +16,11 @@ import FlowSubstepTitle from 'components/FlowSubstepTitle'
 import WebhookUrlInfo from 'components/WebhookUrlInfo'
 import { EditorContext } from 'contexts/Editor'
 import { EXECUTE_FLOW } from 'graphql/mutations/execute-flow'
-import { extractVariables, filterVariables } from 'helpers/variables'
+import {
+  extractVariables,
+  filterVariables,
+  VISIBLE_VARIABLE_TYPES,
+} from 'helpers/variables'
 
 import TestResult from './TestResult'
 
@@ -76,10 +80,10 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
       return []
     }
 
-    return filterVariables(
-      extractVariables([executionStep]),
-      (variable) => (variable.type ?? 'text') === 'text',
-    )
+    return filterVariables(extractVariables([executionStep]), (variable) => {
+      const variableType = variable.type ?? 'text'
+      return VISIBLE_VARIABLE_TYPES.includes(variableType)
+    })
   }, [executionStep])
 
   const isExecuted = !error && called && !loading

--- a/packages/frontend/src/helpers/__tests__/variables.test.ts
+++ b/packages/frontend/src/helpers/__tests__/variables.test.ts
@@ -334,29 +334,53 @@ describe('variables', () => {
             },
           },
         }
+        // only include metadata for answerArray for testing purposes
+        steps[0].executionSteps[0].dataOutMetadata = {
+          fields: {
+            field1: {
+              answerArray: {
+                type: 'array',
+                label: 'test label',
+                order: 1.1,
+              },
+            },
+          },
+        }
 
         const result = extractVariables(steps)
-        // label exists because no metadata is provided
+        // answerArray object will be at the top due to an order given
         expect(result[0].output).toEqual([
+          expect.objectContaining({
+            name: 'step.step1-id.fields.field1.answerArray',
+            label: 'test label',
+            value: 'Lunch, Dinner',
+            type: 'array',
+            displayedValue: null,
+            order: 1.1,
+          }),
           expect.objectContaining({
             name: 'step.step1-id.fields.field1.order',
             label: 'fields.field1.order',
             value: 1,
+            type: null,
+            displayedValue: null,
+            order: null,
           }),
           expect.objectContaining({
             name: 'step.step1-id.fields.field1.question',
             label: 'fields.field1.question',
             value: 'Have you eaten your meals?',
+            type: null,
+            displayedValue: null,
+            order: null,
           }),
           expect.objectContaining({
             name: 'step.step1-id.fields.field1.fieldType',
             label: 'fields.field1.fieldType',
             value: 'checkbox',
-          }),
-          expect.objectContaining({
-            name: 'step.step1-id.fields.field1.answerArray',
-            label: 'fields.field1.answerArray',
-            value: 'Lunch, Dinner',
+            type: null,
+            displayedValue: null,
+            order: null,
           }),
         ])
       })

--- a/packages/frontend/src/helpers/__tests__/variables.test.ts
+++ b/packages/frontend/src/helpers/__tests__/variables.test.ts
@@ -300,6 +300,67 @@ describe('variables', () => {
         ])
       })
     })
+
+    describe('process arrays in dataout', () => {
+      it('data without formsg checkbox field will have the array flat-mapped', () => {
+        steps[0].executionSteps[0].dataOut = {
+          recipients: ['coolbeans@open.gov.sg', 'plumbros@open.gov.sg'],
+        }
+
+        const result = extractVariables(steps)
+        // label exists because no metadata is provided
+        expect(result[0].output).toEqual([
+          expect.objectContaining({
+            name: 'step.step1-id.recipients.0',
+            label: 'recipients.0',
+            value: 'coolbeans@open.gov.sg',
+          }),
+          expect.objectContaining({
+            name: 'step.step1-id.recipients.1',
+            label: 'recipients.1',
+            value: 'plumbros@open.gov.sg',
+          }),
+        ])
+      })
+
+      it('data with formsg checkbox field will not have the array flat-mapped', () => {
+        steps[0].executionSteps[0].dataOut = {
+          fields: {
+            field1: {
+              order: 1,
+              question: 'Have you eaten your meals?',
+              fieldType: 'checkbox',
+              answerArray: ['Lunch', 'Dinner'],
+            },
+          },
+        }
+
+        const result = extractVariables(steps)
+        // label exists because no metadata is provided
+        expect(result[0].output).toEqual([
+          expect.objectContaining({
+            name: 'step.step1-id.fields.field1.order',
+            label: 'fields.field1.order',
+            value: 1,
+          }),
+          expect.objectContaining({
+            name: 'step.step1-id.fields.field1.question',
+            label: 'fields.field1.question',
+            value: 'Have you eaten your meals?',
+          }),
+          expect.objectContaining({
+            name: 'step.step1-id.fields.field1.fieldType',
+            label: 'fields.field1.fieldType',
+            value: 'checkbox',
+          }),
+          expect.objectContaining({
+            name: 'step.step1-id.fields.field1.answerArray',
+            label: 'fields.field1.answerArray',
+            value: 'Lunch, Dinner',
+          }),
+        ])
+      })
+    })
   })
 
   describe('filterVariables', () => {

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -117,25 +117,18 @@ const process = (
    *  ]
    * ]
    */
-  let shouldNotProcess = false
-  for (const entry of entries) {
-    const [name, _value] = entry
-
+  return entries.flatMap(([name, value]) => {
     // lodash get metadata by specifying the fullName path e.g. fields.fieldId.answerArray
-    // search for type: 'array' in metadata field to not flatmap
     const fullName = joinBy('.', parentKey, (index as number)?.toString(), name)
     const { type = null } = get(metadata, fullName, {}) as IDataOutMetadatum
-    if (type === 'array') {
-      shouldNotProcess = true
-    }
-  }
 
-  return entries.flatMap(([name, value]) => {
-    const fullName = joinBy('.', parentKey, (index as number)?.toString(), name)
     if (Array.isArray(value)) {
-      // ONLY for formSG checkbox, it should not flatmap [answerArray, [option 1, option 2, ...]]
-      // but it should return to the frontend as a comma-separated value response
-      if (shouldNotProcess) {
+      /**
+       * ONLY for formSG checkbox now: it should not flatmap [answerArray, [option 1, option 2, ...]]
+       * search for type: 'array' in metadata field to not flatmap
+       * but it should return to the frontend as a comma-separated value response
+       */
+      if (type === 'array') {
         return [
           {
             name: fullName,
@@ -143,6 +136,7 @@ const process = (
           },
         ]
       }
+
       return value.flatMap((item, index) =>
         process(item, metadata, fullName, index),
       )

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -120,12 +120,10 @@ const process = (
   let shouldNotProcess = false
   for (const entry of entries) {
     const [name, _value] = entry
-    console.log(metadata)
 
     // lodash get metadata by specifying the fullName path e.g. fields.fieldId.answerArray
     // search for type: 'array' in metadata field to not flatmap
     const fullName = joinBy('.', parentKey, (index as number)?.toString(), name)
-    console.log(fullName)
     const { type = null } = get(metadata, fullName, {}) as IDataOutMetadatum
     if (type === 'array') {
       shouldNotProcess = true

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -48,7 +48,11 @@ export interface IConnection {
   createdAt: string
 }
 
-export type TDataOutMetadatumType = 'text' | 'file'
+/**
+ * 'array' is currently used only in formSG checkbox field but
+ * will be extended to for-each feature handling
+ */
+export type TDataOutMetadatumType = 'text' | 'file' | 'array'
 
 /**
  * This should only be defined on _leaf_ nodes (i.e. **primitive array
@@ -279,7 +283,9 @@ export interface IFieldDropdown extends IBaseField {
   source?: IFieldDropdownSource
 }
 
-export type DropdownAddNewId = 'tiles-createTileRow-tableId' | 'tiles-createTileRow-columnId'
+export type DropdownAddNewId =
+  | 'tiles-createTileRow-tableId'
+  | 'tiles-createTileRow-columnId'
 
 export interface IFieldDropdownSource {
   type: string


### PR DESCRIPTION
## Problem

The FormSG test data currently returns the checkbox options that users selected only during the test submission. Some users complained that some options would be missing because the number of options selected per test submission may not match.

<img width="856" alt="Screenshot 2024-06-27 at 11 59 48 AM" src="https://github.com/opengovsg/plumber/assets/65110268/fd893d3f-2783-4ce5-8695-134940ec93c5">

## Solution
- Treat the `answerArray` variable as it is, specifically check for it in the `variables.ts` file to prevent it from being recursively processed.
- On the `compute-parameters.ts` file, check for array `dataValue` which will only be this `answerArray` variable. Then join it since the `toString()` for array by default will not add a space to each value.
- Add unit tests to the appropriate files
- Ignore table fields since they should still be allowed to be handled row by row by the user.

## Tests
- [x] Old pipes using the individual selected option still works
- [x] New pipes can only use the combined response (CSV) for checkbox field
- [x] Mock data works
- [x] Webhook passing array as a data value will still be recursively processed
- [x] Sanity check: variables that could be in an array e.g. recipients for postman step are still being recursively processed


