### PR TITLE
PLU-309: [TILES-ATOMIC-INCREMENT-4] backend implementation for increment/decrement row value

### DIFF
--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -156,7 +156,7 @@ const action: IRawAction = {
     function assertNumber(value: string): void {
       if (typeof autoMarshallNumberStrings(value) !== 'number') {
         throw new StepError(
-          'Add/subtract value must be a number',
+          'Unable to update row',
           'The value to add or subtract by must be a number.',
           $.step.position,
           $.app.name,
@@ -210,17 +210,22 @@ const action: IRawAction = {
         } satisfies UpdateRowOutput,
       })
     } catch (e) {
-      if (
-        e instanceof Error &&
-        e.message.includes('The conditional request failed')
-      ) {
-        // This means the corresponding row does not exist
-        $.setActionItem({
-          raw: {
-            updated: false,
-          } satisfies UpdateRowOutput,
-        })
-        return
+      if (e instanceof Error) {
+        if (e.message.includes('The conditional request failed')) {
+          // This means the corresponding row does not exist
+          $.setActionItem({
+            raw: {
+              updated: false,
+            } satisfies UpdateRowOutput,
+          })
+          return
+        }
+        throw new StepError(
+          'Failed to update row',
+          e.message,
+          $.step.position,
+          $.app.name,
+        )
       }
       throw e
     }

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -1,8 +1,11 @@
 import { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
-import { stripInvalidKeys } from '@/models/dynamodb/helpers'
-import { patchTableRow } from '@/models/dynamodb/table-row'
+import {
+  autoMarshallNumberStrings,
+  stripInvalidKeys,
+} from '@/models/dynamodb/helpers'
+import { PatchRowInput, patchTableRow } from '@/models/dynamodb/table-row'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
@@ -117,7 +120,7 @@ const action: IRawAction = {
     const { tableId, rowId, rowData } = $.step.parameters as {
       tableId: string
       rowId: string
-      rowData: { columnId: string; cellValue: string }[]
+      rowData: { columnId: string; cellValue: string; operator?: string }[]
     }
 
     if (!tableId) {
@@ -150,20 +153,48 @@ const action: IRawAction = {
       return
     }
 
-    const patchData = {
-      ...rowData.reduce((acc, { columnId, cellValue }) => {
-        // Check that the column still exists
-        if (columnIds.includes(columnId)) {
-          acc[columnId] = cellValue
-        }
-        return acc
-      }, {} as Record<string, string>),
+    function assertNumber(value: string): void {
+      if (typeof autoMarshallNumberStrings(value) !== 'number') {
+        throw new StepError(
+          'Add/subtract value must be a number',
+          'The value to add or subtract by must be a number.',
+          $.step.position,
+          $.app.name,
+        )
+      }
     }
+
+    const patchData = {
+      ...rowData.reduce(
+        (acc, { columnId, cellValue, operator }) => {
+          // Check that the column still exists
+          if (columnIds.includes(columnId)) {
+            switch (operator) {
+              case 'add':
+                assertNumber(cellValue)
+                acc.add[columnId] = cellValue
+                break
+              case 'subtract':
+                assertNumber(cellValue)
+                acc.subtract[columnId] = cellValue
+                break
+              // we default to set, since old operators will be undefined
+              default:
+                acc.set[columnId] = cellValue
+                break
+            }
+          }
+          return acc
+        },
+        { set: {}, add: {}, subtract: {} } as PatchRowInput['patchData'],
+      ),
+    }
+
     try {
       const updatedRow = await patchTableRow({
         tableId,
         rowId,
-        data: patchData,
+        patchData,
       })
 
       const updatedRowData = stripInvalidKeys({

--- a/packages/backend/src/apps/tiles/common/column-name-metadata.ts
+++ b/packages/backend/src/apps/tiles/common/column-name-metadata.ts
@@ -17,11 +17,12 @@ export async function generateColumnNameMetadata(
 
   const columns = await TableColumnMetadata.query()
     .findByIds(columnIds)
-    .select('id', 'name')
+    .select('id', 'name', 'position')
 
   columns.forEach((column) => {
     columnMetadata[column.id] = {
       label: column.name,
+      order: column.position,
     }
   })
   return { [parentKey]: columnMetadata }

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -390,10 +390,122 @@ describe('dynamodb table row functions', () => {
       const updatedRow = await patchTableRow({
         tableId: dummyTable.id,
         rowId: row.rowId,
-        data: newData,
+        patchData: {
+          set: newData,
+        },
       })
 
       expect(updatedRow.data).toEqual({ ...data, ...newData })
+    })
+
+    it('should set, add or subtract values for the row', async () => {
+      const data = {
+        [dummyColumnIds[0]]: 10,
+        [dummyColumnIds[1]]: 20,
+        [dummyColumnIds[2]]: 30,
+      }
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+      const updatedRow = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        patchData: {
+          set: {
+            [dummyColumnIds[0]]: '1',
+          },
+          add: {
+            [dummyColumnIds[1]]: '2',
+          },
+          subtract: {
+            [dummyColumnIds[2]]: '3',
+          },
+        },
+      })
+
+      const expectedData = {
+        [dummyColumnIds[0]]: 1,
+        [dummyColumnIds[1]]: 22,
+        [dummyColumnIds[2]]: 27,
+      }
+
+      expect(updatedRow.data).toEqual(expectedData)
+    })
+
+    it('should throw a step error if operand is not a number', async () => {
+      const data = {
+        [dummyColumnIds[0]]: 10,
+        [dummyColumnIds[1]]: 20,
+        [dummyColumnIds[2]]: 30,
+      }
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+
+      await expect(
+        patchTableRow({
+          tableId: dummyTable.id,
+          rowId: row.rowId,
+          patchData: {
+            set: {
+              [dummyColumnIds[0]]: '1',
+            },
+            add: {
+              [dummyColumnIds[1]]: 'add',
+            },
+            subtract: {
+              [dummyColumnIds[2]]: '3',
+            },
+          },
+        }),
+      ).rejects.toThrow(Error)
+    })
+
+    it('should throw a generic error if original value is not a number', async () => {
+      const data = {
+        [dummyColumnIds[0]]: 10,
+        [dummyColumnIds[1]]: 20,
+        [dummyColumnIds[2]]: 'string',
+      }
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+
+      await expect(
+        patchTableRow({
+          tableId: dummyTable.id,
+          rowId: row.rowId,
+          patchData: {
+            set: {
+              [dummyColumnIds[0]]: '1',
+            },
+            add: {
+              [dummyColumnIds[1]]: '2re',
+            },
+            subtract: {
+              [dummyColumnIds[2]]: '3',
+            },
+          },
+        }),
+      ).rejects.toThrow(Error)
+    })
+
+    it('should work fine if only add/subtract is provided', async () => {
+      const data = {
+        [dummyColumnIds[0]]: 10,
+        [dummyColumnIds[1]]: 20,
+        [dummyColumnIds[2]]: 30,
+      }
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+
+      const updatedRow = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        patchData: {
+          subtract: {
+            [dummyColumnIds[2]]: '3',
+          },
+        },
+      })
+      expect(updatedRow.data).toEqual({
+        [dummyColumnIds[0]]: 10,
+        [dummyColumnIds[1]]: 20,
+        [dummyColumnIds[2]]: 27,
+      })
     })
 
     it('should not change if no columns are provided', async () => {
@@ -404,7 +516,7 @@ describe('dynamodb table row functions', () => {
       const updatedRow = await patchTableRow({
         tableId: dummyTable.id,
         rowId: row.rowId,
-        data: {},
+        patchData: {},
       })
 
       expect(updatedRow.data).toEqual(data)
@@ -418,7 +530,7 @@ describe('dynamodb table row functions', () => {
       const updatedRow = await patchTableRow({
         tableId: dummyTable.id,
         rowId: row.rowId,
-        data: { [dummyColumnIds[0]]: '123' },
+        patchData: { set: { [dummyColumnIds[0]]: '123' } },
       })
       expect(updatedRow.data).toEqual({ ...data, [dummyColumnIds[0]]: 123 })
     })
@@ -431,7 +543,7 @@ describe('dynamodb table row functions', () => {
       const updatedRow = await patchTableRow({
         tableId: dummyTable.id,
         rowId: row.rowId,
-        data: { [dummyColumnIds[0]]: '123' },
+        patchData: { [dummyColumnIds[0]]: '123' },
       })
       expect(updatedRow.updatedAt).toBeGreaterThan(row.updatedAt)
     })

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -27,6 +27,16 @@ export function handleDynamoDBError(error: unknown): never {
           delayType: 'step',
         })
       }
+      if (
+        message.includes(
+          'An operand in the update expression has an incorrect data type',
+        ) ||
+        message.includes('Incorrect operand type for operator or function')
+      ) {
+        throw new Error(
+          'You can only add or subtract numbers, please check your values',
+        )
+      }
       throw new Error('DynamoDB Internal Error: ' + message)
     }
     if (error.code < 6000) {
@@ -89,11 +99,11 @@ export function stripInvalidKeys({
   columnIds: string[]
   data: Record<string, string | number>
 }) {
-  const validKeys = new Set(columnIds)
   const strippedData: Record<string, string | number> = {}
-  for (const [key, value] of Object.entries(data)) {
-    if (validKeys.has(key)) {
-      strippedData[key] = value
+  // Iterate through columnIds to maintain order
+  for (const columnId of columnIds) {
+    if (columnId in data) {
+      strippedData[columnId] = data[columnId]
     }
   }
   return strippedData

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -34,7 +34,7 @@ export function handleDynamoDBError(error: unknown): never {
         message.includes('Incorrect operand type for operator or function')
       ) {
         throw new Error(
-          'You can only add or subtract numbers, please check your values',
+          'You can only add or subtract numbers, please check your values.',
         )
       }
       throw new Error('DynamoDB Internal Error: ' + message)

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -10,6 +10,7 @@ import {
   CreateRowInput,
   CreateRowsInput,
   DeleteRowsInput,
+  PatchRowInput,
   TableRowFilter,
   TableRowFilterOperator,
   TableRowItem,
@@ -227,26 +228,40 @@ export const updateTableRow = async ({
 export const patchTableRow = async ({
   rowId,
   tableId,
-  data: patchData,
-}: UpdateRowInput): Promise<TableRowItem> => {
+  patchData,
+}: PatchRowInput): Promise<TableRowItem> => {
   try {
-    const res = await TableRow.patch({
+    const patchOperation = TableRow.patch({
       tableId,
       rowId,
+    }).data(({ data }, { set, add, subtract }) => {
+      // Handle set operations
+      Object.entries(patchData.set || {}).forEach(
+        ([key, value]: [string, string]) => {
+          set(data[key], value ? autoMarshallNumberStrings(value) : '')
+        },
+      )
+
+      // Handle add operations
+      Object.entries(patchData.add || {}).forEach(
+        ([key, value]: [string, string]) => {
+          add(data[key], autoMarshallNumberStrings(value))
+        },
+      )
+
+      // Handle subtract operations
+      Object.entries(patchData.subtract || {}).forEach(
+        ([key, value]: [string, string]) => {
+          subtract(data[key], autoMarshallNumberStrings(value))
+        },
+      )
     })
-      .data(({ data }, { set }) => {
-        for (const key in patchData) {
-          set(
-            data[key],
-            patchData[key] ? autoMarshallNumberStrings(patchData[key]) : '',
-          )
-        }
-      })
-      .go({
-        ignoreOwnership: true,
-        // Return the new row data
-        response: 'all_new',
-      })
+
+    const res = await patchOperation.go({
+      ignoreOwnership: true,
+      response: 'all_new',
+    })
+
     return res.data
   } catch (e: unknown) {
     handleDynamoDBError(e)

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -8,7 +8,15 @@ export type CreateRowsInput = {
   tableId: string
   dataArray: Array<TableRowItem['data']>
 }
-export type UpdateRowInput = Pick<TableRowItem, 'tableId' | 'data' | 'rowId'>
+export type UpdateRowInput = Pick<TableRowItem, 'tableId' | 'rowId' | 'data'>
+
+export type PatchRowInput = Pick<TableRowItem, 'tableId' | 'rowId'> & {
+  patchData: {
+    set?: TableRowItem['data']
+    add?: TableRowItem['data']
+    subtract?: TableRowItem['data']
+  }
+}
 export interface DeleteRowsInput {
   tableId: string
   rowIds: string[]

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -38,9 +38,11 @@ class TableColumnMetadata extends Base {
   })
 
   static getColumns = async (tableId: string, $?: IGlobalVariable) => {
-    const columns = await TableColumnMetadata.query().where({
-      table_id: tableId,
-    })
+    const columns = await TableColumnMetadata.query()
+      .where({
+        table_id: tableId,
+      })
+      .orderBy('position')
 
     if (columns.length === 0) {
       throw new StepError(

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -22,8 +22,6 @@ interface SpecificErrorResultProps {
   executionStepId?: string
 }
 
-const contactPlumberMessage = `If this error still persists, contact us at [${SUPPORT_FORM_LINK}](${SUPPORT_FORM_LINK}).`
-
 export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props
   const { name, solution, position, appName, details, partialRetry } =
@@ -55,7 +53,7 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
 
   return (
     <Infobox variant="error">
-      <Box minW="0">
+      <Box minW="0" w="full">
         {/* Actual executions will not need to show step position and app name */}
         {isTestRun && (
           <Badge
@@ -72,9 +70,20 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
         </Text>
 
         <Text textStyle="body-1">
-          <Markdown linkTarget="_blank">
-            {solution + '\n' + contactPlumberMessage}
-          </Markdown>
+          <Markdown linkTarget="_blank">{solution}</Markdown>
+          <Box
+            marginTop={4}
+            borderTop="1px solid #E0E0E0"
+            fontSize="0.8rem"
+            opacity={0.8}
+            w="full"
+          >
+            If this error still persists, contact us at{' '}
+            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
+              {SUPPORT_FORM_LINK}
+            </a>
+            .
+          </Box>
           {details && (
             <>
               <Button

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -32,13 +32,13 @@ function sortVariables(variables: Variable[]): void {
   variables.sort((a, b) => {
     // Put vars with null order last, but preserve ordering (via `sort`'s
     // stability) if both are null.
-    if (!a.order && !b.order) {
+    if (a.order == null && !b.order == null) {
       return 0
     }
-    if (!a.order) {
+    if (a.order == null) {
       return 1
     }
-    if (!b.order) {
+    if (b.order == null) {
       return -1
     }
     return a.order - b.order

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -32,7 +32,7 @@ function sortVariables(variables: Variable[]): void {
   variables.sort((a, b) => {
     // Put vars with null order last, but preserve ordering (via `sort`'s
     // stability) if both are null.
-    if (a.order == null && !b.order == null) {
+    if (a.order == null && b.order == null) {
       return 0
     }
     if (a.order == null) {


### PR DESCRIPTION
### TL;DR
Add backend implementation for 'add' and 'subtract' operations for Tiles update row action

### What changed?
- Modified `patchTableRow` to handle mathematical operations
  - added tests
  - error handling for invalid numeric operations
- Updated column metadata for tiles action to maintain column ordering
  - Fixed variable sorting logic for null order values

### How to test?
1. Create a tile with a few columns and values that are both numbers and strings
2. Test updating cells using:
   - normal updates (set as)
   - adding
   - subtracting
   - mixed
3. Verify error handling by:
   - Attempting math operations on non-numeric values (both original values and operands)
4. Check that columns maintain their order in the UI

### Regression test
1. Check that existing tiles update rows are still working