### PR TITLE
PLU-329: allow cc email address for postman

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -225,6 +225,25 @@ describe('send transactional email', () => {
     })
   })
 
+  it('should send to CC recipients', async () => {
+    const recipients = ['recipient1@open.gov.sg', 'recipient2@open.gov.sg']
+    const ccRecipients = ['cc1@open.gov.sg', 'cc2@open.gov.sg']
+    $.step.parameters.destinationEmail = recipients.join(',')
+    $.step.parameters.destinationEmailCc = ccRecipients.join(',')
+    await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        status: ['ACCEPTED', 'ACCEPTED'],
+        recipient: recipients,
+        subject: 'test subject',
+        body: 'test body',
+        cc: ccRecipients,
+        from: 'jack',
+        reply_to: 'replyTo@open.gov.sg',
+      },
+    })
+  })
+
   it('should throw partial step error if one succeeds while the rest are blacklists', async () => {
     const recipients = ['recipient1@open.gov.sg', 'recipient2@open.gov.sg']
     $.step.parameters.destinationEmail = recipients.join(',')

--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -129,4 +129,30 @@ describe('postman transactional email schema zod validation', () => {
     assert(result.success === true)
     expect(result.data.body).toBe('hello<br>hihi')
   })
+
+  it('should validate multiple valid CC emails', () => {
+    validPayload.destinationEmailCc =
+      'recipient@example.com, recipient2@example.com,recipient3@example.com'
+    const result = transactionalEmailSchema.safeParse(validPayload)
+    assert(result.success === true) // using assert here for type assertion
+    expect(result.data.destinationEmailCc).toEqual([
+      'recipientCc@example.com',
+      'recipientCc2@example.com',
+      'recipientCc3@example.com',
+    ])
+  })
+
+  const invalidCcRecipients: string[][] = [
+    ['invalid-cc-recipient'],
+    ['invalid-cc-recipient2', 'valid@email.com'],
+  ]
+  it.each(invalidCcRecipients)(
+    'should fail if invalid CC recipient',
+    (...ccRecipients: string[]) => {
+      validPayload.destinationEmailCc = ccRecipients.join(',')
+      const result = transactionalEmailSchema.safeParse(validPayload)
+      assert(result.success === false)
+      expect(result.error?.errors[0].message).toEqual('Invalid CC emails')
+    },
+  )
 })

--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -132,7 +132,7 @@ describe('postman transactional email schema zod validation', () => {
 
   it('should validate multiple valid CC emails', () => {
     validPayload.destinationEmailCc =
-      'recipient@example.com, recipient2@example.com,recipient3@example.com'
+      'recipientCc@example.com, recipientCc2@example.com,recipientCc3@example.com'
     const result = transactionalEmailSchema.safeParse(validPayload)
     assert(result.success === true) // using assert here for type assertion
     expect(result.data.destinationEmailCc).toEqual([

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -35,12 +35,14 @@ const action: IRawAction = {
       subject,
       body,
       destinationEmail,
+      destinationEmailCc,
       senderName,
       replyTo,
       attachments = [],
     } = $.step.parameters
     const result = transactionalEmailSchema.safeParse({
       destinationEmail,
+      destinationEmailCc,
       senderName,
       subject,
       body,
@@ -112,6 +114,7 @@ const action: IRawAction = {
           /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
           '<p style="margin: 0">&nbsp;</p>',
         ),
+        ccList: result.data.destinationEmailCc,
         replyTo: result.data.replyTo,
         senderName: result.data.senderName,
         attachments: attachmentFiles,

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -89,7 +89,7 @@ export async function sendTransactionalEmails(
       `${email.senderName} <${appConfig.postman.fromAddress}>`,
     )
     requestData.append('disable_tracking', 'true')
-    if (email.ccList?.length) {
+    if (email.ccList?.length > 0) {
       requestData.append('cc', JSON.stringify(email.ccList))
     }
 

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -89,13 +89,7 @@ export async function sendTransactionalEmails(
       `${email.senderName} <${appConfig.postman.fromAddress}>`,
     )
     requestData.append('disable_tracking', 'true')
-
-    if (email.ccList?.length) {
-      // For single CC, send as JSON array. For multiple CCs, append individually
-      email.ccList.length === 1
-        ? requestData.append('cc', JSON.stringify(email.ccList))
-        : email.ccList.forEach((value) => requestData.append('cc', value))
-    }
+    requestData.append('cc', JSON.stringify(email.ccList))
 
     if (email.replyTo) {
       requestData.append('reply_to', email.replyTo)

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -55,6 +55,7 @@ interface Email {
   senderName: string
   attachments?: { fileName: string; data: Uint8Array }[]
   replyTo?: string
+  ccList?: string[]
 }
 
 interface PostmanPromiseFulfilled {
@@ -89,6 +90,13 @@ export async function sendTransactionalEmails(
     )
     requestData.append('disable_tracking', 'true')
 
+    if (email.ccList?.length) {
+      // For single CC, send as JSON array. For multiple CCs, append individually
+      email.ccList.length === 1
+        ? requestData.append('cc', JSON.stringify(email.ccList))
+        : email.ccList.forEach((value) => requestData.append('cc', value))
+    }
+
     if (email.replyTo) {
       requestData.append('reply_to', email.replyTo)
     }
@@ -122,6 +130,7 @@ export async function sendTransactionalEmails(
           subject,
           from,
           reply_to,
+          ...(email.ccList?.length && { cc: email.ccList }),
         },
       } satisfies PostmanPromiseFulfilled
     } catch (e) {

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -89,7 +89,9 @@ export async function sendTransactionalEmails(
       `${email.senderName} <${appConfig.postman.fromAddress}>`,
     )
     requestData.append('disable_tracking', 'true')
-    requestData.append('cc', JSON.stringify(email.ccList))
+    if (email.ccList?.length) {
+      requestData.append('cc', JSON.stringify(email.ccList))
+    }
 
     if (email.replyTo) {
       requestData.append('reply_to', email.replyTo)

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -47,7 +47,7 @@ export const transactionalEmailFields: IField[] = [
     type: 'string' as const,
     required: true,
     description:
-      'To send to multiple recipients, comma-separate email addresses. Emails will be sent to each email address separately.',
+      'Enter the email addresses of the main recipients, separated by commas.\nEach recipient will receive an individual email.',
     variables: true,
   },
   {
@@ -56,7 +56,7 @@ export const transactionalEmailFields: IField[] = [
     type: 'string' as const,
     required: false,
     description:
-      'To CC multiple recipients, comma-separate email addresses. CC recipients will receive multiple copies of the email.',
+      'Enter the email addresses to CC, separated by commas.\nCC recipients will receive a copy of the email for each main recipient.',
     variables: true,
   },
   {
@@ -64,7 +64,7 @@ export const transactionalEmailFields: IField[] = [
     key: 'senderName',
     type: 'string' as const,
     required: true,
-    description: 'For e.g., HR department',
+    description: 'For e.g., HR department.',
     variables: true,
   },
   {
@@ -72,7 +72,7 @@ export const transactionalEmailFields: IField[] = [
     key: 'replyTo',
     type: 'string' as const,
     required: false,
-    description: 'If left blank, this will default to your email address',
+    description: 'If left blank, this will default to your email address.',
     variables: true,
   },
   {

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -15,6 +15,17 @@ function recipientStringToArray(value: string) {
   return uniq(recipientArray)
 }
 
+function validateEmails(value: string, ctx: z.RefinementCtx, msg: string) {
+  const recipients = recipientStringToArray(value)
+  if (recipients.some((recipient) => !validator.validate(recipient))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: msg,
+    })
+  }
+  return recipients
+}
+
 export const transactionalEmailFields: IField[] = [
   {
     label: 'Email subject',
@@ -37,6 +48,15 @@ export const transactionalEmailFields: IField[] = [
     required: true,
     description:
       'To send to multiple recipients, comma-separate email addresses. Emails will be sent to each email address separately.',
+    variables: true,
+  },
+  {
+    label: 'CC recipient email(s)',
+    key: 'destinationEmailCc',
+    type: 'string' as const,
+    required: false,
+    description:
+      'To CC multiple recipients, comma-separate email addresses. CC recipients will receive multiple copies of the email.',
     variables: true,
   },
   {
@@ -74,16 +94,15 @@ export const transactionalEmailSchema = z.object({
     .min(1, { message: 'Empty body' })
     // for backward-compatibility with content produced by the old editor
     .transform((v) => v.replace(/\n/g, '<br>')),
-  destinationEmail: z.string().transform((value, ctx) => {
-    const recipients = recipientStringToArray(value)
-    if (recipients.some((recipient) => !validator.validate(recipient))) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Invalid recipient emails',
-      })
-    }
-    return recipients
-  }),
+  destinationEmail: z
+    .string()
+    .transform((value, ctx) =>
+      validateEmails(value, ctx, 'Invalid recipient emails'),
+    ),
+  destinationEmailCc: z
+    .string()
+    .transform((value, ctx) => validateEmails(value, ctx, 'Invalid CC emails'))
+    .optional(),
   replyTo: z.preprocess((value) => {
     if (typeof value !== 'string') {
       return value

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -283,7 +283,11 @@ const RichTextEditor = ({
   return (
     <FormControl flex={1} style={customStyle} data-test="text-input-group">
       {label && (
-        <FormLabel isRequired={required} description={description}>
+        <FormLabel
+          isRequired={required}
+          description={description}
+          style={{ whiteSpace: 'pre-wrap' }}
+        >
           {label}
         </FormLabel>
       )}


### PR DESCRIPTION
## Problem
Email by Postman does not support CC.

## Solution
Add CC recipients field.

## Before & After Screenshots
**BEFORE**:
<img width="860" alt="Screenshot 2024-11-26 at 11 58 52 AM" src="https://github.com/user-attachments/assets/7e181fef-6e6d-444a-8fe5-4a8e100f5c7f">

**AFTER**:
<img width="855" alt="Screenshot 2024-11-26 at 12 01 38 PM" src="https://github.com/user-attachments/assets/46cfa69f-a643-4dd9-8ef1-b117bc33f04f">


## Tests
- [x] Existing email functionality works
- [x] Emails can be sent without CC recipients
- [x] Emails can be sent to 1 or many CC recipients
