### PR TITLE
PLU-320: fix: only continue if should not stop execution in branches

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -8,7 +8,81 @@ import onlyContinueIfAction from '../../actions/only-continue-if'
 
 const mocks = vi.hoisted(() => ({
   setActionItem: vi.fn(),
+  stepQueryResult: vi.fn(),
 }))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      where: vi.fn(() => ({
+        orderBy: vi.fn(() => ({
+          throwIfNotFound: mocks.stepQueryResult,
+        })),
+      })),
+    })),
+  },
+}))
+
+const MOCK_FLOW = [
+  {
+    id: 'trigger',
+    appKey: 'formsg',
+    key: 'newSubmission',
+    position: 1,
+  },
+  // only continue if before branches
+  {
+    id: 'test-step',
+    appKey: 'toolbox',
+    key: onlyContinueIfAction.key,
+    position: 2,
+  },
+  // Branch 1
+  {
+    id: 'branch-1',
+    appKey: 'toolbox',
+    key: 'ifThen',
+    position: 3,
+    parameters: {
+      depth: 0,
+    },
+  },
+  // only continue if in branch 1
+  {
+    id: 'branch-1-only-continue-if',
+    appKey: 'toolbox',
+    key: onlyContinueIfAction.key,
+    position: 4,
+  },
+  {
+    id: 'branch-1-action-2',
+    appKey: 'delay',
+    key: 'delayFor',
+    position: 5,
+  },
+  {
+    id: 'branch-2',
+    appKey: 'toolbox',
+    key: 'ifThen',
+    position: 6,
+    parameters: {
+      depth: 0,
+    },
+  },
+  // only continue if in branch 2
+  {
+    id: 'branch-2-only-continue-if',
+    appKey: 'toolbox',
+    key: onlyContinueIfAction.key,
+    position: 7,
+  },
+  {
+    id: 'branch-2-action-1',
+    appKey: 'delay',
+    key: 'delayUntil',
+    position: 8,
+  },
+]
 
 describe('Only continue if', () => {
   let $: IGlobalVariable
@@ -51,13 +125,61 @@ describe('Only continue if', () => {
     })
   })
 
-  it('stops execution if condition fails', async () => {
+  it('stops execution if condition fails before branches', async () => {
     $.step.parameters = {
       field: 1,
       is: 'is',
       condition: 'contains',
       text: 0,
     }
+
+    mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toEqual({
+      nextStep: { command: 'stop-execution' },
+    })
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: false },
+    })
+  })
+
+  it('only continue if in branch 1 jumps to branch 2 if condition fails', async () => {
+    // update only continue if to step 4
+    $.step = {
+      ...MOCK_FLOW[3],
+      parameters: {
+        field: 1,
+        is: 'not',
+        condition: 'equals',
+        text: 1,
+      },
+    }
+
+    mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toEqual({
+      nextStep: { command: 'jump-to-step', stepId: 'branch-2' },
+    })
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: false },
+    })
+  })
+
+  it('execution ends when only continue if in last branch fails', async () => {
+    // update only continue if to step 7
+    $.step = {
+      ...MOCK_FLOW[6],
+      parameters: {
+        field: 1,
+        is: 'not',
+        condition: 'equals',
+        text: 1,
+      },
+    }
+
+    mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
 
     const result = await onlyContinueIfAction.run($)
     expect(result).toEqual({

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -25,7 +25,7 @@ function shouldTakeBranch($: IGlobalVariable): boolean {
 async function getBranchStepIdToSkipTo(
   $: IGlobalVariable,
 ): Promise<IStep['id']> {
-  const currDepth = parseInt($.step.parameters.depth as string)
+  const currDepth = parseInt($.step.parameters?.depth as string)
   if (isNaN(currDepth)) {
     throw new Error(
       `Branch depth for initial branch step ${$.step.id} is not defined.`,
@@ -45,7 +45,7 @@ async function getBranchStepIdToSkipTo(
       return false
     }
 
-    const nextBranchDepth = parseInt(step.parameters.depth as string)
+    const nextBranchDepth = parseInt(step.parameters?.depth as string)
     if (isNaN(nextBranchDepth)) {
       throw new Error(
         `Branch depth for future branch step ${$.step.id} is not defined.`,

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -1,16 +1,10 @@
-import type {
-  IGlobalVariable,
-  IJSONObject,
-  IRawAction,
-  IStep,
-} from '@plumber/types'
+import type { IGlobalVariable, IJSONObject, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
-import Step from '@/models/step'
 
-import toolboxApp from '../..'
 import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
+import { skipToNextBranch } from '../../common/skip-to-next-branch'
 
 const ACTION_KEY = 'ifThen'
 
@@ -20,42 +14,6 @@ function shouldTakeBranch($: IGlobalVariable): boolean {
     throw new Error('No conditions found')
   }
   return conditions.every((condition) => conditionIsTrue(condition))
-}
-
-async function getBranchStepIdToSkipTo(
-  $: IGlobalVariable,
-): Promise<IStep['id']> {
-  const currDepth = parseInt($.step.parameters?.depth as string)
-  if (isNaN(currDepth)) {
-    throw new Error(
-      `Branch depth for initial branch step ${$.step.id} is not defined.`,
-    )
-  }
-
-  // PERF-FIXME: Objectionjs does no caching, so this will almost always be
-  // queried multiple times by the same worker during a test run. If it does
-  // turn out to impact perf, we can LRU memoize this by executionId.
-  const flowSteps = await Step.query()
-    .where('flow_id', $.flow.id)
-    .orderBy('position', 'asc')
-    .throwIfNotFound()
-
-  const nextBranchStep = flowSteps.slice($.step.position).find((step) => {
-    if (!(step.appKey === toolboxApp.key && step.key === ACTION_KEY)) {
-      return false
-    }
-
-    const nextBranchDepth = parseInt(step.parameters?.depth as string)
-    if (isNaN(nextBranchDepth)) {
-      throw new Error(
-        `Branch depth for future branch step ${$.step.id} is not defined.`,
-      )
-    }
-
-    return nextBranchDepth <= currDepth
-  })
-
-  return nextBranchStep?.['id']
 }
 
 const action: IRawAction = {
@@ -116,7 +74,7 @@ const action: IRawAction = {
       return
     }
 
-    const nextStepId = await getBranchStepIdToSkipTo($)
+    const nextStepId = await skipToNextBranch($)
     return nextStepId
       ? {
           nextStep: {

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -3,8 +3,8 @@ import type { IGlobalVariable, IJSONObject, IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 
 import conditionIsTrue from '../../common/condition-is-true'
+import { getBranchStepIdToSkipTo } from '../../common/get-branch-step-id-to-skip-to'
 import getConditionArgs from '../../common/get-condition-args'
-import { skipToNextBranch } from '../../common/skip-to-next-branch'
 
 const ACTION_KEY = 'ifThen'
 
@@ -74,7 +74,7 @@ const action: IRawAction = {
       return
     }
 
-    const nextStepId = await skipToNextBranch($)
+    const nextStepId = await getBranchStepIdToSkipTo($)
     return nextStepId
       ? {
           nextStep: {

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -1,52 +1,10 @@
-import type { IGlobalVariable, IRawAction } from '@plumber/types'
+import type { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
-import Step from '@/models/step'
 
 import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
-
-async function getNextBranchStepId($: IGlobalVariable) {
-  const flowSteps = await Step.query()
-    .where('flow_id', $.flow.id)
-    .orderBy('position', 'asc')
-    .throwIfNotFound()
-
-  // search for immediate branch before current step
-  const currBranchStep = flowSteps
-    .slice(0, $.step.position)
-    .reverse()
-    .find((step) => step.appKey === 'toolbox' && step.key === 'ifThen')
-
-  // no branches so no next branch step to skip to
-  if (!currBranchStep) {
-    return null
-  }
-
-  const currDepth = parseInt(currBranchStep.parameters?.depth as string)
-  if (isNaN(currDepth)) {
-    throw new Error(
-      `Branch depth for current branch step ${currBranchStep.id} is not defined.`,
-    )
-  }
-
-  // search for next branch after current step
-  const nextBranchStep = flowSteps.slice($.step.position).find((step) => {
-    if (!(step.appKey === 'toolbox' && step.key === 'ifThen')) {
-      return false
-    }
-
-    const nextBranchDepth = parseInt(step.parameters?.depth as string)
-    if (isNaN(nextBranchDepth)) {
-      throw new Error(
-        `Branch depth for future branch step ${$.step.id} is not defined.`,
-      )
-    }
-
-    return nextBranchDepth <= currDepth
-  })
-  return nextBranchStep?.['id']
-}
+import { skipToNextBranch } from '../../common/skip-to-next-branch'
 
 const action: IRawAction = {
   name: 'Only continue if',
@@ -72,7 +30,7 @@ const action: IRawAction = {
 
     // only check for next branch step to jump to if result is false
     if (!result) {
-      const nextBranchStepId = await getNextBranchStepId($)
+      const nextBranchStepId = await skipToNextBranch($, true)
       return nextBranchStepId
         ? {
             nextStep: {

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -1,9 +1,52 @@
-import { IRawAction } from '@plumber/types'
+import type { IGlobalVariable, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
+import Step from '@/models/step'
 
 import conditionIsTrue from '../../common/condition-is-true'
 import getConditionArgs from '../../common/get-condition-args'
+
+async function getNextBranchStepId($: IGlobalVariable) {
+  const flowSteps = await Step.query()
+    .where('flow_id', $.flow.id)
+    .orderBy('position', 'asc')
+    .throwIfNotFound()
+
+  // search for immediate branch before current step
+  const currBranchStep = flowSteps
+    .slice(0, $.step.position)
+    .reverse()
+    .find((step) => step.appKey === 'toolbox' && step.key === 'ifThen')
+
+  // no branches so no next branch step to skip to
+  if (!currBranchStep) {
+    return null
+  }
+
+  const currDepth = parseInt(currBranchStep.parameters?.depth as string)
+  if (isNaN(currDepth)) {
+    throw new Error(
+      `Branch depth for current branch step ${currBranchStep.id} is not defined.`,
+    )
+  }
+
+  // search for next branch after current step
+  const nextBranchStep = flowSteps.slice($.step.position).find((step) => {
+    if (!(step.appKey === 'toolbox' && step.key === 'ifThen')) {
+      return false
+    }
+
+    const nextBranchDepth = parseInt(step.parameters?.depth as string)
+    if (isNaN(nextBranchDepth)) {
+      throw new Error(
+        `Branch depth for future branch step ${$.step.id} is not defined.`,
+      )
+    }
+
+    return nextBranchDepth <= currDepth
+  })
+  return nextBranchStep?.['id']
+}
 
 const action: IRawAction = {
   name: 'Only continue if',
@@ -27,10 +70,17 @@ const action: IRawAction = {
       raw: { result },
     })
 
+    // only check for next branch step to jump to if result is false
     if (!result) {
-      return {
-        nextStep: { command: 'stop-execution' },
-      }
+      const nextBranchStepId = await getNextBranchStepId($)
+      return nextBranchStepId
+        ? {
+            nextStep: {
+              command: 'jump-to-step',
+              stepId: nextBranchStepId as string,
+            },
+          }
+        : { nextStep: { command: 'stop-execution' } }
     }
   },
 }

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -3,8 +3,8 @@ import type { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 
 import conditionIsTrue from '../../common/condition-is-true'
+import { getBranchStepIdToSkipTo } from '../../common/get-branch-step-id-to-skip-to'
 import getConditionArgs from '../../common/get-condition-args'
-import { skipToNextBranch } from '../../common/skip-to-next-branch'
 
 const action: IRawAction = {
   name: 'Only continue if',
@@ -30,7 +30,7 @@ const action: IRawAction = {
 
     // only check for next branch step to jump to if result is false
     if (!result) {
-      const nextBranchStepId = await skipToNextBranch($, true)
+      const nextBranchStepId = await getBranchStepIdToSkipTo($)
       return nextBranchStepId
         ? {
             nextStep: {

--- a/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
+++ b/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
@@ -47,5 +47,5 @@ export async function getBranchStepIdToSkipTo(
 
     return nextBranchDepth <= currDepth
   })
-  return nextBranchStep?.['id']
+  return nextBranchStep?.id
 }

--- a/packages/backend/src/apps/toolbox/common/skip-to-next-branch.ts
+++ b/packages/backend/src/apps/toolbox/common/skip-to-next-branch.ts
@@ -1,0 +1,59 @@
+import type { IGlobalVariable, IStep } from '@plumber/types'
+
+import Step from '@/models/step'
+
+export async function skipToNextBranch(
+  $: IGlobalVariable,
+  onlyContinueIfFlag?: boolean,
+): Promise<IStep['id']> {
+  // PERF-FIXME: Objectionjs does no caching, so this will almost always be
+  // queried multiple times by the same worker during a test run. If it does
+  // turn out to impact perf, we can LRU memoize this by executionId.
+  const flowSteps = await Step.query()
+    .where('flow_id', $.flow.id)
+    .orderBy('position', 'asc')
+    .throwIfNotFound()
+
+  let currBranchStep: Partial<Step> = $.step
+
+  // Only continue if step will require to update currBranchStep as the reference point
+  if (onlyContinueIfFlag) {
+    // search for immediate branch before current step
+    currBranchStep = flowSteps
+      .slice(0, $.step.position)
+      .reverse()
+      .find((step) => step.appKey === 'toolbox' && step.key === 'ifThen')
+
+    // no branches so no next branch step to skip to
+    if (!currBranchStep) {
+      return null
+    }
+  }
+
+  const currDepth = parseInt(currBranchStep.parameters?.depth as string)
+
+  if (isNaN(currDepth)) {
+    throw new Error(
+      `Branch depth for ${
+        onlyContinueIfFlag ? 'only continue if' : 'if then'
+      } branch step ${currBranchStep.id} is not defined.`,
+    )
+  }
+
+  // search for next branch after current step
+  const nextBranchStep = flowSteps.slice($.step.position).find((step) => {
+    if (!(step.appKey === 'toolbox' && step.key === 'ifThen')) {
+      return false
+    }
+
+    const nextBranchDepth = parseInt(step.parameters?.depth as string)
+    if (isNaN(nextBranchDepth)) {
+      throw new Error(
+        `Branch depth for future branch step ${$.step.id} is not defined.`,
+      )
+    }
+
+    return nextBranchDepth <= currDepth
+  })
+  return nextBranchStep?.['id']
+}


### PR DESCRIPTION
## Problem

Right now, if the condition fails for only continue if in a branch, it stops the execution. But the intended outcome is that the execution carries on for the other branches.

## Solution

Check for future branches and skip to next branch when only continue if condition fails. Added unit tests to check it works too.

## Tests
Set up a pipe with 3 only continue if conditions:
Step 1: Trigger
Step 2: Only continue if
Step 3: Branch 1
Step 4: Only continue if
Step 5: Postman email
Step 6: Branch 2
Step 7: Only continue if
Step 8: Postman email

Set all only continue if condition to pass
- [x] Two emails should be sent out

Fail the only continue if condition for step 2
- [x] No emails should be sent

Fail the only continue if condition for step 4
- [x] Email for branch 1 is not sent
- [x] Email for branch 2 is sent

Fail the only continue if condition for step 7
- [x] Email for branch 1 is sent
- [x] Email for branch 2 is not sent

Fail the only continue if condition for both steps 4 and 7
- [x] Emails for branch 1 and 2 are not sent