### PR TITLE
chore: add automatic retries for 502s from M365

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -97,7 +97,7 @@ describe('M365 request error handlers', () => {
     vi.restoreAllMocks()
   })
 
-  it.each([500, 502])(
+  it.each([500, 502, 503])(
     'logs a warning and throws a RetriableError with default step delay on %s',
     async (status) => {
       mockAxiosAdapterToThrowOnce(status)
@@ -117,24 +117,6 @@ describe('M365 request error handlers', () => {
       )
     },
   )
-
-  it('logs a warning and throws a RetriableError with default step delay on 503, if response does not have retry-after', async () => {
-    mockAxiosAdapterToThrowOnce(503)
-    await http
-      .get('/test-url')
-      .then(() => {
-        expect.unreachable()
-      })
-      .catch((error): void => {
-        expect(error).toBeInstanceOf(RetriableError)
-        expect(error.delayType).toEqual('step')
-        expect(error.delayInMs).toEqual(DEFAULT_DELAY_MS)
-      })
-    expect(mocks.logWarning).toHaveBeenCalledWith(
-      expect.stringContaining('HTTP 503'),
-      expect.objectContaining({ event: 'm365-http-503' }),
-    )
-  })
 
   it('logs a warning and throws a RetriableError with step delay set to retry-after, on receiving 503', async () => {
     mockAxiosAdapterToThrowOnce(503, { 'retry-after': 123 })

--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -97,6 +97,27 @@ describe('M365 request error handlers', () => {
     vi.restoreAllMocks()
   })
 
+  it.each([500, 502])(
+    'logs a warning and throws a RetriableError with default step delay on %s',
+    async (status) => {
+      mockAxiosAdapterToThrowOnce(status)
+      await http
+        .get('/test-url')
+        .then(() => {
+          expect.unreachable()
+        })
+        .catch((error): void => {
+          expect(error).toBeInstanceOf(RetriableError)
+          expect(error.delayType).toEqual('step')
+          expect(error.delayInMs).toEqual(DEFAULT_DELAY_MS)
+        })
+      expect(mocks.logWarning).toHaveBeenCalledWith(
+        expect.stringContaining(`HTTP ${status}`),
+        expect.objectContaining({ event: `m365-http-${status}` }),
+      )
+    },
+  )
+
   it('logs a warning and throws a RetriableError with default step delay on 503, if response does not have retry-after', async () => {
     mockAxiosAdapterToThrowOnce(503)
     await http

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -59,7 +59,7 @@ const handle429: ThrowingHandler = ($, error) => {
 //
 // Retry failures due to flakey M365 servers
 //
-const handle500and503: ThrowingHandler = function ($, error) {
+const handle500and502and503: ThrowingHandler = function ($, error) {
   // Log to monitor spikes, just in case
   const status = error.response.status
   logger.warn(`Received HTTP ${status} from MS Graph`, {
@@ -115,8 +115,9 @@ const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
     case 429: // Rate limited
       return handle429($, error)
     case 500:
+    case 502: // Bad gateway
     case 503: // Transient error
-      return handle500and503($, error)
+      return handle500and502and503($, error)
     case 509: // Bandwidth limit reached
       return handle509($, error)
   }


### PR DESCRIPTION
## Problem
User reported receiving 502 bad gateway error for M365 step and had to manually retry for the step / execution to work.

## Solution
**Improvements**:
- Add automatic retries for 502s (already retrying for 500s and 503s)

