### PR TITLE
chore(tiles): improve error screen for missing / unauthorized tiles

### DIFF
--- a/packages/backend/src/errors/graphql-errors/not-found.ts
+++ b/packages/backend/src/errors/graphql-errors/not-found.ts
@@ -1,0 +1,17 @@
+import { GraphQLError } from 'graphql/error'
+
+const NOT_FOUND_ERROR_CODE = 'NOT_FOUND'
+
+export class NotFoundError extends GraphQLError {
+  constructor(message: string) {
+    super(message, {
+      extensions: {
+        code: NOT_FOUND_ERROR_CODE,
+        message,
+        http: {
+          status: 404,
+        },
+      },
+    })
+  }
+}

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -3,6 +3,7 @@ import { ITableRow } from '@plumber/types'
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import getAllRows from '@/graphql/queries/tiles/get-all-rows'
 import { createTableRow } from '@/models/dynamodb/table-row'
 import TableCollaborator from '@/models/table-collaborators'
@@ -177,7 +178,7 @@ describe('get all rows query', () => {
         },
         context,
       ),
-    ).rejects.toThrow('Table not found')
+    ).rejects.toThrow(NotFoundError)
   })
 
   describe('last accessed at', () => {

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import TableMetadataResolver from '@/graphql/custom-resolvers/table-metadata'
 import getTable from '@/graphql/queries/tiles/get-table'
 import TableCollaborator from '@/models/table-collaborators'
@@ -88,7 +89,7 @@ describe('get single table query', () => {
         },
         context,
       ),
-    ).rejects.toThrow('Table not found')
+    ).rejects.toThrow(NotFoundError)
   })
 
   it('should throw an error if collaborator does not exist or is soft deleted', async () => {
@@ -105,7 +106,7 @@ describe('get single table query', () => {
         },
         context,
       ),
-    ).rejects.toThrow('Table not found')
+    ).rejects.toThrow(NotFoundError)
   })
 
   it('should allow all collaborators to call this function', async () => {

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -1,5 +1,6 @@
-import { NotFoundError } from 'objection'
+import { NotFoundError as ObjectionNotFoundError } from 'objection'
 
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import { RateLimitedError } from '@/errors/graphql-errors/rate-limited'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import logger from '@/helpers/logger'
@@ -48,11 +49,11 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
     // TODO: remove keys from rows to reduce payload size
   } catch (e) {
     logger.error(e)
-    if (e instanceof NotFoundError) {
+    if (e instanceof ObjectionNotFoundError) {
       if (context.tilesViewKey) {
         throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
       }
-      throw new Error('Table not found')
+      throw new NotFoundError('Table does not exist or you do not have access.')
     }
     if (e.message.includes(DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE)) {
       throw new RateLimitedError(

--- a/packages/backend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table.ts
@@ -1,5 +1,6 @@
-import { NotFoundError } from 'objection'
+import { NotFoundError as ObjectionNotFoundError } from 'objection'
 
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import logger from '@/helpers/logger'
 import TableMetadata from '@/models/table-metadata'
@@ -29,11 +30,11 @@ const getTable: QueryResolvers['getTable'] = async (
     return table
   } catch (e) {
     logger.error(e)
-    if (e instanceof NotFoundError) {
+    if (e instanceof ObjectionNotFoundError) {
       if (context.tilesViewKey) {
         throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
       }
-      throw new Error('Table not found')
+      throw new NotFoundError('Table does not exist or you do not have access.')
     }
     throw new Error('Error fetching table')
   }

--- a/packages/frontend/src/config/errors.ts
+++ b/packages/frontend/src/config/errors.ts
@@ -5,3 +5,7 @@
 export const NOT_AUTHORISED = 'Not Authorised!'
 
 export const INVALID_TILE_VIEW_KEY = 'Invalid tile view only key'
+
+export const NOT_FOUND = 'NOT_FOUND'
+
+export const RATE_LIMITED = 'RATE_LIMITED'

--- a/packages/frontend/src/helpers/parseGraphqlError.ts
+++ b/packages/frontend/src/helpers/parseGraphqlError.ts
@@ -1,0 +1,35 @@
+import { ApolloError, ServerError } from '@apollo/client'
+
+export function parseGraphqlError(error: ApolloError): {
+  statusCode: number | null
+  message: string | null
+  code: string | null
+} {
+  if (error.networkError) {
+    const serverError = error.networkError as ServerError
+    const statusCode = serverError.statusCode
+    if (serverError.result) {
+      const result = serverError.result as {
+        errors: { message: string; code: string }[]
+      }
+      if (result.errors?.length) {
+        const error = result.errors[0]
+        return {
+          statusCode,
+          message: error?.message,
+          code: error?.code,
+        }
+      }
+      return {
+        statusCode,
+        message: serverError.message,
+        code: null,
+      }
+    }
+  }
+  return {
+    statusCode: null,
+    message: error.message,
+    code: null,
+  }
+}

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -1,10 +1,12 @@
 import { ITableRow } from '@plumber/types'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ApolloError, ServerError, useLazyQuery } from '@apollo/client'
+import { ApolloError, useLazyQuery } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
 
+import { RATE_LIMITED } from '@/config/errors'
 import { GET_ALL_ROWS } from '@/graphql/queries/tiles/get-all-rows'
+import { parseGraphqlError } from '@/helpers/parseGraphqlError'
 
 export function useFetchAllRows({
   tableId,
@@ -56,8 +58,7 @@ export function useFetchAllRows({
       } catch (e) {
         if (
           e instanceof ApolloError &&
-          e.networkError &&
-          (e.networkError as ServerError).statusCode === 429
+          parseGraphqlError(e).code === RATE_LIMITED
         ) {
           setIsThroughputError(true)
           cursorToContinueFrom.current = currentCursor

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -1,6 +1,6 @@
 import { ITableRow } from '@plumber/types'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { ApolloError, useLazyQuery } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
 
@@ -88,11 +88,6 @@ export function useFetchAllRows({
     }
     await fetchAllRows(cursorToContinueFrom.current)
   }, [fetchAllRows, isThroughputError])
-
-  useEffect(() => {
-    setRows([])
-    fetchAllRows()
-  }, [fetchAllRows])
 
   return {
     rows,

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -1,24 +1,32 @@
 import { ITableMetadata } from '@plumber/types'
 
 import { useParams } from 'react-router-dom'
-import { useQuery } from '@apollo/client'
+import { ApolloError, useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
+import { NOT_FOUND } from '@/config/errors'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
+import { parseGraphqlError } from '@/helpers/parseGraphqlError'
+
+import { MissingTile } from '../UnauthorizedTile'
 
 import Table from './components/Table'
 import TableBanner from './components/TableBanner'
 import { TableContextProvider } from './contexts/TableContext'
 import { useFetchAllRows } from './hooks/useFetchAllRows'
 
-export default function Tile(): JSX.Element {
+export default function Tile(): JSX.Element | null {
   const { tileId: tableId, viewOnlyKey: urlViewOnlyKey } = useParams<{
     tileId: string
     viewOnlyKey?: string
   }>()
 
-  const { data: getTableData } = useQuery<{
+  const {
+    data: getTableData,
+    loading: isTableLoading,
+    error: getTableError,
+  } = useQuery<{
     getTable: ITableMetadata
   }>(GET_TABLE, {
     variables: {
@@ -37,12 +45,30 @@ export default function Tile(): JSX.Element {
     urlViewOnlyKey,
   })
 
-  if (!getTableData?.getTable) {
+  if (isTableLoading) {
     return (
       <Center height="100vh">
         <PrimarySpinner fontSize="6xl" thickness="4px" margin="auto" />
       </Center>
     )
+  }
+
+  if (getTableError) {
+    if (getTableError instanceof ApolloError) {
+      const { code } = parseGraphqlError(getTableError)
+      if (code === NOT_FOUND) {
+        return (
+          <MissingTile title="You do not have access to this Tile, or it does not exist." />
+        )
+      }
+    }
+    return (
+      <MissingTile title="Error loading your tile. Please refresh and try again." />
+    )
+  }
+
+  if (!getTableData?.getTable) {
+    return null
   }
 
   const { id, name, columns, viewOnlyKey, collaborators } =

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -22,6 +22,11 @@ export default function Tile(): JSX.Element | null {
     viewOnlyKey?: string
   }>()
 
+  const { rows, isFetching, isThroughputError, refetch } = useFetchAllRows({
+    tableId: tableId as string,
+    urlViewOnlyKey,
+  })
+
   const {
     data: getTableData,
     loading: isTableLoading,
@@ -38,13 +43,12 @@ export default function Tile(): JSX.Element | null {
           headers: { 'x-tiles-view-key': urlViewOnlyKey },
         }
       : undefined,
+    onCompleted: () => {
+      // only start fetching rows after table metadata is loaded
+      refetch()
+    },
   })
   const ownRole = getTableData?.getTable?.role
-
-  const { rows, isFetching, isThroughputError, refetch } = useFetchAllRows({
-    tableId: tableId as string,
-    urlViewOnlyKey,
-  })
 
   // On first load, show loading spinner
   if (isTableLoading && !isGetTableCalled) {

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -26,6 +26,7 @@ export default function Tile(): JSX.Element | null {
     data: getTableData,
     loading: isTableLoading,
     error: getTableError,
+    called: isGetTableCalled,
   } = useQuery<{
     getTable: ITableMetadata
   }>(GET_TABLE, {
@@ -45,7 +46,8 @@ export default function Tile(): JSX.Element | null {
     urlViewOnlyKey,
   })
 
-  if (isTableLoading) {
+  // On first load, show loading spinner
+  if (isTableLoading && !isGetTableCalled) {
     return (
       <Center height="100vh">
         <PrimarySpinner fontSize="6xl" thickness="4px" margin="auto" />

--- a/packages/frontend/src/pages/UnauthorizedTile/InvalidTileLink.tsx
+++ b/packages/frontend/src/pages/UnauthorizedTile/InvalidTileLink.tsx
@@ -1,0 +1,53 @@
+import { Image, Stack, Text, VStack } from '@chakra-ui/react'
+
+import spreadsheetImg from '@/assets/spreadsheet.png'
+
+import styles from './UnauthorizedTile.module.css'
+
+export function InvalidTileLink(): JSX.Element {
+  return (
+    <Stack
+      direction={{ base: 'column', md: 'row' }}
+      maxW="1000px"
+      margin="auto"
+      gap={8}
+      px={8}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Image
+        className={styles.flicker}
+        src={spreadsheetImg}
+        alt="Spreadsheet"
+        w="400px"
+        maxW="50%"
+      />
+      <VStack alignItems={{ base: 'center', md: 'start' }} gap={2}>
+        <Text
+          textStyle="h4"
+          textAlign={{ base: 'center', md: 'left' }}
+          fontWeight="normal"
+        >
+          Your{' '}
+          <Text
+            bgGradient="linear(to-r, primary.400, primary.500)"
+            backgroundClip="text"
+            as="span"
+            className={styles.flicker}
+            fontWeight="bold"
+          >
+            Tile
+          </Text>{' '}
+          link is invalid or has expired.
+        </Text>
+        <Text
+          textStyle="h6"
+          textAlign={{ base: 'center', md: 'left' }}
+          fontWeight="normal"
+        >
+          Please request a new link from the tile owner.
+        </Text>
+      </VStack>
+    </Stack>
+  )
+}

--- a/packages/frontend/src/pages/UnauthorizedTile/MissingTile.tsx
+++ b/packages/frontend/src/pages/UnauthorizedTile/MissingTile.tsx
@@ -1,10 +1,16 @@
 import { Image, Stack, Text, VStack } from '@chakra-ui/react'
+import { Link } from '@opengovsg/design-system-react'
 
 import spreadsheetImg from '@/assets/spreadsheet.png'
+import * as URLS from '@/config/urls'
 
 import styles from './UnauthorizedTile.module.css'
 
-function UnauthorizedTile(): JSX.Element {
+interface MissingTileProps {
+  title: string
+}
+
+export function MissingTile({ title }: MissingTileProps): JSX.Element {
   return (
     <Stack
       direction={{ base: 'column', md: 'row' }}
@@ -28,27 +34,17 @@ function UnauthorizedTile(): JSX.Element {
           textAlign={{ base: 'center', md: 'left' }}
           fontWeight="normal"
         >
-          Your{' '}
-          <Text
-            bgGradient="linear(to-r, primary.400, primary.500)"
-            backgroundClip="text"
-            as="span"
-            className={styles.flicker}
-            fontWeight="bold"
-          >
-            Tiles
-          </Text>{' '}
-          link is invalid or has expired.
+          {title}
         </Text>
-        <Text
+        <Link
           textStyle="h6"
           textAlign={{ base: 'center', md: 'left' }}
           fontWeight="normal"
+          href={URLS.TILES}
         >
-          Please request a new link from the tile owner.
-        </Text>
+          Back to your Tiles
+        </Link>
       </VStack>
     </Stack>
   )
 }
-export default UnauthorizedTile

--- a/packages/frontend/src/pages/UnauthorizedTile/index.ts
+++ b/packages/frontend/src/pages/UnauthorizedTile/index.ts
@@ -1,0 +1,2 @@
+export * from './InvalidTileLink'
+export * from './MissingTile'

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -19,7 +19,7 @@ import TileLayout from '@/pages/Tile/layouts/TileLayout'
 import Tiles from '@/pages/Tiles'
 import Transfers from '@/pages/Transfers'
 import TransfersLayout from '@/pages/Transfers/layouts/TransfersLayout'
-import UnauthorizedTile from '@/pages/UnauthorizedTile'
+import { InvalidTileLink } from '@/pages/UnauthorizedTile'
 
 const Landing = lazy(() => import('@/pages/Landing'))
 const Tile = lazy(() => import('@/pages/Tile'))
@@ -109,7 +109,7 @@ export default createRoutesFromElements(
       }
     />
 
-    <Route path={URLS.UNAUTHORIZED_TILE} element={<UnauthorizedTile />} />
+    <Route path={URLS.UNAUTHORIZED_TILE} element={<InvalidTileLink />} />
 
     <Route
       path={URLS.TILE_PATTERN}


### PR DESCRIPTION
### Problem

Users see a spinner + a temporary error toast when accessing a tile without no permissions

### Solution
- Show a proper error screen for deleted tiles or tiles that the user have no permission to access

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/be8878b8-2bdb-4d0a-a918-26156a9c1e7b.png)

### What changed?

- Created a new `NotFoundError` class that extends GraphQLError with a 404 status code
- Created a `parseGraphqlError` helper function to extract error details from Apollo errors
- Created a new `MissingTile` component to display when a tile doesn't exist or user lacks access
- Renamed UnauthorizedTile component to InvalidTileLink.

### How to test?

1. Try accessing a tile that doesn't exist - you should see the "You do not have access to this Tile, or it does not exist" message
2. Try accessing a tile with an invalid view-only key - you should see the old error screen
3. Verify that creating shareable link and adding collaborators still wor

