### PR TITLE
PLU-115: [SST-4] More refactors and unit tests

### DIFF
--- a/packages/backend/src/graphql/mutations/execute-flow.ts
+++ b/packages/backend/src/graphql/mutations/execute-flow.ts
@@ -19,13 +19,18 @@ const executeFlow: MutationResolvers['executeFlow'] = async (
     throw new Error('Cannot test pipe that is currently published')
   }
 
-  const { executionStep, executionId } = await testRun({ stepId })
+  const { executionStep } = await testRun({ stepId })
 
   /**
-   * Update flow to use the new test execution
+   * We need to unset the test execution id for execute flow because
+   * the test run might not have tested all completed steps.
+   * Need to account for the case where we release Single Step Testing then rollback
+   * to test till step. In that case, we should unset test execution id to ensure we
+   * we fetch the latest test execution steps (including test till step) after we
+   * roll forward again
    */
   await untilStep.flow.$query().patch({
-    testExecutionId: executionId,
+    testExecutionId: null,
   })
 
   untilStep.executionSteps = [executionStep] // attach missing execution step into current step

--- a/packages/backend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-test-execution-steps.ts
@@ -1,6 +1,4 @@
-import { raw } from 'objection'
-
-import ExecutionStep from '@/models/execution-step'
+import { getTestExecutionSteps as getTestExecutionStepsHelper } from '@/helpers/get-test-execution-steps'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -9,53 +7,13 @@ const getTestExecutionSteps: QueryResolvers['getTestExecutionSteps'] = async (
   params,
   context,
 ) => {
+  // For checking if flow belongs to the user
   const flow = await context.currentUser
     .$relatedQuery('flows')
     .findById(params.flowId)
-    .withGraphFetched({
-      testExecution: {
-        executionSteps: {
-          step: true,
-        },
-      },
-      steps: true,
-    })
     .throwIfNotFound()
 
-  if (flow.testExecution) {
-    return flow.testExecution.executionSteps
-  }
-
-  /**
-   * If test execution id does not exist, we fetch the last execution steps for each step
-   */
-  const latestExecutionSteps = await ExecutionStep.query()
-    .with('latest_execution_steps', (builder) => {
-      builder
-        .select(
-          '*',
-          raw(
-            'ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY execution_steps.created_at DESC) as rn',
-          ),
-        )
-        .from('execution_steps')
-        .whereIn(
-          'step_id',
-          flow.steps.map((step) => step.id),
-        )
-    })
-    .select('*')
-    .from('latest_execution_steps')
-    .withGraphFetched({
-      step: true,
-    })
-    .where('rn', '=', 1)
-    .withSoftDeleted() // because this adds a 'execution_steps.deleted_at' column to the query instead of latest_execution_steps
-
-  // sort by step position
-  latestExecutionSteps.sort((a, b) => a.step.position - b.step.position)
-
-  return latestExecutionSteps
+  return getTestExecutionStepsHelper(flow.id)
 }
 
 export default getTestExecutionSteps

--- a/packages/backend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-test-execution-steps.ts
@@ -7,13 +7,14 @@ const getTestExecutionSteps: QueryResolvers['getTestExecutionSteps'] = async (
   params,
   context,
 ) => {
+  const { flowId, ignoreTestExecutionId } = params
   // For checking if flow belongs to the user
   const flow = await context.currentUser
     .$relatedQuery('flows')
-    .findById(params.flowId)
+    .findById(flowId)
     .throwIfNotFound()
 
-  return getTestExecutionStepsHelper(flow.id)
+  return getTestExecutionStepsHelper(flow.id, ignoreTestExecutionId)
 }
 
 export default getTestExecutionSteps

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -16,7 +16,7 @@ type Query {
     name: String
   ): FlowConnection
   getStepWithTestExecutions(stepId: String!): [Step] @deprecated(reason: "Use getTestExecution instead")
-  getTestExecutionSteps(flowId: String!): [ExecutionStep]
+  getTestExecutionSteps(flowId: String!, ignoreTestExecutionId: Boolean): [ExecutionStep]
   getExecution(executionId: String!): Execution
   getExecutions(
     limit: Int!

--- a/packages/backend/src/helpers/__tests__/get-test-execution-steps.itest.ts
+++ b/packages/backend/src/helpers/__tests__/get-test-execution-steps.itest.ts
@@ -61,136 +61,204 @@ describe('get test execution steps', () => {
     })
   })
 
-  it('should return test execution steps if there is only 1 test execution', async () => {
-    const testExecutionSteps = await getTestExecutionSteps(flow.id)
-    expect(testExecutionSteps).to.toHaveLength(3)
-    expect(testExecutionSteps.map((step) => step.id)).toEqual([
-      testExecution1.executionSteps[0].id,
-      testExecution1.executionSteps[1].id,
-      testExecution1.executionSteps[2].id,
-    ])
-  })
-
-  it('should return the most recent test execution steps across exections', async () => {
-    const testExecution2 = await Execution.query().insertGraphAndFetch({
-      flowId: flow.id,
-      testRun: true,
-      executionSteps: [
-        {
-          stepId: flow.steps[0].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-        {
-          stepId: flow.steps[1].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-      ],
+  describe('when test execution id is not set', () => {
+    it('should return test execution steps if there is only 1 test execution', async () => {
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution1.executionSteps[0].id,
+        testExecution1.executionSteps[1].id,
+        testExecution1.executionSteps[2].id,
+      ])
     })
-    const testExecutionSteps = await getTestExecutionSteps(flow.id)
-    expect(testExecutionSteps).to.toHaveLength(3)
-    expect(testExecutionSteps.map((step) => step.id)).toEqual([
-      testExecution2.executionSteps[0].id,
-      testExecution2.executionSteps[1].id,
-      testExecution1.executionSteps[2].id,
-    ])
-  })
 
-  it('should not return real executions even if they are more recent', async () => {
-    await Execution.query().insertGraphAndFetch({
-      flowId: flow.id,
-      testRun: false, // real execution
-      executionSteps: [
-        {
-          stepId: flow.steps[0].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-        {
-          stepId: flow.steps[1].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-        {
-          stepId: flow.steps[2].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-      ],
-    })
-    const testExecutionSteps = await getTestExecutionSteps(flow.id)
-    expect(testExecutionSteps).to.toHaveLength(3)
-    expect(testExecutionSteps.map((step) => step.id)).toEqual([
-      testExecution1.executionSteps[0].id,
-      testExecution1.executionSteps[1].id,
-      testExecution1.executionSteps[2].id,
-    ])
-  })
-
-  it('should return the most recent execution steps if there are more than 1 execution step for a step', async () => {
-    const testExecution2 = await Execution.query().insertGraphAndFetch({
-      flowId: flow.id,
-      testRun: true,
-      executionSteps: [
-        {
-          stepId: flow.steps[0].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-        {
-          stepId: flow.steps[1].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-      ],
-    })
-    const latestExecutionStep = await testExecution2
-      .$relatedQuery('executionSteps')
-      .insertAndFetch({
-        stepId: flow.steps[1].id,
-        status: 'success',
-        dataOut: { someData: 'data' },
+    it('should return the most recent test execution steps across exections', async () => {
+      const testExecution2 = await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: true,
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
       })
-    const testExecutionSteps = await getTestExecutionSteps(flow.id)
-    expect(testExecutionSteps).to.toHaveLength(3)
-    expect(testExecutionSteps.map((step) => step.id)).toEqual([
-      testExecution2.executionSteps[0].id,
-      latestExecutionStep.id,
-      testExecution1.executionSteps[2].id,
-    ])
-  })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution2.executionSteps[0].id,
+        testExecution2.executionSteps[1].id,
+        testExecution1.executionSteps[2].id,
+      ])
+    })
 
-  it('should return failed executiosn as well', async () => {
-    const testExecution2 = await Execution.query().insertGraphAndFetch({
-      flowId: flow.id,
-      testRun: true,
-      executionSteps: [
-        {
-          stepId: flow.steps[0].id,
-          status: 'success',
-          dataOut: { someData: 'data' },
-        },
-        {
+    it('should not return real executions even if they are more recent', async () => {
+      await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: false, // real execution
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[2].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
+      })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution1.executionSteps[0].id,
+        testExecution1.executionSteps[1].id,
+        testExecution1.executionSteps[2].id,
+      ])
+    })
+
+    it('should return the most recent execution steps if there are more than 1 execution step for a step', async () => {
+      const testExecution2 = await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: true,
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
+      })
+      const latestExecutionStep = await testExecution2
+        .$relatedQuery('executionSteps')
+        .insertAndFetch({
           stepId: flow.steps[1].id,
           status: 'success',
           dataOut: { someData: 'data' },
-        },
-      ],
+        })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution2.executionSteps[0].id,
+        latestExecutionStep.id,
+        testExecution1.executionSteps[2].id,
+      ])
     })
-    const latestExecutionStep = await testExecution2
-      .$relatedQuery('executionSteps')
-      .insertAndFetch({
-        stepId: flow.steps[1].id,
-        status: 'failure',
-        dataOut: { someData: 'data' },
+
+    it('should return failed executiosn as well', async () => {
+      const testExecution2 = await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: true,
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
       })
-    const testExecutionSteps = await getTestExecutionSteps(flow.id)
-    expect(testExecutionSteps).to.toHaveLength(3)
-    expect(testExecutionSteps.map((step) => step.id)).toEqual([
-      testExecution2.executionSteps[0].id,
-      latestExecutionStep.id,
-      testExecution1.executionSteps[2].id,
-    ])
+      const latestExecutionStep = await testExecution2
+        .$relatedQuery('executionSteps')
+        .insertAndFetch({
+          stepId: flow.steps[1].id,
+          status: 'failure',
+          dataOut: { someData: 'data' },
+        })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution2.executionSteps[0].id,
+        latestExecutionStep.id,
+        testExecution1.executionSteps[2].id,
+      ])
+    })
+  })
+
+  describe('when test execution id is set', () => {
+    it('should return test execution steps for the given test execution id', async () => {
+      const testExecution2 = await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: true,
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
+      })
+      // If set to test execution 1, it will return 3 exec steps
+      await flow.$query().patch({ testExecutionId: testExecution1.id })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution1.executionSteps[0].id,
+        testExecution1.executionSteps[1].id,
+        testExecution1.executionSteps[2].id,
+      ])
+
+      // If set to test execution 2, it will return 2 exec steps
+      await flow.$query().patch({ testExecutionId: testExecution2.id })
+      const testExecutionSteps2 = await getTestExecutionSteps(flow.id)
+      expect(testExecutionSteps2).to.toHaveLength(2)
+      expect(testExecutionSteps2.map((step) => step.id)).toEqual([
+        testExecution2.executionSteps[0].id,
+        testExecution2.executionSteps[1].id,
+      ])
+    })
+
+    it('should return the latest test execution steps if ignoreTestExecutionId is set to true', async () => {
+      const testExecution2 = await Execution.query().insertGraphAndFetch({
+        flowId: flow.id,
+        testRun: true,
+        executionSteps: [
+          {
+            stepId: flow.steps[0].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+          {
+            stepId: flow.steps[1].id,
+            status: 'success',
+            dataOut: { someData: 'data' },
+          },
+        ],
+      })
+      await flow.$query().patch({ testExecutionId: testExecution1.id })
+      const testExecutionSteps = await getTestExecutionSteps(flow.id, true)
+      expect(testExecutionSteps).to.toHaveLength(3)
+      expect(testExecutionSteps.map((step) => step.id)).toEqual([
+        testExecution2.executionSteps[0].id,
+        testExecution2.executionSteps[1].id,
+        testExecution1.executionSteps[2].id,
+      ])
+    })
   })
 })

--- a/packages/backend/src/helpers/__tests__/get-test-execution-steps.itest.ts
+++ b/packages/backend/src/helpers/__tests__/get-test-execution-steps.itest.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import Execution from '@/models/execution'
+import Flow from '@/models/flow'
+import User from '@/models/user'
+
+import { getTestExecutionSteps } from '../get-test-execution-steps'
+
+describe('get test execution steps', () => {
+  let flow: Flow
+  let testExecution1: Execution
+  beforeEach(async () => {
+    const user = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    flow = await Flow.query().insertGraphAndFetch({
+      userId: user.id,
+      name: 'flowName',
+      steps: [
+        {
+          key: 'newSubmission',
+          appKey: 'formsg',
+          type: 'trigger',
+          position: 1,
+          status: 'completed',
+        },
+        {
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          type: 'action',
+          position: 2,
+          status: 'completed',
+        },
+        {
+          key: 'sendSms',
+          appKey: 'postman-sms',
+          type: 'action',
+          position: 3,
+          status: 'completed',
+        },
+      ],
+    })
+    testExecution1 = await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: true,
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[2].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+  })
+
+  it('should return test execution steps if there is only 1 test execution', async () => {
+    const testExecutionSteps = await getTestExecutionSteps(flow.id)
+    expect(testExecutionSteps).to.toHaveLength(3)
+    expect(testExecutionSteps.map((step) => step.id)).toEqual([
+      testExecution1.executionSteps[0].id,
+      testExecution1.executionSteps[1].id,
+      testExecution1.executionSteps[2].id,
+    ])
+  })
+
+  it('should return the most recent test execution steps across exections', async () => {
+    const testExecution2 = await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: true,
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+    const testExecutionSteps = await getTestExecutionSteps(flow.id)
+    expect(testExecutionSteps).to.toHaveLength(3)
+    expect(testExecutionSteps.map((step) => step.id)).toEqual([
+      testExecution2.executionSteps[0].id,
+      testExecution2.executionSteps[1].id,
+      testExecution1.executionSteps[2].id,
+    ])
+  })
+
+  it('should not return real executions even if they are more recent', async () => {
+    await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: false, // real execution
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[2].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+    const testExecutionSteps = await getTestExecutionSteps(flow.id)
+    expect(testExecutionSteps).to.toHaveLength(3)
+    expect(testExecutionSteps.map((step) => step.id)).toEqual([
+      testExecution1.executionSteps[0].id,
+      testExecution1.executionSteps[1].id,
+      testExecution1.executionSteps[2].id,
+    ])
+  })
+
+  it('should return the most recent execution steps if there are more than 1 execution step for a step', async () => {
+    const testExecution2 = await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: true,
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+    const latestExecutionStep = await testExecution2
+      .$relatedQuery('executionSteps')
+      .insertAndFetch({
+        stepId: flow.steps[1].id,
+        status: 'success',
+        dataOut: { someData: 'data' },
+      })
+    const testExecutionSteps = await getTestExecutionSteps(flow.id)
+    expect(testExecutionSteps).to.toHaveLength(3)
+    expect(testExecutionSteps.map((step) => step.id)).toEqual([
+      testExecution2.executionSteps[0].id,
+      latestExecutionStep.id,
+      testExecution1.executionSteps[2].id,
+    ])
+  })
+
+  it('should return failed executiosn as well', async () => {
+    const testExecution2 = await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: true,
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+    const latestExecutionStep = await testExecution2
+      .$relatedQuery('executionSteps')
+      .insertAndFetch({
+        stepId: flow.steps[1].id,
+        status: 'failure',
+        dataOut: { someData: 'data' },
+      })
+    const testExecutionSteps = await getTestExecutionSteps(flow.id)
+    expect(testExecutionSteps).to.toHaveLength(3)
+    expect(testExecutionSteps.map((step) => step.id)).toEqual([
+      testExecution2.executionSteps[0].id,
+      latestExecutionStep.id,
+      testExecution1.executionSteps[2].id,
+    ])
+  })
+})

--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -29,7 +29,7 @@ export async function getTestExecutionSteps(
     .with('latest_execution_steps', (builder) => {
       builder
         .select(
-          '*',
+          'execution_steps.*',
           raw(
             'ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY execution_steps.created_at DESC) as rn',
           ),

--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -5,6 +5,7 @@ import Flow from '@/models/flow'
 
 export async function getTestExecutionSteps(
   flowId: string,
+  ignoreTestExecutionId = false,
 ): Promise<ExecutionStep[]> {
   const flow = await Flow.query()
     .findById(flowId)
@@ -18,7 +19,7 @@ export async function getTestExecutionSteps(
     })
     .throwIfNotFound()
 
-  if (flow.testExecution) {
+  if (flow.testExecution && !ignoreTestExecutionId) {
     return flow.testExecution.executionSteps
   }
 

--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -35,10 +35,19 @@ export async function getTestExecutionSteps(
           ),
         )
         .from('execution_steps')
+        // this join might seem expensive but the query planner is smart enough to optimize it
+        // see notion doc (Single Step Testing) on EXPLAIN ANALYZE results
+        .innerJoin(
+          'executions',
+          'execution_steps.execution_id',
+          'executions.id',
+        )
         .whereIn(
           'step_id',
           flow.steps.map((step) => step.id),
         )
+        // We only look at test runs
+        .andWhere('executions.test_run', true)
     })
     .select('*')
     .from('latest_execution_steps')

--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -1,0 +1,55 @@
+import { raw } from 'objection'
+
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+
+export async function getTestExecutionSteps(
+  flowId: string,
+): Promise<ExecutionStep[]> {
+  const flow = await Flow.query()
+    .findById(flowId)
+    .withGraphFetched({
+      testExecution: {
+        executionSteps: {
+          step: true,
+        },
+      },
+      steps: true,
+    })
+    .throwIfNotFound()
+
+  if (flow.testExecution) {
+    return flow.testExecution.executionSteps
+  }
+
+  /**
+   * If test execution id does not exist, we fetch the last execution steps for each step
+   */
+  const latestExecutionSteps = await ExecutionStep.query()
+    .with('latest_execution_steps', (builder) => {
+      builder
+        .select(
+          '*',
+          raw(
+            'ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY execution_steps.created_at DESC) as rn',
+          ),
+        )
+        .from('execution_steps')
+        .whereIn(
+          'step_id',
+          flow.steps.map((step) => step.id),
+        )
+    })
+    .select('*')
+    .from('latest_execution_steps')
+    .withGraphFetched({
+      step: true,
+    })
+    .where('rn', '=', 1)
+    .withSoftDeleted() // because this adds a 'execution_steps.deleted_at' column to the query instead of latest_execution_steps
+
+  // sort by step position
+  latestExecutionSteps.sort((a, b) => a.step.position - b.step.position)
+
+  return latestExecutionSteps
+}

--- a/packages/backend/src/services/test-run.ts
+++ b/packages/backend/src/services/test-run.ts
@@ -1,26 +1,20 @@
+import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
 import { processAction } from '@/services/action'
 import { processFlow } from '@/services/flow'
 import { processTrigger } from '@/services/trigger'
 
-type TestRunOptions = {
+interface TestRunOptions {
   stepId: string
 }
 
-const testRun = async (options: TestRunOptions) => {
-  let untilStep = await Step.query()
-    .findById(options.stepId)
-    .withGraphFetched({
-      flow: {
-        steps: true,
-      },
-    })
+interface TestRunResult {
+  executionStep: ExecutionStep
+  executionId: string
+}
 
-  //
-  // Start test run
-  //
-
-  untilStep = await Step.query()
+const testRun = async (options: TestRunOptions): Promise<TestRunResult> => {
+  const untilStep = await Step.query()
     .findById(options.stepId)
     .withGraphFetched({
       flow: {
@@ -28,6 +22,10 @@ const testRun = async (options: TestRunOptions) => {
       },
     })
     .modifyGraph('flow.steps', (builder) => builder.orderBy('position', 'asc'))
+
+  //
+  // Start test run
+  //
 
   const flow = untilStep.flow
   const [triggerStep, ...actionSteps] = untilStep.flow.steps
@@ -37,31 +35,22 @@ const testRun = async (options: TestRunOptions) => {
     testRun: true,
   })
 
-  if (triggerError) {
-    const { executionStep: triggerExecutionStepWithError } =
-      await processTrigger({
-        flowId: flow.id,
-        stepId: triggerStep.id,
-        error: triggerError,
-        testRun: true,
-      })
-
-    return { executionStep: triggerExecutionStepWithError }
-  }
-
-  const firstTriggerItem = data[0]
+  // Just giving it a more descriptive name here
+  const hasTriggerStepFailed = !!triggerError
 
   const { executionId, executionStep: triggerExecutionStep } =
     await processTrigger({
       flowId: flow.id,
       stepId: triggerStep.id,
-      triggerItem: firstTriggerItem,
+      error: hasTriggerStepFailed ? triggerError : undefined,
+      triggerItem: hasTriggerStepFailed ? undefined : data[0],
       testRun: true,
     })
 
   // We store the last run executionStep to return
   let executionStepToReturn = triggerExecutionStep
-  if (triggerStep.id === untilStep.id) {
+  // We return early if the trigger step has failed or only trigger step was tested
+  if (hasTriggerStepFailed || triggerStep.id === untilStep.id) {
     return { executionStep: executionStepToReturn, executionId }
   }
 

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -11,6 +11,7 @@ type ProcessTriggerOptions = {
   testRun?: boolean
 }
 
+// TODO(ian): change this function name, it's basically just storing trigger data
 export const processTrigger = async (options: ProcessTriggerOptions) => {
   const { flowId, stepId, triggerItem, error, testRun } = options
 

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -49,7 +49,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
   const { step, selectedActionOrTrigger, variables, isMock = false } = props
 
   // No data only happens if user hasn't executed yet, or step returned null.
-  if (variables == null) {
+  if (!variables?.length) {
     if (step.status !== 'completed') {
       return <></>
     }

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -50,10 +50,13 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
 
   // No data only happens if user hasn't executed yet, or step returned null.
   if (variables == null) {
+    if (step.status !== 'completed') {
+      return <></>
+    }
     return (
       <Infobox variant="warning" width="full">
         <Box>
-          <Text fontWeight="600">{`We couldn't find any test data`}</Text>
+          <Text fontWeight="600">{`We couldn't find any data from your last test`}</Text>
           <Text mt={0.5}>{getNoOutputMessage(selectedActionOrTrigger)}</Text>
         </Box>
       </Infobox>

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -31,6 +31,7 @@ export const EditorProvider = ({
     {
       variables: {
         flowId,
+        ignoreTestExecutionId: true, // TODO(ian): Remove this or use LD flag once SST is enabled
       },
     },
   )

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -1,8 +1,14 @@
 import { gql } from '@apollo/client'
 
 export const GET_TEST_EXECUTION_STEPS = gql`
-  query GetTestExecutionSteps($flowId: String!) {
-    getTestExecutionSteps(flowId: $flowId) {
+  query GetTestExecutionSteps(
+    $flowId: String!
+    $ignoreTestExecutionId: Boolean
+  ) {
+    getTestExecutionSteps(
+      flowId: $flowId
+      ignoreTestExecutionId: $ignoreTestExecutionId
+    ) {
       id
       executionId
       stepId


### PR DESCRIPTION
### TL;DR

Refactored test execution steps retrieval and improved test run logic.

### What changed?

- Extracted `getTestExecutionSteps` logic into a separate helper function.
- Updated `testRun` function to remove duplicate lines of code.

### What to test
- [x] Test steps will automatically reflect last test execution data.
- [x] Test execution data should correspond to the variables dropdown in subsequent steps
- [x] Testing earlier steps should not remove test execution data from later steps that have been previously tested
- [x] If an earlier step fails during testing, it should show the error in the current step. However, this is only temporary and toggle the expansion of the accordion will remove the error. You could see the error message on the corresponding step.