### PR TITLE
feat: add payment forms subscription action to PaySG integration

### DIFF
--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -88,6 +88,7 @@ const action: IRawAction = {
           value: 'monthly',
         },
       ],
+      showOptionValue: false,
       required: true,
     },
     {

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -8,10 +8,10 @@ import StepError, { GenericSolution } from '@/errors/step'
 import { requestSchema } from './schema'
 
 const action: IRawAction = {
-  name: 'Create payment form submission for one-time payment',
-  key: 'createPaymentFormSubmission',
+  name: 'Create payment form submission for subscription',
+  key: 'createPaymentFormSubmissionSubscription',
   description:
-    'Create a new submission for a payment form, and initiate a one-time payment',
+    'Create a new submission for a payment form, and initiate a subscription',
   arguments: [
     {
       label: 'Payment Form Link',
@@ -58,6 +58,20 @@ const action: IRawAction = {
       variables: true,
     },
     {
+      label: 'Payer Address',
+      key: 'payer_address',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
+      label: 'Payer Identifier',
+      key: 'payer_identifier',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
       label: 'Amount (in cents)',
       key: 'amount_in_cents',
       type: 'string' as const,
@@ -65,10 +79,22 @@ const action: IRawAction = {
       variables: true,
     },
     {
+      label: 'Frequency',
+      key: 'frequency',
+      type: 'dropdown',
+      options: [
+        {
+          label: 'Monthly',
+          value: 'monthly',
+        },
+      ],
+      required: true,
+    },
+    {
       label: 'Description',
       key: 'description',
       type: 'string' as const,
-      required: false,
+      required: true,
       variables: true,
     },
     {
@@ -103,7 +129,7 @@ const action: IRawAction = {
       const { formId, ...body } = requestSchema.parse($.step.parameters)
 
       await $.http.post(
-        `/v1/payment-services/:paymentServiceId/forms/:formId/submissions`,
+        `/v1/payment-services/:paymentServiceId/forms/:formId/subscription-submissions`,
         body,
         {
           urlPathParams: {

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -89,6 +89,7 @@ const action: IRawAction = {
         },
       ],
       showOptionValue: false,
+      value: 'monthly',
       required: true,
     },
     {

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -54,7 +54,7 @@ const action: IRawAction = {
       label: 'Payer Email',
       key: 'payer_email',
       type: 'string' as const,
-      required: false,
+      required: true,
       variables: true,
     },
     {

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
@@ -1,3 +1,4 @@
+import emailValidator from 'email-validator'
 import { z } from 'zod'
 
 import { requestSchema as createPaymentFormSubmissionRequestSchema } from '../create-payment-form-submission/schema'
@@ -9,6 +10,21 @@ export const requestSchema = createPaymentFormSubmissionRequestSchema.extend({
     .min(1, { message: 'Specify a description' })
     .max(500, { message: 'Description cannot be more than 500 characters' }),
   frequency: z.literal('monthly'),
+  payer_email: z
+    .string({ invalid_type_error: 'Empty payer email' })
+    .trim()
+    .max(255, { message: 'Payer email cannot be more than 255 characters' })
+    .transform((value, context) => {
+      if (!emailValidator.validate(value)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid payer email',
+        })
+        return z.NEVER
+      }
+
+      return value
+    }),
   payer_address: z
     .string()
     .trim()

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
@@ -1,0 +1,23 @@
+import emailValidator from 'email-validator'
+import { z } from 'zod'
+
+import { requestSchema as createPaymentFormSubmissionRequestSchema } from '../create-payment-form-submission/schema'
+
+export const requestSchema = createPaymentFormSubmissionRequestSchema.extend({
+  description: z
+    .string({ invalid_type_error: 'Empty description' })
+    .trim()
+    .min(1, { message: 'Specify a description' })
+    .max(500, { message: 'Description cannot be more than 500 characters' }),
+  frequency: z.literal('monthly'),
+  payer_address: z
+    .string()
+    .trim()
+    .transform((value) => value || undefined)
+    .optional(),
+  payer_identifier: z
+    .string()
+    .trim()
+    .transform((value) => value || undefined)
+    .optional(),
+})

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
@@ -1,4 +1,3 @@
-import emailValidator from 'email-validator'
 import { z } from 'zod'
 
 import { requestSchema as createPaymentFormSubmissionRequestSchema } from '../create-payment-form-submission/schema'

--- a/packages/backend/src/apps/paysg/actions/index.ts
+++ b/packages/backend/src/apps/paysg/actions/index.ts
@@ -1,5 +1,6 @@
 import createPayment from './create-payment'
 import createPaymentFormSubmission from './create-payment-form-submission'
+import createPaymentFormSubmissionSubscription from './create-payment-form-submission-subscription'
 import getPayment from './get-payment'
 import sendEmail from './send-email'
 
@@ -8,4 +9,5 @@ export default [
   getPayment,
   sendEmail,
   createPaymentFormSubmission,
+  createPaymentFormSubmissionSubscription,
 ]


### PR DESCRIPTION
## Problem

The PaySG team wants to add a new action to the existing PaySG integration. This PR implements this action.

For background, the PaySG team is implementing a feature where payers can sign up for a subscription where they will be recurringly billed on a monthly basis. This action allows PaySG admins to add a FormSG form in front of their subscription signup page. (Basically, identical to the previous PR #870 except that after submitting the FormSG form, payers will get directed to a subscription signup page rather than a payment page). As such, the action looks almost identical to the previous PR, with the exception of the associated PaySG API endpoint and some of the data fields.

## Solution

The action is implemented in this PR, under the PaySG integration folder. 

## Screenshots

<img width="849" alt="image" src="https://github.com/user-attachments/assets/62ce3d27-8cfd-409f-be9f-f476c4221224" />

## Tests

For both PaySG staging and production
-  [ ] Create a new payment form in PaySG. Set up the plumber pipe with relevant fields. Now, go to the PaySG payment link and ensure that the subscription page works as intended.
- [ ] Ensure that the payment form still works, even if all the optional fields are missing.
