### PR TITLE
PLU-324: [TILES-TRANSFER-2] update permissions so that editor can use tiles in pipes

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
@@ -73,10 +73,14 @@ describe('tiles create row action', () => {
     expect($.setActionItem).toBeCalled()
   })
 
-  it('should now allow non-owners to create row', async () => {
-    $.user = viewer
-    await expect(createRowAction.run($)).rejects.toThrow(StepError)
+  it('should allow editors to create row', async () => {
     $.user = editor
+    await expect(createRowAction.run($)).resolves.toBeUndefined()
+    expect($.setActionItem).toBeCalled()
+  })
+
+  it('should not allow viewers to create row', async () => {
+    $.user = viewer
     await expect(createRowAction.run($)).rejects.toThrow(StepError)
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -81,10 +81,14 @@ describe('tiles create row action', () => {
     expect($.setActionItem).toBeCalled()
   })
 
-  it('should now allow non-owners to find single row', async () => {
-    $.user = viewer
-    await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+  it('should allow editors to find single row', async () => {
     $.user = editor
+    await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+    expect($.setActionItem).toBeCalled()
+  })
+
+  it('should not allow viewers to find single row', async () => {
+    $.user = viewer
     await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -82,10 +82,14 @@ describe('tiles create row action', () => {
     expect($.setActionItem).toBeCalled()
   })
 
-  it('should now allow non-owners to update row', async () => {
-    $.user = viewer
-    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+  it('should allow editors to update row', async () => {
     $.user = editor
+    await expect(updateRowAction.run($)).resolves.toBeUndefined()
+    expect($.setActionItem).toBeCalled()
+  })
+
+  it('should not allow viewers to update row', async () => {
+    $.user = viewer
     await expect(updateRowAction.run($)).rejects.toThrow(StepError)
   })
 })

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -94,7 +94,7 @@ const action: IRawAction = {
       rowData: { columnId: string; cellValue: string }[]
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'owner', $)
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     const table = await TableMetadata.query().findById(tableId)
 

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -149,7 +149,7 @@ const action: IRawAction = {
       returnLastRow: boolean | undefined
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'owner', $)
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     const columns = await TableColumnMetadata.query().where({
       table_id: tableId,

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -108,7 +108,7 @@ const action: IRawAction = {
       )
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'owner', $)
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     /**
      * Row ID is empty, this could be because the previous get single row action

--- a/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
@@ -25,7 +25,7 @@ const dynamicData: IDynamicData = {
       const tile = await currentUser
         .$relatedQuery('tables')
         .findById($.step.parameters.tableId as string)
-        .where('role', 'owner')
+        .whereIn('role', ['owner', 'editor'])
         .throwIfNotFound()
       const columns = await tile
         .$relatedQuery('columns')

--- a/packages/backend/src/apps/tiles/dynamic-data/list-tables.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-tables.ts
@@ -19,7 +19,7 @@ const dynamicData: IDynamicData = {
       const currentUser = await User.query().findById($.user.id)
       const tiles = await currentUser
         .$relatedQuery('tables')
-        .where('role', 'owner')
+        .whereIn('role', ['owner', 'editor'])
         .orderBy('created_at', 'desc')
 
       return {

--- a/packages/backend/src/errors/graphql-errors/forbidden.ts
+++ b/packages/backend/src/errors/graphql-errors/forbidden.ts
@@ -1,0 +1,17 @@
+import { GraphQLError } from 'graphql/error'
+
+const FORBIDDEN_ERROR_CODE = 'FORBIDDEN'
+
+export class ForbiddenError extends GraphQLError {
+  constructor(message: string) {
+    super(message, {
+      extensions: {
+        code: FORBIDDEN_ERROR_CODE,
+        message,
+        http: {
+          status: 403,
+        },
+      },
+    })
+  }
+}

--- a/packages/backend/src/errors/graphql-errors/index.ts
+++ b/packages/backend/src/errors/graphql-errors/index.ts
@@ -1,1 +1,2 @@
 export * from './bad-user-input'
+export * from './forbidden'

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import createRow from '@/graphql/mutations/tiles/create-row'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
@@ -112,6 +113,6 @@ describe('create row mutation', () => {
         },
         context,
       ),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import createRows from '@/graphql/mutations/tiles/create-rows'
 import { getTableRows } from '@/models/dynamodb/table-row/functions'
 import TableMetadata from '@/models/table-metadata'
@@ -118,6 +119,6 @@ describe('create row mutation', () => {
         },
         context,
       ),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteRows from '@/graphql/mutations/tiles/delete-rows'
 import { createTableRows, getTableRowCount } from '@/models/dynamodb/table-row'
 import TableMetadata from '@/models/table-metadata'
@@ -100,6 +101,6 @@ describe('delete rows mutation', () => {
         { input: { tableId: dummyTable.id, rowIds: slicedRows } },
         context,
       ),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteTable from '@/graphql/mutations/tiles/delete-table'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
@@ -64,11 +65,11 @@ describe('delete table mutation', () => {
     context.currentUser = editor
     await expect(
       deleteTable(null, { input: { id: dummyTable.id } }, context),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
 
     context.currentUser = viewer
     await expect(
       deleteTable(null, { input: { id: dummyTable.id } }, context),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import updateRow from '@/graphql/mutations/tiles/update-row'
 import { createTableRow, TableRow } from '@/models/dynamodb/table-row'
 import TableMetadata from '@/models/table-metadata'
@@ -185,6 +186,6 @@ describe('update row mutation', () => {
         },
         context,
       ),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import updateTable from '@/graphql/mutations/tiles/update-table'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
@@ -313,6 +314,6 @@ describe('update table mutation', () => {
         },
         context,
       ),
-    ).rejects.toThrow('You do not have access to this tile')
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -71,7 +71,7 @@ class TableCollaborator extends Base {
     ) {
       if ($) {
         throw new StepError(
-          'You do not sufficient permissions to this tile',
+          'You do not have sufficient permissions for this tile',
           `Please ensure that you are ${
             role === 'viewer' ? 'a' : 'an'
           } ${role} of this tile.`,
@@ -79,7 +79,9 @@ class TableCollaborator extends Base {
           $.app.name,
         )
       }
-      throw new ForbiddenError('You do not sufficient permissions to this tile')
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this tile',
+      )
     }
   }
 }

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -1,5 +1,6 @@
 import { IGlobalVariable, ITableCollabRole } from '@plumber/types'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
 
 import Base from './base'
@@ -70,7 +71,7 @@ class TableCollaborator extends Base {
     ) {
       if ($) {
         throw new StepError(
-          'You do not have access to this tile',
+          'You do not sufficient permissions to this tile',
           `Please ensure that you are ${
             role === 'viewer' ? 'a' : 'an'
           } ${role} of this tile.`,
@@ -78,7 +79,7 @@ class TableCollaborator extends Base {
           $.app.name,
         )
       }
-      throw new Error('You do not have access to this tile.')
+      throw new ForbiddenError('You do not sufficient permissions to this tile')
     }
   }
 }

--- a/packages/frontend/src/graphql/link.ts
+++ b/packages/frontend/src/graphql/link.ts
@@ -28,6 +28,7 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
 
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
+        console.log('message', message)
         if (autoSnackbar) {
           callback?.(message)
         }
@@ -45,9 +46,7 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
           window.location.href = URLS.UNAUTHORIZED_TILE
         }
       })
-    }
-
-    if (networkError) {
+    } else if (networkError) {
       if (autoSnackbar) {
         callback?.(networkError.toString())
       }

--- a/packages/frontend/src/graphql/link.ts
+++ b/packages/frontend/src/graphql/link.ts
@@ -28,7 +28,6 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
 
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
-        console.log('message', message)
         if (autoSnackbar) {
           callback?.(message)
         }

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareButton.tsx
@@ -1,12 +1,5 @@
-import { useCallback, useState } from 'react'
-import { BiCopy, BiShareAlt } from 'react-icons/bi'
-import { useMutation } from '@apollo/client'
+import { BiShareAlt } from 'react-icons/bi'
 import {
-  Divider,
-  Flex,
-  FormControl,
-  InputGroup,
-  InputRightAddon,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -14,51 +7,20 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Text,
   useDisclosure,
-  VStack,
 } from '@chakra-ui/react'
+import { Button, ButtonProps } from '@opengovsg/design-system-react'
+
+import ShareLink from './ShareLink'
 import {
-  Button,
-  ButtonProps,
-  FormHelperText,
-  IconButton,
-  Input,
-} from '@opengovsg/design-system-react'
-import copy from 'clipboard-copy'
-
-import * as URLS from '@/config/urls'
-import { CREATE_SHAREABLE_TABLE_LINK } from '@/graphql/mutations/tiles/create-shareable-link'
-import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
-
-import { useTableContext } from '../../contexts/TableContext'
-
+  ShareModalContextProvider,
+  useShareModalContext,
+} from './ShareModalContext'
 import TableCollaborators from './TableCollaborators'
+import TransferOwnership from './TransferOwnership'
 
-const ShareModal = ({ onClose }: { onClose: () => void }) => {
-  const { tableId, viewOnlyKey, hasEditPermission } = useTableContext()
-  const [isNewLink, setIsNewLink] = useState(false)
-
-  const shareableLink = viewOnlyKey
-    ? `${window.location.origin}${URLS.TILE(tableId)}/${viewOnlyKey}`
-    : ''
-
-  const [createNewLink, { loading }] = useMutation(
-    CREATE_SHAREABLE_TABLE_LINK,
-    {
-      variables: {
-        tableId,
-      },
-      refetchQueries: [GET_TABLE],
-    },
-  )
-
-  const onGenerate = useCallback(async () => {
-    await createNewLink()
-    setIsNewLink(true)
-  }, [createNewLink])
-
-  const inputBorderColor = isNewLink ? 'green.400' : 'secondary.200'
+const ShareModal = () => {
+  const { onClose, emailToTransfer } = useShareModalContext()
 
   return (
     <Modal isOpen={true} onClose={onClose} motionPreset="none" isCentered>
@@ -66,67 +28,15 @@ const ShareModal = ({ onClose }: { onClose: () => void }) => {
       <ModalContent>
         <ModalHeader>Share tile</ModalHeader>
         <ModalCloseButton />
-        <ModalBody mt={2}>
-          <FormControl>
-            {(viewOnlyKey || hasEditPermission) && (
-              <>
-                <VStack spacing={2} alignItems="flex-start">
-                  <Text textStyle="subhead-3">General Access</Text>
-                  <Text textStyle="body-1">
-                    {hasEditPermission
-                      ? 'Generate a shareable link to allow'
-                      : 'This shareable link allows'}{' '}
-                    viewing and exporting only. No login required.
-                  </Text>
-                  <Flex alignSelf="stretch" gap={2}>
-                    {viewOnlyKey && (
-                      <InputGroup borderWidth={0}>
-                        <Input
-                          value={shareableLink}
-                          borderRightWidth={0}
-                          paddingRight={0}
-                          borderColor={inputBorderColor}
-                          _focusVisible={{ borderColor: inputBorderColor }}
-                          isReadOnly
-                        />
-                        <InputRightAddon
-                          padding={0}
-                          background="white"
-                          borderColor={inputBorderColor}
-                        >
-                          <IconButton
-                            icon={<BiCopy />}
-                            colorScheme="secondary"
-                            variant="clear"
-                            aria-label={'Copy'}
-                            onClick={() => copy(shareableLink ?? '')}
-                          />
-                        </InputRightAddon>
-                      </InputGroup>
-                    )}
-                    {hasEditPermission && (
-                      <Button
-                        variant="outline"
-                        isLoading={loading}
-                        onClick={onGenerate}
-                      >
-                        Generate new link
-                      </Button>
-                    )}
-                  </Flex>
-                  {viewOnlyKey && hasEditPermission && (
-                    <FormHelperText variant={isNewLink ? 'success' : undefined}>
-                      {isNewLink
-                        ? 'New link generated!'
-                        : 'By generating a new link, your previous link will not work anymore.'}
-                    </FormHelperText>
-                  )}
-                </VStack>
-                <Divider my={6} />
-              </>
-            )}
-            <TableCollaborators />
-          </FormControl>
+        <ModalBody pt={2}>
+          {emailToTransfer ? (
+            <TransferOwnership />
+          ) : (
+            <>
+              <ShareLink />
+              <TableCollaborators />
+            </>
+          )}
         </ModalBody>
         <ModalFooter></ModalFooter>
       </ModalContent>
@@ -138,7 +48,7 @@ const ShareButton = (props: ButtonProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
-    <>
+    <ShareModalContextProvider onClose={onClose}>
       <Button
         variant="clear"
         colorScheme="secondary"
@@ -150,8 +60,8 @@ const ShareButton = (props: ButtonProps) => {
         Share
       </Button>
       {/* unmount component when closed to reset all state */}
-      {isOpen && <ShareModal onClose={onClose} />}
-    </>
+      {isOpen && <ShareModal />}
+    </ShareModalContextProvider>
   )
 }
 

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareLink.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareLink.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useState } from 'react'
+import { BiCopy } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import {
+  Divider,
+  Flex,
+  FormControl,
+  InputGroup,
+  InputRightAddon,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  Button,
+  FormHelperText,
+  IconButton,
+  Input,
+} from '@opengovsg/design-system-react'
+import copy from 'clipboard-copy'
+
+import * as URLS from '@/config/urls'
+import { CREATE_SHAREABLE_TABLE_LINK } from '@/graphql/mutations/tiles/create-shareable-link'
+import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
+
+import { useTableContext } from '../../contexts/TableContext'
+
+const ShareLink = () => {
+  const { tableId, viewOnlyKey, hasEditPermission } = useTableContext()
+  const [isNewLink, setIsNewLink] = useState(false)
+
+  const shareableLink = viewOnlyKey
+    ? `${window.location.origin}${URLS.TILE(tableId)}/${viewOnlyKey}`
+    : ''
+
+  const [createNewLink, { loading }] = useMutation(
+    CREATE_SHAREABLE_TABLE_LINK,
+    {
+      variables: {
+        tableId,
+      },
+      refetchQueries: [GET_TABLE],
+    },
+  )
+
+  const onGenerate = useCallback(async () => {
+    await createNewLink()
+    setIsNewLink(true)
+  }, [createNewLink])
+
+  const inputBorderColor = isNewLink ? 'green.400' : 'secondary.200'
+
+  if (!viewOnlyKey && !hasEditPermission) {
+    return null
+  }
+  return (
+    <FormControl>
+      <VStack spacing={2} alignItems="flex-start">
+        <Text textStyle="subhead-3">General Access</Text>
+        <Text textStyle="body-1">
+          {hasEditPermission
+            ? 'Generate a shareable link to allow'
+            : 'This shareable link allows'}{' '}
+          viewing and exporting only. No login required.
+        </Text>
+        <Flex alignSelf="stretch" gap={2}>
+          {viewOnlyKey && (
+            <InputGroup borderWidth={0}>
+              <Input
+                value={shareableLink}
+                borderRightWidth={0}
+                paddingRight={0}
+                borderColor={inputBorderColor}
+                _focusVisible={{ borderColor: inputBorderColor }}
+                isReadOnly
+              />
+              <InputRightAddon
+                padding={0}
+                background="white"
+                borderColor={inputBorderColor}
+              >
+                <IconButton
+                  icon={<BiCopy />}
+                  colorScheme="secondary"
+                  variant="clear"
+                  aria-label={'Copy'}
+                  onClick={() => copy(shareableLink ?? '')}
+                />
+              </InputRightAddon>
+            </InputGroup>
+          )}
+          {hasEditPermission && (
+            <Button variant="outline" isLoading={loading} onClick={onGenerate}>
+              Generate new link
+            </Button>
+          )}
+        </Flex>
+        {viewOnlyKey && hasEditPermission && (
+          <FormHelperText variant={isNewLink ? 'success' : undefined}>
+            {isNewLink
+              ? 'New link generated!'
+              : 'By generating a new link, your previous link will not work anymore.'}
+          </FormHelperText>
+        )}
+      </VStack>
+      <Divider my={6} />
+    </FormControl>
+  )
+}
+
+export default ShareLink

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareModalContext.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareModalContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, ReactNode, useContext, useState } from 'react'
+
+interface ShareModalContextProps {
+  onClose: () => void
+  emailToTransfer: string | null
+  setEmailToTransfer: (email: string | null) => void
+}
+
+const ShareModalContext = createContext<ShareModalContextProps | null>(null)
+
+export const useShareModalContext = () => {
+  const context = useContext(ShareModalContext)
+  if (!context) {
+    throw new Error(
+      'useShareModalContext must be used within a ShareModalContextProvider',
+    )
+  }
+  return context
+}
+
+interface ShareModalContextProviderProps {
+  onClose: () => void
+  children: ReactNode
+}
+
+export const ShareModalContextProvider = ({
+  onClose,
+  children,
+}: ShareModalContextProviderProps) => {
+  const [emailToTransfer, setEmailToTransfer] = useState<string | null>(null)
+
+  return (
+    <ShareModalContext.Provider
+      value={{
+        onClose,
+        emailToTransfer,
+        setEmailToTransfer,
+      }}
+    >
+      {children}
+    </ShareModalContext.Provider>
+  )
+}

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TableCollaborators.tsx
@@ -59,7 +59,7 @@ const TableCollabRoleSelect = ({
       >
         {value}
       </MenuButton>
-      <MenuList w={32} pointerEvents={isEditable ? 'auto' : 'none'}>
+      <MenuList w={32}>
         {role === 'owner' && (
           <MenuItem onClick={() => onChange('owner')}>Owner</MenuItem>
         )}
@@ -144,6 +144,7 @@ const CollaboratorListRow = ({
   const [isDeleting, setIsDeleting] = useState(false)
   const isOwner = collaborator.role === 'owner'
   const isSelf = collaborator.email === currentUser?.email
+  const isEditable = hasEditPermission && !isOwner && !isSelf
 
   const onDeleteHandler = useCallback(async () => {
     setIsDeleting(true)
@@ -169,9 +170,9 @@ const CollaboratorListRow = ({
           value={collaborator.role}
           onChange={onRoleChange}
           variant="clear"
-          isEditable={!isOwner && !isSelf && hasEditPermission}
+          isEditable={isEditable}
         />
-        {!isOwner && !isSelf && hasEditPermission && (
+        {isEditable && (
           <IconButton
             colorScheme="critical"
             onClick={onDeleteHandler}

--- a/packages/frontend/src/pages/Tile/components/TableBanner/TransferOwnership.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/TransferOwnership.tsx
@@ -1,0 +1,70 @@
+import { useMutation } from '@apollo/client'
+import { Flex, Text, VStack } from '@chakra-ui/react'
+import { Button, useToast } from '@opengovsg/design-system-react'
+
+import { UPSERT_TABLE_COLLABORATOR } from '@/graphql/mutations/tiles/upsert-table-collaborator'
+import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
+
+import { useTableContext } from '../../contexts/TableContext'
+
+import { useShareModalContext } from './ShareModalContext'
+
+const TransferOwnership = () => {
+  const { tableId } = useTableContext()
+  const { emailToTransfer, setEmailToTransfer } = useShareModalContext()
+
+  const toast = useToast({
+    status: 'success',
+    duration: 3000,
+    isClosable: true,
+  })
+
+  const [transferOwnership] = useMutation(UPSERT_TABLE_COLLABORATOR, {
+    refetchQueries: [GET_TABLE],
+    awaitRefetchQueries: false,
+    variables: {
+      input: {
+        tableId,
+        email: emailToTransfer ?? '',
+        role: 'owner',
+      },
+    },
+    onCompleted: () => {
+      setEmailToTransfer(null)
+      toast({
+        title: `Ownership transferred`,
+        description: (
+          <Text>{emailToTransfer} is now the owner of this tile</Text>
+        ),
+      })
+    },
+  })
+
+  if (!emailToTransfer) {
+    return null
+  }
+
+  return (
+    <VStack gap={4} alignItems="start">
+      <Text textStyle="subhead-3">Ownership Transfer</Text>
+      <Text>
+        You are about to transfer ownership of this tile to{' '}
+        <b>{emailToTransfer}</b>. Your role will changed be <b>Editor</b>.
+      </Text>
+      <Flex gap={4} alignSelf="end">
+        <Button
+          variant="clear"
+          colorScheme="secondary"
+          onClick={() => setEmailToTransfer(null)}
+        >
+          Cancel
+        </Button>
+        <Button variant="solid" onClick={() => transferOwnership()}>
+          Confirm
+        </Button>
+      </Flex>
+    </VStack>
+  )
+}
+
+export default TransferOwnership

--- a/packages/frontend/src/theme/components/Modal.ts
+++ b/packages/frontend/src/theme/components/Modal.ts
@@ -14,6 +14,9 @@ const baseStyle = definePartsStyle({
     fontSize: 'lg',
     fontWeight: 'bold',
   },
+  dialog: {
+    margin: 'auto',
+  },
 })
 
 export const Modal = defineMultiStyleConfig({


### PR DESCRIPTION
## Problem
Currently, only tiles owner can use tiles in pipes. However, this will break pipes when transferring to new owners.

## Solution
Allow editors to also use pipes in their tiles, which makes sense since they can already add, update and delete data in the UI