### PR TITLE
fix: remove extraneous defaultValue for search input

### DIFF
--- a/packages/frontend/src/components/DebouncedSearchInput/index.tsx
+++ b/packages/frontend/src/components/DebouncedSearchInput/index.tsx
@@ -50,7 +50,6 @@ export default function DebouncedSearchInput({
         maxW="100%"
         fontSize="md"
         onChange={onSearchInputChange}
-        defaultValue={searchValue}
         value={tempSearchValue}
         placeholder="Search"
       />

--- a/packages/frontend/src/pages/Executions/components/SearchWithFilterInput.tsx
+++ b/packages/frontend/src/pages/Executions/components/SearchWithFilterInput.tsx
@@ -67,7 +67,6 @@ export default function SearchWithFilterInput({
         maxW="100%"
         pr={inputPadding}
         placeholder="Search by pipe name"
-        defaultValue={searchValue}
         value={tempSearchValue}
         onChange={onSearchInputChange}
       />


### PR DESCRIPTION
## Problem
I left both `defaultValue` and `value` populated for input fields.

<img width="770" alt="image" src="https://github.com/user-attachments/assets/6f5a12b1-0313-433b-aa4c-3270d81becff">

## Solution

Remove defaultValue since it's already the default value in the `useState` hook