### PR TITLE
feat: add payment forms action to paysg integration

### DIFF
--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -3,7 +3,7 @@ import type { IRawAction } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
-import StepError, { GenericSolution } from '@/errors/step'
+import StepError from '@/errors/step'
 
 import { requestSchema } from './schema'
 
@@ -79,14 +79,14 @@ const action: IRawAction = {
       required: false,
       subFields: [
         {
-          label: 'Question',
+          placeholder: 'Question',
           key: 'question',
           type: 'string' as const,
           required: true,
           variables: true,
         },
         {
-          label: 'Answer',
+          placeholder: 'Answer',
           key: 'answer',
           type: 'string' as const,
           required: true,
@@ -119,7 +119,7 @@ const action: IRawAction = {
 
         throw new StepError(
           `${firstError.message} at "${firstError.path}"`,
-          GenericSolution.ReconfigureInvalidField,
+          `${firstError.message} under set up step`,
           $.step.position,
           $.app.name,
         )

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -3,7 +3,7 @@ import type { IRawAction } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
-import StepError from '@/errors/step'
+import StepError, { GenericSolution } from '@/errors/step'
 
 import { requestSchema } from './schema'
 
@@ -118,8 +118,8 @@ const action: IRawAction = {
         const firstError = fromZodError(error).details[0]
 
         throw new StepError(
-          `${firstError.message} at "${firstError.path}"`,
           `${firstError.message} under set up step`,
+          GenericSolution.ReconfigureInvalidField,
           $.step.position,
           $.app.name,
         )

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -72,7 +72,8 @@ const action: IRawAction = {
       variables: true,
     },
     {
-      label: 'Responses',
+      label: 'Additional responses',
+      description: 'These will be included in reports exported from PaySG',
       key: 'responses',
       type: 'multirow' as const,
       required: false,

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -19,6 +19,7 @@ const action: IRawAction = {
       key: 'formId',
       type: 'string' as const,
       required: true,
+      placeholder: 'e.g. https://pay.gov.sg/forms/aBC123Def456HijK789LMn',
     },
     {
       label: 'FormSG Form ID',

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -1,0 +1,131 @@
+import type { IRawAction } from '@plumber/types'
+
+import { ZodError } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+
+import StepError, { GenericSolution } from '@/errors/step'
+
+import { requestSchema } from './schema'
+
+const action: IRawAction = {
+  name: 'Create payment form submission',
+  key: 'createPaymentFormSubmission',
+  description:
+    'Create a new submission for a payment form, and initiate a payment request',
+  arguments: [
+    {
+      label: 'Payment Form Link',
+      description: 'This can be found on your PaySG payment services dashboard',
+      key: 'formId',
+      type: 'string' as const,
+      required: true,
+    },
+    {
+      label: 'FormSG Form ID',
+      description: 'Input the variable corresponding to form ID here',
+      key: 'formsg_form_id',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      label: 'FormSG Submission ID',
+      key: 'formsg_submission_id',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      label: 'FormSG Reference Field Answer',
+      key: 'nonce',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      label: 'Payer Name',
+      key: 'payer_name',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      label: 'Payer Email',
+      key: 'payer_email',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
+      label: 'Amount (in cents)',
+      key: 'amount_in_cents',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+    {
+      label: 'Description',
+      key: 'description',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
+      label: 'Responses',
+      key: 'responses',
+      type: 'multirow' as const,
+      required: false,
+      subFields: [
+        {
+          label: 'Question',
+          key: 'question',
+          type: 'string' as const,
+          required: true,
+          variables: true,
+        },
+        {
+          label: 'Answer',
+          key: 'answer',
+          type: 'string' as const,
+          required: true,
+          variables: true,
+        },
+      ],
+    },
+  ],
+
+  async run($) {
+    const paymentServiceId = $.auth.data.paymentServiceId as string
+
+    try {
+      const { formId, ...body } = requestSchema.parse($.step.parameters)
+
+      await $.http.post(
+        `/v1/payment-services/:paymentServiceId/forms/:formId/submissions`,
+        body,
+        {
+          urlPathParams: {
+            paymentServiceId,
+            formId,
+          },
+        },
+      )
+      $.setActionItem({ raw: { success: true } })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const firstError = fromZodError(error).details[0]
+
+        throw new StepError(
+          `${firstError.message} at "${firstError.path}"`,
+          GenericSolution.ReconfigureInvalidField,
+          $.step.position,
+          $.app.name,
+        )
+      }
+
+      throw error
+    }
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
@@ -9,9 +9,9 @@ const PAYMENT_FORM_LINK_REGEX = /^https:\/\/(staging.)?pay.gov.sg\/forms\/(.*)$/
 
 export const requestSchema = z.object({
   formId: z
-    .string()
+    .string({ invalid_type_error: 'Empty payment form link' })
     .trim()
-    .min(1, { message: 'Specify a form link' })
+    .min(1, { message: 'Specify a payment form link' })
     .transform((value, context) => {
       const match = value.match(PAYMENT_FORM_LINK_REGEX)
 
@@ -26,16 +26,19 @@ export const requestSchema = z.object({
       return match[2]
     }),
   formsg_form_id: z
-    .string()
+    .string({ invalid_type_error: 'Empty FormSG form ID' })
     .trim()
     .length(FORM_ID_LENGTH, { message: 'Specify a valid FormSG form ID' }),
   formsg_submission_id: z
-    .string()
+    .string({ invalid_type_error: 'Empty FormSG submission ID' })
     .trim()
     .min(1, { message: 'Specify a submission ID' }),
-  nonce: z.string().trim().min(1, { message: 'Specify a nonce field' }),
+  nonce: z
+    .string({ invalid_type_error: 'Empty FormSG reference field answer' })
+    .trim()
+    .min(1, { message: 'Specify a FormSG reference field answer' }),
   payer_name: z
-    .string()
+    .string({ invalid_type_error: 'Empty payer name' })
     .trim()
     .min(1, { message: 'Empty payer name' })
     .max(255, { message: 'Payer name cannot be more than 255 characters' })
@@ -65,8 +68,10 @@ export const requestSchema = z.object({
     .min(1, { message: 'Empty payment amount' })
     .pipe(
       z.coerce
-        .number()
-        .int('Payment amount must be round number')
+        .number({
+          invalid_type_error: 'Payment amount must be a number',
+        })
+        .int('Payment amount must be a round number')
         .min(50, { message: 'Payment amount must be larger than 50 cents' })
         .max(99999999, {
           message: 'Payment amount cannot be larger than $999999.99',
@@ -80,8 +85,14 @@ export const requestSchema = z.object({
     .optional(),
   responses: z.array(
     z.object({
-      question: z.string().trim().min(1, { message: 'Empty question' }),
-      answer: z.string().trim().min(1, { message: 'Empty answer' }),
+      question: z
+        .string({ invalid_type_error: 'Empty question' })
+        .trim()
+        .min(1, { message: 'Empty question' }),
+      answer: z
+        .string({ invalid_type_error: 'Empty answer' })
+        .trim()
+        .min(1, { message: 'Empty answer' }),
     }),
   ),
 })

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
@@ -76,6 +76,7 @@ export const requestSchema = z.object({
     .string()
     .trim()
     .max(500, { message: 'Description cannot be more than 500 characters' })
+    .transform((value) => value || undefined)
     .optional(),
   responses: z.array(
     z.object({

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
@@ -1,0 +1,86 @@
+import emailValidator from 'email-validator'
+import { z } from 'zod'
+
+import { FORM_ID_LENGTH } from '@/apps/formsg/common/constants'
+
+import { normalizeSpecialChars } from '../create-payment/normalize-special-chars'
+
+const PAYMENT_FORM_LINK_REGEX = /^https:\/\/(staging.)?pay.gov.sg\/forms\/(.*)$/
+
+export const requestSchema = z.object({
+  formId: z
+    .string()
+    .trim()
+    .min(1, { message: 'Specify a form link' })
+    .transform((value, context) => {
+      const match = value.match(PAYMENT_FORM_LINK_REGEX)
+
+      if (!match || !match[0]) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid payment form link',
+        })
+        return z.NEVER
+      }
+
+      return match[2]
+    }),
+  formsg_form_id: z
+    .string()
+    .trim()
+    .length(FORM_ID_LENGTH, { message: 'Specify a valid FormSG form ID' }),
+  formsg_submission_id: z
+    .string()
+    .trim()
+    .min(1, { message: 'Specify a submission ID' }),
+  nonce: z.string().trim().min(1, { message: 'Specify a nonce field' }),
+  payer_name: z
+    .string()
+    .trim()
+    .min(1, { message: 'Empty payer name' })
+    .max(255, { message: 'Payer name cannot be more than 255 characters' })
+    .transform((value) => normalizeSpecialChars(value)),
+  payer_email: z
+    .string()
+    .trim()
+    .max(255, { message: 'Payer email cannot be more than 255 characters' })
+    .transform((value, context) => {
+      if (!value || value.length === 0) {
+        return undefined
+      }
+      if (!emailValidator.validate(value)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid payer email',
+        })
+        return z.NEVER
+      }
+
+      return value
+    })
+    .optional(),
+  amount_in_cents: z
+    .string()
+    .trim()
+    .min(1, { message: 'Empty payment amount' })
+    .pipe(
+      z.coerce
+        .number()
+        .int('Payment amount must be round number')
+        .min(50, { message: 'Payment amount must be larger than 50 cents' })
+        .max(99999999, {
+          message: 'Payment amount cannot be larger than $999999.99',
+        }),
+    ),
+  description: z
+    .string()
+    .trim()
+    .max(500, { message: 'Description cannot be more than 500 characters' })
+    .optional(),
+  responses: z.array(
+    z.object({
+      question: z.string().trim().min(1, { message: 'Empty question' }),
+      answer: z.string().trim().min(1, { message: 'Empty answer' }),
+    }),
+  ),
+})

--- a/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
@@ -67,7 +67,7 @@ export const requestSchema = z
       .string()
       .trim()
       .min(1, { message: 'Empty description' })
-      .max(500, { message: 'Payer email cannot be more than 500 characters' }),
+      .max(500, { message: 'Description cannot be more than 500 characters' }),
     paymentAmountCents: z
       .string()
       .trim()

--- a/packages/backend/src/apps/paysg/actions/index.ts
+++ b/packages/backend/src/apps/paysg/actions/index.ts
@@ -1,5 +1,11 @@
 import createPayment from './create-payment'
+import createPaymentFormSubmission from './create-payment-form-submission'
 import getPayment from './get-payment'
 import sendEmail from './send-email'
 
-export default [createPayment, getPayment, sendEmail]
+export default [
+  createPayment,
+  getPayment,
+  sendEmail,
+  createPaymentFormSubmission,
+]


### PR DESCRIPTION
## Problem

The PaySG team wants to add a new action to the existing PaySG integration. This PR implements this action.

For background, the PaySG team is implementing an integration with FormSG so that payers can have a cohesive experience filling in a FormSG form and then being redirected to a payment page within the same browser session. This is currently not yet possible - the closest alternative is to use the createPayment action in the existing PaySG integration, but this creates a payment link that is sent out separately via email rather than being a redirect flow.

Currently, users will need to use the "Custom HTTP request" action in order to implement it, as a workaround. However, the team wants to make this an action actually available on the UI.

## Solution

The action is implemented in this PR, under the PaySG integration folder. 

## Screenshots

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9a732e3d-4e00-4297-9896-ba3fecfdb6ae" />

## Tests

For both PaySG staging and production
-  [x] Create a new payment form in PaySG. Set up the plumber pipe with relevant fields. Now, go to the PaySG payment link and ensure that the payment form works as intended.
- [x] Ensure that the payment form still works, even if all the optional fields are missing.
