### PR TITLE
PLU-309: [TILES-ATOMIC-INCREMENT-3] enhance multirow-multicol UI with custom styles and operators

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -61,6 +61,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: false,
+          customStyle: { flex: 2 },
         },
         {
           placeholder: 'Value',
@@ -68,6 +69,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -69,7 +69,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -49,7 +49,7 @@ const action: IRawAction = {
     {
       label: 'Row data',
       key: 'rowData',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       description:
         'Enter the data to update the row with. Columns not specified will not be updated.',
       required: true,
@@ -79,6 +79,22 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 2 },
+        },
+        {
+          key: 'operator' as const,
+          type: 'dropdown' as const,
+          isSearchable: false,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          value: 'set',
+          options: [
+            { label: '=', value: 'set', description: 'Set as' },
+            { label: '+', value: 'add', description: 'Add by' },
+            { label: '-', value: 'subtract', description: 'Subtract by' },
+          ],
+          customStyle: { flexBasis: '44px' },
         },
         {
           placeholder: 'Value',
@@ -86,6 +102,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -79,7 +79,7 @@ const action: IRawAction = {
               },
             ],
           },
-          customStyle: { flex: 2 },
+          customStyle: { flex: 2, minWidth: 0 },
         },
         {
           key: 'operator' as const,
@@ -106,7 +106,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -91,10 +91,14 @@ const action: IRawAction = {
           value: 'set',
           options: [
             { label: '=', value: 'set', description: 'Set as' },
-            { label: '+', value: 'add', description: 'Add by' },
-            { label: '-', value: 'subtract', description: 'Subtract by' },
+            { label: '+', value: 'add', description: 'Add by (numbers only)' },
+            {
+              label: '-',
+              value: 'subtract',
+              description: 'Subtract by (numbers only)',
+            },
           ],
-          customStyle: { flexBasis: '44px' },
+          customStyle: { flexBasis: '71px' },
         },
         {
           placeholder: 'Value',

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -183,8 +183,10 @@ type ActionSubstepArgument {
   variables: Boolean
   variableTypes: [String]
   allowArbitrary: Boolean
+  isSearchable: Boolean
   placeholder: String
   showOptionValue: Boolean
+  customStyle: JSONObject
   options: [ArgumentOption]
   value: JSONObject
   source: ActionSubstepArgumentSource

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -23,6 +23,7 @@ export interface ControlledAutocompleteProps {
   required?: boolean
   placeholder?: string
   addNewOption?: IFieldDropdown['addNewOption']
+  isSearchable?: boolean
 }
 
 const formComboboxOptions = (
@@ -62,6 +63,7 @@ function ControlledAutocomplete(
     required,
     placeholder,
     addNewOption,
+    isSearchable,
   } = props
 
   const items = useMemo(
@@ -92,6 +94,7 @@ function ControlledAutocomplete(
     name,
     control,
     rules: { required },
+    // fixme: this default value is not working as expected
     defaultValue: defaultValue ?? '',
   })
 
@@ -146,14 +149,14 @@ function ControlledAutocomplete(
       )}
       {/* Dropdown row option content */}
       <Flex>
-        <Box flexGrow={1}>
+        <Box flex={1}>
           <SingleSelect
             name="choose-dropdown-option"
             colorScheme="secondary"
             isClearable={!required}
             items={items}
             onChange={fieldOnChange}
-            value={fieldValue}
+            value={fieldValue ?? defaultValue}
             placeholder={placeholder}
             ref={ref}
             data-test={`${name}-autocomplete`}
@@ -161,6 +164,7 @@ function ControlledAutocomplete(
             isRefreshLoading={loading}
             freeSolo={freeSolo}
             isReadOnly={isCreatingNewOption}
+            isSearchable={isSearchable}
             addNew={
               addNewOption
                 ? {

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -87,6 +87,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     const preparedOptions = schema.options || optionGenerator(data)
     return (
       <ControlledAutocomplete
+        isSearchable={schema.isSearchable ?? true}
         name={computedName}
         required={required}
         freeSolo={schema.allowArbitrary}
@@ -130,9 +131,6 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           disabled={disabled}
           placeholder={placeholder}
           isSingleLine={parentType === 'multicol'}
-          customStyle={
-            parentType === 'multicol' ? { flex: 1, minWidth: 0 } : {}
-          }
           variablesEnabled
         />
       )
@@ -152,7 +150,6 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         clickToCopy={clickToCopy}
         autoComplete={schema.autoComplete}
-        customStyle={parentType === 'multicol' ? { flex: 0.5 } : {}}
       />
     )
   }

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -138,18 +138,14 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
 
     return (
       <TextField
-        defaultValue={value}
         required={required}
         placeholder={placeholder}
         readOnly={readOnly || disabled}
         name={computedName}
-        size="small"
         label={label}
-        fullWidth
         multiline={type === 'multiline'}
         description={description}
         clickToCopy={clickToCopy}
-        autoComplete={schema.autoComplete}
       />
     )
   }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,4 +1,4 @@
-import type { IField } from '@plumber/types'
+import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 import { BiTrash } from 'react-icons/bi'
 import { Flex } from '@chakra-ui/react'
@@ -8,7 +8,7 @@ import InputCreator from '@/components/InputCreator'
 
 type MultiColProps = {
   name: string
-  subFields: IField[]
+  subFields: IFieldMultiRowMultiColSubField[]
   canRemoveRow?: boolean
   isEditorReadOnly?: boolean
   remove?: (index?: number | number[]) => void
@@ -29,13 +29,14 @@ export default function MultiCol(props: MultiColProps) {
     <Flex flexDir="row" gap={2}>
       {subFields.map((subF) => {
         return (
-          <InputCreator
-            key={`${name}.${subF.key}`}
-            schema={subF}
-            namePrefix={name}
-            parentType="multicol"
-            {...forwardedInputCreatorProps}
-          />
+          <div key={`${name}.${subF.key}`} style={subF.customStyle}>
+            <InputCreator
+              schema={subF}
+              namePrefix={name}
+              parentType="multicol"
+              {...forwardedInputCreatorProps}
+            />
+          </div>
         )
       })}
       {canRemoveRow && (

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,7 +1,7 @@
 import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 import { BiTrash } from 'react-icons/bi'
-import { Flex } from '@chakra-ui/react'
+import { Flex, useBreakpointValue } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
@@ -25,11 +25,16 @@ export default function MultiCol(props: MultiColProps) {
     index,
     ...forwardedInputCreatorProps
   } = props
+
+  const isMobile = useBreakpointValue({ base: true, sm: false })
   return (
-    <Flex flexDir="row" gap={2}>
+    <Flex flexDir={isMobile ? 'column' : 'row'} gap={2}>
       {subFields.map((subF) => {
         return (
-          <div key={`${name}.${subF.key}`} style={subF.customStyle}>
+          <div
+            key={`${name}.${subF.key}`}
+            style={isMobile ? { flex: 1 } : subF.customStyle}
+          >
             <InputCreator
               schema={subF}
               namePrefix={name}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -108,6 +108,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                         isEditorReadOnly={isEditorReadOnly}
                         remove={remove}
                         index={index}
+                        {...forwardedInputCreatorProps}
                       />
                       {/*
                        * "And" divider

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -203,6 +203,11 @@
   height: 100%;
   justify-content: center;
 
+  &:focus-within {
+    border-color: var(--chakra-colors-primary-500);
+    box-shadow: 0 0 0 1px var(--chakra-colors-primary-500);
+  }
+
   .tiptap p.is-editor-empty:first-child::before {
     color: #adb5bd;
     content: attr(data-placeholder);

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -260,7 +260,6 @@ interface RichTextEditorProps {
   description?: string
   disabled?: boolean
   placeholder?: string
-  customStyle?: React.CSSProperties
   variablesEnabled?: boolean
   isRich?: boolean
   isSingleLine?: boolean
@@ -273,7 +272,6 @@ const RichTextEditor = ({
   description,
   disabled,
   placeholder,
-  customStyle,
   variablesEnabled,
   isRich,
   isSingleLine,
@@ -281,7 +279,7 @@ const RichTextEditor = ({
   const { control } = useFormContext()
 
   return (
-    <FormControl flex={1} style={customStyle} data-test="text-input-group">
+    <FormControl flex={1} data-test="text-input-group">
       {label && (
         <FormLabel
           isRequired={required}

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -61,6 +61,7 @@ export interface SingleSelectProviderProps<
     onSelected: (value: string) => void
     isCreating: boolean
   }
+  isSearchable?: boolean
 }
 
 function constructFreeSoloItem(freeSoloValue: string) {
@@ -371,6 +372,7 @@ export const SingleSelectProvider = ({
   return (
     <SelectContext.Provider
       value={{
+        isSearchable,
         size,
         isOpen,
         selectedItem,
@@ -387,7 +389,6 @@ export const SingleSelectProvider = ({
         items: filteredItems,
         nothingFoundLabel,
         inputValue,
-        isSearchable,
         isClearable,
         isInvalid,
         isDisabled,

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -99,14 +99,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             direction="row"
             spacing="1rem"
             aria-disabled={isDisabled}
-            sx={{
-              ...styles.selected,
-              ...(!isSearchable && {
-                margin: 'auto',
-                pr: 0,
-                pl: 0,
-              }),
-            }}
+            sx={styles.selected}
             aria-hidden
           >
             {selectedItemMeta.icon ? (
@@ -135,7 +128,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
               'aria-expanded': !!isOpen,
             })}
           />
-          {isSearchable && <ToggleChevron />}
+          <ToggleChevron />
         </InputGroup>
         <ComboboxClearButton />
       </Flex>

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -99,7 +99,14 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             direction="row"
             spacing="1rem"
             aria-disabled={isDisabled}
-            sx={styles.selected}
+            sx={{
+              ...styles.selected,
+              ...(!isSearchable && {
+                margin: 'auto',
+                pr: 0,
+                pl: 0,
+              }),
+            }}
             aria-hidden
           >
             {selectedItemMeta.icon ? (
@@ -112,22 +119,23 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             <Text noOfLines={1}>{textToDisplay}</Text>
           </Stack>
           <Input
-            isReadOnly={!isSearchable || isReadOnly}
             isInvalid={isInvalid}
-            isDisabled={isDisabled}
             placeholder={textToDisplay ? '' : placeholder}
-            sx={styles.field}
+            sx={{
+              ...styles.field,
+              cursor: isSearchable ? 'text' : 'pointer',
+            }}
             {...getInputProps({
               onClick: handleToggleMenu,
               onBlur: () => !isOpen && resetInputValue(),
               ref: mergedInputRef,
               disabled: isDisabled,
-              readOnly: isReadOnly,
+              readOnly: !isSearchable || isReadOnly,
               required: isRequired,
               'aria-expanded': !!isOpen,
             })}
           />
-          <ToggleChevron />
+          {isSearchable && <ToggleChevron />}
         </InputGroup>
         <ComboboxClearButton />
       </Flex>

--- a/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
@@ -37,7 +37,7 @@ export const SelectMenu = (): JSX.Element => {
           { suppressRefError: true },
         )}
         style={floatingStyles}
-        sx={styles.list}
+        sx={{ ...styles.list, minWidth: '150px' }}
         zIndex="dropdown"
       >
         {isOpen && items.length > 0 && (

--- a/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectMenu.tsx
@@ -37,7 +37,7 @@ export const SelectMenu = (): JSX.Element => {
           { suppressRefError: true },
         )}
         style={floatingStyles}
-        sx={{ ...styles.list, minWidth: '150px' }}
+        sx={{ ...styles.list, minWidth: '230px' }}
         zIndex="dropdown"
       >
         {isOpen && items.length > 0 && (

--- a/packages/frontend/src/components/TextField/index.tsx
+++ b/packages/frontend/src/components/TextField/index.tsx
@@ -19,7 +19,6 @@ type TextFieldProps = {
   clickToCopy?: boolean
   readOnly?: boolean
   description?: string
-  customStyle?: React.CSSProperties
 } & MuiTextFieldProps
 
 const createCopyAdornment = (
@@ -51,7 +50,6 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
     readOnly,
     onBlur,
     onChange,
-    customStyle,
     ...textFieldProps
   } = props
 
@@ -70,7 +68,7 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
           ...field
         },
       }) => (
-        <FormControl style={customStyle}>
+        <FormControl>
           {label && (
             <FormLabel
               isRequired={required}

--- a/packages/frontend/src/components/TextField/index.tsx
+++ b/packages/frontend/src/components/TextField/index.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { BiCopy } from 'react-icons/bi'
 import Markdown from 'react-markdown'
-import { FormControl } from '@chakra-ui/react'
-import ContentCopyIcon from '@mui/icons-material/ContentCopy'
-import IconButton from '@mui/material/IconButton'
-import InputAdornment from '@mui/material/InputAdornment'
-import MuiTextField, {
-  TextFieldProps as MuiTextFieldProps,
-} from '@mui/material/TextField'
-import { FormLabel } from '@opengovsg/design-system-react'
-
-import copyInputValue from '@/helpers/copyInputValue'
+import { FormControl, InputGroup, InputRightElement } from '@chakra-ui/react'
+import {
+  FormLabel,
+  IconButton,
+  Input,
+  Textarea,
+} from '@opengovsg/design-system-react'
+import copy from 'clipboard-copy'
 
 type TextFieldProps = {
   shouldUnregister?: boolean
@@ -19,50 +18,46 @@ type TextFieldProps = {
   clickToCopy?: boolean
   readOnly?: boolean
   description?: string
-} & MuiTextFieldProps
-
-const createCopyAdornment = (
-  ref: React.RefObject<HTMLInputElement | null>,
-): React.ReactElement => {
-  return (
-    <InputAdornment position="end">
-      <IconButton
-        onClick={() => copyInputValue(ref.current as HTMLInputElement)}
-        edge="end"
-      >
-        <ContentCopyIcon color="primary" />
-      </IconButton>
-    </InputAdornment>
-  )
+  required?: boolean
+  multiline?: boolean
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  onBlur?: (
+    event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void
+  placeholder?: string
+  defaultValue?: string
 }
 
 export default function TextField(props: TextFieldProps): React.ReactElement {
   const { control } = useFormContext()
-  const inputRef = React.useRef<HTMLInputElement | null>(null)
   const {
     required,
     name,
     label,
     description,
     defaultValue,
+    placeholder,
     shouldUnregister,
     clickToCopy,
+    multiline,
     readOnly,
     onBlur,
     onChange,
-    ...textFieldProps
   } = props
+
+  const SelectedComponent = multiline ? Textarea : Input
 
   return (
     <Controller
-      rules={{ required }}
+      rules={{ required: required }}
       name={name}
       defaultValue={defaultValue || ''}
       control={control}
       shouldUnregister={shouldUnregister}
       render={({
         field: {
-          ref,
           onChange: controllerOnChange,
           onBlur: controllerOnBlur,
           ...field
@@ -81,35 +76,37 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
               {label}
             </FormLabel>
           )}
-          <MuiTextField
-            {...textFieldProps}
-            {...field}
-            onChange={(...args) => {
-              controllerOnChange(...args)
-              onChange?.(...args)
-            }}
-            onBlur={(...args) => {
-              controllerOnBlur()
-              onBlur?.(...args)
-            }}
-            inputRef={(element) => {
-              inputRef.current = element
-              ref(element)
-            }}
-            InputProps={{
-              readOnly,
-              endAdornment: clickToCopy ? createCopyAdornment(inputRef) : null,
-            }}
-          />
+          <InputGroup>
+            <SelectedComponent
+              {...field}
+              placeholder={placeholder}
+              onChange={(...args) => {
+                controllerOnChange(...args)
+                onChange?.(...args)
+              }}
+              onBlur={(...args) => {
+                controllerOnBlur()
+                onBlur?.(...args)
+              }}
+              isReadOnly={readOnly}
+            />
+            {clickToCopy && (
+              <InputRightElement>
+                <IconButton
+                  icon={<BiCopy />}
+                  colorScheme="primary"
+                  variant="clear"
+                  aria-label={'Copy'}
+                  minHeight="42px"
+                  mr="2px"
+                  borderRadius="base"
+                  onClick={() => copy(field.value)}
+                />
+              </InputRightElement>
+            )}
+          </InputGroup>
         </FormControl>
       )}
     />
   )
-}
-
-TextField.defaultProps = {
-  readOnly: false,
-  disabled: false,
-  clickToCopy: false,
-  shouldUnregister: false,
 }

--- a/packages/frontend/src/components/WebhookUrlInfo/index.tsx
+++ b/packages/frontend/src/components/WebhookUrlInfo/index.tsx
@@ -2,6 +2,7 @@ import { ITriggerInstructions } from '@plumber/types'
 
 import * as React from 'react'
 import ReactMarkdown from 'react-markdown'
+import { Box } from '@chakra-ui/react'
 import type { AlertProps } from '@mui/material/Alert'
 
 import TextField from '../TextField'
@@ -14,7 +15,7 @@ type WebhookUrlInfoProps = {
 } & AlertProps
 
 function WebhookUrlInfo(props: WebhookUrlInfoProps): React.ReactElement {
-  const { webhookUrl, webhookTriggerInstructions, ...alertProps } = props
+  const { webhookTriggerInstructions, ...alertProps } = props
 
   const { beforeUrlMsg, afterUrlMsg, hideWebhookUrl } =
     webhookTriggerInstructions
@@ -27,16 +28,9 @@ function WebhookUrlInfo(props: WebhookUrlInfoProps): React.ReactElement {
     <Alert icon={false} color="info" {...alertProps}>
       {beforeUrlMsg && <ReactMarkdown>{beforeUrlMsg}</ReactMarkdown>}
       {!hideWebhookUrl && (
-        <TextField
-          sx={{
-            my: '1rem',
-          }}
-          readOnly
-          clickToCopy={true}
-          name="webhookUrl"
-          fullWidth
-          defaultValue={webhookUrl}
-        />
+        <Box my={4}>
+          <TextField readOnly clickToCopy={true} name="webhookUrl" />
+        </Box>
       )}
       {afterUrlMsg && <ReactMarkdown>{afterUrlMsg}</ReactMarkdown>}
     </Alert>

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -188,8 +188,10 @@ export const GET_APPS = gql`
             variables
             variableTypes
             allowArbitrary
+            isSearchable
             addRowButtonText
             showOptionValue
+            customStyle
             value
             options {
               label
@@ -225,7 +227,10 @@ export const GET_APPS = gql`
               variables
               variableTypes
               allowArbitrary
+              isSearchable
               showOptionValue
+              customStyle
+              value
               hiddenIf {
                 fieldKey
                 fieldValue

--- a/packages/frontend/src/helpers/copyInputValue.ts
+++ b/packages/frontend/src/helpers/copyInputValue.ts
@@ -1,5 +1,0 @@
-import copy from 'clipboard-copy'
-
-export default function copyInputValue(element: HTMLInputElement): void {
-  copy(element.value)
-}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -288,6 +288,7 @@ export interface IFieldDropdown extends IBaseField {
   type: 'dropdown'
   showOptionValue?: boolean
   allowArbitrary?: boolean
+  isSearchable?: boolean
   addNewOption?: {
     id: DropdownAddNewId // identifier when add new option is selected
     type: DropdownAddNewType
@@ -352,12 +353,15 @@ export interface IFieldMultiSelect extends IBaseField {
   variableTypes?: TDataOutMetadatumType[]
 }
 
+type IFieldMultiRowMultiColSubField = IField & {
+  customStyle?: Record<string, string | number>
+}
+
 export interface IFieldMultiRowMultiCol extends IBaseField {
   type: 'multirow-multicol'
   value?: string
   addRowButtonText?: string
-
-  subFields: IField[]
+  subFields: IFieldMultiRowMultiColSubField[]
 }
 
 export interface IFieldMultiRow extends IBaseField {


### PR DESCRIPTION
## TLDR;
FRONTEND-ONLY
For update-row action, allow users to set increment or decrement existing value.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/5d5fd96b-f1b2-48df-867d-6eabceb77ece.png)

## What changed
- Introduce 2 new attributes to dropdown fields, `isSearchable` and `subFields.customStyles`
- if `isSearchable` is set to false, it prevent users from typing to search and center aligns the content (this is an existing prop that is unused)
- `subFields.customStyles` allows users to override the container of the subfields in `multirow-multicol` fields 

## Why
This frontend change will allow users to change the way the value is modified, either set-as, add by or subtract by. 