### PR TITLE
PLU-115: [SST-3] Refactor execute flow to not throw error

### DIFF
--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -23,15 +23,12 @@ const executeFlow: MutationResolvers['executeFlow'] = async (
 
   untilStep.executionSteps = [executionStep] // attach missing execution step into current step
 
-  if (executionStep.isFailed) {
-    throw new Error(JSON.stringify(executionStep.errorDetails))
+  if (!executionStep.isFailed) {
+    await untilStep.$query().patch({
+      status: 'completed',
+    })
   }
-
-  await untilStep.$query().patch({
-    status: 'completed',
-  })
-
-  return { data: executionStep.dataOut, step: untilStep }
+  return executionStep
 }
 
 export default executeFlow

--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -19,7 +19,14 @@ const executeFlow: MutationResolvers['executeFlow'] = async (
     throw new Error('Cannot test pipe that is currently published')
   }
 
-  const { executionStep } = await testRun({ stepId })
+  const { executionStep, executionId } = await testRun({ stepId })
+
+  /**
+   * Update flow to use the new test execution
+   */
+  await untilStep.flow.$query().patch({
+    testExecutionId: executionId,
+  })
 
   untilStep.executionSteps = [executionStep] // attach missing execution step into current step
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -70,7 +70,7 @@ type Mutation {
   updateFlow(input: UpdateFlowInput): Flow
   updateFlowStatus(input: UpdateFlowStatusInput): Flow
   updateFlowConfig(input: UpdateFlowConfigInput): Flow
-  executeFlow(input: ExecuteFlowInput): ExecuteFlowType
+  executeFlow(input: ExecuteFlowInput): ExecutionStep!
   deleteFlow(input: DeleteFlowInput): Boolean
   createStep(input: CreateStepInput): Step
   updateStep(input: UpdateStepInput): Step
@@ -279,11 +279,6 @@ type Connection {
 
 type ConnectionData {
   screenName: String
-}
-
-type ExecuteFlowType {
-  data: JSONObject
-  step: Step
 }
 
 type ExecutionStep {

--- a/packages/backend/src/services/test-run.ts
+++ b/packages/backend/src/services/test-run.ts
@@ -59,8 +59,10 @@ const testRun = async (options: TestRunOptions) => {
       testRun: true,
     })
 
+  // We store the last run executionStep to return
+  let executionStepToReturn = triggerExecutionStep
   if (triggerStep.id === untilStep.id) {
-    return { executionStep: triggerExecutionStep }
+    return { executionStep: executionStepToReturn, executionId }
   }
 
   // Actions may redirect steps. We keep track here so that we can let users
@@ -77,7 +79,9 @@ const testRun = async (options: TestRunOptions) => {
       })
 
     if (actionExecutionStep.isFailed || actionStep.id === untilStep.id) {
-      return { executionStep: actionExecutionStep }
+      // Store as test execution for easy retrieval later on
+      executionStepToReturn = actionExecutionStep
+      break
     }
 
     // Don't update next step ID if actionStep wouldn't have been run in real
@@ -87,9 +91,7 @@ const testRun = async (options: TestRunOptions) => {
     }
   }
 
-  await flow.$query().patch({
-    testExecutionId: executionId,
-  })
+  return { executionStep: executionStepToReturn, executionId }
 }
 
 export default testRun

--- a/packages/backend/src/services/test-run.ts
+++ b/packages/backend/src/services/test-run.ts
@@ -86,6 +86,10 @@ const testRun = async (options: TestRunOptions) => {
       nextStepId = nextStep?.id
     }
   }
+
+  await flow.$query().patch({
+    testExecutionId: executionId,
+  })
 }
 
 export default testRun

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -1,13 +1,14 @@
 import type {
   IAction,
   IBaseTrigger,
+  IJSONObject,
   IStep,
   ISubstep,
   ITrigger,
   ITriggerInstructions,
 } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { Box, Collapse } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
@@ -16,7 +17,9 @@ import ErrorResult from '@/components/ErrorResult'
 import FlowSubstepTitle from '@/components/FlowSubstepTitle'
 import WebhookUrlInfo from '@/components/WebhookUrlInfo'
 import { EditorContext } from '@/contexts/Editor'
+import { ExecutionStep } from '@/graphql/__generated__/graphql'
 import { EXECUTE_FLOW } from '@/graphql/mutations/execute-flow'
+import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import {
   extractVariables,
   filterVariables,
@@ -42,19 +45,6 @@ type TestSubstepProps = {
   selectedActionOrTrigger?: ITrigger | IAction
 }
 
-function serializeErrors(graphQLErrors: any) {
-  return graphQLErrors?.map((error: Record<string, unknown>) => {
-    try {
-      return {
-        ...error,
-        errorDetails: JSON.parse(error.message as string),
-      }
-    } catch {
-      return error
-    }
-  })
-}
-
 function TestSubstep(props: TestSubstepProps): JSX.Element {
   const {
     substep,
@@ -67,13 +57,49 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
   } = props
 
   const { readOnly, testExecutionSteps } = useContext(EditorContext)
-
-  const [executeFlow, { error, loading }] = useMutation(EXECUTE_FLOW, {
-    context: { autoSnackbar: false },
-  })
-
   const currentExecutionStep = testExecutionSteps.find(
     (executionStep) => executionStep.stepId === step.id,
+  )
+
+  /**
+   * Temporary state to store the last execution step error details,
+   * which could come from prior steps.
+   * To remove after single step testing is implemented
+   */
+  const [lastErrorDetails, setLastErrorDetails] = useState<
+    IJSONObject | undefined
+  >()
+
+  useEffect(() => {
+    setLastErrorDetails(currentExecutionStep?.errorDetails)
+  }, [currentExecutionStep])
+
+  const [executeFlow, { loading: isTestExecuting }] = useMutation(
+    EXECUTE_FLOW,
+    {
+      context: { autoSnackbar: false },
+      awaitRefetchQueries: true,
+      refetchQueries: [GET_TEST_EXECUTION_STEPS],
+      update(cache, { data }) {
+        // If last execution step is successful, it means the test run is successful
+        // Update the step status to completed without refreshing
+        const lastExecutionStep: ExecutionStep = data?.executeFlow
+        if (lastExecutionStep.status === 'success') {
+          const stepCache = cache.identify({
+            __typename: 'Step',
+            id: step.id,
+          })
+          cache.modify({
+            id: stepCache,
+            fields: {
+              status: () => 'completed',
+            },
+          })
+        } else {
+          setLastErrorDetails(lastExecutionStep.errorDetails ?? undefined)
+        }
+      },
+    },
   )
 
   const testVariables = useMemo(() => {
@@ -132,26 +158,16 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
               sx={{ mb: 2 }}
             />
           )}
-
-          {!!error?.graphQLErrors?.length && (
+          {lastErrorDetails ? (
             <Box w="100%">
-              {serializeErrors(error.graphQLErrors).map(
-                (error: any, index: number) => (
-                  <ErrorResult
-                    key={index}
-                    errorDetails={error.errorDetails}
-                    isTestRun={true}
-                  />
-                ),
-              )}
+              <ErrorResult errorDetails={lastErrorDetails} isTestRun={true} />
             </Box>
-          )}
-          {isTestSuccessful && (
+          ) : (
             <TestResult
               step={step}
               selectedActionOrTrigger={selectedActionOrTrigger}
               variables={testVariables}
-              isMock={currentExecutionStep.metadata?.isMock}
+              isMock={currentExecutionStep?.metadata?.isMock}
             />
           )}
 
@@ -160,7 +176,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
             variant={isTestSuccessful ? 'clear' : 'solid'}
             onClick={executeTestFlow}
             mt={2}
-            isLoading={loading}
+            isLoading={isTestExecuting}
             isDisabled={readOnly}
             data-test="flow-substep-continue-button"
           >
@@ -171,7 +187,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
               isFullWidth
               onClick={onContinueClick}
               mt={2}
-              isLoading={loading}
+              isLoading={isTestExecuting}
               isDisabled={readOnly}
               data-test="flow-substep-continue-button"
             >

--- a/packages/frontend/src/graphql/mutations/execute-flow.ts
+++ b/packages/frontend/src/graphql/mutations/execute-flow.ts
@@ -3,23 +3,17 @@ import { gql } from '@apollo/client'
 export const EXECUTE_FLOW = gql`
   mutation ExecuteFlow($input: ExecuteFlowInput) {
     executeFlow(input: $input) {
+      id
+      executionId
+      status
+      dataOut
+      dataOutMetadata
+      errorDetails
+      stepId
       step {
         id
         status
-        appKey
-        executionSteps {
-          id
-          executionId
-          stepId
-          status
-          dataOut
-          dataOutMetadata
-          metadata {
-            isMock
-          }
-        }
       }
-      data
     }
   }
 `


### PR DESCRIPTION
# TLDR;
This PR refactors the current execute flow mutation, both frontend and backend.

### Backend Changes:
1. Refactored `executeFlow` mutation to return `ExecutionStep` directly instead of `Step` and `dataOut`
2. `executeFlow` no longer returns the error by throwing. It now returns the last execution step ran together with the error details.
3. Modified `testRun` service to patch `testExecutionId` into the flow after processing all steps.

### Frontend Changes:
1. Updated `EXECUTE_FLOW` mutation to align with backend changes, refetching GET_TEST_EXECUTION_STEPS on complete.
2. Removed the `serializeErrors` function and using `errorDetails` directly.
3. Enhanced cache update logic in `TestSubstep` component to set the step status to 'completed' if the last execution step is successful, without refetching the entire flow.
4. Stores the last execution step error details in a state to display temporarily since the errorDetails could come from previous steps. (this is temporary since it would only test current step after all implementation is completed)

### To test
1. Click `Test Run`, the new variables should appear accordingly.
2. If the step was not tested, it should reflect tested after running test run.
3. If previous step failed, it should show the previous step error temporarily.
4. If current step failed, it should show the current step error even after refreshing.

