### PR TITLE
fix: missing formsg connection causing webhook error

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -50,6 +50,17 @@ export async function decryptFormResponse(
     return false
   }
 
+  // Note: this could occur due to pipe transfer since connection becomes null
+  if (!$.auth.data) {
+    logger.warn('Form is not connected to any pipe after pipe is transferred', {
+      event: 'formsg-missing-connection',
+      flowId: $.flow.id,
+      stepId: $.step.id,
+      userId: $.user.id,
+    })
+    return false
+  }
+
   const formSgSdk = getSdk(parseFormEnv($))
 
   const {
@@ -64,17 +75,6 @@ export async function decryptFormResponse(
     )
   } catch (e) {
     logger.error('Unable to verify formsg signature')
-    return false
-  }
-
-  // Note: this could occur due to pipe transfer since connection becomes null
-  if (!$.auth.data) {
-    logger.warn('Form is not connected to any pipe after pipe is transferred', {
-      event: 'formsg-missing-connection',
-      flowId: $.flow.id,
-      stepId: $.step.id,
-      userId: $.user.id,
-    })
     return false
   }
 


### PR DESCRIPTION
## Problem

Webhook error occurs because when a form response is submitted, we forgot to check if there is a formsg connection and hence `$.auth` is undefined and it errors out

|<img width="1269" alt="Screenshot 2024-08-23 at 1 25 13 PM" src="https://github.com/user-attachments/assets/99ae07f8-8809-48c7-a60b-b2c3346e1f9e">|
|:--:| 
| *Error stack trace* |

## Solution

Move the check to an earlier part of the code

## Tests
- [x] Configured the webhook on formsg to a pipe without connection to test, no more error
- [x] Pipes with formsg connection still work