### PR TITLE
PLU-318: [TEMPLATES-6]: Substitute parameters on template

### DIFF
--- a/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
+++ b/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
@@ -26,7 +26,7 @@ export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: Template = {
         body: '<p style="margin: 0">Hi <span data-type="variable" data-id="Replace with response 1 name" data-label="Replace with response 1 name">{{Replace with response 1 name}}</span>,</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration, here is what you submitted:</p><p style="margin: 0"></p><table style="border-collapse:collapse;"><tbody><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Question</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Response</p></td></tr><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace with question}}</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace with response}}</p></td></tr></tbody></table><p style="margin: 0"></p><p style="margin: 0">More details will be sent to you nearer to the date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event committee</p>',
         subject: 'We have received your registration!',
         senderName: 'Event committee',
-        destinationEmail: '{{Replace with response 2 email}}',
+        destinationEmail: '{{user_email}}',
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-follow-ups.ts
+++ b/packages/backend/src/db/storage/send-follow-ups.ts
@@ -27,7 +27,7 @@ export const SEND_FOLLOW_UPS_TEMPLATE: Template = {
         body: '<p style="margin: 0">Hi {{Replace with response 1 name}},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration for this event! More details will be sent to you nearer to the event date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event organising committee</p>',
         subject: 'Thank you for registering!',
         senderName: 'Event committee',
-        destinationEmail: '{{Replace with response 2 email}}',
+        destinationEmail: '{{user_email}}',
       },
     },
   ],

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -87,8 +87,13 @@ export async function createFlowFromTemplate(
       const step: TemplateStep = steps[i]
       validateAppAndEventKey(step, flowName)
       // replace all parameters with {{user_email}} to the current user email
-      const updatedParameters = structuredClone(step.parameters ?? {})
+      const updatedParameters = structuredClone(step?.parameters ?? {})
       for (const [key, value] of Object.entries(updatedParameters)) {
+        // ignore objects e.g. conditions because nothing to replace inside for now
+        if (typeof value === 'object') {
+          continue
+        }
+
         const substitutedValue = String(value).replaceAll(
           '{{user_email}}',
           user.email,

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -91,7 +91,7 @@ export async function createFlowFromTemplate(
       for (const [key, value] of Object.entries(updatedParameters)) {
         // ignore objects e.g. conditions because nothing to replace inside for now
         if (typeof value === 'string') {
-          const substitutedValue = String(value).replaceAll(
+          const substitutedValue = value.replaceAll(
             '{{user_email}}',
             user.email,
           )

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -90,15 +90,13 @@ export async function createFlowFromTemplate(
       const updatedParameters = structuredClone(step?.parameters ?? {})
       for (const [key, value] of Object.entries(updatedParameters)) {
         // ignore objects e.g. conditions because nothing to replace inside for now
-        if (typeof value === 'object') {
-          continue
+        if (typeof value === 'string') {
+          const substitutedValue = String(value).replaceAll(
+            '{{user_email}}',
+            user.email,
+          )
+          updatedParameters[key] = substitutedValue
         }
-
-        const substitutedValue = String(value).replaceAll(
-          '{{user_email}}',
-          user.email,
-        )
-        updatedParameters[key] = substitutedValue
       }
 
       await flow.$relatedQuery('steps', trx).insert({

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -87,7 +87,7 @@ export async function createFlowFromTemplate(
       const step: TemplateStep = steps[i]
       validateAppAndEventKey(step, flowName)
       // replace all parameters with {{user_email}} to the current user email
-      const updatedParameters = step.parameters ?? {}
+      const updatedParameters = structuredClone(step.parameters ?? {})
       for (const [key, value] of Object.entries(updatedParameters)) {
         const substitutedValue = String(value).replaceAll(
           '{{user_email}}',

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -86,13 +86,22 @@ export async function createFlowFromTemplate(
     for (let i = 1; i < steps.length; i++) {
       const step: TemplateStep = steps[i]
       validateAppAndEventKey(step, flowName)
+      // replace all parameters with {{user_email}} to the current user email
+      const updatedParameters = step.parameters ?? {}
+      for (const [key, value] of Object.entries(updatedParameters)) {
+        const substitutedValue = String(value).replaceAll(
+          '{{user_email}}',
+          user.email,
+        )
+        updatedParameters[key] = substitutedValue
+      }
 
       await flow.$relatedQuery('steps', trx).insert({
         type: 'action',
         position: step.position,
         appKey: step.appKey,
         key: step.eventKey,
-        parameters: step.parameters ?? {},
+        parameters: updatedParameters,
       })
     }
 


### PR DESCRIPTION
## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
- Substitute parameters on the backend e.g. `{{user_email}}` since templates are supposed to be generic

TODO:
- [x] First two templates may need this same functionality after checking with Stacey

## Tests
- [x] First 3 template will have the user email substituted in the recipient email for postman step