### PR TITLE
PLU-241: [name-your-pipe-1]: add create flow modal and flow for empty flows

### DIFF
--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -5,11 +5,13 @@ const createFlow: MutationResolvers['createFlow'] = async (
   params,
   context,
 ) => {
+  // TODO: remove connection id and app key in the next PR
   const connectionId = params?.input?.connectionId
   const appKey = params?.input?.triggerAppKey
+  const flowName = params?.input?.flowName ?? 'Name your pipe'
 
   const flow = await context.currentUser.$relatedQuery('flows').insert({
-    name: 'Name your pipe',
+    name: flowName,
   })
 
   if (connectionId) {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -414,6 +414,7 @@ input RegisterConnectionInput {
 input CreateFlowInput {
   triggerAppKey: String
   connectionId: String
+  flowName: String
 }
 
 input CreateTemplatedFlowInput {

--- a/packages/frontend/src/components/EmptyFlows/index.tsx
+++ b/packages/frontend/src/components/EmptyFlows/index.tsx
@@ -43,7 +43,11 @@ interface EmptyFlowsProps {
 export default function EmptyFlows(props: EmptyFlowsProps) {
   const { count } = props
   // for creation of flows
-  const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isCreateFlowModalOpen,
+    onOpen: onCreateFlowModalOpen,
+    onClose: onCreateFlowModalClose,
+  } = useDisclosure()
 
   return (
     <>
@@ -88,12 +92,14 @@ export default function EmptyFlows(props: EmptyFlowsProps) {
             </Box>
           </AbsoluteCenter>
         </Box>
-        <Button w="100%" onClick={onOpen}>
+        <Button w="100%" onClick={onCreateFlowModalOpen}>
           Create my own pipe
         </Button>
       </Box>
 
-      {isOpen && <CreateFlowModal onClose={onClose} />}
+      {isCreateFlowModalOpen && (
+        <CreateFlowModal onClose={onCreateFlowModalClose} />
+      )}
     </>
   )
 }

--- a/packages/frontend/src/components/EmptyFlows/index.tsx
+++ b/packages/frontend/src/components/EmptyFlows/index.tsx
@@ -1,7 +1,6 @@
 import { BiWinkSmile } from 'react-icons/bi'
 import {
   AbsoluteCenter,
-  As,
   Box,
   Divider,
   Flex,
@@ -9,11 +8,13 @@ import {
   Hide,
   Icon,
   Text,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
 import NavigationDrawer from '@/components/Layout/NavigationDrawer'
 import ApproveTransfersInfobox from '@/pages/Flows/components/ApproveTransfersInfobox'
+import CreateFlowModal from '@/pages/Flows/components/CreateFlowModal'
 
 import FlowTemplate, { FlowTemplateProps } from './FlowTemplate'
 
@@ -36,57 +37,63 @@ const flowTemplates: FlowTemplateProps[] = [
 ]
 
 interface EmptyFlowsProps {
-  CreateFlowLink: As
   count?: number
 }
 
 export default function EmptyFlows(props: EmptyFlowsProps) {
-  const { CreateFlowLink, count } = props
-  return (
-    <Box px="10vw" py="10vh">
-      {count === undefined || count === 0 ? (
-        <></>
-      ) : (
-        <ApproveTransfersInfobox count={count} />
-      )}
+  const { count } = props
+  // for creation of flows
+  const { isOpen, onOpen, onClose } = useDisclosure()
 
-      <Flex>
-        <Hide above="sm">
-          <Box mt={-1.5}>
-            <NavigationDrawer />
-          </Box>
-        </Hide>
-        <Text textStyle="h4" display="inline">
-          {`You don't have any pipes, see what others are creating`}{' '}
-          <Icon
-            as={BiWinkSmile}
-            verticalAlign="middle"
-            color="primary.500"
-            boxSize={8}
-          />
-        </Text>
-      </Flex>
-      <Grid mt={4} gridTemplateColumns="repeat(3, 1fr)" gap={4}>
-        {flowTemplates.map(({ title, description, link }, index) => (
-          <FlowTemplate
-            key={index}
-            title={title}
-            description={description}
-            link={link}
-          />
-        ))}
-      </Grid>
-      <Box position="relative" my={8}>
-        <Divider />
-        <AbsoluteCenter>
-          <Box bg="white" p={3}>
-            <Text textStyle="subhead-1">OR</Text>
-          </Box>
-        </AbsoluteCenter>
+  return (
+    <>
+      <Box px="10vw" py="10vh">
+        {count === undefined || count === 0 ? (
+          <></>
+        ) : (
+          <ApproveTransfersInfobox count={count} />
+        )}
+
+        <Flex>
+          <Hide above="sm">
+            <Box mt={-1.5}>
+              <NavigationDrawer />
+            </Box>
+          </Hide>
+          <Text textStyle="h4" display="inline">
+            {`You don't have any pipes, see what others are creating`}{' '}
+            <Icon
+              as={BiWinkSmile}
+              verticalAlign="middle"
+              color="primary.500"
+              boxSize={8}
+            />
+          </Text>
+        </Flex>
+        <Grid mt={4} gridTemplateColumns="repeat(3, 1fr)" gap={4}>
+          {flowTemplates.map(({ title, description, link }, index) => (
+            <FlowTemplate
+              key={index}
+              title={title}
+              description={description}
+              link={link}
+            />
+          ))}
+        </Grid>
+        <Box position="relative" my={8}>
+          <Divider />
+          <AbsoluteCenter>
+            <Box bg="white" p={3}>
+              <Text textStyle="subhead-1">OR</Text>
+            </Box>
+          </AbsoluteCenter>
+        </Box>
+        <Button w="100%" onClick={onOpen}>
+          Create my own pipe
+        </Button>
       </Box>
-      <Button w="100%" as={CreateFlowLink}>
-        Create my own pipe
-      </Button>
-    </Box>
+
+      {isOpen && <CreateFlowModal onClose={onClose} />}
+    </>
   )
 }

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -63,6 +63,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
                 placeholder="For e.g. track event feedback, send customised replies"
                 value={flowName}
                 onChange={(event) => setFlowName(event.target.value)}
+                required
               />
             </Flex>
             <Infobox icon={<BiBulb />} variant="primary">
@@ -87,7 +88,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
 
         <ModalFooter>
           <Button
-            isDisabled={flowName === ''}
+            isDisabled={flowName.trim() === ''}
             isLoading={loading}
             onClick={onCreateFlow}
           >

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useState } from 'react'
+import { BiBulb } from 'react-icons/bi'
+import { useNavigate } from 'react-router-dom'
+import { useMutation } from '@apollo/client'
+import {
+  chakra,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+import { Button, Infobox, Input, Link } from '@opengovsg/design-system-react'
+
+import MarkdownRenderer from '@/components/MarkdownRenderer'
+import * as URLS from '@/config/urls'
+import { CREATE_FLOW } from '@/graphql/mutations/create-flow'
+
+interface CreateFlowModalProps {
+  onClose: () => void
+}
+
+export default function CreateFlowModal(props: CreateFlowModalProps) {
+  const { onClose } = props
+  const [flowName, setFlowName] = useState('')
+  const navigate = useNavigate()
+  const [createFlow, { loading }] = useMutation(CREATE_FLOW)
+
+  const onCreateFlow = useCallback(async () => {
+    const response = await createFlow({
+      variables: {
+        input: {
+          flowName,
+        },
+      },
+    })
+    navigate(URLS.FLOW_EDITOR(response.data?.createFlow?.id), { replace: true })
+  }, [createFlow, flowName, navigate])
+
+  return (
+    <Modal
+      isOpen={true}
+      onClose={onClose}
+      motionPreset="none"
+      closeOnEsc={false}
+      isCentered
+    >
+      <ModalOverlay bg="base.canvas.overlay" />
+      <ModalContent>
+        <ModalHeader p="2.5rem 2rem 1.5rem">
+          <Text textStyle="h4">Create Pipe</Text>
+        </ModalHeader>
+
+        <ModalBody>
+          <Flex flexDir="column" rowGap={4}>
+            <Flex flexDir="column" rowGap={2}>
+              <Text textStyle="subhead-1">Name your pipe</Text>
+              <Input
+                placeholder="For e.g. track event feedback, send customised replies"
+                value={flowName}
+                onChange={(event) => setFlowName(event.target.value)}
+              />
+            </Flex>
+            <Infobox icon={<BiBulb />} variant="primary">
+              <MarkdownRenderer
+                source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
+                components={{
+                  a: ({ ...props }) => (
+                    <Link
+                      isExternal
+                      color="interaction.links.neutral-default"
+                      _hover={{ color: 'interaction.links.neutral-hover' }}
+                      {...props}
+                    />
+                  ),
+                  p: ({ ...props }) => <chakra.p {...props} />,
+                }}
+              />
+            </Infobox>
+          </Flex>
+        </ModalBody>
+        <ModalCloseButton mt={3} />
+
+        <ModalFooter>
+          <Button
+            isDisabled={flowName === ''}
+            isLoading={loading}
+            onClick={onCreateFlow}
+          >
+            Create
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -119,7 +119,6 @@ export default function Flows(): React.ReactElement {
   if (!loading && !hasFlows && flowName === '' && page === 1) {
     return (
       <EmptyFlowsTemplate
-        CreateFlowLink={CreateFlowLink}
         count={flowTransfersLoading ? 0 : flowTransfers.length}
       />
     )

--- a/packages/frontend/src/theme/components/Infobox.ts
+++ b/packages/frontend/src/theme/components/Infobox.ts
@@ -1,5 +1,14 @@
 export const Infobox = {
   variants: {
+    primary: {
+      messagebox: {
+        bg: 'primary.100',
+        borderRadius: '0.25rem',
+      },
+      icon: {
+        color: 'primary.500',
+      },
+    },
     warning: {
       icon: {
         color: 'yellow.200',


### PR DESCRIPTION
## Problem
We have too many "name your pipe" pipes and it is hard for us to tell what the user is doing at one glance, so we should make the user name their pipe so that it is easier for them to track their own pipes as well.

## Details
This PR focuses on creating the flow modal and allowing it to be activated only in the `EmptyFlows` template (when user has no pipes)
- The `editor/create` route will be deleted in the next PR.

Frontend:
- Add the modal to empty flows, create new pipe button
- Modified `Infobox`

Backend:
- Add new `flowName` to the `create-flow` graphQL mutation

## Tests
- [x] Create pipe modal appears only when user has no flows and clicks on the create pipe button
- [x] Pipe can be created and named accordingly upon clicking on the create button
- [x] Pipes still can be renamed