### PR TITLE
PLU-374 [UI-REVAMP-APP-SELECT-1]: add modal for new step for both triggers and actions

### DIFF
--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   Divider,
   Flex,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
@@ -20,44 +21,69 @@ import {
   StepExecutionsToIncludeContext,
   StepExecutionsToIncludeProvider,
 } from '@/contexts/StepExecutionsToInclude'
+import client from '@/graphql/client'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIfThenInitializer,
+} from '@/helpers/toolbox'
+
+import EmptyFlowStepHeaderModal from '../EmptyFlowStepHeader/EmptyFlowStepHeaderModal'
 
 // TODO(mal): Remove this comment before merging this main PR
 interface AddStepButtonProps {
-  onClick: () => void
+  onClick: (appKey: string, eventKey: string) => void
   isDisabled: boolean
   isLastStep: boolean
 }
 
 function AddStepButton(props: AddStepButtonProps): JSX.Element {
   const { onClick, isDisabled, isLastStep } = props
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const handleSubmit = (appKey: string, actionKey: string) => {
+    onClick(appKey, actionKey)
+    onClose()
+  }
 
   return (
-    <Box pos="relative" h={24}>
-      {/* Top vertical line */}
-      <Box h="1.875rem">
-        <Divider orientation="vertical" borderColor="base.divider.strong" />
-      </Box>
-      {/* Bottom vertical line */}
-      {!isLastStep && (
-        <Box mt={9} h="1.875rem">
+    <>
+      <Box pos="relative" h={24}>
+        {/* Top vertical line */}
+        <Box h="1.875rem">
           <Divider orientation="vertical" borderColor="base.divider.strong" />
         </Box>
-      )}
-      <AbsoluteCenter>
-        <IconButton
-          onClick={onClick}
-          isDisabled={isDisabled}
-          aria-label="Add Step"
-          icon={<BiPlus />}
-          variant="outline"
-          size="xs"
-        />
-      </AbsoluteCenter>
-    </Box>
+        {/* Bottom vertical line */}
+        {!isLastStep && (
+          <Box mt={9} h="1.875rem">
+            <Divider orientation="vertical" borderColor="base.divider.strong" />
+          </Box>
+        )}
+        <AbsoluteCenter>
+          <IconButton
+            // onClick={onClick}
+            onClick={onOpen}
+            isDisabled={isDisabled}
+            aria-label="Add Step"
+            icon={<BiPlus />}
+            variant="outline"
+            size="xs"
+          />
+        </AbsoluteCenter>
+      </Box>
+
+      <EmptyFlowStepHeaderModal
+        isOpen={isOpen}
+        onClose={onClose}
+        isTrigger={false} // Can only add an action all the time
+        isLastStep={isLastStep}
+        onSubmit={handleSubmit}
+      />
+    </>
   )
 }
 
@@ -69,9 +95,23 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
       query: GET_FLOW,
       variables: { id: flowId },
     })
+
+    // getFlow requires certain attributes to be returned
+    const completeCreatedStep = {
+      ...createdStep,
+      iconUrl: null,
+      webhookUrl: null,
+      config: {
+        templateConfig: {
+          appEventKey: null,
+        },
+      },
+      createdAt: new Date().toISOString(),
+    }
+
     const steps = flow.steps.reduce((steps: any[], currentStep: any) => {
       if (currentStep.id === previousStepId) {
-        return [...steps, currentStep, createdStep]
+        return [...steps, currentStep, completeCreatedStep]
       }
 
       return [...steps, currentStep]
@@ -96,6 +136,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
     CREATE_STEP,
     { refetchQueries: [GET_FLOW] },
   )
+  const [initializeIfThen] = useIfThenInitializer()
 
   const { flow, steps: rawSteps } = props
   const steps = useMemo(
@@ -142,8 +183,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [updateStep, flow.id],
   )
 
+  // Add a step to the flow with the given appKey and eventKey
   const addStep = useCallback(
-    async (previousStepId: string) => {
+    async (previousStepId: string, appKey: string, eventKey: string) => {
       const mutationInput = {
         previousStep: {
           id: previousStepId,
@@ -151,17 +193,41 @@ export default function Editor(props: EditorProps): React.ReactElement {
         flow: {
           id: flow.id,
         },
+        appKey,
+        key: eventKey,
       }
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
         update: updateHandlerFactory(flow.id, previousStepId),
       })
-      const createdStepId = createdStep.data.createStep.id
 
-      setCurrentStepId(createdStepId)
+      const newStep = createdStep.data.createStep
+      setCurrentStepId(newStep.id)
+
+      // account for the if-then edge case
+      if (appKey === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen) {
+        // Get the complete step data from the cache
+        const { getFlow: updatedFlow } = client.readQuery({
+          query: GET_FLOW,
+          variables: { id: flow.id },
+        })
+
+        const completeStep = updatedFlow.steps.find(
+          (s: IStep) => s.id === newStep.id,
+        )
+
+        if (completeStep) {
+          const completeStepWithFlow = {
+            ...completeStep,
+            flow,
+            flowId: flow.id,
+          }
+          await initializeIfThen(completeStepWithFlow)
+        }
+      }
     },
-    [createStep, flow.id],
+    [createStep, flow, initializeIfThen],
   )
 
   // FIXME (ogp-weeloong): optimize this a bit further by omitting query.
@@ -277,7 +343,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 templateConfig={flow?.config?.templateConfig}
               />
               <AddStepButton
-                onClick={() => addStep(step.id)}
+                onClick={(appKey, eventKey) => {
+                  addStep(step.id, appKey, eventKey)
+                }}
                 isDisabled={creationInProgress || isReadOnlyEditor}
                 isLastStep={index === steps.length - 1}
               />

--- a/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
@@ -1,0 +1,252 @@
+import type { IAction, IApp, IStep, ITrigger } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+import { BiArrowFromRight, BiChevronRight } from 'react-icons/bi'
+import { Box, Flex, Icon, Image, Text } from '@chakra-ui/react'
+import { Badge } from '@opengovsg/design-system-react'
+
+import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from '@/config/flags'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIfThenInitializer,
+} from '@/helpers/toolbox'
+
+interface ModalBodyContentProps {
+  apps: IApp[]
+  selectedApp: IApp | null
+  setSelectedApp: (app: IApp | null) => void
+  step: IStep
+  isLastStep: boolean
+  onChange: ({ step }: { step: IStep }) => void
+  onSubmit: () => void
+}
+
+export default function ModalBodyContent(
+  props: ModalBodyContentProps,
+): JSX.Element {
+  const {
+    apps,
+    selectedApp,
+    setSelectedApp,
+    step,
+    isLastStep,
+    onChange,
+    onSubmit,
+  } = props
+  const isTrigger = step.type === 'trigger'
+
+  const launchDarkly = useContext(LaunchDarklyContext)
+  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
+  const isLoading = launchDarkly.isLoading || isInitializingIfThen
+
+  const filteredApps = useMemo(
+    () =>
+      apps?.filter((app) => {
+        // Filter away apps hidden behind feature flags
+        if (isLoading || !launchDarkly.flags || !app?.key) {
+          return true
+        }
+        const ldAppFlag = getAppFlag(app.key)
+        return launchDarkly.flags[ldAppFlag] ?? true
+      }),
+    [apps, launchDarkly.flags, isLoading],
+  )
+
+  const filteredTriggersOrActions = useMemo(() => {
+    if (!selectedApp) {
+      return []
+    }
+
+    const triggersOrActions = isTrigger
+      ? selectedApp.triggers
+      : selectedApp.actions
+    return triggersOrActions?.filter((triggerOrAction) => {
+      // Filter away triggers or actions hidden behind feature flags
+      if (isLoading || !launchDarkly.flags || !selectedApp?.key) {
+        return true
+      }
+      const launchDarklyKey = isTrigger
+        ? getAppTriggerFlag(selectedApp.key, triggerOrAction.key)
+        : getAppActionFlag(selectedApp.key, triggerOrAction.key)
+      return launchDarkly.flags[launchDarklyKey] ?? true
+    })
+  }, [selectedApp, isTrigger, launchDarkly.flags, isLoading])
+
+  const handleTriggerOrActionSelection = async (
+    app: IApp,
+    triggerOrAction: IAction | ITrigger,
+  ) => {
+    // account for the if-then edge case
+    if (
+      app.key === TOOLBOX_APP_KEY &&
+      triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
+    ) {
+      await initializeIfThen(step)
+      onSubmit()
+      return
+    }
+
+    onChange({
+      step: {
+        ...step,
+        appKey: app.key,
+        key: triggerOrAction.key,
+        parameters: {},
+      },
+    })
+    onSubmit()
+  }
+
+  /**
+   * Returns second level modal view of triggers or actions: if an app has multiple
+   * triggers or actions, it will be shown as a list of items
+   */
+  if (selectedApp) {
+    return (
+      <Flex flexDir="column" gap={3}>
+        {filteredTriggersOrActions?.map((triggerOrAction) => {
+          const isIfThen =
+            selectedApp.key === TOOLBOX_APP_KEY &&
+            triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
+          const isDisabled = isIfThen && !isLastStep
+
+          return (
+            <Box
+              key={triggerOrAction.key}
+              p={4}
+              borderWidth="1px"
+              borderRadius="lg"
+              onClick={() =>
+                !isDisabled &&
+                handleTriggerOrActionSelection(selectedApp, triggerOrAction)
+              }
+              opacity={isDisabled ? 0.5 : 1}
+              _hover={{
+                bg: 'interaction.muted.neutral.hover',
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+              }}
+              _active={{
+                bg: 'interaction.muted.neutral.active',
+              }}
+              _focus={{
+                outline: 'none',
+                boxShadow: isDisabled
+                  ? 'none'
+                  : '0 0 0 2px var(--chakra-colors-primary-500)',
+              }}
+              tabIndex={isDisabled ? -1 : 0} // Make focusable unless disabled
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleTriggerOrActionSelection(selectedApp, triggerOrAction)
+                }
+              }}
+            >
+              <Text textStyle="subhead-1">{triggerOrAction.name}</Text>
+              <Text textStyle="body-2">
+                {isDisabled
+                  ? 'This can only be used in the last step'
+                  : triggerOrAction.description}
+              </Text>
+            </Box>
+          )
+        })}
+      </Flex>
+    )
+  }
+
+  /**
+   * Returns first level modal view of apps: if an app only has one trigger or action,
+   * it will be shown as a single item. Else, it will be shown as an expandable item
+   * to the next page
+   */
+  return (
+    <Flex flexDir="column" gap={3}>
+      {filteredApps?.map((app) => {
+        const triggersOrActions = isTrigger ? app.triggers : app.actions
+        const singleTriggerOrAction =
+          triggersOrActions?.length === 1 ? triggersOrActions[0] : null
+
+        return (
+          <Flex
+            key={app.key}
+            p={4}
+            borderWidth="1px"
+            borderColor="base.divider.medium"
+            borderRadius="lg"
+            onClick={() => {
+              if (singleTriggerOrAction) {
+                handleTriggerOrActionSelection(app, singleTriggerOrAction)
+              } else {
+                setSelectedApp(app)
+              }
+            }}
+            justifyContent="space-between"
+            alignItems="center"
+            _hover={{
+              bg: 'interaction.muted.neutral.hover',
+              cursor: 'pointer',
+            }}
+            _active={{
+              bg: 'interaction.muted.neutral.active',
+            }}
+            _focus={{
+              outline: 'none',
+              boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
+            }}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                if (singleTriggerOrAction) {
+                  handleTriggerOrActionSelection(app, singleTriggerOrAction)
+                } else {
+                  setSelectedApp(app)
+                }
+              }
+            }}
+          >
+            <Flex alignItems="center" gap={4}>
+              <Image
+                src={app.iconUrl}
+                boxSize={8}
+                borderStyle="solid"
+                fit="contain"
+                fallback={
+                  <Icon
+                    boxSize={6}
+                    as={BiArrowFromRight}
+                    color="base.content.default"
+                  />
+                }
+              />
+
+              <Flex flexDir="column" gap={1}>
+                <Flex gap={2}>
+                  <Text textStyle="subhead-1">{app.name}</Text>
+                  {app.isNewApp && (
+                    <Badge
+                      bgColor="interaction.muted.main.active"
+                      color="primary.500"
+                    >
+                      New
+                    </Badge>
+                  )}
+                </Flex>
+                <Text textStyle="body-2">
+                  {singleTriggerOrAction
+                    ? singleTriggerOrAction.description
+                    : app.description}
+                </Text>
+              </Flex>
+            </Flex>
+
+            {triggersOrActions && triggersOrActions?.length > 1 && (
+              <Icon as={BiChevronRight} />
+            )}
+          </Flex>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
@@ -59,10 +59,10 @@ export default function ModalBodyContent(
       return []
     }
 
-    const triggersOrActions = isTrigger
-      ? selectedApp.triggers
-      : selectedApp.actions
-    return triggersOrActions?.filter((triggerOrAction) => {
+    const triggersOrActions: Array<ITrigger | IAction> = isTrigger
+      ? selectedApp.triggers ?? []
+      : selectedApp.actions ?? []
+    return triggersOrActions?.filter((triggerOrAction: ITrigger | IAction) => {
       // Filter away triggers or actions hidden behind feature flags
       if (isLoading || !launchDarkly.flags || !selectedApp?.key) {
         return true
@@ -76,7 +76,7 @@ export default function ModalBodyContent(
 
   const handleTriggerOrActionSelection = async (
     app: IApp,
-    triggerOrAction: IAction | ITrigger,
+    triggerOrAction: ITrigger | IAction,
   ) => {
     // account for the if-then edge case
     if (
@@ -106,52 +106,54 @@ export default function ModalBodyContent(
   if (selectedApp) {
     return (
       <Flex flexDir="column" gap={3}>
-        {filteredTriggersOrActions?.map((triggerOrAction) => {
-          const isIfThen =
-            selectedApp.key === TOOLBOX_APP_KEY &&
-            triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
-          const isDisabled = isIfThen && !isLastStep
+        {filteredTriggersOrActions?.map(
+          (triggerOrAction: ITrigger | IAction) => {
+            const isIfThen =
+              selectedApp.key === TOOLBOX_APP_KEY &&
+              triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
+            const isDisabled = isIfThen && !isLastStep
 
-          return (
-            <Box
-              key={triggerOrAction.key}
-              p={4}
-              borderWidth="1px"
-              borderRadius="lg"
-              onClick={() =>
-                !isDisabled &&
-                handleTriggerOrActionSelection(selectedApp, triggerOrAction)
-              }
-              opacity={isDisabled ? 0.5 : 1}
-              _hover={{
-                bg: 'interaction.muted.neutral.hover',
-                cursor: isDisabled ? 'not-allowed' : 'pointer',
-              }}
-              _active={{
-                bg: 'interaction.muted.neutral.active',
-              }}
-              _focus={{
-                outline: 'none',
-                boxShadow: isDisabled
-                  ? 'none'
-                  : '0 0 0 2px var(--chakra-colors-primary-500)',
-              }}
-              tabIndex={isDisabled ? -1 : 0} // Make focusable unless disabled
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
+            return (
+              <Box
+                key={triggerOrAction.key}
+                p={4}
+                borderWidth="1px"
+                borderRadius="lg"
+                onClick={() =>
+                  !isDisabled &&
                   handleTriggerOrActionSelection(selectedApp, triggerOrAction)
                 }
-              }}
-            >
-              <Text textStyle="subhead-1">{triggerOrAction.name}</Text>
-              <Text textStyle="body-2">
-                {isDisabled
-                  ? 'This can only be used in the last step'
-                  : triggerOrAction.description}
-              </Text>
-            </Box>
-          )
-        })}
+                opacity={isDisabled ? 0.5 : 1}
+                _hover={{
+                  bg: 'interaction.muted.neutral.hover',
+                  cursor: isDisabled ? 'not-allowed' : 'pointer',
+                }}
+                _active={{
+                  bg: 'interaction.muted.neutral.active',
+                }}
+                _focus={{
+                  outline: 'none',
+                  boxShadow: isDisabled
+                    ? 'none'
+                    : '0 0 0 2px var(--chakra-colors-primary-500)',
+                }}
+                tabIndex={isDisabled ? -1 : 0} // Make focusable unless disabled
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleTriggerOrActionSelection(selectedApp, triggerOrAction)
+                  }
+                }}
+              >
+                <Text textStyle="subhead-1">{triggerOrAction.name}</Text>
+                <Text textStyle="body-2">
+                  {isDisabled
+                    ? 'This can only be used in the last step'
+                    : triggerOrAction.description}
+                </Text>
+              </Box>
+            )
+          },
+        )}
       </Flex>
     )
   }

--- a/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/ModalBodyContent.tsx
@@ -1,4 +1,4 @@
-import type { IAction, IApp, IStep, ITrigger } from '@plumber/types'
+import type { IAction, IApp, ITrigger } from '@plumber/types'
 
 import { useContext, useMemo } from 'react'
 import { BiArrowFromRight, BiChevronRight } from 'react-icons/bi'
@@ -11,34 +11,25 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
   useIfThenInitializer,
+  useIsIfThenSelectable,
 } from '@/helpers/toolbox'
 
 interface ModalBodyContentProps {
   apps: IApp[]
   selectedApp: IApp | null
   setSelectedApp: (app: IApp | null) => void
-  step: IStep
+  isTrigger: boolean
   isLastStep: boolean
-  onChange: ({ step }: { step: IStep }) => void
-  onSubmit: () => void
+  onSubmit: (appKey: string, actionKey: string) => void
 }
 
 export default function ModalBodyContent(
   props: ModalBodyContentProps,
 ): JSX.Element {
-  const {
-    apps,
-    selectedApp,
-    setSelectedApp,
-    step,
-    isLastStep,
-    onChange,
-    onSubmit,
-  } = props
-  const isTrigger = step.type === 'trigger'
-
+  const { apps, selectedApp, setSelectedApp, isTrigger, isLastStep, onSubmit } =
+    props
   const launchDarkly = useContext(LaunchDarklyContext)
-  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
+  const [_, isInitializingIfThen] = useIfThenInitializer()
   const isLoading = launchDarkly.isLoading || isInitializingIfThen
 
   const filteredApps = useMemo(
@@ -78,26 +69,10 @@ export default function ModalBodyContent(
     app: IApp,
     triggerOrAction: ITrigger | IAction,
   ) => {
-    // account for the if-then edge case
-    if (
-      app.key === TOOLBOX_APP_KEY &&
-      triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
-    ) {
-      await initializeIfThen(step)
-      onSubmit()
-      return
-    }
-
-    onChange({
-      step: {
-        ...step,
-        appKey: app.key,
-        key: triggerOrAction.key,
-        parameters: {},
-      },
-    })
-    onSubmit()
+    onSubmit(app.key, triggerOrAction.key)
   }
+
+  const isIfThenSelectable = useIsIfThenSelectable({ isLastStep })
 
   /**
    * Returns second level modal view of triggers or actions: if an app has multiple
@@ -111,7 +86,7 @@ export default function ModalBodyContent(
             const isIfThen =
               selectedApp.key === TOOLBOX_APP_KEY &&
               triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
-            const isDisabled = isIfThen && !isLastStep
+            const isDisabled = isIfThen && !isIfThenSelectable
 
             return (
               <Box

--- a/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/index.tsx
@@ -1,4 +1,4 @@
-import type { IApp, IStep } from '@plumber/types'
+import type { IApp } from '@plumber/types'
 
 import { useEffect, useState } from 'react'
 import { BiChevronLeft, BiLinkExternal } from 'react-icons/bi'
@@ -25,17 +25,15 @@ import ModalBodyContent from './ModalBodyContent'
 interface EmptyFlowStepHeaderModalProps {
   isOpen: boolean
   onClose: () => void
-  step: IStep
+  isTrigger: boolean
   isLastStep: boolean
-  onChange: ({ step }: { step: IStep }) => void
-  onSubmit: () => void
+  onSubmit: (appKey: string, eventKey: string) => void
 }
 
 export default function EmptyFlowStepHeaderModal(
   props: EmptyFlowStepHeaderModalProps,
 ): JSX.Element {
-  const { isOpen, onClose, isLastStep, step, onChange, onSubmit } = props
-  const isTrigger = step.type === 'trigger'
+  const { isOpen, onClose, isLastStep, isTrigger, onSubmit } = props
 
   const [selectedApp, setSelectedApp] = useState<IApp | null>(null)
 
@@ -90,9 +88,8 @@ export default function EmptyFlowStepHeaderModal(
             apps={apps}
             selectedApp={selectedApp}
             setSelectedApp={setSelectedApp}
-            step={step}
+            isTrigger={isTrigger}
             isLastStep={isLastStep}
-            onChange={onChange}
             onSubmit={onSubmit}
           />
         </ModalBody>

--- a/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/EmptyFlowStepHeaderModal/index.tsx
@@ -1,0 +1,114 @@
+import type { IApp, IStep } from '@plumber/types'
+
+import { useEffect, useState } from 'react'
+import { BiChevronLeft, BiLinkExternal } from 'react-icons/bi'
+import { useQuery } from '@apollo/client'
+import {
+  Button,
+  Flex,
+  Icon,
+  Link,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+
+import * as URLS from '@/config/urls'
+import { GET_APPS } from '@/graphql/queries/get-apps'
+
+import ModalBodyContent from './ModalBodyContent'
+
+interface EmptyFlowStepHeaderModalProps {
+  isOpen: boolean
+  onClose: () => void
+  step: IStep
+  isLastStep: boolean
+  onChange: ({ step }: { step: IStep }) => void
+  onSubmit: () => void
+}
+
+export default function EmptyFlowStepHeaderModal(
+  props: EmptyFlowStepHeaderModalProps,
+): JSX.Element {
+  const { isOpen, onClose, isLastStep, step, onChange, onSubmit } = props
+  const isTrigger = step.type === 'trigger'
+
+  const [selectedApp, setSelectedApp] = useState<IApp | null>(null)
+
+  const { data } = useQuery(GET_APPS)
+  const apps: IApp[] = data?.getApps?.filter((app: IApp) =>
+    isTrigger ? !!app.triggers?.length : !!app.actions?.length,
+  )
+
+  // Reset selected app when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedApp(null)
+    }
+  }, [isOpen])
+
+  return (
+    <Modal
+      isCentered
+      isOpen={isOpen}
+      onClose={onClose}
+      size="xl"
+      scrollBehavior="inside"
+      autoFocus={false}
+    >
+      <ModalOverlay bg="base.canvas.overlay" />
+      <ModalContent>
+        <ModalHeader>
+          {selectedApp ? (
+            <Flex gap={2} flexDir="column" alignItems="flex-start">
+              <Button
+                variant="clear"
+                onClick={() => setSelectedApp(null)}
+                leftIcon={<BiChevronLeft />}
+                ml={-4}
+              >
+                Back
+              </Button>
+              <Text textStyle="h3-semibold">{selectedApp.name}</Text>
+              {/* TODO: Check if description is needed for each app */}
+            </Flex>
+          ) : (
+            <Text textStyle="h3-semibold" pt={4}>
+              {isTrigger
+                ? 'Choose how you want your workflow to start'
+                : 'Choose which action you want to run next'}
+            </Text>
+          )}
+        </ModalHeader>
+
+        <ModalBody>
+          <ModalBodyContent
+            apps={apps}
+            selectedApp={selectedApp}
+            setSelectedApp={setSelectedApp}
+            step={step}
+            isLastStep={isLastStep}
+            onChange={onChange}
+            onSubmit={onSubmit}
+          />
+        </ModalBody>
+
+        <ModalFooter justifyContent="center" gap={2}>
+          <Text textStyle="caption-1">{`Can't find what you need? Let us know`}</Text>
+          <Link
+            href={URLS.FEEDBACK_FORM_LINK}
+            isExternal
+            color="interaction.links.neutral-default"
+            mt={1}
+          >
+            <Icon as={BiLinkExternal} />
+          </Link>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -1,0 +1,61 @@
+import type { IStep } from '@plumber/types'
+
+import { BiRun, BiSolidBolt } from 'react-icons/bi'
+import { Flex, Icon, Text, useDisclosure } from '@chakra-ui/react'
+
+import EmptyFlowStepHeaderModal from './EmptyFlowStepHeaderModal'
+
+interface EmptyFlowStepHeaderProps {
+  step: IStep
+  isLastStep: boolean
+  onChange: ({ step }: { step: IStep }) => void
+  onSubmit: () => void
+}
+
+export default function EmptyFlowStepHeader(
+  props: EmptyFlowStepHeaderProps,
+): JSX.Element {
+  const { step, isLastStep, onChange, onSubmit } = props
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const isTrigger = step.type === 'trigger'
+  return (
+    <>
+      <Flex
+        w="full"
+        borderWidth="1px"
+        borderColor="base.divider.medium"
+        borderRadius="lg"
+        bg="white"
+        p={4}
+        justifyContent="center"
+        alignItems="center"
+        gap={4}
+        onClick={onOpen}
+        _hover={{
+          bg: 'interaction.muted.neutral.hover',
+          cursor: 'pointer',
+        }}
+        _active={{
+          bg: 'interaction.muted.neutral.active',
+        }}
+      >
+        <Icon as={isTrigger ? BiSolidBolt : BiRun} />
+        <Text>
+          {isTrigger
+            ? 'Choose how you want your workflow to start'
+            : 'Choose which action you want to run next'}
+        </Text>
+      </Flex>
+
+      <EmptyFlowStepHeaderModal
+        isOpen={isOpen}
+        onClose={onClose}
+        step={step}
+        isLastStep={isLastStep}
+        onChange={onChange}
+        onSubmit={onSubmit}
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -1,24 +1,20 @@
-import type { IStep } from '@plumber/types'
-
 import { BiRun, BiSolidBolt } from 'react-icons/bi'
 import { Flex, Icon, Text, useDisclosure } from '@chakra-ui/react'
 
 import EmptyFlowStepHeaderModal from './EmptyFlowStepHeaderModal'
 
 interface EmptyFlowStepHeaderProps {
-  step: IStep
+  isTrigger: boolean
   isLastStep: boolean
-  onChange: ({ step }: { step: IStep }) => void
-  onSubmit: () => void
+  onSubmit: (appKey: string, eventKey: string) => void
 }
 
 export default function EmptyFlowStepHeader(
   props: EmptyFlowStepHeaderProps,
 ): JSX.Element {
-  const { step, isLastStep, onChange, onSubmit } = props
+  const { isTrigger, isLastStep, onSubmit } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  const isTrigger = step.type === 'trigger'
   return (
     <>
       <Flex
@@ -51,9 +47,8 @@ export default function EmptyFlowStepHeader(
       <EmptyFlowStepHeaderModal
         isOpen={isOpen}
         onClose={onClose}
-        step={step}
+        isTrigger={isTrigger}
         isLastStep={isLastStep}
-        onChange={onChange}
         onSubmit={onSubmit}
       />
     </>

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -39,6 +39,11 @@ import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { replacePlaceholdersForHelpMessage } from '@/helpers/flow-templates'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+  useIfThenInitializer,
+} from '@/helpers/toolbox'
 
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
@@ -221,19 +226,38 @@ export default function FlowStep(
   const shouldShowInfobox: boolean =
     stepAppEventKey === templateStepAppEventKey && !!templateStepHelpMessage
 
+  const [initializeIfThen] = useIfThenInitializer()
+
   if (!apps) {
     return <CircularProgress isIndeterminate my={2} />
   }
   const toggleSubstep = (substepIndex: number) =>
     setCurrentSubstep((value) => (value !== substepIndex ? substepIndex : null))
 
-  if (!selectedActionOrTrigger) {
+  const onSubmitForEmptyHeader = async (appKey: string, eventKey: string) => {
+    // account for the if-then edge case
+    if (appKey === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen) {
+      await initializeIfThen(step)
+    } else {
+      handleChange({
+        step: {
+          ...step,
+          appKey,
+          key: eventKey,
+          parameters: {},
+        },
+      })
+    }
+    expandNextStep()
+    onOpen()
+  }
+
+  if (!app) {
     return (
       <EmptyFlowStepHeader
-        step={step}
+        isTrigger={isTrigger}
         isLastStep={isLastStep}
-        onChange={handleChange}
-        onSubmit={expandNextStep}
+        onSubmit={onSubmitForEmptyHeader}
       />
     )
   }

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -40,6 +40,7 @@ import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { replacePlaceholdersForHelpMessage } from '@/helpers/flow-templates'
 
+import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
 
 type FlowStepProps = {
@@ -226,6 +227,17 @@ export default function FlowStep(
   const toggleSubstep = (substepIndex: number) =>
     setCurrentSubstep((value) => (value !== substepIndex ? substepIndex : null))
 
+  if (!selectedActionOrTrigger) {
+    return (
+      <EmptyFlowStepHeader
+        step={step}
+        isLastStep={isLastStep}
+        onChange={handleChange}
+        onSubmit={expandNextStep}
+      />
+    )
+  }
+
   return (
     <Flex w="100%" flexDir="column">
       {shouldShowInfobox && (
@@ -268,6 +280,8 @@ export default function FlowStep(
             onSubmit={handleSubmit}
             resolver={stepValidationSchema}
           >
+            {/* Note: keeping this to allow users to still modify their app or event but can change
+            to pop open the modal instead if */}
             {!cannotChooseApp && (
               <ChooseAppAndEventSubstep
                 expanded={currentSubstep === 0}


### PR DESCRIPTION
### TL;DR
Added a new empty flow step header component with a modal to improve the app/action selection experience.

### What changed?
- Created a new `EmptyFlowStepHeader` component that displays when no app/action is selected
- Added a modal interface for selecting apps and their associated triggers/actions
- Implemented a two-level navigation system in the modal:
  - First level shows available apps
  - Second level displays specific triggers/actions for the selected app
- Added feature flag support for conditionally showing apps and actions
- Integrated special handling for if-then actions that can only be used in the last step

### After screenshots

https://github.com/user-attachments/assets/272914fc-28a0-4544-8364-1c054f7cf763



### How to test?
1. Open a workflow
2. Verify the empty step header appears when no app/action is selected
3. Click the header to open the selection modal
4. Test navigation between apps and their actions
5. Verify the if-then action is only selectable in the last step
6. Confirm feature flags correctly hide/show apps and actions
7. Test keyboard navigation and accessibility features

### Why make this change?
To provide a more intuitive and user-friendly interface for selecting workflow apps and actions, while maintaining proper feature flag controls and accessibility standards. The modal approach offers better organization and clearer navigation compared to the previous implementation.