### PR TITLE
fix: pasted variables not displaying properly

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -167,6 +167,11 @@ const Editor = ({
       const editorElement = editor.view.dom as HTMLElement
       editorElement.style.minHeight = isRich ? '9rem' : '2.625rem' // Set initial minHeight directly
     },
+    editorProps: {
+      transformPastedHTML: (html) => {
+        return substituteOldTemplates(html, varInfo)
+      },
+    },
   })
   useEffect(() => {
     // have to listen to editable as this element might not re-render upon


### PR DESCRIPTION
## Problem

When copying and pasting variables, the pasted variables render as an empty pill.

<img width="612" alt="image" src="https://github.com/user-attachments/assets/7b6c56c5-59f3-48fa-ba71-535d2708e37a">

## Solution

Substitute variables according when pasting