### PR TITLE
PLU-416 [GSI-1] : add tiles gsi into model schema

### DIFF
--- a/packages/backend/src/config/dynamodb.ts
+++ b/packages/backend/src/config/dynamodb.ts
@@ -26,6 +26,7 @@ export async function createDynamoDBTable() {
         { AttributeName: 'tableId', AttributeType: 'S' },
         { AttributeName: 'rowId', AttributeType: 'S' },
         { AttributeName: 'createdAt', AttributeType: 'N' },
+        { AttributeName: 'skString1', AttributeType: 'S' },
       ],
       BillingMode: 'PAY_PER_REQUEST',
       LocalSecondaryIndexes: [
@@ -36,6 +37,18 @@ export async function createDynamoDBTable() {
             { AttributeName: 'createdAt', KeyType: 'RANGE' },
           ],
           Projection: { ProjectionType: 'ALL' },
+        },
+      ],
+      GlobalSecondaryIndexes: [
+        {
+          IndexName: 'gsiString1',
+          KeySchema: [
+            { AttributeName: 'tableId', KeyType: 'HASH' },
+            { AttributeName: 'skString1', KeyType: 'RANGE' },
+          ],
+          Projection: {
+            ProjectionType: 'ALL',
+          },
         },
       ],
       KeySchema: [

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -39,6 +39,10 @@ export const TableRow = new Entity(
         default: () => Date.now(),
         set: () => Date.now(),
       },
+      skString1: {
+        type: 'string',
+        required: false,
+      },
     },
     indexes: {
       byRowId: {
@@ -62,6 +66,17 @@ export const TableRow = new Entity(
           composite: ['createdAt'],
         },
       },
+      byGsiString1: {
+        index: 'gsiString1',
+        pk: {
+          field: 'tableId',
+          composite: ['tableId'],
+        },
+        sk: {
+          field: 'skString1',
+          composite: ['skString1'],
+        },
+      },
     },
   },
   {
@@ -69,3 +84,15 @@ export const TableRow = new Entity(
     table: tableName,
   },
 )
+
+export function getSkKeyValue(
+  indexName: string,
+  value: unknown,
+): { [key: string]: unknown } {
+  switch (indexName) {
+    case 'gsiString1':
+      return { skString1: value.toString() }
+    default:
+      return {}
+  }
+}


### PR DESCRIPTION
## Changes

Added a new Global Secondary Index (GSI) to the DynamoDB table.



- Added a new attribute `skString1` to the DynamoDB table schema
- Created a new Global Secondary Index called `gsiString1` that uses `tableId` as the hash key and `skString1` as the range key
- Updated the TableRow entity model to include the new attribute and index
- Added a utility function `getSkKeyValue()` to generate the appropriate sort key value for different indexes
