### PR TITLE
fix: templates list styling

### DIFF
--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -61,20 +61,26 @@ export default function Templates(): JSX.Element {
                 <Tile
                   key={index}
                   icon={() => (
-                    <Box bg="primary.100" p={2} borderRadius="base">
-                      <TemplateIcon iconName={template.iconName} />
+                    <Box py={2}>
+                      <TemplateIcon
+                        iconName={template.iconName}
+                        fontSize="2rem"
+                      />
                     </Box>
                   )}
+                  badge={
+                    isDemoTemplate ? (
+                      <Badge bg="primary.100" color="primary.500">
+                        Demo included
+                      </Badge>
+                    ) : undefined
+                  }
+                  display="flex"
                   onClick={() => navigate(URLS.TEMPLATE(template.id))}
                 >
                   <Flex flexDir="column" gap={2} mt={2}>
                     <Flex gap={2}>
                       <Text textStyle="subhead-1">{template.name}</Text>
-                      {isDemoTemplate && (
-                        <Badge bg="primary.100" color="primary.500">
-                          Demo included
-                        </Badge>
-                      )}
                     </Flex>
                     <Text textStyle="body-2">{template.description}</Text>
                   </Flex>


### PR DESCRIPTION
### TL;DR

Updated the Templates page UI to improve layout and styling of template tiles.

### What changed?

- Removed the background color from the template icon container
- Increased the icon size to 2rem
- Moved the "Demo included" badge to the top of the tile
- Adjusted the layout of the template information

### How to test?

1. Navigate to the Templates page
2. Verify that the template tiles have a new layout:
   - Icons are larger and without a background
   - "Demo included" badge appears at the top of applicable tiles
   - Template name and description are aligned properly

### Why make this change?

This change enhances the visual appeal and usability of the Templates page. The larger icons without backgrounds provide a cleaner look, while the repositioned "Demo included" badge makes it more prominent and easier to spot. These adjustments create a more consistent and user-friendly interface for browsing available templates.