### PR TITLE
chore: improve rich text editor performance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default code reviewers to plumber team
+* @opengovsg/plumber

--- a/packages/frontend/src/components/Form/index.tsx
+++ b/packages/frontend/src/components/Form/index.tsx
@@ -6,7 +6,6 @@ import {
   SubmitHandler,
   useForm,
   UseFormReturn,
-  useWatch,
 } from 'react-hook-form'
 
 type FormProps = {
@@ -26,35 +25,26 @@ export default function Form(props: FormProps): React.ReactElement {
     onSubmit = noop,
     defaultValues,
     resolver,
-    render,
     mode = 'all',
     ...formProps
   } = props
 
-  const methods: UseFormReturn = useForm({
+  const form: UseFormReturn = useForm({
     defaultValues,
     reValidateMode: 'onBlur',
     resolver,
     mode,
   })
 
-  const form = useWatch({ control: methods.control })
-
-  /**
-   * For fields having `hiddenIf` fields, we need to re-validate the form.
-   */
   React.useEffect(() => {
-    methods.trigger()
-  }, [methods.trigger, form, methods])
-
-  React.useEffect(() => {
-    methods.reset(defaultValues)
-  }, [defaultValues, methods])
+    form.reset(defaultValues)
+    form.trigger()
+  }, [defaultValues, form])
 
   return (
-    <FormProvider {...methods}>
-      <form onSubmit={methods.handleSubmit(onSubmit)} {...formProps}>
-        {render ? render(methods) : children}
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} {...formProps}>
+        {children}
       </form>
     </FormProvider>
   )

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -87,7 +87,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
             {actualRows.map((row, index) => {
               const namePrefix = `${name}.${index}`
               return (
-                <Flex key={row.id} flexDir="column" gap={4} mb={4}>
+                <Flex key={`${name}.${index}`} flexDir="column" gap={4} mb={4}>
                   {/*
                    * Sub-Fields
                    *

--- a/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
+++ b/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { Box, Collapse, Divider, Flex, Text } from '@chakra-ui/react'
 
 import VariablesList from '@/components/VariablesList'
@@ -9,7 +9,7 @@ interface SuggestionsProps {
   onSuggestionClick: (variable: Variable) => void
 }
 
-export default function Suggestions(props: SuggestionsProps) {
+function Suggestions(props: SuggestionsProps) {
   const { data, onSuggestionClick = () => null } = props
   const [current, setCurrent] = useState<number>(0)
 
@@ -98,3 +98,5 @@ export default function Suggestions(props: SuggestionsProps) {
     </Flex>
   )
 }
+
+export default memo(Suggestions)

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -200,7 +200,9 @@ const Editor = ({
       autoFocus={false}
       gutter={0}
       matchWidth={true}
-      isOpen={isSuggestionsOpen}
+      isLazy
+      lazyBehavior="unmount"
+      isOpen={isSuggestionsOpen && variablesEnabled}
     >
       <div
         className="editor"
@@ -220,23 +222,21 @@ const Editor = ({
           <Box>
             {isRich && <MenuBar editor={editor} />}
             <EditorContent className="editor__content" editor={editor} />
-            {variablesEnabled && (
-              <PopoverContent
-                w="100%"
-                motionProps={POPOVER_MOTION_PROPS}
-                onFocus={(e) => {
-                  // Go back to previous focus when clicking on suggestions to resume typing
-                  if (e.relatedTarget instanceof HTMLElement) {
-                    e.relatedTarget?.focus()
-                  }
-                }}
-              >
-                <Suggestions
-                  data={stepsWithVariables}
-                  onSuggestionClick={handleVariableClick}
-                />
-              </PopoverContent>
-            )}
+            <PopoverContent
+              w="100%"
+              motionProps={POPOVER_MOTION_PROPS}
+              onFocus={(e) => {
+                // Go back to previous focus when clicking on suggestions to resume typing
+                if (e.relatedTarget instanceof HTMLElement) {
+                  e.relatedTarget?.focus()
+                }
+              }}
+            >
+              <Suggestions
+                data={stepsWithVariables}
+                onSuggestionClick={handleVariableClick}
+              />
+            </PopoverContent>
           </Box>
         </PopoverTrigger>
       </div>

--- a/packages/frontend/src/graphql/client.ts
+++ b/packages/frontend/src/graphql/client.ts
@@ -1,5 +1,7 @@
 import { ApolloClient } from '@apollo/client'
 
+import appConfig from '@/config/app'
+
 import cache from './cache'
 import createLink from './link'
 
@@ -13,6 +15,7 @@ const GRAPHQL_URL = '/graphql'
 const client = new ApolloClient({
   cache,
   link: createLink({ uri: GRAPHQL_URL }),
+  connectToDevTools: appConfig.isDev,
   defaultOptions: {
     watchQuery: {
       fetchPolicy: 'cache-and-network',

--- a/packages/frontend/src/helpers/isFieldHidden.ts
+++ b/packages/frontend/src/helpers/isFieldHidden.ts
@@ -43,7 +43,17 @@ export function useIsFieldHidden(
   namePrefix: string | undefined | null,
   field: IField,
 ): boolean {
-  const { getValues } = useFormContext()
-  const siblingParams = namePrefix ? getValues(namePrefix) : getValues()
-  return isFieldHidden(field.hiddenIf, siblingParams)
+  const { watch } = useFormContext()
+  const fieldKeyToWatch =
+    field.hiddenIf && 'fieldKey' in field.hiddenIf
+      ? field.hiddenIf.fieldKey
+      : null
+
+  if (!fieldKeyToWatch) {
+    return isFieldHidden(field.hiddenIf, {})
+  }
+  const value = watch(
+    namePrefix ? `${namePrefix}.${fieldKeyToWatch}` : fieldKeyToWatch,
+  )
+  return isFieldHidden(field.hiddenIf, { [fieldKeyToWatch]: value })
 }


### PR DESCRIPTION
## Problem
Rich text editors gets unresponsive and laggy when user create a lot of rows in MultiRow fields.

This is caused by the re-rendering of the entire react-hook-form onChange. 

## Solution

The re-rendering of the entire form is due to a useWatch hook at the form level that listens to changes to dynamically render conditional fields (hiddenIf). The hook has been removed in favour of a watch function that only detects changes in related fields. (for example, if field A depends on field B, it will only re-render if field B changes)

## What to test
- [ ] Check that hiddenIf fields still work
- [ ] Check that required fields work
- [ ] Check that form fields are saved properly.
- [ ] Lastly, check that creating multiple rows in MultiRow fields do not result in performance degradation