### PR TITLE
PLU-375: [UI-REVAMP-APP-SELECT-7] Allow deletion of trigger

### DIFF
--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -27,26 +27,32 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       throw new Error('All steps to be deleted must be from the same pipe!')
     }
 
+    const flow = steps[0].flow
+
     //
     // ** IMPORTANT NOTE **
-    // We only support contiguous steps for now.
+    // We only support deleting single trigger steps or contiguous action steps.
     //
     if (steps.length === 1 && steps[0].type === 'trigger') {
-      await steps[0].$query().patchAndFetch({
+      // we delete and add a new trigger upon deletion to preserve past execution steps' context
+      await steps[0].$query().delete()
+      await flow.$relatedQuery('steps', trx).insert({
         key: null,
         appKey: null,
-        connectionId: null,
+        type: 'trigger',
+        position: 1,
         parameters: {},
-        status: 'incomplete',
+        connectionId: null,
       })
     } else {
       if (
         !steps.every(
           (step, index) =>
-            index === 0 || step.position === steps[index - 1].position + 1,
+            (index === 0 || step.position === steps[index - 1].position + 1) &&
+            step.type === 'action',
         )
       ) {
-        throw new Error('Must delete contiguous steps!')
+        throw new Error('Must delete contiguous action steps!')
       }
 
       const stepIds = steps.map((step) => step.id)
@@ -58,13 +64,13 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       // await Step.relatedQuery('executionSteps', trx).for(stepIds).delete()
       await Step.query(trx).findByIds(stepIds).delete()
 
-      await steps[0].flow
+      await flow
         .$relatedQuery('steps', trx)
         .where('position', '>', steps[steps.length - 1].position)
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    return await steps[0].flow
+    return await flow
       .$query(trx)
       .withGraphJoined('steps')
       .orderBy('steps.position', 'asc')

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -31,28 +31,38 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     // ** IMPORTANT NOTE **
     // We only support contiguous steps for now.
     //
-    if (
-      !steps.every(
-        (step, index) =>
-          index === 0 || step.position === steps[index - 1].position + 1,
-      )
-    ) {
-      throw new Error('Must delete contiguous steps!')
+    if (steps.length === 1 && steps[0].type === 'trigger') {
+      await steps[0].$query().patchAndFetch({
+        key: null,
+        appKey: null,
+        connectionId: null,
+        parameters: {},
+        status: 'incomplete',
+      })
+    } else {
+      if (
+        !steps.every(
+          (step, index) =>
+            index === 0 || step.position === steps[index - 1].position + 1,
+        )
+      ) {
+        throw new Error('Must delete contiguous steps!')
+      }
+
+      const stepIds = steps.map((step) => step.id)
+
+      /**
+       * NOTE: do not delete execution steps
+       * The deletion causes RDS CPU Utilisation to spike for high volume pipes.
+       */
+      // await Step.relatedQuery('executionSteps', trx).for(stepIds).delete()
+      await Step.query(trx).findByIds(stepIds).delete()
+
+      await steps[0].flow
+        .$relatedQuery('steps', trx)
+        .where('position', '>', steps[steps.length - 1].position)
+        .patch({ position: raw(`position - ${steps.length}`) })
     }
-
-    const stepIds = steps.map((step) => step.id)
-
-    /**
-     * NOTE: do not delete execution steps
-     * The deletion causes RDS CPU Utilisation to spike for high volume pipes.
-     */
-    // await Step.relatedQuery('executionSteps', trx).for(stepIds).delete()
-    await Step.query(trx).findByIds(stepIds).delete()
-
-    await steps[0].flow
-      .$relatedQuery('steps', trx)
-      .where('position', '>', steps[steps.length - 1].position)
-      .patch({ position: raw(`position - ${steps.length}`) })
 
     return await steps[0].flow
       .$query(trx)

--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -1,0 +1,100 @@
+import { BiPlus } from 'react-icons/bi'
+import { Box, Divider, useDisclosure } from '@chakra-ui/react'
+import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
+
+import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
+import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
+
+interface AddStepButtonProps {
+  isHidden: boolean
+  isDisabled: boolean
+  isLastStep: boolean
+  showEmptyAction: boolean
+  stepId: string
+}
+
+export function AddStepButton(props: AddStepButtonProps): JSX.Element {
+  const { isHidden, isLastStep, stepId, isDisabled, showEmptyAction } = props
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  // If in between add button is disabled, we hide it
+  if (isHidden || (isDisabled && !isLastStep)) {
+    return (
+      <Box pos="relative" h={24} py={2}>
+        {/* dont show line if last step, leave box for padding */}
+        {!isLastStep && (
+          <Divider orientation="vertical" borderColor="base.divider.strong" />
+        )}
+      </Box>
+    )
+  }
+
+  return (
+    <>
+      <Box
+        pos="relative"
+        display="flex"
+        flexDir="column"
+        alignItems="center"
+        alignSelf="stretch"
+      >
+        {/* Show empty action instead of add button */}
+        {showEmptyAction && (
+          <>
+            {/* Top vertical line */}
+            <Divider
+              orientation="vertical"
+              borderColor="base.divider.strong"
+              h={20}
+              my={2}
+            />
+            <EmptyFlowStepHeader isTrigger={false} onModalOpen={onOpen} />
+          </>
+        )}
+        {/* Top vertical line */}
+        <Box h={5} mt={2}>
+          <Divider orientation="vertical" borderColor="base.divider.strong" />
+        </Box>
+        <TouchableTooltip
+          label={isDisabled ? 'Add your first action first' : 'Add step'}
+          placement="right"
+          display={isDisabled && !isLastStep ? 'none' : 'flex'}
+          marginX="auto"
+        >
+          <IconButton
+            onClick={onOpen}
+            aria-label="Add Step"
+            isDisabled={isDisabled || showEmptyAction}
+            icon={<BiPlus />}
+            variant={isLastStep ? 'outline' : 'clear'}
+            size="xs"
+            color="interaction.sub.default"
+            borderRadius="full"
+            _hover={{
+              bg: 'interaction.muted.neutral.hover',
+            }}
+            _active={{
+              bg: 'interaction.muted.neutral.active',
+            }}
+            borderColor={isLastStep ? 'interaction.sub.default' : undefined}
+          />
+        </TouchableTooltip>
+        {/* Bottom vertical line */}
+        {!isLastStep && (
+          <Box h={5} mb={2}>
+            <Divider orientation="vertical" borderColor="base.divider.strong" />
+          </Box>
+        )}
+      </Box>
+
+      {isOpen && (
+        <FlowStepConfigurationModal
+          onClose={onClose}
+          isTrigger={false} // Can only add an action all the time
+          isLastStep={isLastStep}
+          prevStepId={stepId}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -1,17 +1,7 @@
 import type { IApp, IFlow, IStep } from '@plumber/types'
 
 import { Fragment, useContext, useMemo } from 'react'
-import { BiPlus } from 'react-icons/bi'
-import {
-  AbsoluteCenter,
-  Box,
-  Center,
-  CircularProgress,
-  Divider,
-  Flex,
-  useDisclosure,
-} from '@chakra-ui/react'
-import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
+import { Center, Flex } from '@chakra-ui/react'
 
 import FlowStep from '@/components/FlowStep'
 import FlowStepGroup from '@/components/FlowStepGroup'
@@ -20,88 +10,18 @@ import {
   StepExecutionsToIncludeContext,
   StepExecutionsToIncludeProvider,
 } from '@/contexts/StepExecutionsToInclude'
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 
-import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
+import PrimarySpinner from '../PrimarySpinner'
 
-interface AddStepButtonProps {
-  isHidden: boolean
-  isDisabled: boolean
-  isLastStep: boolean
-  stepId: string
-}
-
-function AddStepButton(props: AddStepButtonProps): JSX.Element {
-  const { isHidden, isLastStep, stepId, isDisabled } = props
-  const { isOpen, onOpen, onClose } = useDisclosure()
-
-  if (isHidden) {
-    return (
-      <Box pos="relative" h={24} py={2}>
-        {/* dont show line if last step, leave box for padding */}
-        {!isLastStep && (
-          <Divider orientation="vertical" borderColor="base.divider.strong" />
-        )}
-      </Box>
-    )
-  }
-
-  return (
-    <>
-      <Box pos="relative" h={24}>
-        {/* Top vertical line */}
-        <Box mt={2} h={5}>
-          <Divider orientation="vertical" borderColor="base.divider.strong" />
-        </Box>
-        {/* Bottom vertical line */}
-        {!isLastStep && (
-          <Box mt={10} h={5}>
-            <Divider orientation="vertical" borderColor="base.divider.strong" />
-          </Box>
-        )}
-        <AbsoluteCenter display={isHidden ? 'none' : 'flex'}>
-          <TouchableTooltip
-            label={isDisabled ? 'Add your first action first' : 'Add step'}
-            placement="right"
-          >
-            <IconButton
-              onClick={onOpen}
-              aria-label="Add Step"
-              isDisabled={isDisabled}
-              icon={<BiPlus />}
-              variant={isLastStep ? 'outline' : 'clear'}
-              size="xs"
-              color="interaction.sub.default"
-              borderRadius="full"
-              _hover={{
-                bg: 'interaction.muted.neutral.hover',
-              }}
-              _active={{
-                bg: 'interaction.muted.neutral.active',
-              }}
-              borderColor={isLastStep ? 'interaction.sub.default' : undefined}
-            />
-          </TouchableTooltip>
-        </AbsoluteCenter>
-      </Box>
-
-      {isOpen && (
-        <FlowStepConfigurationModal
-          onClose={onClose}
-          isTrigger={false} // Can only add an action all the time
-          isLastStep={isLastStep}
-          prevStepId={stepId}
-        />
-      )}
-    </>
-  )
-}
+import { AddStepButton } from './AddStepButton'
 
 type EditorProps = {
   flow: IFlow
   steps: IStep[]
 }
 
-export default function Editor(props: EditorProps): React.ReactElement {
+export default function Editor(props: EditorProps) {
   const { flow, steps: rawSteps } = props
 
   const {
@@ -203,12 +123,23 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [parentStepExecutionsToInclude, stepsBeforeGroup],
   )
 
-  const isFirstActionAbsent = !steps[1]?.appKey || !steps[1]?.key
+  const nonIfThenActionSteps = stepsBeforeGroup.filter(
+    (step) =>
+      step.type === 'action' &&
+      step.appKey !== TOOLBOX_APP_KEY &&
+      step.key !== TOOLBOX_ACTIONS.IfThen,
+  )
+  // Disables last add step and hide in-between add step buttons
+  const hasExactlyOneEmptyActionStep =
+    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
 
-  if (!appsWithActions) {
+  // Disables last add step button but show empty action instead
+  const hasNoActionSteps = nonIfThenActionSteps.length === 0
+
+  if (!appsWithActions || !groupingActions) {
     return (
-      <Center w="full" h="100vh">
-        <CircularProgress isIndeterminate my={2} />
+      <Center height="100vh" position="fixed" width="full" top={0} left={0}>
+        <PrimarySpinner fontSize="4xl" />
       </Center>
     )
   }
@@ -224,44 +155,47 @@ export default function Editor(props: EditorProps): React.ReactElement {
         maxW="full"
       >
         <StepExecutionsToIncludeProvider value={stepExecutionsToInclude}>
-          {stepsBeforeGroup.map((step, index) => (
-            <Fragment key={`${step.id}-${index}`}>
-              <FlowStep
-                step={step}
-                isLastStep={index === steps.length - 1}
-                index={index + 1}
-                collapsed={currentStepId !== step.id}
-                onOpen={() => setCurrentStepId(step.id)}
-                onClose={() => {
-                  setCurrentStepId(null)
-                }}
-                onChange={onUpdateStep}
-                onContinue={() => {
-                  if (
-                    index === stepsBeforeGroup.length - 1 &&
-                    groupedSteps.length > 0
-                  ) {
-                    setCurrentStepId(groupedSteps[0].id)
-                  } else {
-                    setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
+          {stepsBeforeGroup.map((step, index) => {
+            return (
+              <Fragment key={`${step.id}-${index}`}>
+                <FlowStep
+                  step={step}
+                  isLastStep={index === steps.length - 1}
+                  index={index + 1}
+                  collapsed={currentStepId !== step.id}
+                  onOpen={() => setCurrentStepId(step.id)}
+                  onClose={() => {
+                    setCurrentStepId(null)
+                  }}
+                  onChange={onUpdateStep}
+                  onContinue={() => {
+                    if (
+                      index === stepsBeforeGroup.length - 1 &&
+                      groupedSteps.length > 0
+                    ) {
+                      setCurrentStepId(groupedSteps[0].id)
+                    } else {
+                      setCurrentStepId(stepsBeforeGroup[index + 1]?.id)
+                    }
+                  }}
+                  templateConfig={flow?.config?.templateConfig}
+                />
+                <AddStepButton
+                  // hide all add button steps if is readonly
+                  isHidden={isReadOnlyEditor}
+                  // show empty action if no action step exists
+                  showEmptyAction={hasNoActionSteps && !groupedSteps.length}
+                  // Disable add button steps if first action is not set up
+                  isDisabled={
+                    (hasExactlyOneEmptyActionStep || hasNoActionSteps) &&
+                    !groupedSteps.length
                   }
-                }}
-                templateConfig={flow?.config?.templateConfig}
-              />
-              <AddStepButton
-                // hide all add button steps if is readonly
-                // hide in-between add button steps if first action is absent
-                isHidden={
-                  isReadOnlyEditor ||
-                  (isFirstActionAbsent && index !== steps.length - 1)
-                }
-                // Disable all add button steps if first action is absent
-                isDisabled={isFirstActionAbsent}
-                isLastStep={index === steps.length - 1}
-                stepId={step.id}
-              />
-            </Fragment>
-          ))}
+                  isLastStep={index === steps.length - 1}
+                  stepId={step.id}
+                />
+              </Fragment>
+            )
+          })}
           {groupedSteps.length > 0 && (
             <FlowStepGroup
               iconUrl={flowStepGroupIconUrl}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -179,7 +179,7 @@ export default function FlowStep(
   )
 
   const isDeletable =
-    displayOverrides?.disableDelete === true ? false : !isTrigger && !readOnly
+    displayOverrides?.disableDelete === true ? false : !readOnly
   const [deleteStep, { loading: isDeletingStep }] = useMutation(DELETE_STEP, {
     refetchQueries: [GET_FLOW],
   })
@@ -187,6 +187,7 @@ export default function FlowStep(
     async (e) => {
       e.stopPropagation()
       await deleteStep({ variables: { input: { ids: [step.id] } } })
+      setCurrentSubstep(0)
     },
     [deleteStep, step.id],
   )

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -8,7 +8,9 @@ import {
   useState,
 } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
+import { Center } from '@chakra-ui/react'
 
+import PrimarySpinner from '@/components/PrimarySpinner'
 import { SINGLE_STEP_TEST_KILL_SWITCH } from '@/config/flags'
 import client from '@/graphql/client'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
@@ -109,7 +111,7 @@ export const EditorProvider = ({
 
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
 
-  const { data: getAppsData } = useQuery(GET_APPS)
+  const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
   const allApps = getAppsData?.getApps ?? []
 
   const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
@@ -217,6 +219,14 @@ export const EditorProvider = ({
     },
     [updateStep, flowId],
   )
+
+  if (isLoadingAllApps) {
+    return (
+      <Center height="100vh" position="fixed" width="full" top={0} left={0}>
+        <PrimarySpinner fontSize="4xl" />
+      </Center>
+    )
+  }
 
   return (
     <EditorContext.Provider


### PR DESCRIPTION
### TL;DR

Allow trigger steps to be reset instead of deleted, and enable the delete button for trigger steps.

### What changed?

- Modified the `deleteStep` mutation to handle trigger steps differently:
  - When deleting a trigger step, it now resets the step properties (key, appKey, connectionId, parameters) and sets status to 'incomplete' instead of actually deleting it
  - For non-trigger steps, the existing deletion logic is maintained
- Updated the frontend to:
  - Enable the delete button for trigger steps by removing the `!isTrigger` condition
  - Reset the current substep to 0 after deleting a step

### Screenshots

https://github.com/user-attachments/assets/6dc94f2d-0466-4014-a8e1-278063f9a014

### Changes (ian)
- Show empty action if last action is delete

#### Screenshots
If all actions are deleted OR only one empty action left
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/f655ba13-ddea-49e5-a58f-f36c483fde2d.png)

If IF-THEN exists
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/8121c4f3-fb8f-40ce-a9d9-8bf3d49b317b.png)

If at least one non-empty action exists
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/a428b5c5-7c30-4758-8239-05fe6ff2086c.png)

Inside an empty IF-THEN branch
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/4b9d1b9b-f4d1-4d57-8bae-cd2a793ac908.png)

### How to test?

1. Create a flow with a trigger step
2. Click the delete button on the trigger step
3. Verify that the trigger step is reset (not deleted) and shows as incomplete
4. Create a flow with multiple steps
5. Delete a non-trigger step
6. Verify that the step is completely removed and subsequent steps' positions are updated

### Why make this change?

Flows require a trigger step to function properly. This change allows users to reset a trigger step when they want to change it, rather than preventing deletion entirely. This improves the user experience by providing a way to start over with trigger configuration without having to recreate the entire flow.