### PR TITLE
chore: rename attachment name for lettersg

### DIFF
--- a/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
+++ b/packages/backend/src/apps/lettersg/__tests__/actions/create-letter.test.ts
@@ -15,10 +15,18 @@ const MOCK_RESPONSE = {
   issuedLetter: '<h1>Hello World</h1>',
 }
 
-const MOCK_S3_ATTACHMENT_KEY =
-  's3:plumber-development-common-bucket:123/letter.pdf'
+const MOCK_TEMPLATE_NAME = 'Basic template'
+const MOCK_TEMPLATE_DATA = {
+  templateId: 456,
+  name: MOCK_TEMPLATE_NAME,
+}
+
+const MOCK_S3_ATTACHMENT_KEY = `s3:plumber-development-common-bucket:123/${MOCK_TEMPLATE_NAME}.pdf`
 
 const mocks = vi.hoisted(() => ({
+  httpGet: vi.fn(() => ({
+    data: MOCK_TEMPLATE_DATA,
+  })),
   httpPost: vi.fn(() => ({
     data: MOCK_RESPONSE,
   })),
@@ -54,6 +62,7 @@ describe('create letter from template', () => {
         hasFileProcessingActions: true,
       },
       http: {
+        get: mocks.httpGet,
         post: mocks.httpPost,
       } as unknown as IGlobalVariable['http'],
       setActionItem: vi.fn(),

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -51,8 +51,18 @@ const action: IRawAction = {
       type: 'boolean-radio' as const,
       required: true,
       description:
-        'You will need to add an Email by Postman action after this step to send out the generated PDF.',
+        'You will need to add an Email by Postman action after this step to send out the generated PDF. The PDF will use the template name as the filename.',
       value: false,
+      options: [
+        {
+          label: 'No, I can send the letter link directly.',
+          value: false,
+        },
+        {
+          label: 'Yes, I require the additional PDF.',
+          value: true,
+        },
+      ],
     },
     {
       label: 'Personalised fields',
@@ -124,10 +134,12 @@ const action: IRawAction = {
         },
       )
 
+      // Note: s3 won't allow for template names with .., we only need to replace / with _ because of how we denote a S3 ID
+      const templateName = templateData.name.replaceAll('/', '_')
       const attachmentS3Key = await downloadAndStoreAttachmentInS3(
         $,
         response.publicId,
-        templateData.name,
+        templateName,
       )
       $.setActionItem({
         raw: {

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -6,6 +6,7 @@ import { fromZodError } from 'zod-validation-error'
 import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
 
+import { getTemplateData } from '../../common/get-template-data'
 import { downloadAndStoreAttachmentInS3 } from '../../helpers/attachment'
 import { processMissingFields } from '../../helpers/process-missing-fields'
 
@@ -46,20 +47,20 @@ const action: IRawAction = {
       },
     },
     {
-      label: 'Generate PDF',
+      label: 'Export as PDF',
       key: 'shouldGeneratePdf',
       type: 'boolean-radio' as const,
       required: true,
       description:
-        'You will need to add an Email by Postman action after this step to send out the generated PDF. The PDF will use the template name as the filename.',
+        'Please add an "Email by Postman" action to send the letter. By default, recipients will receive a link to view the mobile-friendly digital letter. If necessary, they can download the letter as a PDF from the link.',
       value: false,
       options: [
         {
-          label: 'No, I can send the letter link directly.',
+          label: 'Send the letter link directly (Recommended)',
           value: false,
         },
         {
-          label: 'Yes, I require the additional PDF.',
+          label: 'Export letter as PDF to send',
           value: true,
         },
       ],
@@ -125,14 +126,7 @@ const action: IRawAction = {
         return
       }
 
-      const { data: templateData } = await $.http.get(
-        '/v1/templates/:templateId',
-        {
-          urlPathParams: {
-            templateId: $.step.parameters.templateId,
-          },
-        },
-      )
+      const { data: templateData } = await getTemplateData($)
 
       // Note: s3 won't allow for template names with .., we only need to replace / with _ because of how we denote a S3 ID
       const templateName = templateData.name.replaceAll('/', '_')
@@ -163,7 +157,7 @@ const action: IRawAction = {
         if (lettersErrorData?.message === 'Invalid letter params.') {
           throw new StepError(
             `Personalised field(s) not specified${
-              missingFields.length === 0 ? '' : `: ${missingFields}`
+              missingFields.length === 0 ? '' : `: ${missingFields.join(', ')}`
             }`,
             'Click on set up action and check that you have entered all the fields and values in the letter parameters.',
             $.step.position,

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -115,9 +115,19 @@ const action: IRawAction = {
         return
       }
 
+      const { data: templateData } = await $.http.get(
+        '/v1/templates/:templateId',
+        {
+          urlPathParams: {
+            templateId: $.step.parameters.templateId,
+          },
+        },
+      )
+
       const attachmentS3Key = await downloadAndStoreAttachmentInS3(
         $,
         response.publicId,
+        templateData.name,
       )
       $.setActionItem({
         raw: {

--- a/packages/backend/src/apps/lettersg/common/get-template-data.ts
+++ b/packages/backend/src/apps/lettersg/common/get-template-data.ts
@@ -1,0 +1,9 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+export async function getTemplateData($: IGlobalVariable) {
+  return await $.http.get('/v1/templates/:templateId', {
+    urlPathParams: {
+      templateId: $.step.parameters.templateId,
+    },
+  })
+}

--- a/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
+++ b/packages/backend/src/apps/lettersg/dynamic-data/get-template-fields.ts
@@ -4,6 +4,8 @@ import {
   IGlobalVariable,
 } from '@plumber/types'
 
+import { getTemplateData } from '../common/get-template-data'
+
 const dynamicData: IDynamicData = {
   key: 'getTemplateFields',
   name: 'Get Template Fields',
@@ -16,11 +18,7 @@ const dynamicData: IDynamicData = {
     }
 
     try {
-      const { data } = await $.http.get('/v1/templates/:templateId', {
-        urlPathParams: {
-          templateId,
-        },
-      })
+      const { data } = await getTemplateData($)
 
       if (!data?.fields) {
         return {

--- a/packages/backend/src/apps/lettersg/helpers/attachment.ts
+++ b/packages/backend/src/apps/lettersg/helpers/attachment.ts
@@ -5,6 +5,7 @@ import { COMMON_S3_BUCKET, putObject } from '@/helpers/s3'
 export async function downloadAndStoreAttachmentInS3(
   $: IGlobalVariable,
   publicId: string,
+  templateName: string,
 ): Promise<string> {
   // Note: no try catch because no known error found yet: will still throw general error
   // separated the two http calls to avoid confusion
@@ -20,8 +21,8 @@ export async function downloadAndStoreAttachmentInS3(
     },
   })
 
-  // objectKey: `executionId/appKey/publicId/letter.pdf`
-  const objectKey = `${$.execution.id}/${$.step.appKey}/${publicId}/letter.pdf`
+  // objectKey: `executionId/appKey/publicId/templateName.pdf`
+  const objectKey = `${$.execution.id}/${$.step.appKey}/${publicId}/${templateName}.pdf`
   return await putObject(COMMON_S3_BUCKET, objectKey, pdfData, {
     flowId: $.flow.id,
     stepId: $.step.id,

--- a/packages/backend/src/apps/lettersg/helpers/attachment.ts
+++ b/packages/backend/src/apps/lettersg/helpers/attachment.ts
@@ -21,7 +21,6 @@ export async function downloadAndStoreAttachmentInS3(
     },
   })
 
-  // objectKey: `executionId/appKey/publicId/templateName.pdf`
   const objectKey = `${$.execution.id}/${$.step.appKey}/${publicId}/${templateName}.pdf`
   return await putObject(COMMON_S3_BUCKET, objectKey, pdfData, {
     flowId: $.flow.id,

--- a/packages/backend/src/apps/lettersg/helpers/process-missing-fields.ts
+++ b/packages/backend/src/apps/lettersg/helpers/process-missing-fields.ts
@@ -1,15 +1,12 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import { getTemplateData } from '../common/get-template-data'
+
 export async function processMissingFields(
   $: IGlobalVariable,
 ): Promise<string[]> {
   try {
-    const templateId = $.step.parameters.templateId as string
-    const { data } = await $.http.get('/v1/templates/:templateId', {
-      urlPathParams: {
-        templateId,
-      },
-    })
+    const { data } = await getTemplateData($)
 
     if (!data?.fields) {
       return []


### PR DESCRIPTION
## Problem

Alexis mentioned that some users want/hope their template pdf is named more "legitly" i.e. using the template name instead of `letter.pdf`

## Solution

Fetch the template name using the template id chosen in the `$.step.parameters` and replace the name when putting it in the s3 bucket.

Pipes still using the old filename will not be affected because we `getObject` based on the filename and the old files still exist.

Did simple check that no postman body contains `letter.pdf` references!

## Tests
- [x] Old pipes with the lettersg attachment still work
- [x] New pipes with the new attachment name work