### PR TITLE
chore: improve Pipe Editor UX

### DIFF
--- a/packages/backend/src/apps/m365-excel/index.ts
+++ b/packages/backend/src/apps/m365-excel/index.ts
@@ -23,7 +23,6 @@ const app: IApp = {
   dynamicData,
   getTransferDetails,
   queue,
-  isNewApp: true,
   substepLabels: {
     connectionStepLabel: 'Connect to M365 Excel',
   },

--- a/packages/backend/src/apps/postman-sms/index.ts
+++ b/packages/backend/src/apps/postman-sms/index.ts
@@ -20,7 +20,6 @@ const app: IApp = {
   auth,
   actions,
   queue,
-  isNewApp: true,
 }
 
 export default app

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -271,7 +271,14 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 onClose={() => setCurrentStepId(null)}
                 onChange={onStepChange}
                 onContinue={() => {
-                  setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
+                  if (
+                    index === stepsBeforeGroup.length - 1 &&
+                    groupedSteps.length > 0
+                  ) {
+                    setCurrentStepId(groupedSteps[0].id)
+                  } else {
+                    setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
+                  }
                 }}
                 templateConfig={flow?.config?.templateConfig}
               />

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -290,6 +290,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
               collapsed={currentStepId !== groupedSteps[0].id}
               onOpen={() => setCurrentStepId(groupedSteps[0].id)}
               onClose={() => setCurrentStepId(null)}
+              setCurrentStepId={setCurrentStepId}
             />
           )}
         </StepExecutionsToIncludeProvider>

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -31,17 +31,18 @@ import {
 } from '@/contexts/StepDisplayOverrides'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { isIfThenBranchCompleted } from '@/helpers/toolbox'
+import { isIfThenBranchCompleted, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 import { BranchContext } from './BranchContext'
 
 interface BranchProps {
   flow: IFlow
   steps: IStep[]
+  setCurrentStepId: (stepId: string) => void
 }
 
 export default function Branch(props: BranchProps): JSX.Element {
-  const { flow, steps } = props
+  const { flow, steps, setCurrentStepId } = props
   const {
     isOpen: editorIsOpen,
     onOpen: openEditor,
@@ -86,11 +87,23 @@ export default function Branch(props: BranchProps): JSX.Element {
     [openDeleteConfirmationImpl],
   )
   const deleteBranch = useCallback(async () => {
+    const idsToDelete = steps.map((step) => step.id)
     await deleteStep({
-      variables: { input: { ids: steps.map((step) => step.id) } },
+      variables: { input: { ids: idsToDelete } },
     })
+
+    // prevents accordion from collapsing when deleting the first branch
+    const ifThenRemaining = flow.steps
+      .filter(
+        (step) =>
+          step.key === TOOLBOX_ACTIONS.IfThen && !idsToDelete.includes(step.id),
+      )
+      .map((step) => step.id)
+    if (ifThenRemaining.length > 0) {
+      setCurrentStepId(ifThenRemaining[0])
+    }
     closeDeleteConfirmation()
-  }, [closeDeleteConfirmation, deleteStep, steps])
+  }, [closeDeleteConfirmation, deleteStep, flow, steps, setCurrentStepId])
 
   return (
     <>

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
@@ -19,7 +19,7 @@ import Branch from './Branch'
 import { BranchContext } from './BranchContext'
 
 export default function IfThen(props: ContentProps): JSX.Element {
-  const { flow, steps } = props
+  const { flow, steps, setCurrentStepId } = props
 
   const { depth } = useContext(BranchContext)
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
@@ -82,7 +82,11 @@ export default function IfThen(props: ContentProps): JSX.Element {
     <Flex flexDir="column">
       {branchesWithSteps.map((branchSteps, index) => (
         <Fragment key={branchSteps[0].id}>
-          <Branch flow={flow} steps={branchSteps} />
+          <Branch
+            flow={flow}
+            steps={branchSteps}
+            setCurrentStepId={setCurrentStepId}
+          />
           {index < branchesWithSteps.length - 1 && (
             <Divider borderColor="base.divider.medium" />
           )}

--- a/packages/frontend/src/components/FlowStepGroup/Content/types.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/types.ts
@@ -3,4 +3,5 @@ import { type IFlow, type IStep } from '@plumber/types'
 export interface ContentProps {
   flow: IFlow
   steps: IStep[]
+  setCurrentStepId: (stepId: string) => void
 }

--- a/packages/frontend/src/components/FlowStepGroup/NestedEditor/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/NestedEditor/index.tsx
@@ -28,6 +28,7 @@ export default function NestedEditor(props: NestedEditorProps): JSX.Element {
       onClose={onClose}
       size="6xl"
       closeOnEsc={false}
+      closeOnOverlayClick={false}
       motionPreset="none"
     >
       <ModalOverlay />

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -44,12 +44,14 @@ interface FlowStepGroupProps {
   onOpen: () => void
   onClose: () => void
   collapsed: boolean
+  setCurrentStepId: (stepId: string) => void
 }
 
 const ifThenHelpMessage = 'Customise what happens in each of your branches.'
 
 function FlowStepGroup(props: FlowStepGroupProps): JSX.Element {
-  const { iconUrl, flow, steps, onOpen, onClose, collapsed } = props
+  const { iconUrl, flow, steps, onOpen, onClose, collapsed, setCurrentStepId } =
+    props
   const isTemplatedFlow = !!flow.config?.templateConfig?.templateId
 
   const { StepContent, hintAboveCaption, caption, isStepGroupCompleted } =
@@ -83,7 +85,11 @@ function FlowStepGroup(props: FlowStepGroupProps): JSX.Element {
         isCompleted={isStepGroupCompleted}
         isInfoboxPresent={!isStepGroupCompleted}
       >
-        <StepContent flow={flow} steps={steps} />
+        <StepContent
+          flow={flow}
+          steps={steps}
+          setCurrentStepId={setCurrentStepId}
+        />
       </FlowStepHeader>
     </Flex>
   )

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -169,7 +169,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
             type="submit"
             data-test="flow-substep-continue-button"
           >
-            Continue
+            Save and continue
           </Button>
         </Box>
       </Collapse>


### PR DESCRIPTION
## Problems

- Users are unaware that they must click the “Continue” button in the Set Up step to save their inputs. This has led to numerous support tickets reporting “bugs” where inputs appear to have disappeared.
- If-Then Editor modal is closing when users accidentally click outside the modal overlay, losing unsaved progress.
- If-Then accordion is closing when users delete the first if-then branch

## Solution

- Rename the “Continue” button to “Save and Continue” to make it clear that users must save their inputs.
- Prevent the If-Then Editor from closing when clicking outside the modal overlay, only can exit by clicking the 'Back To Pipe' button
- Sets the current step id to the second if-then branch if user is deleting the first

## Screenshots
### Save and continue
**BEFORE**:
<img width="864" alt="Screenshot 2025-03-11 at 9 05 52 AM" src="https://github.com/user-attachments/assets/040c4c6b-ef7e-4151-8b24-fa8857a032d9" />

**AFTER**:
<img width="862" alt="Screenshot 2025-03-11 at 9 07 37 AM" src="https://github.com/user-attachments/assets/1238f2ba-b44e-4fbd-94d6-fcab0ccd55a4" />

### Prevent If-Then Editor from closing
**BEFORE**:

https://github.com/user-attachments/assets/b96a814c-4a57-43f0-bb1b-888d84e47bf3



**AFTER**:


https://github.com/user-attachments/assets/fc3b0811-7f12-427c-bba5-fba548f20029


### Prevent If-Then accordion from closing on first branch delete
**BEFORE**:

https://github.com/user-attachments/assets/17a5758d-a5e4-4d37-8228-be619540356a


**AFTER**:

https://github.com/user-attachments/assets/16b214e8-8de7-449d-8d2e-1c71d9992960


## Tests
Frontend change.
- [ ] Verify that 'Save and continue' button is being displayed in the set up step
- [ ] Verify that If-Then editor modal does not close when clicking outside the overlay
- [ ] Verify that If-Then accordion does not close when deleting the first If-Then branch


