### PR TITLE
PLU-443 [SIDE-DRAWER-2]: Save + Complete step buttons

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import updateStep from '@/graphql/mutations/update-step'
+import Step from '@/models/step'
+import Context from '@/types/express/context'
+
+import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
+
+import { generateMockContext } from './tiles/table.mock'
+
+const mockConnectionId = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
+const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
+
+describe('updateStep mutation', () => {
+  let context: Context
+  let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
+
+  const genericInputParams = {
+    id: mockStepId,
+    flow: { id: mockFlowId },
+    key: 'sendTransactionalEmail',
+    appKey: 'postman',
+    parameters: { testParam: 'value' },
+    connection: { id: mockConnectionId },
+  }
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+    // Create a mock context with a current user
+    context = await generateMockContext()
+
+    // Create a test flow
+    await generateMockFlow(context, mockFlowId)
+
+    // Create a test step
+    await generateMockStep(
+      context,
+      'sendTransactionalEmail',
+      'postman',
+      'action',
+      mockFlowId,
+      1,
+      { testParam: 'value' },
+    )
+
+    // Create spy for patchAndFetchById
+    patchAndFetchByIdSpy = vi.fn().mockImplementation((id, data) => ({
+      id,
+      ...data,
+      withGraphFetched: vi.fn().mockResolvedValue({
+        id,
+        ...data,
+        connection: { id: mockConnectionId },
+      }),
+    }))
+
+    // Mock Step.transaction
+    vi.spyOn(Step, 'transaction').mockImplementation(async (callback) => {
+      const trx = {}
+      return callback(trx)
+    })
+
+    // Mock Step.query
+    vi.spyOn(Step, 'query').mockReturnValue({
+      patchAndFetchById: patchAndFetchByIdSpy,
+    } as any)
+
+    // Mock context.currentUser.$relatedQuery for steps
+    context.currentUser.$relatedQuery = vi
+      .fn()
+      .mockImplementation((relation) => {
+        if (relation === 'steps') {
+          return {
+            findOne: vi.fn().mockResolvedValue({
+              id: mockStepId,
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              status: 'completed',
+            }),
+          }
+        }
+        if (relation === 'connections') {
+          return {
+            findOne: vi.fn().mockResolvedValue({ id: mockConnectionId }),
+          }
+        }
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      })
+  })
+
+  it('should successfully update a step', async () => {
+    const input = {
+      ...genericInputParams,
+      parameters: { updatedParam: 'newValue' },
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      connectionId: mockConnectionId,
+      parameters: { updatedParam: 'newValue' },
+      status: 'completed',
+    })
+  })
+
+  it('should update step with a connection', async () => {
+    const connectionId = mockConnectionId
+    const input = {
+      ...genericInputParams,
+      connection: { id: connectionId },
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      connectionId,
+      parameters: { testParam: 'value' },
+      status: 'completed',
+    })
+  })
+
+  it('should throw error if connection not found', async () => {
+    const input = {
+      ...genericInputParams,
+      parameters: { testParam: 'value' },
+      connection: { id: 'non-existent-connection' },
+    }
+
+    // Override only the connections query
+    context.currentUser.$relatedQuery = vi
+      .fn()
+      .mockImplementation((relation) => {
+        if (relation === 'steps') {
+          return {
+            findOne: vi.fn().mockResolvedValue({
+              id: mockStepId,
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              status: 'completed',
+            }),
+          }
+        }
+        if (relation === 'connections') {
+          return {
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      })
+
+    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+  })
+
+  it('should throw error if step not found', async () => {
+    const input = {
+      ...genericInputParams,
+      id: 'non-existent-step',
+    }
+
+    // Override the steps query to return null
+    context.currentUser.$relatedQuery = vi
+      .fn()
+      .mockImplementation((relation) => {
+        if (relation === 'steps') {
+          return {
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+        if (relation === 'connections') {
+          return {
+            findOne: vi.fn().mockResolvedValue({ id: mockConnectionId }),
+          }
+        }
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      })
+
+    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+  })
+
+  it('should set status to incomplete when key or appKey changes', async () => {
+    const input = {
+      ...genericInputParams,
+      key: 'newKey',
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'newKey',
+      appKey: 'postman',
+      connectionId: mockConnectionId,
+      parameters: { testParam: 'value' },
+      status: 'incomplete',
+    })
+  })
+
+  it('should set status to incomplete when explicitly requested', async () => {
+    const input = {
+      ...genericInputParams,
+      status: 'incomplete',
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      connectionId: mockConnectionId,
+      parameters: { testParam: 'value' },
+      status: 'incomplete',
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -83,7 +83,9 @@ describe('updateStep mutation', () => {
         }
         if (relation === 'connections') {
           return {
-            findOne: vi.fn().mockResolvedValue({ id: mockConnectionId }),
+            findOne: vi
+              .fn()
+              .mockResolvedValue({ id: mockConnectionId, key: 'postman' }),
           }
         }
         return {

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -31,7 +31,9 @@ const updateStep: MutationResolvers['updateStep'] = async (
     }
 
     const shouldInvalidate =
-      step.key !== input.key || step.appKey !== input.appKey
+      step.key !== input.key ||
+      step.appKey !== input.appKey ||
+      input.status === 'incomplete'
 
     return await Step.query(trx)
       .patchAndFetchById(input.id, {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -526,6 +526,7 @@ input UpdateStepInput {
   flow: StepFlowInput
   parameters: JSONObject
   previousStep: PreviousStepInput
+  status: String
 }
 
 input DeleteStepInput {

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -113,8 +113,8 @@ export default function Step(props: StepProps): React.ReactElement | null {
   const { app, apps, isTrigger, selectedActionOrTrigger, substeps } =
     useStepMetadata(step)
 
-  const handleSubmit = (val: any) => {
-    onUpdateStep(val as IStep)
+  const handleSubmit = async (val: any) => {
+    await onUpdateStep(val as IStep)
   }
 
   const expandNextStep = useCallback(() => {

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -115,6 +115,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
 
   const handleSubmit = async (val: any) => {
     await onUpdateStep(val as IStep)
+    expandNextStep()
   }
 
   const expandNextStep = useCallback(() => {
@@ -223,8 +224,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
                           substep={substep}
                           onExpand={() => toggleSubstep(index)}
                           onCollapse={() => toggleSubstep(index)}
-                          onSubmit={expandNextStep}
-                          onChange={handleSubmit}
+                          onSubmit={handleSubmit}
                           step={step}
                           settingsLabel={
                             selectedActionOrTrigger?.settingsStepLabel ??

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -26,7 +26,7 @@ type FlowSubstepProps = {
   onExpand: () => void
   onCollapse: () => void
   onChange: ({ step }: { step: IStep }) => void
-  onSubmit: () => void
+  onSubmit: (type?: string, currentStep?: IStep) => Promise<boolean> | void
   step: IStep
   settingsLabel?: string
   selectedActionOrTrigger?: ITrigger | IAction
@@ -183,13 +183,18 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
             <Button
               isDisabled={editorContext.readOnly}
               type="submit"
-              data-test="flow-substep-continue-button"
               variant="clear"
+              onClick={() => {
+                // NOTE: saving does not require validation
+                // this is meant to avoid users losing progress
+                const currentStep = formContext.getValues() as IStep
+                onSubmit('save', currentStep)
+              }}
             >
               Save
             </Button>
             <Button
-              onClick={onSubmit}
+              onClick={() => onSubmit()}
               type="submit"
               data-test="flow-substep-continue-button"
               isDisabled={!validationStatus || editorContext.readOnly}

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -243,7 +243,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
                 !validationStatus || editorContext.readOnly || isSaving
               }
             >
-              Complete step
+              Check step
             </Button>
           </Stack>
         </Box>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -171,16 +171,32 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
             ))}
           </Stack>
 
-          <Button
-            isFullWidth
-            onClick={onSubmit}
+          <Stack
+            direction="row"
+            spacing={4}
             mt={4}
-            isDisabled={!validationStatus || editorContext.readOnly}
-            type="submit"
-            data-test="flow-substep-continue-button"
+            justify="flex-end"
+            borderTop="1px solid"
+            borderTopColor="base.divider.medium"
+            pt={4}
           >
-            Save and continue
-          </Button>
+            <Button
+              isDisabled={editorContext.readOnly}
+              type="submit"
+              data-test="flow-substep-continue-button"
+              variant="clear"
+            >
+              Save
+            </Button>
+            <Button
+              onClick={onSubmit}
+              type="submit"
+              data-test="flow-substep-continue-button"
+              isDisabled={!validationStatus || editorContext.readOnly}
+            >
+              Complete step
+            </Button>
+          </Stack>
         </Box>
       </Collapse>
     </>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -8,7 +8,7 @@ import type {
   ITrigger,
 } from '@plumber/types'
 
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { Box, Collapse, Stack } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
@@ -26,7 +26,11 @@ type FlowSubstepProps = {
   onExpand: () => void
   onCollapse: () => void
   onChange: ({ step }: { step: IStep }) => void
-  onSubmit: (type?: string, currentStep?: IStep) => Promise<boolean> | void
+  onSubmit: (
+    type?: string,
+    currentStep?: IStep,
+    status?: string,
+  ) => Promise<boolean> | void
   step: IStep
   settingsLabel?: string
   selectedActionOrTrigger?: ITrigger | IAction
@@ -135,6 +139,17 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
 
   const onToggle = expanded ? onCollapse : onExpand
 
+  // NOTE: this is meant to avoid users losing progress
+  // we validate the substeps so that the header reflects the correct status
+  const handleSave = useCallback(() => {
+    const currentStep = formContext.getValues() as IStep
+    const isValid = validateSubstep(substep, currentStep)
+    editorContext.onUpdateStep({
+      ...currentStep,
+      status: isValid ? 'completed' : 'incomplete',
+    })
+  }, [editorContext, formContext, substep])
+
   // Skip to the next step if the substep is meant to be hidden
   useEffect(() => {
     if (!expanded) {
@@ -182,14 +197,8 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
           >
             <Button
               isDisabled={editorContext.readOnly}
-              type="submit"
               variant="clear"
-              onClick={() => {
-                // NOTE: saving does not require validation
-                // this is meant to avoid users losing progress
-                const currentStep = formContext.getValues() as IStep
-                onSubmit('save', currentStep)
-              }}
+              onClick={() => handleSave()}
             >
               Save
             </Button>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -8,10 +8,10 @@ import type {
   ITrigger,
 } from '@plumber/types'
 
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { Box, Collapse, Stack } from '@chakra-ui/react'
-import { Button } from '@opengovsg/design-system-react'
+import { Button, useToast } from '@opengovsg/design-system-react'
 
 import FlowSubstepTitle from '@/components/FlowSubstepTitle'
 import InputCreator from '@/components/InputCreator'
@@ -30,7 +30,7 @@ type FlowSubstepProps = {
     type?: string,
     currentStep?: IStep,
     status?: string,
-  ) => Promise<boolean> | void
+  ) => Promise<{ data?: { updateStep?: any } } | void> | void
   step: IStep
   settingsLabel?: string
   selectedActionOrTrigger?: ITrigger | IAction
@@ -106,10 +106,13 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   } = props
 
   const { name, arguments: args } = substep
+  const toast = useToast()
+  const [isSaving, setIsSaving] = useState(false)
 
   const { flags } = useContext(LaunchDarklyContext)
   const editorContext = useContext(EditorContext)
   const formContext = useFormContext()
+  const { isDirty } = formContext.formState
   const [validationStatus, setValidationStatus] = useState<boolean>(
     validateSubstep(substep, formContext.getValues() as IStep),
   )
@@ -141,14 +144,35 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
 
   // NOTE: this is meant to avoid users losing progress
   // we validate the substeps so that the header reflects the correct status
-  const handleSave = useCallback(() => {
-    const currentStep = formContext.getValues() as IStep
-    const isValid = validateSubstep(substep, currentStep)
-    editorContext.onUpdateStep({
-      ...currentStep,
-      status: isValid ? 'completed' : 'incomplete',
-    })
-  }, [editorContext, formContext, substep])
+
+  const handleSave = async () => {
+    try {
+      setIsSaving(true)
+      const currentStep = formContext.getValues() as IStep
+      const isValid = validateSubstep(substep, currentStep)
+      const result = await editorContext.onUpdateStep({
+        ...currentStep,
+        status: isValid ? 'completed' : 'incomplete',
+      })
+
+      if (!result) {
+        throw new Error('Failed to save step')
+      }
+    } catch (error) {
+      toast({
+        title: 'Error saving step',
+        description:
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
 
   // Skip to the next step if the substep is meant to be hidden
   useEffect(() => {
@@ -181,7 +205,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
                 schema={argument}
                 namePrefix="parameters"
                 stepId={step.id}
-                disabled={editorContext.readOnly}
+                disabled={editorContext.readOnly || isSaving}
               />
             ))}
           </Stack>
@@ -196,17 +220,20 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
             pt={4}
           >
             <Button
-              isDisabled={editorContext.readOnly}
+              isDisabled={editorContext.readOnly || isSaving || !isDirty}
+              isLoading={isSaving}
               variant="clear"
               onClick={() => handleSave()}
             >
-              Save
+              {isDirty ? 'Save' : 'Saved'}
             </Button>
             <Button
               onClick={() => onSubmit()}
               type="submit"
               data-test="flow-substep-continue-button"
-              isDisabled={!validationStatus || editorContext.readOnly}
+              isDisabled={
+                !validationStatus || editorContext.readOnly || isSaving
+              }
             >
               Complete step
             </Button>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -226,7 +226,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
               isDisabled={editorContext.readOnly || isSaving || !isDirty}
               isLoading={isSaving}
               variant="clear"
-              onClick={() => handleSave()}
+              onClick={handleSave}
             >
               {isDirty ? 'Save' : 'Saved'}
             </Button>

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -112,7 +112,15 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const { flags } = useContext(LaunchDarklyContext)
   const editorContext = useContext(EditorContext)
   const formContext = useFormContext()
-  const { isDirty } = formContext.formState
+  /*
+   * NOTE: we use dirtyFields instead of isDirty because dirtyFields only tracks
+   * fields that are currently different from their default values, whereas
+   * isDirty tracks if the form values have changed at all from the default values
+   * — even if you change a field back to its original value.
+   */
+  const { dirtyFields } = formContext.formState
+  const isDirty = Object.keys(dirtyFields).length > 0
+
   const [validationStatus, setValidationStatus] = useState<boolean>(
     validateSubstep(substep, formContext.getValues() as IStep),
   )

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -25,12 +25,7 @@ type FlowSubstepProps = {
   expanded?: boolean
   onExpand: () => void
   onCollapse: () => void
-  onChange: ({ step }: { step: IStep }) => void
-  onSubmit: (
-    type?: string,
-    currentStep?: IStep,
-    status?: string,
-  ) => Promise<{ data?: { updateStep?: any } } | void> | void
+  onSubmit: (val: any) => Promise<void>
   step: IStep
   settingsLabel?: string
   selectedActionOrTrigger?: ITrigger | IAction
@@ -188,9 +183,9 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       return
     }
     if (!argsToDisplay || argsToDisplay.length === 0) {
-      onSubmit()
+      onSubmit(formContext.getValues() as IStep)
     }
-  }, [argsToDisplay, expanded, onSubmit])
+  }, [argsToDisplay, expanded, formContext, onSubmit])
 
   if (!argsToDisplay || argsToDisplay.length === 0) {
     return <></>
@@ -236,8 +231,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
               {isDirty ? 'Save' : 'Saved'}
             </Button>
             <Button
-              onClick={() => onSubmit()}
-              type="submit"
+              onClick={() => onSubmit(formContext.getValues() as IStep)}
               data-test="flow-substep-continue-button"
               isDisabled={
                 !validationStatus || editorContext.readOnly || isSaving

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -230,6 +230,7 @@ export const EditorProvider = ({
         flow: {
           id: flowId,
         },
+        ...(step.status !== undefined && { status: step.status }),
       }
 
       if (step.appKey) {


### PR DESCRIPTION
## TL;DR
Split the existing 'Save and continue' button into separate 'Save' and 'Complete step' buttons.

## What changed?
* 'Save': saves current progress, invalidates status if saving causes the step to be incomplete
* 'Check step': same behaviour as existing 'Save and continue'; only enabled when all required fields are filled and opens the test step accordion

**Note to reviewers:** 'Check step' will be enhanced to execute the single step test in subsequent PRs when modifying the test step accordion

## Why make this change?
* Previous implementation required users to complete all required steps before the inputs could be saved
* Resulted in loss of progress when users clicked out of the accordions

## How to test?
- [ ] Saving fields (incomplete)
  - Create a Step
  - Select App and event
  - Configure some required fields and click 'Save'
  - Exit Editor and reopen Pipe
  - Verify that fields were saved
- [ ] Editing and reverting a saved field
  - Open a completed step
  - Make some changes
  - Verify that button becomes 'Save'
  - Revert the changes
  - Verify that the button reverts to 'Saved'
- [ ] Editing a completed step (completed -> incomplete)
  - Complete a step (including test step)
  - Remove some required field(s)
  - Click 'Save' 
  - Verify that header shows incomplete status
- [ ] Editing a completed step
  - Complete a step (including test step)
  - Edit some field
  - Click 'Save' 
  - Verify that header still shows complete status


## Before & After Screenshots
### Before
Only can save 'Completed' steps
![Screenshot 2025-03-21 at 4.23.26 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/8a646964-ee52-4669-98c0-81b72c140bfd.png)

![Screenshot 2025-03-21 at 4.22.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/90944bba-3544-4de5-875c-7bc7f81739c1.png)


### After
**Saving incomplete step**

[Screen Recording 2025-04-03 at 10.45.41 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/e13b14aa-d75c-45e6-b593-20b4324f4933.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/e13b14aa-d75c-45e6-b593-20b4324f4933.mov)

**Editing a completed step**
* should allow saving of changes

[Screen Recording 2025-04-03 at 10.50.33 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/a2d1b4d6-52d2-495d-af53-e5d70ca0741e.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/a2d1b4d6-52d2-495d-af53-e5d70ca0741e.mov)

* should revert back to saved if the changes were reverted

[Screen Recording 2025-04-03 at 10.46.59 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/aecf1df9-8b07-4d5f-af16-a31673b69b07.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/aecf1df9-8b07-4d5f-af16-a31673b69b07.mov)

## How to test
