### PR TITLE
[PLU-315]: feat: add flexible date comparison for conditions

### DIFF
--- a/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
+++ b/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon'
+import { generateTimestampFromFormats } from '@/helpers/generate-timestamp-from-formats'
 
 const VALID_DATETIME_FORMATS = [
   'yyyy-MM-dd HH:mm',
@@ -8,22 +8,5 @@ const VALID_DATETIME_FORMATS = [
 
 export default function generateTimestamp(date: string, time: string): number {
   const datetimeString = `${date} ${time}`
-  // check through our accepted formats
-  for (const datetimeFormat of VALID_DATETIME_FORMATS) {
-    // check both en-SG and en-US because Sept accepted for SG but Sep accepted for US
-    let datetime = DateTime.fromFormat(datetimeString, datetimeFormat, {
-      locale: 'en-SG',
-    })
-    if (datetime.isValid) {
-      return datetime.toMillis()
-    }
-
-    datetime = DateTime.fromFormat(datetimeString, datetimeFormat, {
-      locale: 'en-US',
-    })
-    if (datetime.isValid) {
-      return datetime.toMillis()
-    }
-  }
-  return NaN
+  return generateTimestampFromFormats(datetimeString, VALID_DATETIME_FORMATS)
 }

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -94,16 +94,12 @@ describe('Condition is true', () => {
     expect(result).toEqual(expectedResult)
   })
 
-  /**
-   * Typical datetime formats:
-   * yyyy-MM-dd HH:mm
-   * dd MMM yyyy
-   * dd/MM/yyyy HH:mm:ss
-   * ISO format
-   */
+  // check all date formats
   it.each([
-    { text: '2024-11-06 12:00', expectedResult: true },
-    { text: '03/11/2024 12:00:30', expectedResult: false },
+    { text: '05/11/24', expectedResult: true }, // 'dd/LL/yy'
+    { text: '03/11/2024', expectedResult: false }, // 'dd/LL/yyyy'
+    { text: '05 Nov 2024', expectedResult: true }, // 'dd LLL yyyy'
+    { text: '03 November 2024', expectedResult: false }, // 'dd LLLL yyyy'
   ])('supports before', ({ text, expectedResult }) => {
     const result = conditionIsTrue({
       field: '04 Nov 2024',
@@ -116,8 +112,9 @@ describe('Condition is true', () => {
   })
 
   it.each([
-    { text: '2024-11-06T12:00:00.500+08:00', expectedResult: false },
-    { text: '03 Nov 2024 23:59', expectedResult: true },
+    { text: '2024/11/03', expectedResult: true }, // 'yyyy/LL/dd'
+    { text: '04 Nov 2024 12:01 AM', expectedResult: false }, // 'dd LLL yyyy hh:mm a'
+    { text: '03 Nov 2024 11:59:59 PM', expectedResult: true }, // 'dd LLL yyyy hh:mm:ss a'
   ])('supports after', ({ text, expectedResult }) => {
     const result = conditionIsTrue({
       field: '04 Nov 2024',
@@ -173,8 +170,8 @@ describe('Condition is true', () => {
   it.each([
     { field: 10, condition: 'gte', text: 'abc' },
     { field: 'abc', condition: 'lt', text: 10 },
-    { field: '04 Nov 2024', condition: 'before', text: 'abc' },
-    { field: 'abc', condition: 'before', text: '04 Nov 2024' },
+    { field: '04 Sep 2024', condition: 'before', text: 'abc' },
+    { field: '123', condition: 'before', text: '04 Nov 2024' },
   ])(
     'throws an error for invalid field or value for comparison',
     ({ field, condition, text }) => {

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -94,6 +94,41 @@ describe('Condition is true', () => {
     expect(result).toEqual(expectedResult)
   })
 
+  /**
+   * Typical datetime formats:
+   * yyyy-MM-dd HH:mm
+   * dd MMM yyyy
+   * dd/MM/yyyy HH:mm:ss
+   * ISO format
+   */
+  it.each([
+    { text: '2024-11-06 12:00', expectedResult: true },
+    { text: '03/11/2024 12:00:30', expectedResult: false },
+  ])('supports before', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: '04 Nov 2024',
+      is: 'is',
+      condition: 'before',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
+  it.each([
+    { text: '2024-11-06T12:00:00.500+08:00', expectedResult: false },
+    { text: '03 Nov 2024 23:59', expectedResult: true },
+  ])('supports after', ({ text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field: '04 Nov 2024',
+      is: 'is',
+      condition: 'after',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
   it.each([
     { field: 'hello', text: 9.9, condition: 'equals', expectedResult: true },
     { field: 10, text: 10, condition: 'gte', expectedResult: false },
@@ -132,6 +167,25 @@ describe('Condition is true', () => {
         text: null,
       })
       expect(result).toEqual(expectedResult)
+    },
+  )
+
+  it.each([
+    { field: 10, condition: 'gte', text: 'abc' },
+    { field: 'abc', condition: 'lt', text: 10 },
+    { field: '04 Nov 2024', condition: 'before', text: 'abc' },
+    { field: 'abc', condition: 'before', text: '04 Nov 2024' },
+  ])(
+    'throws an error for invalid field or value for comparison',
+    ({ field, condition, text }) => {
+      expect(() =>
+        conditionIsTrue({
+          field,
+          is: 'is',
+          condition,
+          text,
+        }),
+      ).toThrowError()
     },
   )
 

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -1,5 +1,7 @@
 import type { IJSONObject, IJSONValue } from '@plumber/types'
 
+import { generateTimestampFromFormats } from '@/helpers/generate-timestamp-from-formats'
+
 function compareNumbers(
   field: IJSONValue,
   condition: 'gte' | 'gt' | 'lte' | 'lt',
@@ -26,17 +28,34 @@ function compareNumbers(
   }
 }
 
+// support only formatter date formats
+const VALID_DATETIME_FORMATS = [
+  'dd/LL/yy',
+  'dd/LL/yyyy',
+  'dd LLL yyyy',
+  'dd LLLL yyyy',
+  'yyyy/LL/dd',
+  'dd LLL yyyy hh:mm a',
+  'dd LLL yyyy hh:mm:ss a',
+]
+
 function compareDates(
   field: IJSONValue,
   condition: 'before' | 'after',
   value: IJSONValue,
 ) {
-  const fieldTimestamp = new Date(field as string).getTime()
+  const fieldTimestamp = generateTimestampFromFormats(
+    field as string,
+    VALID_DATETIME_FORMATS,
+  )
   if (isNaN(fieldTimestamp)) {
     throw new Error('Invalid date used in field for comparison')
   }
 
-  const valueTimestamp = new Date(value as string).getTime()
+  const valueTimestamp = generateTimestampFromFormats(
+    value as string,
+    VALID_DATETIME_FORMATS,
+  )
   if (isNaN(valueTimestamp)) {
     throw new Error('Invalid date used in value for comparison')
   }

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -6,9 +6,14 @@ function compareNumbers(
   value: IJSONValue,
 ): boolean {
   // WARNING: can only compare safely up till Number.MAX_SAFE_INTEGER but BigInt cannot compare floats...
-  if (isNaN(Number(field)) || isNaN(Number(value))) {
-    throw new Error('Non-number used in field or value for comparison')
+  if (isNaN(Number(field))) {
+    throw new Error('Non-number used in field for comparison')
   }
+
+  if (isNaN(Number(value))) {
+    throw new Error('Non-number used in value for comparison')
+  }
+
   switch (condition) {
     case 'gte':
       return Number(field) >= Number(value)
@@ -21,6 +26,29 @@ function compareNumbers(
   }
 }
 
+function compareDates(
+  field: IJSONValue,
+  condition: 'before' | 'after',
+  value: IJSONValue,
+) {
+  const fieldTimestamp = new Date(field as string).getTime()
+  if (isNaN(fieldTimestamp)) {
+    throw new Error('Invalid date used in field for comparison')
+  }
+
+  const valueTimestamp = new Date(value as string).getTime()
+  if (isNaN(valueTimestamp)) {
+    throw new Error('Invalid date used in value for comparison')
+  }
+
+  switch (condition) {
+    case 'before':
+      return fieldTimestamp < valueTimestamp
+    case 'after':
+      return fieldTimestamp > valueTimestamp
+  }
+}
+
 export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
   // `value` is named `text` for legacy reasons.
   const { field, is, condition, text: value } = conditionArgs
@@ -29,6 +57,10 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
   switch (condition) {
     case 'equals':
       result = field === value
+      break
+    case 'before':
+    case 'after':
+      result = compareDates(field, condition, value)
       break
     case 'gte':
     case 'gt':

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -42,12 +42,12 @@ export default function getConditionArgs({
         {
           label: 'Equals to',
           value: 'equals',
-          description: 'Used for text values',
         },
+        { label: 'Empty', value: 'empty' },
         {
           label: 'Contains',
           value: 'contains',
-          description: 'Used for text values',
+          description: 'Used for text',
         },
 
         { label: 'Greater than', value: 'gt', description: 'Used for numbers' },
@@ -72,7 +72,6 @@ export default function getConditionArgs({
           value: 'after',
           description: 'Used for dates',
         },
-        { label: 'Empty', value: 'empty' },
       ],
     },
     {

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -39,12 +39,39 @@ export default function getConditionArgs({
       variables: false,
       showOptionValue: false,
       options: [
-        { label: 'Equals to', value: 'equals' },
-        { label: 'Greater than ', value: 'gt' },
-        { label: 'Greater than or equals to', value: 'gte' },
-        { label: 'Less than', value: 'lt' },
-        { label: 'Less than or equals to', value: 'lte' },
-        { label: 'Contains', value: 'contains' },
+        {
+          label: 'Equals to',
+          value: 'equals',
+          description: 'Used for text values',
+        },
+        {
+          label: 'Contains',
+          value: 'contains',
+          description: 'Used for text values',
+        },
+
+        { label: 'Greater than', value: 'gt', description: 'Used for numbers' },
+        {
+          label: 'Greater than or equals to',
+          value: 'gte',
+          description: 'Used for numbers',
+        },
+        { label: 'Less than', value: 'lt', description: 'Used for numbers' },
+        {
+          label: 'Less than or equals to',
+          value: 'lte',
+          description: 'Used for numbers',
+        },
+        {
+          label: 'Before',
+          value: 'before',
+          description: 'Used for dates',
+        },
+        {
+          label: 'After',
+          value: 'after',
+          description: 'Used for dates',
+        },
         { label: 'Empty', value: 'empty' },
       ],
     },

--- a/packages/backend/src/helpers/generate-timestamp-from-formats.ts
+++ b/packages/backend/src/helpers/generate-timestamp-from-formats.ts
@@ -1,0 +1,25 @@
+import { DateTime } from 'luxon'
+
+export function generateTimestampFromFormats(
+  datetimeString: string,
+  datetimeFormats: string[],
+): number {
+  // check through the list of formats
+  for (const datetimeFormat of datetimeFormats) {
+    // check both en-SG and en-US because Sept accepted for SG but Sep accepted for US
+    let datetime = DateTime.fromFormat(datetimeString, datetimeFormat, {
+      locale: 'en-SG',
+    })
+    if (datetime.isValid) {
+      return datetime.toMillis()
+    }
+
+    datetime = DateTime.fromFormat(datetimeString, datetimeFormat, {
+      locale: 'en-US',
+    })
+    if (datetime.isValid) {
+      return datetime.toMillis()
+    }
+  }
+  return NaN
+}


### PR DESCRIPTION
## Problem

Dates cannot be compared now for conditions.

## Solution

Added description to each option instead of separating them into group for now because it is clear enough (Zapier also does this)
<img width="383" alt="image" src="https://github.com/user-attachments/assets/04cc62d7-619c-4ddb-8099-956a33bd3c26">

To maintain backwards compatibility, add 2 options: `before` and `after` to compare dates: decided to allow any datetime format because it is not realistic to check for a similar datetime format before comparing.
- Convert the datetime to a timestamp for easy comparison
- Throw step error if the datetime is invalid
- Added unit tests

## Screenshots
### Before

https://github.com/user-attachments/assets/2f771b1e-75cd-46c5-a4c3-cc684ec1d9b8



### After
https://github.com/user-attachments/assets/6a3122a0-7868-49ff-a050-3588fbaa46bd



## Tests
- [x] Other conditions still work
- [x] Before and after datetime works for more common fields e.g. formsg date field and formsg submission time
