### PR TITLE
PLU-416 [GSI-3]: modify findSingleRow to use GSI if exists

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -9,7 +9,11 @@ import {
   generateMockTableColumns,
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
-import { createTableRow, TableRowFilter } from '@/models/dynamodb/table-row'
+import {
+  createTableRow,
+  TableRowFilter,
+  TableRowFilterOperator,
+} from '@/models/dynamodb/table-row'
 import * as tableFunctions from '@/models/dynamodb/table-row/functions'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
@@ -83,11 +87,19 @@ describe('tiles create row action', () => {
           filters: [
             {
               columnId: dummyColumnIds[0],
-              operator: 'equals',
+              operator: TableRowFilterOperator.Equals,
               value: originalData[dummyColumnIds[0]],
+            },
+            {
+              columnId: dummyColumnIds[1],
+              operator: TableRowFilterOperator.LessThan,
+              value: originalData[dummyColumnIds[1]],
             },
           ] as TableRowFilter[],
         },
+      },
+      execution: {
+        id: '789',
       },
       app: {
         name: tiles.name,
@@ -157,6 +169,96 @@ describe('tiles create row action', () => {
       filters: $.step.parameters.filters,
       scanLimit: 100,
       order: 'desc',
+    })
+  })
+
+  describe('GSI filter', () => {
+    it('should call getTableRows with extracted GSI filter', async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: {
+              indexName: 'gsiString1',
+              status: 'ready',
+              type: 'string',
+            },
+          },
+        })
+        .where({ id: dummyColumnIds[0] })
+      const getTableRowsSpy = vi
+        .spyOn(tableFunctions, 'getTableRows')
+        .mockResolvedValueOnce({
+          rows: [],
+          stringifiedCursor: undefined,
+        })
+      $.step.parameters.returnLastRow = true
+      await findSingleRowAction.run($)
+      expect(getTableRowsSpy).toHaveBeenCalledWith({
+        tableId: $.step.parameters.tableId,
+        filters: [($.step.parameters.filters as any[])[1]],
+        gsi: {
+          indexName: 'gsiString1',
+          filter: ($.step.parameters.filters as any[])[0],
+        },
+        scanLimit: 100,
+        order: 'desc',
+      })
+    })
+
+    it('should not call getTableRows with GSI filter if status is not ready', async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: {
+              indexName: 'gsiString1',
+              status: 'pending',
+              type: 'string',
+            },
+          },
+        })
+        .where({ id: dummyColumnIds[0] })
+      const getTableRowsSpy = vi
+        .spyOn(tableFunctions, 'getTableRows')
+        .mockResolvedValueOnce({
+          rows: [],
+          stringifiedCursor: undefined,
+        })
+      $.step.parameters.returnLastRow = true
+      await findSingleRowAction.run($)
+      expect(getTableRowsSpy).toHaveBeenCalledWith({
+        tableId: $.step.parameters.tableId,
+        filters: $.step.parameters.filters as any[],
+        scanLimit: 100,
+        order: 'desc',
+      })
+    })
+
+    it('should not call getTableRows with GSI filter if operator is not supported', async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: {
+              indexName: 'gsiString1',
+              status: 'ready',
+              type: 'string',
+            },
+          },
+        })
+        .where({ id: dummyColumnIds[1] })
+      const getTableRowsSpy = vi
+        .spyOn(tableFunctions, 'getTableRows')
+        .mockResolvedValueOnce({
+          rows: [],
+          stringifiedCursor: undefined,
+        })
+      $.step.parameters.returnLastRow = true
+      await findSingleRowAction.run($)
+      expect(getTableRowsSpy).toHaveBeenCalledWith({
+        tableId: $.step.parameters.tableId,
+        filters: $.step.parameters.filters as any[],
+        scanLimit: 100,
+        order: 'desc',
+      })
     })
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -198,7 +198,10 @@ describe('tiles create row action', () => {
         filters: [($.step.parameters.filters as any[])[1]],
         gsi: {
           indexName: 'gsiString1',
-          filter: ($.step.parameters.filters as any[])[0],
+          filter: {
+            ...($.step.parameters.filters as any[])[0],
+            columnId: 'skString1',
+          },
         },
         scanLimit: 100,
         order: 'desc',

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -1,5 +1,6 @@
 import { IRawAction } from '@plumber/types'
 
+import IntermediateStepError from '@/errors/intermediate-step-error'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import {
@@ -144,78 +145,90 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
-    const { tableId, filters, returnLastRow } = $.step.parameters as {
-      tableId: string
-      filters: TableRowFilter[]
-      returnLastRow: boolean | undefined
-    }
-
-    const step = await Step.query().findById($.step.id).throwIfNotFound()
-    /**
-     * Check for columns first, there will not be any columns if the tile has been deleted.
-     */
-    const columns = await TableColumnMetadata.getColumns(tableId, $)
-
-    await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
-
-    // Check that filters are valid
     try {
-      validateFilters(filters, columns)
-    } catch (e) {
-      logger.error({
-        message: 'Invalid filters',
-        executionId: $.execution.id,
-        stepId: $.step.id,
-        app: $.app.name,
-        action: 'find-single-row',
-        error: e,
+      const {
+        tableId,
+        filters: rawFilters,
+        returnLastRow,
+      } = $.step.parameters as {
+        tableId: string
+        filters: TableRowFilter[]
+        returnLastRow: boolean | undefined
+      }
+
+      const step = await Step.query().findById($.step.id).throwIfNotFound()
+      /**
+       * Check for columns first, there will not be any columns if the tile has been deleted.
+       */
+      const columns = await TableColumnMetadata.getColumns(tableId, $)
+
+      await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
+
+      // Check that filters are valid and extract the GSI filter if it exists
+      const { filters, gsi } = validateFilters(rawFilters, columns)
+
+      // Retrieve the manual scan limit override, converting it to a number.
+      // If the conversion results in NaN, we set scanLimit to undefined.
+      const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
+      const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
+
+      const { rows } = await getTableRows({
+        tableId,
+        filters,
+        order: returnLastRow ? 'desc' : 'asc',
+        scanLimit,
+        gsi,
       })
-      throw new StepError(
-        'Invalid filters',
-        'One or more filters are invalid. Please check that the columns in your filters still exist',
-        $.step.position,
-        $.app.name,
-      )
-    }
-    // Retrieve the manual scan limit override, converting it to a number.
-    // If the conversion results in NaN, we set scanLimit to undefined.
-    const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
-    const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
 
-    const { rows } = await getTableRows({
-      tableId,
-      filters,
-      order: returnLastRow ? 'desc' : 'asc',
-      scanLimit,
-    })
+      if (!rows || !rows.length) {
+        $.setActionItem({
+          raw: {
+            rowsFound: 0,
+          } satisfies FindSingleRowOutput,
+        })
+        return
+      }
+      const rowIdToUse = rows[0].rowId
 
-    if (!rows || !rows.length) {
+      /**
+       * We use raw row data instead of mapped column names as we want them to
+       * be distinct in data_out
+       */
+      const rowToReturn = await getRawRowById({
+        tableId,
+        rowId: rowIdToUse,
+        columnIds: columns.map((c) => c.id),
+      })
+
       $.setActionItem({
         raw: {
-          rowsFound: 0,
+          rowsFound: rows.length,
+          rowId: rowIdToUse,
+          row: rowToReturn.data,
         } satisfies FindSingleRowOutput,
       })
-      return
+    } catch (e) {
+      logger.error({
+        message: 'Find single row error',
+        executionId: $.execution?.id,
+        stepId: $.step.id,
+        app: $.app.name,
+        error: e,
+      })
+      if (e instanceof IntermediateStepError) {
+        throw StepError.fromIntermediateStepError(e, {
+          position: $.step.position,
+          appName: $.app.name,
+        })
+      }
+      throw new StepError(
+        'Find single row error',
+        'An error occurred while finding the single row',
+        $.step.position,
+        $.app.name,
+        e,
+      )
     }
-    const rowIdToUse = rows[0].rowId
-
-    /**
-     * We use raw row data instead of mapped column names as we want them to
-     * be distinct in data_out
-     */
-    const rowToReturn = await getRawRowById({
-      tableId,
-      rowId: rowIdToUse,
-      columnIds: columns.map((c) => c.id),
-    })
-
-    $.setActionItem({
-      raw: {
-        rowsFound: rows.length,
-        rowId: rowIdToUse,
-        row: rowToReturn.data,
-      } satisfies FindSingleRowOutput,
-    })
   },
 }
 

--- a/packages/backend/src/apps/tiles/common/validate-filters.ts
+++ b/packages/backend/src/apps/tiles/common/validate-filters.ts
@@ -1,15 +1,87 @@
-import { TableRowFilter } from '@/models/dynamodb/table-row'
+import IntermediateStepError from '@/errors/intermediate-step-error'
+import logger from '@/helpers/logger'
+import {
+  type TableRowFilter,
+  TableRowFilterOperator,
+  type TableRowIndexName,
+} from '@/models/dynamodb/table-row'
 import TableColumnMetadata from '@/models/table-column-metadata'
+
+interface ValidateFiltersResult {
+  filters: TableRowFilter[]
+  gsi?: {
+    indexName: TableRowIndexName
+    filter: TableRowFilter
+  }
+}
+
+const VALID_GSI_STRING_OPERATORS = [
+  TableRowFilterOperator.Equals,
+  TableRowFilterOperator.BeginsWith,
+]
+
+const VALID_GSI_NUMBER_OPERATORS = [
+  TableRowFilterOperator.GreaterThan,
+  TableRowFilterOperator.GreaterThanOrEquals,
+  TableRowFilterOperator.LessThan,
+  TableRowFilterOperator.LessThanOrEquals,
+  TableRowFilterOperator.Equals,
+]
 
 export function validateFilters(
   filters: TableRowFilter[],
   columns: TableColumnMetadata[],
-) {
-  const columnIds = columns.map((c) => c.id)
-  const columnIdSet = new Set(columnIds)
-  for (const filter of filters) {
-    if (!columnIdSet.has(filter.columnId)) {
-      throw new Error(`Invalid columnId: ${filter.columnId}`)
-    }
+): ValidateFiltersResult {
+  const columnIdMap: Record<string, TableColumnMetadata> = {}
+  for (const column of columns) {
+    columnIdMap[column.id] = column
   }
+  const result: ValidateFiltersResult = {
+    filters: [],
+    gsi: undefined,
+  }
+  for (const filter of filters) {
+    const column = columnIdMap[filter.columnId]
+    if (
+      !column ||
+      !Object.values(TableRowFilterOperator).includes(filter.operator)
+    ) {
+      logger.error({
+        message: 'Invalid filters',
+        action: 'find-single-row',
+        columnId: filter.columnId,
+      })
+      throw new IntermediateStepError(
+        'Invalid columnId',
+        'One or more filters are invalid. Please check that the columns in your filters still exist',
+      )
+    }
+    if (column.config?.gsi?.status === 'ready') {
+      switch (column.config.gsi.type) {
+        case 'string':
+          if (VALID_GSI_STRING_OPERATORS.includes(filter.operator)) {
+            result.gsi = {
+              indexName: column.config.gsi.indexName as TableRowIndexName,
+              filter,
+            }
+            continue
+          }
+          break
+        case 'number':
+          if (VALID_GSI_NUMBER_OPERATORS.includes(filter.operator)) {
+            result.gsi = {
+              indexName: column.config.gsi.indexName as TableRowIndexName,
+              filter,
+            }
+            continue
+          }
+          break
+        default:
+          // do nothing - do not treat as valid GSI filter
+          break
+      }
+    }
+    result.filters.push(filter)
+  }
+  return result
 }

--- a/packages/backend/src/apps/tiles/common/validate-filters.ts
+++ b/packages/backend/src/apps/tiles/common/validate-filters.ts
@@ -1,6 +1,7 @@
 import IntermediateStepError from '@/errors/intermediate-step-error'
 import logger from '@/helpers/logger'
 import {
+  GSIS,
   type TableRowFilter,
   TableRowFilterOperator,
   type TableRowIndexName,
@@ -28,6 +29,12 @@ const VALID_GSI_NUMBER_OPERATORS = [
   TableRowFilterOperator.Equals,
 ]
 
+/**
+ * This function validates the filters and extracts the GSI filter if it exists
+ * The GSI filter should replace the rowId with the GSI sort key
+ *
+ * TODO: write tests for this
+ */
 export function validateFilters(
   filters: TableRowFilter[],
   columns: TableColumnMetadata[],
@@ -57,12 +64,27 @@ export function validateFilters(
       )
     }
     if (column.config?.gsi?.status === 'ready') {
+      const correspondingGsi = GSIS.find(
+        (g) => g.gsi === column.config.gsi.indexName,
+      )
+      if (!correspondingGsi) {
+        logger.error({
+          message: 'Invalid GSI',
+          action: 'find-single-row',
+          columnId: filter.columnId,
+        })
+        throw new IntermediateStepError('Invalid GSI', 'The GSI is not valid')
+      }
+
       switch (column.config.gsi.type) {
         case 'string':
           if (VALID_GSI_STRING_OPERATORS.includes(filter.operator)) {
             result.gsi = {
-              indexName: column.config.gsi.indexName as TableRowIndexName,
-              filter,
+              indexName: correspondingGsi.gsi,
+              filter: {
+                ...filter,
+                columnId: correspondingGsi.sk,
+              },
             }
             continue
           }
@@ -70,8 +92,11 @@ export function validateFilters(
         case 'number':
           if (VALID_GSI_NUMBER_OPERATORS.includes(filter.operator)) {
             result.gsi = {
-              indexName: column.config.gsi.indexName as TableRowIndexName,
-              filter,
+              indexName: correspondingGsi.gsi,
+              filter: {
+                ...filter,
+                columnId: correspondingGsi.sk,
+              },
             }
             continue
           }

--- a/packages/backend/src/apps/tiles/common/validate-filters.ts
+++ b/packages/backend/src/apps/tiles/common/validate-filters.ts
@@ -59,8 +59,8 @@ export function validateFilters(
         columnId: filter.columnId,
       })
       throw new IntermediateStepError(
-        'Invalid columnId',
-        'One or more filters are invalid. Please check that the columns in your filters still exist',
+        'Invalid lookup column(s)',
+        'One of the lookup columns in your filters might have been deleted. Please check that the columns still exist in your Tile.',
       )
     }
     if (column.config?.gsi?.status === 'ready') {

--- a/packages/backend/src/errors/intermediate-step-error.ts
+++ b/packages/backend/src/errors/intermediate-step-error.ts
@@ -1,7 +1,6 @@
 import { IJSONObject, IStepError } from '@plumber/types'
 
 import HttpError from './http'
-import IntermediateStepError from './intermediate-step-error'
 
 //
 // Some generic solutions for common errors
@@ -10,39 +9,28 @@ export enum GenericSolution {
   ReconfigureInvalidField = 'Click on set up action and reconfigure the invalid field. Error could also result from the variables used in the field.',
 }
 
-export default class StepError extends Error {
+export default class IntermediateStepError extends Error {
+  solution: string
+  error?: HttpError
+  extraProperties?: Record<string, unknown>
+
   constructor(
     name: string,
     solution: string,
-    position: number,
-    appName: string,
     error?: HttpError,
     extraProperties?: Record<string, unknown>,
   ) {
-    const stepError: IStepError = {
+    const stepError: Partial<IStepError> = {
       name,
       solution,
-      position,
-      appName,
       details: error?.details as IJSONObject,
       ...extraProperties,
     }
     const computedMessage = JSON.stringify(stepError)
     super(computedMessage, { cause: error })
-    this.name = this.constructor.name
-  }
-
-  static fromIntermediateStepError(
-    error: IntermediateStepError,
-    { position, appName }: { position: number; appName: string },
-  ) {
-    return new StepError(
-      error.name,
-      error.solution,
-      position,
-      appName,
-      error.error,
-      error.extraProperties,
-    )
+    this.solution = solution
+    this.error = error
+    this.extraProperties = extraProperties
+    this.name = name
   }
 }

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -550,14 +550,14 @@ describe('dynamodb table row functions', () => {
   })
 
   describe('GSI', () => {
-    it('should get the correct rows with equals operator using GSI', async () => {
+    beforeEach(async () => {
       const dataArray = []
       for (let i = 0; i < 1000; i++) {
         const data = generateMockTableRowData({
           columnIds: dummyColumnIds,
         })
-        // force the first column to have a deterministic value
-        data[dummyColumnIds[0]] = `${i}`
+        data[dummyColumnIds[0]] = i % 2 === 0 ? `even${i}` : `odd${i}`
+        data[dummyColumnIds[1]] = `${i}`
         dataArray.push(data)
       }
       await createTableRows({
@@ -568,6 +568,8 @@ describe('dynamodb table row functions', () => {
           columnIdToMap: dummyColumnIds[0],
         },
       })
+    })
+    it('should get the correct rows with equals operator using GSI', async () => {
       const { rows } = await getTableRows({
         tableId: dummyTable.id,
         gsi: {
@@ -575,33 +577,15 @@ describe('dynamodb table row functions', () => {
           filter: {
             columnId: 'skString1',
             operator: TableRowFilterOperator.Equals,
-            value: '5',
+            value: 'odd5',
           },
         },
-        includeTimestamps: true,
         scanLimit: 1, // this is to ensure that we are using the index and not scanning all rows
       })
       expect(rows).toHaveLength(1)
     })
 
     it('should get the correct rows with begins with operator using GSI', async () => {
-      const dataArray = []
-      for (let i = 0; i < 1000; i++) {
-        const data = generateMockTableRowData({
-          columnIds: dummyColumnIds,
-        })
-        // force the first column to have a deterministic value
-        data[dummyColumnIds[0]] = `${i}`
-        dataArray.push(data)
-      }
-      await createTableRows({
-        tableId: dummyTable.id,
-        dataArray,
-        gsi: {
-          indexName: 'gsiString1',
-          columnIdToMap: dummyColumnIds[0],
-        },
-      })
       const { rows } = await getTableRows({
         tableId: dummyTable.id,
         gsi: {
@@ -609,13 +593,12 @@ describe('dynamodb table row functions', () => {
           filter: {
             columnId: 'skString1',
             operator: TableRowFilterOperator.BeginsWith,
-            value: '4',
+            value: 'even4',
           },
         },
-        includeTimestamps: true,
-        scanLimit: 111, // this is to ensure that we are using the index and not scanning all rows
+        scanLimit: 56, // this is to ensure that we are using the index and not scanning all rows
       })
-      expect(rows).toHaveLength(111)
+      expect(rows).toHaveLength(56)
     })
 
     it('should automatically convert numbers to strings when using GSI', async () => {
@@ -642,41 +625,23 @@ describe('dynamodb table row functions', () => {
           indexName: 'gsiString1',
           filter: {
             columnId: 'skString1',
-            operator: TableRowFilterOperator.GreaterThan,
+            operator: TableRowFilterOperator.Equals,
             value: '500',
           },
         },
-        includeTimestamps: true,
-        scanLimit: 1000,
+        scanLimit: 1,
       })
-      expect(rows).toHaveLength(552)
+      expect(rows).toHaveLength(1)
     })
 
     it('should work with filters', async () => {
-      const dataArray = []
-      for (let i = 0; i < 1000; i++) {
-        const data = generateMockTableRowData({
-          columnIds: dummyColumnIds,
-        })
-        data[dummyColumnIds[0]] = i % 2 === 0 ? 'even' : 'odd'
-        data[dummyColumnIds[1]] = `${i}`
-        dataArray.push(data)
-      }
-      await createTableRows({
-        tableId: dummyTable.id,
-        dataArray,
-        gsi: {
-          indexName: 'gsiString1',
-          columnIdToMap: dummyColumnIds[0],
-        },
-      })
       const { rows } = await getTableRows({
         tableId: dummyTable.id,
         gsi: {
           indexName: 'gsiString1',
           filter: {
             columnId: 'skString1',
-            operator: TableRowFilterOperator.Equals,
+            operator: TableRowFilterOperator.BeginsWith,
             value: 'even',
           },
         },
@@ -692,10 +657,68 @@ describe('dynamodb table row functions', () => {
             value: '700',
           },
         ],
-        columnIds: dummyColumnIds,
         scanLimit: 500,
       })
       expect(rows).toHaveLength(100)
+    })
+
+    it('should work with specified columnIds', async () => {
+      const { rows } = await getTableRows({
+        tableId: dummyTable.id,
+        gsi: {
+          indexName: 'gsiString1',
+          filter: {
+            columnId: 'skString1',
+            operator: TableRowFilterOperator.BeginsWith,
+            value: 'even',
+          },
+        },
+        columnIds: dummyColumnIds,
+        scanLimit: 1000,
+      })
+      expect(rows[0].data).toHaveProperty(dummyColumnIds[0])
+      expect(rows[0].data).toHaveProperty(dummyColumnIds[1])
+      expect(rows[0].data).toHaveProperty(dummyColumnIds[2])
+    })
+
+    it('should respect the sort direction (desc - most recent row)', async () => {
+      const { rows } = await getTableRows({
+        tableId: dummyTable.id,
+        gsi: {
+          indexName: 'gsiString1',
+          filter: {
+            columnId: 'skString1',
+            operator: TableRowFilterOperator.BeginsWith,
+            value: 'even',
+          },
+        },
+        columnIds: [dummyColumnIds[1]],
+        // returns most recent row
+        order: 'desc',
+        scanLimit: 500,
+      })
+      expect(rows).toHaveLength(500)
+      expect(rows[0].data[dummyColumnIds[1]]).toEqual(998)
+    })
+
+    it('should respect the sort direction (asc - oldest row)', async () => {
+      const { rows } = await getTableRows({
+        tableId: dummyTable.id,
+        gsi: {
+          indexName: 'gsiString1',
+          filter: {
+            columnId: 'skString1',
+            operator: TableRowFilterOperator.BeginsWith,
+            value: 'even',
+          },
+        },
+        columnIds: [dummyColumnIds[1]],
+        // returns oldest row
+        order: 'asc',
+        scanLimit: 500,
+      })
+      expect(rows).toHaveLength(500)
+      expect(rows[0].data[dummyColumnIds[1]]).toEqual(0)
     })
   })
 })

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -387,7 +387,6 @@ export const getTableRows = async ({
       includeTimestamps: !!gsi,
       indexUsed: gsi?.indexName ?? 'createdAtIndex',
     })
-  console.log({ ProjectionExpression, ExpressionAttributeNames })
   const tableRows = []
 
   let remainingScanLimit = scanLimit ?? Infinity

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -352,7 +352,6 @@ export const getTableRows = async ({
   stringifiedCursor,
   scanLimit,
   gsi,
-  includeTimestamps = false,
 }: {
   tableId: string
   columnIds?: string[]
@@ -371,7 +370,6 @@ export const getTableRows = async ({
     indexName: TableRowIndexName
     filter: TableRowFilter
   }
-  includeTimestamps?: boolean
 }): Promise<{
   rows: TableRowOutput[]
   stringifiedCursor?: string
@@ -385,9 +383,11 @@ export const getTableRows = async ({
     generateProjectionExpressions({
       columnIds,
       filters,
-      includeTimestamps,
+      // if we're using a GSI, we need to include the timestamps to sort later on
+      includeTimestamps: !!gsi,
       indexUsed: gsi?.indexName ?? 'createdAtIndex',
     })
+  console.log({ ProjectionExpression, ExpressionAttributeNames })
   const tableRows = []
 
   let remainingScanLimit = scanLimit ?? Infinity
@@ -443,8 +443,21 @@ export const getTableRows = async ({
       // loop only if cursor is
     } while (cursor && !stringifiedCursor && remainingScanLimit > 0)
 
+    /**
+     * When using GSI's we do the sorting ourselves
+     */
+    const sortedRows = gsi
+      ? tableRows.sort((a, b) => {
+          return order === 'asc'
+            ? // we sort by earliest createdAt first
+              a.createdAt - b.createdAt
+            : // we sort by latest createdAt first
+              b.createdAt - a.createdAt
+        })
+      : tableRows
+
     return {
-      rows: tableRows.map((row) => ({
+      rows: sortedRows.map((row) => ({
         ...row,
         data: row.data || {}, // data can be undefined if values are empty
       })),

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -27,7 +27,10 @@ export interface DeleteRowsInput {
   tableId: string
   rowIds: string[]
 }
-export type TableRowOutput = Pick<TableRowItem, 'rowId' | 'data'>
+export type TableRowOutput = Pick<
+  TableRowItem,
+  'rowId' | 'data' | 'createdAt' | 'updatedAt'
+>
 
 export enum TableRowFilterOperator {
   Equals = 'equals',

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -2,7 +2,15 @@ import { CreateEntityItem } from 'electrodb'
 
 import { TableRow } from './model'
 
-export type TableRowIndexName = 'gsiString1' | 'createdAtIndex'
+export const GSIS = [
+  {
+    gsi: 'gsiString1',
+    sk: 'skString1',
+    type: 'string',
+  },
+] as const
+export type TableRowIndexName = (typeof GSIS)[number]['gsi'] | 'createdAtIndex'
+export type TableRowSortKeyName = (typeof GSIS)[number]['sk']
 
 export type TableRowItem = CreateEntityItem<typeof TableRow>
 export type CreateRowInput = Pick<TableRowItem, 'tableId' | 'data'>

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -882,6 +882,11 @@ export interface IStepError {
 // Tiles
 export interface ITableColumnConfig {
   width?: number
+  gsi?: {
+    indexName: string
+    type: 'string' | 'number'
+    status: 'pending' | 'ready' | 'error'
+  }
 }
 
 export interface ITableColumnMetadata {


### PR DESCRIPTION
## Changes
Added GSI support to the find-single-row action in the Tiles

- Enhanced the `validateFilters` function to identify and extract GSI filters from the provided filters
- Added support for respecting sort direction (asc/desc) when using GSI

### Other changes
- Created a new `IntermediateStepError` class for better error handling in step execution
- Added `fromIntermediateStepError` static method to `StepError` class
- Updated the `getTableRows` function to properly handle GSI queries with sorting

### How to test?
- Review new tests in `functions.itest.ts` and `find-single-row.itest.ts`