### PR TITLE
chore: change postman credentials

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -34,6 +34,10 @@
     },
     {
       "name": "POSTMAN_FROM_ADDRESS",
+      "value": "info@plumber.gov.sg"
+    },
+    {
+      "name": "POSTMAN_OLD_FROM_ADDRESS",
       "value": "donotreply@plumber.gov.sg"
     },
     {
@@ -109,6 +113,10 @@
     {
       "name": "POSTMAN_API_KEY",
       "valueFrom": "plumber-<ENVIRONMENT>-postman-api-key"
+    },
+    {
+      "name": "POSTMAN_OLD_API_KEY",
+      "valueFrom": "plumber-<ENVIRONMENT>-postman-old-api-key"
     },
     {
       "name": "FORMSG_API_KEY",

--- a/packages/backend/.env-example
+++ b/packages/backend/.env-example
@@ -20,6 +20,7 @@ REDIS_CLUSTER_MODE=false
 ENABLE_BULLMQ_DASHBOARD=false
 ADMIN_USER_EMAIL=admin@example.gov.sg
 POSTMAN_API_KEY=api_key
+POSTMAN_OLD_API_KEY=api_key
 FORMSG_API_KEY=sample-formsg-api-key
 FORMSG_STAGING_API_KEY=sample-formsg-api-key
 FORMSG_UAT_API_KEY=sample-formsg-api-key

--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   getObjectFromS3Id: vi.fn(),
   getDefaultReplyTo: vi.fn(() => 'replyTo@open.gov.sg'),
   sendBlacklistEmail: vi.fn(),
+  getLdFlagValue: vi.fn(),
 }))
 
 vi.mock('@/helpers/s3', async () => {
@@ -34,6 +35,10 @@ vi.mock('../../common/parameters-helper', () => ({
 vi.mock('../../common/send-blacklist-email', () => ({
   sendBlacklistEmail: mocks.sendBlacklistEmail,
   createRequestBlacklistFormLink: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
 }))
 
 describe('send transactional email', () => {

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -5,6 +5,7 @@ import { sortBy } from 'lodash'
 
 import appConfig from '@/config/app'
 import HttpError from '@/errors/http'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 
 import {
   PostmanEmailDataOut,
@@ -79,6 +80,12 @@ export async function sendTransactionalEmails(
   errorStatus?: PostmanEmailSendStatus
   error?: HttpError
 }> {
+  const shouldUseNewCredentials = await getLdFlagValue<boolean>(
+    'new_postman_credentials',
+    'plumber@open.gov.sg', // mock email
+    false,
+  )
+
   const promises = recipients.map(async (recipientEmail) => {
     const requestData = new FormData()
     requestData.append('subject', email.subject)
@@ -86,7 +93,11 @@ export async function sendTransactionalEmails(
     requestData.append('recipient', recipientEmail)
     requestData.append(
       'from',
-      `${email.senderName} <${appConfig.postman.fromAddress}>`,
+      `${email.senderName} <${
+        shouldUseNewCredentials
+          ? appConfig.postman.fromAddress
+          : appConfig.postman.oldFromAddress
+      }>`,
     )
     requestData.append('disable_tracking', 'true')
     if (email.ccList?.length > 0) {
@@ -112,7 +123,11 @@ export async function sendTransactionalEmails(
         {
           headers: {
             ...requestData.getHeaders(),
-            Authorization: `Bearer ${appConfig.postman.apiKey}`,
+            Authorization: `Bearer ${
+              shouldUseNewCredentials
+                ? appConfig.postman.apiKey
+                : appConfig.postman.oldApiKey
+            }`,
           },
         },
       )

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -36,6 +36,8 @@ type AppConfig = {
     apiKey: string
     fromAddress: string
     rateLimit: number
+    oldApiKey: string
+    oldFromAddress: string
   }
   isWorker: boolean
   workerActionConcurrency: number
@@ -100,9 +102,11 @@ const appConfig: AppConfig = {
   },
   postman: {
     apiKey: process.env.POSTMAN_API_KEY,
-    fromAddress:
-      process.env.POSTMAN_FROM_ADDRESS || 'donotreply@plumber.gov.sg',
+    fromAddress: process.env.POSTMAN_FROM_ADDRESS || 'info@plumber.gov.sg',
     rateLimit: parseInt(process.env.POSTMAN_RATE_LIMIT) || 169,
+    oldApiKey: process.env.POSTMAN_OLD_API_KEY,
+    oldFromAddress:
+      process.env.POSTMAN_OLD_FROM_ADDRESS || 'donotreply@plumber.gov.sg',
   },
   launchDarklySdkKey: process.env.LAUNCH_DARKLY_SDK_KEY,
   maxJobAttempts: Number(process.env.MAX_JOB_ATTEMPTS ?? '10'),
@@ -122,6 +126,10 @@ if (!appConfig.adminJwtSecretKey) {
 
 if (!appConfig.postman.apiKey) {
   throw new Error('POSTMAN_API_KEY environment variable needs to be set!')
+}
+
+if (!appConfig.postman.oldApiKey) {
+  throw new Error('POSTMAN_OLD_API_KEY environment variable needs to be set!')
 }
 
 if (

--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -3,6 +3,7 @@ import axios from 'axios'
 import appConfig from '@/config/app'
 import HttpError from '@/errors/http'
 
+import { getLdFlagValue } from './launch-darkly'
 import logger from './logger'
 
 export interface PostmanEmailRequestBody {
@@ -19,20 +20,34 @@ export async function sendEmail({
   replyTo,
 }: PostmanEmailRequestBody): Promise<void> {
   try {
+    const shouldUseNewCredentials = await getLdFlagValue<boolean>(
+      'new_postman_credentials',
+      'plumber@open.gov.sg', // mock email
+      false,
+    )
+
     await axios.post(
       'https://api.postman.gov.sg/v1/transactional/email/send',
       {
         subject,
         body,
         recipient,
-        from: `Plumber <${appConfig.postman.fromAddress}>`,
+        from: `Plumber <${
+          shouldUseNewCredentials
+            ? appConfig.postman.fromAddress
+            : appConfig.postman.oldFromAddress
+        }>`,
         ...(replyTo && { reply_to: replyTo }),
         disable_tracking: true,
       },
       {
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${appConfig.postman.apiKey}`,
+          Authorization: `Bearer ${
+            shouldUseNewCredentials
+              ? appConfig.postman.apiKey
+              : appConfig.postman.oldApiKey
+          }`,
         },
       },
     )


### PR DESCRIPTION
## Problem

Right now, email is sent from `donotreply@plumber.gov.sg` but we want to change it to `info@plumber.gov.sg`

## Solution

Introduce a flag on LD to toggle between the old and new credentials
- Turn on to use new credentials
- This is in case the new credentials don't work, can easily use back the old credentials

Created a new group email: info@plumber.gov.sg, and ensured that two API keys are created for staging and prod respectively, with the rate limit of 250 applied to the user.

## TODO
- [x] Add to parameter store for staging and prod

## Tests
- [x] Check that email can be sent through test step
- [x] Check that OTP email can be sent
- [x] Check that blacklist and error emails can be sent

**New environment variables**:

- `POSTMAN_OLD_FROM_ADDRESS` : donotreply@plumber.gov.sg (this is the old from address)
- `POSTMAN_OLD_API_KEY`: for staging and prod