### PR TITLE
fix: filter deleted steps that failed when retrieving test execution

### DIFF
--- a/packages/backend/src/helpers/get-test-execution-steps.ts
+++ b/packages/backend/src/helpers/get-test-execution-steps.ts
@@ -29,7 +29,7 @@ export async function getTestExecutionSteps(
     /**
      * NOTE: filters out test execution steps for steps that have been deleted
      */
-    testExecutionSteps
+    const filteredTestExecutionSteps = testExecutionSteps
       .filter((e) => e.step)
       .sort((a, b) => a.step.position - b.step.position)
 
@@ -38,22 +38,25 @@ export async function getTestExecutionSteps(
      * If more than 1 exists, we return the latest one sorted by createdAt
      */
     const stepIds = new Set<string>()
-    const dedupedTestExecutionSteps = testExecutionSteps.reduce((acc, curr) => {
-      if (stepIds.has(curr.stepId)) {
-        const otherExecutionStep = acc[acc.length - 1]
-        // possible bug in single step testing !! this should not happen
-        console.warn(
-          `Bug: More than 1 execution step found for step ${curr.stepId}`,
-        )
-        if (curr.createdAt > otherExecutionStep.createdAt) {
-          acc[acc.length - 1] = curr
+    const dedupedTestExecutionSteps = filteredTestExecutionSteps.reduce(
+      (acc, curr) => {
+        if (stepIds.has(curr.stepId)) {
+          const otherExecutionStep = acc[acc.length - 1]
+          // possible bug in single step testing !! this should not happen
+          console.warn(
+            `Bug: More than 1 execution step found for step ${curr.stepId}`,
+          )
+          if (curr.createdAt > otherExecutionStep.createdAt) {
+            acc[acc.length - 1] = curr
+          }
+        } else {
+          stepIds.add(curr.stepId)
+          acc.push(curr)
         }
-      } else {
-        stepIds.add(curr.stepId)
-        acc.push(curr)
-      }
-      return acc
-    }, [] as ExecutionStep[])
+        return acc
+      },
+      [] as ExecutionStep[],
+    )
 
     return dedupedTestExecutionSteps
   }


### PR DESCRIPTION
## Description
- Filtered test execution steps is not being used when calling `getTestExecutionSteps`, resulting in an error

## How to recreate
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/470a59d2-eac6-4bdb-a3c2-d4b483d2ddc9" />

1. Add step and make a failed test execution
2. Delete the step and refresh the page