### PR TITLE
PLU-115: [SST-1] Rewrite query for test execution steps

### DIFF
--- a/packages/backend/src/db/migrations/20240703104252_add_test_execution_column.ts
+++ b/packages/backend/src/db/migrations/20240703104252_add_test_execution_column.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex'
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.table('flows', (table) => {
     table
-      .uuid('test_execution')
+      .uuid('test_execution_id')
       .nullable()
       .references('id')
       .inTable('executions')
@@ -12,6 +12,6 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.schema.table('flows', (table) => {
-    table.dropColumn('test_execution')
+    table.dropColumn('test_execution_id')
   })
 }

--- a/packages/backend/src/db/migrations/20240703104252_add_test_execution_column.ts
+++ b/packages/backend/src/db/migrations/20240703104252_add_test_execution_column.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('flows', (table) => {
+    table
+      .uuid('test_execution')
+      .nullable()
+      .references('id')
+      .inTable('executions')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('flows', (table) => {
+    table.dropColumn('test_execution')
+  })
+}

--- a/packages/backend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-test-execution-steps.ts
@@ -1,0 +1,55 @@
+import { raw } from 'objection'
+
+import ExecutionStep from '@/models/execution-step'
+
+import type { QueryResolvers } from '../__generated__/types.generated'
+
+const getTestExecutionSteps: QueryResolvers['getTestExecutionSteps'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const flow = await context.currentUser
+    .$relatedQuery('flows')
+    .findById(params.flowId)
+    .withGraphFetched({
+      testExecution: {
+        executionSteps: true,
+      },
+      steps: true,
+    })
+    .throwIfNotFound()
+
+  if (flow.testExecution) {
+    return flow.testExecution.executionSteps
+  }
+
+  /**
+   * If test execution id does not exist, we fetch the last execution steps for each step
+   */
+  const latestExecutionSteps = await ExecutionStep.query()
+    .with('latest_execution_steps', (builder) => {
+      builder
+        .select(
+          '*',
+          raw(
+            'ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY execution_steps.created_at DESC) as rn',
+          ),
+        )
+        .from('execution_steps')
+        .join('executions', 'execution_steps.execution_id', 'executions.id')
+        .whereIn(
+          'step_id',
+          flow.steps.map((step) => step.id),
+        )
+        .andWhere('execution_steps.status', '=', 'success')
+    })
+    .select('*')
+    .from('latest_execution_steps')
+    .where('rn', '=', 1)
+    .withSoftDeleted() // because this adds a 'execution_steps.deleted_at' column to the query instead of latest_execution_steps
+
+  return latestExecutionSteps
+}
+
+export default getTestExecutionSteps

--- a/packages/backend/src/graphql/query-resolvers.ts
+++ b/packages/backend/src/graphql/query-resolvers.ts
@@ -13,6 +13,7 @@ import getFlows from './queries/get-flows'
 import getPendingFlowTransfers from './queries/get-pending-flow-transfers'
 import getPlumberStats from './queries/get-plumber-stats'
 import getStepWithTestExecutions from './queries/get-step-with-test-executions'
+import getTestExecutionSteps from './queries/get-test-execution-steps'
 import healthcheck from './queries/healthcheck'
 import testConnection from './queries/test-connection'
 import tilesQueryResolvers from './queries/tiles'
@@ -36,6 +37,7 @@ export default {
   getFlow,
   getFlows,
   getStepWithTestExecutions,
+  getTestExecutionSteps,
   getExecution,
   getExecutions,
   getExecutionSteps,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -15,7 +15,8 @@ type Query {
     connectionId: String
     name: String
   ): FlowConnection
-  getStepWithTestExecutions(stepId: String!): [Step]
+  getStepWithTestExecutions(stepId: String!): [Step] @deprecated(reason: "Use getTestExecution instead")
+  getTestExecutionSteps(flowId: String!): [ExecutionStep]
   getExecution(executionId: String!): Execution
   getExecutions(
     limit: Int!

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -21,6 +21,7 @@ class Flow extends Base {
   publishedAt: string
   remoteWebhookId: string
   executions?: Execution[]
+  testExecution?: Execution
   user: User
 
   /**
@@ -40,6 +41,7 @@ class Flow extends Base {
       userId: { type: 'string', format: 'uuid' },
       remoteWebhookId: { type: 'string' },
       active: { type: 'boolean' },
+
       config: {
         type: 'object',
         properties: {
@@ -78,27 +80,35 @@ class Flow extends Base {
       relation: Base.HasManyRelation,
       modelClass: Execution,
       join: {
-        from: 'flows.id',
-        to: 'executions.flow_id',
+        from: `${this.tableName}.id`,
+        to: `${Execution.tableName}.flow_id`,
       },
     },
     user: {
       relation: Base.BelongsToOneRelation,
       modelClass: User,
       join: {
-        from: 'flows.user_id',
-        to: 'users.id',
+        from: `${this.tableName}.user_id`,
+        to: `${User.tableName}.id`,
       },
     },
     pendingTransfer: {
       relation: Base.BelongsToOneRelation,
       modelClass: FlowTransfer,
       join: {
-        from: 'flows.id',
-        to: 'flow_transfers.flow_id',
+        from: `${this.tableName}.id`,
+        to: `${FlowTransfer.tableName}.flow_id`,
       },
       filter(builder: ExtendedQueryBuilder<FlowTransfer>) {
         builder.where('status', 'pending')
+      },
+    },
+    testExecution: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Execution,
+      join: {
+        from: `${this.tableName}.test_execution`,
+        to: `${Execution.tableName}.id`,
       },
     },
   })

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -21,6 +21,7 @@ class Flow extends Base {
   publishedAt: string
   remoteWebhookId: string
   executions?: Execution[]
+  testExecutionId: string
   testExecution?: Execution
   user: User
 
@@ -107,7 +108,7 @@ class Flow extends Base {
       relation: Base.BelongsToOneRelation,
       modelClass: Execution,
       join: {
-        from: `${this.tableName}.test_execution`,
+        from: `${this.tableName}.test_execution_id`,
         to: `${Execution.tableName}.id`,
       },
     },

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client'
+
+export const GET_TEST_EXECUTION_STEPS = gql`
+  query GetTestExecutionSteps($flowId: String!) {
+    getTestExecutionSteps(flowId: $flowId) {
+      id
+      executionId
+      stepId
+      step {
+        id
+        position
+      }
+      status
+      appKey
+      dataOut
+      dataOutMetadata
+      errorDetails
+      metadata {
+        isMock
+      }
+    }
+  }
+`


### PR DESCRIPTION
### TL;DR

This pull request adds a new database column, `test_execution_id`, to the `flows` table and a corresponding GraphQL query `getTestExecutionSteps`. The query returns the execution steps for a specific test execution or the latest execution steps if no test execution exists.

### What changed?
1. Added a new migration to introduce the `test_execution_id` column in the `flows` table.
2. Implemented the `getTestExecutionSteps` GraphQL query to fetch execution steps for a test or the latest ones if none exists. This includes execution steps from different execution ids and regardless of success status.
3. Updated the `Flow` model to include new relations (`testExecution`).
4. Deprecated the `getStepWithTestExecutions` query in favor of the new `getTestExecutionSteps` query.

### How to test?
1. Run the new migration script to update the database schema.
2. Ensure that the `getTestExecutionSteps` query returns correct execution steps for flows with and without `test_execution_id`.


### Why make this change?
This change is necessary to facilitate better tracking and retrieval of test execution steps, improving overall system functionality and maintainability.

