### PR TITLE
fix: add backend check to prevent test runs for published pipes

### DIFF
--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -11,8 +11,13 @@ const executeFlow: MutationResolvers['executeFlow'] = async (
 
   const untilStep = await context.currentUser
     .$relatedQuery('steps')
+    .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()
+
+  if (untilStep.flow.active) {
+    throw new Error('Cannot test pipe that is currently published')
+  }
 
   const { executionStep } = await testRun({ stepId })
 


### PR DESCRIPTION
## Problem

Users can still test run (by bypassing frontend) published pipes (only if trigger is scheduler).

## Solution

Check if pipe is active before allow executeFlow to run