### PR TITLE
refactor: date formatter options

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
@@ -66,7 +66,7 @@ describe('common date-time formatter functions', () => {
     )
 
     it('supports parsing MyInfo Child date field', () => {
-      const dateTime = parseDateTime('formsgDateField', '25/03/2024')
+      const dateTime = parseDateTime('dd/LL/yyyy', '25/03/2024')
       expect(dateTime.toUnixInteger()).toEqual(1711296000)
     })
   })

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -71,7 +71,54 @@ describe('convert date time', () => {
       toFormat: 'dd/LL/yy',
       expectedResult: '01/04/24',
     },
-    // TODO: add tests
+    {
+      inputFormat: 'dd/LL/yy',
+      inputValue: '01/04/24',
+      toFormat: 'dd/LL/yyyy',
+      expectedResult: '01/04/2024',
+    },
+    {
+      inputFormat: 'dd/LL/yyyy',
+      inputValue: '01/04/2024',
+      toFormat: 'dd LLLL yyyy',
+      expectedResult: '01 April 2024',
+    },
+    {
+      inputFormat: 'dd LLLL yyyy',
+      inputValue: '01 April 2024',
+      toFormat: 'yyyy/LL/dd',
+      expectedResult: '2024/04/01',
+    },
+    {
+      inputFormat: 'yyyy/LL/dd',
+      inputValue: '2024/04/01',
+      toFormat: 'hh:mm a',
+      expectedResult: '12:00 am',
+    },
+    {
+      inputFormat: 'hh:mm a',
+      inputValue: '11:45 pm',
+      toFormat: 'hh:mm:ss a',
+      expectedResult: '11:45:00 pm',
+    },
+    {
+      inputFormat: 'hh:mm:ss a',
+      inputValue: '11:45:00 pm',
+      toFormat: 'hh:mm a',
+      expectedResult: '11:45 pm',
+    },
+    {
+      inputFormat: 'dd LLL yyyy hh:mm a',
+      inputValue: '01 Apr 2024 11:45 pm',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '01 Apr 2024',
+    },
+    {
+      inputFormat: 'dd LLL yyyy hh:mm:ss a',
+      inputValue: '01 Apr 2024 11:45:30 pm',
+      toFormat: 'hh:mm:ss a',
+      expectedResult: '11:45:30 pm',
+    },
   ])('can handle all supported input formats', (testParams) => {
     const { inputFormat, inputValue, toFormat, expectedResult } = testParams
     $.step.parameters = {

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -71,6 +71,7 @@ describe('convert date time', () => {
       toFormat: 'dd/LL/yy',
       expectedResult: '01/04/24',
     },
+    // TODO: add tests
   ])('can handle all supported input formats', (testParams) => {
     const { inputFormat, inputValue, toFormat, expectedResult } = testParams
     $.step.parameters = {

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod'
+
+import { ensureZodEnumValue } from '@/helpers/zod-utils'
+
+// These are the list of common input and output date format options
+export const commonDateFormats = [
+  'dd/LL/yy',
+  'dd/LL/yyyy',
+  'dd LLL yyyy',
+  'dd LLLL yyyy',
+  'yyyy/LL/dd',
+  'hh:mm a',
+  'hh:mm:ss a',
+  'dd LLL yyyy hh:mm a',
+  'dd LLL yyyy hh:mm:ss a',
+] as const
+
+const formatStringsEnum = z.enum(commonDateFormats)
+
+export const commonDateFormatOptions = [
+  {
+    label: 'DD/MM/YY',
+    description: '02/01/24',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yy'),
+  },
+  {
+    label: 'DD/MM/YYYY',
+    description: '02/01/2024',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yyyy'),
+  },
+  {
+    label: 'DD MMM YYYY',
+    description: '02 Jan 2006',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy'),
+  },
+  {
+    label: 'DD MMMM YYYY',
+    description: '02 January 2006',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
+  },
+  {
+    label: 'YYYY/MM/DD',
+    description: '2024/01/22',
+    value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
+  },
+  {
+    label: 'HH:mm (am/pm)',
+    description: '12:04 PM',
+    value: ensureZodEnumValue(formatStringsEnum, 'hh:mm a'),
+  },
+  {
+    label: 'HH:mm:ss (am/pm)',
+    description: '12:04:05 pm',
+    value: ensureZodEnumValue(formatStringsEnum, 'hh:mm:ss a'),
+  },
+  {
+    label: 'DD MMM YYYY HH:mm (am/pm)',
+    description: '02 Jan 2006 12:04 pm',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm a'),
+  },
+  {
+    label: 'DD MMM YYYY HH:mm:ss (am/pm)',
+    description: '02 Jan 2006 12:04:05 pm',
+    value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
+  },
+]

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
@@ -20,27 +20,27 @@ const formatStringsEnum = z.enum(commonDateFormats)
 export const commonDateFormatOptions = [
   {
     label: 'DD/MM/YY',
-    description: '02/01/24',
+    description: '25/03/24',
     value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yy'),
   },
   {
     label: 'DD/MM/YYYY',
-    description: '02/01/2024',
+    description: '25/03/2024',
     value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yyyy'),
   },
   {
     label: 'DD MMM YYYY',
-    description: '02 Jan 2006',
+    description: '25 Mar 2024',
     value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy'),
   },
   {
     label: 'DD MMMM YYYY',
-    description: '02 January 2006',
+    description: '25 March 2024',
     value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
   },
   {
     label: 'YYYY/MM/DD',
-    description: '2024/01/22',
+    description: '2024/03/25',
     value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
   },
   {
@@ -55,12 +55,12 @@ export const commonDateFormatOptions = [
   },
   {
     label: 'DD MMM YYYY HH:mm (am/pm)',
-    description: '02 Jan 2006 12:04 pm',
+    description: '25 Mar 2024 12:04 pm',
     value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm a'),
   },
   {
     label: 'DD MMM YYYY HH:mm:ss (am/pm)',
-    description: '02 Jan 2006 12:04:05 pm',
+    description: '25 Mar 2024 12:04:05 pm',
     value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
   },
 ]

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -61,14 +61,17 @@ const formatConverters = Object.assign({
     stringify: (dateTime: DateTime): string => dateTime.toFormat('dd MMM yyyy'),
   },
   ...Object.fromEntries(
-    commonDateFormats.map((format) => [
-      format,
-      {
-        description: format,
-        parse: (input: string): DateTime => DateTime.fromFormat(input, format),
-        stringify: (dateTime: DateTime): string => dateTime.toFormat(format),
-      },
-    ]),
+    commonDateFormats
+      .filter((format) => format !== 'dd LLL yyyy') // Exclude repeated option due to formsgDateField
+      .map((format) => [
+        format,
+        {
+          description: format,
+          parse: (input: string): DateTime =>
+            DateTime.fromFormat(input, format),
+          stringify: (dateTime: DateTime): string => dateTime.toFormat(format),
+        },
+      ]),
   ),
 }) satisfies Record<z.infer<typeof supportedFormats>, DateFormatConverter>
 
@@ -104,7 +107,10 @@ export const field = {
       description: 'Select this if you are transforming a FormSG date field',
       value: supportedFormats.enum.formsgDateField,
     },
-    ...commonDateFormatOptions,
+    // Exclude repeated option due to formsgDateField
+    ...commonDateFormatOptions.filter(
+      (option) => option.value !== 'dd LLL yyyy',
+    ),
   ],
 } satisfies IField
 

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -95,16 +95,15 @@ export const field = {
   showOptionValue: false,
   options: [
     {
-      label: 'FormSG submission time - e.g. 2024-02-25T08:15:30.250+08:00',
-      description:
-        'Select this if you are transforming a FormSG submission time',
+      label: 'FormSG Submission Time',
+      description: '2024-03-25T08:15:30.250+08:00',
       value: supportedFormats.enum.formsgSubmissionTime,
     },
     {
       // FormSG UI is a bit misleading; although the field shows dd/mm/yyyy,
       // date fields are sent as dd MMM yyyy over webhooks.
-      label: 'FormSG date field - e.g. 25 Mar 2024',
-      description: 'Select this if you are transforming a FormSG date field',
+      label: 'FormSG Date Field - DD MMM YYYY',
+      description: '25 Mar 2024',
       value: supportedFormats.enum.formsgDateField,
     },
     // Exclude repeated option due to formsgDateField

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -3,6 +3,11 @@ import type { IField } from '@plumber/types'
 import { DateTime } from 'luxon'
 import z from 'zod'
 
+import {
+  commonDateFormatOptions,
+  commonDateFormats,
+} from './date-format-options'
+
 /**
  * This file contains stuff to handle all the date formats we want to support:
  * - Field and schema definitions
@@ -17,9 +22,13 @@ interface DateFormatConverter {
   stringify: (dateTime: DateTime) => string
 }
 
-const supportedFormats = z.enum(['formsgSubmissionTime', 'formsgDateField'])
+const supportedFormats = z.enum([
+  'formsgSubmissionTime',
+  'formsgDateField', // dd LLL yyyy; this is kept due to backwards compatibility
+  ...commonDateFormats,
+])
 
-const formatConverters = {
+const formatConverters = Object.assign({
   formsgSubmissionTime: {
     description: 'FormSG submission time',
     parse: (input: string): DateTime => DateTime.fromISO(input),
@@ -46,22 +55,22 @@ const formatConverters = {
         return dateTime
       }
 
-      /**
-       * NOTE: special handling for MyInfo Child, which sends birth date in dd/mm/yyyy format.
-       * Keep this to a single converter for FormSG date fields to minimise confusion for users.
-       */
-      const dtMyInfoChild = DateTime.fromFormat(input, 'dd/MM/yyyy')
-
-      if (dtMyInfoChild.isValid) {
-        return dtMyInfoChild
-      }
-
       // en-US parsing failed, fall back to en-SG.
       return DateTime.fromFormat(input, 'dd MMM yyyy')
     },
     stringify: (dateTime: DateTime): string => dateTime.toFormat('dd MMM yyyy'),
   },
-} satisfies Record<z.infer<typeof supportedFormats>, DateFormatConverter>
+  ...Object.fromEntries(
+    commonDateFormats.map((format) => [
+      format,
+      {
+        description: format,
+        parse: (input: string): DateTime => DateTime.fromFormat(input, format),
+        stringify: (dateTime: DateTime): string => dateTime.toFormat(format),
+      },
+    ]),
+  ),
+}) satisfies Record<z.infer<typeof supportedFormats>, DateFormatConverter>
 
 //
 // Field definitions and schema
@@ -95,6 +104,7 @@ export const field = {
       description: 'Select this if you are transforming a FormSG date field',
       value: supportedFormats.enum.formsgDateField,
     },
+    ...commonDateFormatOptions,
   ],
 } satisfies IField
 
@@ -110,7 +120,7 @@ export function parseDateTime(
 
   if (!result.isValid) {
     throw new Error(
-      `'${valueToTransform}' is not a valid ${formatConverters[dateTimeFormat].description}`,
+      `${valueToTransform}' is not a valid ${formatConverters[dateTimeFormat].description}`,
     )
   }
 

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -2,22 +2,15 @@ import type { IFieldDropdown } from '@plumber/types'
 
 import z from 'zod'
 
-import { ensureZodEnumValue, ensureZodObjectKey } from '@/helpers/zod-utils'
+import { ensureZodObjectKey } from '@/helpers/zod-utils'
 
-const formatStringsEnum = z.enum([
-  'dd/LL/yy',
-  'dd/LL/yyyy',
-  'dd LLL yyyy',
-  'dd LLLL yyyy',
-  'yyyy/LL/dd',
-  'hh:mm a',
-  'hh:mm:ss a',
-  'dd LLL yyyy hh:mm a',
-  'dd LLL yyyy hh:mm:ss a',
-])
+import {
+  commonDateFormatOptions,
+  commonDateFormats,
+} from '../../common/date-format-options'
 
 export const fieldSchema = z.object({
-  formatDateTimeToFormat: formatStringsEnum,
+  formatDateTimeToFormat: z.enum(commonDateFormats),
 })
 
 export const field = {
@@ -27,51 +20,5 @@ export const field = {
   required: true,
   variables: false,
   showOptionValue: false,
-  options: [
-    {
-      label: 'DD/MM/YY',
-      description: '02/01/24',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yy'),
-    },
-    {
-      label: 'DD/MM/YYYY',
-      description: '02/01/2024',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd/LL/yyyy'),
-    },
-    {
-      label: 'DD MMM YYYY',
-      description: '02 Jan 2006',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy'),
-    },
-    {
-      label: 'DD MMMM YYYY',
-      description: '02 January 2006',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd LLLL yyyy'),
-    },
-    {
-      label: 'YYYY/MM/DD',
-      description: '2024/01/22',
-      value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
-    },
-    {
-      label: 'HH:mm (am/pm)',
-      description: '12:04 PM',
-      value: ensureZodEnumValue(formatStringsEnum, 'hh:mm a'),
-    },
-    {
-      label: 'HH:mm:ss (am/pm)',
-      description: '12:04:05 pm',
-      value: ensureZodEnumValue(formatStringsEnum, 'hh:mm:ss a'),
-    },
-    {
-      label: 'DD MMM YYYY HH:mm (am/pm)',
-      description: '02 Jan 2006 12:04 pm',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm a'),
-    },
-    {
-      label: 'DD MMM YYYY HH:mm:ss (am/pm)',
-      description: '02 Jan 2006 12:04:05 pm',
-      value: ensureZodEnumValue(formatStringsEnum, 'dd LLL yyyy hh:mm:ss a'),
-    },
-  ],
+  options: commonDateFormatOptions,
 } satisfies IFieldDropdown


### PR DESCRIPTION
Note: Created a PR out of it so it is less confusing

## Details
- Refactor input date formatter options to be similar to output date fields

RFC:
- I decided to reuse the fields from the output date fields so as to keep the formsg options (due to backward compatibility), so formsg date field option is kept exactly the same without any change.

## Tests
- [x] Formatting date options work
- [x] Add/subtract date time with new formatter input options work