### PR TITLE
PLU-115: [SST-2] Fetch test execution steps with new query

### DIFF
--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,6 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
-import { ReactElement, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { BiChevronLeft, BiCog } from 'react-icons/bi'
 import { Link, useParams } from 'react-router-dom'
 import { ApolloError, useMutation, useQuery } from '@apollo/client'
@@ -34,7 +34,7 @@ import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
 
 import EditorSnackbar from './EditorSnackbar'
 
-export default function EditorLayout(): ReactElement {
+export default function EditorLayout() {
   const { flowId } = useParams()
   const [updateFlow] = useMutation(UPDATE_FLOW)
   const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS)
@@ -126,6 +126,10 @@ export default function EditorLayout(): ReactElement {
 
   const isEditorReadOnly = hasFlowTransfer || flow?.active
 
+  if (!flowId || !flow) {
+    return null
+  }
+
   return (
     <>
       <VStack h="100%">
@@ -208,10 +212,8 @@ export default function EditorLayout(): ReactElement {
         </HStack>
 
         <Container maxW={852} p={0}>
-          <EditorProvider value={{ readOnly: isEditorReadOnly }}>
-            {!flow && !loading && 'not found'}
-
-            {flow && <Editor flow={flow} steps={flow.steps} />}
+          <EditorProvider readOnly={isEditorReadOnly} flowId={flowId}>
+            <Editor flow={flow} steps={flow.steps} />
           </EditorProvider>
         </Container>
       </VStack>

--- a/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
+++ b/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
@@ -1,14 +1,14 @@
-import type { IStep, TDataOutMetadatumType } from '@plumber/types'
+import type { IExecutionStep, TDataOutMetadatumType } from '@plumber/types'
 
 import { ComboboxItem } from '@opengovsg/design-system-react'
 
 import { extractVariables } from '@/helpers/variables'
 
 function extractVariablesAsItems(
-  steps: IStep[],
+  executionSteps: IExecutionStep[],
   allowedTypes: TDataOutMetadatumType[] | null,
 ): ComboboxItem[] {
-  const stepsWithVariables = extractVariables(steps)
+  const stepsWithVariables = extractVariables(executionSteps)
 
   const result: ComboboxItem[] = []
   for (const step of stepsWithVariables) {

--- a/packages/frontend/src/components/MultiSelect/index.tsx
+++ b/packages/frontend/src/components/MultiSelect/index.tsx
@@ -37,11 +37,11 @@ function MultiSelect(props: MultiSelectProps): React.ReactElement {
     placeholder = null,
   } = props
   const { control } = useFormContext()
-  const priorSteps = useContext(StepExecutionsContext)
+  const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
   const items = useMemo(
-    () => extractVariablesAsItems(priorSteps, variableTypes),
-    [priorSteps, variableTypes],
+    () => extractVariablesAsItems(priorExecutionSteps, variableTypes),
+    [priorExecutionSteps, variableTypes],
   )
 
   return (

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -88,11 +88,11 @@ const Editor = ({
   variablesEnabled,
   isRich,
 }: EditorProps) => {
-  const priorStepsWithExecutions = useContext(StepExecutionsContext)
+  const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
-      extractVariables(priorStepsWithExecutions),
+      extractVariables(priorExecutionSteps),
       (variable) => {
         const variableType = variable.type ?? 'text'
         return VISIBLE_VARIABLE_TYPES.includes(variableType)
@@ -100,7 +100,7 @@ const Editor = ({
     )
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]
-  }, [priorStepsWithExecutions])
+  }, [priorExecutionSteps])
 
   const extensions: Array<any> = [
     Placeholder.configure({

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -1,11 +1,11 @@
 import type { IAction, IStep, ITrigger } from '@plumber/types'
 
-import { Box, Link, Text } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
 
 import VariablesList from '@/components/VariablesList'
 import { isIfThenStep } from '@/helpers/toolbox'
-import { type StepWithVariables } from '@/helpers/variables'
+import type { Variable } from '@/helpers/variables'
 
 function getNoOutputMessage(
   selectedActionOrTrigger: TestResultsProps['selectedActionOrTrigger'],
@@ -40,47 +40,22 @@ function getMockDataMessage(
 interface TestResultsProps {
   step: IStep
   selectedActionOrTrigger: ITrigger | IAction | undefined
-  stepsWithVariables: StepWithVariables[]
-  isExecuted: boolean
+  // if null, the step probably hasnt been tested yet
+  variables: Variable[] | null
   isMock?: boolean
 }
 
 export default function TestResult(props: TestResultsProps): JSX.Element {
-  const {
-    step,
-    selectedActionOrTrigger,
-    stepsWithVariables,
-    isExecuted,
-    isMock = false,
-  } = props
+  const { step, selectedActionOrTrigger, variables, isMock = false } = props
 
   // No data only happens if user hasn't executed yet, or step returned null.
-  if (stepsWithVariables.length == 0) {
-    if (isExecuted) {
-      return (
-        <Infobox variant="warning" width="full">
-          <Box>
-            <Text fontWeight="600">{`We couldn't find any test data`}</Text>
-            <Text mt={0.5}>{getNoOutputMessage(selectedActionOrTrigger)}</Text>
-          </Box>
-        </Infobox>
-      )
-    } else {
-      return <></>
-    }
-  }
-
-  // Paranoia, because all code after assumes that only 1 step was run.
-  if (stepsWithVariables.length > 1) {
+  if (variables == null) {
     return (
-      <Infobox variant="error" w="full">
-        <Text>
-          An unexpected error occurred, please contact{' '}
-          <Link href="mailto:support@plumber.gov.sg">
-            support@plumber.gov.sg
-          </Link>{' '}
-          for help!
-        </Text>
+      <Infobox variant="warning" width="full">
+        <Box>
+          <Text fontWeight="600">{`We couldn't find any test data`}</Text>
+          <Text mt={0.5}>{getNoOutputMessage(selectedActionOrTrigger)}</Text>
+        </Box>
       </Infobox>
     )
   }
@@ -90,7 +65,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
   // FIXME (ogp-weeloong): Revamp UI to allow special handling for
   // toolbox actions in an isolated codepath.
   if (isIfThenStep(step)) {
-    const isConditionMet = stepsWithVariables[0].output[0].value as boolean
+    const isConditionMet = variables[0].value as boolean
 
     if (isConditionMet) {
       return (
@@ -123,7 +98,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
           }
         </Text>
       </Infobox>
-      <VariablesList variables={stepsWithVariables[0].output} />
+      <VariablesList variables={variables} />
     </Box>
   )
 }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -2,7 +2,8 @@ import type { IExecutionStep } from '@plumber/types'
 
 import { createContext, ReactNode } from 'react'
 import { useQuery } from '@apollo/client'
-import { GET_TEST_EXECUTION_STEPS } from 'graphql/queries/get-test-execution-steps'
+
+import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 
 interface IEditorContextValue {
   readOnly: boolean

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -1,23 +1,49 @@
-import * as React from 'react'
+import type { IExecutionStep } from '@plumber/types'
 
-interface IEditorContext {
+import { createContext, ReactNode } from 'react'
+import { useQuery } from '@apollo/client'
+import { GET_TEST_EXECUTION_STEPS } from 'graphql/queries/get-test-execution-steps'
+
+interface IEditorContextValue {
   readOnly: boolean
+  testExecutionSteps: IExecutionStep[]
 }
 
-export const EditorContext = React.createContext<IEditorContext>({
+export const EditorContext = createContext<IEditorContextValue>({
   readOnly: false,
+  testExecutionSteps: [],
 })
 
 type EditorProviderProps = {
-  children: React.ReactNode
-  value: IEditorContext
+  children: ReactNode
+  readOnly: boolean
+  flowId: string
 }
 
-export const EditorProvider = (
-  props: EditorProviderProps,
-): React.ReactElement => {
-  const { children, value } = props
+export const EditorProvider = ({
+  readOnly,
+  flowId,
+  children,
+}: EditorProviderProps) => {
+  const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
+    GET_TEST_EXECUTION_STEPS,
+    {
+      variables: {
+        flowId,
+      },
+    },
+  )
+
+  const testExecutionSteps = data?.getTestExecutionSteps ?? []
+
   return (
-    <EditorContext.Provider value={value}>{children}</EditorContext.Provider>
+    <EditorContext.Provider
+      value={{
+        readOnly,
+        testExecutionSteps,
+      }}
+    >
+      {children}
+    </EditorContext.Provider>
   )
 }

--- a/packages/frontend/src/contexts/StepExecutions.tsx
+++ b/packages/frontend/src/contexts/StepExecutions.tsx
@@ -1,20 +1,22 @@
-import type { IStep } from '@plumber/types'
+import type { IExecutionStep } from '@plumber/types'
 
 import * as React from 'react'
 
-export const StepExecutionsContext = React.createContext<IStep[]>([])
+export const StepExecutionsContext = React.createContext<{
+  priorExecutionSteps: IExecutionStep[]
+}>({ priorExecutionSteps: [] })
 
 type StepExecutionsProviderProps = {
   children: React.ReactNode
-  value: IStep[]
+  priorExecutionSteps: IExecutionStep[]
 }
 
 export const StepExecutionsProvider = (
   props: StepExecutionsProviderProps,
 ): React.ReactElement => {
-  const { children, value } = props
+  const { children, priorExecutionSteps } = props
   return (
-    <StepExecutionsContext.Provider value={value}>
+    <StepExecutionsContext.Provider value={{ priorExecutionSteps }}>
       {children}
     </StepExecutionsContext.Provider>
   )

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -1,7 +1,7 @@
 import type {
   IDataOutMetadata,
   IDataOutMetadatum,
-  IStep,
+  IExecutionStep,
   TDataOutMetadatumType,
 } from '@plumber/types'
 
@@ -128,30 +128,32 @@ const process = (
   })
 }
 
-export function extractVariables(steps: IStep[]): StepWithVariables[] {
-  if (!steps) {
+export function extractVariables(
+  executionSteps: IExecutionStep[],
+): StepWithVariables[] {
+  if (!executionSteps) {
     return []
   }
-  return steps
-    .filter((step: IStep) => {
-      const hasExecutionSteps = !!step.executionSteps?.length
-      return hasExecutionSteps
+  return executionSteps
+    .filter((executionStep: IExecutionStep) => {
+      const hasDataOut = Object.keys(executionStep.dataOut ?? {}).length
+      return hasDataOut
     })
-    .map((step: IStep, index: number) => {
-      const metadata = step.executionSteps?.[0]?.dataOutMetadata ?? {}
+    .map((executionStep: IExecutionStep, index: number) => {
+      const metadata = executionStep.dataOutMetadata ?? {}
       const variables = process(
-        step.id,
-        step.executionSteps?.[0]?.dataOut || {},
+        executionStep.id,
+        executionStep.dataOut || {},
         metadata,
         '',
       )
       // sort variable by order key in-place
       sortVariables(variables)
       return {
-        id: step.id,
-        // TODO: replace with step.name once introduced
+        id: executionStep.stepId,
         name: `${index + 1}. ${
-          (step.appKey || '').charAt(0)?.toUpperCase() + step.appKey?.slice(1)
+          (executionStep.appKey || '').charAt(0)?.toUpperCase() +
+          executionStep.appKey?.slice(1)
         }`,
         output: variables,
       }

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -142,7 +142,7 @@ export function extractVariables(
     .map((executionStep: IExecutionStep, index: number) => {
       const metadata = executionStep.dataOutMetadata ?? {}
       const variables = process(
-        executionStep.id,
+        executionStep.stepId,
         executionStep.dataOut || {},
         metadata,
         '',


### PR DESCRIPTION
### TL;DR

Replaces the repeated lazy querying of execution test results with the new query 'GetTestExecutionSteps`. This also ensures the test variables are still present even after user exits the editor.

### What changed?

1. Removed repeated calls of the old query whenever an accordion is expanded
2. Calls the new `GetTestExecutionSteps` query in `EditorContext` for managing test step execution states.
3. Updated `FlowStep`, `TestResult`, `TestSubstep`, and other affected components to use `testExecutionSteps`.

### How to test?

1. Run the app
2. Navigate to a pre-tested pipe. 
3. Expand accordions to see test results / error details.

Note: refreshing of data upon re-test steps will be introduced in the next PR
