### PR TITLE
PLU-372: [UI-Prevamp] add delete step confirmation

### DIFF
--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -182,7 +182,7 @@ export default function FlowStep(
 
   const isDeletable =
     displayOverrides?.disableDelete === true ? false : !isTrigger && !readOnly
-  const [deleteStep] = useMutation(DELETE_STEP, {
+  const [deleteStep, { loading: isDeletingStep }] = useMutation(DELETE_STEP, {
     refetchQueries: [GET_FLOW],
   })
   const onDelete = useCallback<MouseEventHandler>(
@@ -254,6 +254,7 @@ export default function FlowStep(
         }
         isCompleted={step.status === 'completed'}
         onDelete={isDeletable ? onDelete : undefined}
+        isDeleting={isDeletable ? isDeletingStep : undefined}
         onOpen={onOpen}
         onClose={onClose}
         collapsed={collapsed ?? false}

--- a/packages/frontend/src/components/FlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/FlowStepHeader/index.tsx
@@ -3,6 +3,7 @@ import {
   type MouseEventHandler,
   type ReactNode,
   useCallback,
+  useRef,
   useState,
 } from 'react'
 import {
@@ -30,6 +31,8 @@ import { IconButton } from '@opengovsg/design-system-react'
 
 import DemoVideoModalContent from '@/components/FlowRow/DemoVideoModalContent'
 
+import MenuAlertDialog from '../MenuAlertDialog'
+
 // Chakra's `Collapse` sets `overflow: hidden` by default, which causes dropdown
 // menu items to be hidden. We override overflow by making `Collapse` a Chakra
 // element.
@@ -41,6 +44,7 @@ interface FlowStepHeaderProps {
   hintAboveCaption: string
   isCompleted?: boolean
   onDelete?: MouseEventHandler
+  isDeleting?: boolean
   onOpen: () => void
   onClose: () => void
   collapsed: boolean
@@ -61,6 +65,7 @@ export default function FlowStepHeader(
     hintAboveCaption,
     isCompleted,
     onDelete,
+    isDeleting,
     onOpen,
     onClose,
     collapsed,
@@ -78,6 +83,13 @@ export default function FlowStepHeader(
       onClose()
     }
   }, [collapsed, onOpen, onClose])
+
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const {
+    isOpen: isDialogOpen,
+    onOpen: onDialogOpen,
+    onClose: onDialogClose,
+  } = useDisclosure()
 
   // for loading demo modal
   const {
@@ -231,7 +243,10 @@ export default function FlowStepHeader(
           {onDelete && (
             <Flex ml="auto">
               <IconButton
-                onClick={onDelete}
+                onClick={(event) => {
+                  onDialogOpen()
+                  event.stopPropagation()
+                }}
                 variant="clear"
                 aria-label="Delete Step"
                 icon={<BiTrashAlt />}
@@ -261,6 +276,18 @@ export default function FlowStepHeader(
             <DemoVideoModalContent src={demoVideoUrl} title={demoVideoTitle} />
           </ModalContent>
         </Modal>
+      )}
+
+      {onDelete && isDeleting !== undefined && (
+        <MenuAlertDialog
+          isDialogOpen={isDialogOpen}
+          cancelRef={cancelRef}
+          onDialogClose={onDialogClose}
+          dialogHeader="Step"
+          dialogType="delete"
+          onClick={onDelete}
+          isLoading={isDeleting}
+        />
       )}
     </>
   )

--- a/packages/frontend/src/components/MenuAlertDialog/index.tsx
+++ b/packages/frontend/src/components/MenuAlertDialog/index.tsx
@@ -1,3 +1,4 @@
+import { type MouseEventHandler } from 'react'
 import {
   AlertDialog,
   AlertDialogBody,
@@ -9,7 +10,7 @@ import {
 import { Button } from '@opengovsg/design-system-react'
 
 export type AlertDialogType = 'delete' | 'duplicate'
-export type AlertHeaderType = 'Connection' | 'Pipe' | 'Tile'
+export type AlertHeaderType = 'Connection' | 'Pipe' | 'Tile' | 'Step'
 
 interface MenuAlertDialogProps {
   isDialogOpen: boolean
@@ -17,7 +18,7 @@ interface MenuAlertDialogProps {
   onDialogClose: () => void
   dialogType: AlertDialogType
   dialogHeader: AlertHeaderType
-  onClick: () => void
+  onClick: (() => void) | MouseEventHandler
   isLoading: boolean
 }
 


### PR DESCRIPTION
## Problem

No confirmation before deleting a step from a pipe...

## Solution

Reuse the `AlertDialog` and add it to the delete icon

## Tests
- [x] Can delete step with the modal
- [x] Can cancel the deleting of step