### PR TITLE
chore: add execution time to tooltip label

### DIFF
--- a/packages/frontend/src/components/ExecutionHeader/index.tsx
+++ b/packages/frontend/src/components/ExecutionHeader/index.tsx
@@ -96,7 +96,7 @@ function ExecutionDate(props: Pick<IExecution, 'createdAt'>) {
 
   return (
     <Tooltip
-      label={createdAt.toLocaleString(DateTime.DATE_MED)}
+      label={createdAt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}
       aria-label="Created at tooltip"
     >
       <Text textStyle="body-1">{relativeCreatedAt}</Text>


### PR DESCRIPTION
## Problem
Execution date on executions page is unclear as it only shows 'XX days ago' and only shows the date in the tooltip.
Note: only frontend change

## Solution
Changed the tooltip label to display the date and time with seconds.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2025-03-21 at 9 09 35 AM](https://github.com/user-attachments/assets/e156192e-a93c-43dc-8691-c718950b8546)


**AFTER**:
<img width="1207" alt="Screenshot 2025-03-21 at 9 10 20 AM" src="https://github.com/user-attachments/assets/657b56ff-8618-4b7d-bbe9-48c3edde7b88" />

## Tests
- [ ] Verify that past executions are showing the correct date and time in Executions page
