### PR TITLE
PLU-318: [TEMPLATES-5]: Add infobox content for each step in flow editor

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -58,7 +58,7 @@ const trigger: IRawTrigger = {
   ],
   // TODO (mal): change form link to correct one
   helpMessage:
-    'Connect your form to this step. If you don’t have one, here is a [sample](https://go.gov.sg/request-template).',
+    'Connect your form to this step. Here is an [example](https://go.gov.sg/request-template) for this template.',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -56,6 +56,9 @@ const trigger: IRawTrigger = {
       showOptionValue: false,
     },
   ],
+  // TODO (mal): change form link to correct one
+  helpMessage:
+    'Connect your form to this step. If you don’t have one, here is a [sample](https://go.gov.sg/request-template).',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -29,6 +29,7 @@ const action: IRawAction = {
       (step.parameters.attachments as IJSONArray).length > 0
     )
   },
+  helpMessage: 'Customise how your email looks like in this step.',
 
   async run($) {
     const {

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -63,7 +63,7 @@ const action: IRawAction = {
       variables: true,
     },
   ],
-  helpMessage: 'Connect a Slack channel to this step.',
+  helpMessage: 'Connect a Slack channel in this step.',
 
   async run($) {
     await postMessage($)

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -63,6 +63,7 @@ const action: IRawAction = {
       variables: true,
     },
   ],
+  helpMessage: 'Connect a Slack channel to this step.',
 
   async run($) {
     await postMessage($)

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -57,7 +57,7 @@ const action: IRawAction = {
       variables: true,
     },
   ],
-  helpMessage: 'Connect your Telegram bot to this step.',
+  helpMessage: 'Connect your Telegram bot in this step.',
 
   preprocessVariable(key: string, value: unknown) {
     if (key === 'text' && typeof value === 'string') {

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -57,6 +57,7 @@ const action: IRawAction = {
       variables: true,
     },
   ],
+  helpMessage: 'Connect your Telegram bot to this step.',
 
   preprocessVariable(key: string, value: unknown) {
     if (key === 'text' && typeof value === 'string') {

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -85,7 +85,8 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage: 'Customise it by adding the columns you need.',
+  helpMessage:
+    'Customise your columns and choose the data that goes into them. You can recreate this example for this template.',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -85,6 +85,7 @@ const action: IRawAction = {
       ],
     },
   ],
+  helpMessage: 'Customise it by adding the columns you need.',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -140,7 +140,8 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage: 'This step identifies the row that you are making updates to.',
+  helpMessage:
+    'This step finds a row in your Tile based on conditions you set.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -140,6 +140,7 @@ const action: IRawAction = {
       ],
     },
   ],
+  helpMessage: 'This step identifies the row that you are making updates to.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -90,6 +90,7 @@ const action: IRawAction = {
       ],
     },
   ],
+  helpMessage: 'This step updates the row you have identified above.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -90,7 +90,8 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage: 'This step updates the row you have identified above.',
+  helpMessage:
+    'This step updates the row that was found. You need a Find row step before this.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -95,7 +95,6 @@ const action: IRawAction = {
       subFields: getConditionArgs({ usePlaceholders: true }),
     },
   ],
-  helpMessage: 'Customise what happens in each of your branches.',
 
   async run($) {
     let isConditionMet

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -95,6 +95,7 @@ const action: IRawAction = {
       subFields: getConditionArgs({ usePlaceholders: true }),
     },
   ],
+  helpMessage: 'Customise what happens in each of your branches.',
 
   async run($) {
     let isConditionMet

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -154,6 +154,7 @@ type Action {
   groupsLaterSteps: Boolean
   setupMessage: SetupMessage
   substeps: [ActionSubstep]
+  helpMessage: String
 }
 
 type ActionSubstep {
@@ -585,6 +586,7 @@ type Trigger {
   webhookTriggerInstructions: TriggerInstructions
   settingsStepLabel: String
   substeps: [TriggerSubstep]
+  helpMessage: String
 }
 
 type TriggerInstructions {

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -188,6 +188,9 @@ export default function FlowStep(
     caption = 'This step happens after the previous step'
   }
 
+  const shouldShowInfobox: boolean =
+    step.status === 'incomplete' && !!selectedActionOrTrigger?.helpMessage
+
   if (!apps) {
     return <CircularProgress isIndeterminate my={2} />
   }
@@ -197,7 +200,7 @@ export default function FlowStep(
   return (
     <Flex w="100%" flexDir="column">
       {/* Show infobox only if the step is incomplete and has a help message */}
-      {step.status === 'incomplete' && selectedActionOrTrigger?.helpMessage && (
+      {shouldShowInfobox && (
         <Infobox
           icon={<BiInfoCircle />}
           variant="primaryExcludeIconColor"
@@ -207,7 +210,7 @@ export default function FlowStep(
           }}
         >
           <MarkdownRenderer
-            source={selectedActionOrTrigger?.helpMessage}
+            source={selectedActionOrTrigger?.helpMessage ?? ''}
             components={{
               // Force all links in our message to be opened in a new tab.
               a: ({ ...props }) => (
@@ -237,6 +240,7 @@ export default function FlowStep(
         collapsed={collapsed ?? false}
         demoVideoUrl={app?.demoVideoDetails?.url}
         demoVideoTitle={app?.demoVideoDetails?.title}
+        isInfoboxPresent={shouldShowInfobox}
       >
         <StepExecutionsProvider priorExecutionSteps={priorExecutionSteps}>
           <Form

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -203,7 +203,7 @@ export default function FlowStep(
       {shouldShowInfobox && (
         <Infobox
           icon={<BiInfoCircle />}
-          variant="primaryExcludeIconColor"
+          variant="secondary"
           style={{
             borderBottomLeftRadius: '0',
             borderBottomRightRadius: '0',

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -1,6 +1,9 @@
 import { type IFlow, type IStep } from '@plumber/types'
 
 import { type FunctionComponent, useMemo } from 'react'
+import { BiInfoCircle } from 'react-icons/bi'
+import { Flex } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
 
 import FlowStepHeader from '@/components/FlowStepHeader'
 import { areAllIfThenBranchesCompleted, isIfThenStep } from '@/helpers/toolbox'
@@ -43,6 +46,8 @@ interface FlowStepGroupProps {
   collapsed: boolean
 }
 
+const ifThenHelpMessage = 'Customise what happens in each of your branches.'
+
 function FlowStepGroup(props: FlowStepGroupProps): JSX.Element {
   const { iconUrl, flow, steps, onOpen, onClose, collapsed } = props
 
@@ -50,17 +55,33 @@ function FlowStepGroup(props: FlowStepGroupProps): JSX.Element {
     useMemo(() => getStepContent(steps), [steps])
 
   return (
-    <FlowStepHeader
-      iconUrl={iconUrl}
-      caption={caption}
-      hintAboveCaption={hintAboveCaption}
-      onOpen={onOpen}
-      onClose={onClose}
-      collapsed={collapsed ?? false}
-      isCompleted={isStepGroupCompleted}
-    >
-      <StepContent flow={flow} steps={steps} />
-    </FlowStepHeader>
+    <Flex w="100%" flexDir="column">
+      {/* Show infobox only if the step group is incomplete */}
+      {!isStepGroupCompleted && (
+        <Infobox
+          icon={<BiInfoCircle />}
+          variant="secondary"
+          style={{
+            borderBottomLeftRadius: '0',
+            borderBottomRightRadius: '0',
+          }}
+        >
+          {ifThenHelpMessage}
+        </Infobox>
+      )}
+
+      <FlowStepHeader
+        iconUrl={iconUrl}
+        caption={caption}
+        hintAboveCaption={hintAboveCaption}
+        onOpen={onOpen}
+        onClose={onClose}
+        collapsed={collapsed ?? false}
+        isCompleted={isStepGroupCompleted}
+      >
+        <StepContent flow={flow} steps={steps} />
+      </FlowStepHeader>
+    </Flex>
   )
 }
 

--- a/packages/frontend/src/components/FlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/FlowStepHeader/index.tsx
@@ -47,7 +47,7 @@ interface FlowStepHeaderProps {
   children: ReactNode
   demoVideoUrl?: string
   demoVideoTitle?: string
-  isInfoboxPresent: boolean
+  isInfoboxPresent?: boolean
 }
 
 const LOCAL_STORAGE_DEMO_TOOLTIP_KEY = 'demo-tooltip-clicked'

--- a/packages/frontend/src/components/FlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/FlowStepHeader/index.tsx
@@ -47,6 +47,7 @@ interface FlowStepHeaderProps {
   children: ReactNode
   demoVideoUrl?: string
   demoVideoTitle?: string
+  isInfoboxPresent: boolean
 }
 
 const LOCAL_STORAGE_DEMO_TOOLTIP_KEY = 'demo-tooltip-clicked'
@@ -66,6 +67,7 @@ export default function FlowStepHeader(
     children,
     demoVideoUrl,
     demoVideoTitle,
+    isInfoboxPresent,
   } = props
 
   const handleClick = useCallback(() => {
@@ -107,6 +109,7 @@ export default function FlowStepHeader(
         borderWidth="1px"
         borderColor="base.divider.medium"
         borderRadius="lg"
+        borderTopRadius={isInfoboxPresent ? 'none' : 'lg'}
         p={0}
         bg="white"
         boxShadow={collapsed ? undefined : 'sm'}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -98,6 +98,7 @@ export const GET_APPS = gql`
           hideWebhookUrl
           mockDataMsg
         }
+        helpMessage
         substeps {
           key
           name
@@ -174,6 +175,7 @@ export const GET_APPS = gql`
           variant
           messageBody
         }
+        helpMessage
         groupsLaterSteps
         substeps {
           key

--- a/packages/frontend/src/theme/components/Infobox.ts
+++ b/packages/frontend/src/theme/components/Infobox.ts
@@ -9,10 +9,13 @@ export const Infobox = {
         color: 'primary.500',
       },
     },
-    primaryExcludeIconColor: {
+    secondary: {
       messagebox: {
-        bg: 'primary.100',
+        bg: 'interaction.sub-subtle.default',
         borderRadius: '0.25rem',
+      },
+      icon: {
+        color: 'interaction.sub.default',
       },
     },
     warning: {

--- a/packages/frontend/src/theme/components/Infobox.ts
+++ b/packages/frontend/src/theme/components/Infobox.ts
@@ -9,6 +9,12 @@ export const Infobox = {
         color: 'primary.500',
       },
     },
+    primaryExcludeIconColor: {
+      messagebox: {
+        bg: 'primary.100',
+        borderRadius: '0.25rem',
+      },
+    },
     warning: {
       icon: {
         color: 'yellow.200',

--- a/packages/frontend/src/theme/foundations/colors.ts
+++ b/packages/frontend/src/theme/foundations/colors.ts
@@ -39,6 +39,11 @@ const bbBearColors = {
     sub: {
       default: '#5D6785',
     },
+    'sub-subtle': {
+      default: '#e9eaee',
+      hover: '#babecb',
+      active: '#9aa0b3',
+    },
     success: {
       default: '#0F796F',
     },

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -619,6 +619,10 @@ export interface IBaseTrigger {
    * message to the user during pipe setup / config.
    */
   setupMessage?: SetupMessage
+  /**
+   * Displays an infobox to provide a general guide/help for users during step config
+   */
+  helpMessage?: string
 }
 
 export interface IRawTrigger extends IBaseTrigger {
@@ -712,6 +716,10 @@ export interface IBaseAction {
    * message to the user during pipe setup / config.
    */
   setupMessage?: SetupMessage
+  /**
+   * Displays an infobox to provide a general guide/help for users during step config
+   */
+  helpMessage?: string
 }
 
 export interface IRawAction extends IBaseAction {


### PR DESCRIPTION
## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
- Add a `helpMessage` to each trigger and action substep
- Infobox appears on top of each step in the flow editor if the step is not complete

## Tests
- [x] Only formsg, tiles, if-then, postman, telegram, slack have the infobox
- [x] Inside if-then editor, these apps also have the infobox
- [x] Infobox disappears once the step is completed