### PR TITLE
fix: stop deleting execution steps on step delete

### DIFF
--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -40,7 +40,12 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     }
 
     const stepIds = steps.map((step) => step.id)
-    await Step.relatedQuery('executionSteps', trx).for(stepIds).delete()
+
+    /**
+     * NOTE: do not delete execution steps
+     * The deletion causes RDS CPU Utilisation to spike
+     */
+    // await Step.relatedQuery('executionSteps', trx).for(stepIds).delete()
     await Step.query(trx).findByIds(stepIds).delete()
 
     await steps[0].flow

--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -25,7 +25,13 @@ export async function getTestExecutionSteps(
 
   if (flow.testExecution && !ignoreTestExecutionId) {
     const testExecutionSteps = flow.testExecution.executionSteps
-    testExecutionSteps.sort((a, b) => a.step.position - b.step.position)
+
+    /**
+     * NOTE: filters out test execution steps for steps that have been deleted
+     */
+    testExecutionSteps
+      .filter((e) => e.step)
+      .sort((a, b) => a.step.position - b.step.position)
 
     /**
      * Sanity check to ensure not more than 1 execution step per step is returned

--- a/packages/backend/src/services/test-step.ts
+++ b/packages/backend/src/services/test-step.ts
@@ -38,7 +38,7 @@ const testStep = async (options: TestStepOptions): Promise<TestStepResult> => {
 
   const testExecutionSteps = await getTestExecutionSteps(flow.id)
   const testActionExecutionSteps = testExecutionSteps.filter(
-    (executionStep) => executionStep.step.isAction,
+    (executionStep) => executionStep.step && executionStep.step.isAction,
   )
 
   /**


### PR DESCRIPTION
## Problem
RDS CPU Utilisation spikes when user deletes a step due to the deletion of corresponding execution steps.

## Solution
**Improvements**:

- Do not delete the execution steps as there is no impact to the pipe when execution steps are not deleted
- Only impact is at the retrieval of test execution steps, where deleted steps have to be filtered out. This tradeoff is deemed acceptable as the query to delete execution steps is expensive for Pipes with many executions.

## Tests
- [ ] Deleting steps does not affect Pipes, i.e. data for existing steps remain and Pipe can execute properly
- [ ] Adding new steps to a Pipe works and Pipe executes properly
