### PR TITLE
PLU-428 [FIND-MULTIPLE-ROWS-1]: Tiles

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -174,30 +174,51 @@ describe('findMultipleRowsAction', () => {
         rowsFound: 500,
         rows: expect.objectContaining({
           rowData: expect.any(Array),
-          columns: expect.any(Object),
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: dummyColumnIds[0],
+              name: 'Test Column 0',
+            }),
+            expect.objectContaining({
+              id: dummyColumnIds[1],
+              name: 'Test Column 1',
+            }),
+            expect.objectContaining({
+              id: dummyColumnIds[2],
+              name: 'Test Column 2',
+            }),
+            expect.objectContaining({
+              id: dummyColumnIds[3],
+              name: 'Test Column 3',
+            }),
+            expect.objectContaining({
+              id: dummyColumnIds[4],
+              name: 'Test Column 4',
+            }),
+          ]),
         }),
-        columns: expect.objectContaining({
-          'Test Column 0': expect.objectContaining({
-            id: expect.any(String),
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            id: dummyColumnIds[1],
+            name: 'Test Column 1',
             value: expect.any(String),
           }),
-          'Test Column 1': expect.objectContaining({
-            id: expect.any(String),
+          expect.objectContaining({
+            id: dummyColumnIds[2],
+            name: 'Test Column 2',
             value: expect.any(String),
           }),
-          'Test Column 2': expect.objectContaining({
-            id: expect.any(String),
+          expect.objectContaining({
+            id: dummyColumnIds[3],
+            name: 'Test Column 3',
             value: expect.any(String),
           }),
-          'Test Column 3': expect.objectContaining({
-            id: expect.any(String),
+          expect.objectContaining({
+            id: dummyColumnIds[4],
+            name: 'Test Column 4',
             value: expect.any(String),
           }),
-          'Test Column 4': expect.objectContaining({
-            id: expect.any(String),
-            value: expect.any(String),
-          }),
-        }),
+        ]),
       }),
     })
 

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -172,7 +172,29 @@ describe('findMultipleRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500,
-        rows: expect.stringMatching(/^\[.*\]$/),
+        rows: expect.stringMatching(/^\{.*\}$/),
+        columns: expect.objectContaining({
+          'Test Column 0': expect.objectContaining({
+            id: expect.any(String),
+            value: expect.any(String),
+          }),
+          'Test Column 1': expect.objectContaining({
+            id: expect.any(String),
+            value: expect.any(String),
+          }),
+          'Test Column 2': expect.objectContaining({
+            id: expect.any(String),
+            value: expect.any(String),
+          }),
+          'Test Column 3': expect.objectContaining({
+            id: expect.any(String),
+            value: expect.any(String),
+          }),
+          'Test Column 4': expect.objectContaining({
+            id: expect.any(String),
+            value: expect.any(String),
+          }),
+        }),
       }),
     })
 
@@ -183,8 +205,9 @@ describe('findMultipleRowsAction', () => {
     const parsedRows = JSON.parse(
       ($.setActionItem as any).mock.calls[0][0].raw.rows,
     )
-    expect(parsedRows).toHaveLength(500)
-    expect(parsedRows[0].rowId).toBe('row0')
-    expect(parsedRows[499].rowId).toBe('row499')
+    const parsedRowData = JSON.parse(parsedRows.rowData)
+    expect(parsedRowData).toHaveLength(500)
+    expect(parsedRowData[0].rowId).toBe('row0')
+    expect(parsedRowData[499].rowId).toBe('row499')
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -172,7 +172,10 @@ describe('findMultipleRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500,
-        rows: expect.stringMatching(/^\{.*\}$/),
+        rows: expect.objectContaining({
+          rowData: expect.any(Array),
+          columns: expect.any(Object),
+        }),
         columns: expect.objectContaining({
           'Test Column 0': expect.objectContaining({
             id: expect.any(String),
@@ -198,16 +201,11 @@ describe('findMultipleRowsAction', () => {
       }),
     })
 
-    expect(() => {
-      JSON.parse(($.setActionItem as any).mock.calls[0][0].raw.rows)
-    }).not.toThrow()
+    const rows = ($.setActionItem as any).mock.calls[0][0].raw.rows
 
-    const parsedRows = JSON.parse(
-      ($.setActionItem as any).mock.calls[0][0].raw.rows,
-    )
-    const parsedRowData = JSON.parse(parsedRows.rowData)
-    expect(parsedRowData).toHaveLength(500)
-    expect(parsedRowData[0].rowId).toBe('row0')
-    expect(parsedRowData[499].rowId).toBe('row499')
+    const rowData = rows.rowData
+    expect(rowData).toHaveLength(500)
+    expect(rowData[0].rowId).toBe('row0')
+    expect(rowData[499].rowId).toBe('row499')
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -1,0 +1,156 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+import {
+  generateMockContext,
+  generateMockTable,
+  generateMockTableColumns,
+  generateMockTableRowData,
+} from '@/graphql/__tests__/mutations/tiles/table.mock'
+import { createTableRow, TableRowFilter } from '@/models/dynamodb/table-row'
+import * as tableFunctions from '@/models/dynamodb/table-row/functions'
+import TableColumnMetadata from '@/models/table-column-metadata'
+import TableMetadata from '@/models/table-metadata'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import tiles from '../..'
+import findMultipleRowsAction from '../../actions/find-multiple-rows'
+
+const mocks = vi.hoisted(() => {
+  const TILE_SCAN_LIMIT = 3
+  return {
+    TILE_SCAN_LIMIT,
+    stepQueryResult: vi.fn().mockResolvedValue({
+      config: {
+        adminOverride: {
+          tileScanLimit: TILE_SCAN_LIMIT,
+        },
+      },
+    }),
+  }
+})
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn().mockReturnThis(),
+    findById: vi.fn().mockReturnThis(),
+    throwIfNotFound: mocks.stepQueryResult,
+  },
+}))
+
+describe('findMultipleRowsAction', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+  let dummyColumnIds: string[]
+  let editor: User
+  let viewer: User
+  let $: IGlobalVariable
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    const mockTable = await generateMockTable({
+      userId: context.currentUser.id,
+    })
+
+    dummyTable = mockTable.table
+    editor = mockTable.editor
+    viewer = mockTable.viewer
+
+    dummyColumnIds = await generateMockTableColumns({
+      tableId: dummyTable.id,
+      numColumns: 5,
+    })
+
+    const originalData = generateMockTableRowData({
+      columnIds: dummyColumnIds,
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+    }
+
+    $ = {
+      user: context.currentUser,
+      flow: {
+        id: '123',
+        userId: context.currentUser.id,
+      },
+      step: {
+        id: '456',
+        appKey: tiles.name,
+        key: findMultipleRowsAction.key,
+        position: 2,
+        parameters: {
+          tableId: dummyTable.id,
+          filters: [
+            {
+              columnId: dummyColumnIds[0],
+              operator: 'equals',
+              value: originalData[dummyColumnIds[0]],
+            },
+          ] as TableRowFilter[],
+          order: 'asc',
+        },
+      },
+      app: {
+        name: tiles.name,
+      },
+      setActionItem: vi.fn(),
+    } as unknown as IGlobalVariable
+  })
+
+  it('should allow owners to find multiple rows', async () => {
+    await expect(findMultipleRowsAction.run($)).resolves.toBeUndefined()
+    expect($.setActionItem).toBeCalled()
+  })
+
+  it('should allow editors to find multiple rows', async () => {
+    $.user = editor
+    await expect(findMultipleRowsAction.run($)).resolves.toBeUndefined()
+    expect($.setActionItem).toBeCalled()
+  })
+
+  it('should not allow viewers to find multiple rows', async () => {
+    $.user = viewer
+    await expect(findMultipleRowsAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should throw correct error if Tile deleted', async () => {
+    $.user = editor
+    await TableMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ id: $.step.parameters.tableId })
+    await TableColumnMetadata.query()
+      .patch({
+        deletedAt: new Date().toISOString(),
+      })
+      .where({ table_id: $.step.parameters.tableId })
+    await expect(findMultipleRowsAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should call getTableRows with scan limit if exists in step config', async () => {
+    const getTableRowsSpy = vi
+      .spyOn(tableFunctions, 'getTableRows')
+      .mockResolvedValueOnce({
+        rows: [],
+        stringifiedCursor: undefined,
+      })
+    await findMultipleRowsAction.run($)
+    expect(getTableRowsSpy).toHaveBeenCalledWith({
+      columnIds: dummyColumnIds,
+      tableId: $.step.parameters.tableId,
+      filters: $.step.parameters.filters,
+      scanLimit: mocks.TILE_SCAN_LIMIT,
+      order: 'asc',
+    })
+  })
+})

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -153,4 +153,38 @@ describe('findMultipleRowsAction', () => {
       order: 'asc',
     })
   })
+
+  it('should limit the returned rows to 500 even if more rows match the conditions', async () => {
+    const mockRows = Array(520)
+      .fill(null)
+      .map((_, i) => ({
+        rowId: `row${i}`,
+        data: generateMockTableRowData({ columnIds: dummyColumnIds }),
+      }))
+
+    vi.spyOn(tableFunctions, 'getTableRows').mockResolvedValueOnce({
+      rows: mockRows,
+      stringifiedCursor: undefined,
+    })
+
+    await findMultipleRowsAction.run($)
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: expect.objectContaining({
+        rowsFound: 500,
+        rows: expect.stringMatching(/^\[.*\]$/),
+      }),
+    })
+
+    expect(() => {
+      JSON.parse(($.setActionItem as any).mock.calls[0][0].raw.rows)
+    }).not.toThrow()
+
+    const parsedRows = JSON.parse(
+      ($.setActionItem as any).mock.calls[0][0].raw.rows,
+    )
+    expect(parsedRows).toHaveLength(500)
+    expect(parsedRows[0].rowId).toBe('row0')
+    expect(parsedRows[499].rowId).toBe('row499')
+  })
 })

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -38,9 +38,10 @@ async function getDataOutMetadata(
 
   const columnMetadata: IDataOutMetadata = {}
   if (dataOut.columns) {
-    Object.entries(dataOut.columns).forEach(([name, { id }]) => {
-      columnMetadata[name] = {
+    Object.entries(dataOut.columns).forEach(([id, { name }]) => {
+      columnMetadata[id] = {
         id: { isHidden: true },
+        name: { isHidden: true },
         value: {
           label: name,
           order: columnOrder[id] ? columnOrder[id] + 2 : null,

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -53,7 +53,6 @@ async function getDataOutMetadata(
       }
     })
   }
-  console.log('columnMetadata', columnMetadata)
 
   return { ...metadata, columns: columnMetadata }
 }

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -1,33 +1,59 @@
 import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
+import Step from '@/models/step'
+import TableColumnMetadata from '@/models/table-column-metadata'
+
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
-  const { dataOut } = executionStep
+  const { dataOut, stepId } = executionStep
 
   if (!dataOut?.rows) {
     return null
   }
 
+  // NOTE: extract column order from table column metadata so that frontend
+  // can display the columns in the same order as in the Tile
+  const columnOrder: Record<string, number> = {}
+  const step = await Step.query().findById(stepId).throwIfNotFound()
+  const tableId = step.parameters.tableId
+  const tableColumns = await TableColumnMetadata.getColumns(tableId as string)
+  tableColumns.forEach((c) => {
+    // position is 0-indexed
+    columnOrder[c.id] = c.position + 1
+  })
+
   const metadata: IDataOutMetadata = {
-    rowsFound: {
-      label: 'No. of rows found',
-    },
     rows: {
-      label: 'Data rows',
-      displayedValue: `${dataOut.rowsFound} rows`,
+      label: 'List of row(s) found',
+      displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
+      type: 'array',
+      order: 1,
+    },
+    rowsFound: {
+      label: 'Number of rows found',
+      order: 2,
+    },
+    rowId: {
+      label: 'Row ID',
+      value: 'rowId',
+      displayedValue: ' ',
     },
   }
+
   const columnMetadata: IDataOutMetadata = {}
   if (dataOut.columns) {
-    Object.entries(dataOut.columns).forEach(([name]) => {
+    Object.entries(dataOut.columns).forEach(([name, { id }]) => {
       columnMetadata[name] = {
-        label: name,
-        // leave as blank to not display column id in the frontend
-        displayedValue: '',
+        id: { type: 'hidden' },
+        value: {
+          label: name,
+          order: columnOrder[id] ? columnOrder[id] + 2 : null,
+        },
       }
     })
   }
+  console.log('columnMetadata', columnMetadata)
 
   return { ...metadata, columns: columnMetadata }
 }

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -45,7 +45,7 @@ async function getDataOutMetadata(
   if (dataOut.columns) {
     Object.entries(dataOut.columns).forEach(([name, { id }]) => {
       columnMetadata[name] = {
-        id: { type: 'hidden' },
+        id: { isHidden: true },
         value: {
           label: name,
           order: columnOrder[id] ? columnOrder[id] + 2 : null,

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -1,27 +1,18 @@
 import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
-import Step from '@/models/step'
-import TableColumnMetadata from '@/models/table-column-metadata'
+import { TileColumnMetadata } from '../../types'
+
+import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
-  const { dataOut, stepId } = executionStep
+  const { dataOut: rawDataOut } = executionStep
 
-  if (!dataOut?.rows) {
+  if (!rawDataOut) {
     return null
   }
-
-  // NOTE: extract column order from table column metadata so that frontend
-  // can display the columns in the same order as in the Tile
-  const columnOrder: Record<string, number> = {}
-  const step = await Step.query().findById(stepId).throwIfNotFound()
-  const tableId = step.parameters.tableId
-  const tableColumns = await TableColumnMetadata.getColumns(tableId as string)
-  tableColumns.forEach((c) => {
-    // position is 0-indexed
-    columnOrder[c.id] = c.position + 1
-  })
+  const dataOut = dataOutSchema.parse(rawDataOut)
 
   const metadata: IDataOutMetadata = {
     rows: {
@@ -36,20 +27,16 @@ async function getDataOutMetadata(
     },
   }
 
-  const columnMetadata: IDataOutMetadata = {}
+  const columnMetadata: IDataOutMetadata = []
   if (dataOut.columns) {
-    Object.entries(dataOut.columns).forEach(([id, { name }]) => {
-      columnMetadata[id] = {
+    dataOut.columns.forEach((column: TileColumnMetadata) => {
+      columnMetadata.push({
         id: { isHidden: true },
         name: { isHidden: true },
-        value: {
-          label: name,
-          order: columnOrder[id] ? columnOrder[id] + 2 : null,
-        },
-      }
+        value: { label: column.name },
+      })
     })
   }
-
   return { ...metadata, columns: columnMetadata }
 }
 

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -1,0 +1,35 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+
+  if (!dataOut?.rows) {
+    return null
+  }
+
+  const metadata: IDataOutMetadata = {
+    rowsFound: {
+      label: 'No. of rows found',
+    },
+    rows: {
+      label: 'Data rows',
+      displayedValue: `${dataOut.rowsFound} rows`,
+    },
+  }
+  const columnMetadata: IDataOutMetadata = {}
+  if (dataOut.columns) {
+    Object.entries(dataOut.columns).forEach(([name]) => {
+      columnMetadata[name] = {
+        label: name,
+        // leave as blank to not display column id in the frontend
+        displayedValue: '',
+      }
+    })
+  }
+
+  return { ...metadata, columns: columnMetadata }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -34,11 +34,6 @@ async function getDataOutMetadata(
       label: 'Number of rows found',
       order: 2,
     },
-    rowId: {
-      label: 'Row ID',
-      value: 'rowId',
-      displayedValue: ' ',
-    },
   }
 
   const columnMetadata: IDataOutMetadata = {}

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -11,6 +11,7 @@ import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
+import { FIND_MULTIPLE_ROWS_LIMIT } from '../../common/constants'
 import { validateFilters } from '../../common/validate-filters'
 import { FindMultipleRowsOutput } from '../../types'
 
@@ -42,7 +43,8 @@ const action: IRawAction = {
     },
     {
       label: 'Lookup conditions',
-      description: 'All rows that meet the conditions will be returned',
+      description:
+        'Only the first 500 rows that meet the conditions will be returned',
       key: 'filters',
       type: 'multirow' as const,
       required: true,
@@ -207,11 +209,12 @@ const action: IRawAction = {
     columns.forEach((c) => {
       columnsToReturn[c.name] = c.id
     })
+    const slicedRows = rows.slice(0, FIND_MULTIPLE_ROWS_LIMIT)
 
     $.setActionItem({
       raw: {
-        rowsFound: rows.length,
-        rows: JSON.stringify(rows),
+        rowsFound: slicedRows.length,
+        rows: JSON.stringify(slicedRows),
         columns: columnsToReturn,
       } satisfies FindMultipleRowsOutput,
     })

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -194,10 +194,10 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
-          rows: JSON.stringify({
-            rowData: JSON.stringify([]),
+          rows: {
+            rowData: [],
             columns: {},
-          }),
+          },
           columns: {},
         } satisfies FindMultipleRowsOutput,
       })
@@ -236,10 +236,10 @@ const action: IRawAction = {
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
-        rows: JSON.stringify({
-          rowData: JSON.stringify(slicedRows),
+        rows: {
+          rowData: slicedRows,
           columns: columnData,
-        }),
+        },
         columns: consolidatedColumns,
         rowId: 'rowId',
       } satisfies FindMultipleRowsOutput,

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -190,20 +190,6 @@ const action: IRawAction = {
       scanLimit,
     })
 
-    if (!rows || !rows.length) {
-      $.setActionItem({
-        raw: {
-          rowsFound: 0,
-          rows: {
-            rowData: [],
-            columns: {},
-          },
-          columns: {},
-        } satisfies FindMultipleRowsOutput,
-      })
-      return
-    }
-
     // NOTE: there are 2 types of column data that we return
     // 1. column name and id for use in for-each
     const columnData: Record<string, string> = {}

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -1,0 +1,221 @@
+import { IRawAction } from '@plumber/types'
+
+import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
+import {
+  getTableRows,
+  TableRowFilter,
+  TableRowFilterOperator,
+} from '@/models/dynamodb/table-row'
+import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+import { validateFilters } from '../../common/validate-filters'
+import { FindMultipleRowsOutput } from '../../types'
+
+import getDataOutMetadata from './get-data-out-metadata'
+
+const action: IRawAction = {
+  name: 'Find multiple rows',
+  key: 'findMultipleRows',
+  description: 'Gets data of multiple rows from your tile',
+  settingsStepLabel: 'Set up rows to find',
+  arguments: [
+    {
+      label: 'Select Tile',
+      key: 'tableId',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTables',
+          },
+        ],
+      },
+    },
+    {
+      label: 'Lookup conditions',
+      description: 'All rows that meet the conditions will be returned',
+      key: 'filters',
+      type: 'multirow' as const,
+      required: true,
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
+      subFields: [
+        {
+          placeholder: 'Column',
+          key: 'columnId',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          source: {
+            type: 'query' as const,
+            name: 'getDynamicData' as const,
+            arguments: [
+              {
+                name: 'key',
+                value: 'listColumns',
+              },
+              {
+                name: 'parameters.tableId',
+                value: '{parameters.tableId}',
+              },
+            ],
+          },
+        },
+        {
+          placeholder: 'Condition',
+          key: 'operator',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          options: [
+            { label: 'Equals to', value: TableRowFilterOperator.Equals },
+            {
+              label: 'Greater than ',
+              value: TableRowFilterOperator.GreaterThan,
+            },
+            {
+              label: 'Greater than or equals to',
+              value: TableRowFilterOperator.GreaterThanOrEquals,
+            },
+            { label: 'Less than', value: TableRowFilterOperator.LessThan },
+            {
+              label: 'Less than or equals to',
+              value: TableRowFilterOperator.LessThanOrEquals,
+            },
+            { label: 'Begins with', value: TableRowFilterOperator.BeginsWith },
+            { label: 'Contains', value: TableRowFilterOperator.Contains },
+            {
+              label: 'Is empty',
+              value: TableRowFilterOperator.IsEmpty,
+            },
+          ],
+        },
+        {
+          placeholder: 'Value',
+          key: 'value',
+          type: 'string' as const,
+          required: true,
+          variables: true,
+          hiddenIf: {
+            fieldKey: 'operator',
+            op: 'equals',
+            fieldValue: TableRowFilterOperator.IsEmpty,
+          },
+        },
+      ],
+    },
+    {
+      label: 'Order of rows',
+      key: 'returnLastRowFirst',
+      type: 'boolean-radio' as const,
+      required: true,
+      value: false,
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
+      options: [
+        {
+          label: 'Ascending (oldest first)',
+          value: false,
+        },
+        {
+          label: 'Descending (newest first)',
+          value: true,
+        },
+      ],
+    },
+  ],
+  getDataOutMetadata,
+
+  async run($) {
+    const { tableId, filters, returnLastRowFirst } = $.step.parameters as {
+      tableId: string
+      filters: TableRowFilter[]
+      returnLastRowFirst: string | undefined
+    }
+
+    const step = await Step.query().findById($.step.id).throwIfNotFound()
+    /**
+     * Check for columns first, there will not be any columns if the tile has been deleted.
+     */
+    const columns = await TableColumnMetadata.getColumns(tableId, $)
+
+    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+
+    // Check that filters are valid
+    try {
+      validateFilters(filters, columns)
+    } catch (e) {
+      logger.error({
+        message: 'Invalid filters',
+        executionId: $.execution.id,
+        stepId: $.step.id,
+        app: $.app.name,
+        action: 'find-single-row',
+        error: e,
+      })
+      throw new StepError(
+        'Invalid filters',
+        'One or more filters are invalid. Please check that the columns in your filters still exist',
+        $.step.position,
+        $.app.name,
+      )
+    }
+    // Retrieve the manual scan limit override, converting it to a number.
+    // If the conversion results in NaN, we set scanLimit to undefined.
+    const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
+    const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
+
+    const { rows } = await getTableRows({
+      tableId,
+      columnIds: columns.map((c) => c.id),
+      filters,
+      order: returnLastRowFirst ? 'desc' : 'asc',
+      scanLimit,
+    })
+
+    if (!rows || !rows.length) {
+      $.setActionItem({
+        raw: {
+          rowsFound: 0,
+          rows: JSON.stringify([]),
+          columns: {},
+        } satisfies FindMultipleRowsOutput,
+      })
+      return
+    }
+
+    /**
+     * We use raw row data instead of mapped column names as we want them to
+     * be distinct in data_out
+     */
+    const columnsToReturn: Record<string, string> = {}
+    columns.forEach((c) => {
+      columnsToReturn[c.name] = c.id
+    })
+
+    $.setActionItem({
+      raw: {
+        rowsFound: rows.length,
+        rows: JSON.stringify(rows),
+        columns: columnsToReturn,
+      } satisfies FindMultipleRowsOutput,
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -192,11 +192,15 @@ const action: IRawAction = {
 
     // NOTE: there are 2 types of column data that we return
     // 1. column name and id for use in for-each
-    const columnData: Record<string, string> = {}
+    // use an array to preserve the order of the columns
+    const columnData: Record<string, string>[] = []
     columns
       .sort((a, b) => a.position - b.position)
       .forEach((c) => {
-        columnData[c.id] = c.name
+        columnData.push({
+          id: c.id,
+          name: c.name,
+        })
       })
 
     // 2. column data that combines all the values of all rows into a single string
@@ -208,13 +212,13 @@ const action: IRawAction = {
           values.push(value)
         }
       }
-      acc[column.id] = {
+      acc.push({
         id: column.id,
         name: column.name,
         value: values.join(', '),
-      }
+      })
       return acc
-    }, {} as Record<string, TileColumnMetadata>)
+    }, [] as TileColumnMetadata[])
 
     const slicedRows = rows.slice(0, FIND_MULTIPLE_ROWS_LIMIT)
 

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -167,7 +167,7 @@ const action: IRawAction = {
         executionId: $.execution.id,
         stepId: $.step.id,
         app: $.app.name,
-        action: 'find-single-row',
+        action: 'find-multiple-rows',
         error: e,
       })
       throw new StepError(
@@ -194,28 +194,54 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
-          rows: JSON.stringify([]),
+          rows: JSON.stringify({
+            rowData: JSON.stringify([]),
+            columns: {},
+          }),
           columns: {},
         } satisfies FindMultipleRowsOutput,
       })
       return
     }
 
-    /**
-     * We use raw row data instead of mapped column names as we want them to
-     * be distinct in data_out
-     */
-    const columnsToReturn: Record<string, string> = {}
-    columns.forEach((c) => {
-      columnsToReturn[c.name] = c.id
-    })
+    // NOTE: there are 2 types of column data that we return
+    // 1. column name and id for use in for-each
+    const columnData: Record<string, string> = {
+      'Row ID': 'rowId',
+    }
+    columns
+      .sort((a, b) => a.position - b.position)
+      .forEach((c) => {
+        columnData[c.name] = c.id
+      })
+
+    // 2. column data that combines all the values of all rows into a single string
+    const consolidatedColumns = columns.reduce((acc, column) => {
+      const values: string[] = []
+      for (const row of rows) {
+        const value = row.data[column.id]
+        if (value) {
+          values.push(value)
+        }
+      }
+      acc[column.name] = {
+        id: column.id,
+        value: values.join(', '),
+      }
+      return acc
+    }, {} as Record<string, { id: string; value: string }>)
+
     const slicedRows = rows.slice(0, FIND_MULTIPLE_ROWS_LIMIT)
 
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
-        rows: JSON.stringify(slicedRows),
-        columns: columnsToReturn,
+        rows: JSON.stringify({
+          rowData: JSON.stringify(slicedRows),
+          columns: columnData,
+        }),
+        columns: consolidatedColumns,
+        rowId: 'rowId',
       } satisfies FindMultipleRowsOutput,
     })
   },

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -13,7 +13,7 @@ import TableColumnMetadata from '@/models/table-column-metadata'
 
 import { FIND_MULTIPLE_ROWS_LIMIT } from '../../common/constants'
 import { validateFilters } from '../../common/validate-filters'
-import { FindMultipleRowsOutput } from '../../types'
+import { FindMultipleRowsOutput, TileColumnMetadata } from '../../types'
 
 import getDataOutMetadata from './get-data-out-metadata'
 
@@ -196,7 +196,7 @@ const action: IRawAction = {
     columns
       .sort((a, b) => a.position - b.position)
       .forEach((c) => {
-        columnData[c.name] = c.id
+        columnData[c.id] = c.name
       })
 
     // 2. column data that combines all the values of all rows into a single string
@@ -208,12 +208,13 @@ const action: IRawAction = {
           values.push(value)
         }
       }
-      acc[column.name] = {
+      acc[column.id] = {
         id: column.id,
+        name: column.name,
         value: values.join(', '),
       }
       return acc
-    }, {} as Record<string, { id: string; value: string }>)
+    }, {} as Record<string, TileColumnMetadata>)
 
     const slicedRows = rows.slice(0, FIND_MULTIPLE_ROWS_LIMIT)
 

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -206,9 +206,7 @@ const action: IRawAction = {
 
     // NOTE: there are 2 types of column data that we return
     // 1. column name and id for use in for-each
-    const columnData: Record<string, string> = {
-      'Row ID': 'rowId',
-    }
+    const columnData: Record<string, string> = {}
     columns
       .sort((a, b) => a.position - b.position)
       .forEach((c) => {
@@ -241,7 +239,6 @@ const action: IRawAction = {
           columns: columnData,
         },
         columns: consolidatedColumns,
-        rowId: 'rowId',
       } satisfies FindMultipleRowsOutput,
     })
   },

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+const tableRowOutputSchema = z.object({
+  rowId: z.string(),
+  data: z.record(z.string(), z.string().or(z.number())),
+})
+
+export const dataOutSchema = z.object({
+  rowsFound: z.number(),
+  columns: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      value: z.string(),
+    }),
+  ),
+  rows: z
+    .object({
+      rowData: z.array(tableRowOutputSchema),
+      columns: z.array(
+        z.object({
+          id: z.string(),
+          name: z.string(),
+        }),
+      ),
+    })
+    .optional(),
+})

--- a/packages/backend/src/apps/tiles/actions/index.ts
+++ b/packages/backend/src/apps/tiles/actions/index.ts
@@ -1,5 +1,6 @@
 import createRow from './create-row'
+import findMultipleRows from './find-multiple-rows'
 import findSingleRow from './find-single-row'
 import updateRow from './update-row'
 
-export default [findSingleRow, createRow, updateRow]
+export default [findSingleRow, findMultipleRows, createRow, updateRow]

--- a/packages/backend/src/apps/tiles/common/constants.ts
+++ b/packages/backend/src/apps/tiles/common/constants.ts
@@ -1,0 +1,1 @@
+export const FIND_MULTIPLE_ROWS_LIMIT = 500

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -10,7 +10,7 @@ export interface FindSingleRowOutput extends IJSONObject {
 
 export interface FindMultipleRowsOutput extends IJSONObject {
   rowsFound: number
-  columns?: Record<string, string>
+  columns?: Record<string, { id: string; value: string }>
   rows?: string | TableRowOutput[]
 }
 

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -1,9 +1,17 @@
 import { IJSONObject } from '@plumber/types'
 
+import { TableRowOutput } from '@/models/dynamodb/table-row'
+
 export interface FindSingleRowOutput extends IJSONObject {
   rowsFound: number
   rowId?: string
   row?: Record<string, string | number>
+}
+
+export interface FindMultipleRowsOutput extends IJSONObject {
+  rowsFound: number
+  columns?: Record<string, string>
+  rows?: string | TableRowOutput[]
 }
 
 export interface CreateRowOutput extends IJSONObject {

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -11,7 +11,10 @@ export interface FindSingleRowOutput extends IJSONObject {
 export interface FindMultipleRowsOutput extends IJSONObject {
   rowsFound: number
   columns?: Record<string, { id: string; value: string }>
-  rows?: string | TableRowOutput[]
+  rows?: {
+    rowData: TableRowOutput[]
+    columns: Record<string, string>
+  }
 }
 
 export interface CreateRowOutput extends IJSONObject {

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -8,9 +8,15 @@ export interface FindSingleRowOutput extends IJSONObject {
   row?: Record<string, string | number>
 }
 
+export type TileColumnMetadata = {
+  id: string
+  name: string
+  value: string
+}
+
 export interface FindMultipleRowsOutput extends IJSONObject {
   rowsFound: number
-  columns?: Record<string, { id: string; value: string }>
+  columns?: Record<string, TileColumnMetadata>
   rows?: {
     rowData: TableRowOutput[]
     columns: Record<string, string>

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -16,10 +16,10 @@ export type TileColumnMetadata = {
 
 export interface FindMultipleRowsOutput extends IJSONObject {
   rowsFound: number
-  columns?: Record<string, TileColumnMetadata>
+  columns: TileColumnMetadata[]
   rows?: {
     rowData: TableRowOutput[]
-    columns: Record<string, string>
+    columns: Record<string, string>[]
   }
 }
 

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -198,7 +198,9 @@ const Editor = ({
         attrs: {
           id: variable.name,
           label: variable.label,
-          value: variable.value,
+          value: variable.displayedValue
+            ? variable.displayedValue
+            : variable.value,
         },
       })
       editor?.commands.focus()

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -120,6 +120,21 @@ const process = (
         })
   }
 
+  // special handling for Tiles multiple row
+  // we do not do not join like strings as it contains objects and do not flatmap the data as we want to use it as a whole
+  if (type === 'array') {
+    return [
+      {
+        name: `step.${stepId}.${parentKey}`, // Don't mess with this because of lodash get!!!
+        value: JSON.stringify(data),
+        label: label ?? parentKey,
+        displayedValue,
+        type,
+        order,
+      },
+    ]
+  }
+
   /**
    * handle objects here
    */


### PR DESCRIPTION
### TL;DR

Added a new "Find Multiple Rows" action to the Tiles app that allows users to retrieve multiple rows from a tile based on specified filters.

This is a prerequisite for for-each.

### What changed?

- Created a new `findMultipleRows` action that retrieves multiple rows from a tile based on filter conditions
- Implemented permission checks to ensure only owners and editors can access the data
- Added support for sorting results in ascending or descending order
- Implemented scan limit functionality to control the number of rows returned
- Created comprehensive tests to verify the action's functionality
- Added appropriate error handling for invalid filters and deleted tiles
- Integrated the new action with the existing Tiles app

### How to test?

1. Create a new action and select the "Find multiple rows" event from the Tiles app
2. Select a tile and configure filter conditions to match the rows you want to retrieve
3. Choose the order of results (ascending or descending)
4. Test the step and verify that the correct rows are returned


### Note to reviewers
This is meant to be the backend implementation of the findMultipleRows action, the data-out metadata will be updated again.

Feature flag has been added on LaunchDarkly to allow for progressive rollout.