### PR TITLE
PLU-175: BullMQ Pro - Move apps to specific queues

### DIFF
--- a/packages/backend/src/apps/postman/index.ts
+++ b/packages/backend/src/apps/postman/index.ts
@@ -1,5 +1,7 @@
 import { IApp } from '@plumber/types'
 
+import { getGenericAppQueue } from '@/queues/helpers/get-generic-app-queue'
+
 import actions from './actions'
 
 const app: IApp = {
@@ -18,6 +20,7 @@ const app: IApp = {
     url: 'https://demo.arcade.software/VppMAbGKfFXFEsKxnKiw?embed&show_copy_link=true',
     title: 'Setting up Email by Postman',
   },
+  queue: getGenericAppQueue('POSTMAN_EMAIL'),
 }
 
 export default app

--- a/packages/backend/src/apps/slack/index.ts
+++ b/packages/backend/src/apps/slack/index.ts
@@ -1,5 +1,7 @@
 import { IApp } from '@plumber/types'
 
+import { getGenericAppQueue } from '@/queues/helpers/get-generic-app-queue'
+
 import addAuthHeader from './common/add-auth-header'
 import actions from './actions'
 import auth from './auth'
@@ -17,6 +19,7 @@ const app: IApp = {
   auth,
   actions,
   dynamicData,
+  queue: getGenericAppQueue('SLACK'),
 }
 
 export default app

--- a/packages/backend/src/apps/telegram-bot/index.ts
+++ b/packages/backend/src/apps/telegram-bot/index.ts
@@ -1,5 +1,7 @@
 import { IApp } from '@plumber/types'
 
+import { getGenericAppQueue } from '@/queues/helpers/get-generic-app-queue'
+
 import addAuthHeader from './common/add-auth-header'
 import rateLimitHandler from './common/interceptor/rate-limit'
 import actions from './actions'
@@ -19,6 +21,7 @@ const app: IApp = {
   dynamicData,
   auth,
   actions,
+  queue: getGenericAppQueue('TELEGRAM'),
 }
 
 export default app

--- a/packages/backend/src/config/queues.ts
+++ b/packages/backend/src/config/queues.ts
@@ -1,0 +1,5 @@
+export const QUEUE_CONCURRENCY = {
+  POSTMAN_EMAIL: 3,
+  SLACK: 3,
+  TELEGRAM: 3,
+}

--- a/packages/backend/src/config/workers.ts
+++ b/packages/backend/src/config/workers.ts
@@ -1,0 +1,8 @@
+export const WORKER_CONCURRENCY = {
+  'm365-excel': 3,
+  postman: 3,
+  'postman-sms': 3,
+  slack: 3,
+  'telegram-bot': 3,
+  tiles: 3,
+}

--- a/packages/backend/src/queues/__tests__/helpers.get-generic-app-queue.test.ts
+++ b/packages/backend/src/queues/__tests__/helpers.get-generic-app-queue.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { QUEUE_CONCURRENCY } from '@/config/queues'
+
+import { getGenericAppQueue } from '../helpers/get-generic-app-queue'
+
+describe('tests for apps with generic queue', () => {
+  // apps that have a generic queue
+  const apps = Object.keys(QUEUE_CONCURRENCY)
+
+  it.each(apps)(
+    'should return a generic queue with the correct group config for %s',
+    async (app) => {
+      const appKey = app as keyof typeof QUEUE_CONCURRENCY
+      const queue = getGenericAppQueue(appKey)
+      const groupConfig = await queue.getGroupConfigForJob({
+        flowId: 'some-flow-id',
+        executionId: 'some-execution-id',
+        stepId: 'some-step-id',
+      })
+      expect(groupConfig).toEqual({ id: app })
+    },
+  )
+
+  it.each(apps)(
+    'should return a generic queue with the correct concurrency for %s',
+    (app) => {
+      const appKey = app as keyof typeof QUEUE_CONCURRENCY
+      const queue = getGenericAppQueue(appKey)
+      expect(queue.groupLimits.type).toBe('concurrency')
+      if (queue.groupLimits.type === 'concurrency') {
+        expect(queue.groupLimits.concurrency).toBe(QUEUE_CONCURRENCY[appKey])
+      }
+    },
+  )
+
+  it('should return a generic queue with concurrency 2 if the app is not in the QUEUE_CONCURRENCY object', async () => {
+    const queue = getGenericAppQueue(
+      'NOT_A_REAL_APP' as keyof typeof QUEUE_CONCURRENCY,
+    )
+    const groupConfig = await queue.getGroupConfigForJob({
+      flowId: 'some-flow-id',
+      executionId: 'some-execution-id',
+      stepId: 'some-step-id',
+    })
+    expect(groupConfig).toEqual({ id: 'NOT_A_REAL_APP' })
+
+    expect(queue.groupLimits.type).toBe('concurrency')
+    if (queue.groupLimits.type === 'concurrency') {
+      expect(queue.groupLimits.concurrency).toBe(2)
+    }
+  })
+})

--- a/packages/backend/src/queues/helpers/get-generic-app-queue.ts
+++ b/packages/backend/src/queues/helpers/get-generic-app-queue.ts
@@ -1,0 +1,28 @@
+import type { IAppQueue } from '@plumber/types'
+
+import { QUEUE_CONCURRENCY } from '@/config/queues'
+
+/**
+ * NOTE: this creates a generic queue for apps that do not require
+ * any special queue configuration.
+ * It adds a generic group id to the jobs to ensure that the
+ * concurrency limit is applied.
+ */
+export function getGenericAppQueue(
+  app: keyof typeof QUEUE_CONCURRENCY,
+): IAppQueue {
+  const concurrency = QUEUE_CONCURRENCY[app] || 2
+
+  const getGroupConfigForJob = async () => {
+    return { id: app }
+  }
+
+  return {
+    getGroupConfigForJob,
+    groupLimits: {
+      type: 'concurrency',
+      concurrency: concurrency,
+    },
+    isQueueDelayable: false,
+  } satisfies IAppQueue
+}

--- a/packages/backend/src/workers/__tests__/action.test.ts
+++ b/packages/backend/src/workers/__tests__/action.test.ts
@@ -44,6 +44,7 @@ describe('action workers', () => {
 
   it('creates the worker for the main action queue and makes it undelayable', () => {
     expect(mocks.makeActionWorker).toHaveBeenCalledWith({
+      appKey: MAIN_ACTION_QUEUE_NAME,
       queueName: MAIN_ACTION_QUEUE_NAME,
       redisConnectionPrefix: MAIN_ACTION_QUEUE_REDIS_CONNECTION_PREFIX,
       queueConfig: {
@@ -54,10 +55,12 @@ describe('action workers', () => {
 
   it('creates a worker for each app that has their own action queue', () => {
     expect(mocks.makeActionWorker).toHaveBeenCalledWith({
+      appKey: 'app-with-queue-1',
       queueName: '{app-actions-app-with-queue-1}',
       queueConfig: { stubQueueConfig: 1 },
     })
     expect(mocks.makeActionWorker).toHaveBeenCalledWith({
+      appKey: 'app-with-queue-2',
       queueName: '{app-actions-app-with-queue-2}',
       queueConfig: { stubQueueConfig: 2 },
     })

--- a/packages/backend/src/workers/__tests__/helpers.make-action-worker.test.ts
+++ b/packages/backend/src/workers/__tests__/helpers.make-action-worker.test.ts
@@ -63,6 +63,7 @@ describe('makeActionWorker', () => {
 
   it('creates a worker for the specified queue name', () => {
     makeActionWorker({
+      appKey: 'test-app',
       queueName: '{test-app-queue}',
       queueConfig: { isQueueDelayable: false },
     })
@@ -78,6 +79,7 @@ describe('makeActionWorker', () => {
 
   it('supports specifying a redis connection prefix', () => {
     makeActionWorker({
+      appKey: 'test-app',
       queueName: 'some-queue',
       redisConnectionPrefix: '{test}',
       queueConfig: { isQueueDelayable: false },
@@ -170,6 +172,7 @@ describe('makeActionWorker', () => {
     "sets up queue according to the app's queue config",
     ({ appQueueConfig, expectedWorkerOptions }) => {
       makeActionWorker({
+        appKey: 'test-app',
         queueName: '{test-app-queue}',
         queueConfig: appQueueConfig,
       })

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -14,6 +14,7 @@ import { makeActionWorker } from '@/workers/helpers/make-action-worker'
 
 // Worker for our main action queue
 export const mainActionWorker = makeActionWorker({
+  appKey: MAIN_ACTION_QUEUE_NAME,
   queueName: MAIN_ACTION_QUEUE_NAME,
   redisConnectionPrefix: MAIN_ACTION_QUEUE_REDIS_CONNECTION_PREFIX,
   queueConfig: {
@@ -32,6 +33,7 @@ for (const [appKey, app] of Object.entries(apps)) {
   }
 
   appActionWorkers[appKey] = makeActionWorker({
+    appKey,
     queueName: appActionQueues[appKey].name,
     queueConfig: app.queue,
   })

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -8,6 +8,7 @@ import {
 
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
+import { WORKER_CONCURRENCY } from '@/config/workers'
 import { handleFailedStepAndThrow } from '@/helpers/actions'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
 import {
@@ -30,12 +31,16 @@ import { processAction } from '@/services/action'
 function convertParamsToBullMqOptions(
   params: MakeActionWorkerParams,
 ) /* inferred type */ {
-  const { queueName, redisConnectionPrefix, queueConfig } = params
+  const { appKey, queueName, redisConnectionPrefix, queueConfig } = params
   const { isQueueDelayable, queueRateLimit } = queueConfig
+
+  const concurrency =
+    WORKER_CONCURRENCY[appKey as keyof typeof WORKER_CONCURRENCY] ||
+    appConfig.workerActionConcurrency
 
   const workerOptions: WorkerProOptions = {
     connection: createRedisClient(),
-    concurrency: appConfig.workerActionConcurrency,
+    concurrency,
     settings: {
       backoffStrategy: exponentialBackoffWithJitter,
     },
@@ -74,6 +79,7 @@ function convertParamsToBullMqOptions(
 }
 
 interface MakeActionWorkerParams {
+  appKey: string
   queueName: string
   redisConnectionPrefix?: string
   queueConfig: IAppQueue


### PR DESCRIPTION
## App-specific Queues
Implementing app-specific queues to provide more granular control over actions and applications in Plumber.
This allows us to manage queues in cases where certain apps experience downtime without affecting other actions.

## Solution
**Features**:
- Introduced `getGenericAppQueue` helper function to create generic queues
- Added `QUEUE_CONCURRENCY` configuration for specific apps
- Applied generic queues to Postman, Slack, and Telegram apps
- Implemented tests for generic app queue configuration

## Before & After Screenshots

**BEFORE**:
N.A.

**AFTER**:
<img width="1512" alt="Screenshot 2025-02-19 at 9 49 53 AM" src="https://github.com/user-attachments/assets/740ebf08-c0ad-4a66-b913-18e333fbb939" />



## Tests

- [ ] Verify that all test runs and executions function as expected.
- [ ] Ensure queues can be paused for specific apps without losing executions.
- [ ] Confirm that actions adhere to the set concurrency limit for each app, i.e., the maximum number of “Active” jobs remains within the defined limit.

## Deploy Notes
**New scripts**:
- `packages/backend/src/config/queues.ts` : configures the concurrency limit for each app
- `packages/backend/src/queues/__tests__/helpers.get-generic-app-queue.test.ts` : tests for creating the generic app queue
- `packages/backend/src/queues/helpers/get-generic-app-queue.ts` : script to create a generic queue for an app

