### PR TITLE
PLU-311: [GSIB-1] proxy arcade url on gsib browser

### DIFF
--- a/packages/frontend/src/components/FlowRow/DemoVideoModalContent.tsx
+++ b/packages/frontend/src/components/FlowRow/DemoVideoModalContent.tsx
@@ -1,3 +1,5 @@
+import { useProxyUrl } from '@/hooks/useGovtBrowser'
+
 interface DemoVideoModalContentProps {
   src?: string
   title?: string
@@ -5,8 +7,14 @@ interface DemoVideoModalContentProps {
 
 export default function DemoVideoModalContent(
   props: DemoVideoModalContentProps,
-): JSX.Element {
+) {
   const { src, title } = props
+  const { createProxiedUrl } = useProxyUrl()
+
+  if (!src) {
+    return null
+  }
+
   return (
     <div
       style={{
@@ -17,7 +25,7 @@ export default function DemoVideoModalContent(
       }}
     >
       <iframe
-        src={src}
+        src={createProxiedUrl(src)}
         title={title}
         loading="lazy"
         allowFullScreen
@@ -30,7 +38,7 @@ export default function DemoVideoModalContent(
           height: '100%',
           colorScheme: 'light',
         }}
-      ></iframe>
+      />
     </div>
   )
 }

--- a/packages/frontend/src/hooks/useGovtBrowser.ts
+++ b/packages/frontend/src/hooks/useGovtBrowser.ts
@@ -1,0 +1,24 @@
+/**
+ * Use this hook to check if user is proxied via Menlo Security, if so, prepend the proxy url
+ * When proxied, the window.name property is set to "JSON:{\"safe_rid\":\"4vnqcfBf\",\"mpa_id\":\"\",\"cid\":\"******\",
+ * \"cluster_id\":\"od_menlo_2b\",\"tab_id\":1,\"protocol_domain\":\"xhr-asia-southeast1-menlo-view.menlosecurity.com\",
+ * \"cluster_domain\":\"asia-southeast1-menlo-view.menlosecurity.com\",\"inspect_domain\":\"asia-southeast1-menlo-view.menlosecurity.com\"}"
+ * We check for existence of "menlo-view.menlosecurity.com" in window.name to determine if we should prepend the proxy url
+ */
+
+import { useCallback } from 'react'
+
+const isGovtBrowser = window.name?.includes('menlo-view.menlosecurity.com')
+
+const useProxyUrl = () => {
+  const createProxiedUrl = useCallback((url: string) => {
+    if (isGovtBrowser) {
+      return `https://safe.menlosecurity.com/${url}`
+    }
+    return url
+  }, [])
+
+  return { createProxiedUrl }
+}
+
+export { useProxyUrl }


### PR DESCRIPTION
## Problem
GSIB not able to load arcade videos on iframe. Results in too many redirects. Even custom domain on arcade results in a lot of CORS error and unable to load properly.

## Solution
Add https://safe.menlosecurity.com/ as a prefix to the arcard URL to use safe browsing proxy when user is on GSIB. We detect by inspecting `window.name` and looking for menlosecurity url