### PR TITLE
PLU-318:  [TEMPLATES-11]: add template variable placeholders

### DIFF
--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -1,6 +1,8 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
   TILE_ID_PLACEHOLDER,
@@ -35,13 +37,16 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
       parameters: {
         filters: [
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Email',
+            ),
             value: 'jane@email.com',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
-        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
+        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
       },
     },
     {
@@ -49,14 +54,17 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
       appKey: 'tiles',
       eventKey: 'updateSingleRow',
       parameters: {
-        rowId: '{{Replace with Row ID from step 2}}',
+        rowId: CREATE_TEMPLATE_STEP_VARIABLE('rowId', 2),
         rowData: [
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Attended?}}`,
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Attended?',
+            ),
             cellValue: 'Yes',
           },
         ],
-        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
+        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
       },
     },
   ],

--- a/packages/backend/src/db/storage/attendance-taking.ts
+++ b/packages/backend/src/db/storage/attendance-taking.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
@@ -37,16 +36,13 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
       parameters: {
         filters: [
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Email',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Email'),
             value: 'jane@email.com',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
-        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
+        tableId: TILE_ID_PLACEHOLDER,
       },
     },
     {
@@ -57,14 +53,11 @@ export const ATTENDANCE_TAKING_TEMPLATE: ITemplate = {
         rowId: CREATE_TEMPLATE_STEP_VARIABLE('rowId', 2),
         rowData: [
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Attended?',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Attended?'),
             cellValue: 'Yes',
           },
         ],
-        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
+        tableId: TILE_ID_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/constants.ts
+++ b/packages/backend/src/db/storage/constants.ts
@@ -1,13 +1,32 @@
 export const FORMSG_SAMPLE_URL_DESCRIPTION = 'View a sample form'
 export const TILES_SAMPLE_URL_DESCRIPTION = 'View a sample table'
 
-// placeholders for each template step to be replaced
-export const USER_EMAIL_PLACEHOLDER = 'user_email'
-export const TILE_ID_PLACEHOLDER = 'tile_table_id'
-export const TILE_COL_DATA_PLACEHOLDER = 'tile_col_data'
-export const STEP_ID_PLACEHOLDER = (position: number) => `step_id_${position}`
+// placeholder keys to be used for the placeholder replacement map
+export const USER_EMAIL_KEY = 'user_email'
+export const TILE_ID_KEY = 'tile_table_id'
+export const TILE_COL_DATA_KEY = 'tile_col_data'
+export const STEP_ID_KEY = (position: number) => `step_id_${position}`
 
-// construct template placeholders e.g. <<placeholder>>
+/**
+ * These placeholders are constructed by the respective keys above
+ * e.g. user_email becomes <<user_email>>
+ * nested placeholders could exist e.g. <<tile_col_data.email>>
+ * Create your own placeholder here if you have additional ones
+ */
+export const USER_EMAIL_PLACEHOLDER = `<<${USER_EMAIL_KEY}>>`
+export const TILE_ID_PLACEHOLDER = `<<${TILE_ID_KEY}>>`
+export const TILE_COL_DATA_PLACEHOLDER = (colName: string) =>
+  `<<${TILE_COL_DATA_KEY}.${colName}>>`
+export const STEP_ID_PLACEHOLDER = (position: number) =>
+  `<<${STEP_ID_KEY(position)}>>`
+
+/**
+ * Some templates require a step variable which follows the format of
+ * our step i.e. {{step.step_id.label}}
+ * If the step variable does not need to take reference to a previous step,
+ * so we fill the step id with the placeholder template step id
+ * since no step data is required.
+ */
 const PLACEHOLDER_TEMPLATE_STEP_ID = '00000000-0000-0000-0000-000000000000'
 export const CREATE_TEMPLATE_STEP_VARIABLE = (
   varLabel: string,
@@ -17,14 +36,5 @@ export const CREATE_TEMPLATE_STEP_VARIABLE = (
   if (!position) {
     return `{{step.${PLACEHOLDER_TEMPLATE_STEP_ID}.${varLabel}}}`
   }
-  return `{{step.<<${STEP_ID_PLACEHOLDER(position)}>>.${varLabel}}}`
-}
-export const CREATE_TEMPLATE_PLACEHOLDER = (
-  placeholderKey: string,
-  nestedKey?: string,
-) => {
-  if (nestedKey) {
-    return `<<${placeholderKey}.${nestedKey}>>` // for nested placeholders
-  }
-  return `<<${placeholderKey}>>`
+  return `{{step.${STEP_ID_PLACEHOLDER(position)}.${varLabel}}}`
 }

--- a/packages/backend/src/db/storage/constants.ts
+++ b/packages/backend/src/db/storage/constants.ts
@@ -5,3 +5,26 @@ export const TILES_SAMPLE_URL_DESCRIPTION = 'View a sample table'
 export const USER_EMAIL_PLACEHOLDER = 'user_email'
 export const TILE_ID_PLACEHOLDER = 'tile_table_id'
 export const TILE_COL_DATA_PLACEHOLDER = 'tile_col_data'
+export const STEP_ID_PLACEHOLDER = (position: number) => `step_id_${position}`
+
+// construct template placeholders e.g. <<placeholder>>
+const PLACEHOLDER_TEMPLATE_STEP_ID = '00000000-0000-0000-0000-000000000000'
+export const CREATE_TEMPLATE_STEP_VARIABLE = (
+  varLabel: string,
+  position?: number,
+) => {
+  // note that most step variable will be empty so a standard/fake step id is used
+  if (!position) {
+    return `{{step.${PLACEHOLDER_TEMPLATE_STEP_ID}.${varLabel}}}`
+  }
+  return `{{step.<<${STEP_ID_PLACEHOLDER(position)}>>.${varLabel}}}`
+}
+export const CREATE_TEMPLATE_PLACEHOLDER = (
+  placeholderKey: string,
+  nestedKey?: string,
+) => {
+  if (nestedKey) {
+    return `<<${placeholderKey}.${nestedKey}>>` // for nested placeholders
+  }
+  return `<<${placeholderKey}>>`
+}

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -27,15 +27,6 @@ function deepFreeze<T>(object: T): T {
   return Object.freeze(object)
 }
 
-/**
- * Right now, some parameters have to be replaced dynamically.
- * 1. <<user_email>> will be replaced with the actual user email
- * 2. <<tile_col_data.col_name>>, the column name value will be replaced with the col id.
- * 3. <<tile_table_id>> will be replaced with the tile id if created
- *
- * Use `CREATE_TEMPLATE_STEP_VARIABLE` to create empty placeholders
- * for users to change them to the variable pills
- */
 export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   SEND_FOLLOW_UPS_TEMPLATE,
   SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE,

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -29,13 +29,12 @@ function deepFreeze<T>(object: T): T {
 
 /**
  * Right now, some parameters have to be replaced dynamically.
- * 1. {{user_email}} will be replaced with the actual user email
- * 2. {{tile_col_data.col_name}}, the column name value will be replaced with the col id.
- * 3. {{tile_table_id}} will be replaced with the tile id if created
+ * 1. <<user_email>> will be replaced with the actual user email
+ * 2. <<tile_col_data.col_name>>, the column name value will be replaced with the col id.
+ * 3. <<tile_table_id>> will be replaced with the tile id if created
  *
- * Note that parameters will have {{Replace with __}}, these are
- * placeholders for users to change them to the variable pills
- * TODO (mal): change this in a later PR after discussing with the team
+ * Use `CREATE_TEMPLATE_STEP_VARIABLE` to create empty placeholders
+ * for users to change them to the variable pills
  */
 export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   SEND_FOLLOW_UPS_TEMPLATE,

--- a/packages/backend/src/db/storage/route-support-enquiries.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries.ts
@@ -1,6 +1,11 @@
 import type { ITemplate } from '@plumber/types'
 
-import { FORMSG_SAMPLE_URL_DESCRIPTION } from './constants'
+import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
+  FORMSG_SAMPLE_URL_DESCRIPTION,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
 
 const ROUTE_SUPPORT_ENQUIRIES_ID = '2a84e2f6-4806-46a2-890a-0dba1411b12f'
 
@@ -29,7 +34,9 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           {
             is: 'is',
             text: 'Resetting device',
-            field: '{{Replace with response 1 request}}',
+            field: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 1 request',
+            ),
             condition: 'equals',
           },
         ],
@@ -40,11 +47,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
       appKey: 'postman',
       eventKey: 'sendTransactionalEmail',
       parameters: {
-        body: '<p style="margin: 0">You have received a support request from {{Replace this with data from step 1}}! </p><p style="margin: 0"></p><p style="margin: 0">Here is what their request is about: </p><p style="margin: 0">{{Replace this with data from step 1}}</p><p style="margin: 0"></p><p style="margin: 0">Please respond to them within 3 working days. Thank you!</p>',
-        subject:
-          'You have received a IT support request from {{Replace this with data from step 1}}!',
+        body: `<p style="margin: 0">You have received a support request from ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}! </p><p style="margin: 0"></p><p style="margin: 0">Here is what their request is about: </p><p style="margin: 0">${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}</p><p style="margin: 0"></p><p style="margin: 0">Please respond to them within 3 working days. Thank you!</p>`,
+        subject: `You have received a IT support request from ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}!`,
         senderName: 'IT support request',
-        destinationEmail: '{{Replace with reset device team email}}',
+        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
       },
     },
     {
@@ -58,7 +70,9 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           {
             is: 'is',
             text: 'Damaged device',
-            field: '{{Replace with response 1 request}}',
+            field: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 1 request',
+            ),
             condition: 'equals',
           },
         ],
@@ -69,11 +83,16 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
       appKey: 'postman',
       eventKey: 'sendTransactionalEmail',
       parameters: {
-        body: '<p style="margin: 0">You have received a support request from {{Replace this with data from step 1}}!</p><p style="margin: 0"></p><p style="margin: 0">Here is what their request is about:</p><p style="margin: 0">{{Replace this with data from step 1}}</p><p style="margin: 0"></p><p style="margin: 0">Please respond to them within 3 working days. Thank you!</p>',
-        subject:
-          'You have received a IT support request from {{Replace this with data from step 1}}!',
+        body: `<p style="margin: 0">You have received a support request from ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}!</p><p style="margin: 0"></p><p style="margin: 0">Here is what their request is about:</p><p style="margin: 0">${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}</p><p style="margin: 0"></p><p style="margin: 0">Please respond to them within 3 working days. Thank you!</p>`,
+        subject: `You have received a IT support request from ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )}!`,
         senderName: 'IT support ',
-        destinationEmail: '{{Replace with damage device email}}',
+        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
       },
     },
     {
@@ -87,7 +106,9 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           {
             is: 'is',
             text: 'Lost device',
-            field: '{{Replace with response 1 request}}',
+            field: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 1 request',
+            ),
             condition: 'equals',
           },
         ],
@@ -107,7 +128,9 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           {
             is: 'is',
             text: 'New device',
-            field: '{{Replace with response 1 request}}',
+            field: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 1 request',
+            ),
             condition: 'equals',
           },
         ],

--- a/packages/backend/src/db/storage/route-support-enquiries.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   USER_EMAIL_PLACEHOLDER,
@@ -56,7 +55,7 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           'Replace this with data from step 1',
         )}!`,
         senderName: 'IT support request',
-        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
       },
     },
     {
@@ -92,7 +91,7 @@ export const ROUTE_SUPPORT_ENQUIRIES_TEMPLATE: ITemplate = {
           'Replace this with data from step 1',
         )}!`,
         senderName: 'IT support ',
-        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
       },
     },
     {

--- a/packages/backend/src/db/storage/schedule-reminders.ts
+++ b/packages/backend/src/db/storage/schedule-reminders.ts
@@ -1,6 +1,9 @@
 import type { ITemplate } from '@plumber/types'
 
-import { USER_EMAIL_PLACEHOLDER } from './constants'
+import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
 
 const SCHEDULE_REMINDERS_ID = '65e90f41-b605-4e83-bcd7-e4d2e349299d'
 
@@ -27,7 +30,7 @@ export const SCHEDULE_REMINDERS_TEMPLATE: ITemplate = {
         body: '<p style="margin: 0">This is a scheduled reminder to do you best this week! </p>',
         subject: "It's a new week!",
         senderName: 'Weekly motivation',
-        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
+        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
       },
     },
   ],

--- a/packages/backend/src/db/storage/schedule-reminders.ts
+++ b/packages/backend/src/db/storage/schedule-reminders.ts
@@ -1,9 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
-import {
-  CREATE_TEMPLATE_PLACEHOLDER,
-  USER_EMAIL_PLACEHOLDER,
-} from './constants'
+import { USER_EMAIL_PLACEHOLDER } from './constants'
 
 const SCHEDULE_REMINDERS_ID = '65e90f41-b605-4e83-bcd7-e4d2e349299d'
 
@@ -30,7 +27,7 @@ export const SCHEDULE_REMINDERS_TEMPLATE: ITemplate = {
         body: '<p style="margin: 0">This is a scheduled reminder to do you best this week! </p>',
         subject: "It's a new week!",
         senderName: 'Weekly motivation',
-        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
+++ b/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
@@ -1,6 +1,8 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   USER_EMAIL_PLACEHOLDER,
 } from './constants'
@@ -26,10 +28,16 @@ export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: ITemplate = {
       appKey: 'postman',
       eventKey: 'sendTransactionalEmail',
       parameters: {
-        body: '<p style="margin: 0">Hi {{Replace this with data from step 1}},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration, here is what you submitted:</p><p style="margin: 0"></p><table style="border-collapse:collapse;"><tbody><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Question</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Response</p></td></tr><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace this with question from step 1}}</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">{{Replace this with response from step 1}}</p></td></tr></tbody></table><p style="margin: 0"></p><p style="margin: 0">More details will be sent to you nearer to the date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event committee</p>',
+        body: `<p style="margin: 0">Hi ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration, here is what you submitted:</p><p style="margin: 0"></p><table style="border-collapse:collapse;"><tbody><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Question</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">Response</p></td></tr><tr><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with question from step 1',
+        )}</p></td><td style="border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;" colspan="1" rowspan="1"><p style="margin: 0">${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with response from step 1',
+        )}</p></td></tr></tbody></table><p style="margin: 0"></p><p style="margin: 0">More details will be sent to you nearer to the date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event committee</p>`,
         subject: 'We have received your registration!',
         senderName: 'Event committee',
-        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
+        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
+++ b/packages/backend/src/db/storage/send-a-copy-of-form-response.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   USER_EMAIL_PLACEHOLDER,
@@ -37,7 +36,7 @@ export const SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE: ITemplate = {
         )}</p></td></tr></tbody></table><p style="margin: 0"></p><p style="margin: 0">More details will be sent to you nearer to the date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event committee</p>`,
         subject: 'We have received your registration!',
         senderName: 'Event committee',
-        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-follow-ups.ts
+++ b/packages/backend/src/db/storage/send-follow-ups.ts
@@ -1,6 +1,8 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   USER_EMAIL_PLACEHOLDER,
 } from './constants'
@@ -27,10 +29,12 @@ export const SEND_FOLLOW_UPS_TEMPLATE: ITemplate = {
       appKey: 'postman',
       eventKey: 'sendTransactionalEmail',
       parameters: {
-        body: '<p style="margin: 0">Hi {{Replace this with data from step 1},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration for this event! More details will be sent to you nearer to the event date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event organising committee</p>',
+        body: `<p style="margin: 0">Hi ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace this with data from step 1',
+        )},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration for this event! More details will be sent to you nearer to the event date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event organising committee</p>`,
         subject: 'Thank you for registering!',
         senderName: 'Event committee',
-        destinationEmail: `{{${USER_EMAIL_PLACEHOLDER}}}`,
+        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
       },
     },
   ],

--- a/packages/backend/src/db/storage/send-follow-ups.ts
+++ b/packages/backend/src/db/storage/send-follow-ups.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   USER_EMAIL_PLACEHOLDER,
@@ -34,7 +33,7 @@ export const SEND_FOLLOW_UPS_TEMPLATE: ITemplate = {
         )},</p><p style="margin: 0"></p><p style="margin: 0">We have received your registration for this event! More details will be sent to you nearer to the event date.</p><p style="margin: 0"></p><p style="margin: 0">Cheers,</p><p style="margin: 0">Event organising committee</p>`,
         subject: 'Thank you for registering!',
         senderName: 'Event committee',
-        destinationEmail: CREATE_TEMPLATE_PLACEHOLDER(USER_EMAIL_PLACEHOLDER),
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -1,6 +1,8 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
   TILE_ID_PLACEHOLDER,
@@ -34,19 +36,34 @@ export const TRACK_FEEDBACK_TEMPLATE: ITemplate = {
       parameters: {
         rowData: [
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Rating}}`,
-            cellValue: '{{Replace with response 1 rating}}',
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Rating',
+            ),
+            cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 1 rating',
+            ),
           },
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Reason for rating}}`,
-            cellValue: '{{Replace with response 2 reason}}',
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Reason for rating',
+            ),
+            cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 2 reason',
+            ),
           },
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
-            cellValue: '{{Replace with response 3 email}}',
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Email',
+            ),
+            cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with response 3 email',
+            ),
           },
         ],
-        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
+        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
       },
     },
   ],

--- a/packages/backend/src/db/storage/track-feedback.ts
+++ b/packages/backend/src/db/storage/track-feedback.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
@@ -36,34 +35,25 @@ export const TRACK_FEEDBACK_TEMPLATE: ITemplate = {
       parameters: {
         rowData: [
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Rating',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Rating'),
             cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
               'Replace with response 1 rating',
             ),
           },
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Reason for rating',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Reason for rating'),
             cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
               'Replace with response 2 reason',
             ),
           },
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Email',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Email'),
             cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
               'Replace with response 3 email',
             ),
           },
         ],
-        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
+        tableId: TILE_ID_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -1,7 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
-  CREATE_TEMPLATE_PLACEHOLDER,
   CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
@@ -36,16 +35,13 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
       parameters: {
         filters: [
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Name',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Name'),
             value: 'Anna Lee',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
-        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
+        tableId: TILE_ID_PLACEHOLDER,
       },
     },
     {
@@ -56,16 +52,13 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
         rowId: CREATE_TEMPLATE_STEP_VARIABLE('rowId', 2),
         rowData: [
           {
-            columnId: CREATE_TEMPLATE_PLACEHOLDER(
-              TILE_COL_DATA_PLACEHOLDER,
-              'Mobile number',
-            ),
+            columnId: TILE_COL_DATA_PLACEHOLDER('Mobile number'),
             cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
               'Replace with new mobile number from step 1',
             ),
           },
         ],
-        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
+        tableId: TILE_ID_PLACEHOLDER,
       },
     },
   ],

--- a/packages/backend/src/db/storage/update-mailing-lists.ts
+++ b/packages/backend/src/db/storage/update-mailing-lists.ts
@@ -1,6 +1,8 @@
 import type { ITemplate } from '@plumber/types'
 
 import {
+  CREATE_TEMPLATE_PLACEHOLDER,
+  CREATE_TEMPLATE_STEP_VARIABLE,
   FORMSG_SAMPLE_URL_DESCRIPTION,
   TILE_COL_DATA_PLACEHOLDER,
   TILE_ID_PLACEHOLDER,
@@ -34,13 +36,16 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
       parameters: {
         filters: [
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Name}}`,
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Name',
+            ),
             value: 'Anna Lee',
             operator: 'equals',
           },
         ],
         returnLastRow: true,
-        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
+        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
       },
     },
     {
@@ -48,18 +53,19 @@ export const UPDATE_MAILING_LISTS_TEMPLATE: ITemplate = {
       appKey: 'tiles',
       eventKey: 'updateSingleRow',
       parameters: {
-        rowId: '{{Replace with row ID from step 2}}',
+        rowId: CREATE_TEMPLATE_STEP_VARIABLE('rowId', 2),
         rowData: [
           {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Email}}`,
-            cellValue: '{{Replace with email result from step 2}}',
-          },
-          {
-            columnId: `{{${TILE_COL_DATA_PLACEHOLDER}.Mobile number}}`,
-            cellValue: '{{Replace with response 4 mobile number from step 1}}',
+            columnId: CREATE_TEMPLATE_PLACEHOLDER(
+              TILE_COL_DATA_PLACEHOLDER,
+              'Mobile number',
+            ),
+            cellValue: CREATE_TEMPLATE_STEP_VARIABLE(
+              'Replace with new mobile number from step 1',
+            ),
           },
         ],
-        tableId: `{{${TILE_ID_PLACEHOLDER}}}`,
+        tableId: CREATE_TEMPLATE_PLACEHOLDER(TILE_ID_PLACEHOLDER),
       },
     },
   ],

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -183,8 +183,13 @@
     outline: none;
   }
 
-  .node-variable.ProseMirror-selectednode .chakra-badge {
+  .node-variable.ProseMirror-selectednode .chakra-badge[data-content='filled'] {
     box-shadow: 0 0 0 1px var(--chakra-colors-primary-600);
+  }
+
+  .node-variable.ProseMirror-selectednode .chakra-badge[data-content='empty'] {
+    box-shadow: 'none';
+    background-color: var(--chakra-colors-primary-100);
   }
 }
 

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -1,27 +1,54 @@
 import { Badge, Text } from '@chakra-ui/react'
+import { TouchableTooltip } from '@opengovsg/design-system-react'
 import { Node } from '@tiptap/pm/model'
 import { NodeViewWrapper } from '@tiptap/react'
 
+const PLACEHOLDER_TEMPLATE_STEP_ID = '00000000-0000-0000-0000-000000000000'
+
 export const VariableBadge = ({ node }: { node: Node }) => {
+  // this happens when there is no value mapped properly
+  const isEmpty = node.attrs.value === ''
+  const isTemplate = String(node.attrs.id).includes(
+    PLACEHOLDER_TEMPLATE_STEP_ID,
+  )
+
   return (
     <NodeViewWrapper>
-      <Badge
-        maxW="full"
-        variant="solid"
-        bg="primary.100"
-        borderRadius="50px"
-        mx={0.5}
-        cursor="default"
+      {/* Only show tooltip if value is empty and not a template */}
+      <TouchableTooltip
+        label={
+          isEmpty && !isTemplate
+            ? 'Data is missing for this variable, please test previous steps and reselect the variable'
+            : ''
+        }
+        aria-label="variable badge tooltip"
       >
-        <Text isTruncated color="base.content.strong" mr={1}>
-          {node.attrs.label}
-        </Text>
-        {node.attrs.value && (
-          <Text isTruncated maxW="50ch" color="base.content.medium">
-            {node.attrs.value}
+        <Badge
+          maxW="full"
+          variant="solid"
+          borderRadius="50px"
+          mx={0.5}
+          cursor="default"
+          bg={isEmpty ? 'transparent' : 'primary.100'}
+          borderStyle={isEmpty ? 'dashed' : 'solid'}
+          borderWidth={isEmpty ? '2px' : '0px'}
+          borderColor={isEmpty ? 'primary.600' : 'transparent'}
+          data-content={isEmpty ? 'empty' : 'filled'}
+        >
+          <Text
+            isTruncated
+            color="base.content.strong"
+            mr={isEmpty ? undefined : '0.25rem'}
+          >
+            {node.attrs.label}
           </Text>
-        )}
-      </Badge>
+          {node.attrs.value && (
+            <Text isTruncated maxW="50ch" color="base.content.medium">
+              {node.attrs.value}
+            </Text>
+          )}
+        </Badge>
+      </TouchableTooltip>
     </NodeViewWrapper>
   )
 }

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -34,6 +34,11 @@ export function genVariableInfoMap(
   return result
 }
 
+/**
+ * Note: template variable will not require varInfo since value should be empty.
+ * Template variable should take the same format as a step variable
+ * but using a fake step id defined in VariableBadge.tsx file
+ */
 function constructVariableSpanElement(
   varInfo: VariableInfoMap,
   id: string,


### PR DESCRIPTION
## Problem
Users are unaware of what they can do with Plumber.

## Solution
Introduce templates to speed up their pipe creation and provide new ideas for them to automate. 

## Details
- Simulate template placeholder variable by following the step variable format to maintain backward compatibility: `step.fixed_uuid.template_label`
- For empty variable pill, add a different design to it, to confirm copy changes with Stacey

## Tests
For empty non-template variable:
1. Create webhook and test a variable: `test`
2. Use the variable in step 2.
3. Go back and test a different variable: `test1`
4. Click open step 2 and the pill should be updated to the empty variable (there should be an additional tooltip)

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/1538b401-d4c3-4f43-ba5a-e4779f9223f2">


For template variable:
1. Test with any of the first 7 templates
2. Check the pipe and it should show the empty variable pill without any tooltip
<img width="921" alt="image" src="https://github.com/user-attachments/assets/8ea45d78-312c-4a7c-b5d0-3a21ef26504a">


For working variable:
Should still work accordingly