### PR TITLE
PLU-318: [TEMPLATES-7]: Add pre template automation

### DIFF
--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -2,6 +2,8 @@ import type { Template } from '@/graphql/__generated__/types.generated'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
+  TILE_COL_DATA_PLACEHOLDER,
+  TILE_ID_PLACEHOLDER,
   TILES_SAMPLE_URL_DESCRIPTION,
 } from './constants'
 
@@ -32,12 +34,13 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
       parameters: {
         filters: [
           {
-            columnId: 'Email',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
             value: 'jane@email.com',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
+        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
       },
     },
     {
@@ -48,10 +51,11 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
         rowId: '{{Replace with row id result from step 2}}',
         rowData: [
           {
-            columnId: 'Attended?',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Attended?}}`,
             cellValue: 'Yes',
           },
         ],
+        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -29,11 +29,50 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/c77bc8fc-e1ca-4300-a50d-7f2933b9e5b4/a4ca3902-f0ef-41e1-9f5d-45c602c04d50',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
+      tileTemplateStepData: [
+        {
+          columnName: 'Email',
+          value: 'jane@email.com',
+          operator: 'equals',
+        },
+      ],
     },
     {
       position: 3,
       appKey: 'tiles',
       eventKey: 'updateSingleRow',
+      parameters: {
+        rowId: '{{Replace with row id result from step 2}}',
+      },
+      tileTemplateStepData: [
+        {
+          columnName: 'Attended?',
+          cellValue: 'Yes',
+        },
+      ],
     },
   ],
+  tileTemplateData: {
+    name: 'Event attendance',
+    columns: [
+      { name: 'Name', position: 0 },
+      { name: 'Email', position: 1 },
+      { name: 'Attended?', position: 2 },
+    ],
+    rowData: [
+      {
+        Name: 'Jane Doe',
+        Email: 'jane@email.com',
+        'Attended?': 'No',
+      },
+      {
+        Name: 'John Doe',
+        Email: 'john@email.com',
+        'Attended?': 'Yes',
+      },
+      {},
+      {},
+      {},
+    ],
+  },
 }

--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -29,13 +29,16 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/c77bc8fc-e1ca-4300-a50d-7f2933b9e5b4/a4ca3902-f0ef-41e1-9f5d-45c602c04d50',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
-      tileTemplateStepData: [
-        {
-          columnName: 'Email',
-          value: 'jane@email.com',
-          operator: 'equals',
-        },
-      ],
+      parameters: {
+        filters: [
+          {
+            columnId: 'Email',
+            value: 'jane@email.com',
+            operator: 'equals',
+          },
+        ],
+        returnLastRow: true,
+      },
     },
     {
       position: 3,
@@ -43,13 +46,13 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
       eventKey: 'updateSingleRow',
       parameters: {
         rowId: '{{Replace with row id result from step 2}}',
+        rowData: [
+          {
+            columnId: 'Attended?',
+            cellValue: 'Yes',
+          },
+        ],
       },
-      tileTemplateStepData: [
-        {
-          columnName: 'Attended?',
-          cellValue: 'Yes',
-        },
-      ],
     },
   ],
   tileTemplateData: {
@@ -70,9 +73,6 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
         Email: 'john@email.com',
         'Attended?': 'Yes',
       },
-      {},
-      {},
-      {},
     ],
   },
 }

--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
@@ -9,7 +9,7 @@ import {
 
 const ATTENDANCE_TAKING_ID = '04f95a37-46fe-455b-aa96-28c421379e1a'
 
-export const ATTENDANCE_TAKING_TEMPLATE: Template = {
+export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
   id: ATTENDANCE_TAKING_ID,
   name: 'Attendance taking',
   description: 'Track attendance for your event',
@@ -61,11 +61,7 @@ export const ATTENDANCE_TAKING_TEMPLATE: Template = {
   ],
   tileTemplateData: {
     name: 'Event attendance',
-    columns: [
-      { name: 'Name', position: 0 },
-      { name: 'Email', position: 1 },
-      { name: 'Attended?', position: 2 },
-    ],
+    columns: ['Name', 'Email', 'Attended?'],
     rowData: [
       {
         Name: 'Jane Doe',

--- a/packages/backend/src/db/storage/constants.ts
+++ b/packages/backend/src/db/storage/constants.ts
@@ -1,2 +1,7 @@
 export const FORMSG_SAMPLE_URL_DESCRIPTION = 'View a sample form'
 export const TILES_SAMPLE_URL_DESCRIPTION = 'View a sample table'
+
+// placeholders for each template step to be replaced
+export const USER_EMAIL_PLACEHOLDER = 'user_email'
+export const TILE_ID_PLACEHOLDER = 'tile_table_id'
+export const TILE_COL_DATA_PLACEHOLDER = 'tile_col_data'

--- a/packages/backend/src/db/storage/demo-send-notifications.ts
+++ b/packages/backend/src/db/storage/demo-send-notifications.ts
@@ -1,9 +1,9 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 // Note: template id is the same as demo video id for backwards compatibility
 export const SEND_NOTIFICATIONS_DEMO_TEMPLATE_ID = 'formsg-postman'
 
-export const SEND_NOTIFICATIONS_DEMO_TEMPLATE: Template = {
+export const SEND_NOTIFICATIONS_DEMO_TEMPLATE: ITemplate = {
   id: SEND_NOTIFICATIONS_DEMO_TEMPLATE_ID,
   name: 'Send notifications',
   description:

--- a/packages/backend/src/db/storage/get-live-updates-through-telegram.ts
+++ b/packages/backend/src/db/storage/get-live-updates-through-telegram.ts
@@ -1,11 +1,11 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import { FORMSG_SAMPLE_URL_DESCRIPTION } from './constants'
 
 const GET_LIVE_UPDATES_THROUGH_TELEGRAM_ID =
   '9c964678-8e24-440e-b2fd-b42da4dea4b1'
 
-export const GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE: Template = {
+export const GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE: ITemplate = {
   id: GET_LIVE_UPDATES_THROUGH_TELEGRAM_ID,
   name: 'Get live updates through Telegram',
   description:

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import { ATTENDANCE_TAKING_TEMPLATE } from './attendance-taking'
 import { SEND_NOTIFICATIONS_DEMO_TEMPLATE } from './demo-send-notifications'
@@ -37,7 +37,7 @@ function deepFreeze<T>(object: T): T {
  * placeholders for users to change them to the variable pills
  * TODO (mal): change this in a later PR after discussing with the team
  */
-export const TEMPLATES: Template[] = deepFreeze<Template[]>([
+export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   SEND_FOLLOW_UPS_TEMPLATE,
   SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE,
   SCHEDULE_REMINDERS_TEMPLATE,

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -30,8 +30,8 @@ function deepFreeze<T>(object: T): T {
 /**
  * Right now, some parameters have to be replaced dynamically.
  * 1. {{user_email}} will be replaced with the actual user email
- * 2. For tiles, any `columnId` key has the column name initially,
- * upon creating the tile, the column name value will be replaced with the id.
+ * 2. {{tile_col_data.col_name}}, the column name value will be replaced with the col id.
+ * 3. {{tile_table_id}} will be replaced with the tile id if created
  *
  * Note that parameters will have {{Replace with __}}, these are
  * placeholders for users to change them to the variable pills

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -28,6 +28,11 @@ function deepFreeze<T>(object: T): T {
 }
 
 /**
+ * Right now, some parameters have to be replaced dynamically.
+ * 1. {{user_email}} will be replaced with the actual user email
+ * 2. For tiles, any `columnId` key has the column name initially,
+ * upon creating the tile, the column name value will be replaced with the id.
+ *
  * Note that parameters will have {{Replace with __}}, these are
  * placeholders for users to change them to the variable pills
  * TODO (mal): change this in a later PR after discussing with the team

--- a/packages/backend/src/db/storage/route-support-enquiries.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries.ts
@@ -1,10 +1,10 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import { FORMSG_SAMPLE_URL_DESCRIPTION } from './constants'
 
 const ROUTE_SUPPORT_ENQUIRIES_ID = '2a84e2f6-4806-46a2-890a-0dba1411b12f'
 
-export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: Template = {
+export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
   id: ROUTE_SUPPORT_ENQUIRIES_ID,
   name: 'Route support enquiries',
   description: 'Route enquiries to the correct departments to process',

--- a/packages/backend/src/db/storage/schedule-reminders.ts
+++ b/packages/backend/src/db/storage/schedule-reminders.ts
@@ -1,5 +1,7 @@
 import type { Template } from '@/graphql/__generated__/types.generated'
 
+import { USER_EMAIL_PLACEHOLDER } from './constants'
+
 const SCHEDULE_REMINDERS_ID = '65e90f41-b605-4e83-bcd7-e4d2e349299d'
 
 export const SCHEDULE_REMINDERS_TEMPLATE: Template = {
@@ -25,7 +27,7 @@ export const SCHEDULE_REMINDERS_TEMPLATE: Template = {
         body: '<p style="margin: 0">This is a scheduled reminder to do you best this week! </p>',
         subject: "It's a new week!",
         senderName: 'Weekly motivation',
-        destinationEmail: '{{user_email}}',
+        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/schedule-reminders.ts
+++ b/packages/backend/src/db/storage/schedule-reminders.ts
@@ -1,10 +1,10 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import { USER_EMAIL_PLACEHOLDER } from './constants'
 
 const SCHEDULE_REMINDERS_ID = '65e90f41-b605-4e83-bcd7-e4d2e349299d'
 
-export const SCHEDULE_REMINDERS_TEMPLATE: Template = {
+export const SCHEDULE_REMINDERS_TEMPLATE: ITemplate = {
   id: SCHEDULE_REMINDERS_ID,
   name: 'Schedule reminders',
   description:

--- a/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
+++ b/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
@@ -1,6 +1,9 @@
 import type { Template } from '@/graphql/__generated__/types.generated'
 
-import { FORMSG_SAMPLE_URL_DESCRIPTION } from './constants'
+import {
+  FORMSG_SAMPLE_URL_DESCRIPTION,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
 
 const SEND_A_COPY_OF_FORM_RESPONSE_ID = 'd06d1024-2f1d-46ca-b9b3-2d3d073eddfe'
 
@@ -26,7 +29,7 @@ export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: Template = {
         body: '<p style="margin: 0">Hi <span data-type="variable" data-id="Replace with response 1 name" data-label="Replace with response 1 name">{{Replace with response 1 name}}</span>,</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration, here is what you submitted:</p><p style="margin: 0"></p><table style="border-collapse:collapse;"><tbody><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Question</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Response</p></td></tr><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace with question}}</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace with response}}</p></td></tr></tbody></table><p style="margin: 0"></p><p style="margin: 0">More details will be sent to you nearer to the date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event committee</p>',
         subject: 'We have received your registration!',
         senderName: 'Event committee',
-        destinationEmail: '{{user_email}}',
+        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
+++ b/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
@@ -7,7 +7,7 @@ import {
 
 const SEND_A_COPY_OF_FORM_RESPONSE_ID = 'd06d1024-2f1d-46ca-b9b3-2d3d073eddfe'
 
-export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: Template = {
+export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: ITemplate = {
   id: SEND_A_COPY_OF_FORM_RESPONSE_ID,
   name: 'Send a copy of form response',
   description: 'Send respondents a copy of their form response',

--- a/packages/backend/src/db/storage/send-follow-ups.ts
+++ b/packages/backend/src/db/storage/send-follow-ups.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
@@ -7,7 +7,7 @@ import {
 
 const SEND_FOLLOW_UPS_ID = 'aae185f7-2592-4683-a812-2d412232e403'
 
-export const SEND_FOLLOW_UPS_TEMPLATE: Template = {
+export const SEND_FOLLOW_UPS_TEMPLATE: ITemplate = {
   id: SEND_FOLLOW_UPS_ID,
   name: 'Send follow ups',
   description: 'Send follow up emails to respondents after they submit a form',

--- a/packages/backend/src/db/storage/send-follow-ups.ts
+++ b/packages/backend/src/db/storage/send-follow-ups.ts
@@ -1,6 +1,9 @@
 import type { Template } from '@/graphql/__generated__/types.generated'
 
-import { FORMSG_SAMPLE_URL_DESCRIPTION } from './constants'
+import {
+  FORMSG_SAMPLE_URL_DESCRIPTION,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
 
 const SEND_FOLLOW_UPS_ID = 'aae185f7-2592-4683-a812-2d412232e403'
 
@@ -27,7 +30,7 @@ export const SEND_FOLLOW_UPS_TEMPLATE: Template = {
         body: '<p style="margin: 0">Hi {{Replace with response 1 name}},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration for this event! More details will be sent to you nearer to the event date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event organising committee</p>',
         subject: 'Thank you for registering!',
         senderName: 'Event committee',
-        destinationEmail: '{{user_email}}',
+        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-message-to-a-slack-channel.ts
+++ b/packages/backend/src/db/storage/send-message-to-a-slack-channel.ts
@@ -1,9 +1,9 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 const SEND_MESSAGE_TO_A_SLACK_CHANNEL_ID =
   'c88d03f7-862b-45e5-8a51-33e293236bd8'
 
-export const SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE: Template = {
+export const SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE: ITemplate = {
   id: SEND_MESSAGE_TO_A_SLACK_CHANNEL_ID,
   name: 'Send message to a Slack channel',
   description: 'Schedule a recurring message to a Slack channel',

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -29,6 +29,36 @@ export const TRACK_FEEDBACK_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/18a72737-4a7e-4f90-8bb5-7d65bdac4136/d6f806c0-eb80-451b-872d-6e9a3d434ab2',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
+      tileTemplateStepData: [
+        {
+          columnName: 'Rating',
+          cellValue: '{{Replace with response 1 rating}}',
+        },
+        {
+          columnName: 'Reason for rating',
+          cellValue: '{{Replace with response 2 reason}}',
+        },
+        {
+          columnName: 'Email',
+          cellValue: '{{Replace with response 3 email}}',
+        },
+      ],
     },
   ],
+  tileTemplateData: {
+    name: 'Event feedback',
+    columns: [
+      { name: 'Rating', position: 0 },
+      { name: 'Reason for rating', position: 1 },
+      { name: 'Email', position: 2 },
+    ],
+    rowData: [
+      {
+        Rating: '4',
+        'Reason for rating':
+          'Plumber is good, please continue to make it better!',
+        Email: 'support@plumber.gov.sg',
+      },
+    ],
+  },
 }

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -2,6 +2,8 @@ import type { Template } from '@/graphql/__generated__/types.generated'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
+  TILE_COL_DATA_PLACEHOLDER,
+  TILE_ID_PLACEHOLDER,
   TILES_SAMPLE_URL_DESCRIPTION,
 } from './constants'
 
@@ -32,18 +34,19 @@ export const TRACK_FEEDBACK_TEMPLATE: Template = {
       parameters: {
         rowData: [
           {
-            columnId: 'Rating',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Rating}}`,
             cellValue: '{{Replace with response 1 rating}}',
           },
           {
-            columnId: 'Reason for rating',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Reason for rating}}`,
             cellValue: '{{Replace with response 2 reason}}',
           },
           {
-            columnId: 'Email',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
             cellValue: '{{Replace with response 3 email}}',
           },
         ],
+        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
@@ -9,7 +9,7 @@ import {
 
 const TRACK_FEEDBACK_ID = 'b237ff81-dbe9-4513-8135-0b59eec2de97'
 
-export const TRACK_FEEDBACK_TEMPLATE: Template = {
+export const TRACK_FEEDBACK_TEMPLATE: ITemplate = {
   id: TRACK_FEEDBACK_ID,
   name: 'Track feedback',
   description:
@@ -52,11 +52,7 @@ export const TRACK_FEEDBACK_TEMPLATE: Template = {
   ],
   tileTemplateData: {
     name: 'Event feedback',
-    columns: [
-      { name: 'Rating', position: 0 },
-      { name: 'Reason for rating', position: 1 },
-      { name: 'Email', position: 2 },
-    ],
+    columns: ['Rating', 'Reason for rating', 'Email'],
     rowData: [
       {
         Rating: '4',

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -29,20 +29,22 @@ export const TRACK_FEEDBACK_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/18a72737-4a7e-4f90-8bb5-7d65bdac4136/d6f806c0-eb80-451b-872d-6e9a3d434ab2',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
-      tileTemplateStepData: [
-        {
-          columnName: 'Rating',
-          cellValue: '{{Replace with response 1 rating}}',
-        },
-        {
-          columnName: 'Reason for rating',
-          cellValue: '{{Replace with response 2 reason}}',
-        },
-        {
-          columnName: 'Email',
-          cellValue: '{{Replace with response 3 email}}',
-        },
-      ],
+      parameters: {
+        rowData: [
+          {
+            columnId: 'Rating',
+            cellValue: '{{Replace with response 1 rating}}',
+          },
+          {
+            columnId: 'Reason for rating',
+            cellValue: '{{Replace with response 2 reason}}',
+          },
+          {
+            columnId: 'Email',
+            cellValue: '{{Replace with response 3 email}}',
+          },
+        ],
+      },
     },
   ],
   tileTemplateData: {

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -28,13 +28,16 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/ba2150f6-14d5-44cf-8a77-083c18f43518/c6b75dfa-9fa9-494c-b027-773da38ebaff',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
-      tileTemplateStepData: [
-        {
-          columnName: 'Name',
-          value: 'Anna Lee',
-          operator: 'equals',
-        },
-      ],
+      parameters: {
+        filters: [
+          {
+            columnId: 'Name',
+            value: 'Anna Lee',
+            operator: 'equals',
+          },
+        ],
+        returnLastRow: true,
+      },
     },
     {
       position: 3,
@@ -42,17 +45,17 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
       eventKey: 'updateSingleRow',
       parameters: {
         rowId: '{{Replace with row id result from step 2}}',
+        rowData: [
+          {
+            columnId: 'Email',
+            cellValue: '{{Replace with email result from step 2}}',
+          },
+          {
+            columnId: 'Mobile number',
+            cellValue: '{{Replace with response 4 mobile number from step 1}}',
+          },
+        ],
       },
-      tileTemplateStepData: [
-        {
-          columnName: 'Email',
-          cellValue: '{{Replace with email result from step 2}}',
-        },
-        {
-          columnName: 'Mobile number',
-          cellValue: '{{Replace with response 4 mobile number from step 1}}',
-        },
-      ],
     },
   ],
   tileTemplateData: {

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -28,11 +28,62 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
       sampleUrl:
         'https://plumber.gov.sg/tiles/ba2150f6-14d5-44cf-8a77-083c18f43518/c6b75dfa-9fa9-494c-b027-773da38ebaff',
       sampleUrlDescription: TILES_SAMPLE_URL_DESCRIPTION,
+      tileTemplateStepData: [
+        {
+          columnName: 'Name',
+          value: 'Anna Lee',
+          operator: 'equals',
+        },
+      ],
     },
     {
       position: 3,
       appKey: 'tiles',
       eventKey: 'updateSingleRow',
+      parameters: {
+        rowId: '{{Replace with row id result from step 2}}',
+      },
+      tileTemplateStepData: [
+        {
+          columnName: 'Email',
+          cellValue: '{{Replace with email result from step 2}}',
+        },
+        {
+          columnName: 'Mobile number',
+          cellValue: '{{Replace with response 4 mobile number from step 1}}',
+        },
+      ],
     },
   ],
+  tileTemplateData: {
+    name: 'Mailing list',
+    columns: [
+      { name: 'Name', position: 0 },
+      { name: 'Email', position: 1 },
+      { name: 'Mobile number', position: 2 },
+    ],
+    rowData: [
+      {
+        Name: 'Anna Lee',
+        Email: 'anna_lee@email.com',
+        'Mobile number': '+6598625072',
+      },
+      {
+        Name: 'Susan Tan Jia Ling',
+        Email: 'susan_tjl@email.com',
+      },
+      {
+        Name: 'Jane Lim',
+        Email: 'jane_98@email.com',
+      },
+      {
+        Name: 'Amy Low',
+        Email: 'amy_low_ll@email.com',
+      },
+      {
+        Name: 'Judy Ng',
+        Email: 'judy_00@email.com',
+      },
+    ],
+  },
 }

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -2,6 +2,8 @@ import type { Template } from '@/graphql/__generated__/types.generated'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
+  TILE_COL_DATA_PLACEHOLDER,
+  TILE_ID_PLACEHOLDER,
   TILES_SAMPLE_URL_DESCRIPTION,
 } from './constants'
 
@@ -31,12 +33,13 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
       parameters: {
         filters: [
           {
-            columnId: 'Name',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Name}}`,
             value: 'Anna Lee',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
+        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
       },
     },
     {
@@ -47,14 +50,15 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
         rowId: '{{Replace with row id result from step 2}}',
         rowData: [
           {
-            columnId: 'Email',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
             cellValue: '{{Replace with email result from step 2}}',
           },
           {
-            columnId: 'Mobile number',
+            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Mobile number}}`,
             cellValue: '{{Replace with response 4 mobile number from step 1}}',
           },
         ],
+        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
       },
     },
   ],

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -1,4 +1,4 @@
-import type { Template } from '@/graphql/__generated__/types.generated'
+import type { ITemplate } from '@plumber/types'
 
 import {
   FORMSG_SAMPLE_URL_DESCRIPTION,
@@ -9,7 +9,7 @@ import {
 
 const UPDATE_MAILING_LISTS_ID = '8ec2728a-6e4a-49c7-8721-ef6d4eb1d946'
 
-export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
+export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
   id: UPDATE_MAILING_LISTS_ID,
   name: 'Update mailing lists',
   description: 'Maintain mailing lists with updated recipient information',
@@ -64,11 +64,7 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: Template = {
   ],
   tileTemplateData: {
     name: 'Mailing list',
-    columns: [
-      { name: 'Name', position: 0 },
-      { name: 'Email', position: 1 },
-      { name: 'Mobile number', position: 2 },
-    ],
+    columns: ['Name', 'Email', 'Mobile number'],
     rowData: [
       {
         Name: 'Anna Lee',

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -844,6 +844,8 @@ input UpdateFlowTransferStatusInput {
 
 # End of flow transfers types
 
+# Start of template types
+
 type Template {
   id: String!
   name: String!
@@ -851,7 +853,6 @@ type Template {
   steps: [TemplateStep!]!
   iconName: String # demo templates have no icon
   tag: TemplateTagType # TODO: change to tags in later PR
-  tileTemplateData: TileTemplateData
 }
 
 type TemplateStep {
@@ -863,22 +864,12 @@ type TemplateStep {
   parameters: JSONObject
 }
 
-# This is for creation of tile for a template
-type TileTemplateData {
-  name: String!
-  columns: [TileColumnData!]!
-  rowData: [JSONObject]
-}
-
-type TileColumnData {
-  name: String!
-  position: Int!
-}
-
 enum TemplateTagType {
   demo
   empty # for empty flows state
 }
+
+# End of template types
 
 schema {
   query: Query

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -851,6 +851,7 @@ type Template {
   steps: [TemplateStep!]!
   iconName: String # demo templates have no icon
   tag: TemplateTagType # TODO: change to tags in later PR
+  tileTemplateData: TileTemplateData
 }
 
 type TemplateStep {
@@ -860,6 +861,19 @@ type TemplateStep {
   sampleUrl: String # specific to template e.g. form or tile link
   sampleUrlDescription: String # differs for each step e.g. view a sample form
   parameters: JSONObject
+  tileTemplateStepData: [JSONObject] # the column names must match the tile that was created above!
+}
+
+# This is for creation of tile for a template
+type TileTemplateData {
+  name: String!
+  columns: [TileColumnData!]!
+  rowData: [JSONObject]
+}
+
+type TileColumnData {
+  name: String!
+  position: Int!
 }
 
 enum TemplateTagType {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -861,7 +861,6 @@ type TemplateStep {
   sampleUrl: String # specific to template e.g. form or tile link
   sampleUrlDescription: String # differs for each step e.g. view a sample form
   parameters: JSONObject
-  tileTemplateStepData: [JSONObject] # the column names must match the tile that was created above!
 }
 
 # This is for creation of tile for a template

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -1,4 +1,4 @@
-import type { IApp } from '@plumber/types'
+import type { IApp, IJSONObject } from '@plumber/types'
 
 import apps from '@/apps'
 import { TEMPLATES } from '@/db/storage'
@@ -6,6 +6,7 @@ import type {
   FlowConfig,
   TemplateStep,
 } from '@/graphql/__generated__/types.generated'
+import { createTableRows } from '@/models/dynamodb/table-row'
 import Flow from '@/models/flow'
 import User from '@/models/user'
 
@@ -35,6 +36,65 @@ function validateAppAndEventKey(step: TemplateStep, templateName: string) {
   }
 }
 
+// This replaces the keys of columns which are names to the column ids for row data
+// e.g. { Rating: 5 } --> { column_id: 5 }
+function replaceRowData(
+  rowData: IJSONObject[],
+  columnNameToIdMap: Record<string, string>,
+) {
+  const replacedRowData: IJSONObject[] = []
+  for (const row of rowData) {
+    const newRow: IJSONObject = {}
+    for (const key in row) {
+      if (!columnNameToIdMap[key]) {
+        throw new Error(
+          'Creation of tile ran into an issue, please contact support@plumber.gov.sg',
+        )
+      }
+      const newKey = columnNameToIdMap[key]
+      newRow[newKey] = row[key]
+    }
+    replacedRowData.push(newRow)
+  }
+  return replacedRowData
+}
+
+/**
+ * This replaces the column name to the column id in each tile event data.
+ * This is because tiles apis uses column ids instead of the names
+ * e.g. { columnName: <Name> } --> { columnId: <id> }
+ * Then, generates parameters based on the format for each tile action
+ */
+function generateParametersForTilesAction(
+  tileEventData: IJSONObject[],
+  columnNameToIdMap: Record<string, string>,
+  eventKey: string,
+) {
+  const updatedTileEventData: IJSONObject[] = JSON.parse(
+    JSON.stringify(tileEventData),
+  )
+
+  for (const row of updatedTileEventData) {
+    row['columnId'] = columnNameToIdMap[String(row['columnName'])]
+    delete row['columnName']
+  }
+
+  // This follows the parameters format for each tile action
+  switch (eventKey) {
+    case 'createTileRow':
+    case 'updateSingleRow':
+      return {
+        rowData: updatedTileEventData,
+      } as IJSONObject
+    case 'findSingleRow':
+      return {
+        filters: updatedTileEventData,
+        returnLastRow: true,
+      } as IJSONObject
+  }
+  return {} as IJSONObject
+}
+
 export async function createFlowFromTemplate(
   templateId: string,
   user: User,
@@ -47,7 +107,7 @@ export async function createFlowFromTemplate(
   }
 
   // check if the template is a demo template first: affects name, config and logging only
-  const { name: flowName, steps, tag } = template
+  const { name: flowName, steps, tag, tileTemplateData } = template
   const isDemoTemplate = tag === 'demo'
   const flowConfig: FlowConfig = isDemoTemplate
     ? {
@@ -72,6 +132,29 @@ export async function createFlowFromTemplate(
     })
 
     validateAppAndEventKey(steps[0], flowName)
+    // create a tile with its columns and rows first if template uses tiles
+    let tableId: string | undefined
+    const columnNameToIdMap: Record<string, string> = {}
+    if (tileTemplateData) {
+      const { name, columns, rowData } = tileTemplateData
+      const table = await user.$relatedQuery('tables').insertGraph({
+        name,
+        role: 'owner',
+        columns,
+      })
+      tableId = table.id
+
+      // obtain a map of column name to the column id for easy replacement
+      for (const tableColumn of table.columns) {
+        columnNameToIdMap[tableColumn.name] = tableColumn.id
+      }
+
+      // replace row data and create table rows
+      const newRowData = replaceRowData(rowData, columnNameToIdMap)
+      await createTableRows({ tableId, dataArray: newRowData })
+    }
+
+    // account for trigger/action step having null for app or event key
     // insert trigger step
     await flow.$relatedQuery('steps', trx).insert({
       type: 'trigger',
@@ -87,7 +170,8 @@ export async function createFlowFromTemplate(
       const step: TemplateStep = steps[i]
       validateAppAndEventKey(step, flowName)
       // replace all parameters with {{user_email}} to the current user email
-      const updatedParameters = structuredClone(step?.parameters ?? {})
+      let updatedParameters = structuredClone(step.parameters ?? {})
+
       for (const [key, value] of Object.entries(updatedParameters)) {
         // ignore objects e.g. conditions because nothing to replace inside for now
         if (typeof value === 'string') {
@@ -99,6 +183,21 @@ export async function createFlowFromTemplate(
         }
       }
 
+      // perform tiles parameter update with tile template step data
+      if (step.appKey === 'tiles') {
+        // update all the parameters and map the column name to id
+        updatedParameters['tableId'] = tableId
+        updatedParameters = {
+          ...generateParametersForTilesAction(
+            step.tileTemplateStepData,
+            columnNameToIdMap,
+            step.eventKey,
+          ),
+          ...updatedParameters,
+        }
+      }
+
+      // insert action step
       await flow.$relatedQuery('steps', trx).insert({
         type: 'action',
         position: step.position,

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -149,7 +149,7 @@ export async function createFlowFromTemplate(
         columnNameToIdMap[tableColumn.name] = tableColumn.id
       }
 
-      // replace row data and create table rows
+      // replace column names with column ids for each row data and create table rows
       const newRowData = replaceRowData(rowData, columnNameToIdMap)
       await createTableRows({ tableId, dataArray: newRowData })
     }

--- a/packages/frontend/src/components/EmptyFlows/FlowTemplate.tsx
+++ b/packages/frontend/src/components/EmptyFlows/FlowTemplate.tsx
@@ -1,3 +1,5 @@
+import type { ITemplate } from '@plumber/types'
+
 import { useCallback } from 'react'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
@@ -6,12 +8,11 @@ import { Box, Card, CardBody, CardFooter, Flex, Text } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
-import type { Template } from '@/graphql/__generated__/graphql'
 import { CREATE_TEMPLATED_FLOW } from '@/graphql/mutations/create-templated-flow'
 import { TemplateIcon } from '@/helpers/flow-templates'
 
 export interface FlowTemplateProps {
-  template: Template
+  template: ITemplate
 }
 
 export default function FlowTemplate(props: FlowTemplateProps) {

--- a/packages/frontend/src/components/EmptyFlows/index.tsx
+++ b/packages/frontend/src/components/EmptyFlows/index.tsx
@@ -1,3 +1,5 @@
+import type { ITemplate } from '@plumber/types'
+
 import { useQuery } from '@apollo/client'
 import {
   AbsoluteCenter,
@@ -13,7 +15,6 @@ import {
 import { Button } from '@opengovsg/design-system-react'
 
 import NavigationDrawer from '@/components/Layout/NavigationDrawer'
-import type { Template } from '@/graphql/__generated__/graphql'
 import { GET_TEMPLATES } from '@/graphql/queries/get-templates'
 import ApproveTransfersInfobox from '@/pages/Flows/components/ApproveTransfersInfobox'
 import CreateFlowModal from '@/pages/Flows/components/CreateFlowModal'
@@ -34,7 +35,7 @@ export default function EmptyFlows(props: EmptyFlowsProps) {
       tag: 'empty',
     },
   })
-  const emptyFlowsTemplates: Template[] = data?.getTemplates
+  const emptyFlowsTemplates: ITemplate[] = data?.getTemplates
 
   // for creation of flows
   const {

--- a/packages/frontend/src/pages/Template/components/IfThenTemplateStepContent.tsx
+++ b/packages/frontend/src/pages/Template/components/IfThenTemplateStepContent.tsx
@@ -1,13 +1,11 @@
-import type { IApp } from '@plumber/types'
+import type { IApp, ITemplateStep } from '@plumber/types'
 
 import { BiQuestionMark } from 'react-icons/bi'
 import { Box, Card, Flex, Icon, Image, Text } from '@chakra-ui/react'
 
-import type { TemplateStep } from '@/graphql/__generated__/graphql'
-
 interface IfThenTemplateStepContentProps {
   app?: IApp
-  templateSteps: TemplateStep[]
+  templateSteps: ITemplateStep[]
 }
 
 export default function IfThenTemplateStepContent(

--- a/packages/frontend/src/pages/Template/components/TemplateBody.tsx
+++ b/packages/frontend/src/pages/Template/components/TemplateBody.tsx
@@ -1,4 +1,4 @@
-import type { IApp } from '@plumber/types'
+import type { IApp, ITemplateStep } from '@plumber/types'
 
 import { Fragment, useMemo } from 'react'
 import { BiPlus } from 'react-icons/bi'
@@ -6,14 +6,13 @@ import { useQuery } from '@apollo/client'
 import { AbsoluteCenter, Box, Divider, Flex, Text } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
 
-import type { TemplateStep } from '@/graphql/__generated__/graphql'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 
 import IfThenTemplateStepContent from './IfThenTemplateStepContent'
 import TemplateStepContent from './TemplateStepContent'
 
 interface TemplateBodyProps {
-  templateSteps: TemplateStep[]
+  templateSteps: ITemplateStep[]
 }
 
 function AddStepGraphic() {
@@ -48,7 +47,7 @@ export default function TemplateBody(props: TemplateBodyProps) {
 
   const [templateStepsBeforeIfThen, templateStepsAfterIfThen] = useMemo(() => {
     const ifThenStartIndex = templateSteps.findIndex(
-      (templateStep: TemplateStep) =>
+      (templateStep: ITemplateStep) =>
         templateStep?.appKey === 'toolbox' &&
         templateStep?.eventKey === 'ifThen',
     )

--- a/packages/frontend/src/pages/Template/components/TemplateStepContent.tsx
+++ b/packages/frontend/src/pages/Template/components/TemplateStepContent.tsx
@@ -1,13 +1,11 @@
-import type { IApp } from '@plumber/types'
+import type { IApp, ITemplateStep } from '@plumber/types'
 
 import { BiQuestionMark } from 'react-icons/bi'
 import { Card, Flex, Icon, Image, Link, Text } from '@chakra-ui/react'
 
-import type { TemplateStep } from '@/graphql/__generated__/graphql'
-
 interface TemplateStepContentProps {
   app?: IApp
-  templateStep: TemplateStep
+  templateStep: ITemplateStep
 }
 
 const FALLBACK_EVENT_NAME = 'Sample Event'

--- a/packages/frontend/src/pages/Template/index.tsx
+++ b/packages/frontend/src/pages/Template/index.tsx
@@ -1,3 +1,5 @@
+import type { ITemplate } from '@plumber/types'
+
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
@@ -15,14 +17,13 @@ import {
 import { Button } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
-import type { Template } from '@/graphql/__generated__/graphql'
 import { CREATE_TEMPLATED_FLOW } from '@/graphql/mutations/create-templated-flow'
 import { TemplateIcon } from '@/helpers/flow-templates'
 
 import TemplateBody from './components/TemplateBody'
 
 interface TemplateProps {
-  template: Template
+  template: ITemplate
 }
 
 // The template page is a modal and the route is /templates/:templateId

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -1,3 +1,5 @@
+import { ITemplate } from '@plumber/types'
+
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Box, Center, Flex, Grid, Text } from '@chakra-ui/react'
@@ -7,7 +9,6 @@ import Container from '@/components/Container'
 import PageTitle from '@/components/PageTitle'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import * as URLS from '@/config/urls'
-import { Template } from '@/graphql/__generated__/graphql'
 import { GET_TEMPLATES } from '@/graphql/queries/get-templates'
 import { TemplateIcon } from '@/helpers/flow-templates'
 
@@ -19,7 +20,7 @@ export default function Templates(): JSX.Element {
   const navigate = useNavigate()
   const { data, loading } = useQuery(GET_TEMPLATES)
 
-  const templates: Template[] = data?.getTemplates
+  const templates: ITemplate[] = data?.getTemplates
   const { templateId } = useParams()
   const template = templates?.find((template) => template.id === templateId)
   return (

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -892,3 +892,33 @@ export interface IFlowTransfer {
   newOwner: IUser
   flow: IFlow
 }
+
+// Templates
+export interface ITemplate {
+  id: string
+  name: string
+  description: string
+  steps: ITemplateStep[]
+  iconName?: string // demo templates have no icons
+  tag?: TemplateTagType // TODO: change to tags in later PR
+  tileTemplateData?: TileTemplateData
+}
+
+// demo template or for empty flows state
+export type TemplateTagType = 'demo' | 'empty'
+
+export interface ITemplateStep {
+  position: number // primary key, no need id for now
+  appKey?: string
+  eventKey?: string
+  sampleUrl?: string // specific to template e.g. form or tile link
+  sampleUrlDescription?: string // differs for each step e.g. view a sample form
+  parameters?: IJSONObject
+}
+
+// This is for creation of tile for a template
+export type TileTemplateData = {
+  name: string
+  columns: string[]
+  rowData?: IJSONObject[]
+}


### PR DESCRIPTION
## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
Need to add pre-template automation: creation of tile upon using the template
- Solution 1: Make use of frontend mutations e.g. create-table-row and columns
  - Can make use of the checks done in the mutations already but data required to pass to the frontend is more complicated and differs for each tile action
- Solution 2 (chosen): Perform the functionality on the backend while creating the templated flow
  - This is preferred because all the data creation is already done on the backend so I don’t want to display or show any of the data on the frontend
  - It looks way cleaner on the frontend

High level idea: we need to generate the correct parameters for each tile action
- We create a tile for them and return the `tableId` since it is required for all tile actions
- Each tile has its own rows so we need the `rowData` in its proper format (column ids are required) so the `replaceRowData` function maps the column name to column id
- Each tile action: create row, find row and update row has different parameters and we need the `columnId` for each action so I mapped the `column name` to the respective `column id` and generated the correct parameters respectively for each tile action using `generateParametersForTilesAction`

## Tests
- [x] Table and the respective columns are created for the 3 templates involving tiles
- [x] The pipes have the correct fields mapped
- [x] Other templates without tiles still work as intended