### PR TITLE
chore: change email to plumber support form

### DIFF
--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -6,6 +6,8 @@ import { Button, Infobox } from '@opengovsg/design-system-react'
 
 import JSONViewer from '@/components/JSONViewer'
 
+import { CONTACT_PLUMBER_LINK } from './constants'
+
 interface GenericErrorResultProps {
   errorDetails: IJSONObject
   isTestRun: boolean
@@ -29,16 +31,20 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
           {`Check if you have configured ${
             isTestRun ? 'the steps above' : 'this step'
           } correctly and retest. If
-          this error still persists, contact us at support@plumber.gov.sg. `}
-          <Button
-            onClick={toggleDropdown}
-            variant="link"
-            size="sm"
-            sx={{ textDecoration: 'underline' }}
-          >
-            View error details below.
-          </Button>
+          this error still persists, contact us at `}
+          <Text as="a" href={CONTACT_PLUMBER_LINK} target="_blank">
+            {CONTACT_PLUMBER_LINK}
+          </Text>
+          .
         </Text>
+        <Button
+          onClick={toggleDropdown}
+          variant="link"
+          size="sm"
+          sx={{ textDecoration: 'underline' }}
+        >
+          View error details below.
+        </Button>
 
         <Box>
           <Collapse in={isOpen}>

--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -5,8 +5,7 @@ import { Box, Collapse, Text } from '@chakra-ui/react'
 import { Button, Infobox } from '@opengovsg/design-system-react'
 
 import JSONViewer from '@/components/JSONViewer'
-
-import { CONTACT_PLUMBER_LINK } from './constants'
+import { SUPPORT_FORM_LINK } from '@/config/urls'
 
 interface GenericErrorResultProps {
   errorDetails: IJSONObject
@@ -32,8 +31,8 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
             isTestRun ? 'the steps above' : 'this step'
           } correctly and retest. If
           this error still persists, contact us at `}
-          <Text as="a" href={CONTACT_PLUMBER_LINK} target="_blank">
-            {CONTACT_PLUMBER_LINK}
+          <Text as="a" href={SUPPORT_FORM_LINK} target="_blank">
+            {SUPPORT_FORM_LINK}
           </Text>
           .
         </Text>

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -15,14 +15,15 @@ import JSONViewer from '@/components/JSONViewer'
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
+import { CONTACT_PLUMBER_LINK } from './constants'
+
 interface SpecificErrorResultProps {
   errorDetails: IStepError
   isTestRun: boolean
   executionStepId?: string
 }
 
-const contactPlumberMessage =
-  'If this error still persists, contact us at support@plumber.gov.sg.'
+const contactPlumberMessage = `If this error still persists, contact us at [${CONTACT_PLUMBER_LINK}](${CONTACT_PLUMBER_LINK}).`
 
 export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -12,10 +12,9 @@ import {
 } from '@opengovsg/design-system-react'
 
 import JSONViewer from '@/components/JSONViewer'
+import { SUPPORT_FORM_LINK } from '@/config/urls'
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
-
-import { CONTACT_PLUMBER_LINK } from './constants'
 
 interface SpecificErrorResultProps {
   errorDetails: IStepError
@@ -23,7 +22,7 @@ interface SpecificErrorResultProps {
   executionStepId?: string
 }
 
-const contactPlumberMessage = `If this error still persists, contact us at [${CONTACT_PLUMBER_LINK}](${CONTACT_PLUMBER_LINK}).`
+const contactPlumberMessage = `If this error still persists, contact us at [${SUPPORT_FORM_LINK}](${SUPPORT_FORM_LINK}).`
 
 export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props

--- a/packages/frontend/src/components/ErrorResult/constants.ts
+++ b/packages/frontend/src/components/ErrorResult/constants.ts
@@ -1,1 +1,0 @@
-export const CONTACT_PLUMBER_LINK = 'https://go.gov.sg/plumber-support'

--- a/packages/frontend/src/components/ErrorResult/constants.ts
+++ b/packages/frontend/src/components/ErrorResult/constants.ts
@@ -1,0 +1,1 @@
+export const CONTACT_PLUMBER_LINK = 'https://go.gov.sg/plumber-support'

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -83,3 +83,4 @@ export const STATUS_LINK = 'https://status.plumber.gov.sg/'
 export const SGID_CHECK_ELIGIBILITY_URL =
   'https://docs.id.gov.sg/faq-users#as-a-government-officer-why-am-i-not-able-to-login-to-my-work-tool-using-sgid'
 export const TEMPLATES_FORM_LINK = 'https://go.gov.sg/request-template'
+export const SUPPORT_FORM_LINK = 'https://go.gov.sg/plumber-support'


### PR DESCRIPTION
* Updating step error for users to contact us via support form instead of Plumber's email
* Change support@plumber.gov.sg to https://go.gov.sg/plumber-support

## Before & After Screenshots

**BEFORE**:
***Editor***
<img width="870" alt="Screenshot 2025-03-04 at 2 54 11 PM" src="https://github.com/user-attachments/assets/d4cd7638-ffda-49fb-9e00-4b71f186cf5a" />
<img width="864" alt="Screenshot 2025-03-04 at 2 55 52 PM" src="https://github.com/user-attachments/assets/55ca63d2-0e14-48ec-8f42-081f96d16d57" />

***Executions Page***
<img width="1268" alt="Screenshot 2025-03-04 at 2 55 08 PM" src="https://github.com/user-attachments/assets/b9708c16-4d91-4f50-ac51-2a5d1d530d04" />

**AFTER**:
***Editor***
<img width="872" alt="Screenshot 2025-03-04 at 2 52 22 PM" src="https://github.com/user-attachments/assets/eb44dd82-fbf7-4ad2-8d0d-58c4730e8edc" />
<img width="868" alt="Screenshot 2025-03-04 at 2 53 19 PM" src="https://github.com/user-attachments/assets/1d637dc3-f70b-4f29-8fd6-0964b64bd480" />

***Executions Page***
<img width="1176" alt="Screenshot 2025-03-04 at 2 52 36 PM" src="https://github.com/user-attachments/assets/9cf37289-bb99-4144-9bbc-da7c5dd0c52a" />


## How to test
- [ ] Create error by clicking on 'Test step' before all required field are completed. Verify that contact link is the support form link instead of support email
- [ ] Create a step error. Verify that contact link is the support form link instead of support email
- [ ] Publish a pipe that will throw an error. Verify that contact link is the support form link instead of support email
