### PR TITLE
chore: make nullable return types for admin search

### DIFF
--- a/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-execution-owner.ts
@@ -12,7 +12,10 @@ const getExecutionOwner: AdminQueryResolvers['getExecutionOwner'] = async (
   const execution = await Execution.query()
     .findById(executionId)
     .withGraphJoined({ flow: { user: true } })
-    .throwIfNotFound()
+
+  if (!execution) {
+    return null
+  }
 
   return execution.flow.user
 }

--- a/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-flow-owner.ts
@@ -12,7 +12,10 @@ const getFlowOwner: AdminQueryResolvers['getFlowOwner'] = async (
   const flow = await Flow.query()
     .findById(flowId)
     .withGraphJoined({ user: true })
-    .throwIfNotFound()
+
+  if (!flow) {
+    return null
+  }
 
   return flow.user
 }

--- a/packages/backend/src/graphql/admin/queries/get-table-owner.ts
+++ b/packages/backend/src/graphql/admin/queries/get-table-owner.ts
@@ -13,8 +13,11 @@ const getTableOwner: AdminQueryResolvers['getTableOwner'] = async (
     .where('table_id', tableId)
     .andWhere('role', 'owner')
     .withGraphJoined({ user: true })
-    .throwIfNotFound()
     .first()
+
+  if (!tableCollaborator) {
+    return null
+  }
 
   return tableCollaborator.user
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -56,9 +56,9 @@ type Query {
 }
 
 type AdminQuery {
-  getFlowOwner(flowId: String!): User!
-  getExecutionOwner(executionId: String!): User!
-  getTableOwner(tableId: String!): User!
+  getFlowOwner(flowId: String!): User
+  getExecutionOwner(executionId: String!): User
+  getTableOwner(tableId: String!): User
   searchUsersByEmail(query: String!): [User!]!
 }
 


### PR DESCRIPTION
### Problem

To allow for admin search by UUID, im gonna try searching for pipes -> tiles -> executions.

### Solution

Prevent throwing errors but instead return null when the UUID does not exist