### PR TITLE
fix: testRun for triggers should depend on test executions only

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -71,23 +71,26 @@ const trigger: IRawTrigger = {
 
     // data out should never be empty after test step is pressed once: either mock or actual data
     const { formId } = getFormDetailsFromGlobalVariable($)
-    const lastExecutionStep = await $.getLastExecutionStep()
-
+    // We use last test execution step
+    const lastTestExecutionStep = await $.getLastExecutionStep({
+      testRunOnly: true,
+    })
     // If no past submission (no form) or the form is changed, it is a mock run (re-pull mock data)
     const hasNoPastSubmission =
-      lastExecutionStep?.dataOut?.formId !== formId ||
-      lastExecutionStep.metadata.isMock
+      lastTestExecutionStep?.dataOut?.formId !== formId ||
+      lastTestExecutionStep.metadata.isMock
 
     // if different or no form is detected, use mock data
     await $.pushTriggerItem({
       raw: hasNoPastSubmission
         ? await getMockData($)
-        : lastExecutionStep?.dataOut,
+        : lastTestExecutionStep?.dataOut,
       meta: {
         internalId: '',
       },
       isMock:
-        hasNoPastSubmission || (lastExecutionStep.metadata?.isMock ?? false), // use previous mock run status from metadata by default
+        hasNoPastSubmission ||
+        (lastTestExecutionStep.metadata?.isMock ?? false), // use previous mock run status from metadata by default
     })
   },
 }

--- a/packages/backend/src/apps/webhook/triggers/catch-raw-webhook/index.ts
+++ b/packages/backend/src/apps/webhook/triggers/catch-raw-webhook/index.ts
@@ -11,7 +11,9 @@ const trigger: IRawTrigger = {
   },
 
   async testRun($: IGlobalVariable) {
-    const lastExecutionStep = await $.getLastExecutionStep()
+    const lastExecutionStep = await $.getLastExecutionStep({
+      testRunOnly: true,
+    })
     // Allow for empty webhook body
     await $.pushTriggerItem({
       raw: lastExecutionStep?.dataOut ?? {},

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -96,9 +96,10 @@ const globalVariable = async (
         throw new Error('Execution ID is required to get last execution step')
       }
       return (
-        await step?.getLastExecutionStep(
-          options?.sameExecution ? execution.id : undefined,
-        )
+        await step?.getLastExecutionStep({
+          executionId: options?.sameExecution ? execution.id : undefined,
+          testRunOnly: options?.testRunOnly,
+        })
       )?.toJSON()
     },
     triggerOutput: {

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -119,14 +119,23 @@ class Step extends Base {
     return apps[this.appKey]
   }
 
-  async getLastExecutionStep(executionId?: string) {
+  async getLastExecutionStep({
+    executionId,
+    testRunOnly,
+  }: {
+    executionId?: string
+    testRunOnly?: boolean
+  }) {
     const query = this.$relatedQuery('executionSteps')
       .orderBy('created_at', 'desc')
       .limit(1)
+      .where(true)
       .first()
-
+    if (testRunOnly) {
+      query.withGraphJoined('execution').andWhere('test_run', true)
+    }
     if (executionId) {
-      query.where('execution_id', executionId)
+      query.andWhere('execution_id', executionId)
     }
     const lastExecutionStep = await query
     if (lastExecutionStep?.appKey !== this.appKey) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -766,9 +766,10 @@ export type IGlobalVariable = {
     appKey: string
     parameters: IJSONObject
   }
-  getLastExecutionStep?: (options?: {
-    sameExecution?: boolean
-  }) => Promise<IExecutionStep | undefined>
+  getLastExecutionStep?: (options?: Partial<{
+    sameExecution: boolean
+    testRunOnly: boolean
+  }>) => Promise<IExecutionStep | undefined>
   execution?: {
     id: string
     testRun: boolean


### PR DESCRIPTION
## Problem

With the new changes to execution test results, we should only be using test execution steps. However, the testRuns for triggers (specifically webhook and formsg) still use the getLastExecutionStep function which includes real flows.

## Solution
This PR fixes this by introducing a parameter to only fetch test runs.

## How test
1. Create a formsg triggered pipe
2. Test step to see mock data
3. Publish and submit the form.
4. Unpublish and test step
5. You should see fresh mock data rather than the submission.

Also try:
1. Create a formsg triggered pipe
2. Submit a form while unpublished
3. Test step to see form data
3. Publish and submit the form.
4. Unpublish and test step
5. You should see the form data from when it was unpublished

Also test with webhooks