### PR TITLE
PLU-115: [SST-7] launchdarkly flags for info and kill-switch

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -95,6 +95,8 @@ describe('decrypt form response', () => {
       user: {
         id: 'userid',
         email: 'test-email@open.gov.sg',
+        createdAt: `${new Date().getTime()}`,
+        updatedAt: `${new Date().getTime()}`,
       },
       app,
     }

--- a/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
@@ -34,6 +34,8 @@ describe('formsg webhook registration', () => {
       user: {
         id: 'abc-def',
         email: 'tester@open.gov.sg',
+        createdAt: `${new Date().getTime()}`,
+        updatedAt: `${new Date().getTime()}`,
       },
       app,
     }

--- a/packages/frontend/src/components/FlowSubstepTitle/index.tsx
+++ b/packages/frontend/src/components/FlowSubstepTitle/index.tsx
@@ -12,6 +12,7 @@ type FlowSubstepTitleProps = {
   onClick: () => void
   title: string
   valid?: boolean | null
+  rightEl?: React.ReactElement
 }
 
 const validIcon = (
@@ -27,7 +28,13 @@ const errorIcon = (
 )
 
 function FlowSubstepTitle(props: FlowSubstepTitleProps): React.ReactElement {
-  const { expanded = false, onClick = () => null, valid = null, title } = props
+  const {
+    expanded = false,
+    onClick = () => null,
+    valid = null,
+    title,
+    rightEl,
+  } = props
 
   const hasValidation = valid !== null
   const validationStatusIcon = valid ? validIcon : errorIcon
@@ -47,6 +54,7 @@ function FlowSubstepTitle(props: FlowSubstepTitleProps): React.ReactElement {
             {expanded ? <BiChevronUp /> : <BiChevronDown />}
           </Box>
           <Text textStyle="subhead-1">{title}</Text>
+          {rightEl}
         </Flex>
 
         {hasValidation && validationStatusIcon}

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -9,7 +9,7 @@ const IF_THEN_EXTERNAL_LINK =
 
 export const NEWS_ITEM_LIST: NewsItemProps[] = [
   {
-    date: '2024-08-04',
+    date: '2024-09-05',
     tag: NEW_ENHANCEMENT_TAG,
     title: `Improved step testing`,
     details: dedent`

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -9,6 +9,14 @@ const IF_THEN_EXTERNAL_LINK =
 
 export const NEWS_ITEM_LIST: NewsItemProps[] = [
   {
+    date: '2024-08-04',
+    tag: NEW_ENHANCEMENT_TAG,
+    title: `Improved step testing`,
+    details: dedent`
+      🧪 Test your steps with ease! We’ve enhanced the step testing experience, allowing you to test individual steps without running the previous ones.
+    `,
+  },
+  {
     date: '2024-08-02',
     tag: NEW_ENHANCEMENT_TAG,
     title: `Improvements we made`,

--- a/packages/frontend/src/components/NewsDrawer/NewsItemTag.tsx
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemTag.tsx
@@ -35,10 +35,7 @@ const newEnhancementTag = (
     }}
   >
     <React.Fragment>
-      <BadgeLeftIcon
-        as={BiSolidSmile}
-        style={{ marginRight: '0.25rem', color: '#5D6785' }}
-      />
+      <BadgeLeftIcon as={BiSolidSmile} style={{ marginRight: '0.25rem' }} />
       Enhancements
     </React.Fragment>
   </Badge>

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -6,7 +6,6 @@ import { Infobox } from '@opengovsg/design-system-react'
 import VariablesList from '@/components/VariablesList'
 import { isIfThenStep } from '@/helpers/toolbox'
 import type { Variable } from '@/helpers/variables'
-import useAuthentication from '@/hooks/useAuthentication'
 
 function getNoOutputMessage(
   selectedActionOrTrigger: TestResultsProps['selectedActionOrTrigger'],
@@ -44,18 +43,6 @@ interface TestResultsProps {
   // if null, the step probably hasnt been tested yet
   variables: Variable[] | null
   isMock?: boolean
-}
-
-export function SingleStepTestingInfoBox() {
-  const { currentUser } = useAuthentication()
-  if (currentUser?.createdAt) {
-    return (
-      <Infobox variant="success">
-        <Text>{`What's new`}</Text>
-      </Infobox>
-    )
-  }
-  return null
 }
 
 export default function TestResult(props: TestResultsProps): JSX.Element {

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -6,6 +6,7 @@ import { Infobox } from '@opengovsg/design-system-react'
 import VariablesList from '@/components/VariablesList'
 import { isIfThenStep } from '@/helpers/toolbox'
 import type { Variable } from '@/helpers/variables'
+import useAuthentication from '@/hooks/useAuthentication'
 
 function getNoOutputMessage(
   selectedActionOrTrigger: TestResultsProps['selectedActionOrTrigger'],
@@ -43,6 +44,18 @@ interface TestResultsProps {
   // if null, the step probably hasnt been tested yet
   variables: Variable[] | null
   isMock?: boolean
+}
+
+export function SingleStepTestingInfoBox() {
+  const { currentUser } = useAuthentication()
+  if (currentUser?.createdAt) {
+    return (
+      <Infobox variant="success">
+        <Text>{`What's new`}</Text>
+      </Infobox>
+    )
+  }
+  return null
 }
 
 export default function TestResult(props: TestResultsProps): JSX.Element {

--- a/packages/frontend/src/components/TestSubstep/TestSubstepTitleTooltip.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestSubstepTitleTooltip.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useContext, useRef, useState } from 'react'
+import { BiHelpCircle } from 'react-icons/bi'
+import { Box, Icon, Tooltip } from '@chakra-ui/react'
+
+import { SINGLE_STEP_TEST_SHOW_BEFORE_FLAG } from '@/config/flags'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+import * as localStorage from '@/helpers/storage'
+import useAuthentication from '@/hooks/useAuthentication'
+
+const SINGLE_STEP_TEST_STOP_PULSATE_STORAGE_KEY =
+  'single_step_test_stop_pulsate'
+
+function TestSubstepTitleTooltip() {
+  const { currentUser } = useAuthentication()
+  const { flags } = useContext(LaunchDarklyContext)
+
+  const [pulsate, setPulsate] = useState(
+    localStorage.getItem(SINGLE_STEP_TEST_STOP_PULSATE_STORAGE_KEY) !== 'true',
+  )
+
+  /**
+   * Stop puslating after 1 second of hover
+   */
+  const hoverTimeoutRef = useRef<NodeJS.Timeout>()
+  const handleMouseEnter = useCallback(() => {
+    hoverTimeoutRef.current = setTimeout(() => {
+      localStorage.setItem(SINGLE_STEP_TEST_STOP_PULSATE_STORAGE_KEY, 'true')
+      setPulsate(false)
+    }, 1000)
+  }, [])
+  const handleMouseLeave = useCallback(() => {
+    clearTimeout(hoverTimeoutRef.current)
+  }, [])
+
+  /**
+   * We only want to show popover for users created before a certain time
+   */
+  const shouldShowTooltip =
+    flags?.[SINGLE_STEP_TEST_SHOW_BEFORE_FLAG] &&
+    currentUser &&
+    +currentUser.createdAt < flags[SINGLE_STEP_TEST_SHOW_BEFORE_FLAG]
+
+  if (!shouldShowTooltip) {
+    return null
+  }
+
+  return (
+    <Tooltip
+      label={
+        <span>
+          <b>New behaviour:</b> The test button now only tests this step, rather
+          than all steps up to this point
+        </span>
+      }
+      placement="right-start"
+      gutter={0}
+      hasArrow
+    >
+      <Box
+        boxSize="18px"
+        ml={2}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        cursor="help"
+      >
+        <Icon
+          as={BiHelpCircle}
+          boxSize="inherit"
+          sx={{
+            borderRadius: '50%',
+            animation: pulsate ? 'pulse 2s infinite' : undefined,
+          }}
+        />
+      </Box>
+    </Tooltip>
+  )
+}
+
+export default TestSubstepTitleTooltip

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -14,7 +14,6 @@ import { Box, Collapse } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
 import ErrorResult from '@/components/ErrorResult'
-import FlowSubstepTitle from '@/components/FlowSubstepTitle'
 import WebhookUrlInfo from '@/components/WebhookUrlInfo'
 import { EditorContext } from '@/contexts/Editor'
 import { ExecutionStep } from '@/graphql/__generated__/graphql'
@@ -26,7 +25,10 @@ import {
   VISIBLE_VARIABLE_TYPES,
 } from '@/helpers/variables'
 
+import FlowSubstepTitle from '../FlowSubstepTitle'
+
 import TestResult from './TestResult'
+import TestSubstepTitleTooltip from './TestSubstepTitleTooltip'
 
 // the default alert follows the raw webhook alert
 const defaultTriggerInstructions: ITriggerInstructions = {
@@ -149,6 +151,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
         expanded={expanded}
         onClick={onToggle}
         title={substep.name}
+        rightEl={<TestSubstepTitleTooltip />}
       />
       <Collapse in={expanded} unmountOnExit style={{ overflow: 'initial' }}>
         <Box p="1rem 1rem 1.5rem">

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -15,8 +15,11 @@ import { Button } from '@opengovsg/design-system-react'
 
 import ErrorResult from '@/components/ErrorResult'
 import WebhookUrlInfo from '@/components/WebhookUrlInfo'
+import { SINGLE_STEP_TEST_KILL_SWITCH } from '@/config/flags'
 import { EditorContext } from '@/contexts/Editor'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { ExecutionStep } from '@/graphql/__generated__/graphql'
+import { EXECUTE_FLOW } from '@/graphql/mutations/execute-flow'
 import { EXECUTE_STEP } from '@/graphql/mutations/execute-step'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import {
@@ -63,6 +66,10 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
     (executionStep) => executionStep.stepId === step.id,
   )
 
+  // TODO: remove this kill switch once Single Step Testing is stable
+  const { flags } = useContext(LaunchDarklyContext)
+  const shouldUseSingleStepTest = !flags?.[SINGLE_STEP_TEST_KILL_SWITCH]
+
   /**
    * Temporary state to store the last execution step error details,
    * which could come from prior steps.
@@ -77,7 +84,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
   }, [currentExecutionStep])
 
   const [executeStep, { loading: isTestExecuting }] = useMutation(
-    EXECUTE_STEP,
+    shouldUseSingleStepTest ? EXECUTE_STEP : EXECUTE_FLOW,
     {
       context: { autoSnackbar: false },
       awaitRefetchQueries: true,
@@ -85,7 +92,9 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
       update(cache, { data }) {
         // If last execution step is successful, it means the test run is successful
         // Update the step status to completed without refreshing
-        const lastExecutionStep: ExecutionStep = data?.executeStep
+        const lastExecutionStep: ExecutionStep = shouldUseSingleStepTest
+          ? data?.executeStep
+          : data?.executeFlow
         if (lastExecutionStep.status === 'success') {
           const stepCache = cache.identify({
             __typename: 'Step',
@@ -123,7 +132,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
 
   const isTestSuccessful = currentExecutionStep?.status === 'success'
 
-  const executeTestFlow = useCallback(async () => {
+  const executeTestStep = useCallback(async () => {
     try {
       await executeStep({
         variables: {
@@ -181,7 +190,7 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
           <Button
             isFullWidth
             variant={isTestSuccessful ? 'clear' : 'solid'}
-            onClick={executeTestFlow}
+            onClick={executeTestStep}
             mt={2}
             isLoading={isTestExecuting}
             isDisabled={readOnly}

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -5,8 +5,10 @@
  * Display flags
  */
 export const BANNER_TEXT_FLAG = 'banner_display'
-// we only want to show this infobox to users created before this date (ms since epoch)
+// we only want to show this notification to users created before this date (ms since epoch)
 export const SINGLE_STEP_TEST_SHOW_BEFORE_FLAG = 'single_step_test_show_before'
+// kill-switch for single-step testing in case of issues
+export const SINGLE_STEP_TEST_KILL_SWITCH = 'single_step_test_kill_switch'
 
 /**
  * Feature flags

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -5,6 +5,8 @@
  * Display flags
  */
 export const BANNER_TEXT_FLAG = 'banner_display'
+// we only want to show this infobox to users created before this date (ms since epoch)
+export const SINGLE_STEP_TEST_SHOW_BEFORE_FLAG = 'single_step_test_show_before'
 
 /**
  * Feature flags

--- a/packages/frontend/src/contexts/Authentication.tsx
+++ b/packages/frontend/src/contexts/Authentication.tsx
@@ -9,7 +9,10 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import { LOGOUT } from '@/graphql/mutations/logout'
 import { GET_CURRENT_USER } from '@/graphql/queries/get-current-user'
 
-type CurrentUser = Pick<IUser, 'id' | 'email'> | null
+type CurrentUser = Pick<
+  IUser,
+  'id' | 'email' | 'createdAt' | 'updatedAt'
+> | null
 
 export type AuthenticationContextParams = {
   currentUser: CurrentUser

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -1,9 +1,12 @@
 import type { IExecutionStep } from '@plumber/types'
 
-import { createContext, ReactNode } from 'react'
+import { createContext, ReactNode, useContext } from 'react'
 import { useQuery } from '@apollo/client'
 
+import { SINGLE_STEP_TEST_KILL_SWITCH } from '@/config/flags'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
+
+import { LaunchDarklyContext } from './LaunchDarkly'
 
 interface IEditorContextValue {
   readOnly: boolean
@@ -26,12 +29,17 @@ export const EditorProvider = ({
   flowId,
   children,
 }: EditorProviderProps) => {
+  // TODO: remove this kill switch once Single Step Testing is stable
+  const { flags } = useContext(LaunchDarklyContext)
+  const shouldUseSingleStepTest = !flags?.[SINGLE_STEP_TEST_KILL_SWITCH]
+
   const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
     GET_TEST_EXECUTION_STEPS,
     {
       variables: {
         flowId,
-        ignoreTestExecutionId: true, // TODO(ian): Remove this or use LD flag once SST is enabled
+        // ignore test execution id and fetch execution steps by ordering if SST not enabled
+        ignoreTestExecutionId: !shouldUseSingleStepTest,
       },
     },
   )

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -196,6 +196,8 @@ export interface IFlow {
 export interface IUser {
   id: string
   email: string
+  createdAt: string
+  updatedAt: string
   // TODO: remove these unused properties?
   connections?: IConnection[]
   flows?: IFlow[]


### PR DESCRIPTION
## Changes

1. Add new tooltip for users created before a certain timestamp set on launchdarkly.
2. Add kill-switch on LD to easily rollback to non-single step testing.

## New LD flags
- `single_step_test_show_before`
- `single_step_test_kill_switch`

## What to test
1. tooltip
- Existing users should see the tooltip and pulsating should on hover for more than 1 second.
- New users should not see the tooltip.


2. Kill-switch
- Triggering kill-switch should revert back to testing till that step. Testing without SST should still preserve all test results (even those subsequent steps that were previously tested). The tooltip should disappear as well.
- Disabling the kill-switch should enable SST and everything should work as intended.

