### PR TITLE
chore: modify input for create flow modal

### DIFF
--- a/packages/backend/src/graphql/mutations/create-flow.ts
+++ b/packages/backend/src/graphql/mutations/create-flow.ts
@@ -5,13 +5,13 @@ const createFlow: MutationResolvers['createFlow'] = async (
   params,
   context,
 ) => {
-  const { flowName } = params.input
-  if (flowName.trim() === '') {
+  const trimmedFlowName = params.input.flowName.trim()
+  if (trimmedFlowName === '') {
     throw new Error('Pipe name needs to have at least 1 character.')
   }
 
   const flow = await context.currentUser.$relatedQuery('flows').insert({
-    name: flowName,
+    name: trimmedFlowName,
   })
 
   await flow.$relatedQuery('steps').insert([

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -85,16 +85,16 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
     >
       <ModalOverlay bg="base.canvas.overlay" />
       <Form onSubmit={handleSubmit}>
-        <FormControl isRequired>
-          <ModalContent>
-            <ModalHeader p="2.5rem 2rem 1.5rem">
-              <Text textStyle="h4">Create Pipe</Text>
-            </ModalHeader>
+        <ModalContent>
+          <ModalHeader p="2.5rem 2rem 1.5rem">
+            <Text textStyle="h4">Create Pipe</Text>
+          </ModalHeader>
 
-            <ModalBody>
-              <Flex flexDir="column" rowGap={4}>
-                {/* Specific form items */}
-                <Flex flexDir="column">
+          <ModalBody>
+            <Flex flexDir="column" rowGap={4}>
+              {/* Specific form items */}
+              <Flex flexDir="column">
+                <FormControl isRequired>
                   <FormLabel textStyle="subhead-1">Name your pipe</FormLabel>
                   <Input
                     ref={inputRef}
@@ -102,39 +102,39 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
                     onChange={handleInputChange}
                     required
                   />
-                </Flex>
-
-                <Infobox icon={<BiBulb />} variant="primary">
-                  <MarkdownRenderer
-                    source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
-                    components={{
-                      a: ({ ...props }) => (
-                        <Link
-                          isExternal
-                          color="interaction.links.neutral-default"
-                          _hover={{ color: 'interaction.links.neutral-hover' }}
-                          {...props}
-                        />
-                      ),
-                      p: ({ ...props }) => <chakra.p {...props} />,
-                    }}
-                  />
-                </Infobox>
+                </FormControl>
               </Flex>
-            </ModalBody>
-            <ModalCloseButton mt={3} />
 
-            <ModalFooter>
-              <Button
-                type="submit"
-                isDisabled={isButtonDisabled}
-                isLoading={loading}
-              >
-                Create
-              </Button>
-            </ModalFooter>
-          </ModalContent>
-        </FormControl>
+              <Infobox icon={<BiBulb />} variant="primary">
+                <MarkdownRenderer
+                  source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
+                  components={{
+                    a: ({ ...props }) => (
+                      <Link
+                        isExternal
+                        color="interaction.links.neutral-default"
+                        _hover={{ color: 'interaction.links.neutral-hover' }}
+                        {...props}
+                      />
+                    ),
+                    p: ({ ...props }) => <chakra.p {...props} />,
+                  }}
+                />
+              </Infobox>
+            </Flex>
+          </ModalBody>
+          <ModalCloseButton mt={3} />
+
+          <ModalFooter>
+            <Button
+              type="submit"
+              isDisabled={isButtonDisabled}
+              isLoading={loading}
+            >
+              Create
+            </Button>
+          </ModalFooter>
+        </ModalContent>
       </Form>
     </Modal>
   )

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState } from 'react'
+import { FormEvent, useCallback, useRef, useState } from 'react'
 import { BiBulb } from 'react-icons/bi'
-import { useNavigate } from 'react-router-dom'
+import { Form, useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
   chakra,
   Flex,
+  FormControl,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -14,7 +15,13 @@ import {
   ModalOverlay,
   Text,
 } from '@chakra-ui/react'
-import { Button, Infobox, Input, Link } from '@opengovsg/design-system-react'
+import {
+  Button,
+  FormLabel,
+  Infobox,
+  Input,
+  Link,
+} from '@opengovsg/design-system-react'
 
 import MarkdownRenderer from '@/components/MarkdownRenderer'
 import * as URLS from '@/config/urls'
@@ -26,20 +33,47 @@ interface CreateFlowModalProps {
 
 export default function CreateFlowModal(props: CreateFlowModalProps) {
   const { onClose } = props
-  const [flowName, setFlowName] = useState('')
   const navigate = useNavigate()
   const [createFlow, { loading }] = useMutation(CREATE_FLOW)
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true)
+  const inputRef = useRef<HTMLInputElement>(null)
 
-  const onCreateFlow = useCallback(async () => {
-    const response = await createFlow({
-      variables: {
-        input: {
-          flowName,
+  // to minimise the re-renders to the max, didn't use react hook form cus overkill
+  const handleInputChange = () => {
+    const trimmedInputValue = inputRef.current?.value.trim() || ''
+    if (trimmedInputValue !== '') {
+      if (isButtonDisabled) {
+        setIsButtonDisabled(false)
+      }
+    } else {
+      if (!isButtonDisabled) {
+        setIsButtonDisabled(true)
+      }
+    }
+  }
+
+  const onCreateFlow = useCallback(
+    async (flowName: string) => {
+      const response = await createFlow({
+        variables: {
+          input: {
+            flowName,
+          },
         },
-      },
-    })
-    navigate(URLS.FLOW_EDITOR(response.data?.createFlow?.id), { replace: true })
-  }, [createFlow, flowName, navigate])
+      })
+      navigate(URLS.FLOW_EDITOR(response.data?.createFlow?.id), {
+        replace: true,
+      })
+    },
+    [createFlow, navigate],
+  )
+
+  const handleSubmit = (_event: FormEvent<HTMLFormElement>) => {
+    const trimmedFlowName = inputRef.current?.value.trim()
+    if (trimmedFlowName) {
+      onCreateFlow(trimmedFlowName)
+    }
+  }
 
   return (
     <Modal
@@ -50,52 +84,58 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
       isCentered
     >
       <ModalOverlay bg="base.canvas.overlay" />
-      <ModalContent>
-        <ModalHeader p="2.5rem 2rem 1.5rem">
-          <Text textStyle="h4">Create Pipe</Text>
-        </ModalHeader>
+      <Form onSubmit={handleSubmit}>
+        <FormControl isRequired>
+          <ModalContent>
+            <ModalHeader p="2.5rem 2rem 1.5rem">
+              <Text textStyle="h4">Create Pipe</Text>
+            </ModalHeader>
 
-        <ModalBody>
-          <Flex flexDir="column" rowGap={4}>
-            <Flex flexDir="column" rowGap={2}>
-              <Text textStyle="subhead-1">Name your pipe</Text>
-              <Input
-                placeholder="For e.g. track event feedback, send customised replies"
-                value={flowName}
-                onChange={(event) => setFlowName(event.target.value)}
-                required
-              />
-            </Flex>
-            <Infobox icon={<BiBulb />} variant="primary">
-              <MarkdownRenderer
-                source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
-                components={{
-                  a: ({ ...props }) => (
-                    <Link
-                      isExternal
-                      color="interaction.links.neutral-default"
-                      _hover={{ color: 'interaction.links.neutral-hover' }}
-                      {...props}
-                    />
-                  ),
-                  p: ({ ...props }) => <chakra.p {...props} />,
-                }}
-              />
-            </Infobox>
-          </Flex>
-        </ModalBody>
-        <ModalCloseButton mt={3} />
+            <ModalBody>
+              <Flex flexDir="column" rowGap={4}>
+                {/* Specific form items */}
+                <Flex flexDir="column">
+                  <FormLabel textStyle="subhead-1">Name your pipe</FormLabel>
+                  <Input
+                    ref={inputRef}
+                    placeholder="For e.g. track event feedback, send customised replies"
+                    onChange={handleInputChange}
+                    required
+                  />
+                </Flex>
 
-        <ModalFooter>
-          <Button
-            isDisabled={flowName.trim() === ''}
-            isLoading={loading}
-            onClick={onCreateFlow}
-          >
-            Create
-          </Button>
-        </ModalFooter>
-      </ModalContent>
+                <Infobox icon={<BiBulb />} variant="primary">
+                  <MarkdownRenderer
+                    source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
+                    components={{
+                      a: ({ ...props }) => (
+                        <Link
+                          isExternal
+                          color="interaction.links.neutral-default"
+                          _hover={{ color: 'interaction.links.neutral-hover' }}
+                          {...props}
+                        />
+                      ),
+                      p: ({ ...props }) => <chakra.p {...props} />,
+                    }}
+                  />
+                </Infobox>
+              </Flex>
+            </ModalBody>
+            <ModalCloseButton mt={3} />
+
+            <ModalFooter>
+              <Button
+                type="submit"
+                isDisabled={isButtonDisabled}
+                isLoading={loading}
+              >
+                Create
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </FormControl>
+      </Form>
     </Modal>
   )
 }


### PR DESCRIPTION
## Problem

Cannot press enter to create pipe for modal because it is a button with `onClick`

## Solution

- Use a `Form` and `<Button type="submit">` instead and make it uncontrolled to avoid unnecessary re-renders.
- Also trimmed the flow name on the backend if a user tries to manually call the graphql mutation...

## Tests
- [x] Pipe cannot be created if it is empty after trimming the input
- [x] Pipe can still be created with the correct flow name (and using enter button)
- [x] Pipe still works after creating and testing a workflow