### PR TITLE
[RFC] [ADMIN-PANEL-3] Admin-related GraphQL queries

### DIFF
--- a/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
@@ -1,0 +1,20 @@
+import Execution from '@/models/execution'
+
+import type { AdminQueryResolvers } from '../../__generated__/types.generated'
+
+const getExecutionOwner: AdminQueryResolvers['getExecutionOwner'] = async (
+  _parent,
+  params,
+  _context,
+) => {
+  const { executionId } = params
+
+  const execution = await Execution.query()
+    .findById(executionId)
+    .withGraphJoined({ flow: { user: true } })
+    .throwIfNotFound()
+
+  return execution.flow.user
+}
+
+export default getExecutionOwner

--- a/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
@@ -1,0 +1,20 @@
+import Flow from '@/models/flow'
+
+import type { AdminQueryResolvers } from '../../__generated__/types.generated'
+
+const getFlowOwner: AdminQueryResolvers['getFlowOwner'] = async (
+  _parent,
+  params,
+  _context,
+) => {
+  const { flowId } = params
+
+  const flow = await Flow.query()
+    .findById(flowId)
+    .withGraphJoined({ user: true })
+    .throwIfNotFound()
+
+  return flow.user
+}
+
+export default getFlowOwner

--- a/packages/backend/src/graphql/admin/queries/get-table-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-table-owner.ts
@@ -1,0 +1,22 @@
+import TableCollaborator from '@/models/table-collaborators'
+
+import type { AdminQueryResolvers } from '../../__generated__/types.generated'
+
+const getTableOwner: AdminQueryResolvers['getTableOwner'] = async (
+  _parent,
+  params,
+  _context,
+) => {
+  const { tableId } = params
+
+  const tableCollaborator = await TableCollaborator.query()
+    .where('table_id', tableId)
+    .andWhere('role', 'owner')
+    .withGraphJoined({ user: true })
+    .throwIfNotFound()
+    .first()
+
+  return tableCollaborator.user
+}
+
+export default getTableOwner

--- a/packages/backend/src/graphql/admin/queries/index.ts
+++ b/packages/backend/src/graphql/admin/queries/index.ts
@@ -1,0 +1,13 @@
+import type { AdminQueryResolvers } from '../../__generated__/types.generated'
+
+import getExecutionOwner from './get-execution-owner'
+import getFlowOwner from './get-flow-owner'
+import getTableOwner from './get-table-owner'
+import searchUsersByEmail from './search-users-by-email'
+
+export default {
+  getExecutionOwner,
+  getFlowOwner,
+  getTableOwner,
+  searchUsersByEmail,
+} satisfies AdminQueryResolvers

--- a/packages/backend/src/graphql/admin/queries/search-users-by-email.ts
+++ b/packages/backend/src/graphql/admin/queries/search-users-by-email.ts
@@ -1,0 +1,21 @@
+import User from '@/models/user'
+
+import type { AdminQueryResolvers } from '../../__generated__/types.generated'
+
+const MIN_QUERY_CHARS = 3
+
+const searchUsersByEmail: AdminQueryResolvers['searchUsersByEmail'] = async (
+  _parent,
+  params,
+  _context,
+) => {
+  const { query } = params
+
+  if (!query || query.trim().length < MIN_QUERY_CHARS) {
+    throw new Error(`Query needs to be at least ${MIN_QUERY_CHARS} characters.`)
+  }
+
+  return User.query().where('email', 'like', `%${query.toLowerCase()}%`)
+}
+
+export default searchUsersByEmail

--- a/packages/backend/src/graphql/query-resolvers.ts
+++ b/packages/backend/src/graphql/query-resolvers.ts
@@ -46,4 +46,9 @@ export default {
   getPendingFlowTransfers,
   getFlowTransferDetails,
   ...tilesQueryResolvers,
+
+  // This is a special stub that enables us to group all our admin-related
+  // queries into a special AdminQuery object; each "query" is handled by field
+  // resolvers defined in @/graphql/admin/queries.
+  admin: () => ({}),
 } satisfies QueryResolvers

--- a/packages/backend/src/graphql/resolvers.ts
+++ b/packages/backend/src/graphql/resolvers.ts
@@ -1,4 +1,5 @@
 import type { Resolvers } from './__generated__/types.generated'
+import adminQueryResolvers from './admin/queries'
 import customResolvers from './custom-resolvers'
 import mutationResolvers from './mutation-resolvers'
 import queryResolvers from './query-resolvers'
@@ -6,5 +7,6 @@ import queryResolvers from './query-resolvers'
 export default {
   Query: queryResolvers,
   Mutation: mutationResolvers,
+  AdminQuery: adminQueryResolvers,
   ...customResolvers,
 } satisfies Resolvers

--- a/packages/backend/src/graphql/schema.gql-to-typescript.ts
+++ b/packages/backend/src/graphql/schema.gql-to-typescript.ts
@@ -19,3 +19,8 @@ export type ExecutionConnectionGraphQLType = ReturnType<
   typeof paginate<Execution>
 >
 export type FlowConnectionGraphQLType = ReturnType<typeof paginate<Flow>>
+
+// This is a special stub that enables us to group all our admin-related
+// queries into a special AdminQuery object. See @/graphql/query-resolvers for
+// more context.
+export type AdminQueryGraphQLType = Record<string, never>

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -44,6 +44,15 @@ type Query {
   # Flow transfers
   getPendingFlowTransfers: [FlowTransfer!]!
   getFlowTransferDetails(flowId: String!): [StepTransferDetails]!
+  # Admin queries
+  admin: AdminQuery!
+}
+
+type AdminQuery {
+  getFlowOwner(flowId: String!): User!
+  getExecutionOwner(executionId: String!): User!
+  getTableOwner(tableId: String!): User!
+  searchUsersByEmail(query: String!): [User!]!
 }
 
 type Mutation {

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -85,6 +85,7 @@ const authentication = shield(
       getCurrentUser: allow,
       getPlumberStats: allow,
     },
+    AdminQuery: isAdminOperation,
     Mutation: {
       '*': and(
         isAuthenticated,

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -8,6 +8,7 @@ class Execution extends Base {
   flowId!: string
   testRun: boolean
   internalId: string
+  flow: Flow
   executionSteps: ExecutionStep[]
   status: ExecutionStatus
 


### PR DESCRIPTION
# Problem
For admin panel, we need to be able to determine the owner of a pipe / tile / execution given its ID. This is so that we can generate a  `x-plumber-admin-token` that contains the correct user ID for the pipe / tile / execution we're inspecting .

# Solution
Implement these queries (self explanatory):
- `getFlowOwner`
- `getExecutionOwner`
- `getTableOwner`
- `searchUsersByEmail`

# Tests
- Check that the queries work in admin panel
- Check that I cannot query these queries if I don't have a `x-plumber-admin-token`, even if I'm logged in.
- Regression test: check that I can still make other queries.