### PR TITLE
fix: add back route for add connections

### DIFF
--- a/packages/frontend/src/pages/Application/index.tsx
+++ b/packages/frontend/src/pages/Application/index.tsx
@@ -143,6 +143,13 @@ export default function Application(): React.ReactElement | null {
 
       <Routes>
         <Route
+          path="/connections/add"
+          element={
+            <AddAppConnection onClose={goToApplicationPage} application={app} />
+          }
+        />
+
+        <Route
           path="/connections/:connectionId/reconnect"
           element={
             <ReconnectConnection


### PR DESCRIPTION
## Problem

Users cannot add slack connections because the add connections functionality got removed.

## Solution

Instead of reverting this entire [commit](https://github.com/opengovsg/plumber/pull/683) , add back the route only instead

## Tests
- [x] Connections can still be added from the apps page only using the route: `apps/connections/add`
- [x] Can create slack connection
- [x] Existing slack connections still work
- [x] Other connections e.g. formSG, telegram still work