### PR TITLE
PLU-115: [SST-5] backend mutation for single step testing

### DIFF
--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -10,6 +10,7 @@ import deleteFlow from './mutations/delete-flow'
 import deleteStep from './mutations/delete-step'
 import duplicateFlow from './mutations/duplicate-flow'
 import executeFlow from './mutations/execute-flow'
+import executeStep from './mutations/execute-step'
 import generateAuthUrl from './mutations/generate-auth-url'
 import loginWithSelectedSgid from './mutations/login-with-selected-sgid'
 import loginWithSgid from './mutations/login-with-sgid'
@@ -61,6 +62,7 @@ export default {
   updateFlowStatus,
   updateFlowConfig,
   executeFlow,
+  executeStep,
   deleteFlow,
   createStep,
   updateStep,

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -1,0 +1,38 @@
+import testStep from '@/services/test-step'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const executeStep: MutationResolvers['executeStep'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { stepId } = params.input
+
+  // Just checking for permissions here
+  const stepToTest = await context.currentUser
+    .$relatedQuery('steps')
+    .withGraphFetched('flow')
+    .findById(stepId)
+    .throwIfNotFound()
+
+  const { executionStep, executionId } = await testStep({
+    stepId: stepToTest.id,
+  })
+
+  // Update flow to use the new test execution
+  await stepToTest.flow.$query().patch({
+    testExecutionId: executionId,
+  })
+
+  // Update step status
+  if (!executionStep.isFailed) {
+    await stepToTest.$query().patch({
+      status: 'completed',
+    })
+  }
+
+  return executionStep
+}
+
+export default executeStep

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -71,6 +71,7 @@ type Mutation {
   updateFlowStatus(input: UpdateFlowStatusInput): Flow
   updateFlowConfig(input: UpdateFlowConfigInput): Flow
   executeFlow(input: ExecuteFlowInput): ExecutionStep!
+  executeStep(input: ExecuteStepInput): ExecutionStep!
   deleteFlow(input: DeleteFlowInput): Boolean
   createStep(input: CreateStepInput): Step
   updateStep(input: UpdateStepInput): Step
@@ -435,6 +436,10 @@ input UpdateFlowConfigInput {
 }
 
 input ExecuteFlowInput {
+  stepId: String!
+}
+
+input ExecuteStepInput {
   stepId: String!
 }
 

--- a/packages/backend/src/services/flow.ts
+++ b/packages/backend/src/services/flow.ts
@@ -8,6 +8,7 @@ type ProcessFlowOptions = {
   testRun?: boolean
 }
 
+// TODO(ian): change this function name, it's actually processing trigger
 export const processFlow = async (options: ProcessFlowOptions) => {
   const flow = await Flow.query()
     .findById(options.flowId)

--- a/packages/backend/src/services/test-step.ts
+++ b/packages/backend/src/services/test-step.ts
@@ -1,0 +1,141 @@
+import { getTestExecutionSteps } from '@/helpers/get-test-execution-steps'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import { processAction } from '@/services/action'
+import { processFlow } from '@/services/flow'
+import { processTrigger } from '@/services/trigger'
+
+interface TestStepOptions {
+  stepId: string
+}
+
+interface TestStepResult {
+  executionStep: ExecutionStep
+  executionId: string
+}
+/**
+ * What this does?
+ * - We test a single step rather than from trigger to this step
+ * - If a trigger is tested, a new excution is created and assigned to the flow as test_excection
+ * Caveats:
+ * - We do not check that prior steps have been executed. We assume that prior steps variables cant be used if they are not already tested
+ * - This allows us to test steps from a if-then branch without having to test other branches
+ */
+const testStep = async (options: TestStepOptions): Promise<TestStepResult> => {
+  const stepToTest = await Step.query()
+    .findById(options.stepId)
+    .withGraphFetched({
+      flow: true,
+    })
+    .throwIfNotFound()
+
+  let flow = stepToTest.flow
+  if (flow.active) {
+    throw new Error('Pipe is active. Cannot test steps in active pipe')
+  }
+
+  const testExecutionSteps = await getTestExecutionSteps(flow.id)
+
+  /**
+   * If none of the steps have been tested before, we create a new test execution
+   */
+  if (!testExecutionSteps.length) {
+    const testExecution = await Execution.query().insert({
+      flowId: flow.id,
+      testRun: true,
+    })
+    flow.testExecution = testExecution
+    flow.testExecutionId = testExecution.id
+  }
+
+  /**
+   * For backwards compatibility, in the case where the test execution ID is not set
+   * but has been tested before (i.e. test execution steps exist), we set the test execution ID
+   */
+  if (!flow.testExecutionId) {
+    const [testTriggerExecutionStep, ...testActionExecutionSteps] =
+      testExecutionSteps
+    // We set the test execution ID to the test trigger execution id
+    flow = await Flow.transaction(async (trx) => {
+      const updatedFlow = await flow.$query(trx).patchAndFetch({
+        testExecutionId: testTriggerExecutionStep.executionId,
+      })
+      // We then set the execution id for the rest of the test execution steps
+      await ExecutionStep.query(trx)
+        .patch({
+          executionId: testTriggerExecutionStep.executionId,
+        })
+        .whereIn(
+          'id',
+          testActionExecutionSteps.map((execStep) => execStep.id),
+        )
+      return updatedFlow
+    })
+  }
+
+  /**
+   * If step is action, replace old execution step by setting execution id to null
+   * and creating a new execution step with the test execution id
+   */
+  if (stepToTest.isAction) {
+    const previousExecutionStep = testExecutionSteps.find(
+      (execStep) => execStep.stepId === stepToTest.id,
+    )
+
+    const { executionStep: newExecutionStep } = await processAction({
+      flowId: flow.id,
+      stepId: stepToTest.id,
+      executionId: flow.testExecutionId,
+      testRun: true,
+    })
+
+    if (previousExecutionStep) {
+      await previousExecutionStep.$query().delete()
+    }
+    return {
+      executionStep: newExecutionStep,
+      executionId: flow.testExecutionId,
+    }
+  }
+
+  /**
+   * If step is trigger, it gets a bit more complicated.
+   * We need to create a new test execution and execution step.
+   * Rewrite all the action execution steps with the new execution id
+   */
+  if (stepToTest.isTrigger) {
+    const { data, error: triggerError } = await processFlow({
+      flowId: flow.id,
+      testRun: true,
+    })
+
+    const hasTriggerStepFailed = !!triggerError
+
+    const { executionId, executionStep: triggerExecutionStep } =
+      await processTrigger({
+        flowId: flow.id,
+        stepId: stepToTest.id,
+        error: hasTriggerStepFailed ? triggerError : undefined,
+        triggerItem: hasTriggerStepFailed ? undefined : data[0],
+        testRun: true,
+      })
+    const [_previousTriggerExecutionStep, ...testActionExecutionSteps] =
+      testExecutionSteps
+
+    if (testActionExecutionSteps.length) {
+      await ExecutionStep.query()
+        .patch({
+          executionId: executionId,
+        })
+        .whereIn(
+          'id',
+          testActionExecutionSteps.map((execStep) => execStep.id),
+        )
+    }
+    return { executionStep: triggerExecutionStep, executionId }
+  }
+}
+
+export default testStep


### PR DESCRIPTION
### TL;DR

Added functionality to execute and test individual steps in a flow.

### What changed?

- Introduced a new `executeStep` mutation in the GraphQL schema
- Created a new `execute-step.ts` file to handle the execution of individual steps
- Updated `mutation-resolvers.ts` to include the new `executeStep` resolver
- Modified `get-test-execution-steps.ts` to filter for test runs
- Implemented a new `test-step.ts` service to handle the logic for testing individual steps


