### PR TITLE
fix: tiles rows not refreshing after csv import

### DIFF
--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -46,7 +46,9 @@ export default function Tile(): JSX.Element {
           headers: { 'x-tiles-view-key': urlViewOnlyKey },
         }
       : undefined,
-    fetchPolicy: 'network-only',
+    // this fetchPolicy needs to be set for onCompleted to be called on refetch
+    // i.e. after csv upload
+    fetchPolicy: 'cache-and-network',
     onCompleted: async (data) => {
       if (!data.getAllRows) {
         return


### PR DESCRIPTION
## Problem
Tiles not auto-refreshing after CSV import

## Solution
Set cache policy to `cache-and-network` to trigger onComplete hook on refetch