### PR TITLE
chore: remove duplicate demovideodetails from graphql

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -224,11 +224,6 @@ type DemoVideoDetails {
   title: String!
 }
 
-type DemoVideoDetails {
-  url: String!
-  title: String!
-}
-
 type StepLabel {
   connectionStepLabel: String
   settingsStepLabel: String


### PR DESCRIPTION
# Problem
The `DemoVideoDetails` type in our GraphQL schema is duplicated. This actually makes our schema invalid.

# Solution
Remove the duplicate `DemoVideoDetails` definition.

# Tests
- [x] Regression test: check that demo video still works.