### PR TITLE
PLU-370: [CUSTOM-API-FIX-2] do not overwrite Content-Type

### DIFF
--- a/packages/backend/src/apps/custom-api/common/add-headers.ts
+++ b/packages/backend/src/apps/custom-api/common/add-headers.ts
@@ -2,8 +2,9 @@ import { TBeforeRequest } from '@plumber/types'
 
 const addHeaders: TBeforeRequest = async ($, requestConfig) => {
   const authData = $.auth.data
+  requestConfig.headers.set('Content-Type', 'application/json', false)
+
   if (authData?.headers) {
-    requestConfig.headers.set('Content-Type', 'application/json', true)
     Object.entries(authData.headers).forEach(([key, value]) =>
       requestConfig.headers.set(key, value),
     )


### PR DESCRIPTION
### TL;DR
Updated Custom API header handling to ensure:
* `Content-Type = application/json`, if not set by user
* `Content-Type` set in Connection step is not overwritten by `Content-Type` set in Custom Headers

### What changed?
- `Content-Type` header is now set for all requests to `application/json` instead of Axios' default `application/x-www-form-urlencoded`

### How to test?
1. Make a request to the custom API endpoint with no `Content-Type` set
2. Verify that the `Content-Type` header is present and is `application/json`
3. Create a Connection in **Add connection** step with a custom `Content-Type`
4. Verify that the `Content-Type` header is present and matches what was set
5. Add a different `Content-Type` to **Custom header** step
6. Verify that it does not overwrite the `Content-Type` set in the **Add connection** step


### Why make this change?
The Content-Type header should be set consistently for all requests. The previous implementation only set it for requests with headers specified in the Connection step.