### PR TITLE
chore: modify templates page layout

### DIFF
--- a/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
+++ b/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   BiShow,
   BiTrash,
 } from 'react-icons/bi'
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
   Icon,
@@ -35,6 +35,7 @@ interface FlowContextMenuProps {
 
 export default function FlowContextMenu(props: FlowContextMenuProps) {
   const { flow } = props
+  const navigate = useNavigate()
 
   // dialog control
   const {
@@ -146,9 +147,11 @@ export default function FlowContextMenu(props: FlowContextMenuProps) {
         />
         <MenuList w="12.5rem">
           <MenuItem
-            as={Link}
-            to={URLS.FLOW(flow.id)}
             icon={<Icon as={BiShow} boxSize={5} />}
+            onClick={(event) => {
+              event.preventDefault() // default behavior of the Link in the CardBody
+              navigate(URLS.FLOW(flow.id))
+            }}
           >
             View
           </MenuItem>

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -25,14 +25,14 @@ export default function Templates(): JSX.Element {
   const template = templates?.find((template) => template.id === templateId)
   return (
     <>
-      <Container
-        py={9}
-        pl={{ base: '2rem', xl: '3.5rem' }}
-        pr={{ base: '2rem', xl: '8.5rem' }}
-      >
+      <Container py={9}>
         <Flex flexDir="column" mb={8} rowGap={2}>
           <PageTitle title={TEMPLATES_TITLE} />
-          <Text textStyle="body-1">
+          <Text
+            textStyle="body-1"
+            pl={{ base: 2, md: 8 }}
+            mt={{ base: -10, md: -6 }}
+          >
             Pre-built pipes that you can use as is or customise further for your
             own use case
           </Text>
@@ -49,6 +49,8 @@ export default function Templates(): JSX.Element {
               md: '1fr 1fr',
               lg: '1fr 1fr 1fr',
             }}
+            pl={{ base: '0.5rem', md: '2rem', xl: '3.5rem' }}
+            pr={{ base: '0.5rem', md: '2rem', xl: '8.5rem' }}
             columnGap={10}
             rowGap={6}
             mb={8}

--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -125,7 +125,10 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
             <MenuList w={144}>
               <MenuItem
                 icon={<Icon as={BiShow} boxSize={5} />}
-                onClick={() => navigate(URLS.TILE(table.id))}
+                onClick={(event) => {
+                  event.preventDefault() // default behavior of the Link in the parent
+                  navigate(URLS.TILE(table.id))
+                }}
               >
                 View
               </MenuItem>


### PR DESCRIPTION
Changes:
- Make templates page layout changes based on code refactor, testing to create on top of your graphite stack too thanks

Fix (second commit):
- Console keep showing error for nested <a> tag, fixed it by changing the `Link` to use an `onClick` instead for `FlowContextMenu`
- Added `event.preventDefault()` for both `contextMenu` for flows and tiles since right now, it loads the parent link behaviour and has a buggy behaviour of loading the flow or tile page twice