### PR TITLE
PLU-353: chore: Show proper error when tiles is deleted

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
@@ -83,4 +83,14 @@ describe('tiles create row action', () => {
     $.user = viewer
     await expect(createRowAction.run($)).rejects.toThrow(StepError)
   })
+
+  it('should throw correct error if Tile deleted', async () => {
+    $.user = editor
+    await TableMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ id: $.step.parameters.tableId })
+    await expect(createRowAction.run($)).rejects.toThrow(StepError)
+  })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -10,6 +10,7 @@ import {
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import { createTableRow, TableRowFilter } from '@/models/dynamodb/table-row'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -89,6 +90,21 @@ describe('tiles create row action', () => {
 
   it('should not allow viewers to find single row', async () => {
     $.user = viewer
+    await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should throw correct error if Tile deleted', async () => {
+    $.user = editor
+    await TableMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ id: $.step.parameters.tableId })
+    await TableColumnMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ table_id: $.step.parameters.tableId })
     await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -10,6 +10,7 @@ import {
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import { createTableRow } from '@/models/dynamodb/table-row'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -90,6 +91,26 @@ describe('tiles create row action', () => {
 
   it('should not allow viewers to update row', async () => {
     $.user = viewer
+    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should throw error if no tableId', async () => {
+    $.step.parameters.tableId = ''
+    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should throw correct error if Tile deleted', async () => {
+    $.user = editor
+    await TableMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ id: $.step.parameters.tableId })
+    await TableColumnMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ table_id: $.step.parameters.tableId })
     await expect(updateRowAction.run($)).rejects.toThrow(StepError)
   })
 })

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -97,6 +97,14 @@ const action: IRawAction = {
     await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     const table = await TableMetadata.query().findById(tableId)
+    if (!table) {
+      throw new StepError(
+        'Tile not found',
+        'Tile may have been deleted. Please check your tile.',
+        $.step.position,
+        'tiles',
+      )
+    }
 
     /**
      * convert array to object

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -94,8 +94,6 @@ const action: IRawAction = {
       rowData: { columnId: string; cellValue: string }[]
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
-
     const table = await TableMetadata.query().findById(tableId)
     if (!table) {
       throw new StepError(
@@ -105,6 +103,8 @@ const action: IRawAction = {
         'tiles',
       )
     }
+
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     /**
      * convert array to object

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -120,7 +120,7 @@ const action: IRawAction = {
         'Invalid column ID(s)',
         'Column(s) may have been deleted or modified. Please check your tile and pipe setup.',
         $.step.position,
-        'tiles',
+        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -149,11 +149,12 @@ const action: IRawAction = {
       returnLastRow: boolean | undefined
     }
 
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+    /**
+     * Check for columns first, there will not be any columns if the tile has been deleted.
+     */
+    const columns = await TableColumnMetadata.getColumns(tableId, $)
 
-    const columns = await TableColumnMetadata.query().where({
-      table_id: tableId,
-    })
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     // Check that filters are valid
     try {

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -108,6 +108,12 @@ const action: IRawAction = {
       )
     }
 
+    /**
+     * Check for columns first, there will not be any columns if the tile has been deleted.
+     */
+    const columns = await TableColumnMetadata.getColumns(tableId, $)
+    const columnIds = columns.map((c) => c.id)
+
     await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     /**
@@ -122,13 +128,6 @@ const action: IRawAction = {
       })
       return
     }
-
-    const columns = await TableColumnMetadata.query()
-      .where({
-        table_id: tableId,
-      })
-      .select('id', 'name')
-    const columnIds = columns.map((c) => c.id)
 
     const row = await getRawRowById({
       tableId,

--- a/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
+++ b/packages/backend/src/apps/tiles/dynamic-data/list-columns.ts
@@ -26,7 +26,9 @@ const dynamicData: IDynamicData = {
         .$relatedQuery('tables')
         .findById($.step.parameters.tableId as string)
         .whereIn('role', ['owner', 'editor'])
-        .throwIfNotFound()
+        .throwIfNotFound({
+          message: 'Tile may have been deleted. Please check your tile.',
+        })
       const columns = await tile
         .$relatedQuery('columns')
         .orderBy('position', 'asc')
@@ -38,14 +40,17 @@ const dynamicData: IDynamicData = {
           name: name,
         })),
       }
-    } catch (e) {
-      logger.error('Tiles dynamic data: list columns error', {
-        userId: $.user?.id,
-        tableId: $.step.parameters.tableId,
-        flowId: $.flow?.id,
-        stepId: $.step?.id,
-      })
-      throw new Error('Unable to fetch columns')
+    } catch (err) {
+      logger.error(
+        err.data.message ?? 'Tiles dynamic data: list columns error',
+        {
+          userId: $.user?.id,
+          tableId: $.step.parameters.tableId,
+          flowId: $.flow?.id,
+          stepId: $.step?.id,
+        },
+      )
+      throw new Error(err.data.message ?? 'Unable to fetch columns')
     }
   },
 }

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteTable from '@/graphql/mutations/tiles/delete-table'
+import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -35,7 +36,7 @@ describe('delete table mutation', () => {
     })
   })
 
-  it('should delete table and columns', async () => {
+  it('should delete table, columns and collaborators', async () => {
     const success = await deleteTable(
       null,
       { input: { id: dummyTable.id } },
@@ -46,9 +47,13 @@ describe('delete table mutation', () => {
       .resultSize()
 
     const deletedTable = await TableMetadata.query().findById(dummyTable.id)
+    const tableCollaborators = await TableCollaborator.query().where({
+      table_id: dummyTable.id,
+    })
     expect(success).toBe(true)
     expect(deletedTable).toBeUndefined()
     expect(tableColumnCount).toBe(0)
+    expect(tableCollaborators.length).toBe(0)
   })
 
   it('should throw an error if table is not found', async () => {

--- a/packages/backend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table.ts
@@ -20,6 +20,9 @@ const deleteTable: MutationResolvers['deleteTable'] = async (
       .throwIfNotFound()
 
     await table.$relatedQuery('columns', trx).delete()
+    await TableCollaborator.query().where({ table_id: params.input.id }).patch({
+      deletedAt: new Date().toISOString(),
+    })
     await table.$query(trx).delete()
   })
 

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -38,18 +38,16 @@ class TableColumnMetadata extends Base {
   })
 
   static getColumns = async (tableId: string, $?: IGlobalVariable) => {
-    const columns = await TableColumnMetadata.query()
-      .where({
-        table_id: tableId,
-      })
-      .debug()
+    const columns = await TableColumnMetadata.query().where({
+      table_id: tableId,
+    })
 
     if (columns.length === 0) {
       throw new StepError(
         'Tile not found',
         'Tile may have been deleted. Please check your tile.',
         $.step.position,
-        'tiles',
+        $.app.name,
       )
     }
     return columns

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -1,4 +1,6 @@
-import { ITableColumnConfig } from '@plumber/types'
+import { IGlobalVariable, ITableColumnConfig } from '@plumber/types'
+
+import StepError from '@/errors/step'
 
 import Base from './base'
 import TableMetadata from './table-metadata'
@@ -34,6 +36,24 @@ class TableColumnMetadata extends Base {
       },
     },
   })
+
+  static getColumns = async (tableId: string, $?: IGlobalVariable) => {
+    const columns = await TableColumnMetadata.query()
+      .where({
+        table_id: tableId,
+      })
+      .debug()
+
+    if (columns.length === 0) {
+      throw new StepError(
+        'Tile not found',
+        'Tile may have been deleted. Please check your tile.',
+        $.step.position,
+        'tiles',
+      )
+    }
+    return columns
+  }
 }
 
 export default TableColumnMetadata


### PR DESCRIPTION
## Problem
Error message is unclear when Tile has been deleted.

## Solution
Add specific error message for when Tile has been deleted.

**Improvements**:
- Detailed error message for to inform user that Tile has been deleted and to check on Tile
- Soft delete table collaborators when Tile is deleted

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/user-attachments/assets/b9ed8966-db1d-4775-a7a7-46e2f75546ac)
<img width="1512" alt="Screenshot 2024-11-27 at 11 59 52 AM" src="https://github.com/user-attachments/assets/e99a3dff-93b6-430e-8ba6-cbc6080383cc">
<img width="1512" alt="Screenshot 2024-11-27 at 12 02 27 PM" src="https://github.com/user-attachments/assets/c4fb46eb-4378-49b4-85fa-c6a2f5d849ba">

**AFTER**:
![image](https://github.com/user-attachments/assets/01f15ab5-0662-4c42-9e13-55f4e15093ca)
<img width="1512" alt="Screenshot 2024-11-27 at 1 57 55 PM" src="https://github.com/user-attachments/assets/d5c04c53-faaa-4fc1-8720-a53de1e44c0d">


## Tests
- [x] Existing pipes run without issues
- [x] Error is shown during pipe creation
- [x] Error is shown for failed pipe execution
