### PR TITLE
chore: bold email otp

### DIFF
--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -49,7 +49,7 @@ const requestOtp: MutationResolvers['requestOtp'] = async (_parent, params) => {
     // Send otp
     await sendEmail({
       subject: 'Your OTP for Plumber',
-      body: `Your OTP is ${otp}. It's valid for ${
+      body: `Your OTP is <b>${otp}</b>. It's valid for ${
         OTP_VALIDITY_IN_MS / 1000 / 60
       } minutes.`,
       recipient: email,


### PR DESCRIPTION
Bold the OTP in the email for easy viewing

## Before & After Screenshots

**BEFORE**:
<img width="437" alt="Screenshot 2025-02-25 at 9 20 34 AM" src="https://github.com/user-attachments/assets/afea4694-161b-4471-a8f6-f910c646f098" />


**AFTER**:

<img width="378" alt="Screenshot 2025-02-25 at 9 20 08 AM" src="https://github.com/user-attachments/assets/498addf6-93de-4420-8e7e-9e890856b7fc" />
