### PR TITLE
PLU-115: [SST-8] fix issues with test data when changing app

### DIFF
--- a/packages/backend/src/graphql/__tests__/custom-resolvers/execution-step.test.ts
+++ b/packages/backend/src/graphql/__tests__/custom-resolvers/execution-step.test.ts
@@ -50,6 +50,7 @@ describe('execution step', () => {
   beforeEach(() => {
     executionStep = {
       $relatedQuery: mocks.$relatedQuery,
+      appKey: 'testApp',
     } as unknown as ExecutionStep
   })
 
@@ -125,5 +126,16 @@ describe('execution step', () => {
         expect(result).toBeNull()
       },
     )
+
+    it('should return null if appKey is different', async () => {
+      mocks.$relatedQuery.mockReturnValueOnce({
+        appKey: 'differentApp',
+        key: 'trigger1',
+        isTrigger: true,
+        isAction: false,
+      })
+      const result = await resolver.dataOutMetadata(executionStep, {}, null)
+      expect(result).toBeNull()
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/get-test-execution-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/get-test-execution-steps.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import getTestExecutionSteps from '@/graphql/queries/get-test-execution-steps'
+import type Context from '@/types/express/context'
+
+const context = {
+  currentUser: {
+    $relatedQuery: vi.fn(() => {
+      return {
+        withGraphFetched: vi.fn(() => {
+          return {
+            findById: vi.fn(() => {
+              return {
+                throwIfNotFound: vi.fn(() => {
+                  return {
+                    id: 'flow-id',
+                    steps: [
+                      {
+                        id: 'step-id-1',
+                        status: 'completed',
+                      },
+                      {
+                        id: 'step-id-2',
+                        status: 'incomplete',
+                      },
+                      {
+                        id: 'step-id-3',
+                        status: 'incomplete',
+                      },
+                      {
+                        id: 'step-id-4',
+                        status: 'completed',
+                      },
+                    ],
+                  }
+                }),
+              }
+            }),
+          }
+        }),
+      }
+    }),
+  },
+} as unknown as Context
+
+vi.mock('@/helpers/get-test-execution-steps', () => ({
+  getTestExecutionSteps: vi.fn(() => {
+    return [
+      {
+        isFailed: false,
+        stepId: 'step-id-1',
+      },
+      {
+        isFailed: true,
+        stepId: 'step-id-2',
+      },
+      {
+        isFailed: false,
+        stepId: 'step-id-3',
+      },
+      {
+        isFailed: true,
+        stepId: 'step-id-4',
+      },
+    ]
+  }),
+}))
+
+describe('Get test execution steps mutation', () => {
+  it('filter out execution steps that belong to incomplete steps', async () => {
+    const result = await getTestExecutionSteps(
+      {},
+      { flowId: 'flow-id' },
+      context,
+    )
+    expect(result.map((r) => r.stepId)).toEqual([
+      'step-id-1',
+      'step-id-2',
+      'step-id-4',
+    ])
+  })
+})

--- a/packages/backend/src/graphql/custom-resolvers/execution-step.ts
+++ b/packages/backend/src/graphql/custom-resolvers/execution-step.ts
@@ -14,9 +14,15 @@ const dataOutMetadata: ExecutionStepResolver['dataOutMetadata'] = async (
     isTrigger,
   } = await parent.$relatedQuery('step')
   if (!appKey || !stepKey) {
-    return
+    return null
   }
 
+  /**
+   * Best effort to prevent unrelated dataout metadata
+   */
+  if (appKey !== parent.appKey) {
+    return null
+  }
   const app = await App.findOneByKey(appKey)
 
   if (isAction) {

--- a/packages/backend/src/services/__tests__/test-step.itest.ts
+++ b/packages/backend/src/services/__tests__/test-step.itest.ts
@@ -1,0 +1,244 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import User from '@/models/user'
+
+import testStep from '../test-step'
+
+const NEW_TRIGGER_EXECUTION_STEP_ID = randomUUID()
+const NEW_ACTION_EXECUTION_STEP_ID = randomUUID()
+const NEW_EXECUTION_ID = randomUUID()
+
+vi.mock('@/services/flow', () => ({
+  processFlow: vi.fn(() => ({
+    data: { someData: 'data' },
+    error: undefined,
+  })),
+}))
+
+vi.mock('@/services/trigger', () => ({
+  processTrigger: vi.fn(
+    async ({ flowId, testRun }: { flowId: string; testRun: boolean }) => {
+      const newExecution = await Execution.query().insertAndFetch({
+        id: NEW_EXECUTION_ID,
+        flowId,
+        testRun,
+      })
+      const newExecutionStep = await ExecutionStep.query().insertAndFetch({
+        executionId: NEW_EXECUTION_ID,
+        id: NEW_TRIGGER_EXECUTION_STEP_ID,
+        status: 'success',
+        dataOut: { someData: 'data' },
+      })
+      return {
+        executionId: newExecution.id,
+        executionStep: {
+          id: newExecutionStep.id,
+        },
+      }
+    },
+  ),
+}))
+
+vi.mock('@/services/action', () => ({
+  processAction: vi.fn(
+    async ({
+      stepId,
+      executionId,
+    }: {
+      stepId: string
+      executionId: string
+    }) => {
+      await ExecutionStep.query().insert({
+        id: NEW_ACTION_EXECUTION_STEP_ID,
+        executionId,
+        stepId,
+        status: 'success',
+        dataOut: { someData: 'data' },
+      })
+      return {
+        executionStep: {
+          id: NEW_ACTION_EXECUTION_STEP_ID,
+        },
+      }
+    },
+  ),
+}))
+
+describe('test single step', () => {
+  let flow: Flow
+  let testExecution1: Execution
+  beforeEach(async () => {
+    const user = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    flow = await Flow.query().insertGraphAndFetch({
+      userId: user.id,
+      name: 'flowName',
+      steps: [
+        {
+          key: 'newSubmission',
+          appKey: 'formsg',
+          type: 'trigger',
+          position: 1,
+          status: 'completed',
+        },
+        {
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          type: 'action',
+          position: 2,
+          status: 'completed',
+        },
+        {
+          key: 'sendSms',
+          appKey: 'postman-sms',
+          type: 'action',
+          position: 3,
+          status: 'completed',
+        },
+      ],
+    })
+    testExecution1 = await Execution.query().insertGraphAndFetch({
+      flowId: flow.id,
+      testRun: true,
+      executionSteps: [
+        {
+          stepId: flow.steps[0].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[1].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+        {
+          stepId: flow.steps[2].id,
+          status: 'success',
+          dataOut: { someData: 'data' },
+        },
+      ],
+    })
+  })
+
+  describe('when test execution id is assigned', () => {
+    beforeEach(async () => {
+      await flow.$query().patch({ testExecutionId: testExecution1.id })
+    })
+    it('should create a new execution id and return maintain the prev executions steps when trigger is tested', async () => {
+      const result = await testStep({
+        stepId: flow.steps[0].id,
+      })
+
+      expect(result).toEqual({
+        executionId: NEW_EXECUTION_ID,
+        executionStep: {
+          id: NEW_TRIGGER_EXECUTION_STEP_ID,
+        },
+      })
+      const executionSteps = await ExecutionStep.query().where(
+        'execution_id',
+        NEW_EXECUTION_ID,
+      )
+      expect(executionSteps.map((step) => step.id).sort()).toEqual(
+        [
+          NEW_TRIGGER_EXECUTION_STEP_ID,
+          testExecution1.executionSteps[1].id,
+          testExecution1.executionSteps[2].id,
+        ].sort(),
+      )
+    })
+
+    it('should replace the prev executions step when action is tested', async () => {
+      const result = await testStep({
+        stepId: flow.steps[1].id,
+      })
+
+      expect(result).toEqual({
+        executionId: testExecution1.id,
+        executionStep: {
+          id: NEW_ACTION_EXECUTION_STEP_ID,
+        },
+      })
+      const executionSteps = await ExecutionStep.query().where(
+        'execution_id',
+        testExecution1.id,
+      )
+      expect(executionSteps.map((step) => step.id).sort()).toEqual(
+        [
+          testExecution1.executionSteps[0].id,
+          NEW_ACTION_EXECUTION_STEP_ID,
+          testExecution1.executionSteps[2].id,
+        ].sort(),
+      )
+    })
+  })
+
+  describe('when test execution id is not assigned', () => {
+    it('should create a new execution id and return maintain the prev executions steps when trigger is tested', async () => {
+      const result = await testStep({
+        stepId: flow.steps[0].id,
+      })
+
+      expect(result).toEqual({
+        executionId: NEW_EXECUTION_ID,
+        executionStep: {
+          id: NEW_TRIGGER_EXECUTION_STEP_ID,
+        },
+      })
+      const executionSteps = await ExecutionStep.query().where(
+        'execution_id',
+        NEW_EXECUTION_ID,
+      )
+      expect(executionSteps.map((step) => step.id).sort()).toEqual(
+        [
+          NEW_TRIGGER_EXECUTION_STEP_ID,
+          testExecution1.executionSteps[1].id,
+          testExecution1.executionSteps[2].id,
+        ].sort(),
+      )
+    })
+
+    it('should replace the prev executions step when action is tested', async () => {
+      const result = await testStep({
+        stepId: flow.steps[1].id,
+      })
+
+      expect(result).toEqual({
+        executionId: testExecution1.id,
+        executionStep: {
+          id: NEW_ACTION_EXECUTION_STEP_ID,
+        },
+      })
+      const executionSteps = await ExecutionStep.query().where(
+        'execution_id',
+        testExecution1.id,
+      )
+      expect(executionSteps.map((step) => step.id).sort()).toEqual(
+        [
+          testExecution1.executionSteps[0].id,
+          NEW_ACTION_EXECUTION_STEP_ID,
+          testExecution1.executionSteps[2].id,
+        ].sort(),
+      )
+    })
+
+    it('should assign the prev trigger execution id to the flow if trigger is tested', async () => {
+      await testStep({
+        stepId: flow.steps[0].id,
+      })
+      const updatedFlow = await flow.$query().select()
+      expect(updatedFlow.testExecutionId).toEqual(testExecution1.id)
+    })
+
+    it('should assign the prev trigger execution id to the flow if action is tested', async () => {
+      await testStep({
+        stepId: flow.steps[0].id,
+      })
+      const updatedFlow = await flow.$query().select()
+      expect(updatedFlow.testExecutionId).toEqual(testExecution1.id)
+    })
+  })
+})

--- a/packages/frontend/src/components/TestSubstep/TestResult.tsx
+++ b/packages/frontend/src/components/TestSubstep/TestResult.tsx
@@ -48,11 +48,12 @@ interface TestResultsProps {
 export default function TestResult(props: TestResultsProps): JSX.Element {
   const { step, selectedActionOrTrigger, variables, isMock = false } = props
 
+  if (step.status !== 'completed') {
+    return <></>
+  }
+
   // No data only happens if user hasn't executed yet, or step returned null.
   if (!variables?.length) {
-    if (step.status !== 'completed') {
-      return <></>
-    }
     return (
       <Infobox variant="warning" width="full">
         <Box>

--- a/packages/frontend/src/components/TestSubstep/index.tsx
+++ b/packages/frontend/src/components/TestSubstep/index.tsx
@@ -63,7 +63,8 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
 
   const { readOnly, testExecutionSteps } = useContext(EditorContext)
   const currentExecutionStep = testExecutionSteps.find(
-    (executionStep) => executionStep.stepId === step.id,
+    (executionStep) =>
+      executionStep.stepId === step.id && executionStep.appKey === step.appKey,
   )
 
   // TODO: remove this kill switch once Single Step Testing is stable
@@ -130,7 +131,8 @@ function TestSubstep(props: TestSubstepProps): JSX.Element {
     return []
   }, [currentExecutionStep])
 
-  const isTestSuccessful = currentExecutionStep?.status === 'success'
+  const isTestSuccessful =
+    step.status === 'completed' && currentExecutionStep?.status === 'success'
 
   const executeTestStep = useCallback(async () => {
     try {


### PR DESCRIPTION
### What changed?

- `getTestExecutionSteps` query now filters out test executions belonging to incomplete steps. This ensures that we do not show test data from other app / events when user changes it. However, we still show error messages regardless in case the step has never been successfully test before.
- Improved `getTestExecutionSteps` helper to dedupe multiple test execution steps belonging to the same step if something unexpected happens 
- `test-step` now deletes old execution steps properly and takes into account executions with no trigger step (now possible with SST).
- Modified frontend to handle incomplete steps and no test data properly
- Added new unit and integration tests for affected files

### Test cases

1. Check that changing the app / event for a tested step should no longer show the test results until tested again
2. Check that changing the app / event for a tested but failed step will hide the error. However, switching back to the same app but different event will bring back the error.
3. Check that error test message for incomplete step still shows after refresh
4. Create a new pipe --> testing actions without test triggers should work. Testing trigger afterwards should preserve test results for actions.
5. If a pipe was tested before SST, it should work as intended even if SST is enabled (use launch darkly flag to toggle)

