### PR TITLE
PLU-318: [TEMPLATES-10]: Make empty flows page redirect to template page

### DIFF
--- a/packages/frontend/src/components/EmptyFlows/FlowTemplate.tsx
+++ b/packages/frontend/src/components/EmptyFlows/FlowTemplate.tsx
@@ -1,14 +1,11 @@
 import type { ITemplate } from '@plumber/types'
 
-import { useCallback } from 'react'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
-import { useMutation } from '@apollo/client'
 import { Box, Card, CardBody, CardFooter, Flex, Text } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
-import { CREATE_TEMPLATED_FLOW } from '@/graphql/mutations/create-templated-flow'
 import { TemplateIcon } from '@/helpers/flow-templates'
 
 export interface FlowTemplateProps {
@@ -19,18 +16,6 @@ export default function FlowTemplate(props: FlowTemplateProps) {
   const { template } = props
   const { id, name, description, iconName } = template
   const navigate = useNavigate()
-
-  const [createTemplatedFlow, { loading }] = useMutation(CREATE_TEMPLATED_FLOW)
-  const onCreateTemplatedFlow = useCallback(async () => {
-    const response = await createTemplatedFlow({
-      variables: {
-        input: {
-          templateId: id,
-        },
-      },
-    })
-    navigate(URLS.FLOW(response.data?.createTemplatedFlow?.id))
-  }, [createTemplatedFlow, id, navigate])
 
   return (
     <Card variant="outline">
@@ -49,8 +34,7 @@ export default function FlowTemplate(props: FlowTemplateProps) {
         <Button
           rightIcon={<BiRightArrowAlt style={{ marginLeft: '-0.25rem' }} />}
           variant="link"
-          onClick={onCreateTemplatedFlow}
-          isLoading={loading}
+          onClick={() => navigate(URLS.TEMPLATE(id))}
         >
           <Text textStyle="caption-1">Use template</Text>
         </Button>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -106,7 +106,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
 
               <Infobox icon={<BiBulb />} variant="primary">
                 <MarkdownRenderer
-                  source={`Need suggestions on what to automate? [See use cases](${window.location.origin}${URLS.TEMPLATES})`}
+                  source={`Need suggestions on what to automate? [See use cases](${URLS.TEMPLATES})`}
                   components={infoboxMdComponents}
                 />
               </Infobox>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -106,7 +106,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
 
               <Infobox icon={<BiBulb />} variant="primary">
                 <MarkdownRenderer
-                  source="Need suggestions on what to automate? [See use cases](/templates)"
+                  source={`Need suggestions on what to automate? [See use cases](${window.location.origin}${URLS.TEMPLATES})`}
                   components={infoboxMdComponents}
                 />
               </Infobox>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal.tsx
@@ -106,7 +106,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
 
               <Infobox icon={<BiBulb />} variant="primary">
                 <MarkdownRenderer
-                  source="Need suggestions on what to automate? [See use cases](https://guide.plumber.gov.sg/popular-workflows/all-workflows)"
+                  source="Need suggestions on what to automate? [See use cases](/templates)"
                   components={infoboxMdComponents}
                 />
               </Infobox>


### PR DESCRIPTION
**Need feedback on whether this UX is better**
TODO:
- [x] Check with Ian

## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
- Use template button in `EmptyFlows` page should redirect to the template page instead of creating a templated flow immediately
- Direct `see use cases` link when creating pipe to templates page instead

## Tests
- [x] Templated flow is not immediately created upon using template from empty flows page
- [x] Can still create template at the template page
- [x] Create pipe `see use cases` link directs to templates page