### PR TITLE
fix: validate table id for excel actions

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/validate-dynamic-fields.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/validate-dynamic-fields.test.ts
@@ -1,0 +1,68 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import StepError from '@/errors/step'
+
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
+
+const VALID_FILE_ID = '1234ABCD1234ABCD1234ABCD1234ABCD'
+const VALID_TABLE_ID = `{${VALID_FILE_ID}}`
+const INVALID_FILE_ID_ERROR_PREFIX = 'Your file'
+const INVALID_TABLE_ID_ERROR_PREFIX = 'Your table'
+
+describe('validate dynamic fields', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      step: {
+        position: 2,
+      },
+      app: {
+        name: 'test-app',
+      },
+    } as unknown as IGlobalVariable
+  })
+
+  describe('invalid fields', () => {
+    it('empty file id', () => {
+      expect(() =>
+        validateDynamicFieldsAndThrowError('', VALID_TABLE_ID, $),
+      ).toThrow(INVALID_FILE_ID_ERROR_PREFIX)
+    })
+
+    it('undefined table id', () => {
+      expect(() =>
+        validateDynamicFieldsAndThrowError(VALID_FILE_ID, undefined, $),
+      ).toThrow(INVALID_TABLE_ID_ERROR_PREFIX)
+    })
+
+    it('path traversal spotted', () => {
+      const INVALID_FILE_ID = `../../${VALID_FILE_ID}`
+      expect(() =>
+        validateDynamicFieldsAndThrowError(INVALID_FILE_ID, VALID_TABLE_ID, $),
+      ).toThrow(INVALID_FILE_ID_ERROR_PREFIX)
+    })
+
+    it('table id has no braces', () => {
+      expect(() =>
+        validateDynamicFieldsAndThrowError(VALID_FILE_ID, VALID_FILE_ID, $),
+      ).toThrow(INVALID_TABLE_ID_ERROR_PREFIX)
+    })
+  })
+
+  describe('valid fields', () => {
+    it('test 1', () => {
+      expect(() =>
+        validateDynamicFieldsAndThrowError(VALID_FILE_ID, VALID_TABLE_ID, $),
+      ).not.toThrow(StepError)
+    })
+
+    it('test 2', () => {
+      expect(() =>
+        validateDynamicFieldsAndThrowError('123ABC', '{456-XYZ}', $),
+      ).not.toThrow(StepError)
+    })
+  })
+})

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -2,6 +2,7 @@ import type { IGlobalVariable, IJSONObject, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
 
+import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
 import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
@@ -135,6 +136,17 @@ const action: IRawAction = {
     }
 
     const { fileId, tableId } = $.step.parameters
+
+    // Validation to prevent path traversals
+    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
+      throw new StepError(
+        'Table is of an invalid format',
+        'Check that your table is selected correctly.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
     const columnValues = ($.step.parameters.columnValues as IJSONObject[]) ?? []
     if (columnValues.length === 0) {
       $.setActionItem({

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -2,8 +2,8 @@ import type { IGlobalVariable, IJSONObject, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
 
-import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
 import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
 import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
@@ -138,14 +138,7 @@ const action: IRawAction = {
     const { fileId, tableId } = $.step.parameters
 
     // Validation to prevent path traversals
-    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
-      throw new StepError(
-        'Table is of an invalid format',
-        'Check that your table is selected correctly.',
-        $.step.position,
-        $.app.name,
-      )
-    }
+    validateDynamicFieldsAndThrowError(String(fileId), String(tableId), $)
 
     const columnValues = ($.step.parameters.columnValues as IJSONObject[]) ?? []
     if (columnValues.length === 0) {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -4,7 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
-import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
 import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
@@ -131,14 +131,7 @@ const action: IRawAction = {
       parametersParseResult.data
 
     // Validation to prevent path traversals
-    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
-      throw new StepError(
-        'Table is of an invalid format',
-        'Check that your table is selected correctly.',
-        $.step.position,
-        $.app.name,
-      )
-    }
+    validateDynamicFieldsAndThrowError(fileId, tableId, $)
 
     const session = await WorkbookSession.acquire($, fileId)
     const results = await getTableRowImpl({

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
 import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
@@ -128,6 +129,16 @@ const action: IRawAction = {
 
     const { fileId, tableId, lookupColumn, lookupValue } =
       parametersParseResult.data
+
+    // Validation to prevent path traversals
+    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
+      throw new StepError(
+        'Table is of an invalid format',
+        'Check that your table is selected correctly.',
+        $.step.position,
+        $.app.name,
+      )
+    }
 
     const session = await WorkbookSession.acquire($, fileId)
     const results = await getTableRowImpl({

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -4,8 +4,8 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
-import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
 import {
   constructMsGraphValuesArrayForRowWrite,
   convertRowToHexEncodedRowRecord,
@@ -101,14 +101,7 @@ const action: IRawAction = {
       parametersParseResult.data
 
     // Validation to prevent path traversals
-    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
-      throw new StepError(
-        'Table is of an invalid format',
-        'Check that your table is selected correctly.',
-        $.step.position,
-        $.app.name,
-      )
-    }
+    validateDynamicFieldsAndThrowError(fileId, tableId, $)
 
     //
     // Find index of row to update

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import { TABLE_ID_WITH_BRACES_REGEX } from '../../common/constants'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
 import {
   constructMsGraphValuesArrayForRowWrite,
@@ -98,6 +99,16 @@ const action: IRawAction = {
 
     const { fileId, tableId, lookupColumn, lookupValue, columnsToUpdate } =
       parametersParseResult.data
+
+    // Validation to prevent path traversals
+    if (!TABLE_ID_WITH_BRACES_REGEX.test(String(tableId))) {
+      throw new StepError(
+        'Table is of an invalid format',
+        'Check that your table is selected correctly.',
+        $.step.position,
+        $.app.name,
+      )
+    }
 
     //
     // Find index of row to update

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -4,7 +4,9 @@ export const APP_KEY = 'm365-excel'
 
 export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
 
-// This format is {UUID-VERSION-4}
-// Reference: https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
-export const TABLE_ID_WITH_BRACES_REGEX =
-  /^\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}$/
+/**
+ * Very loose regex to just accept only alphanumeric characters and dashes
+ * since there is no proper public documentation with M365
+ */
+export const TABLE_ID_REGEX = /^\{[a-zA-Z0-9-]+\}$/ // this include start and end braces
+export const FILE_ID_REGEX = /^[a-zA-Z0-9-]+$/

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -3,3 +3,8 @@
 export const APP_KEY = 'm365-excel'
 
 export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
+
+// This format is {UUID-VERSION-4}
+// Reference: https://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
+export const TABLE_ID_WITH_BRACES_REGEX =
+  /^\{[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}$/

--- a/packages/backend/src/apps/m365-excel/common/validate-dynamic-fields.ts
+++ b/packages/backend/src/apps/m365-excel/common/validate-dynamic-fields.ts
@@ -1,0 +1,29 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import StepError from '@/errors/step'
+
+import { FILE_ID_REGEX, TABLE_ID_REGEX } from './constants'
+
+export function validateDynamicFieldsAndThrowError(
+  fileId: string,
+  tableId: string,
+  $: IGlobalVariable,
+): void {
+  if (!FILE_ID_REGEX.test(fileId)) {
+    throw new StepError(
+      'Your file is of an invalid format',
+      'Check that you have selected the file in your step correctly.',
+      $.step.position,
+      $.app.name,
+    )
+  }
+
+  if (!TABLE_ID_REGEX.test(tableId)) {
+    throw new StepError(
+      'Your table is of an invalid format',
+      'Check that you have selected the table in your step correctly.',
+      $.step.position,
+      $.app.name,
+    )
+  }
+}


### PR DESCRIPTION
## Problem

TLDR: Our excel action is prone to path traversal for the dynamic field `tableId` but this is not severe since we perform a check that the file is in the correct folder.
More details [here](https://www.notion.so/opengov/Path-Traversal-Vulnerability-2d05e290d9e0479ba11586ff483e4e28)

## Solution

Add a uuid validation check for the tableId

## Tests
- [x] Ensure that the 3 actions for m365 still work