### PR TITLE
chore: update reply-to desc, only 1 email allowed

### DIFF
--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -72,7 +72,8 @@ export const transactionalEmailFields: IField[] = [
     key: 'replyTo',
     type: 'string' as const,
     required: false,
-    description: 'If left blank, this will default to your email address.',
+    description:
+      'If left blank, this will default to your email address. Only one email address is allowed.',
     variables: true,
   },
   {


### PR DESCRIPTION
## Problem
* Multiple users have attempted to input more than one email address into the reply-to field, which throws error that says `Invalid reply to email`, which is unclear as the emails are valid

## Solution
**Improvements**:
- Updated description to specifically add that `Only one email address is allowed`

## Before & After Screenshots

**BEFORE**:
<img width="876" alt="Screenshot 2025-03-10 at 11 46 24 AM" src="https://github.com/user-attachments/assets/d3903f78-72d6-4dbc-b43f-42ec6be4369e" />


**AFTER**:
<img width="877" alt="Screenshot 2025-03-10 at 11 46 37 AM" src="https://github.com/user-attachments/assets/a8e3e713-f383-4b78-97be-be744f1a64f1" />

## Tests
N.A. frontend change.
