### PR TITLE
[UI-REVAMP-APP-SELECT-9] Add design changes before bug bash

### DIFF
--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -24,7 +24,6 @@ type ChooseConnectionSubstepProps = {
 type ConnectionLink = {
   url: string
   text: string
-  isExternal: boolean
 }
 
 interface ConnectionStatus {
@@ -110,8 +109,7 @@ function ChooseConnectionSubstep(
       if (application.key === 'formsg') {
         connectionLink = {
           url: formLinkGenerator(connectionOption),
-          text: 'View form',
-          isExternal: true,
+          text: '(View form)',
         }
       }
 
@@ -145,7 +143,6 @@ function ChooseConnectionSubstep(
             {connectionStatus.connectionLink && (
               <Link
                 href={connectionStatus.connectionLink.url}
-                isExternal={connectionStatus.connectionLink.isExternal}
                 target="_blank"
                 ml={2}
               >

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -63,16 +63,10 @@ function ChooseConnectionSubstep(
       connectionId: connection?.id,
       flowId: supportsConnectionRegistration ? step.flowId : undefined,
     },
-    // cache-first to prevent the test connection from being called multiple times
-    fetchPolicy: 'cache-first',
     skip: !connection?.id,
   })
 
   const isTestStepValid = useMemo(() => {
-    if (application.key === APP_ALLOWING_EMPTY_CONNECTION) {
-      return true
-    }
-
     if (testResultLoading || !testConnectionData?.testConnection) {
       return null
     }
@@ -83,13 +77,20 @@ function ChooseConnectionSubstep(
       return false
     }
     return true
-  }, [application.key, testConnectionData, testResultLoading])
+  }, [testConnectionData, testResultLoading])
 
   const connectionStatus: ConnectionStatus = useMemo(() => {
     if (!connection) {
-      return {
-        text: 'Not connected',
-        color: 'yellow.200',
+      if (application.key === APP_ALLOWING_EMPTY_CONNECTION) {
+        return {
+          text: 'No connection',
+          color: 'green.500',
+        }
+      } else {
+        return {
+          text: 'Not connected',
+          color: 'yellow.200',
+        }
       }
     } else if (testResultLoading) {
       return {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -20,13 +20,17 @@ import Form from '../../Form'
 import { infoboxMdComponents } from '../../MarkdownRenderer/CustomMarkdownComponents'
 import { DEFAULT_ADD_CONNECTION_LABEL } from '../constants'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+import { useConnectionVerification } from '../hooks/useConnectionRegistration'
 import InvalidModalScreen from '../InvalidModalScreen'
 
 import ConnectionHeader from './ConnectionHeader'
 
 type AddConnectionProps = {
-  onSubmit: (response: Record<string, unknown>) => void
-  onBack: () => void
+  handleConnectionChange: (
+    connectionId: string,
+    shouldRefetch: boolean,
+  ) => Promise<void>
+  onCreateOrUpdateStep: (connectionId: string) => Promise<void>
 }
 
 type Response = {
@@ -34,10 +38,11 @@ type Response = {
 }
 
 export default function AddConnection(props: AddConnectionProps): JSX.Element {
-  const { onSubmit, onBack } = props
-  const {
-    modalState: { selectedApp },
-  } = useContext(FlowStepConfigurationContext)
+  const { handleConnectionChange, onCreateOrUpdateStep } = props
+  const { modalState, patchModalState } = useContext(
+    FlowStepConfigurationContext,
+  )
+  const { selectedApp } = modalState
   const { name, authDocUrl, key, auth } = selectedApp || {}
 
   const [error, setError] = useState<IJSONObject | null>(null)
@@ -60,6 +65,57 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
       )
     }
   }, [])
+
+  const supportsConnectionRegistration =
+    !!selectedApp?.auth?.connectionRegistrationType
+
+  const { onRegisterConnection, testConnection } = useConnectionVerification({
+    supportsConnectionRegistration,
+  })
+
+  /**
+   * Test connection first for apps that support connection registration
+   * If connection is not verified, redirect to choose-connection screen to connect
+   * If connection is verified, register connection and create step
+   *
+   * For apps without connection registration, create step directly
+   */
+  const handleAddConnection = useCallback(
+    async (response: Record<string, any>) => {
+      const newConnectionId = response?.createConnection?.id as
+        | string
+        | undefined
+
+      if (newConnectionId) {
+        patchModalState({ isLoading: true })
+        if (supportsConnectionRegistration) {
+          const testResult = await testConnection(newConnectionId)
+          // If connection is not verified and has an error message
+          if (!testResult?.registrationVerified && !!testResult?.message) {
+            await handleConnectionChange(newConnectionId, true)
+            patchModalState({
+              selectedConnectionId: newConnectionId,
+              currentScreen: 'choose-connection',
+              isLoading: false,
+            })
+            return
+          } else {
+            await onRegisterConnection(newConnectionId)
+          }
+        }
+        // Create or update step at the end
+        await onCreateOrUpdateStep(newConnectionId)
+      }
+    },
+    [
+      handleConnectionChange,
+      onCreateOrUpdateStep,
+      onRegisterConnection,
+      patchModalState,
+      supportsConnectionRegistration,
+      testConnection,
+    ],
+  )
 
   const submitHandler: SubmitHandler<FieldValues> = useCallback(
     async (data) => {
@@ -95,14 +151,16 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
         stepIndex++
 
         if (stepIndex === steps.length) {
-          onSubmit(response)
+          await handleAddConnection(response)
         }
       }
 
       setInProgress(false)
     },
-    [key, steps, onSubmit],
+    [key, steps, handleAddConnection],
   )
+
+  const onBack = () => patchModalState({ currentScreen: 'choose-connection' })
 
   if (!selectedApp) {
     return <InvalidModalScreen />
@@ -129,7 +187,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
           DEFAULT_ADD_CONNECTION_LABEL
         }
       />
-      <ModalCloseButton mt={6} size="xs" />
+      <ModalCloseButton mt={2} size="xs" />
 
       <ModalBody mt={2}>
         {auth?.connectionType !== 'user-added' ? (

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -110,7 +110,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
 
   return (
     <>
-      <ModalHeader>
+      <ModalHeader pt={0}>
         <Button
           variant="clear"
           colorScheme="secondary"
@@ -129,9 +129,9 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
           DEFAULT_ADD_CONNECTION_LABEL
         }
       />
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={6} size="xs" />
 
-      <ModalBody mt={2} mb={4}>
+      <ModalBody mt={2}>
         {auth?.connectionType !== 'user-added' ? (
           <>
             <Text textStyle="h4">Error</Text>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
@@ -1,14 +1,9 @@
-import type { ITestConnectionOutput } from '@plumber/types'
-
-import { useCallback, useContext } from 'react'
+import { useContext } from 'react'
 import { BiChevronLeft } from 'react-icons/bi'
-import { useMutation, useQuery } from '@apollo/client'
 import { Flex, ModalBody, ModalHeader } from '@chakra-ui/react'
 import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
-import { REGISTER_CONNECTION } from '@/graphql/mutations/register-connection'
-import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 
 import { DEFAULT_CHOOSE_CONNECTION_LABEL } from '../constants'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
@@ -22,8 +17,11 @@ import { ConnectionDropdownOption } from '.'
 interface ChooseConnectionProps {
   appConnectionsLoading: boolean
   connectionOptions: ConnectionDropdownOption[]
-  handleConnectionChange: (value: string, shouldRefetch: boolean) => void
-  onCreateOrUpdateStep: (connectionId: string) => void
+  handleConnectionChange: (
+    value: string,
+    shouldRefetch: boolean,
+  ) => Promise<void>
+  onCreateOrUpdateStep: (connectionId: string) => Promise<void>
 }
 
 export default function ChooseConnection(
@@ -35,54 +33,13 @@ export default function ChooseConnection(
     handleConnectionChange,
     onCreateOrUpdateStep,
   } = props
-  const { readOnly, flowId } = useContext(EditorContext)
+  const { readOnly } = useContext(EditorContext)
 
   const { modalState, patchModalState, step } = useContext(
     FlowStepConfigurationContext,
   )
   const { selectedApp, selectedConnectionId } = modalState
-
-  const supportsConnectionRegistration =
-    !!selectedApp?.auth?.connectionRegistrationType
-
   const connectionModalLabel = selectedApp?.auth?.connectionModalLabel
-
-  const {
-    loading: testResultLoading,
-    refetch: retestConnection,
-    data: testConnectionData,
-  } = useQuery<{
-    testConnection: ITestConnectionOutput
-  }>(TEST_CONNECTION, {
-    variables: {
-      connectionId: selectedConnectionId,
-      flowId: supportsConnectionRegistration ? flowId : undefined,
-    },
-    skip: !selectedConnectionId,
-  })
-
-  const [registerConnection, { loading: registerConnectionLoading }] =
-    useMutation(REGISTER_CONNECTION)
-
-  const onRegisterConnection = useCallback(async () => {
-    if (selectedConnectionId && supportsConnectionRegistration) {
-      await registerConnection({
-        variables: {
-          input: {
-            connectionId: selectedConnectionId,
-            flowId,
-          },
-        },
-      })
-      await retestConnection()
-    }
-  }, [
-    selectedConnectionId,
-    supportsConnectionRegistration,
-    registerConnection,
-    flowId,
-    retestConnection,
-  ])
 
   const onBack = () => {
     if (!selectedApp) {
@@ -133,7 +90,7 @@ export default function ChooseConnection(
           }
         />
       </ModalHeader>
-      <ModalCloseButton mt={6} size="xs" />
+      <ModalCloseButton mt={2} size="xs" />
 
       <ModalBody>
         <Flex flexDir="column" alignItems="center" gap={6}>
@@ -149,13 +106,10 @@ export default function ChooseConnection(
               }
             />
             <SetConnectionButton
-              onNextStep={() => onCreateOrUpdateStep(selectedConnectionId)}
-              onRegisterConnection={onRegisterConnection}
+              onNextStep={async () =>
+                await onCreateOrUpdateStep(selectedConnectionId)
+              }
               readOnly={readOnly}
-              supportsConnectionRegistration={supportsConnectionRegistration}
-              testResult={testConnectionData?.testConnection}
-              testResultLoading={testResultLoading}
-              registerConnectionLoading={registerConnectionLoading}
               isNewStep={!step?.appKey || !step?.key}
             />
           </Flex>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
@@ -23,7 +23,7 @@ interface ChooseConnectionProps {
   appConnectionsLoading: boolean
   connectionOptions: ConnectionDropdownOption[]
   handleConnectionChange: (value: string, shouldRefetch: boolean) => void
-  handleSubmit: () => void
+  onCreateOrUpdateStep: (connectionId: string) => void
 }
 
 export default function ChooseConnection(
@@ -33,7 +33,7 @@ export default function ChooseConnection(
     appConnectionsLoading,
     connectionOptions,
     handleConnectionChange,
-    handleSubmit,
+    onCreateOrUpdateStep,
   } = props
   const { readOnly, flowId } = useContext(EditorContext)
 
@@ -112,7 +112,7 @@ export default function ChooseConnection(
   return (
     <>
       {/* Hide back button only if step has both the key and appKey */}
-      <ModalHeader>
+      <ModalHeader pt={0}>
         {(!step?.key || !step?.appKey) && (
           <Button
             variant="clear"
@@ -133,9 +133,9 @@ export default function ChooseConnection(
           }
         />
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={6} size="xs" />
 
-      <ModalBody mb={4}>
+      <ModalBody>
         <Flex flexDir="column" alignItems="center" gap={6}>
           <Flex w="100%" flexDir="column" gap={4}>
             <ChooseConnectionDropdown
@@ -149,7 +149,7 @@ export default function ChooseConnection(
               }
             />
             <SetConnectionButton
-              onNextStep={handleSubmit}
+              onNextStep={() => onCreateOrUpdateStep(selectedConnectionId)}
               onRegisterConnection={onRegisterConnection}
               readOnly={readOnly}
               supportsConnectionRegistration={supportsConnectionRegistration}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
@@ -68,7 +68,7 @@ function SuccessfulConnectionContent({
   handleSubmit: () => void
 }) {
   return (
-    <Flex flexDir="column" gap={3} mb={4}>
+    <Flex flexDir="column" gap={3}>
       <Text fontSize="sm" ml={4}>
         {`1. Find the `}
         <Text as="span" textDecoration="underline">
@@ -80,7 +80,7 @@ function SuccessfulConnectionContent({
         {`2. Place your Excel files in this folder to start using them`}
       </Text>
 
-      <Button isFullWidth onClick={handleSubmit}>
+      <Button isFullWidth onClick={handleSubmit} mt={4}>
         Ok, got it!
       </Button>
     </Flex>
@@ -97,7 +97,7 @@ function ConfigurationConnectionContent({
   isLoading: boolean
 }) {
   return (
-    <Flex flexDir="column" gap={3} mb={4}>
+    <Flex flexDir="column" gap={3}>
       <Text>How it works:</Text>
       <Text fontSize="sm" ml={4}>
         {`1. We'll create a folder named `}
@@ -114,6 +114,7 @@ function ConfigurationConnectionContent({
         size="lg"
         onClick={onRegisterConnection}
         isLoading={isLoading}
+        mt={4}
       >
         Connect
       </Button>
@@ -123,7 +124,7 @@ function ConfigurationConnectionContent({
 
 interface ConfigureExcelConnectionProps {
   onBack: () => void
-  handleSubmit: () => void
+  onCreateOrUpdateStep: (connectionId: string) => void
 }
 
 /**
@@ -134,7 +135,7 @@ interface ConfigureExcelConnectionProps {
 export default function ConfigureExcelConnection(
   props: ConfigureExcelConnectionProps,
 ) {
-  const { onBack, handleSubmit } = props
+  const { onBack, onCreateOrUpdateStep } = props
   const { flowId } = useContext(EditorContext)
   const { modalState, step } = useContext(FlowStepConfigurationContext)
   const { selectedApp, selectedConnectionId } = modalState
@@ -186,7 +187,7 @@ export default function ConfigureExcelConnection(
 
   return (
     <>
-      <ModalHeader>
+      <ModalHeader pt={0}>
         {!isConnectionValid && (!step?.key || !step?.appKey) && (
           <Button
             variant="clear"
@@ -211,13 +212,13 @@ export default function ConfigureExcelConnection(
           />
         )}
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={6} size="xs" />
 
       <ModalBody>
         {isConnectionValid ? (
           <SuccessfulConnectionContent
             userEmail={currentUser?.email ?? ''}
-            handleSubmit={handleSubmit}
+            handleSubmit={() => onCreateOrUpdateStep(selectedConnectionId)}
           />
         ) : (
           <ConfigurationConnectionContent

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
@@ -1,8 +1,7 @@
-import type { IApp, ITestConnectionOutput } from '@plumber/types'
+import type { IApp } from '@plumber/types'
 
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useContext, useMemo } from 'react'
 import { BiChevronLeft, BiQuestionMark, BiRightArrowAlt } from 'react-icons/bi'
-import { useMutation, useQuery } from '@apollo/client'
 import {
   Flex,
   Icon,
@@ -14,12 +13,10 @@ import {
 import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
 
 import microsoftFolder from '@/assets/microsoft-folder.svg'
-import { EditorContext } from '@/contexts/Editor'
-import { REGISTER_CONNECTION } from '@/graphql/mutations/register-connection'
-import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 import useAuthentication from '@/hooks/useAuthentication'
 
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+import { useConnectionVerification } from '../hooks/useConnectionRegistration'
 
 import ConnectionHeader from './ConnectionHeader'
 
@@ -65,7 +62,7 @@ function SuccessfulConnectionContent({
   handleSubmit,
 }: {
   userEmail: string
-  handleSubmit: () => void
+  handleSubmit: () => Promise<void>
 }) {
   return (
     <Flex flexDir="column" gap={3}>
@@ -93,7 +90,7 @@ function ConfigurationConnectionContent({
   isLoading,
 }: {
   userEmail: string
-  onRegisterConnection: () => void
+  onRegisterConnection: () => Promise<void>
   isLoading: boolean
 }) {
   return (
@@ -124,7 +121,7 @@ function ConfigurationConnectionContent({
 
 interface ConfigureExcelConnectionProps {
   onBack: () => void
-  onCreateOrUpdateStep: (connectionId: string) => void
+  onCreateOrUpdateStep: (connectionId: string) => Promise<void>
 }
 
 /**
@@ -136,54 +133,33 @@ export default function ConfigureExcelConnection(
   props: ConfigureExcelConnectionProps,
 ) {
   const { onBack, onCreateOrUpdateStep } = props
-  const { flowId } = useContext(EditorContext)
   const { modalState, step } = useContext(FlowStepConfigurationContext)
   const { selectedApp, selectedConnectionId } = modalState
   const connectionModalLabel = selectedApp?.auth?.connectionModalLabel
-
-  const [isRegistered, setIsRegistered] = useState(false) // track connection registration
   const { currentUser } = useAuthentication()
 
-  const { loading: testResultLoading, data: testConnectionData } = useQuery<{
-    testConnection: ITestConnectionOutput
-  }>(TEST_CONNECTION, {
-    variables: {
-      connectionId: selectedConnectionId,
-      flowId,
-    },
-    skip: !selectedConnectionId || !isRegistered, // skip if not registered yet
+  const {
+    testResult,
+    testResultLoading,
+    registerConnectionLoading,
+    onRegisterConnection,
+  } = useConnectionVerification({
+    supportsConnectionRegistration: true, // Excel always supports connection registration
   })
-
-  const [registerConnection, { loading: registerConnectionLoading }] =
-    useMutation(REGISTER_CONNECTION)
-
-  const onRegisterConnection = useCallback(async () => {
-    if (selectedConnectionId) {
-      await registerConnection({
-        variables: {
-          input: {
-            connectionId: selectedConnectionId,
-            flowId,
-          },
-        },
-      })
-      setIsRegistered(true)
-    }
-  }, [flowId, selectedConnectionId, registerConnection])
 
   // Determine if the connection test was successful
   const isConnectionValid = useMemo(() => {
-    if (testResultLoading || !testConnectionData?.testConnection) {
+    if (testResultLoading || !testResult) {
       return false
     }
     if (
-      testConnectionData?.testConnection?.connectionVerified === false ||
-      testConnectionData?.testConnection?.registrationVerified === false
+      testResult?.connectionVerified === false ||
+      testResult?.registrationVerified === false
     ) {
       return false
     }
     return true
-  }, [testConnectionData?.testConnection, testResultLoading])
+  }, [testResult, testResultLoading])
 
   return (
     <>
@@ -212,18 +188,22 @@ export default function ConfigureExcelConnection(
           />
         )}
       </ModalHeader>
-      <ModalCloseButton mt={6} size="xs" />
+      <ModalCloseButton mt={2} size="xs" />
 
       <ModalBody>
         {isConnectionValid ? (
           <SuccessfulConnectionContent
             userEmail={currentUser?.email ?? ''}
-            handleSubmit={() => onCreateOrUpdateStep(selectedConnectionId)}
+            handleSubmit={async () =>
+              await onCreateOrUpdateStep(selectedConnectionId)
+            }
           />
         ) : (
           <ConfigurationConnectionContent
             userEmail={currentUser?.email ?? ''}
-            onRegisterConnection={onRegisterConnection}
+            onRegisterConnection={async () =>
+              await onRegisterConnection(selectedConnectionId)
+            }
             isLoading={registerConnectionLoading}
           />
         )}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/SetConnectionButton.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/SetConnectionButton.tsx
@@ -1,43 +1,60 @@
-import { ITestConnectionOutput } from '@plumber/types'
-
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Alert, AlertIcon } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
+import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+import { useConnectionVerification } from '../hooks/useConnectionRegistration'
+
 interface SetConnectionButtonProps {
-  onNextStep: () => void
-  onRegisterConnection: () => void
+  onNextStep: () => Promise<void>
   readOnly: boolean
-  supportsConnectionRegistration: boolean
-  testResult: ITestConnectionOutput | undefined
-  testResultLoading: boolean
-  registerConnectionLoading: boolean
   isNewStep: boolean
 }
 
 const SetConnectionButton = ({
   onNextStep,
   readOnly,
-  onRegisterConnection,
-  supportsConnectionRegistration,
-  testResult,
-  testResultLoading,
-  registerConnectionLoading,
   isNewStep,
 }: SetConnectionButtonProps) => {
-  const onSubmit = useCallback(() => {
+  const { modalState } = useContext(FlowStepConfigurationContext)
+  const { selectedApp, selectedConnectionId } = modalState
+  const supportsConnectionRegistration =
+    !!selectedApp?.auth?.connectionRegistrationType
+
+  const {
+    testResult,
+    testResultLoading,
+    registerConnectionLoading,
+    testConnection,
+    onRegisterConnection,
+  } = useConnectionVerification({
+    supportsConnectionRegistration,
+  })
+
+  // Load test result for initial connection if present
+  useEffect(() => {
+    async function testInitialConnection() {
+      await testConnection(selectedConnectionId)
+    }
+    if (selectedConnectionId) {
+      testInitialConnection()
+    }
+  }, [selectedConnectionId, testConnection])
+
+  const onSubmit = useCallback(async () => {
     if (
       supportsConnectionRegistration &&
       testResult &&
       !testResult.registrationVerified
     ) {
-      onRegisterConnection()
+      await onRegisterConnection(selectedConnectionId)
     } else {
-      onNextStep()
+      await onNextStep()
     }
   }, [
     onNextStep,
     onRegisterConnection,
+    selectedConnectionId,
     supportsConnectionRegistration,
     testResult,
   ])

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -64,8 +64,7 @@ export default function ChooseAndAddConnection(
   const { modalState, patchModalState, step, prevStepId } = useContext(
     FlowStepConfigurationContext,
   )
-  const { currentScreen, selectedApp, selectedEvent, selectedConnectionId } =
-    modalState
+  const { currentScreen, selectedApp, selectedEvent } = modalState
 
   const {
     data,
@@ -100,7 +99,50 @@ export default function ChooseAndAddConnection(
     [selectedApp, selectedEvent, refetch, patchModalState],
   )
 
-  // Add a new connection for verifying and registering of connection
+  // If the step is not provided, create a new step; else update the existing step
+  const onCreateOrUpdateStep = useCallback(
+    async (connectionId: string) => {
+      if (!selectedApp || !selectedEvent || !connectionId) {
+        return
+      }
+
+      patchModalState({ isLoading: true })
+      try {
+        if (prevStepId) {
+          await onCreateStep(
+            prevStepId,
+            selectedApp.key,
+            selectedEvent.key,
+            connectionId,
+          )
+        } else if (step) {
+          await onUpdateStep({
+            ...step,
+            appKey: selectedApp.key,
+            key: selectedEvent.key,
+            connection: {
+              id: connectionId,
+            },
+          })
+        }
+        onClose()
+      } finally {
+        patchModalState({ isLoading: false })
+      }
+    },
+    [
+      prevStepId,
+      step,
+      selectedApp,
+      selectedEvent,
+      onClose,
+      onCreateStep,
+      onUpdateStep,
+      patchModalState,
+    ],
+  )
+
+  // Add a new connection, create or update the step and close the modal immediately
   const handleAddConnection = useCallback(
     async (response: Record<string, any>) => {
       const newConnectionId = response?.createConnection?.id as
@@ -108,60 +150,11 @@ export default function ChooseAndAddConnection(
         | undefined
 
       if (newConnectionId) {
-        if (!selectedApp || !selectedEvent) {
-          return
-        }
-
-        handleConnectionChange(newConnectionId, true)
-        patchModalState({
-          selectedConnectionId: newConnectionId,
-          currentScreen: 'choose-connection',
-        })
+        await onCreateOrUpdateStep(newConnectionId)
       }
     },
-    [handleConnectionChange, selectedApp, selectedEvent, patchModalState],
+    [onCreateOrUpdateStep],
   )
-
-  // If the step is not provided, create a new step; else update the existing step
-  const handleSubmit = useCallback(async () => {
-    if (!selectedApp || !selectedEvent || !selectedConnectionId) {
-      return
-    }
-
-    patchModalState({ isLoading: true })
-    try {
-      if (prevStepId) {
-        await onCreateStep(
-          prevStepId,
-          selectedApp.key,
-          selectedEvent.key,
-          selectedConnectionId,
-        )
-      } else if (step) {
-        await onUpdateStep({
-          ...step,
-          appKey: selectedApp.key,
-          key: selectedEvent.key,
-          connection: {
-            id: selectedConnectionId,
-          },
-        })
-      }
-      onClose()
-    } finally {
-      patchModalState({ isLoading: false })
-    }
-  }, [
-    selectedApp,
-    selectedEvent,
-    selectedConnectionId,
-    patchModalState,
-    prevStepId,
-    step,
-    onCreateStep,
-    onUpdateStep,
-    onClose,
-  ])
 
   if (!flowId) {
     return <InvalidModalScreen />
@@ -173,7 +166,7 @@ export default function ChooseAndAddConnection(
         appConnectionsLoading={appConnectionsLoading}
         connectionOptions={connectionOptions}
         handleConnectionChange={handleConnectionChange}
-        handleSubmit={handleSubmit}
+        onCreateOrUpdateStep={onCreateOrUpdateStep}
       />
     )
   }
@@ -194,7 +187,7 @@ export default function ChooseAndAddConnection(
     return (
       <ConfigureExcelConnection
         onBack={() => patchModalState({ currentScreen: 'choose-event' })}
-        handleSubmit={handleSubmit}
+        onCreateOrUpdateStep={onCreateOrUpdateStep}
       />
     )
   }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -142,20 +142,6 @@ export default function ChooseAndAddConnection(
     ],
   )
 
-  // Add a new connection, create or update the step and close the modal immediately
-  const handleAddConnection = useCallback(
-    async (response: Record<string, any>) => {
-      const newConnectionId = response?.createConnection?.id as
-        | string
-        | undefined
-
-      if (newConnectionId) {
-        await onCreateOrUpdateStep(newConnectionId)
-      }
-    },
-    [onCreateOrUpdateStep],
-  )
-
   if (!flowId) {
     return <InvalidModalScreen />
   }
@@ -173,8 +159,8 @@ export default function ChooseAndAddConnection(
   if (selectedApp && currentScreen === 'add-connection') {
     return (
       <AddConnection
-        onSubmit={handleAddConnection}
-        onBack={() => patchModalState({ currentScreen: 'choose-connection' })}
+        handleConnectionChange={handleConnectionChange}
+        onCreateOrUpdateStep={onCreateOrUpdateStep}
       />
     )
   }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -77,19 +77,21 @@ export default function ChooseApp(props: ChooseAppProps) {
 
   return (
     <>
-      <ModalHeader>
+      <ModalHeader pt={0}>
         <Flex gap={2} flexDir="column" alignItems="flex-start">
-          <Text textStyle="h3-semibold" pt={4}>
+          <Text textStyle="h3-semibold">
             {isTrigger
               ? 'Choose how you want your workflow to start'
               : 'Add a step'}
           </Text>
-          <Text textStyle="body-1">
-            These are actions that you can add to your workflow.
-          </Text>
+          {!isTrigger && (
+            <Text textStyle="body-1">
+              These are actions that you can add to your workflow.
+            </Text>
+          )}
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={4} size="xs" />
+      <ModalCloseButton mt={6} size="xs" />
 
       {/* Returns first level modal view of apps: if an app only has one trigger or action,
        * it will be shown as a single item. Else, it will be shown as an expandable item

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -91,7 +91,7 @@ export default function ChooseApp(props: ChooseAppProps) {
           )}
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={6} size="xs" />
+      <ModalCloseButton mt={2} size="xs" />
 
       {/* Returns first level modal view of apps: if an app only has one trigger or action,
        * it will be shown as a single item. Else, it will be shown as an expandable item

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -89,7 +89,7 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
           <Text textStyle="body-1">{selectedApp.description}</Text>
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={6} size="xs" />
+      <ModalCloseButton mt={2} size="xs" />
 
       {/* Returns second level modal view of triggers or actions: if an app has multiple
        * triggers or actions, it will be shown as a list of items */}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -73,7 +73,7 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
 
   return (
     <>
-      <ModalHeader>
+      <ModalHeader pt={0}>
         <Flex gap={2} flexDir="column" alignItems="flex-start">
           <Button
             variant="clear"
@@ -89,7 +89,7 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
           <Text textStyle="body-1">{selectedApp.description}</Text>
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={6} size="xs" />
 
       {/* Returns second level modal view of triggers or actions: if an app has multiple
        * triggers or actions, it will be shown as a list of items */}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/FeedbackFooter.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/FeedbackFooter.tsx
@@ -5,7 +5,7 @@ import * as URLS from '@/config/urls'
 
 export default function FeedbackFooter() {
   return (
-    <ModalFooter justifyContent="center" gap={2}>
+    <ModalFooter justifyContent="center" gap={2} pb={0}>
       <Text textStyle="caption-1">{`Can't find what you need? Let us know`}</Text>
       <Link
         href={URLS.FEEDBACK_FORM_LINK}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -121,7 +121,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
           })
         }
       }
-      // For a better visual experience, delay the closing of the modal
       patchModalState({ isLoading: false })
       onClose()
     },

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useConnectionRegistration.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useConnectionRegistration.ts
@@ -1,0 +1,88 @@
+// packages/frontend/src/hooks/useConnectionVerification.ts
+import type { ITestConnectionOutput } from '@plumber/types'
+
+import { useCallback, useContext } from 'react'
+import { useLazyQuery, useMutation } from '@apollo/client'
+
+import { EditorContext } from '@/contexts/Editor'
+import { REGISTER_CONNECTION } from '@/graphql/mutations/register-connection'
+import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
+
+interface UseConnectionVerificationProps {
+  supportsConnectionRegistration: boolean
+}
+
+interface UseConnectionVerificationResult {
+  testResult?: ITestConnectionOutput
+  testResultLoading: boolean
+  registerConnectionLoading: boolean
+  testConnection: (
+    connectionId: string,
+  ) => Promise<ITestConnectionOutput | undefined>
+  onRegisterConnection: (connectionId: string) => Promise<void>
+}
+
+export function useConnectionVerification(
+  props: UseConnectionVerificationProps,
+): UseConnectionVerificationResult {
+  const { flowId } = useContext(EditorContext)
+  const { supportsConnectionRegistration } = props
+
+  const [
+    testConnectionQuery,
+    { loading: testResultLoading, data: testConnectionData },
+  ] = useLazyQuery<{
+    testConnection: ITestConnectionOutput
+  }>(TEST_CONNECTION, {
+    fetchPolicy: 'network-only',
+  })
+
+  // Caveat: Test connection data is returned here because testConnectionData
+  // is not immediately updated (only happens after a re-render)
+  const testConnection = useCallback(
+    async (connectionId: string) => {
+      const { data } = await testConnectionQuery({
+        variables: {
+          connectionId,
+          flowId: supportsConnectionRegistration ? flowId : undefined,
+        },
+      })
+      return data?.testConnection
+    },
+    [flowId, supportsConnectionRegistration, testConnectionQuery],
+  )
+
+  const [registerConnection, { loading: registerConnectionLoading }] =
+    useMutation(REGISTER_CONNECTION)
+
+  // register and retest connection
+  const onRegisterConnection = useCallback(
+    async (connectionId: string) => {
+      if (connectionId && supportsConnectionRegistration) {
+        await registerConnection({
+          variables: {
+            input: {
+              connectionId,
+              flowId,
+            },
+          },
+        })
+        await testConnection(connectionId)
+      }
+    },
+    [
+      supportsConnectionRegistration,
+      registerConnection,
+      flowId,
+      testConnection,
+    ],
+  )
+
+  return {
+    testResult: testConnectionData?.testConnection,
+    testResultLoading,
+    registerConnectionLoading,
+    testConnection,
+    onRegisterConnection,
+  }
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -1,7 +1,7 @@
 import type { IAction, IApp, IStep, ITrigger } from '@plumber/types'
 
 import { useContext } from 'react'
-import { Flex, Modal, ModalContent, ModalOverlay, Text } from '@chakra-ui/react'
+import { Flex, Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 
 import { useIfThenInitializer } from '@/helpers/toolbox'
 
@@ -31,7 +31,7 @@ function FlowStepConfigurationModalContent({
 }: {
   onClose: () => void
 }): JSX.Element {
-  const { modalState, step } = useContext(FlowStepConfigurationContext)
+  const { modalState } = useContext(FlowStepConfigurationContext)
   const { currentScreen, isLoading } = modalState
   const [_, isInitializingIfThen] = useIfThenInitializer()
 
@@ -39,7 +39,6 @@ function FlowStepConfigurationModalContent({
     return (
       <Flex flexDir="column" alignItems="center" gap={6} my={12}>
         <PrimarySpinner margin="auto" fontSize="4xl" />
-        <Text>{step ? 'Updating step...' : 'Adding step...'}</Text>
       </Flex>
     )
   }
@@ -91,6 +90,7 @@ export default function FlowStepConfigurationModal(
           h="auto"
           overflow="hidden"
           borderRadius="lg"
+          py={8}
         >
           <FlowStepConfigurationModalContent onClose={onClose} />
         </ModalContent>


### PR DESCRIPTION
### Design changes from Stacey

- Standardized modal padding and spacing across all modal screens
- Changed FormSG link text from "View form" to "(View form)" for better visual integration (one less icon)
- Simplified connection handling by creating a new `onCreateOrUpdateStep` function that replaces the previous `handleSubmit` flow
- Removed loading text during step creation/update, keeping only the spinner
- Fixed padding in modal headers, bodies, and footers for consistent appearance
- Adjusted modal close button positioning for better alignment
- Created a new `useConnectionVerification` hook to centralize connection testing and registration logic
- Improved handling of apps that allow empty connections
- Removed unnecessary `isExternal` prop from connection links

### Test
For FormSG connections,
- Ensure that new form without any webhook will connect immediately once the new connection is added
- Ensure that new form connection if connected to another pipe will be redirected to the choose connection modal screen

No regressions
- Ensure that step with connections can still be created or updated
- Ensure that step with no connections can still be created or updated