### PR TITLE
chore: remove unnecessary variant prop

### DIFF
--- a/packages/frontend/src/components/SingleSelect/SelectContext.tsx
+++ b/packages/frontend/src/components/SingleSelect/SelectContext.tsx
@@ -35,8 +35,6 @@ export interface SharedSelectContextReturnProps<
   isRefreshLoading?: boolean
   /** Controls if user can add one arbitrary item of their choosing. */
   freeSolo?: boolean
-  /** Variant of the select */
-  variant?: string
 }
 
 interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -61,7 +61,6 @@ export interface SingleSelectProviderProps<
     onSelected: (value: string) => void
     isCreating: boolean
   }
-  variant?: string
 }
 
 function constructFreeSoloItem(freeSoloValue: string) {
@@ -98,7 +97,6 @@ export const SingleSelectProvider = ({
   isRefreshLoading = false,
   freeSolo = false,
   addNew,
-  variant,
 }: SingleSelectProviderProps): JSX.Element => {
   const theme = useTheme()
   // Required in case size is set in theme, we should respect the one set in theme.
@@ -354,7 +352,6 @@ export const SingleSelectProvider = ({
     size,
     isClearable,
     colorScheme,
-    variant,
   })
 
   const virtualListHeight = useMemo(() => {
@@ -411,7 +408,6 @@ export const SingleSelectProvider = ({
         isRefreshLoading,
         freeSolo,
         isCreatingNewOption: addNew?.isCreating,
-        variant: variant ?? 'default',
       }}
     >
       {children}

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -36,7 +36,6 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       inputRef,
       isClearable,
       size,
-      variant,
     } = useSelectContext()
 
     const mergedInputRef = useMergeRefs(inputRef, ref)
@@ -127,7 +126,6 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
               required: isRequired,
               'aria-expanded': !!isOpen,
             })}
-            variant={variant}
           />
           <ToggleChevron />
         </InputGroup>

--- a/packages/frontend/src/theme/components/SingleSelect.ts
+++ b/packages/frontend/src/theme/components/SingleSelect.ts
@@ -33,31 +33,6 @@ const baseStyle = definePartsStyle((props) => {
   }
 })
 
-const borderless = definePartsStyle({
-  field: {
-    bg: 'utility.ui',
-    borderRadius: 'base',
-    fontSize: '0.875rem',
-    gridArea: '1 / 1 / 2 / 3',
-    h: '2.5rem',
-    px: '0.75rem',
-    textStyle: 'body-2',
-    border: 'none!important',
-    _focus: {
-      border: 'none!important',
-      boxShadow: 'none!important',
-    },
-    _active: {
-      border: 'none!important',
-      boxShadow: 'none!important',
-    },
-    _placeholder: {
-      color: 'interaction.support.placeholder',
-    },
-  },
-})
-
 export const SingleSelect = defineMultiStyleConfig({
   baseStyle,
-  variants: { borderless },
 })


### PR DESCRIPTION
Remove unnecessary variant prop that was previously introduced in PLU-405.
- Variant was added to create a custom component in Executions page to combine a borderless SingleSelect with an ExecutionStatusMenu
- However, team adopted the same layout as the Pipes page, making this custom variant no longer necessary.