### PR TITLE
PLU-416 [GSI-4]: modify update and write table rows to map to sort key

### DIFF
--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -809,5 +809,37 @@ describe('dynamodb table row functions', () => {
         updatedData[dummyColumnIds[0]],
       )
     })
+
+    it('should update sort key when patching row', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const originalRow = await createTableRow({ tableId: dummyTable.id, data })
+      const patchData = {
+        set: {
+          [dummyColumnIds[0]]: 'patched',
+        },
+      }
+      await patchTableRow({
+        tableId: dummyTable.id,
+        patchData,
+        rowId: originalRow.rowId,
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
+      })
+      const patchedRow = await TableRow.query
+        .byRowId({
+          tableId: dummyTable.id,
+          rowId: originalRow.rowId,
+        })
+        .go({
+          ignoreOwnership: true,
+        })
+      expect(patchedRow.data[0].skString1).toEqual('patched')
+    })
   })
 })

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -9,7 +9,7 @@ import {
 import TableMetadata from '@/models/table-metadata'
 import Context from '@/types/express/context'
 
-import { TableRowFilterOperator } from '../../table-row'
+import { TableRow, TableRowFilterOperator } from '../../table-row'
 import {
   createTableRow,
   createTableRows,
@@ -549,7 +549,7 @@ describe('dynamodb table row functions', () => {
     })
   })
 
-  describe('GSI', () => {
+  describe('GSI - read', () => {
     beforeEach(async () => {
       const dataArray = []
       for (let i = 0; i < 1000; i++) {
@@ -563,10 +563,12 @@ describe('dynamodb table row functions', () => {
       await createTableRows({
         tableId: dummyTable.id,
         dataArray,
-        gsi: {
-          indexName: 'gsiString1',
-          columnIdToMap: dummyColumnIds[0],
-        },
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
       })
     })
     it('should get the correct rows with equals operator using GSI', async () => {
@@ -614,10 +616,12 @@ describe('dynamodb table row functions', () => {
       await createTableRows({
         tableId: dummyTable.id,
         dataArray,
-        gsi: {
-          indexName: 'gsiString1',
-          columnIdToMap: dummyColumnIds[0],
-        },
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
       })
       const { rows } = await getTableRows({
         tableId: dummyTable.id,
@@ -719,6 +723,91 @@ describe('dynamodb table row functions', () => {
       })
       expect(rows).toHaveLength(500)
       expect(rows[0].data[dummyColumnIds[1]]).toEqual(0)
+    })
+  })
+
+  describe('GSI - write', () => {
+    it('should write into the sort key when creating single row', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const insertedRow = await createTableRow({
+        tableId: dummyTable.id,
+        data,
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
+      })
+      const row = await TableRow.query
+        .byRowId({ tableId: dummyTable.id, rowId: insertedRow.rowId })
+        .go({
+          ignoreOwnership: true,
+        })
+      expect(row.data[0].skString1).toEqual(data[dummyColumnIds[0]])
+    })
+
+    it('should write into the sort key when creating multiple rows', async () => {
+      const dataArray = []
+      for (let i = 0; i < 1000; i++) {
+        const data = generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        })
+        dataArray.push(data)
+      }
+      await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
+      })
+      const rows = await TableRow.query
+        .byCreatedAt({
+          tableId: dummyTable.id,
+        })
+        .go({
+          pages: 'all',
+        })
+      expect(rows.data).toHaveLength(1000)
+      for (const row of rows.data) {
+        expect(row.skString1).toEqual(row.data[dummyColumnIds[0]])
+      }
+    })
+
+    it('should update sort key when updating row', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createTableRow({ tableId: dummyTable.id, data })
+      const updatedData = { ...data, [dummyColumnIds[0]]: 'updated' }
+      await updateTableRow({
+        tableId: dummyTable.id,
+        rowId: row.rowId,
+        data: updatedData,
+        gsis: [
+          {
+            indexName: 'gsiString1',
+            columnIdToMap: dummyColumnIds[0],
+          },
+        ],
+      })
+      const updatedRow = await TableRow.query
+        .byRowId({
+          tableId: dummyTable.id,
+          rowId: row.rowId,
+        })
+        .go({
+          ignoreOwnership: true,
+        })
+      expect(updatedRow.data[0].skString1).toEqual(
+        updatedData[dummyColumnIds[0]],
+      )
     })
   })
 })

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -841,5 +841,117 @@ describe('dynamodb table row functions', () => {
         })
       expect(patchedRow.data[0].skString1).toEqual('patched')
     })
+
+    it.for([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+    ])(
+      'should remove sort key when patching a row if value is %s',
+      { concurrent: false },
+      async ([_description, value]: [string, string | null | undefined]) => {
+        const data = generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        })
+        const originalRow = await createTableRow({
+          tableId: dummyTable.id,
+          data,
+        })
+        const patchData = {
+          set: {
+            [dummyColumnIds[0]]: value,
+          },
+        }
+        await patchTableRow({
+          tableId: dummyTable.id,
+          patchData,
+          rowId: originalRow.rowId,
+          gsis: [
+            {
+              indexName: 'gsiString1',
+              columnIdToMap: dummyColumnIds[0],
+            },
+          ],
+        })
+        const patchedRow = await TableRow.query
+          .byRowId({
+            tableId: dummyTable.id,
+            rowId: originalRow.rowId,
+          })
+          .go({
+            ignoreOwnership: true,
+          })
+        expect(patchedRow.data[0].skString1).toBeUndefined()
+      },
+    )
+
+    it.for([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+    ])(
+      'should not have sort key when creating a row if value is %s',
+      { concurrent: false },
+      async ([_description, value]: [string, string | null | undefined]) => {
+        const data = generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        })
+        const row = await createTableRow({ tableId: dummyTable.id, data })
+        await createTableRow({
+          tableId: dummyTable.id,
+          data: { ...data, [dummyColumnIds[0]]: value },
+          gsis: [
+            {
+              indexName: 'gsiString1',
+              columnIdToMap: dummyColumnIds[0],
+            },
+          ],
+        })
+        const updatedRow = await TableRow.query
+          .byRowId({
+            tableId: dummyTable.id,
+            rowId: row.rowId,
+          })
+          .go({
+            ignoreOwnership: true,
+          })
+        expect(updatedRow.data[0].skString1).toBeUndefined()
+      },
+    )
+
+    it.for([
+      ['empty string', ''],
+      ['null', null],
+      ['undefined', undefined],
+    ])(
+      'should not have sort key when updating a row if value is %s',
+      { concurrent: false },
+      async ([_description, value]: [string, string | null | undefined]) => {
+        const data = generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        })
+        const row = await createTableRow({ tableId: dummyTable.id, data })
+        await updateTableRow({
+          tableId: dummyTable.id,
+          rowId: row.rowId,
+          data: { ...data, [dummyColumnIds[0]]: value },
+          gsis: [
+            {
+              indexName: 'gsiString1',
+              columnIdToMap: dummyColumnIds[0],
+            },
+          ],
+        })
+        const updatedRow = await TableRow.query
+          .byRowId({
+            tableId: dummyTable.id,
+            rowId: row.rowId,
+          })
+          .go({
+            ignoreOwnership: true,
+          })
+        expect(updatedRow.data[0].skString1).toBeUndefined()
+      },
+    )
   })
 })

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -387,7 +387,6 @@ export const getTableRows = async ({
       includeTimestamps: !!gsi,
       indexUsed: gsi?.indexName ?? 'createdAtIndex',
     })
-  console.log({ ProjectionExpression, ExpressionAttributeNames })
   const tableRows = []
 
   let remainingScanLimit = scanLimit ?? Infinity

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -5,7 +5,7 @@ import logger from '@/helpers/logger'
 
 import { autoMarshallNumberStrings, handleDynamoDBError } from '../helpers'
 
-import { constructDataWithGsis, TableRow } from './model'
+import { constructDataWithGsis, getGsiSortKey, TableRow } from './model'
 import {
   type CreateRowInput,
   type CreateRowsInput,
@@ -268,30 +268,35 @@ export const patchTableRow = async ({
   rowId,
   tableId,
   patchData,
+  gsis,
 }: PatchRowInput): Promise<TableRowItem> => {
   try {
     const patchOperation = TableRow.patch({
       tableId,
       rowId,
-    }).data(({ data }, { set, add, subtract }) => {
+    }).data((row, { set, add, subtract }) => {
       // Handle set operations
       Object.entries(patchData.set || {}).forEach(
         ([key, value]: [string, string]) => {
-          set(data[key], value ? autoMarshallNumberStrings(value) : '')
+          set(row.data[key], value ? autoMarshallNumberStrings(value) : null)
+          const sortKey = getGsiSortKey(gsis, key)
+          if (sortKey) {
+            set(row[sortKey as keyof typeof row], value?.toString() || null)
+          }
         },
       )
 
       // Handle add operations
       Object.entries(patchData.add || {}).forEach(
         ([key, value]: [string, string]) => {
-          add(data[key], autoMarshallNumberStrings(value))
+          add(row.data[key], autoMarshallNumberStrings(value))
         },
       )
 
       // Handle subtract operations
       Object.entries(patchData.subtract || {}).forEach(
         ([key, value]: [string, string]) => {
-          subtract(data[key], autoMarshallNumberStrings(value))
+          subtract(row.data[key], autoMarshallNumberStrings(value))
         },
       )
     })

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -387,6 +387,7 @@ export const getTableRows = async ({
       includeTimestamps: !!gsi,
       indexUsed: gsi?.indexName ?? 'createdAtIndex',
     })
+  console.log({ ProjectionExpression, ExpressionAttributeNames })
   const tableRows = []
 
   let remainingScanLimit = scanLimit ?? Infinity

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -5,7 +5,7 @@ import logger from '@/helpers/logger'
 
 import { autoMarshallNumberStrings, handleDynamoDBError } from '../helpers'
 
-import { getSkKeyValue, TableRow } from './model'
+import { constructDataWithGsis, TableRow } from './model'
 import {
   type CreateRowInput,
   type CreateRowsInput,
@@ -202,12 +202,13 @@ const addFiltersToQuery = (
 export const createTableRow = async ({
   tableId,
   data,
+  gsis,
 }: CreateRowInput): Promise<TableRowItem> => {
   try {
     const res = await TableRow.create({
       tableId,
       rowId: randomUUID(),
-      data,
+      ...constructDataWithGsis(data, gsis),
     }).go({ ignoreOwnership: true })
     return res.data
   } catch (e: unknown) {
@@ -218,17 +219,16 @@ export const createTableRow = async ({
 export const createTableRows = async ({
   tableId,
   dataArray,
-  gsi,
+  gsis,
 }: CreateRowsInput): Promise<string[]> => {
   try {
     const rows = dataArray.map((data, i) => {
       return {
         tableId,
         rowId: randomUUID(),
-        data,
         // manually bumping the createdAt timestamp to ensure that row order is preserved
         createdAt: Date.now() + i,
-        ...(gsi ? getSkKeyValue(gsi.indexName, data[gsi.columnIdToMap]) : {}),
+        ...constructDataWithGsis(data, gsis),
       }
     })
     await _batchCreate(rows)
@@ -245,15 +245,14 @@ export const updateTableRow = async ({
   rowId,
   tableId,
   data,
+  gsis,
 }: UpdateRowInput): Promise<void> => {
   try {
     await TableRow.patch({
       tableId,
       rowId,
     })
-      .set({
-        data,
-      })
+      .set(constructDataWithGsis(data, gsis))
       .go({
         ignoreOwnership: true,
       })

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -5,7 +5,12 @@ import logger from '@/helpers/logger'
 
 import { autoMarshallNumberStrings, handleDynamoDBError } from '../helpers'
 
-import { constructDataWithGsis, getGsiSortKey, TableRow } from './model'
+import {
+  castGsiValue,
+  constructDataWithGsis,
+  getGsiSortKey,
+  TableRow,
+} from './model'
 import {
   type CreateRowInput,
   type CreateRowsInput,
@@ -202,7 +207,7 @@ const addFiltersToQuery = (
 export const createTableRow = async ({
   tableId,
   data,
-  gsis,
+  gsis = [],
 }: CreateRowInput): Promise<TableRowItem> => {
   try {
     const res = await TableRow.create({
@@ -219,7 +224,7 @@ export const createTableRow = async ({
 export const createTableRows = async ({
   tableId,
   dataArray,
-  gsis,
+  gsis = [],
 }: CreateRowsInput): Promise<string[]> => {
   try {
     const rows = dataArray.map((data, i) => {
@@ -245,7 +250,7 @@ export const updateTableRow = async ({
   rowId,
   tableId,
   data,
-  gsis,
+  gsis = [],
 }: UpdateRowInput): Promise<void> => {
   try {
     await TableRow.patch({
@@ -268,20 +273,24 @@ export const patchTableRow = async ({
   rowId,
   tableId,
   patchData,
-  gsis,
+  gsis = [],
 }: PatchRowInput): Promise<TableRowItem> => {
   try {
     const patchOperation = TableRow.patch({
       tableId,
       rowId,
-    }).data((row, { set, add, subtract }) => {
+    }).data((row, { set, add, subtract, remove }) => {
       // Handle set operations
       Object.entries(patchData.set || {}).forEach(
         ([key, value]: [string, string]) => {
           set(row.data[key], value ? autoMarshallNumberStrings(value) : null)
           const sortKey = getGsiSortKey(gsis, key)
           if (sortKey) {
-            set(row[sortKey], value ? value.toString() : null)
+            if (castGsiValue(value)) {
+              set(row[sortKey], castGsiValue(value))
+            } else {
+              remove(row[sortKey])
+            }
           }
         },
       )

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -281,7 +281,7 @@ export const patchTableRow = async ({
           set(row.data[key], value ? autoMarshallNumberStrings(value) : null)
           const sortKey = getGsiSortKey(gsis, key)
           if (sortKey) {
-            set(row[sortKey as keyof typeof row], value?.toString() || null)
+            set(row[sortKey], value ? value.toString() : null)
           }
         },
       )

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -115,7 +115,7 @@ export function constructDataWithGsis(
 export function getGsiSortKey(
   gsis: GsiOptions[],
   columnId: string,
-): string | undefined {
+): 'skString1' | undefined {
   const correspondingGsi = gsis.find((gsi) => gsi.columnIdToMap === columnId)
   switch (correspondingGsi?.indexName) {
     case 'gsiString1':

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -92,18 +92,29 @@ interface DataWithGsi {
   [key: string]: string | number | null | unknown
 }
 
+export function castGsiValue(value: string | number | null): string | null {
+  if (value == null || value === '') {
+    return undefined
+  }
+  return value.toString()
+}
+
 export function constructDataWithGsis(
   data: Record<string, string | number | null>,
   gsis?: GsiOptions[],
 ): DataWithGsi {
+  const dataWithoutNullish = Object.fromEntries(
+    Object.entries(data).filter(([_, value]) => value != null),
+  )
   if (!gsis) {
-    return { data }
+    return { data: dataWithoutNullish }
   }
-  const dataWithGsi: DataWithGsi = { data }
+  const dataWithGsi: DataWithGsi = { data: dataWithoutNullish }
   for (const gsi of gsis) {
+    const value = data[gsi.columnIdToMap]
     switch (gsi.indexName) {
       case 'gsiString1':
-        dataWithGsi.skString1 = data[gsi.columnIdToMap]?.toString() || ''
+        dataWithGsi.skString1 = castGsiValue(value)
         break
       default:
         break

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -4,7 +4,7 @@ import client, { tableName } from '@/config/dynamodb'
 
 import { autoMarshallDataObj } from '../helpers'
 
-import type { TableRowIndexName } from './types'
+import type { GsiOptions } from './types'
 
 export const TableRow = new Entity(
   {
@@ -87,14 +87,27 @@ export const TableRow = new Entity(
   },
 )
 
-export function getSkKeyValue(
-  indexName: TableRowIndexName,
-  value: unknown,
-): { [key: string]: unknown } {
-  switch (indexName) {
-    case 'gsiString1':
-      return { skString1: value.toString() }
-    default:
-      return {}
+interface DataWithGsi {
+  data: Record<string, string | number | null>
+  [key: string]: string | number | null | unknown
+}
+
+export function constructDataWithGsis(
+  data: Record<string, string | number | null>,
+  gsis?: GsiOptions[],
+): DataWithGsi {
+  if (!gsis) {
+    return { data }
   }
+  const dataWithGsi: DataWithGsi = { data }
+  for (const gsi of gsis) {
+    switch (gsi.indexName) {
+      case 'gsiString1':
+        dataWithGsi.skString1 = data[gsi.columnIdToMap]?.toString() || ''
+        break
+      default:
+        break
+    }
+  }
+  return dataWithGsi
 }

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -111,3 +111,16 @@ export function constructDataWithGsis(
   }
   return dataWithGsi
 }
+
+export function getGsiSortKey(
+  gsis: GsiOptions[],
+  columnId: string,
+): string | undefined {
+  const correspondingGsi = gsis.find((gsi) => gsi.columnIdToMap === columnId)
+  switch (correspondingGsi?.indexName) {
+    case 'gsiString1':
+      return 'skString1'
+    default:
+      return undefined
+  }
+}

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -39,6 +39,7 @@ export type PatchRowInput = Pick<TableRowItem, 'tableId' | 'rowId'> & {
     add?: TableRowItem['data']
     subtract?: TableRowItem['data']
   }
+  gsis?: GsiOptions[]
 }
 export interface DeleteRowsInput {
   tableId: string

--- a/packages/backend/src/models/dynamodb/table-row/types.ts
+++ b/packages/backend/src/models/dynamodb/table-row/types.ts
@@ -12,17 +12,26 @@ export const GSIS = [
 export type TableRowIndexName = (typeof GSIS)[number]['gsi'] | 'createdAtIndex'
 export type TableRowSortKeyName = (typeof GSIS)[number]['sk']
 
+export type GsiOptions = {
+  indexName: TableRowIndexName
+  columnIdToMap: string
+}
+
 export type TableRowItem = CreateEntityItem<typeof TableRow>
-export type CreateRowInput = Pick<TableRowItem, 'tableId' | 'data'>
+export type CreateRowInput = Pick<TableRowItem, 'tableId' | 'data'> & {
+  gsis?: GsiOptions[]
+}
 export type CreateRowsInput = {
   tableId: string
   dataArray: Array<TableRowItem['data']>
-  gsi?: {
-    indexName: TableRowIndexName
-    columnIdToMap: string
-  }
+  gsis?: GsiOptions[]
 }
-export type UpdateRowInput = Pick<TableRowItem, 'tableId' | 'rowId' | 'data'>
+export type UpdateRowInput = Pick<
+  TableRowItem,
+  'tableId' | 'rowId' | 'data'
+> & {
+  gsis?: GsiOptions[]
+}
 
 export type PatchRowInput = Pick<TableRowItem, 'tableId' | 'rowId'> & {
   patchData: {


### PR DESCRIPTION
## Changes
 Add GSI support for write operations on table rows
- Mapping column values to GSI sort keys during create, update, and patch operations
- Remove empty values ('', null, undefined) from data map and sort key if any
