### PR TITLE
PLU-362: remove duplicate text in dropdowns

### DIFF
--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -16,6 +16,7 @@ const action: IRawAction = {
       value: null,
       description: 'Delay for unit, e.g. minutes, hours, days, weeks.',
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: 'Minutes',

--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -38,6 +38,7 @@ const trigger: IRawTrigger = {
       required: true,
       value: null,
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: '00:00',

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -21,6 +21,7 @@ const trigger: IRawTrigger = {
       required: true,
       value: null,
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: '1',
@@ -156,6 +157,7 @@ const trigger: IRawTrigger = {
       required: true,
       value: null,
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: '00:00',

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -21,6 +21,7 @@ const trigger: IRawTrigger = {
       required: true,
       value: null,
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: 'Monday',
@@ -60,6 +61,7 @@ const trigger: IRawTrigger = {
       required: true,
       value: null,
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: '00:00',

--- a/packages/backend/src/apps/slack/actions/find-message/index.ts
+++ b/packages/backend/src/apps/slack/actions/find-message/index.ts
@@ -25,6 +25,7 @@ const action: IRawAction = {
       required: true,
       value: 'score',
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: 'Match strength',
@@ -45,6 +46,7 @@ const action: IRawAction = {
       required: true,
       value: 'desc',
       variables: false,
+      showOptionValue: false,
       options: [
         {
           label: 'Descending (newest or best match first)',


### PR DESCRIPTION
## Problem
Dropdown options showing unnecessary values.

Closes [PLU-362: remove-duplicate-text-in-dropdowns](https://linear.app/ogp/issue/PLU-362/remove-duplicate-text-in-dropdowns)

## Solution
Set showOptionValue to false to hide duplicate text in dropdown

## Before & After Screenshots

**BEFORE**:
- Delay
<img width="852" alt="Screenshot 2024-11-14 at 9 51 42 AM" src="https://github.com/user-attachments/assets/93fa8f63-e6fc-4140-bec4-5fe33f73715f">

- Scheduler
<img width="858" alt="Screenshot 2024-11-14 at 9 52 45 AM" src="https://github.com/user-attachments/assets/0955e01a-ec4d-4009-9efe-f499041dfb73">
<img width="856" alt="Screenshot 2024-11-14 at 9 53 15 AM" src="https://github.com/user-attachments/assets/154b833c-0bd9-42e2-ae82-912415746a57">
<img width="851" alt="Screenshot 2024-11-14 at 9 54 26 AM" src="https://github.com/user-attachments/assets/4d09d46c-83b9-4c4a-b7b0-f2ed76dcf5ed">


- Slack
<img width="856" alt="Screenshot 2024-11-14 at 9 50 42 AM" src="https://github.com/user-attachments/assets/125a819a-3d8b-47c2-b8c1-1220b49fbdfd">
<img width="853" alt="Screenshot 2024-11-14 at 9 50 55 AM" src="https://github.com/user-attachments/assets/5b64fe29-82ab-452f-b935-ccc264349a53">


**AFTER**:
- Delay
<img width="852" alt="Screenshot 2024-11-14 at 9 51 56 AM" src="https://github.com/user-attachments/assets/5fa9cc62-ab02-4c78-a77d-2a002f126a12">

- Scheduler
<img width="855" alt="Screenshot 2024-11-14 at 9 52 57 AM" src="https://github.com/user-attachments/assets/14b02873-e97f-4614-87c2-76a0ebf783de">
<img width="855" alt="Screenshot 2024-11-14 at 9 53 29 AM" src="https://github.com/user-attachments/assets/93813d20-e9af-454c-976b-c12494100b2e">
<img width="855" alt="Screenshot 2024-11-14 at 9 54 53 AM" src="https://github.com/user-attachments/assets/3c06e1a0-e461-409b-9b4c-537f3d1a9267">

- Slack
<img width="857" alt="Screenshot 2024-11-14 at 9 49 43 AM" src="https://github.com/user-attachments/assets/a33c2480-506d-4eff-865f-2f1d57a25c27">
<img width="856" alt="Screenshot 2024-11-14 at 9 49 53 AM" src="https://github.com/user-attachments/assets/d14eab37-d7bc-4dbd-8775-694ac55bc197">

## Tests
- [x] Action values saved correctly
- [x] Existing steps show the correct options

