### PR TITLE
PLU-333: [PAGINATE-2] filter tiles on frontend

### DIFF
--- a/packages/frontend/src/components/DebouncedSearchInput/index.tsx
+++ b/packages/frontend/src/components/DebouncedSearchInput/index.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useMemo } from 'react'
+import { BiSearch } from 'react-icons/bi'
+import { Icon, InputGroup, InputRightElement } from '@chakra-ui/react'
+import { Input } from '@opengovsg/design-system-react'
+import debounce from 'lodash/debounce'
+
+type DebouncedSearchInputProps = {
+  onChange: (val: string) => void
+  searchValue: string
+}
+
+export default function DebouncedSearchInput({
+  onChange,
+  searchValue,
+}: DebouncedSearchInputProps): React.ReactElement {
+  const handleSearchInputChangeDebounced = useMemo(
+    () => debounce(onChange, 500),
+    [onChange],
+  )
+
+  const onSearchInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      handleSearchInputChangeDebounced(event.target.value)
+    },
+    [handleSearchInputChangeDebounced],
+  )
+
+  return (
+    <InputGroup>
+      <Input
+        type="text"
+        w="full"
+        fontSize="md"
+        onChange={onSearchInputChange}
+        defaultValue={searchValue}
+        placeholder="Search"
+      />
+      <InputRightElement h="100%">
+        <Icon as={BiSearch} style={{ height: 20, width: 20 }} />
+      </InputRightElement>
+    </InputGroup>
+  )
+}

--- a/packages/frontend/src/components/PageTitle/index.tsx
+++ b/packages/frontend/src/components/PageTitle/index.tsx
@@ -1,20 +1,45 @@
-import * as React from 'react'
-import { Flex, Hide, Text } from '@chakra-ui/react'
-
-import NavigationDrawer from '@/components/Layout/NavigationDrawer'
+import { memo } from 'react'
+import { Flex, Grid, GridItem, Text } from '@chakra-ui/react'
 
 interface PageTitleProps {
   title: string
+  searchComponent?: React.ReactNode
+  createComponent?: React.ReactNode
 }
 
-export default function PageTitle(props: PageTitleProps): React.ReactElement {
-  const { title } = props
+const PageTitle = ({
+  title,
+  searchComponent,
+  createComponent,
+}: PageTitleProps): React.ReactElement => {
   return (
-    <Flex alignItems="center">
-      <Hide above="sm">
-        <NavigationDrawer />
-      </Hide>
-      <Text textStyle="h4">{title}</Text>
-    </Flex>
+    <Grid
+      templateAreas={{
+        base: `
+              "title button"
+              "search search"
+            `,
+        md: `"title search button"`,
+      }}
+      gridTemplateColumns={{ base: '1fr auto', md: '2fr 1fr auto' }}
+      columnGap={3}
+      rowGap={5}
+      alignItems="center"
+      pl={{ base: 2, md: 8 }}
+      mb={6}
+      minH={12}
+    >
+      <GridItem area="title">
+        <Flex alignItems="center">
+          <Text textStyle="h4">{title}</Text>
+        </Flex>
+      </GridItem>
+
+      <GridItem area="search">{searchComponent}</GridItem>
+
+      <GridItem area="button">{createComponent}</GridItem>
+    </Grid>
   )
 }
+
+export default memo(PageTitle)

--- a/packages/frontend/src/hooks/usePaginationAndFilter.ts
+++ b/packages/frontend/src/hooks/usePaginationAndFilter.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+interface SearchParams {
+  page: number
+  input: string
+  status: string
+}
+
+export function usePaginationAndFilter() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = parseInt(searchParams.get('page') || '', 10) || 1
+  const input = searchParams.get('input') || ''
+  const status = searchParams.get('status') || ''
+
+  // format search params for empty strings and first page
+  const setFormattedSearchParams = useCallback(
+    (params: Partial<SearchParams>) => {
+      setSearchParams((currentSearchParams) => {
+        const { page, input, status } = params
+        if (page) {
+          currentSearchParams.set('page', page.toString())
+        }
+
+        if (input != null) {
+          currentSearchParams.set('input', input.trim())
+          currentSearchParams.delete('page')
+        }
+
+        if (status != null) {
+          currentSearchParams.set('status', status.trim())
+          currentSearchParams.delete('page')
+        }
+
+        currentSearchParams.forEach((value, key) => {
+          if (key === 'page' && value === '1') {
+            currentSearchParams.delete(key)
+          }
+          if (value === '') {
+            currentSearchParams.delete(key)
+          }
+        })
+
+        return currentSearchParams
+      })
+    },
+    [setSearchParams],
+  )
+
+  return {
+    page,
+    input,
+    status,
+    setSearchParams: setFormattedSearchParams,
+  }
+}

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -1,13 +1,15 @@
-import { useSearchParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 import { Pagination } from '@opengovsg/design-system-react'
 
 import Container from '@/components/Container'
+import DebouncedSearchInput from '@/components/DebouncedSearchInput'
+import NoResultFound from '@/components/NoResultFound'
 import PageTitle from '@/components/PageTitle'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { PaginatedTables } from '@/graphql/__generated__/graphql'
 import { GET_TABLES } from '@/graphql/queries/tiles/get-tables'
+import { usePaginationAndFilter } from '@/hooks/usePaginationAndFilter'
 
 import CreateTileButton from './components/CreateTileButton'
 import EmptyTileList from './components/EmptyTileList'
@@ -18,8 +20,7 @@ const TILES_TITLE = 'Tiles'
 const TILES_PER_PAGE = 10
 
 export default function Tiles(): JSX.Element {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const page = parseInt(searchParams.get('page') || '', 10) || 1
+  const { input, page, setSearchParams } = usePaginationAndFilter()
 
   const { data, loading: isTileListLoading } = useQuery<{
     getTables: PaginatedTables
@@ -27,46 +28,50 @@ export default function Tiles(): JSX.Element {
     variables: {
       limit: TILES_PER_PAGE,
       offset: (page - 1) * TILES_PER_PAGE,
+      name: input,
     },
   })
 
-  if (!data?.getTables || isTileListLoading) {
-    return (
-      <Center h="100%">
-        <PrimarySpinner fontSize="4xl" thickness="4px" margin="auto" />
-      </Center>
-    )
-  }
-
-  const { pageInfo, edges } = data.getTables || {}
+  const { pageInfo, edges } = data?.getTables || { edges: [] }
   const tilesToDisplay = edges.map(({ node }) => node)
-  const isEmpty = tilesToDisplay?.length === 0
+  const hasNoTiles =
+    !isTileListLoading && tilesToDisplay?.length === 0 && input.trim() === ''
+  const hasNoSearchResults =
+    !isTileListLoading && tilesToDisplay?.length === 0 && input.trim() !== ''
 
   return (
     <Container py={9}>
-      <Flex
-        flexDir="column"
-        justifyContent="space-between"
-        alignItems="stretch"
-        gap={8}
-      >
-        <Flex
-          pl={{ base: 0, sm: 8 }}
-          alignItems="center"
-          justifyContent="space-between"
-        >
-          <PageTitle title={TILES_TITLE} />
-          {!isEmpty && <CreateTileButton />}
-        </Flex>
-        {isEmpty ? <EmptyTileList /> : <TileList tiles={tilesToDisplay} />}
-      </Flex>
+      <PageTitle
+        title={TILES_TITLE}
+        searchComponent={
+          !hasNoTiles && (
+            <DebouncedSearchInput
+              searchValue={input}
+              onChange={(input) => setSearchParams({ input })}
+            />
+          )
+        }
+        createComponent={!hasNoTiles && <CreateTileButton />}
+      />
+      {isTileListLoading && (
+        // moved this here to prevent re-rendering of search field
+        <Center h="100%">
+          <PrimarySpinner fontSize="4xl" thickness="4px" margin="auto" />
+        </Center>
+      )}
+      {hasNoTiles && <EmptyTileList />}
+      {hasNoSearchResults && (
+        <NoResultFound
+          description="We couldn't find anything"
+          action="Try using different keywords or checking for typos."
+        />
+      )}
+      <TileList tiles={tilesToDisplay} />
       {pageInfo && pageInfo.totalCount > TILES_PER_PAGE && (
         <Flex justifyContent="center" mt={6}>
           <Pagination
             currentPage={pageInfo.currentPage}
-            onPageChange={(page) =>
-              setSearchParams(page === 1 ? {} : { page: page.toString() })
-            }
+            onPageChange={(page) => setSearchParams({ page })}
             pageSize={TILES_PER_PAGE}
             totalCount={pageInfo.totalCount}
           />


### PR DESCRIPTION
### Changes
- new components `PageTitle`, `DebouncedSearchInput` and new hook `usePaginationAndFilter` to be shared across pages
- the hamburger menu for small devices will be moved to the top left (replacing plumber logo in the next PR)
- implement filtering on Tiles pages