### PR TITLE
refactor: prevent duplicate GET_APPS calls

### DIFF
--- a/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseAppAndEventSubstep/index.tsx
@@ -1,7 +1,6 @@
 import type { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import { useCallback, useContext, useMemo } from 'react'
-import { useQuery } from '@apollo/client'
 import { Box, Collapse, Flex, FormControl } from '@chakra-ui/react'
 import {
   Badge,
@@ -16,7 +15,6 @@ import { ComboboxItem, SingleSelect } from '@/components/SingleSelect'
 import { getAppActionFlag, getAppFlag, getAppTriggerFlag } from '@/config/flags'
 import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
-import { GET_APPS } from '@/graphql/queries/get-apps'
 import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -83,12 +81,11 @@ function ChooseAppAndEventSubstep(
   } = props
 
   const launchDarkly = useContext(LaunchDarklyContext)
-  const editorContext = useContext(EditorContext)
+  const { readOnly, allApps } = useContext(EditorContext)
 
   const isTrigger = step.type === 'trigger'
 
-  const { data } = useQuery(GET_APPS)
-  const apps: IApp[] = data?.getApps?.filter((app: IApp) =>
+  const apps: IApp[] = allApps.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
 
@@ -263,7 +260,7 @@ function ChooseAppAndEventSubstep(
                   name="choose-app-option"
                   colorScheme="secondary"
                   isClearable={false}
-                  isDisabled={isLoading || editorContext.readOnly}
+                  isDisabled={isLoading || readOnly}
                   // Don't display options until we can check feature flags!
                   items={isLoading ? [] : appOptions}
                   onChange={(selectedOption) => {
@@ -285,7 +282,7 @@ function ChooseAppAndEventSubstep(
                     name="choose-event-option"
                     colorScheme="secondary"
                     isClearable={false}
-                    isDisabled={isLoading || editorContext.readOnly}
+                    isDisabled={isLoading || readOnly}
                     // Don't display options until we can check feature flags!
                     items={isLoading ? [] : actionOrTriggerOptions}
                     onChange={(selectedOption) => {
@@ -315,7 +312,7 @@ function ChooseAppAndEventSubstep(
             isFullWidth
             onClick={onSubmit}
             mt={4}
-            isDisabled={!valid || editorContext.readOnly}
+            isDisabled={!valid || readOnly}
             data-test="flow-substep-continue-button"
           >
             Continue

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -2,7 +2,6 @@ import type { IApp, IFlow, IStep } from '@plumber/types'
 
 import { Fragment, useContext, useMemo } from 'react'
 import { BiPlus } from 'react-icons/bi'
-import { useQuery } from '@apollo/client'
 import {
   AbsoluteCenter,
   Box,
@@ -21,7 +20,6 @@ import {
   StepExecutionsToIncludeContext,
   StepExecutionsToIncludeProvider,
 } from '@/contexts/StepExecutionsToInclude'
-import { GET_APPS } from '@/graphql/queries/get-apps'
 
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
 
@@ -106,6 +104,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
     currentStepId,
     onUpdateStep,
     setCurrentStepId,
+    allApps,
   } = useContext(EditorContext)
 
   const steps = useMemo(
@@ -121,25 +120,23 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [flow, rawSteps],
   )
 
-  // FIXME (ogp-weeloong): optimize this a bit further by omitting query.
-  const { data } = useQuery(GET_APPS)
-  const apps: IApp[] = data?.getApps?.filter(
+  const appsWithActions: IApp[] = allApps.filter(
     (app: IApp) => !!app.actions?.length,
   )
 
   const groupingActions = useMemo(() => {
-    if (!apps) {
+    if (!appsWithActions) {
       return null
     }
 
     return new Set(
-      apps?.flatMap((app) =>
+      appsWithActions?.flatMap((app) =>
         app.actions
           ?.filter((action) => action.groupsLaterSteps)
           ?.map((action) => `${app.key}-${action.key}`),
       ) ?? [],
     )
-  }, [apps])
+  }, [appsWithActions])
 
   const [stepsBeforeGroup, groupedSteps] = useMemo(() => {
     if (!groupingActions) {
@@ -173,8 +170,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
     if (groupedSteps.length === 0) {
       return undefined
     }
-    return apps.find((app) => app.key === groupedSteps[0].appKey)?.iconUrl
-  }, [apps, groupedSteps])
+    return appsWithActions.find((app) => app.key === groupedSteps[0].appKey)
+      ?.iconUrl
+  }, [appsWithActions, groupedSteps])
 
   //
   // Compute which steps are eligible for variable extraction.
@@ -208,7 +206,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
       steps[1].appKey === null ||
       steps[1].key === null)
 
-  if (!apps) {
+  if (!appsWithActions) {
     return (
       <Center w="full" h="100vh">
         <CircularProgress isIndeterminate my={2} />
@@ -235,7 +233,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 index={index + 1}
                 collapsed={currentStepId !== step.id}
                 onOpen={() => setCurrentStepId(step.id)}
-                onClose={() => setCurrentStepId(null)}
+                onClose={() => {
+                  setCurrentStepId(null)
+                }}
                 onChange={onUpdateStep}
                 onContinue={() => {
                   if (

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -16,7 +16,7 @@ import {
   useState,
 } from 'react'
 import { BiInfoCircle } from 'react-icons/bi'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation } from '@apollo/client'
 import { Box, CircularProgress, Flex, useDisclosure } from '@chakra-ui/react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { Infobox } from '@opengovsg/design-system-react'
@@ -36,7 +36,6 @@ import { StepDisplayOverridesContext } from '@/contexts/StepDisplayOverrides'
 import { StepExecutionsProvider } from '@/contexts/StepExecutions'
 import { StepExecutionsToIncludeContext } from '@/contexts/StepExecutionsToInclude'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
-import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { replacePlaceholdersForHelpMessage } from '@/helpers/flow-templates'
 
@@ -91,7 +90,7 @@ function generateValidationSchema(substeps: ISubstep[]) {
       }
     },
     {} as ObjectShape,
-  )
+  ) as unknown as ObjectShape
 
   const validationSchema = yup.object({
     parameters: yup.object(fieldValidations),
@@ -120,7 +119,7 @@ export default function FlowStep(
     onClose: onModalClose,
   } = useDisclosure()
 
-  const { readOnly, testExecutionSteps } = useContext(EditorContext)
+  const { readOnly, testExecutionSteps, allApps } = useContext(EditorContext)
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
 
   const cannotChooseApp = displayOverrides?.disableActionChanges ?? false
@@ -129,8 +128,6 @@ export default function FlowStep(
     // collapsed due to matching logic below.
     cannotChooseApp ? 1 : 0,
   )
-
-  const { data } = useQuery(GET_APPS)
 
   // This includes all steps that run even after the current step, but within the same branch.
   const stepExecutionsToInclude = useContext(StepExecutionsToIncludeContext)
@@ -144,7 +141,7 @@ export default function FlowStep(
     [step.position, stepExecutionsToInclude, testExecutionSteps],
   )
 
-  const apps: IApp[] = data?.getApps?.filter((app: IApp) =>
+  const apps: IApp[] = allApps.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
   const app = apps?.find((currentApp: IApp) => currentApp.key === step.appKey)

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -1,6 +1,6 @@
 import { type IAction, IApp, ITrigger } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { BiArrowFromRight, BiChevronRight } from 'react-icons/bi'
 import {
   Box,
@@ -17,21 +17,34 @@ import { groupBy } from 'lodash'
 import { getAppFlag } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 
+import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+
 import FeedbackFooter from './FeedbackFooter'
 
 const OTHERS_CATEGORY = 'Other'
 
 interface ChooseAppProps {
   apps: IApp[]
-  isTrigger: boolean
-  onSelectApp: (app: IApp) => void
   onSelectAppEvent: (app: IApp, triggerOrAction: ITrigger | IAction) => void
 }
 
 export default function ChooseApp(props: ChooseAppProps) {
-  const { apps, isTrigger, onSelectApp, onSelectAppEvent } = props
+  const { apps, onSelectAppEvent } = props
   const launchDarkly = useContext(LaunchDarklyContext)
+  const { patchModalState, isTrigger } = useContext(
+    FlowStepConfigurationContext,
+  )
   const isLoading = launchDarkly.isLoading
+
+  const onSelectApp = useCallback(
+    (app: IApp) => {
+      patchModalState({
+        selectedApp: app,
+        currentScreen: 'choose-event',
+      })
+    },
+    [patchModalState],
+  )
 
   // Combine filtering and grouping logic into a single operation
   const groupedApps = useMemo(() => {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -1,6 +1,6 @@
 import { type IAction, IApp, ITrigger } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Box, Flex, ModalBody, ModalHeader, Text } from '@chakra-ui/react'
 import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
@@ -14,20 +14,25 @@ import {
   useIsIfThenSelectable,
 } from '@/helpers/toolbox'
 
+import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+import InvalidModalScreen from '../InvalidModalScreen'
+
 import FeedbackFooter from './FeedbackFooter'
 
 interface ChooseEventProps {
-  selectedApp: IApp
-  isTrigger: boolean
-  isLastStep: boolean
   onSelectAppEvent: (app: IApp, event: ITrigger | IAction) => void
-  onBack: () => void
 }
 
 export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
-  const { selectedApp, isTrigger, isLastStep, onSelectAppEvent, onBack } = props
+  const { onSelectAppEvent } = props
 
   const launchDarkly = useContext(LaunchDarklyContext)
+
+  const { modalState, isTrigger, isLastStep, patchModalState } = useContext(
+    FlowStepConfigurationContext,
+  )
+  const { selectedApp } = modalState
+
   const [_, isInitializingIfThen] = useIfThenInitializer()
   const isLoading = launchDarkly.isLoading || isInitializingIfThen
 
@@ -52,6 +57,19 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
       return launchDarkly.flags[launchDarklyKey] ?? true
     })
   }, [selectedApp, isTrigger, launchDarkly.flags, isLoading])
+
+  const onBack = useCallback(() => {
+    patchModalState({
+      selectedApp: null,
+      selectedEvent: null,
+      selectedConnectionId: '',
+      currentScreen: 'choose-app',
+    })
+  }, [patchModalState])
+
+  if (!selectedApp) {
+    return <InvalidModalScreen />
+  }
 
   return (
     <>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -1,10 +1,8 @@
 import { type IAction, IApp, ITrigger } from '@plumber/types'
 
 import { useCallback, useContext } from 'react'
-import { useQuery } from '@apollo/client'
 
 import { EditorContext } from '@/contexts/Editor'
-import { GET_APPS } from '@/graphql/queries/get-apps'
 import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -25,21 +23,14 @@ type ChooseAppAndEventProps = {
 export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
   const { onClose } = props
 
-  const { onUpdateStep, onCreateStep } = useContext(EditorContext)
+  const { onUpdateStep, onCreateStep, allApps } = useContext(EditorContext)
 
-  const {
-    modalState,
-    patchModalState,
-    prevStepId,
-    isLastStep,
-    isTrigger,
-    step,
-  } = useContext(FlowStepConfigurationContext)
+  const { modalState, patchModalState, prevStepId, isTrigger, step } =
+    useContext(FlowStepConfigurationContext)
 
   const { currentScreen, selectedApp } = modalState
 
-  const { data } = useQuery(GET_APPS)
-  const apps: IApp[] = data?.getApps?.filter((app: IApp) =>
+  const apps: IApp[] = allApps.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
   )
 
@@ -74,10 +65,8 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
         }
       }
       // For a better visual experience, delay the closing of the modal
-      setTimeout(() => {
-        patchModalState({ isLoading: false })
-        onClose()
-      }, 500)
+      patchModalState({ isLoading: false })
+      onClose()
     },
     [
       patchModalState,
@@ -91,36 +80,9 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
   )
 
   if (currentScreen === 'choose-app') {
-    return (
-      <ChooseApp
-        apps={apps}
-        isTrigger={isTrigger}
-        onSelectApp={(app: IApp) => {
-          patchModalState({
-            selectedApp: app,
-            currentScreen: 'choose-event',
-          })
-        }}
-        onSelectAppEvent={onSelectAppEvent}
-      />
-    )
+    return <ChooseApp apps={apps} onSelectAppEvent={onSelectAppEvent} />
   } else if (selectedApp && currentScreen === 'choose-event') {
-    return (
-      <ChooseEvent
-        selectedApp={selectedApp}
-        isTrigger={isTrigger}
-        isLastStep={isLastStep}
-        onSelectAppEvent={onSelectAppEvent}
-        onBack={() => {
-          patchModalState({
-            selectedApp: null,
-            selectedEvent: null,
-            selectedConnectionId: '',
-            currentScreen: 'choose-app',
-          })
-        }}
-      />
-    )
+    return <ChooseEvent onSelectAppEvent={onSelectAppEvent} />
   } else {
     return <InvalidModalScreen />
   }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -1,4 +1,4 @@
-import type { IExecutionStep, IStep } from '@plumber/types'
+import type { IApp, IExecutionStep, IStep } from '@plumber/types'
 
 import {
   createContext,
@@ -13,6 +13,7 @@ import { SINGLE_STEP_TEST_KILL_SWITCH } from '@/config/flags'
 import client from '@/graphql/client'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
+import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import {
@@ -36,6 +37,7 @@ interface IEditorContextValue {
     connectionId?: string,
   ) => Promise<IStep>
   onUpdateStep: (step: IStep) => Promise<IStep>
+  allApps: IApp[]
 }
 
 export const EditorContext = createContext<IEditorContextValue>({
@@ -46,6 +48,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   setCurrentStepId: () => null,
   onCreateStep: () => Promise.resolve({} as IStep),
   onUpdateStep: () => Promise.resolve({} as IStep),
+  allApps: [],
 })
 
 type EditorProviderProps = {
@@ -105,6 +108,9 @@ export const EditorProvider = ({
   const shouldUseSingleStepTest = !flags?.[SINGLE_STEP_TEST_KILL_SWITCH]
 
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
+
+  const { data: getAppsData } = useQuery(GET_APPS)
+  const allApps = getAppsData?.getApps ?? []
 
   const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
     GET_TEST_EXECUTION_STEPS,
@@ -222,6 +228,7 @@ export const EditorProvider = ({
         setCurrentStepId,
         onCreateStep,
         onUpdateStep,
+        allApps,
       }}
     >
       {children}


### PR DESCRIPTION
## Problem
There are multiple repeated calls to GET_APPS which is quite a large query.

## Solution
Move the GET_APPS query into EditorContext, so that it gets called only once.