### PR TITLE
chore: bump ecs task definition version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,7 @@ jobs:
           image: ${{ steps.ecr-image-uri.outputs.image }}
 
       - name: Deploy Amazon ECS task definition to server
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: ${{ steps.full-task-def.outputs.task-definition }}
           cluster: ${{ inputs.ecs-cluster-name }}


### PR DESCRIPTION
## Problem

Refer to https://opengovproducts.slack.com/archives/CK9GGK6EP/p1736350549788019

## Details
- Bump version for ecs task definition

## Tests
- [ ] Check that deployment to staging and uat works