### PR TITLE
chore: add flag to hide upload attachments

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -7,11 +7,13 @@ import { useQuery } from '@apollo/client'
 import { FormControl, useDisclosure, useOutsideClick } from '@chakra-ui/react'
 import { FormErrorMessage, FormLabel } from '@opengovsg/design-system-react'
 
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import {
   extractVariables,
   filterVariables,
+  StepWithVariables,
   type Variable,
 } from '@/helpers/variables'
 import { useS3Operations } from '@/hooks/useS3Operations'
@@ -46,6 +48,11 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const wrapperRef = useRef(null)
   const { control, setError, getValues } = useFormContext()
   const [currentTab, setCurrentTab] = useState<number>(0)
+
+  // TODO (kevinkim-ogp): remove this after we confirm that upload is stable
+  const launchDarkly = useContext(LaunchDarklyContext)
+  const hideUploadAttachments =
+    launchDarkly.flags?.['hide-postman-upload-attachment']
 
   const flowId = getValues('flowId')
 
@@ -87,9 +94,12 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   })
 
   const uploadedItems = useMemo(() => {
+    if (hideUploadAttachments) {
+      return []
+    }
     const attachmentsConfig = flowData?.getFlow?.config?.attachments ?? []
     return reformatToCheckboxVariables(attachmentsConfig)
-  }, [flowData])
+  }, [flowData, hideUploadAttachments])
 
   const suggestions = useMemo(() => {
     const selectedNames = getValues(name)
@@ -129,15 +139,16 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     ])
     return [
       ...filteredVars,
-      {
+      !hideUploadAttachments && {
         id: 'uploaded',
         name: 'Uploaded attachments',
         output: uploadedItems,
         addNew: true,
       },
-    ]
+    ].filter(Boolean) as StepWithVariables[]
   }, [
     getValues,
+    hideUploadAttachments,
     name,
     priorExecutionSteps,
     setSelectedOptions,

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@apollo/client'
 import { FormControl, useDisclosure, useOutsideClick } from '@chakra-ui/react'
 import { FormErrorMessage, FormLabel } from '@opengovsg/design-system-react'
 
+import { HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
@@ -52,7 +53,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   // TODO (kevinkim-ogp): remove this after we confirm that upload is stable
   const launchDarkly = useContext(LaunchDarklyContext)
   const hideUploadAttachments =
-    launchDarkly.flags?.['hide-postman-upload-attachment']
+    launchDarkly.flags?.[HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG]
 
   const flowId = getValues('flowId')
 

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -94,12 +94,9 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   })
 
   const uploadedItems = useMemo(() => {
-    if (hideUploadAttachments) {
-      return []
-    }
     const attachmentsConfig = flowData?.getFlow?.config?.attachments ?? []
     return reformatToCheckboxVariables(attachmentsConfig)
-  }, [flowData, hideUploadAttachments])
+  }, [flowData])
 
   const suggestions = useMemo(() => {
     const selectedNames = getValues(name)

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -16,6 +16,8 @@ export const SINGLE_STEP_TEST_KILL_SWITCH = 'single_step_test_kill_switch'
 export const BULK_RETRY_EXECUTIONS_FLAG = 'bulk-retry-failed-executions-v1'
 export const SGID_FEATURE_FLAG = 'sgid-login'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
+export const HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG =
+  'hide-postman-upload-attachment'
 
 /**
  * App/events flags


### PR DESCRIPTION
### TL;DR
Adds a flag to hide Postman upload attachment feature by default.
Flag will be removed after Plumbers test and verify that the feature is working as expected in production.

Key considerations for flag before rolling out to all users:
- Need to ensure that Plumber's S3 bucket has been whitelisted on GSIB
- AWS GuardDuty scans are scanning and tagging files appropriately
- Emails by Postman are using the correct attachments

If the Upload attachment function is hidden after it has been released to all users, previously uploaded files will still be visible and can be removed.

### TODO
Remove flag from LaunchDarkly and remove check from `packages/frontend/src/components/AttachmentSuggestions/index.tsx`
