### PR TITLE
fix: remove rate limit on entire group

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/queue.test.ts
+++ b/packages/backend/src/apps/tiles/__tests__/queue.test.ts
@@ -24,10 +24,6 @@ describe('Queue config', () => {
     vi.restoreAllMocks()
   })
 
-  it('configures a delayable queue', () => {
-    expect(tilesApp.queue.isQueueDelayable).toEqual(true)
-  })
-
   it('sets group ID to the file ID', async () => {
     mocks.stepQueryResult.mockResolvedValueOnce({
       parameters: {
@@ -67,9 +63,5 @@ describe('Queue config', () => {
       type: 'concurrency',
       concurrency: 1,
     })
-  })
-
-  it('avoids bursting via a leaky bucket approach', () => {
-    expect(tilesApp.queue.queueRateLimit.max).toEqual(1)
   })
 })

--- a/packages/backend/src/apps/tiles/queue/index.ts
+++ b/packages/backend/src/apps/tiles/queue/index.ts
@@ -1,6 +1,5 @@
 import type { IAppQueue } from '@plumber/types'
 
-import { TILES_INTERVAL_BETWEEN_FIND_SINGLE_ROW_MS } from '@/config/app-env-vars/tiles'
 import Step from '@/models/step'
 
 // Define actions that should be queued
@@ -38,11 +37,7 @@ const queueSettings = {
     type: 'concurrency',
     concurrency: 1,
   },
-  isQueueDelayable: true,
-  queueRateLimit: {
-    max: 1,
-    duration: TILES_INTERVAL_BETWEEN_FIND_SINGLE_ROW_MS,
-  },
+  isQueueDelayable: false,
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/config/app-env-vars/index.ts
+++ b/packages/backend/src/config/app-env-vars/index.ts
@@ -24,4 +24,3 @@
 import './m365'
 import './formsg'
 import './postman-sms'
-import './tiles'

--- a/packages/backend/src/config/app-env-vars/tiles.ts
+++ b/packages/backend/src/config/app-env-vars/tiles.ts
@@ -1,4 +1,0 @@
-// Default to 1 action per second.
-export const TILES_INTERVAL_BETWEEN_FIND_SINGLE_ROW_MS = Number(
-  process.env.TILES_INTERVAL_BETWEEN_FIND_SINGLE_ROW_MS ?? '1000',
-)


### PR DESCRIPTION
## Problem
* Rate limit was applied to entire group of Tile actions

## Solution
* Only set concurrency = 1 for specified groups on findSingleRow action
