### PR TITLE
PLU-403: add tooltip for cc recipients limitations

### DIFF
--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -57,6 +57,8 @@ export const transactionalEmailFields: IField[] = [
     required: false,
     description:
       'Enter the email addresses to CC, separated by commas.\nCC recipients will receive a copy of the email for each main recipient.',
+    tooltipText:
+      'CC recipient status is not tracked, and blacklisted CC recipients will be ignored, but the email will still be sent to other recipients.',
     variables: true,
   },
   {

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -58,7 +58,7 @@ export const transactionalEmailFields: IField[] = [
     description:
       'Enter the email addresses to CC, separated by commas.\nCC recipients will receive a copy of the email for each main recipient.',
     tooltipText:
-      'CC recipient status is not tracked, and blacklisted CC recipients will be ignored, but the email will still be sent to other recipients.',
+      'CC recipient status is not tracked. Blacklisted CC recipients will be ignored, but the email will still be sent to other recipients.',
     variables: true,
   },
   {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -43,7 +43,7 @@ type Query {
   getTableConnections(tableIds: [String!]!): JSONObject
   getTables(limit: Int!, offset: Int!, name: String): PaginatedTables!
   # Tiles rows
- getAllRows(tableId: String!, stringifiedCursor: String): GetTableRowsResult!
+  getAllRows(tableId: String!, stringifiedCursor: String): GetTableRowsResult!
   getCurrentUser: User
   healthcheck: AppHealth
   getPlumberStats: Stats
@@ -192,6 +192,7 @@ type ActionSubstepArgument {
   source: ActionSubstepArgumentSource
   hiddenIf: FieldVisibilityCondition
   addRowButtonText: String
+  tooltipText: String
 
   # Only for dropdown
   addNewOption: DropdownAddNewOption

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -41,6 +41,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     variables,
     type,
     placeholder,
+    tooltipText,
   } = schema
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
@@ -132,6 +133,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           placeholder={placeholder}
           isSingleLine={parentType === 'multicol'}
           variablesEnabled
+          tooltipText={tooltipText}
         />
       )
     }

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -263,6 +263,7 @@ interface RichTextEditorProps {
   variablesEnabled?: boolean
   isRich?: boolean
   isSingleLine?: boolean
+  tooltipText?: string
 }
 const RichTextEditor = ({
   required,
@@ -275,6 +276,7 @@ const RichTextEditor = ({
   variablesEnabled,
   isRich,
   isSingleLine,
+  tooltipText,
 }: RichTextEditorProps) => {
   const { control } = useFormContext()
 
@@ -284,6 +286,7 @@ const RichTextEditor = ({
         <FormLabel
           isRequired={required}
           description={description}
+          tooltipText={tooltipText}
           style={{ whiteSpace: 'pre-wrap' }}
         >
           {label}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -192,6 +192,7 @@ export const GET_APPS = gql`
             addRowButtonText
             showOptionValue
             customStyle
+            tooltipText
             value
             options {
               label

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -265,6 +265,7 @@ export interface IBaseField {
   docUrl?: string
   clickToCopy?: boolean
   variables?: boolean
+  tooltipText?: string
 
   /**
    * Allows hiding a field if other fields' values don't fulfill some condition


### PR DESCRIPTION
## Problem
Postman does not provide notification of failures when CC-ing blacklisted emails.

## Solution
Temporary solution is to notify users of the limitation on the frontend.

## Before & After Screenshots

**BEFORE**:
NA.

**AFTER**:

<img width="862" alt="Screenshot 2025-02-03 at 10 47 17 PM" src="https://github.com/user-attachments/assets/d1596230-8a86-4c0b-97df-7ae9efbd251b" />

## Tests
NA, frontend change.