### PR TITLE
chore: allow excel 500 errors to be retried

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -203,7 +203,7 @@ describe('M365 request error handlers', () => {
   })
 
   it('throws HTTP error on other non-successful codes', async () => {
-    mockAxiosAdapterToThrowOnce(500, { 'retry-after': 123 })
+    mockAxiosAdapterToThrowOnce(501, { 'retry-after': 123 })
     await expect(http.get('/test-url')).rejects.toThrow(HttpError)
   })
 


### PR DESCRIPTION
## Details
We should retry 500s from graph API, at a rate similar to 503 errors.
[Example](https://ogp.datadoghq.com/apm/traces?query=service%3Aplumber%20resource_name%3Aworkers.action%20env%3Aprod%20status%3Aerror%20-%28%40appKey%3Atelegram-bot%20%40error.message%3A%2A%5C%22error_code%5C%22%5C%3A%5C%20429%2A%29%20-%40willRetry%3Atrue%20-%28%40appKey%3Am365-excel%20%40error.message%3A%2ARate%5C%20limited%5C%20by%5C%20Microsoft%5C%20Graph.%2A%29%20-%28%40appKey%3Atiles%20%40error.message%3A%2ANumber.MAX_SAFE_INTEGER%2A%29%20-%28%40appKey%3Atelegram-bot%20%40error.message%3A%2Athe%5C%20group%5C%20chat%5C%20was%5C%20deleted%2A%29&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&source=monitor_notif&spanType=all&spanViewType=logs&storage=hot&traceGroup=&view=spans&start=1725684742000&end=1725685042000&paused=true) of errors and then having the user to manually retry

## Tests
- [x] Mock 500 error and it retries