### PR TITLE
chore: add custom api request timeout

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request-interceptors.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request-interceptors.test.ts
@@ -14,6 +14,18 @@ import {
 const CF_REDIRECTION_WORKER_FOR_UNIT_TESTS =
   'https://http-request-unit-tester.plumber-wrench.workers.dev'
 
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: () => ({
+        throwIfNotFound: vi.fn(() => ({
+          config: {},
+        })),
+      }),
+    }),
+  },
+}))
+
 describe('http request interceptors', () => {
   let $: IGlobalVariable
 

--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -12,19 +12,28 @@ import {
   DISALLOWED_IP_RESOLVED_ERROR,
   RECURSIVE_WEBHOOK_ERROR_NAME,
 } from '../../common/check-urls'
-import {
-  CUSTOM_API_TIMEOUT,
-  CUSTOM_API_TIMEOUT_ERROR,
-  CUSTOM_API_TIMEOUT_ERROR_STR,
-} from '../../common/constants'
+import { CUSTOM_API_TIMEOUT } from '../../common/constants'
 
 const mocks = vi.hoisted(() => ({
   httpRequest: vi.fn(),
   isUrlAllowed: vi.fn(() => true),
+  stepQueryResult: vi.fn(() => ({
+    config: {},
+  })),
 }))
 
 vi.mock('../../common/ip-resolver', () => ({
   isUrlAllowed: mocks.isUrlAllowed,
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: () => ({
+        throwIfNotFound: mocks.stepQueryResult,
+      }),
+    }),
+  },
 }))
 
 describe('make http request', () => {
@@ -246,17 +255,83 @@ describe('make http request', () => {
     )
   })
 
-  it('should throw step error if request times out', async () => {
+  it('should use admin override timeout if set', async () => {
     $.step.parameters.method = 'GET'
     $.step.parameters.url = 'http://test.local/endpoint'
 
-    const timeoutError = new Error(CUSTOM_API_TIMEOUT_ERROR)
-    mocks.httpRequest.mockRejectedValueOnce(timeoutError)
+    // Set up the mock for this specific test
+    mocks.stepQueryResult.mockResolvedValueOnce({
+      config: {
+        adminOverride: {
+          customApiTimeout: 360000,
+        },
+      },
+    })
+    mocks.httpRequest.mockResolvedValueOnce({ data: 'response' })
 
-    await expect(makeRequestAction.run($)).rejects.toThrow(
-      CUSTOM_API_TIMEOUT_ERROR_STR,
+    await makeRequestAction.run($)
+
+    expect(mocks.httpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: 360000,
+      }),
     )
   })
+
+  it.each(['not a number', '33', undefined, null])(
+    'should use default timeout if admin override is %s',
+    async (testOverride: any) => {
+      $.step.parameters.method = 'GET'
+      $.step.parameters.url = 'http://test.local/endpoint'
+
+      mocks.stepQueryResult.mockResolvedValueOnce({
+        config: {
+          adminOverride: {
+            customApiTimeout: testOverride,
+          },
+        },
+      })
+      mocks.httpRequest.mockResolvedValueOnce({ data: 'response' })
+
+      await makeRequestAction.run($)
+
+      expect(mocks.httpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeout: CUSTOM_API_TIMEOUT,
+        }),
+      )
+    },
+  )
+
+  it('should throw step error if request times out', async () => {
+    $.step.parameters.method = 'GET'
+    $.step.parameters.url = 'http://test.local/endpoint'
+    const testTimeout = 1000
+    mocks.stepQueryResult.mockResolvedValueOnce({
+      config: {
+        adminOverride: {
+          customApiTimeout: testTimeout,
+        },
+      },
+    })
+
+    // Simulate a long-running request by delaying the response
+    mocks.httpRequest.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          const timeoutError = new Error(
+            `HTTP request exceeded timeout of ${testTimeout / 1000}s`,
+          )
+          setTimeout(() => {
+            reject(timeoutError)
+          }, 2000) // 2 seconds delay
+        }),
+    )
+
+    await expect(makeRequestAction.run($)).rejects.toThrow(
+      `HTTP request exceeded timeout of ${testTimeout / 1000}s`,
+    )
+  }, 5000)
 
   describe('tests that data is valid JSON', () => {
     // NOTE: caters for existing users that are sending strings in the data field

--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -12,6 +12,11 @@ import {
   DISALLOWED_IP_RESOLVED_ERROR,
   RECURSIVE_WEBHOOK_ERROR_NAME,
 } from '../../common/check-urls'
+import {
+  CUSTOM_API_TIMEOUT,
+  CUSTOM_API_TIMEOUT_ERROR,
+  CUSTOM_API_TIMEOUT_ERROR_STR,
+} from '../../common/constants'
 
 const mocks = vi.hoisted(() => ({
   httpRequest: vi.fn(),
@@ -55,7 +60,7 @@ describe('make http request', () => {
     $.step.parameters.url = 'http://test.local/endpoint?1234'
     mocks.httpRequest.mockReturnValue('mock response')
 
-    await makeRequestAction.run($).catch(() => null)
+    await makeRequestAction.run($).catch((): void => null)
     expect(mocks.httpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         url: $.step.parameters.url,
@@ -75,7 +80,7 @@ describe('make http request', () => {
     ]
     mocks.httpRequest.mockReturnValue('mock response')
 
-    await makeRequestAction.run($).catch(() => null)
+    await makeRequestAction.run($).catch((): void => null)
     expect(mocks.httpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         url: $.step.parameters.url,
@@ -227,6 +232,32 @@ describe('make http request', () => {
     await expect(makeRequestAction.run($)).rejects.toThrowError(StepError)
   })
 
+  it('should include timeout in the request config', async () => {
+    $.step.parameters.method = 'GET'
+    $.step.parameters.url = 'http://test.local/endpoint'
+    mocks.httpRequest.mockResolvedValueOnce({ data: 'response' })
+
+    await makeRequestAction.run($)
+
+    expect(mocks.httpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeout: CUSTOM_API_TIMEOUT,
+      }),
+    )
+  })
+
+  it('should throw step error if request times out', async () => {
+    $.step.parameters.method = 'GET'
+    $.step.parameters.url = 'http://test.local/endpoint'
+
+    const timeoutError = new Error(CUSTOM_API_TIMEOUT_ERROR)
+    mocks.httpRequest.mockRejectedValueOnce(timeoutError)
+
+    await expect(makeRequestAction.run($)).rejects.toThrow(
+      CUSTOM_API_TIMEOUT_ERROR_STR,
+    )
+  })
+
   describe('tests that data is valid JSON', () => {
     // NOTE: caters for existing users that are sending strings in the data field
     it.each(['[1, 2, 3]', 'meep meep'])(
@@ -238,7 +269,7 @@ describe('make http request', () => {
 
         mocks.httpRequest.mockReturnValue('mock response')
 
-        await makeRequestAction.run($).catch(() => null)
+        await makeRequestAction.run($).catch((): void => null)
         expect(mocks.httpRequest).toHaveBeenCalledWith(
           expect.objectContaining({
             url: $.step.parameters.url,
@@ -266,7 +297,7 @@ describe('make http request', () => {
         $.step.parameters.url = 'http://test.local/endpoint?1234'
         mocks.httpRequest.mockReturnValue('mock response')
 
-        await makeRequestAction.run($).catch(() => null)
+        await makeRequestAction.run($).catch((): void => null)
         expect(mocks.httpRequest).toHaveBeenCalledWith(
           expect.objectContaining({
             url: $.step.parameters.url,

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -10,10 +10,7 @@ import {
   DISALLOWED_IP_RESOLVED_ERROR,
   RECURSIVE_WEBHOOK_ERROR_NAME,
 } from '../../common/check-urls'
-import {
-  CUSTOM_API_TIMEOUT,
-  CUSTOM_API_TIMEOUT_ERROR,
-} from '../../common/constants'
+import { CUSTOM_API_TIMEOUT } from '../../common/constants'
 
 import { requestSchema } from './schema'
 
@@ -185,7 +182,7 @@ const action: IRawAction = {
         )
       }
 
-      if (err.message === CUSTOM_API_TIMEOUT_ERROR) {
+      if (err.message === `timeout of ${timeout}ms exceeded`) {
         throw new StepError(
           `HTTP request exceeded timeout of ${timeout / 1000}s`,
           'The request took too long to respond.',

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -9,6 +9,11 @@ import {
   DISALLOWED_IP_RESOLVED_ERROR,
   RECURSIVE_WEBHOOK_ERROR_NAME,
 } from '../../common/check-urls'
+import {
+  CUSTOM_API_TIMEOUT,
+  CUSTOM_API_TIMEOUT_ERROR,
+  CUSTOM_API_TIMEOUT_ERROR_STR,
+} from '../../common/constants'
 
 import { requestSchema } from './schema'
 
@@ -105,6 +110,7 @@ const action: IRawAction = {
         data: parsedData,
         maxRedirects: 0,
         headers: customHeaders,
+        timeout: CUSTOM_API_TIMEOUT,
         //  overwriting this to allow redirects to resolve
         validateStatus: (status) =>
           (status >= 200 && status < 300) ||
@@ -166,6 +172,16 @@ const action: IRawAction = {
           'If you think this is a mistake, please contact us.',
           $.step.position,
           $.app.name,
+        )
+      }
+
+      if (err.message === CUSTOM_API_TIMEOUT_ERROR) {
+        throw new StepError(
+          CUSTOM_API_TIMEOUT_ERROR_STR,
+          'The request took too long to respond. Please check your network connection and try again.',
+          $.step.position,
+          $.app.name,
+          err,
         )
       }
 

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -4,6 +4,7 @@ import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
+import Step from '@/models/step'
 
 import {
   DISALLOWED_IP_RESOLVED_ERROR,
@@ -12,7 +13,6 @@ import {
 import {
   CUSTOM_API_TIMEOUT,
   CUSTOM_API_TIMEOUT_ERROR,
-  CUSTOM_API_TIMEOUT_ERROR_STR,
 } from '../../common/constants'
 
 import { requestSchema } from './schema'
@@ -100,6 +100,16 @@ const action: IRawAction = {
     const data = $.step.parameters.data as string
     const url = $.step.parameters.url as string
 
+    // Check if the step has an admin override for the timeout
+    // There may be certain custom apis that need more time to respond
+    // for e.g., Google Apps Script API which can run for up to 360 seconds
+    const step = await Step.query().findById($.step.id).throwIfNotFound()
+    const customTimeoutRaw = step.config?.adminOverride?.customApiTimeout
+    const timeout =
+      typeof customTimeoutRaw === 'number'
+        ? customTimeoutRaw
+        : CUSTOM_API_TIMEOUT
+
     try {
       const parsedS = requestSchema.parse($.step.parameters)
       const { customHeaders, data: parsedData } = parsedS
@@ -110,7 +120,7 @@ const action: IRawAction = {
         data: parsedData,
         maxRedirects: 0,
         headers: customHeaders,
-        timeout: CUSTOM_API_TIMEOUT,
+        timeout,
         //  overwriting this to allow redirects to resolve
         validateStatus: (status) =>
           (status >= 200 && status < 300) ||
@@ -177,7 +187,7 @@ const action: IRawAction = {
 
       if (err.message === CUSTOM_API_TIMEOUT_ERROR) {
         throw new StepError(
-          CUSTOM_API_TIMEOUT_ERROR_STR,
+          `HTTP request exceeded timeout of ${timeout / 1000}s`,
           'The request took too long to respond. Please check your network connection and try again.',
           $.step.position,
           $.app.name,

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -188,7 +188,7 @@ const action: IRawAction = {
       if (err.message === CUSTOM_API_TIMEOUT_ERROR) {
         throw new StepError(
           `HTTP request exceeded timeout of ${timeout / 1000}s`,
-          'The request took too long to respond. Please check your network connection and try again.',
+          'The request took too long to respond.',
           $.step.position,
           $.app.name,
           err,

--- a/packages/backend/src/apps/custom-api/common/constants.ts
+++ b/packages/backend/src/apps/custom-api/common/constants.ts
@@ -1,0 +1,6 @@
+// Custom API Timeout
+export const CUSTOM_API_TIMEOUT = 1000 * 30 // in milliseconds
+export const CUSTOM_API_TIMEOUT_ERROR = `timeout of ${CUSTOM_API_TIMEOUT}ms exceeded`
+export const CUSTOM_API_TIMEOUT_ERROR_STR = `HTTP request timed out after ${
+  CUSTOM_API_TIMEOUT / 1000
+}s` // in seconds for readability

--- a/packages/backend/src/apps/custom-api/common/constants.ts
+++ b/packages/backend/src/apps/custom-api/common/constants.ts
@@ -1,6 +1,3 @@
 // Custom API Timeout
-export const CUSTOM_API_TIMEOUT = 1000 * 30 // in milliseconds
-export const CUSTOM_API_TIMEOUT_ERROR = `timeout of ${CUSTOM_API_TIMEOUT}ms exceeded`
-export const CUSTOM_API_TIMEOUT_ERROR_STR = `HTTP request timed out after ${
-  CUSTOM_API_TIMEOUT / 1000
-}s` // in seconds for readability
+export const CUSTOM_API_TIMEOUT = 1000 * 60 // in milliseconds
+export const CUSTOM_API_TIMEOUT_ERROR = `timeout exceeded`

--- a/packages/backend/src/apps/custom-api/common/constants.ts
+++ b/packages/backend/src/apps/custom-api/common/constants.ts
@@ -1,3 +1,2 @@
 // Custom API Timeout
 export const CUSTOM_API_TIMEOUT = 1000 * 60 // in milliseconds
-export const CUSTOM_API_TIMEOUT_ERROR = `timeout exceeded`


### PR DESCRIPTION
## Problem
Custom API does not have a timeout for requests.
- Axios does not set a default timeout for requests
- No timeout was explicitly set previously.
- API requests could hang indefinitely if server takes too long to respond

## Solution
**Improvements**:
- Set an explicit timeout of 60s for Custom API HTTP requests
- Allow for configurable timeout using adminOverride in the step config
  -  Accounts for certain apps that take longer than 60s, for e.g., Google Apps Script, which may take up to 6 minutes to respond
- Rationale for 60s: 
  - Provides sufficient time for interactions with third-party APIs, which may take longer to complete
  - Most Custom API calls made in Plumber are within 60s
  - Allows for better error handling by catching failed requests and prompting users to attempt retries
  - Commonly used in the industry by services like AWS API Gateway, Lambda, and Stripe API

## Before & After Screenshots
**BEFORE**:
NA

**AFTER**:
At Test step:
<img width="861" alt="Screenshot 2025-03-04 at 1 32 34 PM" src="https://github.com/user-attachments/assets/1d53b346-5ff6-490a-8188-c29cf21661b1" />

At Executions page:
<img width="1178" alt="Screenshot 2025-03-04 at 1 42 40 PM" src="https://github.com/user-attachments/assets/6098f4dc-4750-415a-b9da-28d9a3c98f71" />


### Verified on Prod that only a few requests take more than 60s
<img width="1562" alt="Screenshot 2025-03-04 at 1 24 00 PM" src="https://github.com/user-attachments/assets/14dfdaec-21fe-413e-b5a4-7798ae72be5e" />


- Reached out to user with long-running API calls to inform us which Pipe requires configuration, we will perform a one-time update to allow for extended timeout


## How to test
- [x] Configure a server that sleeps for more than 60s
- [x] Create a Custom API that calls the server
- [x] Verify that API times out after 60s and error messaging is correct
- [x] Change the API to call another endpoint that returns a response within 60s
- [x] Verify that Custom API request was successful

## Deploy Notes
**New scripts**:
- `packages/backend/src/apps/custom-api/common/constants.ts` : script to store constants for timeout, to be used subsequently to handle API response size

