### PR TITLE
chore: update formsg user not found msg

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/common/webhook-settings.test.ts
@@ -138,7 +138,7 @@ describe('formsg webhook registration', () => {
       $.http.post = vi.fn().mockRejectedValueOnce(new HttpError(error422))
       await expect(verifyWebhookUrl($)).resolves.toEqual({
         registrationVerified: false,
-        message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.UNAUTHORIZED,
+        message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.USER_NOT_FOUND,
       })
     })
   })
@@ -184,7 +184,7 @@ describe('formsg webhook registration', () => {
       } as AxiosError
       $.http.patch = vi.fn().mockRejectedValueOnce(new HttpError(error422))
       await expect(registerWebhookUrl($)).rejects.toThrowError(
-        FORMSG_WEBHOOK_REGISTRATION_MESSAGE.UNAUTHORIZED,
+        FORMSG_WEBHOOK_REGISTRATION_MESSAGE.USER_NOT_FOUND,
       )
     })
 

--- a/packages/backend/src/apps/formsg/common/webhook-settings.ts
+++ b/packages/backend/src/apps/formsg/common/webhook-settings.ts
@@ -20,12 +20,16 @@ export const FORMSG_WEBHOOK_VERIFICATION_MESSAGE = {
     'The form is currently connected to a different endpoint. Continuing with this connection will override this setting.',
   UNAUTHORIZED:
     "We couldn't verify your form connection. Ensure that you are either the form owner or have been added as an editor.",
+  USER_NOT_FOUND:
+    "We couldn't find your FormSG account. Please log in to FormSG with this email and try again.",
   ERROR: "We couldn't verify your form connection. Please try again later.",
 }
 
 export const FORMSG_WEBHOOK_REGISTRATION_MESSAGE = {
   UNAUTHORIZED:
     "We couldn't connect your form. Ensure that you are either the form owner or have been added as an editor.",
+  USER_NOT_FOUND:
+    "We couldn't find your FormSG account. Please log in to FormSG with this email and try again.",
   ERROR: "We couldn't connect your form. Please try again later.",
 }
 
@@ -124,9 +128,12 @@ export async function registerWebhookUrl(
     if (e instanceof HttpError) {
       error = e.response
       // 403 when user email does not have permissions to obtain form settings
-      // 422 when user email cannot be retrieved from the database
-      if (e.response.status === 403 || e.response.status === 422) {
+      if (e.response.status === 403) {
         errorMsg = FORMSG_WEBHOOK_REGISTRATION_MESSAGE.UNAUTHORIZED
+      }
+      // 422 when user email cannot be retrieved from the database
+      if (e.response.status === 422) {
+        errorMsg = FORMSG_WEBHOOK_REGISTRATION_MESSAGE.USER_NOT_FOUND
       }
     }
     logger.error('registerWebhookUrl error', {
@@ -186,9 +193,12 @@ export async function verifyWebhookUrl(
     if (e instanceof HttpError) {
       error = e.response
       // 403 when user email does not have permissions to obtain form settings
-      // 422 when user email cannot be retrieved from the database
-      if (e.response.status === 403 || e.response.status === 422) {
+      if (e.response.status === 403) {
         errorMsg = FORMSG_WEBHOOK_VERIFICATION_MESSAGE.UNAUTHORIZED
+      }
+      // 422 when user email cannot be retrieved from the database
+      if (e.response.status === 422) {
+        errorMsg = FORMSG_WEBHOOK_REGISTRATION_MESSAGE.USER_NOT_FOUND
       }
     }
     logger.error('verifyWebhookUrl error', {


### PR DESCRIPTION
Improve error messaging when user is not found in FormSG database.

## Before & After Screenshots

**BEFORE**:
![image (3)](https://github.com/user-attachments/assets/f453077b-bdea-4907-a54d-af28d5fa24c2)

**AFTER**:
<img width="875" alt="Screenshot 2025-03-06 at 6 08 38 PM" src="https://github.com/user-attachments/assets/489b1eb6-fec9-4134-9125-489923e2c33e" />

## Tests
- [ ] Transfer your Pipe and Form to a new Plumber user (who has not logged into FormSG before)
- [ ] Login to Plumber with that new user
- [ ] Add new connection and verify the correct error message
