### PR TITLE
feat(tiles): resume fetching rows on throughput exceeded

### DIFF
--- a/packages/backend/src/errors/graphql-errors/rate-limited.ts
+++ b/packages/backend/src/errors/graphql-errors/rate-limited.ts
@@ -1,0 +1,17 @@
+import { GraphQLError } from 'graphql/error'
+
+const RATE_LIMITED_ERROR_CODE = 'RATE_LIMITED'
+
+export class RateLimitedError extends GraphQLError {
+  constructor(message: string) {
+    super(message, {
+      extensions: {
+        code: RATE_LIMITED_ERROR_CODE,
+        message,
+        http: {
+          status: 429,
+        },
+      },
+    })
+  }
+}

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -1,7 +1,9 @@
 import { NotFoundError } from 'objection'
 
+import { RateLimitedError } from '@/errors/graphql-errors/rate-limited'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import logger from '@/helpers/logger'
+import { DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE } from '@/models/dynamodb/helpers'
 import { getTableRows } from '@/models/dynamodb/table-row'
 import TableMetadata from '@/models/table-metadata'
 
@@ -37,6 +39,7 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
     }
 
     const columnIds = table.columns.map((column) => column.id)
+
     return await getTableRows({
       tableId,
       columnIds,
@@ -50,6 +53,11 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
         throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
       }
       throw new Error('Table not found')
+    }
+    if (e.message.includes(DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE)) {
+      throw new RateLimitedError(
+        'Unable to fetch rows at the moment. Please retry in a bit.',
+      )
     }
     throw new Error('Error fetching rows')
   }

--- a/packages/backend/src/models/dynamodb/helpers.ts
+++ b/packages/backend/src/models/dynamodb/helpers.ts
@@ -4,6 +4,9 @@ import RetriableError from '@/errors/retriable-error'
 
 import TableColumnMetadata from '../table-column-metadata'
 
+export const DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE =
+  'Throughput exceeds the current capacity'
+
 export function handleDynamoDBError(error: unknown): never {
   console.error(error)
   if (error instanceof ElectroError) {
@@ -19,7 +22,7 @@ export function handleDynamoDBError(error: unknown): never {
       throw new Error('DynamoDB Validation Error: ' + message)
     }
     if (error.code < 5000) {
-      if (message.includes('Throughput exceeds the current capacity')) {
+      if (message.includes(DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE)) {
         // retry on throughput exceeded
         throw new RetriableError({
           error: message,

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -267,7 +267,7 @@ export const ImportCsvModalContent = ({
             },
           })
           if (i === chunkedData.length - 1 && !onPreImport) {
-            refetch()
+            await refetch()
           }
           setRowsImported((i + 1) * CHUNK_SIZE)
         }

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -30,7 +30,6 @@ import { SetRequired } from 'type-fest'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
 import { CREATE_ROWS } from '@/graphql/mutations/tiles/create-rows'
-import { GET_ALL_ROWS } from '@/graphql/queries/tiles/get-all-rows'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 
 import { useTableContext } from '../../contexts/TableContext'
@@ -135,7 +134,7 @@ export const ImportCsvModalContent = ({
   onPostImport?: () => void
   onBack?: () => void
 }) => {
-  const { tableId, tableColumns } = useTableContext()
+  const { tableId, tableColumns, refetch } = useTableContext()
   const { createColumns } = useUpdateTable()
   const [createRows] = useMutation(CREATE_ROWS)
   const [getTableData] = useLazyQuery<{
@@ -266,12 +265,10 @@ export const ImportCsvModalContent = ({
                 dataArray: chunkedData[i],
               },
             },
-            refetchQueries:
-              i === chunkedData.length - 1 && !onPreImport
-                ? [GET_ALL_ROWS]
-                : undefined,
-            awaitRefetchQueries: true,
           })
+          if (i === chunkedData.length - 1 && !onPreImport) {
+            refetch()
+          }
           setRowsImported((i + 1) * CHUNK_SIZE)
         }
       }
@@ -292,6 +289,7 @@ export const ImportCsvModalContent = ({
     mapDataToColumnIds,
     onPostImport,
     onPreImport,
+    refetch,
     result,
     tableColumns,
     tableId,

--- a/packages/frontend/src/pages/Tile/components/TableBanner/RefreshButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/RefreshButton.tsx
@@ -1,10 +1,15 @@
-import { Flex } from '@chakra-ui/react'
+import { BiErrorCircle } from 'react-icons/bi'
+import { Flex, Icon, Text } from '@chakra-ui/react'
 import { Spinner } from '@opengovsg/design-system-react'
 
 import { useTableContext } from '../../contexts/TableContext'
 
 export default function RefreshButton() {
-  const { isFetching } = useTableContext()
+  const {
+    isFetching,
+    isThroughputError,
+    refetch: retryFetching,
+  } = useTableContext()
 
   if (isFetching) {
     return (
@@ -16,6 +21,31 @@ export default function RefreshButton() {
         fontSize="sm"
       >
         <Spinner /> Fetching more rows...
+      </Flex>
+    )
+  }
+
+  if (isThroughputError) {
+    return (
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        w="max-content"
+        gap={2}
+        fontSize="sm"
+        color="red.500"
+      >
+        <Icon boxSize={5} as={BiErrorCircle} />
+
+        <Text>Error loading rows.</Text>
+        <Text
+          cursor="pointer"
+          onClick={retryFetching}
+          decoration="underline"
+          _hover={{ color: 'primary.600' }}
+        >
+          Retry
+        </Text>
       </Flex>
     )
   }

--- a/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/index.tsx
@@ -9,7 +9,7 @@ import ImportExportToolbar from './ImportExportToolbar'
 import RefreshButton from './RefreshButton'
 
 function TableBanner() {
-  const { tableName, role, isFetching } = useTableContext()
+  const { tableName, role } = useTableContext()
 
   return (
     <Flex
@@ -25,7 +25,7 @@ function TableBanner() {
         <EditMode />
       </Flex>
       <Flex gap={2}>
-        {isFetching && <RefreshButton />}
+        <RefreshButton />
         <ImportExportToolbar />
       </Flex>
     </Flex>

--- a/packages/frontend/src/pages/Tile/components/TableFooter/RowCount.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableFooter/RowCount.tsx
@@ -1,4 +1,5 @@
-import { Flex, Text } from '@chakra-ui/react'
+import { BiErrorCircle } from 'react-icons/bi'
+import { Flex, Icon, Text } from '@chakra-ui/react'
 import { Spinner } from '@opengovsg/design-system-react'
 
 import { BORDER_COLOR } from '../../constants'
@@ -10,7 +11,7 @@ interface RowCountProps {
 }
 
 export default function RowCount({ rowCount, rowSelection }: RowCountProps) {
-  const { isFetching } = useTableContext()
+  const { isFetching, isThroughputError } = useTableContext()
 
   const numRowsSelected = Object.keys(rowSelection).length
   const rowCountToShow = numRowsSelected || rowCount
@@ -23,8 +24,12 @@ export default function RowCount({ rowCount, rowSelection }: RowCountProps) {
       bg={numRowsSelected ? 'primary.50' : 'white'}
       borderColor={BORDER_COLOR.DEFAULT}
       px={4}
+      gap={1}
     >
-      {isFetching && <Spinner mr={1} />}
+      {isFetching && <Spinner />}
+      {!isFetching && isThroughputError && (
+        <Icon boxSize={4} as={BiErrorCircle} color="red.500" />
+      )}
       <Text textStyle="body-2" whiteSpace="nowrap">
         {rowCountToShow}
         {' row' +

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -30,6 +30,8 @@ interface TableContextProps {
   collaborators?: ITableCollaborator[]
   role?: string
   isFetching: boolean
+  isThroughputError: boolean
+  refetch: () => Promise<void>
 }
 
 const TableContext = createContext<TableContextProps | undefined>(undefined)
@@ -55,6 +57,8 @@ interface TableContextProviderProps {
   // If null, the tile is accessed by a shareable link
   role?: string
   isFetching: boolean
+  isThroughputError: boolean
+  refetch: () => Promise<void>
 }
 
 export const TableContextProvider = ({
@@ -67,6 +71,8 @@ export const TableContextProvider = ({
   collaborators,
   role,
   isFetching,
+  isThroughputError,
+  refetch,
 }: TableContextProviderProps) => {
   const flattenedData = useMemo(() => flattenRows(tableRows), [tableRows])
   const filteredDataRef = useRef<GenericRowData[]>([])
@@ -91,6 +97,8 @@ export const TableContextProvider = ({
         collaborators,
         role,
         isFetching,
+        isThroughputError,
+        refetch,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -1,0 +1,103 @@
+import { ITableRow } from '@plumber/types'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApolloError, ServerError, useLazyQuery } from '@apollo/client'
+import { datadogRum } from '@datadog/browser-rum'
+
+import { GET_ALL_ROWS } from '@/graphql/queries/tiles/get-all-rows'
+
+export function useFetchAllRows({
+  tableId,
+  urlViewOnlyKey,
+}: {
+  tableId: string
+  urlViewOnlyKey?: string
+}) {
+  const [rows, setRows] = useState<ITableRow[]>([])
+  const [isThroughputError, setIsThroughputError] = useState(false)
+  const [isFetching, setIsFetching] = useState(false)
+
+  const cursorToContinueFrom = useRef<string>()
+  const startTime = useRef<number>()
+
+  const [fetchAllRowsMutation] = useLazyQuery(GET_ALL_ROWS, {
+    context: urlViewOnlyKey
+      ? {
+          headers: { 'x-tiles-view-key': urlViewOnlyKey },
+        }
+      : undefined,
+    fetchPolicy: 'cache-and-network',
+  })
+
+  const fetchAllRows = useCallback(
+    async (cursor?: string) => {
+      startTime.current = performance.now()
+      setIsFetching(true)
+      let rowCount = 0
+      let currentCursor = cursor
+      try {
+        do {
+          const { data, error } = await fetchAllRowsMutation({
+            variables: {
+              stringifiedCursor: currentCursor,
+              tableId: tableId,
+            },
+          })
+          if (error) {
+            throw error
+          }
+          if (!data?.getAllRows) {
+            throw new Error('No data returned from getAllRows')
+          }
+          rowCount += data.getAllRows.rows.length
+          setRows((prev) => [...prev, ...data.getAllRows.rows])
+          currentCursor = data?.getAllRows.stringifiedCursor ?? undefined
+        } while (currentCursor)
+      } catch (e) {
+        if (
+          e instanceof ApolloError &&
+          e.networkError &&
+          (e.networkError as ServerError).statusCode === 429
+        ) {
+          setIsThroughputError(true)
+          cursorToContinueFrom.current = currentCursor
+        } else {
+          setIsThroughputError(false)
+        }
+      } finally {
+        datadogRum.setGlobalContextProperty(
+          'tile_load_time',
+          performance.now() - startTime.current,
+        )
+        datadogRum.setGlobalContextProperty('tile_row_count', rowCount)
+        setIsFetching(false)
+      }
+    },
+    [fetchAllRowsMutation, tableId],
+  )
+
+  const refetch = useCallback(async () => {
+    if (isThroughputError) {
+      // we do not clear the rows here because we want to preserve the rows that have already been fetched
+      setIsThroughputError(false)
+    } else {
+      // if there is no throughput error, we clear the rows and start from the beginning
+      setRows([])
+      cursorToContinueFrom.current = undefined
+    }
+    await fetchAllRows(cursorToContinueFrom.current)
+  }, [fetchAllRows, isThroughputError])
+
+  useEffect(() => {
+    setRows([])
+    fetchAllRows()
+  }, [fetchAllRows])
+
+  return {
+    rows,
+    cursorToContinueFrom,
+    isFetching,
+    isThroughputError,
+    refetch,
+  }
+}

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -1,27 +1,22 @@
-import { ITableMetadata, ITableRow } from '@plumber/types'
+import { ITableMetadata } from '@plumber/types'
 
-import { useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
-import { datadogRum } from '@datadog/browser-rum'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
-import { GET_ALL_ROWS } from '@/graphql/queries/tiles/get-all-rows'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 
 import Table from './components/Table'
 import TableBanner from './components/TableBanner'
 import { TableContextProvider } from './contexts/TableContext'
+import { useFetchAllRows } from './hooks/useFetchAllRows'
 
 export default function Tile(): JSX.Element {
   const { tileId: tableId, viewOnlyKey: urlViewOnlyKey } = useParams<{
     tileId: string
     viewOnlyKey?: string
   }>()
-  const [rows, setRows] = useState<ITableRow[]>([])
-  const [isFetching, setIsFetching] = useState(true)
-  const startTime = useRef(performance.now())
 
   const { data: getTableData } = useQuery<{
     getTable: ITableMetadata
@@ -37,45 +32,12 @@ export default function Tile(): JSX.Element {
   })
   const ownRole = getTableData?.getTable?.role
 
-  const { data: initialData, fetchMore } = useQuery(GET_ALL_ROWS, {
-    variables: {
-      tableId: tableId as string,
-    },
-    context: urlViewOnlyKey
-      ? {
-          headers: { 'x-tiles-view-key': urlViewOnlyKey },
-        }
-      : undefined,
-    // this fetchPolicy needs to be set for onCompleted to be called on refetch
-    // i.e. after csv upload
-    fetchPolicy: 'cache-and-network',
-    onCompleted: async (data) => {
-      if (!data.getAllRows) {
-        return
-      }
-      let currentCursor = data.getAllRows.stringifiedCursor
-      let allRows = data.getAllRows.rows
-      setRows(allRows)
-      while (currentCursor) {
-        const { data: newData } = await fetchMore({
-          variables: {
-            stringifiedCursor: currentCursor,
-          },
-        })
-        allRows = [...allRows, ...newData.getAllRows.rows]
-        currentCursor = newData.getAllRows.stringifiedCursor
-        setRows(allRows)
-      }
-      datadogRum.setGlobalContextProperty(
-        'tile_load_time',
-        performance.now() - startTime.current,
-      )
-      datadogRum.setGlobalContextProperty('tile_row_count', allRows.length)
-      setIsFetching(false)
-    },
+  const { rows, isFetching, isThroughputError, refetch } = useFetchAllRows({
+    tableId: tableId as string,
+    urlViewOnlyKey,
   })
 
-  if (!getTableData?.getTable || !initialData?.getAllRows) {
+  if (!getTableData?.getTable) {
     return (
       <Center height="100vh">
         <PrimarySpinner fontSize="6xl" thickness="4px" margin="auto" />
@@ -96,6 +58,8 @@ export default function Tile(): JSX.Element {
       collaborators={collaborators}
       role={ownRole}
       isFetching={isFetching}
+      isThroughputError={isThroughputError}
+      refetch={refetch}
     >
       <Flex
         flexDir={{ base: 'column' }}

--- a/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
+++ b/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
@@ -160,6 +160,8 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
             tableColumns={[]}
             tableRows={[]}
             isFetching={false}
+            isThroughputError={false}
+            refetch={() => Promise.resolve()} // stubbed refetch
           >
             <ImportCsvModalContent
               onPreImport={() => createTable({ isBlank: true })}


### PR DESCRIPTION
###  Problem

Currently, if a Tile failed to load midway due to throughput exceeded, an error toast is displayed but the spinner keeps on spinning. The user needs to manually refresh to retry.

### Solution
- Keep track of last cursor which was used to fetched the next page of rows
- Allow user to retry from failure point

### Changes
- Shard out getAllRows fetching to custom hook `useFetchAllRows` with error handling for DynamoDB throughput exceeded errors
- Added UI components to display throughput errors and retry options in the table view
- Updated the CSV import function to use the new refetch method instead of Apollo's refetchQueries
- New custom error class for rate limited response

### How to test?

1. Prepare a tile with a substantial number of rows >10k.
2. Checkout branch `donotmerge/retry-tiles-loading`
3. Try loading tile. Clicking "retry" should only load the rows that have not been loaded.
4. Importing CSV should load the tiles properly.
