### PR TITLE
PLU-406: always show delete button on mobile

### DIFF
--- a/packages/frontend/src/pages/Tiles/components/TileList.tsx
+++ b/packages/frontend/src/pages/Tiles/components/TileList.tsx
@@ -26,6 +26,7 @@ import {
   Tag,
   TagLabel,
   TagLeftIcon,
+  useIsMobile,
   useToast,
 } from '@opengovsg/design-system-react'
 
@@ -54,6 +55,7 @@ const TileListItem = ({
   numConnections: number
   table: TableMetadata
 }): JSX.Element => {
+  const isMobile = useIsMobile()
   const toast = useToast()
   const [deleteTable, { loading: isDeletingTable }] = useMutation(
     DELETE_TABLE,
@@ -127,13 +129,13 @@ const TileListItem = ({
           )}
           {table.role === 'owner' && (
             <IconButton
-              className="hover-remove-button"
+              className={isMobile ? undefined : 'hover-remove-button'}
               variant="clear"
               aria-label="Remove"
               icon={<BiTrash />}
               isDisabled={isConnectionsLoading}
               onClick={onDeleteButtonClick}
-              visibility="hidden"
+              visibility={isMobile ? 'visible' : 'hidden'}
             />
           )}
         </Flex>


### PR DESCRIPTION
## Problem
The Delete Tile button was designed to appear only on hover. However, this functionality does not work on mobile devices due to limited hover support. 
Additionally, users have reported that clicking on whitespace unintentionally opens the modal to confirm tile deletion.

## Solution
On mobile devices, always display the Delete Tile button. 
For non-mobile devices, retain the existing behaviour where the button appears on hover.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2025-02-05 at 8 09 14 PM](https://github.com/user-attachments/assets/6acb4e2b-7485-4b5d-bbcb-6f4d208d7b3f)
![Screenshot 2025-02-05 at 8 09 31 PM](https://github.com/user-attachments/assets/2bfbcd49-1a7e-40f0-a6f3-d9b95325f4e7)


**AFTER**:
<img width="340" alt="Screenshot 2025-02-05 at 8 09 53 PM" src="https://github.com/user-attachments/assets/5579fc5b-bb7a-463a-b828-87fc6d836b03" />


## Tests
- [ ] On mobile devices, delete Tile button is always shown
- [ ] On non-mobile devices, delete Tile button is shown on hover
- [ ] Tiles can be deleted successfully

