### PR TITLE
PLU-318: [TEMPLATES-8]: Add customised infobox sample link for each template step

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -56,9 +56,6 @@ const trigger: IRawTrigger = {
       showOptionValue: false,
     },
   ],
-  // TODO (mal): change form link to correct one
-  helpMessage:
-    'Connect your form to this step. Here is an [example](https://go.gov.sg/request-template) for this template.',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -29,7 +29,6 @@ const action: IRawAction = {
       (step.parameters.attachments as IJSONArray).length > 0
     )
   },
-  helpMessage: 'Customise how your email looks like in this step.',
 
   async run($) {
     const {

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -63,7 +63,6 @@ const action: IRawAction = {
       variables: true,
     },
   ],
-  helpMessage: 'Connect a Slack channel in this step.',
 
   async run($) {
     await postMessage($)

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -57,7 +57,6 @@ const action: IRawAction = {
       variables: true,
     },
   ],
-  helpMessage: 'Connect your Telegram bot in this step.',
 
   preprocessVariable(key: string, value: unknown) {
     if (key === 'text' && typeof value === 'string') {

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -85,8 +85,6 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage:
-    'Customise your columns and choose the data that goes into them. You can recreate this example for this template.',
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -140,8 +140,6 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage:
-    'This step finds a row in your Tile based on conditions you set.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -90,8 +90,6 @@ const action: IRawAction = {
       ],
     },
   ],
-  helpMessage:
-    'This step updates the row that was found. You need a Find row step before this.',
   getDataOutMetadata,
 
   async run($) {

--- a/packages/backend/src/db/migrations/20240829102755_add_step_config.ts
+++ b/packages/backend/src/db/migrations/20240829102755_add_step_config.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.table('steps', (table) => {
-    table.jsonb('config').nullable()
+    table.jsonb('config').notNullable().defaultTo('{}')
   })
 }
 

--- a/packages/backend/src/db/migrations/20240829102755_add_step_config.ts
+++ b/packages/backend/src/db/migrations/20240829102755_add_step_config.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.jsonb('config').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.dropColumn('config')
+  })
+}

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -29,6 +29,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
   if (!executionStep.isFailed) {
     await stepToTest.$query().patch({
       status: 'completed',
+      config: {}, // clear template step config when step is tested successfully
     })
   }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -367,6 +367,8 @@ type FlowDemoConfig {
 
 type FlowTemplateConfig {
   templateId: String!
+  formId: String
+  tileId: String
 }
 
 type Execution {
@@ -557,8 +559,7 @@ type StepConfig {
 }
 
 type StepTemplateConfig {
-  templateId: String!
-  helpMessage: String # FormSG and Tiles will have a customised help message
+  appEventKey: String
 }
 
 input StepConnectionInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -154,7 +154,6 @@ type Action {
   groupsLaterSteps: Boolean
   setupMessage: SetupMessage
   substeps: [ActionSubstep]
-  helpMessage: String
 }
 
 type ActionSubstep {
@@ -558,7 +557,8 @@ type StepConfig {
 }
 
 type StepTemplateConfig {
-  helpMessage: String!
+  templateId: String!
+  helpMessage: String # FormSG and Tiles will have a customised help message
 }
 
 input StepConnectionInput {
@@ -595,7 +595,6 @@ type Trigger {
   webhookTriggerInstructions: TriggerInstructions
   settingsStepLabel: String
   substeps: [TriggerSubstep]
-  helpMessage: String
 }
 
 type TriggerInstructions {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -550,6 +550,15 @@ type Step {
   position: Int
   status: String
   executionSteps: [ExecutionStep]
+  config: StepConfig
+}
+
+type StepConfig {
+  templateConfig: StepTemplateConfig
+}
+
+type StepTemplateConfig {
+  helpMessage: String!
 }
 
 input StepConnectionInput {

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -191,6 +191,13 @@ export async function createFlowFromTemplate(
       appKey: steps[0].appKey,
       key: steps[0].eventKey,
       parameters: steps[0].parameters ?? {},
+      ...(steps[0].sampleUrl && {
+        config: {
+          templateConfig: {
+            helpMessage: `Connect your form to this step. Here is an [example](${steps[0].sampleUrl}) for this template.`,
+          },
+        },
+      }),
     })
 
     // action step could have app or event key to be null due to if-then
@@ -212,6 +219,13 @@ export async function createFlowFromTemplate(
         appKey: step.appKey,
         key: step.eventKey,
         parameters: updatedParameters,
+        ...(step.appKey === 'tiles' && {
+          config: {
+            templateConfig: {
+              helpMessage: `We’ve already created a [Tile](${`/tiles/${tableId}`}) for you that you can customise in this step.`,
+            },
+          },
+        }),
       })
     }
 

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -22,18 +22,12 @@ import logger from './logger'
 // e.g. {{user_email}}, {{tile_col_data.Email}}
 const PLACEHOLDER_REGEX = /\{\{[a-zA-Z0-9_.? ]+\}\}/
 const FORM_ID_LENGTH = 24
-const CREATE_APP_EVENT_KEY = (appKey?: string, eventKey?: string) =>
-  `${appKey}_${eventKey}`
-// chose app_event key since it is unique among all triggers and actions
-const HELP_MESSAGE_APP_EVENT_KEY_SET = new Set([
-  'formsg_newSubmission',
-  'tiles_createTileRow',
-  'tiles_findSingleRow',
-  'tiles_updateSingleRow',
-  'postman_sendTransactionalEmail',
-  'slack_sendMessageToChannel',
-  'telegram-bot_sendMessage',
-])
+const CREATE_APP_EVENT_KEY = (appKey?: string, eventKey?: string) => {
+  if (!appKey && !eventKey) {
+    return '' // for empty step
+  }
+  return `${appKey}_${eventKey}`
+}
 
 function validateAppAndEventKey(step: ITemplateStep, templateName: string) {
   let app: IApp
@@ -225,9 +219,7 @@ export async function createFlowFromTemplate(
     )
     const triggerStepConfig: StepConfig = {
       templateConfig: {
-        ...(HELP_MESSAGE_APP_EVENT_KEY_SET.has(triggerAppEventKey) && {
-          appEventKey: triggerAppEventKey,
-        }),
+        appEventKey: triggerAppEventKey,
       },
     }
     // insert trigger step
@@ -256,9 +248,7 @@ export async function createFlowFromTemplate(
       const actionAppEventKey = CREATE_APP_EVENT_KEY(step.appKey, step.eventKey)
       const actionStepConfig: StepConfig = {
         templateConfig: {
-          ...(HELP_MESSAGE_APP_EVENT_KEY_SET.has(actionAppEventKey) && {
-            appEventKey: actionAppEventKey,
-          }),
+          appEventKey: actionAppEventKey,
         },
       }
       // insert action step

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -29,11 +29,7 @@ class Step extends Base {
   connection?: Connection
   flow: Flow
   executionSteps: ExecutionStep[]
-
-  /**
-   * Null means to use default config.
-   */
-  config: StepConfig | null
+  config: StepConfig
 
   static tableName = 'steps'
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -5,6 +5,7 @@ import { URL } from 'url'
 
 import apps from '@/apps'
 import appConfig from '@/config/app'
+import type { StepConfig } from '@/graphql/__generated__/types.generated'
 
 import Base from './base'
 import Connection from './connection'
@@ -28,6 +29,11 @@ class Step extends Base {
   connection?: Connection
   flow: Flow
   executionSteps: ExecutionStep[]
+
+  /**
+   * Null means to use default config.
+   */
+  config: StepConfig | null
 
   static tableName = 'steps'
 

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -273,6 +273,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onContinue={() => {
                   setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
                 }}
+                templateConfig={flow?.config?.templateConfig}
               />
               <AddStepButton
                 onClick={() => addStep(step.id)}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -31,6 +31,7 @@ import { StepExecutionsToIncludeContext } from '@/contexts/StepExecutionsToInclu
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { HELP_MESSAGE_MAP } from '@/helpers/flow-templates'
 
 type FlowStepProps = {
   collapsed?: boolean
@@ -188,8 +189,16 @@ export default function FlowStep(
     caption = 'This step happens after the previous step'
   }
 
+  const templateStepHelpMessage =
+    step.config?.templateConfig?.helpMessage ??
+    HELP_MESSAGE_MAP[step.appKey ?? '']
+
+  // Only show if it is an incomplete step belonging to a template
+  // AND the template step has a help message
   const shouldShowInfobox: boolean =
-    step.status === 'incomplete' && !!selectedActionOrTrigger?.helpMessage
+    step.status === 'incomplete' &&
+    !!step.config?.templateConfig &&
+    !!templateStepHelpMessage
 
   if (!apps) {
     return <CircularProgress isIndeterminate my={2} />
@@ -210,11 +219,7 @@ export default function FlowStep(
           }}
         >
           <MarkdownRenderer
-            source={
-              step?.config?.templateConfig
-                ? step.config.templateConfig.helpMessage
-                : selectedActionOrTrigger?.helpMessage ?? ''
-            }
+            source={templateStepHelpMessage}
             components={{
               // Force all links in our message to be opened in a new tab.
               a: ({ ...props }) => (

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -210,7 +210,11 @@ export default function FlowStep(
           }}
         >
           <MarkdownRenderer
-            source={selectedActionOrTrigger?.helpMessage ?? ''}
+            source={
+              step?.config?.templateConfig
+                ? step.config.templateConfig.helpMessage
+                : selectedActionOrTrigger?.helpMessage ?? ''
+            }
             components={{
               // Force all links in our message to be opened in a new tab.
               a: ({ ...props }) => (

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -50,14 +50,15 @@ const ifThenHelpMessage = 'Customise what happens in each of your branches.'
 
 function FlowStepGroup(props: FlowStepGroupProps): JSX.Element {
   const { iconUrl, flow, steps, onOpen, onClose, collapsed } = props
+  const isTemplatedFlow = !!flow.config?.templateConfig?.templateId
 
   const { StepContent, hintAboveCaption, caption, isStepGroupCompleted } =
     useMemo(() => getStepContent(steps), [steps])
 
   return (
     <Flex w="100%" flexDir="column">
-      {/* Show infobox only if the step group is incomplete */}
-      {!isStepGroupCompleted && (
+      {/* Show infobox only if the step group is incomplete and from a template */}
+      {!isStepGroupCompleted && isTemplatedFlow && (
         <Infobox
           icon={<BiInfoCircle />}
           variant="secondary"

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -21,6 +21,7 @@ import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { ExecutionStep } from '@/graphql/__generated__/graphql'
 import { EXECUTE_FLOW } from '@/graphql/mutations/execute-flow'
 import { EXECUTE_STEP } from '@/graphql/mutations/execute-step'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import {
   extractVariables,
@@ -89,7 +90,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
     {
       context: { autoSnackbar: false },
       awaitRefetchQueries: true,
-      refetchQueries: [GET_TEST_EXECUTION_STEPS],
+      refetchQueries: [GET_TEST_EXECUTION_STEPS, GET_FLOW],
       update(cache, { data }) {
         // If last execution step is successful, it means the test run is successful
         // Update the step status to completed without refreshing

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -4,7 +4,6 @@ interface AppConfig {
   isDev: boolean
   env: string
   version: string
-  webAppUrl: string
 }
 
 function getAppConfig(): AppConfig {
@@ -23,23 +22,14 @@ function getAppConfig(): AppConfig {
         launchDarklyClientId: '64bf4b539077f112ef24e4ae',
         sgidClientId: 'PLUMBER-c24255a5',
         isDev: false,
-        webAppUrl: 'https://plumber.gov.sg',
         ...commonEnv,
       }
     case 'uat':
-      return {
-        launchDarklyClientId: '65016ca0b45b7712e6c95703',
-        sgidClientId: 'PLUMBERSTAGING-776896b1',
-        isDev: false,
-        webAppUrl: 'https://uat.plumber.gov.sg',
-        ...commonEnv,
-      }
     case 'staging':
       return {
         launchDarklyClientId: '65016ca0b45b7712e6c95703',
         sgidClientId: 'PLUMBERSTAGING-776896b1',
         isDev: false,
-        webAppUrl: 'https://staging.plumber.gov.sg',
         ...commonEnv,
       }
     default:
@@ -47,7 +37,6 @@ function getAppConfig(): AppConfig {
         launchDarklyClientId: '64bf4b539077f112ef24e4ad',
         sgidClientId: 'PLUMBERLOCALDEV-dc1a72f7',
         isDev: true,
-        webAppUrl: 'http://localhost:3001',
         ...commonEnv,
       }
   }

--- a/packages/frontend/src/config/app.ts
+++ b/packages/frontend/src/config/app.ts
@@ -4,6 +4,7 @@ interface AppConfig {
   isDev: boolean
   env: string
   version: string
+  webAppUrl: string
 }
 
 function getAppConfig(): AppConfig {
@@ -22,15 +23,23 @@ function getAppConfig(): AppConfig {
         launchDarklyClientId: '64bf4b539077f112ef24e4ae',
         sgidClientId: 'PLUMBER-c24255a5',
         isDev: false,
+        webAppUrl: 'https://plumber.gov.sg',
         ...commonEnv,
       }
     case 'uat':
+      return {
+        launchDarklyClientId: '65016ca0b45b7712e6c95703',
+        sgidClientId: 'PLUMBERSTAGING-776896b1',
+        isDev: false,
+        webAppUrl: 'https://uat.plumber.gov.sg',
+        ...commonEnv,
+      }
     case 'staging':
       return {
         launchDarklyClientId: '65016ca0b45b7712e6c95703',
         sgidClientId: 'PLUMBERSTAGING-776896b1',
         isDev: false,
-
+        webAppUrl: 'https://staging.plumber.gov.sg',
         ...commonEnv,
       }
     default:
@@ -38,6 +47,7 @@ function getAppConfig(): AppConfig {
         launchDarklyClientId: '64bf4b539077f112ef24e4ad',
         sgidClientId: 'PLUMBERLOCALDEV-dc1a72f7',
         isDev: true,
+        webAppUrl: 'http://localhost:3001',
         ...commonEnv,
       }
   }

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -98,7 +98,6 @@ export const GET_APPS = gql`
           hideWebhookUrl
           mockDataMsg
         }
-        helpMessage
         substeps {
           key
           name
@@ -175,7 +174,6 @@ export const GET_APPS = gql`
           variant
           messageBody
         }
-        helpMessage
         groupsLaterSteps
         substeps {
           key

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -39,6 +39,9 @@ export const GET_FLOW = gql`
           isAutoCreated
           videoId
         }
+        templateConfig {
+          templateId
+        }
       }
       pendingTransfer {
         id

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -24,6 +24,11 @@ export const GET_FLOW = gql`
           }
         }
         parameters
+        config {
+          templateConfig {
+            helpMessage
+          }
+        }
       }
       config {
         errorConfig {

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -26,7 +26,7 @@ export const GET_FLOW = gql`
         parameters
         config {
           templateConfig {
-            helpMessage
+            appEventKey
           }
         }
       }
@@ -41,6 +41,8 @@ export const GET_FLOW = gql`
         }
         templateConfig {
           templateId
+          formId
+          tileId
         }
       }
       pendingTransfer {

--- a/packages/frontend/src/helpers/flow-templates.tsx
+++ b/packages/frontend/src/helpers/flow-templates.tsx
@@ -1,6 +1,9 @@
+import { IFlowTemplateConfig } from '@plumber/types'
+
 import { ComponentType } from 'react'
 import * as Icons from 'react-icons/bi'
 
+import appConfig from '@/config/app'
 import type { DemoVideoDetails } from '@/graphql/__generated__/graphql'
 
 /** DEMO TEMPLATES */
@@ -35,8 +38,37 @@ export const TemplateIcon = ({
   return <IconComponent fontSize={fontSize} />
 }
 
+// key: app_event key pair, value: help message
+// <<form_id>> and <<tile_id>> have to be replaced
+const FORM_ID_PLACEHOLDER = '<<form_id>>'
+const TILE_ID_PLACEHOLDER = '<<tile_id>>'
+const tileLink = `${appConfig.webAppUrl}/tiles/${TILE_ID_PLACEHOLDER}`
 export const HELP_MESSAGE_MAP: Record<string, string> = {
-  postman: 'Customise how your email looks like in this step.',
-  slack: 'Connect a Slack channel in this step.',
-  'telegram-bot': 'Connect your Telegram bot in this step.',
+  formsg_newSubmission: `Connect your form to this step. Here is an [example](https://form.gov.sg/${FORM_ID_PLACEHOLDER}) for this template.`,
+  tiles_createTileRow: `We’ve already created a [Tile](${tileLink}) for you that you can customise in this step.`,
+  tiles_findSingleRow: `This step finds a row in your [Tile](${tileLink}) based on conditions you set.`,
+  tiles_updateSingleRow: `This step updates the row that was found in your [Tile](${tileLink}). You need a Find row step before this.`,
+  postman_sendTransactionalEmail:
+    'Customise how your email looks like in this step.',
+  slack_sendMessageToChannel: 'Connect a Slack channel in this step.',
+  'telegram-bot_sendMessage': 'Connect your Telegram bot in this step.',
+}
+
+export function replacePlaceholdersForHelpMessage(
+  appEventKey?: string,
+  templateConfig?: IFlowTemplateConfig,
+): string {
+  if (!appEventKey || !templateConfig) {
+    return ''
+  }
+  const helpMessage = HELP_MESSAGE_MAP[appEventKey] ?? ''
+  const { formId, tileId } = templateConfig
+  if (formId) {
+    helpMessage.replace(FORM_ID_PLACEHOLDER, formId)
+  }
+
+  if (tileId) {
+    return helpMessage.replace(TILE_ID_PLACEHOLDER, tileId)
+  }
+  return helpMessage
 }

--- a/packages/frontend/src/helpers/flow-templates.tsx
+++ b/packages/frontend/src/helpers/flow-templates.tsx
@@ -3,7 +3,7 @@ import { IFlowTemplateConfig } from '@plumber/types'
 import { ComponentType } from 'react'
 import * as Icons from 'react-icons/bi'
 
-import appConfig from '@/config/app'
+import * as URLS from '@/config/urls'
 import type { DemoVideoDetails } from '@/graphql/__generated__/graphql'
 
 /** DEMO TEMPLATES */
@@ -42,7 +42,7 @@ export const TemplateIcon = ({
 // <<form_id>> and <<tile_id>> have to be replaced
 const FORM_ID_PLACEHOLDER = '<<form_id>>'
 const TILE_ID_PLACEHOLDER = '<<tile_id>>'
-const tileLink = `${appConfig.webAppUrl}/tiles/${TILE_ID_PLACEHOLDER}`
+const tileLink = `${window.location.origin}${URLS.TILE(TILE_ID_PLACEHOLDER)}`
 export const HELP_MESSAGE_MAP: Record<string, string> = {
   formsg_newSubmission: `Connect your form to this step. Here is an [example](https://form.gov.sg/${FORM_ID_PLACEHOLDER}) for this template.`,
   tiles_createTileRow: `We’ve already created a [Tile](${tileLink}) for you that you can customise in this step.`,

--- a/packages/frontend/src/helpers/flow-templates.tsx
+++ b/packages/frontend/src/helpers/flow-templates.tsx
@@ -61,14 +61,14 @@ export function replacePlaceholdersForHelpMessage(
   if (!appEventKey || !templateConfig) {
     return ''
   }
-  const helpMessage = HELP_MESSAGE_MAP[appEventKey] ?? ''
+  let helpMessage = HELP_MESSAGE_MAP[appEventKey] ?? ''
   const { formId, tileId } = templateConfig
   if (formId) {
-    helpMessage.replace(FORM_ID_PLACEHOLDER, formId)
+    helpMessage = helpMessage.replace(FORM_ID_PLACEHOLDER, formId)
   }
 
   if (tileId) {
-    return helpMessage.replace(TILE_ID_PLACEHOLDER, tileId)
+    helpMessage = helpMessage.replace(TILE_ID_PLACEHOLDER, tileId)
   }
   return helpMessage
 }

--- a/packages/frontend/src/helpers/flow-templates.tsx
+++ b/packages/frontend/src/helpers/flow-templates.tsx
@@ -38,11 +38,14 @@ export const TemplateIcon = ({
   return <IconComponent fontSize={fontSize} />
 }
 
-// key: app_event key pair, value: help message
-// <<form_id>> and <<tile_id>> have to be replaced
+/**
+ * chose app_event key since it is unique among all triggers and actions
+ * key: app_event key pair, value: help message
+ * <<form_id>> and <<tile_id>> have to be replaced
+ */
 const FORM_ID_PLACEHOLDER = '<<form_id>>'
 const TILE_ID_PLACEHOLDER = '<<tile_id>>'
-const tileLink = `${window.location.origin}${URLS.TILE(TILE_ID_PLACEHOLDER)}`
+const tileLink = URLS.TILE(TILE_ID_PLACEHOLDER)
 export const HELP_MESSAGE_MAP: Record<string, string> = {
   formsg_newSubmission: `Connect your form to this step. Here is an [example](https://form.gov.sg/${FORM_ID_PLACEHOLDER}) for this template.`,
   tiles_createTileRow: `We’ve already created a [Tile](${tileLink}) for you that you can customise in this step.`,

--- a/packages/frontend/src/helpers/flow-templates.tsx
+++ b/packages/frontend/src/helpers/flow-templates.tsx
@@ -34,3 +34,9 @@ export const TemplateIcon = ({
   )[iconName]
   return <IconComponent fontSize={fontSize} />
 }
+
+export const HELP_MESSAGE_MAP: Record<string, string> = {
+  postman: 'Customise how your email looks like in this step.',
+  slack: 'Connect a Slack channel in this step.',
+  'telegram-bot': 'Connect your Telegram bot in this step.',
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -138,7 +138,8 @@ export interface IStepConfig {
 }
 
 export interface IStepTemplateConfig {
-  helpMessage: string
+  templateId: string
+  helpMessage?: string
 }
 
 export interface IStep {
@@ -628,10 +629,6 @@ export interface IBaseTrigger {
    * message to the user during pipe setup / config.
    */
   setupMessage?: SetupMessage
-  /**
-   * Displays an infobox to provide a general guide/help for users during step config
-   */
-  helpMessage?: string
 }
 
 export interface IRawTrigger extends IBaseTrigger {
@@ -725,10 +722,6 @@ export interface IBaseAction {
    * message to the user during pipe setup / config.
    */
   setupMessage?: SetupMessage
-  /**
-   * Displays an infobox to provide a general guide/help for users during step config
-   */
-  helpMessage?: string
 }
 
 export interface IRawAction extends IBaseAction {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -138,8 +138,7 @@ export interface IStepConfig {
 }
 
 export interface IStepTemplateConfig {
-  templateId: string
-  helpMessage?: string
+  appEventKey?: string
 }
 
 export interface IStep {
@@ -158,7 +157,7 @@ export interface IStep {
   connection?: Partial<IConnection>
   flow: IFlow
   executionSteps: IExecutionStep[]
-  config: IStepConfig | null
+  config: IStepConfig
   // FIXME: remove this property once execution steps are properly exposed via queries
   output?: IJSONObject
   appData?: IApp
@@ -187,6 +186,8 @@ export interface IFlowDemoConfig {
 
 export interface IFlowTemplateConfig {
   templateId: string
+  formId?: string
+  tileId?: string
 }
 
 export interface IFlow {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -133,6 +133,14 @@ export interface IExecution {
   createdAt: string
 }
 
+export interface IStepConfig {
+  templateConfig?: IStepTemplateConfig
+}
+
+export interface IStepTemplateConfig {
+  helpMessage: string
+}
+
 export interface IStep {
   id: string
   name?: string
@@ -149,6 +157,7 @@ export interface IStep {
   connection?: Partial<IConnection>
   flow: IFlow
   executionSteps: IExecutionStep[]
+  config: IStepConfig | null
   // FIXME: remove this property once execution steps are properly exposed via queries
   output?: IJSONObject
   appData?: IApp


### PR DESCRIPTION
## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
- Added a migration to add `config` to `step` since each step needs to have an association with a template step
  - Each template step will have a config which stores the `app_event` key created at the point of generating the template e.g. `tiles_createTileRow`
- Only template steps will have an infobox for formsg, tiles, postman, slack, telegram and if-then
  - Infobox only appears when the `app_event` key matches with the current step selection
  - Upon testing step successfully, clear the step config so that the infobox will never appear anymore

## TODO
After getting the solution approved,
- [ ] Need to run migration on staging and UAT
- [ ] Need to run migration on prod

## Tests
- [x] Templates involving tiles would have the created tile URL in the infobox
- [x] Templates involving formsg would have the template formsg URL in the infobox
- [x] Steps that are generated from a template will display the `helpMessage` in the infobox for postman, slack, telegram and if-then
- [x] Normal steps will not have an infobox