### PR TITLE
chore: update generic error to match step error

### DIFF
--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -21,35 +21,46 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
 
   return (
     <Infobox variant="error">
-      <Box>
-        <Text mb={2} textStyle="subhead-1">
+      <Box minW="0" w="full">
+        <Text mb={0.5} textStyle="subhead-1">
           We could not test this step
         </Text>
 
         <Text textStyle="body-1">
-          {`Check if you have configured ${
-            isTestRun ? 'the steps above' : 'this step'
-          } correctly and retest. If
-          this error still persists, contact us at `}
-          <Text as="a" href={SUPPORT_FORM_LINK} target="_blank">
-            {SUPPORT_FORM_LINK}
+          <Text textStyle="body-1">
+            {`Check if you have configured ${
+              isTestRun ? 'the steps above' : 'this step'
+            } correctly and retest.`}
           </Text>
-          .
-        </Text>
-        <Button
-          onClick={toggleDropdown}
-          variant="link"
-          size="sm"
-          sx={{ textDecoration: 'underline' }}
-        >
-          View error details below.
-        </Button>
+          <Box
+            marginTop={4}
+            borderTop="1px solid #E0E0E0"
+            fontSize="0.8rem"
+            opacity={0.8}
+            w="full"
+          >
+            If this error still persists, contact us at{' '}
+            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
+              {SUPPORT_FORM_LINK}
+            </a>
+            .
+          </Box>
+          <Button
+            onClick={toggleDropdown}
+            variant="link"
+            size="sm"
+            sx={{ textDecoration: 'underline' }}
+            mt={2}
+          >
+            View error details below.
+          </Button>
 
-        <Box>
-          <Collapse in={isOpen}>
-            <JSONViewer data={errorDetails}></JSONViewer>
-          </Collapse>
-        </Box>
+          <Box>
+            <Collapse in={isOpen}>
+              <JSONViewer data={errorDetails}></JSONViewer>
+            </Collapse>
+          </Box>
+        </Text>
       </Box>
     </Infobox>
   )


### PR DESCRIPTION
## Problem
Update `GenericErrorResult` to same layout as `SpecificErrorResult`

## Before & After Screenshots

**BEFORE**:
<img width="888" alt="Screenshot 2025-03-12 at 9 13 57 AM" src="https://github.com/user-attachments/assets/09d9d759-6e43-467b-9844-93f1f238a6ea" />

**AFTER**:
<img width="872" alt="Screenshot 2025-03-12 at 9 09 34 AM" src="https://github.com/user-attachments/assets/d71cfd8f-40d0-45de-9aa3-98a3b376af3d" />



## Tests
- [ ] Force a generic error (throw new Error), verify that the error message is aligned with the SpecificErrorResult

