### PR TITLE
chore: remove yy/LL/dd formatter date format

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -35,7 +35,6 @@ describe('convert date time', () => {
     { toFormat: 'dd/LL/yyyy', expectedResult: '01/04/2024' },
     { toFormat: 'dd LLL yyyy', expectedResult: '01 Apr 2024' },
     { toFormat: 'dd LLLL yyyy', expectedResult: '01 April 2024' },
-    { toFormat: 'yy/LL/dd', expectedResult: '24/04/01' },
     { toFormat: 'yyyy/LL/dd', expectedResult: '2024/04/01' },
     { toFormat: 'hh:mm a', expectedResult: '12:05 pm' },
     { toFormat: 'hh:mm:ss a', expectedResult: '12:05:10 pm' },

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -9,7 +9,6 @@ const formatStringsEnum = z.enum([
   'dd/LL/yyyy',
   'dd LLL yyyy',
   'dd LLLL yyyy',
-  'yy/LL/dd',
   'yyyy/LL/dd',
   'hh:mm a',
   'hh:mm:ss a',
@@ -48,11 +47,6 @@ export const field = {
       label: 'DD MMMM YYYY',
       description: '02 January 2006',
       value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
-    },
-    {
-      label: 'YY/MM/DD',
-      description: '24/01/22',
-      value: ensureZodEnumValue(formatStringsEnum, 'yy/LL/dd'),
     },
     {
       label: 'YYYY/MM/DD',


### PR DESCRIPTION
## Problem

Realised that we have conflicting formats `dd/LL/yy` vs `yy/LL/dd` and it could pose as a problem when people use this format later in a delay step

## Solution

Remove the `yy/LL/dd` datetime format

## Regression test
- Check that prod doesn't have any steps that uses this date format thankfully (only 2 but both are deleted)
Simple query:
```
SELECT
	*
FROM
	steps
WHERE
	key = 'dateTime'
	and parameters::text ilike '%"formatDateTimeToFormat": "yy/LL/dd"%''
```

