### PR TITLE
chore: postman attachment size exceeded error

### DIFF
--- a/packages/backend/src/apps/postman/common/data-out-validator.ts
+++ b/packages/backend/src/apps/postman/common/data-out-validator.ts
@@ -8,6 +8,7 @@ export const dataOutSchema = z.object(
         'BLACKLISTED',
         'RATE-LIMITED',
         'INVALID-ATTACHMENT',
+        'ATTACHMENT-SIZE-EXCEEDED',
         'INTERMITTENT-ERROR',
         'ERROR',
       ]),

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -159,14 +159,16 @@ export async function sendTransactionalEmails(
    * Since we can only return one error per postman step, we have to select in terms of priority
    * 1. RATE-LIMITED (so we can auto-retry)
    * 2. INVALID-ATTACHMENT (probably all recipients should fail)
-   * 3. INTERMITTENT-ERROR (some recipients failed, auto-retry)
-   * 4. ERROR (probably all recipients should fail)
-   * 5. BLACKLISTED (blacklisted errors are returned even if there are other errors like invalid attachment)
+   * 3. ATTACHMENT-SIZE-EXCEEDED (probably all recipients should fail)
+   * 4. INTERMITTENT-ERROR (some recipients failed, auto-retry)
+   * 5. ERROR (probably all recipients should fail)
+   * 6. BLACKLISTED (blacklisted errors are returned even if there are other errors like invalid attachment)
    */
   const sortedErrors = sortBy(errors, (error) =>
     [
       'RATE-LIMITED',
       'INVALID-ATTACHMENT',
+      'ATTACHMENT-SIZE-EXCEEDED',
       'INTERMITTENT-ERROR',
       'ERROR',
       'BLACKLISTED',

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -36,6 +36,8 @@ export function getPostmanErrorStatus(
       }
     case 'rate_limit':
       return 'RATE-LIMITED'
+    case 'attachment_limit':
+      return 'ATTACHMENT-SIZE-EXCEEDED'
     default:
       if (POSTMAN_RETRIABLE_HTTP_CODES.includes(error.response?.status)) {
         return 'INTERMITTENT-ERROR'
@@ -101,6 +103,14 @@ export function throwPostmanStepError({
       throw new StepError(
         'Unsupported attachment file type',
         'Click on set up action and check that the attachment type is supported by postman. Please check the supported types at [this link](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).',
+        position,
+        appName,
+        error,
+      )
+    case 'ATTACHMENT-SIZE-EXCEEDED':
+      throw new StepError(
+        'Total attachment size exceeded',
+        'Click on set up action and check that the attachments do not exceed 10MB in total.',
         position,
         appName,
         error,


### PR DESCRIPTION
## Problem

Currently, we don't check for attachment exceeded error for postman step. 
Postman [guide](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments) says that it is 2MB per attachment and 10MB in total, it seems like 2MB is a soft limit and the 413 error only throws when the attachments exceed 10MB in total.
![image](https://github.com/user-attachments/assets/23905adf-44b8-47d8-9b5f-7498f7d4da00)

## Solution

Check for the specific error code: `attachment_limit` and throw step error for that.
<img width="895" alt="image" src="https://github.com/user-attachments/assets/032a4a22-31b8-42a0-a0a9-77ce3a78b02f">

## Tests
- [x] Normal executions still work with postman
- [x] Attachments under the size of 10 MB works although it's slow
- [x] One attachment fails when it exceeds 10MB
- [x] Multiple attachment fails when they exceed 10MB