### PR TITLE
chore: validate s3 metadata on fetch

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -3,7 +3,7 @@ import { IGlobalVariable } from '@plumber/types'
 import { DateTime } from 'luxon'
 import { customAlphabet } from 'nanoid/async'
 
-import { COMMON_S3_BUCKET } from '@/helpers/s3'
+import { COMMON_S3_MOCK_FOLDER_PREFIX } from '@/helpers/s3'
 
 import { filterNric } from '../../auth/decrypt-form-response'
 import { getFormDetailsFromGlobalVariable } from '../../common/webhook-settings'
@@ -18,7 +18,7 @@ type FormField = {
   othersRadioButton?: boolean
 }
 
-const MOCK_ATTACHMENT_FILE_PATH = `s3:${COMMON_S3_BUCKET}:mock/plumber-logo.jpg`
+export const MOCK_ATTACHMENT_FILE_PATH = `${COMMON_S3_MOCK_FOLDER_PREFIX}plumber-logo.jpg`
 const MOCK_NRIC = 'S1234568B'
 
 function generateVerifiedSubmitterInfoData(

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -69,12 +69,11 @@ const action: IRawAction = {
       )
     }
 
-    /**
-     * TODO: properly handle attachment saving
-     */
     const attachmentFiles = await Promise.all(
       result.data.attachments?.map(async (attachment) => {
-        const obj = await getObjectFromS3Id(attachment)
+        // We verify the flowId here to ensure that the attachment is from the same flow and not
+        // maliciously/ manually injected by another user who does not have access to this attachment
+        const obj = await getObjectFromS3Id(attachment, { flowId: $.flow.id })
         return { fileName: obj.name, data: obj.data }
       }),
     )

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -29,6 +29,7 @@ type AppConfig = {
   redisTls: boolean
   redisClusterMode: boolean
   enableBullMQDashboard: boolean
+  s3CommonBucket: string
   adminUserEmail: string
   requestBodySizeLimit: string
   postman: {
@@ -83,6 +84,7 @@ const appConfig: AppConfig = {
   redisClusterMode: process.env.REDIS_CLUSTER_MODE === 'true',
   adminUserEmail: process.env.ADMIN_USER_EMAIL,
   enableBullMQDashboard: process.env.ENABLE_BULLMQ_DASHBOARD === 'true',
+  s3CommonBucket: process.env.S3_COMMON_BUCKET,
   baseUrl: process.env.BASE_URL,
   webAppUrl,
   webhookUrl,
@@ -142,6 +144,10 @@ if (
   throw new Error(
     'MAX_JOB_ATTEMPTS environment variable is not a valid integer!',
   )
+}
+
+if (!appConfig.s3CommonBucket) {
+  throw new Error('S3_COMMON_BUCKET environment variable needs to be set!')
 }
 
 // Force SGT date-time formatting no matter what

--- a/packages/backend/src/helpers/__tests__/s3.test.ts
+++ b/packages/backend/src/helpers/__tests__/s3.test.ts
@@ -91,10 +91,9 @@ describe('s3', () => {
           transformToByteArray: vi.fn(() => 'file data bytes'),
         },
         Metadata: {
-          flowId: 'flow-id',
-          stepId: 'step-id',
-          executionId: 'execution-id',
-          publicId: 'public-id',
+          flowid: 'flow-id',
+          stepid: 'step-id',
+          executionid: 'execution-id',
         },
       })
     })
@@ -123,7 +122,7 @@ describe('s3', () => {
           flowId: 'wrong',
         }),
       ).rejects.toThrowError(
-        `S3 metadata mismatch for s3:${COMMON_S3_BUCKET}:abcd/my file.txt: expected flowId=wrong, got flow-id`,
+        `S3 metadata mismatch for abcd/my file.txt: expected flowId=wrong, got flow-id`,
       )
     })
 

--- a/packages/backend/src/helpers/__tests__/s3.test.ts
+++ b/packages/backend/src/helpers/__tests__/s3.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { parseS3Id, putObject } from '../s3'
+import {
+  COMMON_S3_BUCKET,
+  COMMON_S3_MOCK_FOLDER_PREFIX,
+  getObjectFromS3Id,
+  parseS3Id,
+  putObject,
+} from '../s3'
 
 const mocks = vi.hoisted(() => ({
   s3Client: {
@@ -14,14 +20,19 @@ vi.mock('@aws-sdk/client-s3', () => ({
     return mocks.s3Client
   },
   PutObjectCommand: vi.fn(),
+  GetObjectCommand: vi.fn(),
 }))
 
 describe('s3', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
   describe('parseS3Id', () => {
     it('parses valid S3 IDs', () => {
-      const result = parseS3Id('s3:my-bucket:abcd/def/my file.txt')
+      const result = parseS3Id(`s3:${COMMON_S3_BUCKET}:abcd/def/my file.txt`)
       expect(result).toEqual({
-        bucket: 'my-bucket',
+        bucket: COMMON_S3_BUCKET,
         objectKey: 'abcd/def/my file.txt',
         objectName: 'my file.txt',
       })
@@ -33,25 +44,98 @@ describe('s3', () => {
 
     it('handles object names with colons correctly', () => {
       const result = parseS3Id(
-        's3:my-bucket:abcd/def/my-complicated filename.txt',
+        `s3:${COMMON_S3_BUCKET}:abcd/def/my-complicated filename.txt`,
       )
       expect(result).toEqual({
-        bucket: 'my-bucket',
+        bucket: COMMON_S3_BUCKET,
         objectKey: 'abcd/def/my-complicated filename.txt',
         objectName: 'my-complicated filename.txt',
       })
+    })
+
+    it('should throw an error if path traversal is detected', () => {
+      expect(() =>
+        parseS3Id(`s3:${COMMON_S3_BUCKET}:abcd/../my file.txt`),
+      ).toThrowError(
+        'Invalid S3 ID: path traversal detected in abcd/../my file.txt',
+      )
     })
   })
 
   describe('putObject', () => {
     it("invokes AWS's s3-client's send", async () => {
-      await putObject('my-bucket', 'abcd/my file.txt', 'file data bytes', null)
+      await putObject(
+        COMMON_S3_BUCKET,
+        'abcd/my file.txt',
+        'file data bytes',
+        null,
+      )
       expect(mocks.s3Client.send).toHaveBeenCalledOnce()
     })
 
     it('returns a valid S3 ID', async () => {
-      const result = await putObject('my-bucket', 'abcd/my file.txt', '', null)
-      expect(result).toEqual(`s3:my-bucket:abcd/my file.txt`)
+      const result = await putObject(
+        COMMON_S3_BUCKET,
+        'abcd/my file.txt',
+        '',
+        null,
+      )
+      expect(result).toEqual(`s3:${COMMON_S3_BUCKET}:abcd/my file.txt`)
+    })
+  })
+
+  describe('getObjectFromS3Id', () => {
+    beforeEach(() => {
+      mocks.s3Client.send.mockResolvedValueOnce({
+        Body: {
+          transformToByteArray: vi.fn(() => 'file data bytes'),
+        },
+        Metadata: {
+          flowId: 'flow-id',
+          stepId: 'step-id',
+          executionId: 'execution-id',
+          publicId: 'public-id',
+        },
+      })
+    })
+
+    it('should fetch object from S3 successfully when no metadat is provided', async () => {
+      await getObjectFromS3Id(`s3:${COMMON_S3_BUCKET}:abcd/my file.txt`)
+      expect(mocks.s3Client.send).toHaveBeenCalledOnce()
+    })
+
+    it('should return object body if provided metadata matches subset of stored metadata', async () => {
+      const result = await getObjectFromS3Id(
+        `s3:${COMMON_S3_BUCKET}:abcd/my file.txt`,
+        {
+          flowId: 'flow-id',
+        },
+      )
+      expect(result).toEqual({
+        name: 'my file.txt',
+        data: 'file data bytes',
+      })
+    })
+
+    it('should throw an error if metadata does not match', async () => {
+      await expect(
+        getObjectFromS3Id(`s3:${COMMON_S3_BUCKET}:abcd/my file.txt`, {
+          flowId: 'wrong',
+        }),
+      ).rejects.toThrowError(
+        `S3 metadata mismatch for s3:${COMMON_S3_BUCKET}:abcd/my file.txt: expected flowId=wrong, got flow-id`,
+      )
+    })
+
+    it('should ignore metadata check for files in mock folder', async () => {
+      await expect(
+        getObjectFromS3Id(`${COMMON_S3_MOCK_FOLDER_PREFIX}my file.txt`, {
+          flowId: 'wrong',
+        }),
+      ).resolves.toEqual({
+        name: 'my file.txt',
+        data: 'file data bytes',
+      })
     })
   })
 })

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -126,10 +126,12 @@ export async function getObjectFromS3Id(
    * We ignore metadataToCheck for common S3 mock folder
    */
   if (!id.startsWith(COMMON_S3_MOCK_FOLDER_PREFIX) && metadataToCheck) {
-    for (const [key, value] of Object.entries(metadataToCheck)) {
-      if (metadata?.[key] !== value) {
+    for (const [key, expectedValue] of Object.entries(metadataToCheck)) {
+      // s3 converts metadata keys to lowercase
+      const storedValue = metadata?.[key.toLocaleLowerCase()]
+      if (storedValue !== expectedValue) {
         throw new Error(
-          `S3 metadata mismatch for ${id}: expected ${key}=${value}, got ${metadata?.[key]}`,
+          `S3 metadata mismatch for ${idData.objectKey}: expected ${key}=${expectedValue}, got ${storedValue}`,
         )
       }
     }

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -1,4 +1,8 @@
-import type { PutObjectCommandInput } from '@aws-sdk/client-s3'
+import type {
+  GetObjectCommandInput,
+  GetObjectCommandOutput,
+  PutObjectCommandInput,
+} from '@aws-sdk/client-s3'
 import {
   GetObjectCommand,
   PutObjectCommand,
@@ -7,8 +11,8 @@ import {
 
 import appConfig from '@/config/app'
 
-// TODO: move to appConfig
-export const COMMON_S3_BUCKET = process.env.S3_COMMON_BUCKET
+export const COMMON_S3_BUCKET = appConfig.s3CommonBucket
+export const COMMON_S3_MOCK_FOLDER_PREFIX = `s3:${COMMON_S3_BUCKET}:mock/`
 
 const s3Client = new S3Client({
   region: 'ap-southeast-1',
@@ -40,7 +44,15 @@ export function parseS3Id(id: string): S3IdData | null {
   }
 
   const [_prefix, bucket, ...objectKeyBits] = id.split(':')
+
   const objectKey = objectKeyBits.join(':')
+
+  // check for possible path traversal
+  objectKey.split('/').forEach((segment) => {
+    if (segment === '..') {
+      throw new Error(`Invalid S3 ID: path traversal detected in ${objectKey}`)
+    }
+  })
 
   if (!bucket || objectKey.length == 0) {
     return null
@@ -92,20 +104,35 @@ export interface S3Object {
  * If the ID has an invalid format, or we don't receive an object body, this
  * throws an `Error`.
  */
-export async function getObjectFromS3Id(id: string): Promise<S3Object> {
+export async function getObjectFromS3Id(
+  id: string,
+  metadataToCheck?: Record<string, string>,
+): Promise<S3Object> {
   const idData = parseS3Id(id)
   if (!idData) {
     throw new Error(`Invalid S3 ID: ${id}`)
   }
 
-  const objectData = (
-    await s3Client.send(
-      new GetObjectCommand({ Bucket: idData.bucket, Key: idData.objectKey }),
-    )
-  ).Body
+  const { Body: objectData, Metadata: metadata } = await s3Client.send<
+    GetObjectCommandInput,
+    GetObjectCommandOutput
+  >(new GetObjectCommand({ Bucket: idData.bucket, Key: idData.objectKey }))
 
   if (!objectData) {
     throw new Error(`No object body for ${id}`)
+  }
+
+  /**
+   * We ignore metadataToCheck for common S3 mock folder
+   */
+  if (!id.startsWith(COMMON_S3_MOCK_FOLDER_PREFIX) && metadataToCheck) {
+    for (const [key, value] of Object.entries(metadataToCheck)) {
+      if (metadata?.[key] !== value) {
+        throw new Error(
+          `S3 metadata mismatch for ${id}: expected ${key}=${value}, got ${metadata?.[key]}`,
+        )
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
We want to validate that attachments from s3 truly belongs to the pipe.

Since we already store metadata for each file, we can use this to validate.

However, we ignore validation of mock test files.