### PR TITLE
PLU-392: [CUSTOM-API-FIX-1] escape variable content

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -298,4 +298,19 @@ describe('make http request', () => {
       },
     )
   })
+
+  describe('escaping variables should maintain original type', () => {
+    it.each([
+      [true, true],
+      [false, false],
+      ['true', 'true'],
+      [123, 123],
+      ['string with "quotes" inside', 'string with \\"quotes\\" inside'],
+      ['string without quotes', 'string without quotes'],
+      ['{string with braces}', '{string with braces}'],
+    ])('should escape variables', (input, expected) => {
+      const escaped = makeRequestAction.preprocessVariable('data', input)
+      expect(escaped).toBe(expected)
+    })
+  })
 })

--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -226,4 +226,76 @@ describe('make http request', () => {
     mocks.httpRequest.mockRejectedValueOnce(disallowedIpError)
     await expect(makeRequestAction.run($)).rejects.toThrowError(StepError)
   })
+
+  describe('tests that data is valid JSON', () => {
+    // NOTE: caters for existing users that are sending strings in the data field
+    it.each(['[1, 2, 3]', 'meep meep'])(
+      'should not throw error if data is string',
+      async (testData: any) => {
+        $.step.parameters.method = 'POST'
+        $.step.parameters.data = testData
+        $.step.parameters.url = 'http://test.local/endpoint?1234'
+
+        mocks.httpRequest.mockReturnValue('mock response')
+
+        await makeRequestAction.run($).catch(() => null)
+        expect(mocks.httpRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: $.step.parameters.url,
+            method: $.step.parameters.method,
+            data: $.step.parameters.data,
+          }),
+        )
+      },
+    )
+
+    it.each([
+      '{"abc": 123}',
+      '{"abc": "def", "ghi": 456, "jkl": {"nested": "nested-value"}}',
+      '{"abc": "def", "ghi": 456, "jkl": {"nested": {"nested-nested": "nested-nested-value"}}}',
+      JSON.stringify({ data: undefined }),
+      JSON.stringify({ data: null }),
+      null,
+      '',
+    ])(
+      'should not throw error if data is valid JSON or null or empty string',
+      async (testJSON: any) => {
+        $.step.parameters.method = 'POST'
+        $.step.parameters.data = testJSON
+
+        $.step.parameters.url = 'http://test.local/endpoint?1234'
+        mocks.httpRequest.mockReturnValue('mock response')
+
+        await makeRequestAction.run($).catch(() => null)
+        expect(mocks.httpRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: $.step.parameters.url,
+            method: $.step.parameters.method,
+            data: $.step.parameters.data,
+          }),
+        )
+      },
+    )
+
+    it.each([
+      '{"abc": 123',
+      '"abc": 123}',
+      '{""abc"": "def"}',
+      '{"name": "zuck""}',
+      '{"name": "zuck", "age": "40}',
+      '{ this looks like json but isnt }',
+    ])(
+      'should throw error if data is not valid JSON',
+      async (testJSON: any) => {
+        $.step.parameters.method = 'POST'
+        $.step.parameters.data = testJSON
+        $.step.parameters.url = 'http://test.local/endpoint?1234'
+
+        mocks.httpRequest.mockReturnValue('mock response')
+        await expect(makeRequestAction.run($)).rejects.toThrowError(
+          'Invalid JSON data',
+        )
+      },
+    )
+  })
 })

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -88,12 +88,12 @@ const action: IRawAction = {
 
     try {
       const parsedS = requestSchema.parse($.step.parameters)
-      const { customHeaders } = parsedS
+      const { customHeaders, data: parsedData } = parsedS
 
       let response = await $.http.request({
         url,
         method,
-        data,
+        data: parsedData,
         maxRedirects: 0,
         headers: customHeaders,
         //  overwriting this to allow redirects to resolve

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -81,6 +81,15 @@ const action: IRawAction = {
     },
   ],
 
+  preprocessVariable(parameterKey: string, variableValue: unknown) {
+    if (parameterKey === 'data' && typeof variableValue === 'string') {
+      // NOTE: this removes the " from the start and end of the string
+      // as it is already added in the user input
+      return JSON.stringify(variableValue).slice(1, -1)
+    }
+    return variableValue
+  },
+
   async run($) {
     const method = $.step.parameters.method as TMethod
     const data = $.step.parameters.data as string

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -2,24 +2,6 @@ import { z } from 'zod'
 
 import { sanitizeMarkdown } from '@/apps/telegram-bot/common/markdown-v1'
 
-function isStringifiedJSON(input: string) {
-  if (typeof input !== 'string') {
-    return false // If not a string, it can't be stringified JSON
-  }
-
-  try {
-    // NOTE: assume that user is trying to input JSON data if it starts with { or ends with }
-    if (input.startsWith('{') || input.endsWith('}')) {
-      return true
-    }
-
-    const parsed = JSON.parse(input)
-    return typeof parsed === 'object' && parsed !== null
-  } catch (e) {
-    return false // Not valid JSON
-  }
-}
-
 export const requestSchema = z.object({
   customHeaders: z
     .array(
@@ -74,14 +56,11 @@ export const requestSchema = z.object({
       }
 
       try {
-        if (isStringifiedJSON(str)) {
-          JSON.parse(str) // to test if it's valid JSON
-          return str
-        } else {
-          // NOTE: caters for existing users that are sending strings in the data field
-          // all non JSON-like inputs will be treated as string
-          return str
+        // NOTE: assume that user is trying to input JSON data if it starts with { or ends with }
+        if (str.startsWith('{') || str.endsWith('}')) {
+          JSON.parse(str) // to test for valid JSON
         }
+        return str
       } catch (e) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -2,6 +2,24 @@ import { z } from 'zod'
 
 import { sanitizeMarkdown } from '@/apps/telegram-bot/common/markdown-v1'
 
+function isStringifiedJSON(input: string) {
+  if (typeof input !== 'string') {
+    return false // If not a string, it can't be stringified JSON
+  }
+
+  try {
+    // NOTE: assume that user is trying to input JSON data if it starts with { or ends with }
+    if (input.startsWith('{') || input.endsWith('}')) {
+      return true
+    }
+
+    const parsed = JSON.parse(input)
+    return typeof parsed === 'object' && parsed !== null
+  } catch (e) {
+    return false // Not valid JSON
+  }
+}
+
 export const requestSchema = z.object({
   customHeaders: z
     .array(
@@ -45,6 +63,32 @@ export const requestSchema = z.object({
         result[key] = sanitizeMarkdown(cleanV)
       }
       return result
+    })
+    .nullish(),
+  data: z
+    .string()
+    .transform((str, ctx) => {
+      // Allow empty string
+      if (str === '') {
+        return str
+      }
+
+      try {
+        if (isStringifiedJSON(str)) {
+          JSON.parse(str) // to test if it's valid JSON
+          return str
+        } else {
+          // NOTE: caters for existing users that are sending strings in the data field
+          // all non JSON-like inputs will be treated as string
+          return str
+        }
+      } catch (e) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid JSON data',
+        })
+        return z.NEVER
+      }
     })
     .nullish(),
 })

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -66,11 +66,15 @@ function findAndSubstituteVariables(
 
         // NOTE: dataValue could be an array if it is not processed on variables.ts
         // which is the case for formSG checkbox only, this is to deal with forEach next time
-        return preprocessVariable
+        const processedVar = preprocessVariable
           ? preprocessVariable(parameterKey, dataValue)
           : Array.isArray(dataValue)
           ? dataValue.join(', ')
           : dataValue
+        return parameterKey === 'data'
+          ? // removes " " for custom api data field as its already wrapped
+            JSON.stringify(processedVar).slice(1, -1)
+          : processedVar
       }
 
       return part

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -71,10 +71,14 @@ function findAndSubstituteVariables(
           : Array.isArray(dataValue)
           ? dataValue.join(', ')
           : dataValue
-        return parameterKey === 'data'
-          ? // removes " " for custom api data field as its already wrapped
-            JSON.stringify(processedVar).slice(1, -1)
-          : processedVar
+        /**
+         * NOTE: this is to deal with escaping variables in custom api data field
+         * be careful with this as it may break other apps if the key 'data' is used
+         */
+        if (parameterKey === 'data') {
+          return JSON.stringify(processedVar).slice(1, -1)
+        }
+        return processedVar
       }
 
       return part

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -66,19 +66,11 @@ function findAndSubstituteVariables(
 
         // NOTE: dataValue could be an array if it is not processed on variables.ts
         // which is the case for formSG checkbox only, this is to deal with forEach next time
-        const processedVar = preprocessVariable
+        return preprocessVariable
           ? preprocessVariable(parameterKey, dataValue)
           : Array.isArray(dataValue)
           ? dataValue.join(', ')
           : dataValue
-        /**
-         * NOTE: this is to deal with escaping variables in custom api data field
-         * be careful with this as it may break other apps if the key 'data' is used
-         */
-        if (parameterKey === 'data') {
-          return JSON.stringify(processedVar).slice(1, -1)
-        }
-        return processedVar
       }
 
       return part


### PR DESCRIPTION
# Problem
Users face JSON parsing errors when using variables (likely due to `"` within the variable content).

# Solution
Escape variable content so that `"` or other special characters within content do not cause errors.

**Improvements:**
* Add schema to validate Data field input: if user is attempting to input JSON data, check that its a valid JSON
* Safely escape variable content for use in data field

# Tests
- [x] Existing Pipes with Data fields should run as expected
- [x] Escaping does not alter variable content
- [x] String data inputs are allowed (there are some existing Pipes that do this
- [x] Empty data inputs are allowed
- [x] Invalid JSON inputs are handled gracefully with correct error thrown in Test step