### PR TITLE
PLU-310: show num pipes connected to a tile

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 
+import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
@@ -50,6 +51,56 @@ export async function generateMockTable({
     editor,
     viewer,
   }
+}
+
+// generate mock flow including steps
+export async function generateMockFlow({
+  userId,
+  tableId,
+  numSteps,
+}: {
+  userId: string
+  tableId: string
+  numSteps: number
+}) {
+  const currentUser = await User.query().findById(userId)
+
+  const tableName = `test-flow-${tableId}`
+  const flowRes = await currentUser.$relatedQuery('flows').insert({
+    name: tableName,
+  })
+  const flowId = flowRes.id
+
+  for (let i = 0; i < numSteps; i++) {
+    await generateMockStep({
+      tableId,
+      flowId,
+      position: i + 2,
+    })
+  }
+}
+
+export async function generateMockStep({
+  tableId,
+  flowId,
+  position,
+}: {
+  tableId: string
+  flowId: string
+  position?: number
+}) {
+  await Step.query().insert({
+    key: 'createTileRow',
+    appKey: 'tiles',
+    type: 'action',
+    parameters: {
+      rowData: [],
+      tableId: tableId,
+    },
+    flowId: flowId,
+    status: 'incomplete',
+    position: position,
+  })
 }
 
 export async function generateMockTableColumns({

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -16,9 +16,7 @@ interface TablePipeCountObj {
 }
 
 function getRandNum() {
-  const array = new Uint32Array(1)
-  crypto.getRandomValues(array)
-  return Math.floor((array[0] / (0xffffffff + 1)) * 5) + 1
+  return crypto.randomInt(1, 6)
 }
 
 describe('get table connections query', () => {

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import getTableConnections from '@/graphql/queries/tiles/get-table-connections'
@@ -15,7 +16,9 @@ interface TablePipeCountObj {
 }
 
 function getRandNum() {
-  return Math.floor(Math.random() * 5) + 1
+  const array = new Uint32Array(1)
+  crypto.getRandomValues(array)
+  return Math.floor((array[0] / (0xffffffff + 1)) * 5) + 1
 }
 
 describe('get table connections query', () => {
@@ -46,8 +49,7 @@ describe('get table connections query', () => {
       const res = await generateMockTable({ userId: context.currentUser.id })
       const { id: tableId } = res.table
 
-      const numFlows = Math.floor(Math.random() * 5) + 1
-      const numSteps = Math.floor(Math.random() * 5) + 1
+      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
       tablePipeCount[tableId] = numFlows
 
       for (let i = 0; i < numFlows; i++) {

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -33,7 +33,20 @@ describe('get table connections query', () => {
 
     const tableConnections = await getTableConnections(
       null,
-      { limit: 10, offset: 0 },
+      { tableIds: [] },
+      context,
+    )
+    expect(tableConnections).toEqual({})
+    expect(Object.keys(tableConnections).length).toBe(0)
+  })
+
+  it('should return empty object if user has no access to any tables', async () => {
+    const numTables = 5
+    const testIds = Array.from({ length: numTables }, () => crypto.randomUUID())
+
+    const tableConnections = await getTableConnections(
+      null,
+      { tableIds: testIds },
       context,
     )
     expect(tableConnections).toEqual({})
@@ -79,13 +92,12 @@ describe('get table connections query', () => {
 
       const tableConnections = await getTableConnections(
         null,
-        { limit, offset },
+        { tableIds: pageTableIds },
         context,
       )
       expect(Object.keys(tableConnections).length).toBe(expectedLength)
       expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
 
-      //   Object.keys(tableConnections).forEach()
       Object.entries(tableConnections).forEach(([key, value]) => {
         expect(value).toBe(tablePipeCount[key])
       })
@@ -140,16 +152,77 @@ describe('get table connections query', () => {
 
       const tableConnections = await getTableConnections(
         null,
-        { limit, offset },
+        { tableIds: pageTableIds },
         context,
       )
       expect(Object.keys(tableConnections).length).toBe(expectedLength)
       expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
 
-      //   Object.keys(tableConnections).forEach()
       Object.entries(tableConnections).forEach(([key, value]) => {
         expect(value).toBe(tablePipeCount[key])
       })
     }
+  })
+
+  it('should not return table connections for tables the user does not have access to', async () => {
+    const numTables = 5
+    const tablePipeCount: TablePipeCountObj = {}
+    for (let i = 0; i < numTables; i++) {
+      const res = await generateMockTable({ userId: context.currentUser.id })
+      const { id: tableId } = res.table
+      const { id: editorId } = res.editor
+
+      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
+      const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
+
+      tablePipeCount[tableId] = numFlows + editorFlows
+      for (let i = 0; i < numFlows; i++) {
+        await generateMockFlow({
+          userId: context.currentUser.id,
+          tableId,
+          numSteps,
+        })
+      }
+      for (let i = 0; i < editorFlows; i++) {
+        await generateMockFlow({
+          userId: editorId,
+          tableId,
+          numSteps: editorSteps,
+        })
+      }
+    }
+
+    // test as a whole
+    const { edges, pageInfo } = await getTables(
+      null,
+      { limit: 10, offset: 0 },
+      context,
+    )
+
+    const pageTables = edges.map((edge) => edge.node)
+    expect(pageTables).toHaveLength(numTables)
+    expect(pageInfo.currentPage).toBe(1)
+    expect(pageInfo.totalCount).toBe(numTables)
+
+    const pageTableIds = edges.map((edge) => edge.node.id)
+    const testIds = [...pageTableIds, crypto.randomUUID()] // add a random table id
+    expect(testIds).toHaveLength(numTables + 1)
+    const tableConnections = await getTableConnections(
+      null,
+      { tableIds: testIds },
+      context,
+    )
+    expect(Object.keys(tableConnections).length).toBe(numTables)
+    expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
+
+    Object.entries(tableConnections).forEach(([key, value]) => {
+      expect(value).toBe(tablePipeCount[key])
+    })
+  })
+
+  it('should throw error if tableIds is null', async () => {
+    await expect(
+      getTableConnections(null, { tableIds: null }, context),
+    ).rejects.toThrow('tableIds is required')
   })
 })

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import getTableConnections from '@/graphql/queries/tiles/get-table-connections'
 import getTables from '@/graphql/queries/tiles/get-tables'
+import Flow from '@/models/flow'
 import Context from '@/types/express/context'
 
 import {
@@ -36,6 +37,8 @@ describe('get table connections query', () => {
       { tableIds: [] },
       context,
     )
+    const flowQuerySpy = vi.spyOn(Flow, 'query')
+    expect(flowQuerySpy).not.toHaveBeenCalled()
     expect(tableConnections).toEqual({})
     expect(Object.keys(tableConnections).length).toBe(0)
   })

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import getTableConnections from '@/graphql/queries/tiles/get-table-connections'
+import getTables from '@/graphql/queries/tiles/get-tables'
+import Context from '@/types/express/context'
+
+import {
+  generateMockContext,
+  generateMockFlow,
+  generateMockTable,
+} from '../../mutations/tiles/table.mock'
+
+interface TablePipeCountObj {
+  [key: string]: number
+}
+
+function getRandNum() {
+  return Math.floor(Math.random() * 5) + 1
+}
+
+describe('get table connections query', () => {
+  let context: Context
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+  })
+
+  it('should return empty object if no tables found', async () => {
+    const { edges } = await getTables(null, { limit: 10, offset: 0 }, context)
+    const tables = edges.map((edge) => edge.node)
+    expect(tables).toHaveLength(0)
+
+    const tableConnections = await getTableConnections(
+      null,
+      { limit: 10, offset: 0 },
+      context,
+    )
+    expect(tableConnections).toEqual({})
+    expect(Object.keys(tableConnections).length).toBe(0)
+  })
+
+  it('should return the correct number of table connections for user flows only', async () => {
+    const numTables = 5
+    const tablePipeCount: TablePipeCountObj = {}
+    for (let i = 0; i < numTables; i++) {
+      const res = await generateMockTable({ userId: context.currentUser.id })
+      const { id: tableId } = res.table
+
+      const numFlows = Math.floor(Math.random() * 5) + 1
+      const numSteps = Math.floor(Math.random() * 5) + 1
+      tablePipeCount[tableId] = numFlows
+
+      for (let i = 0; i < numFlows; i++) {
+        await generateMockFlow({
+          userId: context.currentUser.id,
+          tableId,
+          numSteps,
+        })
+      }
+    }
+
+    // tests each page
+    const limit = 2
+    for (let i = 0; i < Math.ceil(numTables / 2); i++) {
+      const offset = limit * i
+      const { edges, pageInfo } = await getTables(
+        null,
+        { limit, offset },
+        context,
+      )
+
+      const pageTables = edges.map((edge) => edge.node)
+      const expectedLength = Math.min(limit, numTables - limit * i)
+      expect(pageTables).toHaveLength(expectedLength)
+      expect(pageInfo.currentPage).toBe(i + 1)
+      expect(pageInfo.totalCount).toBe(numTables)
+
+      const pageTableIds = edges.map((edge) => edge.node.id)
+
+      const tableConnections = await getTableConnections(
+        null,
+        { limit, offset },
+        context,
+      )
+      expect(Object.keys(tableConnections).length).toBe(expectedLength)
+      expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
+
+      //   Object.keys(tableConnections).forEach()
+      Object.entries(tableConnections).forEach(([key, value]) => {
+        expect(value).toBe(tablePipeCount[key])
+      })
+    }
+  })
+
+  it('should return the correct number of table connections for flows by user and editor', async () => {
+    const numTables = 5
+    const tablePipeCount: TablePipeCountObj = {}
+    for (let i = 0; i < numTables; i++) {
+      const res = await generateMockTable({ userId: context.currentUser.id })
+      const { id: tableId } = res.table
+      const { id: editorId } = res.editor
+
+      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
+      const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
+
+      tablePipeCount[tableId] = numFlows + editorFlows
+      for (let i = 0; i < numFlows; i++) {
+        await generateMockFlow({
+          userId: context.currentUser.id,
+          tableId,
+          numSteps,
+        })
+      }
+      for (let i = 0; i < editorFlows; i++) {
+        await generateMockFlow({
+          userId: editorId,
+          tableId,
+          numSteps: editorSteps,
+        })
+      }
+    }
+
+    // tests each page
+    const limit = 2
+    for (let i = 0; i < Math.ceil(numTables / 2); i++) {
+      const offset = limit * i
+      const { edges, pageInfo } = await getTables(
+        null,
+        { limit, offset },
+        context,
+      )
+
+      const pageTables = edges.map((edge) => edge.node)
+      const expectedLength = Math.min(limit, numTables - limit * i)
+      expect(pageTables).toHaveLength(expectedLength)
+      expect(pageInfo.currentPage).toBe(i + 1)
+      expect(pageInfo.totalCount).toBe(numTables)
+
+      const pageTableIds = edges.map((edge) => edge.node.id)
+
+      const tableConnections = await getTableConnections(
+        null,
+        { limit, offset },
+        context,
+      )
+      expect(Object.keys(tableConnections).length).toBe(expectedLength)
+      expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
+
+      //   Object.keys(tableConnections).forEach()
+      Object.entries(tableConnections).forEach(([key, value]) => {
+        expect(value).toBe(tablePipeCount[key])
+      })
+    }
+  })
+})

--- a/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
@@ -6,6 +6,7 @@ import getTables from './get-tables'
 
 interface ExtendedFlow extends Flow {
   tableid: string
+  count: number
 }
 
 interface TableConnection {
@@ -29,16 +30,18 @@ const getTableConnections: QueryResolvers['getTableConnections'] = async (
   // get distinct rows of tables used in flows
   // returns flow id and table id
   const distinctTableFlows = await Flow.query()
-    .distinct('flows.id', Flow.raw("steps.parameters ->> 'tableId' AS tableId"))
+    .select(Flow.raw("steps.parameters ->> 'tableId' AS tableid"))
+    .countDistinct('flows.id')
     .innerJoinRelated('steps')
     .innerJoinRelated('user')
     .where('steps.app_key', 'tiles')
     .whereRaw("steps.parameters ->> 'tableId' IS NOT NULL")
     .whereRaw(`steps.parameters ->> 'tableId' IN (${tableIdStr})`)
+    .groupByRaw("steps.parameters ->> 'tableId'")
 
   const result = distinctTableFlows.reduce(
-    (acc: TableConnection, obj: ExtendedFlow) => {
-      acc[obj.tableid] = (acc[obj.tableid] || 0) + 1
+    (acc: TableConnection, row: ExtendedFlow) => {
+      acc[row.tableid] = row.count
       return acc
     },
     {},

--- a/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
@@ -1,0 +1,50 @@
+import Flow from '@/models/flow'
+
+import type { QueryResolvers } from '../../__generated__/types.generated'
+
+import getTables from './get-tables'
+
+interface ExtendedFlow extends Flow {
+  tableid: string
+}
+
+interface TableConnection {
+  [key: string]: number
+}
+
+const getTableConnections: QueryResolvers['getTableConnections'] = async (
+  _parent,
+  { limit, offset, name },
+  context,
+) => {
+  // get tables of currentUser in the current page
+  const tables = await getTables(_parent, { limit, offset, name }, context)
+
+  if (tables.edges.length === 0) {
+    return {}
+  }
+  const tableIds = tables.edges.map((t) => t.node.id)
+  const tableIdStr = tableIds.map((id) => `'${id}'`).join(', ')
+
+  // get distinct rows of tables used in flows
+  // returns flow id and table id
+  const distinctTableFlows = await Flow.query()
+    .distinct('flows.id', Flow.raw("steps.parameters ->> 'tableId' AS tableId"))
+    .innerJoinRelated('steps')
+    .innerJoinRelated('user')
+    .where('steps.app_key', 'tiles')
+    .whereRaw("steps.parameters ->> 'tableId' IS NOT NULL")
+    .whereRaw(`steps.parameters ->> 'tableId' IN (${tableIdStr})`)
+
+  const result = distinctTableFlows.reduce(
+    (acc: TableConnection, obj: ExtendedFlow) => {
+      acc[obj.tableid] = (acc[obj.tableid] || 0) + 1
+      return acc
+    },
+    {},
+  )
+
+  return result
+}
+
+export default getTableConnections

--- a/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
@@ -25,6 +25,9 @@ const getTableConnections: QueryResolvers['getTableConnections'] = async (
   if (!tableIds) {
     throw new Error('tableIds is required')
   }
+  if (tableIds.length === 0) {
+    return {}
+  }
 
   try {
     // get distinct rows of tables used in flows

--- a/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table-connections.ts
@@ -1,8 +1,11 @@
+import { raw } from 'objection'
+
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
-
-import getTables from './get-tables'
 
 interface ExtendedFlow extends Flow {
   tableid: string
@@ -15,39 +18,55 @@ interface TableConnection {
 
 const getTableConnections: QueryResolvers['getTableConnections'] = async (
   _parent,
-  { limit, offset, name },
+  params,
   context,
 ) => {
-  // get tables of currentUser in the current page
-  const tables = await getTables(_parent, { limit, offset, name }, context)
-
-  if (tables.edges.length === 0) {
-    return {}
+  const { tableIds } = params
+  if (!tableIds) {
+    throw new Error('tableIds is required')
   }
-  const tableIds = tables.edges.map((t) => t.node.id)
-  const tableIdStr = tableIds.map((id) => `'${id}'`).join(', ')
 
-  // get distinct rows of tables used in flows
-  // returns flow id and table id
-  const distinctTableFlows = await Flow.query()
-    .select(Flow.raw("steps.parameters ->> 'tableId' AS tableid"))
-    .countDistinct('flows.id')
-    .innerJoinRelated('steps')
-    .innerJoinRelated('user')
-    .where('steps.app_key', 'tiles')
-    .whereRaw("steps.parameters ->> 'tableId' IS NOT NULL")
-    .whereRaw(`steps.parameters ->> 'tableId' IN (${tableIdStr})`)
-    .groupByRaw("steps.parameters ->> 'tableId'")
+  try {
+    // get distinct rows of tables used in flows
+    // returns flow id and table id
+    // MONITOR (ogp-kevin): add index on steps.parameters->>'tableId' if query is slow
+    const distinctTableFlows = await Flow.query()
+      .innerJoin(
+        Step.query()
+          .as('tileSteps')
+          .select(
+            raw("steps.parameters->>'tableId' AS tableid"),
+            'steps.flow_id',
+          )
+          .andWhere('steps.app_key', 'tiles')
+          .whereNotNull(raw("steps.parameters->>'tableId'"))
+          .whereIn(
+            raw("steps.parameters->>'tableId'"),
+            TableCollaborator.query()
+              .select(raw('"table_id"::TEXT AS table_id')) // Cast to TEXT, steps.parameters is JSONB
+              .whereIn('table_id', tableIds)
+              .where('user_id', context.currentUser.id),
+          ), // Only include tables that the user has access to
+        'flows.id',
+        'tileSteps.flow_id',
+      )
+      .select('tileSteps.tableid')
+      .countDistinct('flows.id')
+      .groupBy('tileSteps.tableid')
 
-  const result = distinctTableFlows.reduce(
-    (acc: TableConnection, row: ExtendedFlow) => {
-      acc[row.tableid] = row.count
-      return acc
-    },
-    {},
-  )
+    const result = distinctTableFlows.reduce(
+      (acc: TableConnection, row: ExtendedFlow) => {
+        acc[row.tableid] = row.count
+        return acc
+      },
+      {},
+    )
 
-  return result
+    return result
+  } catch (e) {
+    logger.error(e)
+    throw new Error('Error fetching table connections')
+  }
 }
 
 export default getTableConnections

--- a/packages/backend/src/graphql/queries/tiles/index.ts
+++ b/packages/backend/src/graphql/queries/tiles/index.ts
@@ -2,6 +2,12 @@ import type { QueryResolvers } from '../../__generated__/types.generated'
 
 import getAllRows from './get-all-rows'
 import getTable from './get-table'
+import getTableConnections from './get-table-connections'
 import getTables from './get-tables'
 
-export default { getTable, getTables, getAllRows } satisfies QueryResolvers
+export default {
+  getTable,
+  getTableConnections,
+  getTables,
+  getAllRows,
+} satisfies QueryResolvers

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -36,11 +36,8 @@ type Query {
   ): [JSONObject]
   # Tiles
   getTable(tableId: String!): TableMetadata!
-  getTables(
-    limit: Int!
-    offset: Int!
-    name: String
-  ): PaginatedTables!
+  getTableConnections(limit: Int!, offset: Int!, name: String): JSONObject
+  getTables(limit: Int!, offset: Int!, name: String): PaginatedTables!
   # Tiles rows
   getAllRows(tableId: String!): Any!
   getCurrentUser: User

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -36,7 +36,7 @@ type Query {
   ): [JSONObject]
   # Tiles
   getTable(tableId: String!): TableMetadata!
-  getTableConnections(limit: Int!, offset: Int!, name: String): JSONObject
+  getTableConnections(tableIds: [String!]!): JSONObject
   getTables(limit: Int!, offset: Int!, name: String): PaginatedTables!
   # Tiles rows
   getAllRows(tableId: String!): Any!

--- a/packages/frontend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table-connections.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export const GET_TABLE_CONNECTIONS = gql`
-  query GetTableConnections($limit: Int!, $offset: Int!, $name: String) {
-    getTableConnections(limit: $limit, offset: $offset, name: $name)
+  query GetTableConnections($tableIds: [String!]!) {
+    getTableConnections(tableIds: $tableIds)
   }
 `

--- a/packages/frontend/src/graphql/queries/tiles/get-table-connections.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table-connections.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client'
+
+export const GET_TABLE_CONNECTIONS = gql`
+  query GetTableConnections($limit: Int!, $offset: Int!, $name: String) {
+    getTableConnections(limit: $limit, offset: $offset, name: $name)
+  }
+`

--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -1,17 +1,15 @@
 import { MouseEvent, useCallback, useRef } from 'react'
-import { BiDotsHorizontalRounded, BiShow, BiTrash } from 'react-icons/bi'
+import { BiTrash } from 'react-icons/bi'
+import { BsDot } from 'react-icons/bs'
 import { MdOutlineRemoveRedEye } from 'react-icons/md'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
   Box,
   Divider,
   Flex,
   Icon,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
+  Skeleton,
   Text,
   useDisclosure,
   VStack,
@@ -31,8 +29,17 @@ import { DELETE_TABLE } from '@/graphql/mutations/tiles/delete-table'
 import { GET_TABLES } from '@/graphql/queries/tiles/get-tables'
 import { toPrettyDateString } from '@/helpers/dateTime'
 
-const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
-  const navigate = useNavigate()
+import { TileConnections } from '..'
+
+const TileListItem = ({
+  isConnectionsLoading,
+  numConnections,
+  table,
+}: {
+  isConnectionsLoading: boolean
+  numConnections: number
+  table: TableMetadata
+}): JSX.Element => {
   const toast = useToast()
   const [deleteTable, { loading: isDeletingTable }] = useMutation(
     DELETE_TABLE,
@@ -50,12 +57,6 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
     isOpen: isDialogOpen,
     onOpen: onDialogOpen,
     onClose: onDialogClose,
-  } = useDisclosure()
-  // need to manage state to prevent bubbling of click event
-  const {
-    isOpen: isMenuOpen,
-    onToggle: onMenuToggle,
-    onClose: onMenuClose,
   } = useDisclosure()
 
   const onDeleteButtonClick = useCallback(
@@ -88,6 +89,9 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
         alignItems="center"
         _hover={{
           bg: 'interaction.muted.neutral.hover',
+          '& .hover-remove-button': {
+            visibility: 'visible',
+          },
         }}
         _active={{
           bg: 'interaction.muted.neutral.active',
@@ -95,9 +99,17 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
       >
         <Box>
           <Text textStyle="h6">{table.name}</Text>
-          <Text textStyle="body-2">
-            Last opened {toPrettyDateString(+table.lastAccessedAt)}
-          </Text>
+          <Flex gap={1} textStyle="body-2" color="base.content.medium">
+            <Text>Last opened {toPrettyDateString(+table.lastAccessedAt)}</Text>
+            {table.role !== 'viewer' && numConnections && (
+              <>
+                <Icon as={BsDot} fontSize="1.5em" />
+                <Skeleton isLoaded={!isConnectionsLoading}>
+                  <Text>Used in {numConnections} pipes</Text>
+                </Skeleton>
+              </>
+            )}
+          </Flex>
         </Box>
         <Flex alignItems="center" gap={4}>
           {table.role === 'viewer' && (
@@ -113,39 +125,16 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
               <TagLabel>View only</TagLabel>
             </Tag>
           )}
-          <Menu onClose={onMenuClose} isOpen={isMenuOpen} gutter={0}>
-            <MenuButton
-              as={IconButton}
-              colorScheme="secondary"
+          {table.role === 'owner' && (
+            <IconButton
+              className="hover-remove-button"
               variant="clear"
-              icon={<BiDotsHorizontalRounded />}
-              aria-label="options"
-              onClick={(event) => {
-                event.preventDefault()
-                onMenuToggle()
-              }}
+              aria-label="Remove"
+              icon={<BiTrash />}
+              onClick={onDeleteButtonClick}
+              visibility="hidden"
             />
-            <MenuList w={144}>
-              <MenuItem
-                icon={<Icon as={BiShow} boxSize={5} />}
-                onClick={(event) => {
-                  event.preventDefault() // default behavior of the Link in the parent
-                  navigate(URLS.TILE(table.id))
-                }}
-              >
-                View
-              </MenuItem>
-              {table.role === 'owner' && (
-                <MenuItem
-                  icon={<Icon as={BiTrash} boxSize={5} />}
-                  color="interaction.critical.default"
-                  onClick={onDeleteButtonClick}
-                >
-                  Delete
-                </MenuItem>
-              )}
-            </MenuList>
-          </Menu>
+          )}
         </Flex>
       </Flex>
       <MenuAlertDialog
@@ -162,10 +151,16 @@ const TileListItem = ({ table }: { table: TableMetadata }): JSX.Element => {
 }
 
 interface TileListProps {
+  isConnectionsLoading: boolean
+  tileConnections: TileConnections
   tiles: TableMetadata[]
 }
 
-const TileList = ({ tiles }: TileListProps): JSX.Element => {
+const TileList = ({
+  isConnectionsLoading,
+  tileConnections,
+  tiles,
+}: TileListProps): JSX.Element => {
   return (
     <VStack
       alignItems="stretch"
@@ -174,7 +169,12 @@ const TileList = ({ tiles }: TileListProps): JSX.Element => {
       spacing={0}
     >
       {tiles.map((tile) => (
-        <TileListItem key={tile.id} table={tile} />
+        <TileListItem
+          key={tile.id}
+          isConnectionsLoading={isConnectionsLoading}
+          numConnections={tileConnections[tile.id]}
+          table={tile}
+        />
       ))}
     </VStack>
   )

--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -104,7 +104,7 @@ const TileListItem = ({
             <Text {...textStyles.lastOpened}>
               Last opened {toPrettyDateString(+table.lastAccessedAt)}
             </Text>
-            {table.role !== 'viewer' && numConnections > 0 && (
+            {numConnections > 0 && (
               <Skeleton isLoaded={!isConnectionsLoading}>
                 <Flex {...flexStyles.usedInPipes}>
                   <Icon
@@ -131,6 +131,7 @@ const TileListItem = ({
               variant="clear"
               aria-label="Remove"
               icon={<BiTrash />}
+              isDisabled={isConnectionsLoading}
               onClick={onDeleteButtonClick}
               visibility="hidden"
             />

--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -5,7 +5,14 @@ import { MdOutlineRemoveRedEye } from 'react-icons/md'
 import { Link } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
   Box,
+  Button,
   Divider,
   Flex,
   Icon,
@@ -22,7 +29,6 @@ import {
   useToast,
 } from '@opengovsg/design-system-react'
 
-import MenuAlertDialog from '@/components/MenuAlertDialog'
 import * as URLS from '@/config/urls'
 import type { TableMetadata } from '@/graphql/__generated__/graphql'
 import { DELETE_TABLE } from '@/graphql/mutations/tiles/delete-table'
@@ -30,6 +36,14 @@ import { GET_TABLES } from '@/graphql/queries/tiles/get-tables'
 import { toPrettyDateString } from '@/helpers/dateTime'
 
 import { TileConnections } from '..'
+
+import {
+  flexStyles,
+  linkStyles,
+  pulsingDotStyles,
+  tagStyles,
+  textStyles,
+} from './style'
 
 const TileListItem = ({
   isConnectionsLoading,
@@ -81,46 +95,32 @@ const TileListItem = ({
 
   return (
     <Link to={URLS.TILE(table.id)}>
-      <Flex
-        px={8}
-        py={6}
-        w="100%"
-        justifyContent="space-between"
-        alignItems="center"
-        _hover={{
-          bg: 'interaction.muted.neutral.hover',
-          '& .hover-remove-button': {
-            visibility: 'visible',
-          },
-        }}
-        _active={{
-          bg: 'interaction.muted.neutral.active',
-        }}
-      >
+      <Flex {...linkStyles}>
         <Box>
-          <Text textStyle="h6">{table.name}</Text>
-          <Flex gap={1} textStyle="body-2" color="base.content.medium">
-            <Text>Last opened {toPrettyDateString(+table.lastAccessedAt)}</Text>
-            {table.role !== 'viewer' && numConnections && (
-              <>
-                <Icon as={BsDot} fontSize="1.5em" />
-                <Skeleton isLoaded={!isConnectionsLoading}>
+          <Flex alignItems="center">
+            <Text textStyle="h6">{table.name}</Text>
+          </Flex>
+          <Flex {...flexStyles.container}>
+            <Text {...textStyles.lastOpened}>
+              Last opened {toPrettyDateString(+table.lastAccessedAt)}
+            </Text>
+            {table.role !== 'viewer' && numConnections > 0 && (
+              <Skeleton isLoaded={!isConnectionsLoading}>
+                <Flex {...flexStyles.usedInPipes}>
+                  <Icon
+                    as={BsDot}
+                    color="interaction.success.default"
+                    sx={pulsingDotStyles}
+                  />
                   <Text>Used in {numConnections} pipes</Text>
-                </Skeleton>
-              </>
+                </Flex>
+              </Skeleton>
             )}
           </Flex>
         </Box>
         <Flex alignItems="center" gap={4}>
           {table.role === 'viewer' && (
-            <Tag
-              colorScheme="secondary"
-              size="xs"
-              variant="subtle"
-              py={2}
-              gap={1}
-              pointerEvents="none"
-            >
+            <Tag {...tagStyles}>
               <TagLeftIcon as={MdOutlineRemoveRedEye} />
               <TagLabel>View only</TagLabel>
             </Tag>
@@ -137,15 +137,42 @@ const TileListItem = ({
           )}
         </Flex>
       </Flex>
-      <MenuAlertDialog
-        isDialogOpen={isDialogOpen}
-        cancelRef={cancelRef}
-        onDialogClose={onDialogClose}
-        dialogHeader="Tile"
-        dialogType="delete"
-        onClick={deleteTile}
-        isLoading={isDeletingTable}
-      />
+      <AlertDialog
+        isOpen={isDialogOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onDialogClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader>Delete Tile</AlertDialogHeader>
+
+            <AlertDialogBody>
+              {numConnections > 0
+                ? `Are you sure? This Tile is used in ${numConnections} pipe(s). You can't undo this action afterwards.`
+                : "Are you sure? You can't undo this action afterwards."}
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button
+                ref={cancelRef}
+                onClick={onDialogClose}
+                variant="clear"
+                colorScheme="secondary"
+              >
+                Cancel
+              </Button>
+              <Button
+                colorScheme="critical"
+                onClick={deleteTile}
+                ml={3}
+                isLoading={isDeletingTable}
+              >
+                Delete
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
     </Link>
   )
 }

--- a/packages/frontend/src/pages/Tiles/components/style.ts
+++ b/packages/frontend/src/pages/Tiles/components/style.ts
@@ -1,0 +1,64 @@
+import { FlexProps } from '@chakra-ui/react'
+
+export const flexStyles = {
+  container: {
+    color: 'base.content.medium',
+    direction: {
+      base: 'column',
+      md: 'row',
+    } as FlexProps['direction'],
+    textStyle: 'body-2',
+  },
+  usedInPipes: {
+    alignItems: 'center',
+    marginLeft: { base: 0, md: '-0.25em' },
+  },
+}
+
+export const linkStyles = {
+  px: 8,
+  py: 6,
+  w: '100%',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  _hover: {
+    bg: 'interaction.muted.neutral.hover',
+    '& .hover-remove-button': {
+      visibility: 'visible',
+    },
+  },
+  _active: {
+    bg: 'interaction.muted.neutral.active',
+  },
+}
+
+export const pulsingDotStyles = {
+  animation: 'pulse 2s infinite',
+  fontSize: '3em',
+  marginLeft: { base: '-0.4em', md: 0 },
+  marginTop: '-0.5em',
+  marginBottom: '-0.5em',
+  '@keyframes pulse': {
+    '0%': { opacity: 0.4 },
+    '50%': { opacity: 1 },
+    '100%': { opacity: 0.4 },
+  },
+}
+
+export const tagStyles = {
+  colorScheme: 'secondary',
+  size: 'xs',
+  variant: 'subtle',
+  py: 2,
+  gap: 1,
+  pointerEvents: 'none' as const,
+}
+
+export const textStyles = {
+  lastOpened: {
+    width: {
+      base: 'full',
+      md: '17.5em',
+    },
+  },
+}

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -87,8 +87,19 @@ export default function Tiles(): JSX.Element {
     variables: queryVars,
   })
 
-  const { pageInfo, edges } = data?.getTables ?? {}
-  const tilesToDisplay = edges?.map(({ node }) => node) ?? []
+  const { pageInfo, edges = [] } = data?.getTables ?? {}
+
+  const { tilesToDisplay, tableIds } = edges.reduce<{
+    tilesToDisplay: TableMetadata[]
+    tableIds: string[]
+  }>(
+    (acc, { node }) => {
+      acc.tilesToDisplay.push(node)
+      acc.tableIds.push(node.id)
+      return acc
+    },
+    { tilesToDisplay: [], tableIds: [] },
+  )
 
   const hasNoUserTiles = tilesToDisplay.length === 0 && !isSearching
   const totalCount: number = pageInfo?.totalCount ?? 0
@@ -97,7 +108,7 @@ export default function Tiles(): JSX.Element {
   const { data: connectionsData, loading: isConnectionsLoading } = useQuery<{
     getTableConnections: JSON
   }>(GET_TABLE_CONNECTIONS, {
-    variables: queryVars,
+    variables: { tableIds },
     skip: hasNoUserTiles,
   })
   const tileConnections = connectionsData?.getTableConnections ?? {}

--- a/packages/frontend/src/pages/Tiles/index.tsx
+++ b/packages/frontend/src/pages/Tiles/index.tsx
@@ -9,6 +9,7 @@ import NoResultFound from '@/components/NoResultFound'
 import PageTitle from '@/components/PageTitle'
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { PaginatedTables, TableMetadata } from '@/graphql/__generated__/graphql'
+import { GET_TABLE_CONNECTIONS } from '@/graphql/queries/tiles/get-table-connections'
 import { GET_TABLES } from '@/graphql/queries/tiles/get-tables'
 import { usePaginationAndFilter } from '@/hooks/usePaginationAndFilter'
 
@@ -20,13 +21,24 @@ const TILES_TITLE = 'Tiles'
 
 const TILES_PER_PAGE = 10
 
+export interface TileConnections {
+  [key: string]: number
+}
 interface TilesContentProps {
   isLoading: boolean
   isSearching: boolean
+  isConnectionsLoading: boolean
   tiles: TableMetadata[]
+  tileConnections: TileConnections
 }
 
-function TilesContent({ isLoading, isSearching, tiles }: TilesContentProps) {
+function TilesContent({
+  isConnectionsLoading,
+  isLoading,
+  isSearching,
+  tileConnections,
+  tiles,
+}: TilesContentProps) {
   const hasTiles = tiles.length > 0
 
   const hasNoUserTiles = !hasTiles && !isSearching
@@ -51,20 +63,28 @@ function TilesContent({ isLoading, isSearching, tiles }: TilesContentProps) {
       />
     )
   }
-  return <TileList tiles={tiles} />
+  return (
+    <TileList
+      isConnectionsLoading={isConnectionsLoading}
+      tileConnections={tileConnections}
+      tiles={tiles}
+    />
+  )
 }
 
 export default function Tiles(): JSX.Element {
   const { input, page, setSearchParams, isSearching } = usePaginationAndFilter()
 
+  const queryVars = {
+    limit: TILES_PER_PAGE,
+    offset: (page - 1) * TILES_PER_PAGE,
+    name: input,
+  }
+
   const { data, loading } = useQuery<{
     getTables: PaginatedTables
   }>(GET_TABLES, {
-    variables: {
-      limit: TILES_PER_PAGE,
-      offset: (page - 1) * TILES_PER_PAGE,
-      name: input,
-    },
+    variables: queryVars,
   })
 
   const { pageInfo, edges } = data?.getTables ?? {}
@@ -73,6 +93,14 @@ export default function Tiles(): JSX.Element {
   const hasNoUserTiles = tilesToDisplay.length === 0 && !isSearching
   const totalCount: number = pageInfo?.totalCount ?? 0
   const hasPagination = !loading && pageInfo && totalCount > TILES_PER_PAGE
+
+  const { data: connectionsData, loading: isConnectionsLoading } = useQuery<{
+    getTableConnections: JSON
+  }>(GET_TABLE_CONNECTIONS, {
+    variables: queryVars,
+    skip: hasNoUserTiles,
+  })
+  const tileConnections = connectionsData?.getTableConnections ?? {}
 
   // ensure invalid pages won't be accessed even after deleting tiles
   const lastPage = Math.ceil(totalCount / TILES_PER_PAGE)
@@ -99,8 +127,10 @@ export default function Tiles(): JSX.Element {
       />
 
       <TilesContent
+        isConnectionsLoading={isConnectionsLoading}
         isLoading={loading}
         isSearching={isSearching}
+        tileConnections={tileConnections}
         tiles={tilesToDisplay}
       />
 


### PR DESCRIPTION
## Problem
Pipes are failing when users accidentally delete Tiles that are connected to existing Pipes.

Closes [PLU-310: show connected pipes to tiles](https://linear.app/ogp/issue/PLU-310/show-connected-pipes-to-tiles)

## Solution
Display the number of Pipes using the Tile, including Pipes of current user and collaborators of the Tile.

**Improvements**:
- Removed unnecessary menu button (current menu only shows "View" / "Delete")
  - User can view the Tile by clicking on the row
  - Delete button will be made visible to Tile owners when they hover a Tile

## Before & After Screenshots

**BEFORE**:
<img width="1512" alt="Screenshot 2024-11-15 at 3 05 26 PM" src="https://github.com/user-attachments/assets/235e190d-fdd5-47a4-b0d7-23c7a2b13ca5">


**AFTER**:
- Show number of Pipes and remove menu
<img width="1512" alt="Screenshot 2024-11-15 at 3 06 03 PM" src="https://github.com/user-attachments/assets/817af8d3-725d-47fc-a044-e2a096603a64">

- Show delete icon on hover
<img width="1512" alt="Screenshot 2024-11-15 at 3 06 46 PM" src="https://github.com/user-attachments/assets/b087596b-1fac-4c5e-ac06-83a4c7e37cc6">


## Tests
- [x] Number of Pipes displayed is correct, including pipes of Tile collaborators
- [x] Able to view Tiles for all roles (Owner / Editor / Viewer)
- [x] Able to delete Tiles


**New scripts**:
- `packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts` : tests for retrieving table connections
- `packages/backend/src/graphql/queries/tiles/get-table-connections.ts` : query for retrieving table connections
- `packages/frontend/src/graphql/queries/tiles/get-table-connections.ts` : query for retrieving table connections

