### PR TITLE
PLU-350: fix: add check for invalid pages in params

### DIFF
--- a/packages/frontend/src/pages/Executions/index.tsx
+++ b/packages/frontend/src/pages/Executions/index.tsx
@@ -34,7 +34,7 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import { GET_EXECUTIONS } from '@/graphql/queries/get-executions'
 import { usePaginationAndFilter } from '@/hooks/usePaginationAndFilter'
 
-const EXECUTION_PER_PAGE = 10
+const EXECUTIONS_PER_PAGE = 10
 const EXECUTIONS_TITLE = 'Executions'
 
 interface ExecutionParameters {
@@ -50,8 +50,8 @@ interface ExecutionsListProps {
 }
 
 const getLimitAndOffset = (params: ExecutionParameters) => ({
-  limit: EXECUTION_PER_PAGE,
-  offset: (params.page - 1) * EXECUTION_PER_PAGE,
+  limit: EXECUTIONS_PER_PAGE,
+  offset: (params.page - 1) * EXECUTIONS_PER_PAGE,
   ...(params.status !== StatusType.Waiting && { status: params.status }),
   searchInput: params.input,
 })
@@ -139,7 +139,14 @@ export default function Executions(): ReactElement {
   )
 
   const hasNoUserExecutions = executions.length === 0 && !isSearching
-  const hasPagination = !loading && pageInfo?.totalCount > EXECUTION_PER_PAGE
+  const totalCount: number = pageInfo?.totalCount ?? 0
+  const hasPagination = !loading && totalCount > EXECUTIONS_PER_PAGE
+
+  // ensure invalid pages won't be accessed even after deleting executions
+  const lastPage = Math.ceil(totalCount / EXECUTIONS_PER_PAGE)
+  if (lastPage !== 0 && page > lastPage) {
+    setSearchParams({ page: lastPage })
+  }
 
   return (
     <Container py={9}>
@@ -188,8 +195,8 @@ export default function Executions(): ReactElement {
           <Pagination
             currentPage={pageInfo?.currentPage}
             onPageChange={(page) => setSearchParams({ page })}
-            pageSize={EXECUTION_PER_PAGE}
-            totalCount={pageInfo?.totalCount}
+            pageSize={EXECUTIONS_PER_PAGE}
+            totalCount={totalCount}
           />
         </Flex>
       )}

--- a/packages/frontend/src/pages/Executions/index.tsx
+++ b/packages/frontend/src/pages/Executions/index.tsx
@@ -1,6 +1,6 @@
 import type { IExecution } from '@plumber/types'
 
-import { ReactElement } from 'react'
+import { ReactElement, useEffect } from 'react'
 import { useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 import { Pagination } from '@opengovsg/design-system-react'
@@ -103,9 +103,12 @@ export default function Executions(): ReactElement {
 
   // ensure invalid pages won't be accessed even after deleting executions
   const lastPage = Math.ceil(totalCount / EXECUTIONS_PER_PAGE)
-  if (lastPage !== 0 && page > lastPage) {
-    setSearchParams({ page: lastPage })
-  }
+  useEffect(() => {
+    // Defer the search params update till after the initial render
+    if (lastPage !== 0 && page > lastPage) {
+      setSearchParams({ page: lastPage })
+    }
+  }, [lastPage, page, setSearchParams])
 
   return (
     <Container py={9}>

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -17,7 +17,7 @@ import ApproveTransfersInfobox from './components/ApproveTransfersInfobox'
 import CreateFlowModal from './components/CreateFlowModal'
 import EmptyFlows from './components/EmptyFlows'
 
-const FLOW_PER_PAGE = 10
+const FLOWS_PER_PAGE = 10
 const FLOWS_TITLE = 'Pipes'
 
 interface FlowsInternalProps {
@@ -28,8 +28,8 @@ interface FlowsInternalProps {
 }
 
 const getLimitAndOffset = (page: number) => ({
-  limit: FLOW_PER_PAGE,
-  offset: (page - 1) * FLOW_PER_PAGE,
+  limit: FLOWS_PER_PAGE,
+  offset: (page - 1) * FLOWS_PER_PAGE,
 })
 
 function FlowsList({
@@ -84,9 +84,15 @@ export default function Flows(): React.ReactElement {
 
   const { pageInfo, edges } = data?.getFlows || {}
   const flows: IFlow[] = edges?.map(({ node }: { node: IFlow }) => node) ?? []
-  const hasPagination =
-    !loading && pageInfo && pageInfo.totalCount > FLOW_PER_PAGE
+  const totalCount: number = pageInfo?.totalCount ?? 0
+  const hasPagination = !loading && totalCount > FLOWS_PER_PAGE
   const hasNoUserFlows = flows.length === 0 && !isSearching
+
+  // ensure invalid pages won't be accessed even after deleting flows
+  const lastPage = Math.ceil(totalCount / FLOWS_PER_PAGE)
+  if (lastPage !== 0 && page > lastPage) {
+    setSearchParams({ page: lastPage })
+  }
 
   return (
     <Container py={9}>
@@ -121,8 +127,8 @@ export default function Flows(): React.ReactElement {
           <Pagination
             currentPage={pageInfo?.currentPage}
             onPageChange={(page) => setSearchParams({ page })}
-            pageSize={FLOW_PER_PAGE}
-            totalCount={pageInfo?.totalCount}
+            pageSize={FLOWS_PER_PAGE}
+            totalCount={totalCount}
           />
         </Flex>
       )}

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -1,5 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
+import { ReactElement, useEffect } from 'react'
 import { useQuery } from '@apollo/client'
 import { Box, Center, Flex, useDisclosure } from '@chakra-ui/react'
 import { Button, Pagination } from '@opengovsg/design-system-react'
@@ -71,7 +72,7 @@ function FlowsList({
   )
 }
 
-export default function Flows(): React.ReactElement {
+export default function Flows(): ReactElement {
   const { input, page, setSearchParams, isSearching } = usePaginationAndFilter()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -90,9 +91,12 @@ export default function Flows(): React.ReactElement {
 
   // ensure invalid pages won't be accessed even after deleting flows
   const lastPage = Math.ceil(totalCount / FLOWS_PER_PAGE)
-  if (lastPage !== 0 && page > lastPage) {
-    setSearchParams({ page: lastPage })
-  }
+  useEffect(() => {
+    // Defer the search params update till after the initial render
+    if (lastPage !== 0 && page > lastPage) {
+      setSearchParams({ page: lastPage })
+    }
+  }, [lastPage, page, setSearchParams])
 
   return (
     <Container py={9}>

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 import { Pagination } from '@opengovsg/design-system-react'
@@ -75,9 +76,12 @@ export default function Tiles(): JSX.Element {
 
   // ensure invalid pages won't be accessed even after deleting tiles
   const lastPage = Math.ceil(totalCount / TILES_PER_PAGE)
-  if (lastPage !== 0 && page > lastPage) {
-    setSearchParams({ page: lastPage })
-  }
+  useEffect(() => {
+    // Defer the search params update till after the initial render
+    if (lastPage !== 0 && page > lastPage) {
+      setSearchParams({ page: lastPage })
+    }
+  }, [lastPage, page, setSearchParams])
 
   return (
     <Container py={9}>

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -70,8 +70,14 @@ export default function Tiles(): JSX.Element {
   const tilesToDisplay = edges?.map(({ node }) => node) ?? []
 
   const hasNoUserTiles = tilesToDisplay.length === 0 && !isSearching
-  const hasPagination =
-    !loading && pageInfo && pageInfo.totalCount > TILES_PER_PAGE
+  const totalCount: number = pageInfo?.totalCount ?? 0
+  const hasPagination = !loading && pageInfo && totalCount > TILES_PER_PAGE
+
+  // ensure invalid pages won't be accessed even after deleting tiles
+  const lastPage = Math.ceil(totalCount / TILES_PER_PAGE)
+  if (lastPage !== 0 && page > lastPage) {
+    setSearchParams({ page: lastPage })
+  }
 
   return (
     <Container py={9}>
@@ -100,7 +106,7 @@ export default function Tiles(): JSX.Element {
             currentPage={pageInfo.currentPage}
             onPageChange={(page) => setSearchParams({ page })}
             pageSize={TILES_PER_PAGE}
-            totalCount={pageInfo.totalCount}
+            totalCount={totalCount}
           />
         </Flex>
       )}


### PR DESCRIPTION
## Problem

Right now, users can access pages out of bounds and this becomes an issue when a user has 11 pipes and if the pipe being deleted falls on the second page, it will continue displaying `?page=2` and load an empty state


## Solution
- Check for the last possible page and load that instead
- Apply to other pages: tiles, executions

## Tests
Test 1
- Start with 11 pipes or tiles, delete the one on the 2nd page, it should load back to the first page and set the page param to be the nearest one which is 1

Test 2
- Search `?page=100` (basically over the current amount), it should load to the last page possible