### PR TITLE
[PLU-304]: feat: Allow headers to be set using variables for Custom API

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -65,6 +65,30 @@ describe('make http request', () => {
     )
   })
 
+  it('invokes the webhook with custom headers', async () => {
+    $.step.parameters.method = 'POST'
+    $.step.parameters.data = 'meep meep'
+    $.step.parameters.url = 'http://test.local/endpoint?1234'
+    $.step.parameters.customHeaders = [
+      { key: 'Key1', value: 'Value1' },
+      { key: 'Key2', value: 'Value2' },
+    ]
+    mocks.httpRequest.mockReturnValue('mock response')
+
+    await makeRequestAction.run($).catch(() => null)
+    expect(mocks.httpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: $.step.parameters.url,
+        method: $.step.parameters.method,
+        data: $.step.parameters.data,
+        headers: {
+          Key1: 'Value1',
+          Key2: 'Value2',
+        },
+      }),
+    )
+  })
+
   it('should throw an error for error with http request', async () => {
     $.step.parameters.method = 'POST'
     $.step.parameters.data = 'meep meep'
@@ -82,6 +106,22 @@ describe('make http request', () => {
     await expect(makeRequestAction.run($)).rejects.toThrowError(
       'Status code: 403',
     )
+  })
+
+  it.each([[{ value: 'test' }], [{ key: 'test' }]])(
+    'should throw error for invalid custom headers (no field)',
+    async () => {
+      $.step.parameters.customHeaders = [{ value: 'test' }]
+      await expect(makeRequestAction.run($)).rejects.toThrowError()
+    },
+  )
+
+  it('should throw error for invalid custom headers (duplicate keys)', async () => {
+    $.step.parameters.customHeaders = [
+      { key: 'test', value: 'value1' },
+      { key: 'test', value: 'value2' },
+    ]
+    await expect(makeRequestAction.run($)).rejects.toThrowError()
   })
 
   it('should follow redirect once', async () => {

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -54,6 +54,7 @@ const action: IRawAction = {
       description: 'Add custom headers here.',
       variables: true,
       customButtonText: 'Add',
+      hideBlankRow: true,
       showDivider: false,
       subFields: [
         {

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -54,7 +54,6 @@ const action: IRawAction = {
       description: 'Add custom headers here.',
       variables: true,
       addRowButtonText: 'Add',
-      hideBlankRow: true,
       subFields: [
         {
           placeholder: 'Key',

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -1,11 +1,16 @@
 import { IRawAction } from '@plumber/types'
 
-import StepError from '@/errors/step'
+import { ZodError } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+
+import StepError, { GenericSolution } from '@/errors/step'
 
 import {
   DISALLOWED_IP_RESOLVED_ERROR,
   RECURSIVE_WEBHOOK_ERROR_NAME,
 } from '../../common/check-urls'
+
+import { requestSchema } from './schema'
 
 type TMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
 
@@ -23,6 +28,7 @@ const action: IRawAction = {
       required: true,
       description: `The HTTP method we'll use to perform the request.`,
       value: 'GET',
+      showOptionValue: false,
       options: [
         { label: 'DELETE', value: 'DELETE' },
         { label: 'GET', value: 'GET' },
@@ -41,6 +47,35 @@ const action: IRawAction = {
       variables: true,
     },
     {
+      label: 'Custom Headers',
+      key: 'customHeaders',
+      type: 'multirow-multicol' as const,
+      required: false,
+      description: 'Add custom headers here.',
+      variables: true,
+      customButtonText: 'Add',
+      showDivider: false,
+      subFields: [
+        {
+          placeholder: 'Key',
+          key: 'key',
+          type: 'string' as const,
+          required: true,
+          variables: false,
+          customStyle: { flex: 0.5 },
+        },
+        {
+          placeholder: 'Value',
+          key: 'value',
+          type: 'string' as const,
+          required: true,
+          variables: true,
+          isSingleLine: true,
+          customStyle: { flex: 1, minWidth: 0 },
+        },
+      ],
+    },
+    {
       label: 'Data',
       key: 'data',
       type: 'string' as const,
@@ -56,11 +91,15 @@ const action: IRawAction = {
     const url = $.step.parameters.url as string
 
     try {
+      const parsedS = requestSchema.parse($.step.parameters)
+      const { customHeaders } = parsedS
+
       let response = await $.http.request({
         url,
         method,
         data,
         maxRedirects: 0,
+        headers: customHeaders,
         //  overwriting this to allow redirects to resolve
         validateStatus: (status) =>
           (status >= 200 && status < 300) ||
@@ -97,6 +136,16 @@ const action: IRawAction = {
 
       $.setActionItem({ raw: { data: responseData } })
     } catch (err) {
+      if (err instanceof ZodError) {
+        const firstError = fromZodError(err).details[0]
+        throw new StepError(
+          `${firstError.message} under set up action`,
+          GenericSolution.ReconfigureInvalidField,
+          $.step.position,
+          $.app.name,
+        )
+      }
+
       if (err.message === RECURSIVE_WEBHOOK_ERROR_NAME) {
         throw new StepError(
           RECURSIVE_WEBHOOK_ERROR_NAME,

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -53,9 +53,8 @@ const action: IRawAction = {
       required: false,
       description: 'Add custom headers here.',
       variables: true,
-      customButtonText: 'Add',
+      addRowButtonText: 'Add',
       hideBlankRow: true,
-      showDivider: false,
       subFields: [
         {
           placeholder: 'Key',
@@ -63,7 +62,6 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: false,
-          customStyle: { flex: 0.5 },
         },
         {
           placeholder: 'Value',
@@ -71,8 +69,6 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          isSingleLine: true,
-          customStyle: { flex: 1, minWidth: 0 },
         },
       ],
     },

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -6,26 +6,27 @@ export const requestSchema = z.object({
   customHeaders: z
     .array(
       z.object({
-        key: z.string().trim().min(1, 'Key empty'),
-        value: z.string().trim().min(1, 'Value empty'),
+        // key cannot be null or empty
+        key: z
+          .string({
+            required_error: 'Key empty',
+            invalid_type_error: 'Key empty',
+          })
+          .trim()
+          .min(1, 'Key empty'),
+        // value optional in the event the substituted variable is empty
+        value: z.string().trim().nullish().optional(),
       }),
     )
     .transform((params, context) => {
       const result = Object.create(null)
       const seenFields = new Set<string>()
       for (const { key, value } of params) {
-        // no null fields or values are allowed
+        // no null keys are allowed
         if (!key) {
           context.addIssue({
             code: z.ZodIssueCode.custom,
             message: 'Key empty',
-          })
-          return z.NEVER
-        }
-        if (!value) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Value empty',
           })
           return z.NEVER
         }
@@ -40,7 +41,7 @@ export const requestSchema = z.object({
         }
         seenFields.add(key)
 
-        const cleanV = value.replaceAll(/\r?\n|\r/g, ' ')
+        const cleanV = value?.replaceAll(/\r?\n|\r/g, ' ') || ''
         result[key] = sanitizeMarkdown(cleanV)
       }
       return result

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+
+import { sanitizeMarkdown } from '@/apps/telegram-bot/common/markdown-v1'
+
+export const requestSchema = z.object({
+  customHeaders: z
+    .array(
+      z.object({
+        key: z.string().trim().min(1, 'Key empty').nullish(),
+        value: z.string().trim().min(1, 'Value empty').nullish(),
+      }),
+    )
+    .transform((params, context) => {
+      const result = Object.create(null)
+      const seenFields = new Set<string>()
+      for (const { key, value } of params) {
+        // no null fields or values are allowed
+        if (!key) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Key empty',
+          })
+          return z.NEVER
+        }
+        if (!value) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Value empty',
+          })
+          return z.NEVER
+        }
+        // catch duplicate fields
+        if (seenFields.has(key)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${key} key is repeated`,
+            fatal: true,
+          })
+          return z.NEVER
+        }
+        seenFields.add(key)
+
+        const cleanV = value.replaceAll(/\r?\n|\r/g, ' ')
+        result[key] = sanitizeMarkdown(cleanV)
+      }
+      return result
+    })
+    .nullish(),
+})

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -44,6 +44,5 @@ export const requestSchema = z.object({
         result[key] = sanitizeMarkdown(cleanV)
       }
       return result
-    })
-    .nullish(),
+    }),
 })

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -44,5 +44,6 @@ export const requestSchema = z.object({
         result[key] = sanitizeMarkdown(cleanV)
       }
       return result
-    }),
+    })
+    .nullish(),
 })

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -6,8 +6,8 @@ export const requestSchema = z.object({
   customHeaders: z
     .array(
       z.object({
-        key: z.string().trim().min(1, 'Key empty').nullish(),
-        value: z.string().trim().min(1, 'Value empty').nullish(),
+        key: z.string().trim().min(1, 'Key empty'),
+        value: z.string().trim().min(1, 'Value empty'),
       }),
     )
     .transform((params, context) => {

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -69,7 +69,7 @@ const action: IRawAction = {
       label: 'Personalised fields',
       key: 'letterParams',
       type: 'multirow' as const,
-      required: false,
+      required: true,
       description:
         'Specify values for each personalised field in your template.',
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -188,11 +188,8 @@ type ActionSubstepArgument {
   value: JSONObject
   source: ActionSubstepArgumentSource
   hiddenIf: FieldVisibilityCondition
-  customButtonText: String
-  customStyle: JSONObject
+  addRowButtonText: String
   hideBlankRow: Boolean
-  showDivider: Boolean
-  isSingleLine: Boolean
 
   # Only for dropdown
   addNewOption: DropdownAddNewOption

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -190,6 +190,7 @@ type ActionSubstepArgument {
   hiddenIf: FieldVisibilityCondition
   customButtonText: String
   customStyle: JSONObject
+  hideBlankRow: Boolean
   showDivider: Boolean
   isSingleLine: Boolean
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -188,6 +188,10 @@ type ActionSubstepArgument {
   value: JSONObject
   source: ActionSubstepArgumentSource
   hiddenIf: FieldVisibilityCondition
+  customButtonText: String
+  customStyle: JSONObject
+  showDivider: Boolean
+  isSingleLine: Boolean
 
   # Only for dropdown
   addNewOption: DropdownAddNewOption

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -189,7 +189,6 @@ type ActionSubstepArgument {
   source: ActionSubstepArgumentSource
   hiddenIf: FieldVisibilityCondition
   addRowButtonText: String
-  hideBlankRow: Boolean
 
   # Only for dropdown
   addNewOption: DropdownAddNewOption

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -164,7 +164,6 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         subFields={schema.subFields}
         required={required}
         addRowButtonText={schema.addRowButtonText}
-        hideBlankRow={schema.hideBlankRow}
         showDivider={type !== 'multirow-multicol'}
         type={type}
         // These are InputCreatorProps which MultiRow will forward.

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -114,6 +114,8 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           description={description}
           disabled={disabled}
           placeholder={placeholder}
+          isSingleLine={schema.isSingleLine}
+          customStyle={schema.customStyle}
           variablesEnabled
         />
       )
@@ -133,6 +135,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         clickToCopy={clickToCopy}
         autoComplete={schema.autoComplete}
+        customStyle={schema.customStyle}
       />
     )
   }
@@ -149,7 +152,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     )
   }
 
-  if (type === 'multirow') {
+  if (type === 'multirow' || type === 'multirow-multicol') {
     return (
       <MultiRow
         name={computedName}
@@ -157,6 +160,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         subFields={schema.subFields}
         required={required}
+        customButtonText={schema.customButtonText}
+        showDivider={schema.showDivider}
+        type={type}
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
         disabled={disabled}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -161,6 +161,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         subFields={schema.subFields}
         required={required}
         customButtonText={schema.customButtonText}
+        hideBlankRow={schema.hideBlankRow}
         showDivider={schema.showDivider}
         type={type}
         // These are InputCreatorProps which MultiRow will forward.

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -15,6 +15,7 @@ export type InputCreatorProps = {
   namePrefix?: string
   stepId?: string
   disabled?: boolean
+  parentType?: string
 }
 
 type RawOption = {
@@ -26,7 +27,7 @@ const optionGenerator = (options: RawOption[]): IFieldDropdownOption[] =>
   options?.map(({ name, value }) => ({ label: name as string, value: value }))
 
 export default function InputCreator(props: InputCreatorProps): JSX.Element {
-  const { schema, namePrefix, stepId, disabled } = props
+  const { schema, namePrefix, stepId, disabled, parentType } = props
 
   const {
     key: name,
@@ -114,8 +115,10 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           description={description}
           disabled={disabled}
           placeholder={placeholder}
-          isSingleLine={schema.isSingleLine}
-          customStyle={schema.customStyle}
+          isSingleLine={parentType === 'multicol'}
+          customStyle={
+            parentType === 'multicol' ? { flex: 1, minWidth: 0 } : {}
+          }
           variablesEnabled
         />
       )
@@ -135,7 +138,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         clickToCopy={clickToCopy}
         autoComplete={schema.autoComplete}
-        customStyle={schema.customStyle}
+        customStyle={parentType === 'multicol' ? { flex: 0.5 } : {}}
       />
     )
   }
@@ -160,9 +163,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         subFields={schema.subFields}
         required={required}
-        customButtonText={schema.customButtonText}
+        addRowButtonText={schema.addRowButtonText}
         hideBlankRow={schema.hideBlankRow}
-        showDivider={schema.showDivider}
+        showDivider={type !== 'multirow-multicol'}
         type={type}
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,0 +1,51 @@
+import type { IField } from '@plumber/types'
+
+import { BiTrash } from 'react-icons/bi'
+import { Flex } from '@chakra-ui/react'
+import { IconButton } from '@opengovsg/design-system-react'
+
+import InputCreator from '@/components/InputCreator'
+
+type MultiColProps = {
+  name: string
+  subFields: IField[]
+  canRemoveRow?: boolean
+  isEditorReadOnly?: boolean
+  remove?: (index?: number | number[]) => void
+  index?: number
+}
+
+export default function MultiCol(props: MultiColProps) {
+  const {
+    name,
+    subFields,
+    canRemoveRow,
+    isEditorReadOnly,
+    remove,
+    index,
+    ...forwardedInputCreatorProps
+  } = props
+  return (
+    <Flex flexDir="row" gap={2}>
+      {subFields.map((subF) => {
+        return (
+          <InputCreator
+            key={`${name}.${subF.key}`}
+            schema={subF}
+            namePrefix={name}
+            {...forwardedInputCreatorProps}
+          />
+        )
+      })}
+      {canRemoveRow && (
+        <IconButton
+          variant="clear"
+          aria-label="Remove"
+          icon={<BiTrash />}
+          isDisabled={isEditorReadOnly}
+          onClick={() => remove && remove(index)}
+        />
+      )}
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -33,6 +33,7 @@ export default function MultiCol(props: MultiColProps) {
             key={`${name}.${subF.key}`}
             schema={subF}
             namePrefix={name}
+            parentType="multicol"
             {...forwardedInputCreatorProps}
           />
         )
@@ -43,7 +44,7 @@ export default function MultiCol(props: MultiColProps) {
           aria-label="Remove"
           icon={<BiTrash />}
           isDisabled={isEditorReadOnly}
-          onClick={() => remove && remove(index)}
+          onClick={() => remove?.(index)}
         />
       )}
     </Flex>

--- a/packages/frontend/src/components/MultiRow/RowDivider.tsx
+++ b/packages/frontend/src/components/MultiRow/RowDivider.tsx
@@ -1,0 +1,13 @@
+import { Divider, Flex, Text } from '@chakra-ui/react'
+
+export default function RowDivider() {
+  return (
+    <Flex alignItems="center">
+      <Divider />
+      <Text textStyle="subhead-3" mx={2.5}>
+        And
+      </Text>
+      <Divider />
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -21,6 +21,7 @@ export type MultiRowProps = {
   label?: string
   description?: string
   flexDir?: string
+  hideBlankRow?: boolean
   showDivider?: boolean
   customButtonText?: string
   type?: string
@@ -34,6 +35,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     required,
     description,
     customButtonText,
+    hideBlankRow,
     showDivider,
     type,
     ...forwardedInputCreatorProps
@@ -72,7 +74,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     <Controller
       name={name}
       control={control}
-      defaultValue={[{ ...newRowDefaultValue }]}
+      defaultValue={hideBlankRow ? [] : [{ ...newRowDefaultValue }]}
       render={({ field: { value: fallbackRows } }): JSX.Element => {
         // HACKFIX (ogp-weeloong): I don't know why `rows` lags behind
         // `fallbackRows` on the 1st render.

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -21,7 +21,6 @@ export type MultiRowProps = {
   label?: string
   description?: string
   flexDir?: string
-  hideBlankRow?: boolean
   showDivider?: boolean
   addRowButtonText?: string
   type?: string
@@ -35,7 +34,6 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     required,
     description,
     addRowButtonText,
-    hideBlankRow,
     showDivider,
     type,
     ...forwardedInputCreatorProps
@@ -74,7 +72,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     <Controller
       name={name}
       control={control}
-      defaultValue={hideBlankRow ? [] : [{ ...newRowDefaultValue }]}
+      defaultValue={!required ? [] : [{ ...newRowDefaultValue }]}
       render={({ field: { value: fallbackRows } }): JSX.Element => {
         // HACKFIX (ogp-weeloong): I don't know why `rows` lags behind
         // `fallbackRows` on the 1st render.

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -72,7 +72,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     <Controller
       name={name}
       control={control}
-      defaultValue={!required ? [] : [{ ...newRowDefaultValue }]}
+      defaultValue={required ? [{ ...newRowDefaultValue }] : []}
       render={({ field: { value: fallbackRows } }): JSX.Element => {
         // HACKFIX (ogp-weeloong): I don't know why `rows` lags behind
         // `fallbackRows` on the 1st render.

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -105,7 +105,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                         name={namePrefix}
                         subFields={subFields}
                         canRemoveRow={canRemoveRow}
-                        isEditorReadOnly={true}
+                        isEditorReadOnly={isEditorReadOnly}
                         remove={remove}
                         index={index}
                       />

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -23,7 +23,7 @@ export type MultiRowProps = {
   flexDir?: string
   hideBlankRow?: boolean
   showDivider?: boolean
-  customButtonText?: string
+  addRowButtonText?: string
   type?: string
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
@@ -34,7 +34,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     label,
     required,
     description,
-    customButtonText,
+    addRowButtonText,
     hideBlankRow,
     showDivider,
     type,
@@ -100,7 +100,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
             {actualRows.map((row, index) => {
               const namePrefix = `${name}.${index}`
               return (
-                <Flex key={`${name}.${index}`} flexDir="column" gap={4} mb={4}>
+                <Flex key={row.id} flexDir="column" gap={4} mb={4}>
                   {type === 'multirow-multicol' ? (
                     <>
                       <MultiCol
@@ -168,7 +168,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               isDisabled={isEditorReadOnly}
               maxW="fit-content"
             >
-              {customButtonText ?? 'And'}
+              {addRowButtonText ?? 'And'}
             </Button>
           </Flex>
         )

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -4,11 +4,15 @@ import { useCallback, useContext, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { BiPlus, BiTrash } from 'react-icons/bi'
 import Markdown from 'react-markdown'
-import { Divider, Flex, Text } from '@chakra-ui/react'
+import { Flex } from '@chakra-ui/react'
 import { Button, FormLabel, IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator, { InputCreatorProps } from '@/components/InputCreator'
 import { EditorContext } from '@/contexts/Editor'
+
+import MultiCol from '../MultiCol.tsx'
+
+import RowDivider from './RowDivider'
 
 export type MultiRowProps = {
   name: string
@@ -16,6 +20,10 @@ export type MultiRowProps = {
   required?: boolean
   label?: string
   description?: string
+  flexDir?: string
+  showDivider?: boolean
+  customButtonText?: string
+  type?: string
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
 function MultiRow(props: MultiRowProps): JSX.Element {
@@ -25,6 +33,9 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     label,
     required,
     description,
+    customButtonText,
+    showDivider,
+    type,
     ...forwardedInputCreatorProps
   } = props
 
@@ -88,48 +99,61 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               const namePrefix = `${name}.${index}`
               return (
                 <Flex key={`${name}.${index}`} flexDir="column" gap={4} mb={4}>
-                  {/*
-                   * Sub-Fields
-                   *
-                   * Note: we edge case the 1st sub-field to show our "remove
-                   * row" icon
-                   */}
-                  <Flex alignItems="center" gap={2}>
-                    <InputCreator
-                      schema={subFields[0]}
-                      namePrefix={namePrefix}
-                      {...forwardedInputCreatorProps}
-                    />
-                    {canRemoveRow && (
-                      <IconButton
-                        variant="clear"
-                        aria-label="Remove"
-                        icon={<BiTrash />}
-                        isDisabled={isEditorReadOnly}
-                        onClick={() => remove(index)}
+                  {type === 'multirow-multicol' ? (
+                    <>
+                      <MultiCol
+                        name={namePrefix}
+                        subFields={subFields}
+                        canRemoveRow={canRemoveRow}
+                        isEditorReadOnly={true}
+                        remove={remove}
+                        index={index}
                       />
-                    )}
-                  </Flex>
-                  {subFields.slice(1).map((subField) => (
-                    <InputCreator
-                      key={`${row.id}.${subField.key}`}
-                      schema={subField}
-                      namePrefix={namePrefix}
-                      {...forwardedInputCreatorProps}
-                    />
-                  ))}
+                      {/*
+                       * "And" divider
+                       */}
+                      {showDivider && index !== actualRows.length - 1 && (
+                        <RowDivider />
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      {/*
+                       * Sub-Fields
+                       *
+                       * Note: we edge case the 1st sub-field to show our "remove
+                       * row" icon
+                       */}
+                      <Flex alignItems="center" gap={2}>
+                        <InputCreator
+                          schema={subFields[0]}
+                          namePrefix={namePrefix}
+                          {...forwardedInputCreatorProps}
+                        />
+                        {canRemoveRow && (
+                          <IconButton
+                            variant="clear"
+                            aria-label="Remove"
+                            icon={<BiTrash />}
+                            isDisabled={isEditorReadOnly}
+                            onClick={() => remove(index)}
+                          />
+                        )}
+                      </Flex>
+                      {subFields.slice(1).map((subField) => (
+                        <InputCreator
+                          key={`${row.id}.${subField.key}`}
+                          schema={subField}
+                          namePrefix={namePrefix}
+                          {...forwardedInputCreatorProps}
+                        />
+                      ))}
 
-                  {/*
-                   * "And" divider
-                   */}
-                  {index !== actualRows.length - 1 && (
-                    <Flex alignItems="center">
-                      <Divider />
-                      <Text textStyle="subhead-3" mx={2.5}>
-                        And
-                      </Text>
-                      <Divider />
-                    </Flex>
+                      {/*
+                       * "And" divider
+                       */}
+                      {index !== actualRows.length - 1 && <RowDivider />}
+                    </>
                   )}
                 </Flex>
               )
@@ -142,7 +166,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               isDisabled={isEditorReadOnly}
               maxW="fit-content"
             >
-              And
+              {customButtonText ?? 'And'}
             </Button>
           </Flex>
         )

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -200,6 +200,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  justify-content: center;
 
   .tiptap p.is-editor-empty:first-child::before {
     color: #adb5bd;

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -1,6 +1,6 @@
 import './RichTextEditor.scss'
 
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import React, { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import {
   Box,
@@ -82,6 +82,7 @@ interface EditorProps {
   placeholder?: string
   variablesEnabled?: boolean
   isRich?: boolean
+  isSingleLine?: boolean
 }
 const Editor = ({
   onChange,
@@ -90,6 +91,7 @@ const Editor = ({
   placeholder,
   variablesEnabled,
   isRich,
+  isSingleLine,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
@@ -167,6 +169,7 @@ const Editor = ({
     onCreate: ({ editor }) => {
       const editorElement = editor.view.dom as HTMLElement
       editorElement.style.minHeight = isRich ? '9rem' : '2.625rem' // Set initial minHeight directly
+      editorElement.style.maxHeight = isSingleLine ? '2.625rem' : ''
     },
     editorProps: {
       transformPastedHTML: (html) => {
@@ -257,8 +260,10 @@ interface RichTextEditorProps {
   description?: string
   disabled?: boolean
   placeholder?: string
+  customStyle?: React.CSSProperties
   variablesEnabled?: boolean
   isRich?: boolean
+  isSingleLine?: boolean
 }
 const RichTextEditor = ({
   required,
@@ -268,12 +273,15 @@ const RichTextEditor = ({
   description,
   disabled,
   placeholder,
+  customStyle,
   variablesEnabled,
   isRich,
+  isSingleLine,
 }: RichTextEditorProps) => {
   const { control } = useFormContext()
+
   return (
-    <FormControl flex={1} data-test="text-input-group">
+    <FormControl flex={1} style={customStyle} data-test="text-input-group">
       {label && (
         <FormLabel isRequired={required} description={description}>
           {label}
@@ -293,6 +301,7 @@ const RichTextEditor = ({
             placeholder={placeholder}
             variablesEnabled={variablesEnabled}
             isRich={isRich}
+            isSingleLine={isSingleLine}
           />
         )}
       />

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -1,6 +1,6 @@
 import './RichTextEditor.scss'
 
-import React, { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import {
   Box,

--- a/packages/frontend/src/components/TextField/index.tsx
+++ b/packages/frontend/src/components/TextField/index.tsx
@@ -19,6 +19,7 @@ type TextFieldProps = {
   clickToCopy?: boolean
   readOnly?: boolean
   description?: string
+  customStyle?: React.CSSProperties
 } & MuiTextFieldProps
 
 const createCopyAdornment = (
@@ -50,6 +51,7 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
     readOnly,
     onBlur,
     onChange,
+    customStyle,
     ...textFieldProps
   } = props
 
@@ -68,7 +70,7 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
           ...field
         },
       }) => (
-        <FormControl>
+        <FormControl style={customStyle}>
           {label && (
             <FormLabel
               isRequired={required}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -188,12 +188,9 @@ export const GET_APPS = gql`
             variables
             variableTypes
             allowArbitrary
-            customButtonText
-            customStyle
+            addRowButtonText
             hideBlankRow
-            showDivider
             showOptionValue
-            isSingleLine
             value
             options {
               label
@@ -229,9 +226,7 @@ export const GET_APPS = gql`
               variables
               variableTypes
               allowArbitrary
-              customStyle
               showOptionValue
-              isSingleLine
               hiddenIf {
                 fieldKey
                 fieldValue

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -188,7 +188,11 @@ export const GET_APPS = gql`
             variables
             variableTypes
             allowArbitrary
+            customButtonText
+            customStyle
+            showDivider
             showOptionValue
+            isSingleLine
             value
             options {
               label
@@ -224,7 +228,9 @@ export const GET_APPS = gql`
               variables
               variableTypes
               allowArbitrary
+              customStyle
               showOptionValue
+              isSingleLine
               hiddenIf {
                 fieldKey
                 fieldValue

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -189,7 +189,6 @@ export const GET_APPS = gql`
             variableTypes
             allowArbitrary
             addRowButtonText
-            hideBlankRow
             showOptionValue
             value
             options {

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -190,6 +190,7 @@ export const GET_APPS = gql`
             allowArbitrary
             customButtonText
             customStyle
+            hideBlankRow
             showDivider
             showOptionValue
             isSingleLine

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -330,6 +330,8 @@ export interface IFieldDropdownOption {
 export interface IFieldText extends IBaseField {
   type: 'string'
   value?: string
+  customStyle?: React.CSSProperties
+  isSingleLine?: boolean
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
@@ -338,6 +340,8 @@ export interface IFieldText extends IBaseField {
 export interface IFieldMultiline extends IBaseField {
   type: 'multiline'
   value?: string
+  customStyle?: React.CSSProperties
+  isSingleLine?: boolean
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
@@ -350,9 +354,20 @@ export interface IFieldMultiSelect extends IBaseField {
   variableTypes?: TDataOutMetadatumType[]
 }
 
+export interface IFieldMultiRowMultiCol extends IBaseField {
+  type: 'multirow-multicol'
+  value?: string
+  customButtonText?: string
+  showDivider?: boolean
+
+  subFields: IField[]
+}
+
 export interface IFieldMultiRow extends IBaseField {
   type: 'multirow'
   value?: string
+  customButtonText?: string
+  showDivider?: boolean
 
   subFields: IField[]
 }
@@ -382,6 +397,7 @@ export type IField =
   | IFieldDropdown
   | IFieldText
   | IFieldMultiline
+  | IFieldMultiRowMultiCol
   | IFieldMultiSelect
   | IFieldMultiRow
   | IFieldRichText

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -330,8 +330,6 @@ export interface IFieldDropdownOption {
 export interface IFieldText extends IBaseField {
   type: 'string'
   value?: string
-  customStyle?: React.CSSProperties
-  isSingleLine?: boolean
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
@@ -340,8 +338,6 @@ export interface IFieldText extends IBaseField {
 export interface IFieldMultiline extends IBaseField {
   type: 'multiline'
   value?: string
-  customStyle?: React.CSSProperties
-  isSingleLine?: boolean
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
@@ -357,9 +353,8 @@ export interface IFieldMultiSelect extends IBaseField {
 export interface IFieldMultiRowMultiCol extends IBaseField {
   type: 'multirow-multicol'
   value?: string
-  customButtonText?: string
+  addRowButtonText?: string
   hideBlankRow?: boolean
-  showDivider?: boolean
 
   subFields: IField[]
 }
@@ -367,9 +362,8 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
 export interface IFieldMultiRow extends IBaseField {
   type: 'multirow'
   value?: string
-  customButtonText?: string
+  addRowButtonText?: string
   hideBlankRow?: boolean
-  showDivider?: boolean
 
   subFields: IField[]
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -358,6 +358,7 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
   type: 'multirow-multicol'
   value?: string
   customButtonText?: string
+  hideBlankRow?: boolean
   showDivider?: boolean
 
   subFields: IField[]
@@ -367,6 +368,7 @@ export interface IFieldMultiRow extends IBaseField {
   type: 'multirow'
   value?: string
   customButtonText?: string
+  hideBlankRow?: boolean
   showDivider?: boolean
 
   subFields: IField[]

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -354,7 +354,6 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
   type: 'multirow-multicol'
   value?: string
   addRowButtonText?: string
-  hideBlankRow?: boolean
 
   subFields: IField[]
 }
@@ -363,7 +362,6 @@ export interface IFieldMultiRow extends IBaseField {
   type: 'multirow'
   value?: string
   addRowButtonText?: string
-  hideBlankRow?: boolean
 
   subFields: IField[]
 }


### PR DESCRIPTION
## Problem
Allow headers to be set using variables for Custom API.

## Solution
Add option to set custom headers in the "Set up step" with ability to select variables.
- Default
<img width="853" alt="Screenshot 2024-11-08 at 5 31 09 PM" src="https://github.com/user-attachments/assets/54d0d598-b063-43cc-b845-bc541a10496f">
- With custom headers
<img width="859" alt="Screenshot 2024-11-08 at 12 13 56 PM" src="https://github.com/user-attachments/assets/56c3720e-2d88-432e-9505-24c144cc6919">

**Features**:
- Enable custom headers to be sent (on top of headers configured during "Add new connection")
- Implement multi column input to adopt similar input style as Postman/Bruno
<img width="851" alt="Screenshot 2024-11-08 at 1 33 24 PM" src="https://github.com/user-attachments/assets/c2194022-4457-4676-ab0d-25a297f10c26">



## Before & After Screenshots

**BEFORE**:
- N/A. New feature

**AFTER**:
1. Custom Headers set on Plumber
<img width="850" alt="Screenshot 2024-11-08 at 1 41 21 PM" src="https://github.com/user-attachments/assets/f1e97f81-2c85-4e5a-9273-51d2ab45b4cd">
2. Custom Headers received
<img width="855" alt="Screenshot 2024-11-08 at 1 42 22 PM" src="https://github.com/user-attachments/assets/696e0305-aeeb-4183-bf93-eb43328a0120">


## Tests
- [x] Validate key-value pairs, i.e. key/value should not be null
- [x] Custom headers should not override headers set up during the "Add new connection" stage
- [x] API calls still execute without custom headers


**New scripts**:
- `packages/backend/src/apps/custom-api/actions/http-request/schema.ts` : validate custom headers
- `packages/frontend/src/components/MultiCol.tsx/index.tsx` : component for multi column input
- `packages/frontend/src/components/MultiRow/RowDivider.tsx` : move "And" divider to separate component


