### PR TITLE
chore: modify blacklisted email error message

### DIFF
--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -46,7 +46,7 @@ export async function sendEmail({
       if (errorMsg.includes('blacklisted')) {
         logger.info('Blacklisted email', { email: recipient })
         errorMsg =
-          'Your email may be blocked. Contact us at support@open.gov.sg'
+          'Your email may be blocked. Contact us at support@plumber.gov.sg'
       }
     }
     throw new Error(errorMsg)


### PR DESCRIPTION
## Problem

Wrong email `support@open.gov.sg` is being displayed to blacklisted users when they try to login
![image (1)](https://github.com/user-attachments/assets/727d0977-c8ef-4072-8a39-2941a5c8389b)
