### PR TITLE
[PLU-360]: chore: remove duplicate text in method for Custom API

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -23,6 +23,7 @@ const action: IRawAction = {
       required: true,
       description: `The HTTP method we'll use to perform the request.`,
       value: 'GET',
+      showOptionValue: false,
       options: [
         { label: 'DELETE', value: 'DELETE' },
         { label: 'GET', value: 'GET' },


### PR DESCRIPTION
## Problem
Duplicate text shown in dropdown for Custom API Method.



Closes https://linear.app/ogp/issue/PLU-360/remove-duplicate-text-in-method-for-custom-api

## Solution
Set showOptionValue to false to hide the value the dropdown options.

## Before & After Screenshots

**BEFORE**:
<img width="853" alt="Screenshot 2024-11-08 at 9 54 57 AM" src="https://github.com/user-attachments/assets/1868ffdb-56ba-4921-b62c-abb1b304aedc">

**AFTER**:
<img width="853" alt="Screenshot 2024-11-08 at 11 30 52 AM" src="https://github.com/user-attachments/assets/6121c038-36b3-4af0-a3e5-65ccf973a868">


## Tests
- [x] Able to execute new api calls based on selection
- [x] Able to update method for existing custom api
