### PR TITLE
fix: do not do partial retries in test runs

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -463,8 +463,47 @@ describe('send transactional email', () => {
         recipient: recipients,
       },
     })
+    $.execution.testRun = false
     await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
     expect($.http.post).toBeCalledTimes(4)
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        status: ['ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED'],
+        recipient: recipients,
+        subject: 'test subject',
+        body: 'test body',
+        from: 'jack',
+        reply_to: 'replyTo@open.gov.sg',
+      },
+    })
+  })
+
+  it('should send to all recipients in test runs', async () => {
+    const recipients = [
+      'recipient1@open.gov.sg',
+      'recipient2@open.gov.sg',
+      'recipient3@open.gov.sg',
+      'recipient4@open.gov.sg',
+      'recipient5@open.gov.sg',
+    ]
+    $.step.parameters.destinationEmail = recipients.join(',')
+    $.getLastExecutionStep = vi.fn().mockResolvedValueOnce({
+      status: 'success',
+      errorDetails: 'error error',
+      dataOut: {
+        status: [
+          'BLACKLISTED',
+          'ACCEPTED',
+          'INTERMITTENT-ERROR',
+          'ERROR',
+          'RATE-LIMITED',
+        ],
+        recipient: recipients,
+      },
+    })
+    $.execution.testRun = true
+    await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+    expect($.http.post).toBeCalledTimes(5)
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
         status: ['ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED'],

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -96,7 +96,10 @@ const action: IRawAction = {
       lastExecutionStep?.dataOut,
     )
     const isPartialRetry =
-      prevDataOutParseResult.success && lastExecutionStep.errorDetails
+      prevDataOutParseResult.success &&
+      lastExecutionStep.errorDetails &&
+      // Don't do partial retry in test runs! always send to all recipients
+      !$.execution.testRun
 
     if (isPartialRetry) {
       const { status, recipient } = prevDataOutParseResult.data


### PR DESCRIPTION
## Problem
 
Postman actions cannot be re-tested when a partial success happened in the last test step.


## Solution

Prevent partial retries in test runs.