### PR TITLE
feat: proxy rum request via our proxy

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -27,6 +27,8 @@ if (['prod', 'staging'].includes(appConfig.env)) {
     clientToken: 'pubdc3dfc4ab0145729ebc91a19e9fae167',
     site: 'datadoghq.com',
     service: 'plumber',
+    // deployed with cloudflare workers
+    proxy: 'https://rum-proxy.plumber.gov.sg',
     env: appConfig.env,
     sessionSampleRate: 100,
     sessionReplaySampleRate: 100,


### PR DESCRIPTION
## Problem

datadog rum intake url not whitelisted on GSIB.

## Solution

Proxy all rum requests via cloudflare worker

## To test
### Local dev
- [x] Check that all rum requests are made to https://rum-proxy.plumber.gov.sg and returns 202 by inspecting network traffic
- [x] Check that it appears on dd rum
### Staging
- [ ] Check that all rum requests are made to https://rum-proxy.plumber.gov.sg and returns 202 by inspecting network traffic
- [ ] Check that it appears on dd rum