### PR TITLE
PLU-429 [FIND-MULTIPLE-ROWS-2]: M365 Excel 

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -21,10 +21,17 @@ describe('getTableRows getDataOutMetadata', () => {
     const result = await getDataOutMetadata(executionStep)
 
     expect(result).toEqual({
+      rows: {
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 0 row(s)',
+        order: 1,
+        type: 'array',
+      },
       rowsFound: {
         label: 'Number of rows found',
         order: 2,
       },
+      columns: {},
     })
   })
 
@@ -104,10 +111,17 @@ describe('getTableRows getDataOutMetadata', () => {
     const result = await getDataOutMetadata(executionStep)
 
     expect(result).toEqual({
+      rows: {
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 0 row(s)',
+        order: 1,
+        type: 'array',
+      },
       rowsFound: {
         label: 'Number of rows found',
         order: 2,
       },
+      columns: {},
     })
   })
 

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -31,7 +31,7 @@ describe('getTableRows getDataOutMetadata', () => {
         label: 'Number of rows found',
         order: 2,
       },
-      columns: {},
+      columns: [],
     })
   })
 
@@ -57,10 +57,18 @@ describe('getTableRows getDataOutMetadata', () => {
             },
           },
         ],
-        columns: {
-          Column1: { id: 'Column1', value: 'value1, value3', order: 1 },
-          Column2: { id: 'Column2', value: 'value2, value4', order: 2 },
-        },
+        columns: [
+          {
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
+            value: 'value1, value3',
+          },
+          {
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
+            value: 'value2, value4',
+          },
+        ],
         numRows: 2,
       },
     } as unknown as IExecutionStep
@@ -78,24 +86,22 @@ describe('getTableRows getDataOutMetadata', () => {
         label: 'Number of rows found',
         order: 2,
       },
-      columns: {
-        Column1: {
+      columns: [
+        {
           id: { isHidden: true },
+          name: { isHidden: true },
           value: {
             label: 'Column1',
-            order: 3,
           },
-          order: { isHidden: true },
         },
-        Column2: {
+        {
           id: { isHidden: true },
+          name: { isHidden: true },
           value: {
             label: 'Column2',
-            order: 4,
           },
-          order: { isHidden: true },
         },
-      },
+      ],
     })
   })
 
@@ -121,7 +127,7 @@ describe('getTableRows getDataOutMetadata', () => {
         label: 'Number of rows found',
         order: 2,
       },
-      columns: {},
+      columns: [],
     })
   })
 

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -32,7 +32,7 @@ describe('getTableRows getDataOutMetadata', () => {
     const executionStep = {
       dataOut: {
         rowsFound: 2,
-        rowData: JSON.stringify([
+        rowData: [
           {
             tableRowIndex: 0,
             sheetRowNumber: 2,
@@ -49,7 +49,7 @@ describe('getTableRows getDataOutMetadata', () => {
               '436f6c756d6e32': { value: 'value4', columnName: 'Column2' },
             },
           },
-        ]),
+        ],
         columns: {
           Column1: { id: 'Column1', value: 'value1, value3', order: 1 },
           Column2: { id: 'Column2', value: 'value2, value4', order: 2 },
@@ -73,20 +73,20 @@ describe('getTableRows getDataOutMetadata', () => {
       },
       columns: {
         Column1: {
-          id: { type: 'hidden' },
+          id: { isHidden: true },
           value: {
             label: 'Column1',
             order: 3,
           },
-          order: { type: 'hidden' },
+          order: { isHidden: true },
         },
         Column2: {
-          id: { type: 'hidden' },
+          id: { isHidden: true },
           value: {
             label: 'Column2',
             order: 4,
           },
-          order: { type: 'hidden' },
+          order: { isHidden: true },
         },
       },
     })
@@ -95,8 +95,8 @@ describe('getTableRows getDataOutMetadata', () => {
   it('should handle missing columns in dataOut', async () => {
     const executionStep = {
       dataOut: {
-        rowsFound: 1,
-        rows: JSON.stringify([{ row: {} }]),
+        rowsFound: 0,
+        rows: [],
         // columns is missing
       },
     } as unknown as IExecutionStep
@@ -108,13 +108,6 @@ describe('getTableRows getDataOutMetadata', () => {
         label: 'Number of rows found',
         order: 2,
       },
-      rows: {
-        label: 'List of row(s) found',
-        displayedValue: 'Preview 1 row(s)',
-        order: 1,
-        type: 'array',
-      },
-      columns: {},
     })
   })
 

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -22,7 +22,8 @@ describe('getTableRows getDataOutMetadata', () => {
 
     expect(result).toEqual({
       rowsFound: {
-        label: 'No. of rows found',
+        label: 'Number of rows found',
+        order: 2,
       },
     })
   })
@@ -49,7 +50,10 @@ describe('getTableRows getDataOutMetadata', () => {
             },
           },
         ]),
-        columns: ['Column1', 'Column2'],
+        columns: {
+          Column1: { id: 'Column1', value: 'value1, value3', order: 1 },
+          Column2: { id: 'Column2', value: 'value2, value4', order: 2 },
+        },
         numRows: 2,
       },
     } as unknown as IExecutionStep
@@ -58,22 +62,33 @@ describe('getTableRows getDataOutMetadata', () => {
 
     expect(result).toEqual({
       rows: {
-        label: 'Data rows',
-        displayedValue: '2 rows',
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 2 row(s)',
+        order: 1,
+        type: 'array',
       },
       rowsFound: {
-        label: 'No. of rows found',
+        label: 'Number of rows found',
+        order: 2,
       },
-      columns: [
-        {
-          label: 'Column1',
-          displayedValue: '',
+      columns: {
+        Column1: {
+          id: { type: 'hidden' },
+          value: {
+            label: 'Column1',
+            order: 3,
+          },
+          order: { type: 'hidden' },
         },
-        {
-          label: 'Column2',
-          displayedValue: '',
+        Column2: {
+          id: { type: 'hidden' },
+          value: {
+            label: 'Column2',
+            order: 4,
+          },
+          order: { type: 'hidden' },
         },
-      ],
+      },
     })
   })
 
@@ -90,13 +105,16 @@ describe('getTableRows getDataOutMetadata', () => {
 
     expect(result).toEqual({
       rowsFound: {
-        label: 'No. of rows found',
+        label: 'Number of rows found',
+        order: 2,
       },
       rows: {
-        label: 'Data rows',
-        displayedValue: '1 rows',
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 1 row(s)',
+        order: 1,
+        type: 'array',
       },
-      columns: [],
+      columns: {},
     })
   })
 

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -1,0 +1,120 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import getDataOutMetadata from '../../actions/get-table-rows/get-data-out-metadata'
+
+describe('getTableRows getDataOutMetadata', () => {
+  it('should return null if no dataOut is provided', async () => {
+    const executionStep = { dataOut: null } as unknown as IExecutionStep
+    const result = await getDataOutMetadata(executionStep)
+    expect(result).toBeNull()
+  })
+
+  it('should return metadata for 0 rows found', async () => {
+    const executionStep = {
+      dataOut: {
+        rowsFound: 0,
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    expect(result).toEqual({
+      rowsFound: {
+        label: 'No. of rows found',
+      },
+    })
+  })
+
+  it('should return metadata for foundRows: true with row data', async () => {
+    const executionStep = {
+      dataOut: {
+        rowsFound: 2,
+        rowData: JSON.stringify([
+          {
+            tableRowIndex: 0,
+            sheetRowNumber: 2,
+            row: {
+              '436f6c756d6e31': { value: 'value1', columnName: 'Column1' },
+              '436f6c756d6e32': { value: 'value2', columnName: 'Column2' },
+            },
+          },
+          {
+            tableRowIndex: 1,
+            sheetRowNumber: 3,
+            row: {
+              '436f6c756d6e31': { value: 'value3', columnName: 'Column1' },
+              '436f6c756d6e32': { value: 'value4', columnName: 'Column2' },
+            },
+          },
+        ]),
+        columns: ['Column1', 'Column2'],
+        numRows: 2,
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    expect(result).toEqual({
+      rows: {
+        label: 'Data rows',
+        displayedValue: '2 rows',
+      },
+      rowsFound: {
+        label: 'No. of rows found',
+      },
+      columns: [
+        {
+          label: 'Column1',
+          displayedValue: '',
+        },
+        {
+          label: 'Column2',
+          displayedValue: '',
+        },
+      ],
+    })
+  })
+
+  it('should handle missing columns in dataOut', async () => {
+    const executionStep = {
+      dataOut: {
+        rowsFound: 1,
+        rows: JSON.stringify([{ row: {} }]),
+        // columns is missing
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    expect(result).toEqual({
+      rowsFound: {
+        label: 'No. of rows found',
+      },
+      rows: {
+        label: 'Data rows',
+        displayedValue: '1 rows',
+      },
+      columns: [],
+    })
+  })
+
+  it('should handle invalid dataOut format gracefully', async () => {
+    // This test verifies that the function doesn't throw when dataOut doesn't match the schema
+    // In a real scenario, the zod schema would throw, but we're testing the error handling
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn())
+
+    const executionStep = {
+      dataOut: {
+        // Missing the required rowsFound field
+        someOtherField: true,
+      },
+    } as unknown as IExecutionStep
+
+    // The function should throw when parsing invalid dataOut
+    await expect(getDataOutMetadata(executionStep)).rejects.toThrow()
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -121,6 +121,8 @@ describe('getTableRowsAction', () => {
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
+        columns: {},
+        rows: [],
         rowsFound: 0,
       },
     })
@@ -132,14 +134,25 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 2, // Two rows match 'test-value'
-        columns: ['Column1', 'Column2'],
-        rows: expect.any(String),
+        columns: {
+          Column1: {
+            id: 'Column1',
+            value: 'test-value, test-value',
+            order: 1,
+          },
+          Column2: {
+            id: 'Column2',
+            value: 'data2, data3',
+            order: 2,
+          },
+        },
+        rows: expect.any(Array),
       }),
     })
 
     // Verify the rowData contains the expected rows
     const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    const rowData = JSON.parse(call.raw.rows)
+    const rowData = call.raw.rows
 
     expect(rowData).toHaveLength(2)
     expect(rowData[0].tableRowIndex).toBe(1)
@@ -165,6 +178,8 @@ describe('getTableRowsAction', () => {
     // Should not find any matches due to case sensitivity
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
+        columns: {},
+        rows: [],
         rowsFound: 0,
       },
     })
@@ -189,8 +204,19 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 1,
-        columns: ['Column1', 'Column2'],
-        rows: expect.any(String),
+        columns: {
+          Column1: {
+            id: 'Column1',
+            value: 'TEST-VALUE',
+            order: 1,
+          },
+          Column2: {
+            id: 'Column2',
+            value: 'data2',
+            order: 2,
+          },
+        },
+        rows: expect.any(Array),
       }),
     })
   })
@@ -212,14 +238,38 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500, // Should be limited to 500 rows
-        columns: ['Column1', 'Column2'],
-        rows: expect.any(String),
+        columns: {
+          Column1: {
+            id: 'Column1',
+            value: `test-value, ${Array.from(
+              { length: 499 },
+              (_) => `test-value`,
+            ).join(', ')}`,
+            order: 1,
+          },
+          Column2: {
+            id: 'Column2',
+            value: `data1, ${Array.from(
+              { length: 499 },
+              (_, i) => `data${i + 2}`,
+            ).join(', ')}`,
+            order: 2,
+          },
+        },
+        rows: expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(String),
+            rowData: expect.any(Object),
+            sheetRowNumber: expect.any(Number),
+            tableRowIndex: expect.any(Number),
+          }),
+        ]),
       }),
     })
 
     // Verify the rowData contains exactly 500 rows
     const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    const rowData = JSON.parse(call.raw.rows)
+    const rowData = call.raw.rows
     expect(rowData).toHaveLength(500)
 
     // Verify the first and last rows are correct

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -121,7 +121,18 @@ describe('getTableRowsAction', () => {
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: {},
+        columns: {
+          Column1: {
+            id: 'Column1',
+            value: '',
+            order: 1,
+          },
+          Column2: {
+            id: 'Column2',
+            value: '',
+            order: 2,
+          },
+        },
         rows: [],
         rowsFound: 0,
       },
@@ -178,7 +189,18 @@ describe('getTableRowsAction', () => {
     // Should not find any matches due to case sensitivity
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: {},
+        columns: {
+          Column1: {
+            id: 'Column1',
+            value: '',
+            order: 1,
+          },
+          Column2: {
+            id: 'Column2',
+            value: '',
+            order: 2,
+          },
+        },
         rows: [],
         rowsFound: 0,
       },

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -194,4 +194,38 @@ describe('getTableRowsAction', () => {
       }),
     })
   })
+
+  it('should limit returned rows to 500 when more matches are found', async () => {
+    // Create an array of 600 matching rows
+    const matchingRows = Array.from({ length: 600 }, (_, i) => [
+      `test-value`,
+      `data${i + 1}`,
+    ])
+    mocks.getTopNTableRows.mockResolvedValue({
+      columns: ['Column1', 'Column2'],
+      rows: matchingRows,
+      headerSheetRowIndex: 0,
+    })
+
+    await getTableRowsAction.run($)
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: expect.objectContaining({
+        rowsFound: 500, // Should be limited to 500 rows
+        columns: ['Column1', 'Column2'],
+        rows: expect.any(String),
+      }),
+    })
+
+    // Verify the rowData contains exactly 500 rows
+    const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const rowData = JSON.parse(call.raw.rows)
+    expect(rowData).toHaveLength(500)
+
+    // Verify the first and last rows are correct
+    expect(rowData[0].tableRowIndex).toBe(0)
+    expect(rowData[0].sheetRowNumber).toBe(2) // headerSheetRowIndex(0) + rowIndex(0) + 2
+    expect(rowData[499].tableRowIndex).toBe(499)
+    expect(rowData[499].sheetRowNumber).toBe(501) // headerSheetRowIndex(0) + rowIndex(499) + 2
+  })
 })

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -121,18 +121,18 @@ describe('getTableRowsAction', () => {
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: {
-          Column1: {
-            id: 'Column1',
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
             value: '',
-            order: 1,
-          },
-          Column2: {
-            id: 'Column2',
+          }),
+          expect.objectContaining({
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
             value: '',
-            order: 2,
-          },
-        },
+          }),
+        ]),
         rows: [],
         rowsFound: 0,
       },
@@ -145,18 +145,18 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 2, // Two rows match 'test-value'
-        columns: {
-          Column1: {
-            id: 'Column1',
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
             value: 'test-value, test-value',
-            order: 1,
-          },
-          Column2: {
-            id: 'Column2',
+          }),
+          expect.objectContaining({
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
             value: 'data2, data3',
-            order: 2,
-          },
-        },
+          }),
+        ]),
         rows: expect.any(Array),
       }),
     })
@@ -189,18 +189,18 @@ describe('getTableRowsAction', () => {
     // Should not find any matches due to case sensitivity
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: {
-          Column1: {
-            id: 'Column1',
+        columns: [
+          {
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
             value: '',
-            order: 1,
           },
-          Column2: {
-            id: 'Column2',
+          {
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
             value: '',
-            order: 2,
           },
-        },
+        ],
         rows: [],
         rowsFound: 0,
       },
@@ -226,18 +226,18 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 1,
-        columns: {
-          Column1: {
-            id: 'Column1',
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
             value: 'TEST-VALUE',
-            order: 1,
-          },
-          Column2: {
-            id: 'Column2',
+          }),
+          expect.objectContaining({
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
             value: 'data2',
-            order: 2,
-          },
-        },
+          }),
+        ]),
         rows: expect.any(Array),
       }),
     })
@@ -260,24 +260,24 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500, // Should be limited to 500 rows
-        columns: {
-          Column1: {
-            id: 'Column1',
+        columns: expect.arrayContaining([
+          expect.objectContaining({
+            id: Buffer.from('Column1').toString('hex'),
+            name: 'Column1',
             value: `test-value, ${Array.from(
               { length: 499 },
               (_) => `test-value`,
             ).join(', ')}`,
-            order: 1,
-          },
-          Column2: {
-            id: 'Column2',
+          }),
+          expect.objectContaining({
+            id: Buffer.from('Column2').toString('hex'),
+            name: 'Column2',
             value: `data1, ${Array.from(
               { length: 499 },
               (_, i) => `data${i + 2}`,
             ).join(', ')}`,
-            order: 2,
-          },
-        },
+          }),
+        ]),
         rows: expect.arrayContaining([
           expect.objectContaining({
             id: expect.any(String),

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -1,0 +1,197 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+import { generateMockContext } from '@/graphql/__tests__/mutations/tiles/table.mock'
+import Context from '@/types/express/context'
+
+import m365Excel from '../..'
+import getTableRowsAction from '../../actions/get-table-rows'
+
+// Mock dependencies
+const mocks = vi.hoisted(() => ({
+  WorkbookSession: {
+    acquire: vi.fn(),
+    request: vi.fn(),
+  },
+  getTopNTableRows: vi.fn(),
+  convertRowToHexEncodedRowRecord: vi.fn(),
+  validateDynamicFieldsAndThrowError: vi.fn(),
+}))
+
+vi.mock('../../common/workbook-session', () => ({
+  default: {
+    acquire: mocks.WorkbookSession.acquire,
+  },
+}))
+
+vi.mock('../../common/get-top-n-table-rows', () => ({
+  default: mocks.getTopNTableRows,
+}))
+
+vi.mock('../../common/validate-dynamic-fields', () => ({
+  validateDynamicFieldsAndThrowError: mocks.validateDynamicFieldsAndThrowError,
+}))
+
+describe('getTableRowsAction', () => {
+  // Test globals
+  let context: Context
+  let $: IGlobalVariable
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    context = await generateMockContext()
+
+    // Setup mock global variable
+    $ = {
+      user: context.currentUser,
+      flow: {
+        id: '123',
+        userId: context.currentUser.id,
+      },
+      step: {
+        id: '123',
+        appKey: m365Excel.name,
+        key: getTableRowsAction.key,
+        position: 2,
+        parameters: {
+          fileId: 'test-file-id',
+          tableId: '{test-table-id}',
+          lookupColumn: 'Column1',
+          lookupValue: 'test-value',
+        },
+      },
+      app: {
+        name: m365Excel.name,
+      },
+      setActionItem: vi.fn(),
+      http: {
+        request: vi.fn(),
+      },
+    } as unknown as IGlobalVariable
+
+    // Setup default mock implementations
+    mocks.getTopNTableRows.mockResolvedValue({
+      columns: ['Column1', 'Column2'],
+      rows: [
+        ['non-matching', 'data1'],
+        ['test-value', 'data2'],
+        ['test-value', 'data3'],
+      ],
+      headerSheetRowIndex: 0,
+    })
+
+    // Setup hex-encoded row record mock
+    mocks.convertRowToHexEncodedRowRecord.mockImplementation(
+      ({ row, columns }: { row: string[]; columns: string[] }) => {
+        // Create a simple mock implementation that converts the row to a record
+        const result: Record<string, { value: string; columnName: string }> = {}
+        columns.forEach((col: string, index: number) => {
+          const hexKey = Buffer.from(col).toString('hex')
+          result[hexKey] = {
+            value: row[index],
+            columnName: col,
+          }
+        })
+        return result
+      },
+    )
+  })
+
+  it('should throw an error if the lookup column does not exist', async () => {
+    mocks.getTopNTableRows.mockResolvedValue({
+      columns: ['OtherColumn', 'Column2'],
+      rows: [['value1', 'data1']],
+      headerSheetRowIndex: 0,
+    })
+
+    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should return foundRows: 0 when no matching rows are found', async () => {
+    mocks.getTopNTableRows.mockResolvedValue({
+      columns: ['Column1', 'Column2'],
+      rows: [['non-matching', 'data1']],
+      headerSheetRowIndex: 0,
+    })
+
+    $.step.parameters.lookupValue = 'test-value'
+    await getTableRowsAction.run($)
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        rowsFound: 0,
+      },
+    })
+  })
+
+  it('should return matching rows when found', async () => {
+    await getTableRowsAction.run($)
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: expect.objectContaining({
+        rowsFound: 2, // Two rows match 'test-value'
+        columns: ['Column1', 'Column2'],
+        rows: expect.any(String),
+      }),
+    })
+
+    // Verify the rowData contains the expected rows
+    const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const rowData = JSON.parse(call.raw.rows)
+
+    expect(rowData).toHaveLength(2)
+    expect(rowData[0].tableRowIndex).toBe(1)
+    expect(rowData[0].sheetRowNumber).toBe(3) // headerSheetRowIndex(0) + rowIndex(1) + 2
+    expect(rowData[1].tableRowIndex).toBe(2)
+    expect(rowData[1].sheetRowNumber).toBe(4) // headerSheetRowIndex(0) + rowIndex(2) + 2
+  })
+
+  it('should handle invalid parameters', async () => {
+    $.step.parameters.fileId = ''
+    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+
+    $.step.parameters.tableId = '!!!'
+    await expect(getTableRowsAction.run($)).rejects.toThrow(StepError)
+  })
+
+  it('should handle case-sensitive matching', async () => {
+    // Change the lookup value to be different case
+    $.step.parameters.lookupValue = 'TEST-VALUE'
+
+    await getTableRowsAction.run($)
+
+    // Should not find any matches due to case sensitivity
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        rowsFound: 0,
+      },
+    })
+  })
+
+  it('should find case-sensitive matches correctly', async () => {
+    mocks.getTopNTableRows.mockResolvedValue({
+      columns: ['Column1', 'Column2'],
+      rows: [
+        ['non-matching', 'data1'],
+        ['TEST-VALUE', 'data2'],
+        ['test-value', 'data3'],
+      ],
+      headerSheetRowIndex: 0,
+    })
+    // Change the lookup value to be different case
+    $.step.parameters.lookupValue = 'TEST-VALUE'
+
+    await getTableRowsAction.run($)
+
+    // Should find the exact case match
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: expect.objectContaining({
+        rowsFound: 1,
+        columns: ['Column1', 'Column2'],
+        rows: expect.any(String),
+      }),
+    })
+  })
+})

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
@@ -2,9 +2,8 @@ import type { IGlobalVariable } from '@plumber/types'
 
 import StepError from '@/errors/step'
 
+import getTopNTableRows from '../../../common/get-top-n-table-rows'
 import type WorkbookSession from '../../../common/workbook-session'
-
-import getTopNTableRows from './get-top-n-table-rows'
 
 // Grabbing ~50k rows takes ~5s. This is similar to our attachment download
 // latency from FormSG, so should be ok...

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -27,21 +27,14 @@ async function getDataOutMetadata(
     order: 1,
   }
 
-  const columnMetadata: IDataOutMetadata = {}
+  const columnMetadata: IDataOutMetadata = []
   if ('columns' in dataOut) {
-    /**
-     * NOTE: Excel does not allow duplicate column names in tables,
-     * don't need to worry about using column names as the unique identifier.
-     */
-    Object.entries(dataOut.columns).forEach(([name, { order }]) => {
-      columnMetadata[name] = {
+    dataOut.columns.forEach(({ name }) => {
+      columnMetadata.push({
         id: { isHidden: true },
-        value: {
-          label: name,
-          order: order ? order + 2 : null,
-        },
-        order: { isHidden: true },
-      }
+        name: { isHidden: true },
+        value: { label: name },
+      })
     })
   }
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -39,12 +39,12 @@ async function getDataOutMetadata(
      */
     Object.entries(dataOut.columns).forEach(([name, { order }]) => {
       columnMetadata[name] = {
-        id: { type: 'hidden' },
+        id: { isHidden: true },
         value: {
           label: name,
           order: order ? order + 2 : null,
         },
-        order: { type: 'hidden' },
+        order: { isHidden: true },
       }
     })
   }
@@ -55,8 +55,8 @@ async function getDataOutMetadata(
 export default getDataOutMetadata
 
 // Example dataOut: {
-//   // rows is a stringified array of objects, where each object is a row of data
-//   rows: '[{"id": "0-2","tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"id": "3-5","tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}]',
+//   // rows is an array of objects, where each object is a row of data
+//   rows: [{"id": "0-2","tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"id": "3-5","tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}],
 //   columns: {"Column1": {"id": "Column1", "order":1, value: "Column1"}, "Column2": {"id": "Column2", "order":2, value: "Column2"}},
 //   rowsFound: 2
 // }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -1,0 +1,52 @@
+import type { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+import { dataOutSchema } from './schemas'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut: rawDataOut } = executionStep
+  if (!rawDataOut) {
+    return null
+  }
+
+  // Parse the data first to get proper type information
+  const dataOut = dataOutSchema.parse(rawDataOut)
+
+  const metadata: IDataOutMetadata = {
+    rowsFound: {
+      label: 'No. of rows found',
+    },
+  }
+
+  if (dataOut.rowsFound === 0) {
+    return metadata
+  }
+
+  // At this point TypeScript knows we're in the second branch of the union
+  metadata.rows = {
+    label: 'Data rows',
+    displayedValue: `${dataOut.rowsFound} rows`,
+  }
+
+  const columnMetadata: IDataOutMetadata = []
+  if ('columns' in dataOut) {
+    dataOut.columns.forEach((column: string) => {
+      columnMetadata.push({
+        label: column,
+        displayedValue: '',
+      })
+    })
+  }
+
+  return { ...metadata, columns: columnMetadata }
+}
+
+export default getDataOutMetadata
+
+// Example dataOut: {
+//   // rows is a stringified array of objects, where each object is a row of data
+//   rows: '[{"tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}]',
+//   columns: [ 'Column1', 'Column2' ],
+//   rowsFound: 2
+// }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -15,7 +15,8 @@ async function getDataOutMetadata(
 
   const metadata: IDataOutMetadata = {
     rowsFound: {
-      label: 'No. of rows found',
+      label: 'Number of rows found',
+      order: 2,
     },
   }
 
@@ -23,19 +24,28 @@ async function getDataOutMetadata(
     return metadata
   }
 
-  // At this point TypeScript knows we're in the second branch of the union
   metadata.rows = {
-    label: 'Data rows',
-    displayedValue: `${dataOut.rowsFound} rows`,
+    label: 'List of row(s) found',
+    displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
+    type: 'array',
+    order: 1,
   }
 
-  const columnMetadata: IDataOutMetadata = []
+  const columnMetadata: IDataOutMetadata = {}
   if ('columns' in dataOut) {
-    dataOut.columns.forEach((column: string) => {
-      columnMetadata.push({
-        label: column,
-        displayedValue: '',
-      })
+    /**
+     * NOTE: Excel does not allow duplicate column names in tables,
+     * don't need to worry about using column names as the unique identifier.
+     */
+    Object.entries(dataOut.columns).forEach(([name, { order }]) => {
+      columnMetadata[name] = {
+        id: { type: 'hidden' },
+        value: {
+          label: name,
+          order: order ? order + 2 : null,
+        },
+        order: { type: 'hidden' },
+      }
     })
   }
 
@@ -46,7 +56,7 @@ export default getDataOutMetadata
 
 // Example dataOut: {
 //   // rows is a stringified array of objects, where each object is a row of data
-//   rows: '[{"tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}]',
-//   columns: [ 'Column1', 'Column2' ],
+//   rows: '[{"id": "0-2","tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"id": "3-5","tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}]',
+//   columns: {"Column1": {"id": "Column1", "order":1, value: "Column1"}, "Column2": {"id": "Column2", "order":2, value: "Column2"}},
 //   rowsFound: 2
 // }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -20,10 +20,6 @@ async function getDataOutMetadata(
     },
   }
 
-  if (dataOut.rowsFound === 0) {
-    return metadata
-  }
-
   metadata.rows = {
     label: 'List of row(s) found',
     displayedValue: `Preview ${dataOut.rowsFound} row(s)`,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import { GET_TABLE_ROWS_LIMIT } from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
 import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
@@ -74,7 +75,7 @@ const action: IRawAction = {
       variables: false,
       label: 'Lookup column',
       description:
-        'If multiple rows meet your condition, the topmost entry will be returned',
+        'Only the first 500 rows that meet the condition will be returned',
       source: {
         type: 'query' as const,
         name: 'getDynamicData' as const,
@@ -178,10 +179,13 @@ const action: IRawAction = {
       return
     }
 
+    // Max limit of 500 rows
+    const slicedRows = rowsToReturn.slice(0, GET_TABLE_ROWS_LIMIT)
+
     $.setActionItem({
       raw: {
-        rowsFound: rowsToReturn.length,
-        rows: JSON.stringify(rowsToReturn),
+        rowsFound: slicedRows.length,
+        rows: JSON.stringify(slicedRows),
         columns,
       } satisfies DataOut,
     })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -1,0 +1,191 @@
+import type { IRawAction } from '@plumber/types'
+
+import z from 'zod'
+
+import StepError from '@/errors/step'
+
+import getTopNTableRows from '../../common/get-top-n-table-rows'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
+import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
+import WorkbookSession from '../../common/workbook-session'
+import { MAX_ROWS } from '../get-table-row/implementation'
+
+import getDataOutMetadata from './get-data-out-metadata'
+import { dataOutSchema, parametersSchema } from './schemas'
+
+type DataOut = z.infer<typeof dataOutSchema>
+
+const action: IRawAction = {
+  name: 'Find table rows',
+  key: 'getTableRows',
+  description: 'Gets multiple rows of data from your Excel table',
+  settingsStepLabel: 'Set up rows to get',
+  arguments: [
+    {
+      key: 'fileId',
+      label: 'Excel File',
+      required: true,
+      description: 'This should be an Excel file in the folder created for you',
+      type: 'dropdown' as const,
+      showOptionValue: false,
+      variables: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listFiles',
+          },
+        ],
+      },
+    },
+    {
+      key: 'tableId',
+      label: 'Table',
+      required: true,
+      // The MAX_ROWS row limit is a hard limit, but the cell limit is a soft
+      // limit. The cell limit serves as messaging to tell users not to feed
+      // enormous tables.
+      description: `Tables should not have more than ${MAX_ROWS.toLocaleString()} rows or 100,000 cells`,
+      type: 'dropdown' as const,
+      showOptionValue: false,
+      variables: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTables',
+          },
+          {
+            name: 'parameters.fileId',
+            value: '{parameters.fileId}',
+          },
+        ],
+      },
+    },
+    {
+      key: 'lookupColumn' as const,
+      type: 'dropdown' as const,
+      showOptionValue: false,
+      required: true,
+      variables: false,
+      label: 'Lookup column',
+      description:
+        'If multiple rows meet your condition, the topmost entry will be returned',
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'listTableColumns',
+          },
+          {
+            name: 'parameters.fileId',
+            value: '{parameters.fileId}',
+          },
+          {
+            name: 'parameters.tableId',
+            value: '{parameters.tableId}',
+          },
+        ],
+      },
+    },
+    {
+      key: 'lookupValue' as const,
+      label: 'Lookup Value',
+      // We don't support matching on Excel-formatted text because it's very
+      // weird (e.g. currency cells have a trailing space), and will lead to too
+      // much user confusion.
+      description:
+        'Case sensitive and should not include units. E.g. $5.20 → 5.2',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+  ],
+
+  getDataOutMetadata,
+
+  async run($) {
+    const parametersParseResult = parametersSchema.safeParse($.step.parameters)
+    if (parametersParseResult.success === false) {
+      throw new StepError(
+        'There was a problem with the input.',
+        parametersParseResult.error.issues[0].message,
+        $.step?.position,
+        $.app.name,
+      )
+    }
+
+    const { fileId, tableId, lookupColumn, lookupValue } =
+      parametersParseResult.data
+
+    // Validation to prevent path traversals
+    validateDynamicFieldsAndThrowError({
+      fileId,
+      tableId,
+      $,
+    })
+
+    const session = await WorkbookSession.acquire($, fileId)
+    const { columns, rows, headerSheetRowIndex } = await getTopNTableRows(
+      $,
+      session,
+      tableId,
+      MAX_ROWS,
+    )
+
+    const columnIndex = columns.indexOf(lookupColumn)
+    if (columnIndex === -1) {
+      throw new StepError(
+        `Column "${lookupColumn}" does not exist in your table.`,
+        `Check that your Excel table contains the "${lookupColumn}" column.`,
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    const rowsToReturn: {
+      tableRowIndex: number
+      sheetRowNumber: number
+      row: Record<string, { value?: string; columnName?: string }>
+    }[] = []
+
+    for (const [rowIndex, row] of rows.entries()) {
+      if (row[columnIndex] === lookupValue) {
+        rowsToReturn.push({
+          tableRowIndex: rowIndex,
+          sheetRowNumber: rowIndex + headerSheetRowIndex + 2,
+          row: convertRowToHexEncodedRowRecord({
+            row,
+            columns,
+          }),
+        })
+      }
+    }
+
+    if (rowsToReturn.length === 0) {
+      $.setActionItem({
+        raw: {
+          rowsFound: 0,
+        } satisfies DataOut,
+      })
+
+      return
+    }
+
+    $.setActionItem({
+      raw: {
+        rowsFound: rowsToReturn.length,
+        rows: JSON.stringify(rowsToReturn),
+        columns,
+      } satisfies DataOut,
+    })
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -172,18 +172,6 @@ const action: IRawAction = {
       }
     }
 
-    if (rowsToReturn.length === 0) {
-      $.setActionItem({
-        raw: {
-          rowsFound: 0,
-          rows: [],
-          columns: {},
-        } satisfies DataOut,
-      })
-
-      return
-    }
-
     // Max limit of 500 rows
     const slicedRows = rowsToReturn.slice(0, GET_TABLE_ROWS_LIMIT)
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -1,3 +1,4 @@
+// dummy commit for do not merge branch
 import type { IRawAction } from '@plumber/types'
 
 import z from 'zod'
@@ -151,17 +152,19 @@ const action: IRawAction = {
     }
 
     const rowsToReturn: {
+      id: string
       tableRowIndex: number
       sheetRowNumber: number
-      row: Record<string, { value?: string; columnName?: string }>
+      rowData: Record<string, { value?: string; columnName?: string }>
     }[] = []
 
     for (const [rowIndex, row] of rows.entries()) {
       if (row[columnIndex] === lookupValue) {
         rowsToReturn.push({
+          id: `${rowIndex}-${rowIndex + headerSheetRowIndex + 2}`,
           tableRowIndex: rowIndex,
           sheetRowNumber: rowIndex + headerSheetRowIndex + 2,
-          row: convertRowToHexEncodedRowRecord({
+          rowData: convertRowToHexEncodedRowRecord({
             row,
             columns,
           }),
@@ -173,6 +176,8 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
+          rows: JSON.stringify([]),
+          columns: {},
         } satisfies DataOut,
       })
 
@@ -182,11 +187,34 @@ const action: IRawAction = {
     // Max limit of 500 rows
     const slicedRows = rowsToReturn.slice(0, GET_TABLE_ROWS_LIMIT)
 
+    const consolidatedColumns = columns.reduce((acc, column, currentIndex) => {
+      const values: string[] = []
+      for (const row of slicedRows) {
+        const rowData = Object.entries(row.rowData).find(([key, value]) => {
+          if (value.columnName === column) {
+            return value.value
+          }
+        })
+
+        const value = rowData?.[1].value
+        if (value) {
+          values.push(value)
+        }
+      }
+      acc[column] = {
+        id: column,
+        value: values.join(', '),
+        order: columns.indexOf(column) + 1,
+      }
+      return acc
+    }, {} as Record<string, { id: string; value: string; order: number }>)
+    console.log('consolidatedColumns', consolidatedColumns)
+
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
         rows: JSON.stringify(slicedRows),
-        columns,
+        columns: consolidatedColumns,
       } satisfies DataOut,
     })
   },

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -176,7 +176,7 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
-          rows: JSON.stringify([]),
+          rows: [],
           columns: {},
         } satisfies DataOut,
       })
@@ -208,12 +208,11 @@ const action: IRawAction = {
       }
       return acc
     }, {} as Record<string, { id: string; value: string; order: number }>)
-    console.log('consolidatedColumns', consolidatedColumns)
 
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
-        rows: JSON.stringify(slicedRows),
+        rows: slicedRows,
         columns: consolidatedColumns,
       } satisfies DataOut,
     })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -187,10 +187,10 @@ const action: IRawAction = {
     // Max limit of 500 rows
     const slicedRows = rowsToReturn.slice(0, GET_TABLE_ROWS_LIMIT)
 
-    const consolidatedColumns = columns.reduce((acc, column, currentIndex) => {
+    const consolidatedColumns = columns.reduce((acc, column) => {
       const values: string[] = []
       for (const row of slicedRows) {
-        const rowData = Object.entries(row.rowData).find(([key, value]) => {
+        const rowData = Object.entries(row.rowData).find(([_, value]) => {
           if (value.columnName === column) {
             return value.value
           }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -189,13 +189,16 @@ const action: IRawAction = {
           values.push(value)
         }
       }
-      acc[column] = {
-        id: column,
+
+      acc.push({
+        // NOTE: convert column to hex to avoid special characters
+        // such as '.' that may affect lodash get
+        id: Buffer.from(column).toString('hex'),
+        name: column,
         value: values.join(', '),
-        order: columns.indexOf(column) + 1,
-      }
+      })
       return acc
-    }, {} as Record<string, { id: string; value: string; order: number }>)
+    }, [])
 
     $.setActionItem({
       raw: {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -26,5 +26,20 @@ export const dataOutSchema = z.object({
       z.object({ id: z.string(), value: z.string(), order: z.number() }),
     )
     .optional(),
-  rows: z.string().optional(),
+  rows: z
+    .array(
+      z.object({
+        id: z.string(),
+        tableRowIndex: z.number(),
+        sheetRowNumber: z.number(),
+        rowData: z.record(
+          z.string(),
+          z.object({
+            value: z.string(),
+            columnName: z.string(),
+          }),
+        ),
+      }),
+    )
+    .optional(),
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -1,0 +1,25 @@
+import z from 'zod'
+
+export const parametersSchema = z.object({
+  fileId: z
+    .string()
+    .trim()
+    .min(1, { message: 'Please choose a file to lookup from.' }),
+  tableId: z
+    .string()
+    .trim()
+    .min(1, { message: 'Please select a table to lookup from.' }),
+  // Populated by dynamic data, so no need to trim.
+  lookupColumn: z.string().min(1, {
+    message: 'Please select a column to lookup from.',
+  }),
+  // * We don't trim as we want to match _exactly_ on the user's input.
+  // * We allow empty strings to support optional form fields.
+  lookupValue: z.string(),
+})
+
+export const dataOutSchema = z.object({
+  rowsFound: z.number(),
+  columns: z.array(z.string()).optional(),
+  rows: z.string().optional(),
+})

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -20,6 +20,11 @@ export const parametersSchema = z.object({
 
 export const dataOutSchema = z.object({
   rowsFound: z.number(),
-  columns: z.array(z.string()).optional(),
+  columns: z
+    .record(
+      z.string(),
+      z.object({ id: z.string(), value: z.string(), order: z.number() }),
+    )
+    .optional(),
   rows: z.string().optional(),
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -21,9 +21,12 @@ export const parametersSchema = z.object({
 export const dataOutSchema = z.object({
   rowsFound: z.number(),
   columns: z
-    .record(
-      z.string(),
-      z.object({ id: z.string(), value: z.string(), order: z.number() }),
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        value: z.string(),
+      }),
     )
     .optional(),
   rows: z

--- a/packages/backend/src/apps/m365-excel/actions/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/index.ts
@@ -1,12 +1,14 @@
 import createTableRow from './create-table-row'
 import getCellValues from './get-cell-values'
 import getTableRow from './get-table-row'
+import getTableRows from './get-table-rows'
 import updateTableRow from './update-table-row'
 import writeCellValues from './write-cell-values'
 
 export default [
   createTableRow,
   getTableRow,
+  getTableRows,
   getCellValues,
   updateTableRow,
   writeCellValues,

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -10,3 +10,5 @@ export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
  */
 export const TABLE_ID_REGEX = /^\{[a-zA-Z0-9-]+\}$/ // this include start and end braces
 export const FILE_ID_REGEX = /^[a-zA-Z0-9-]+$/
+
+export const GET_TABLE_ROWS_LIMIT = 500

--- a/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
+++ b/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
@@ -4,7 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
-import WorkbookSession from '../../../common/workbook-session'
+import WorkbookSession from './workbook-session'
 
 const msGraphResponseSchema = z
   .object({

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -101,7 +101,10 @@ const process = (
       ? [
           {
             name: `step.${stepId}.${parentKey}`, // Don't mess with this because of lodash get!!!
-            value: data.join(', '),
+            value:
+              typeof data[0] === 'object'
+                ? JSON.stringify(data) // special handling for m365 multi row
+                : data.join(', '),
             label: label ?? parentKey,
             displayedValue,
             type,


### PR DESCRIPTION
### TL;DR
* Added a new "Get Multiple Rows" action to the M365 Excel app that allows users to retrieve multiple rows from a excel table based on the specified lookup column and value.
* Cell values for each column will be combined into a single variable under that column

This is a prerequisite for for-each.

#### Note to reviewers
* This is meant to be the backend implementation of getting rows, the data-out metadata will be updated again.
* Feature flag has been added on LaunchDarkly to allow for progressive rollout.
* There will be a PR created below this to display the find multiple row results in a table

### What changed?
* Created a new getTableRows action that retrieves multiple rows from a M365 Excel table based on a specified lookup column and value
*  Only the first 500 rows that meet the condition will be returned

### How to test?
1. Create a new step with M365 Excel app and select the 'Get table rows' event.
2. Select an excel file, table, and set the lookup column and value
3. Test the step and verify that the correct rows are returned

### Screenshots

![Screenshot 2025-04-15 at 2.55.18 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/568e961d-cb5d-4c20-9a9d-314af6320f56.png)

![Screenshot 2025-04-15 at 2.55.27 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/4e89363b-bd52-4c9d-ab85-477c8bb2989c.png)

