### PR TITLE
PLU-416 [GSI-5]: update mutations and actions to use gsis

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
@@ -9,12 +9,16 @@ import {
   generateMockTableColumns,
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
+import * as tableFunctions from '@/models/dynamodb/table-row/functions'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import tiles from '../..'
 import createRowAction from '../../actions/create-row'
+
+const createTableRowSpy = vi.spyOn(tableFunctions, 'createTableRow')
 
 describe('tiles create row action', () => {
   let context: Context
@@ -92,5 +96,34 @@ describe('tiles create row action', () => {
       })
       .where({ id: $.step.parameters.tableId })
     await expect(createRowAction.run($)).rejects.toThrow(StepError)
+  })
+
+  describe('GSI', () => {
+    beforeEach(async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: {
+              status: 'ready',
+              indexName: 'gsiString1',
+              type: 'string',
+            },
+          },
+        })
+        .where({ id: dummyColumnIds[0] })
+    })
+
+    it('should call create row with GSI', async () => {
+      await expect(createRowAction.run($)).resolves.toBeUndefined()
+      const data = ($.step.parameters.rowData as any[]).reduce((acc, row) => {
+        acc[row.columnId] = row.cellValue
+        return acc
+      }, {})
+      expect(createTableRowSpy).toHaveBeenCalledWith({
+        tableId: dummyTable.id,
+        data,
+        gsis: [{ indexName: 'gsiString1', columnIdToMap: dummyColumnIds[0] }],
+      })
+    })
   })
 })

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -10,6 +10,7 @@ import {
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import { createTableRow } from '@/models/dynamodb/table-row'
+import * as tableFunctions from '@/models/dynamodb/table-row/functions'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
@@ -17,6 +18,8 @@ import Context from '@/types/express/context'
 
 import tiles from '../..'
 import updateRowAction from '../../actions/update-row'
+
+const patchTableRowSpy = vi.spyOn(tableFunctions, 'patchTableRow')
 
 describe('tiles update row action', () => {
   let context: Context
@@ -139,6 +142,35 @@ describe('tiles update row action', () => {
           [dummyColumnIds[0]]: 123,
         },
       },
+    })
+  })
+
+  describe('GSI', () => {
+    beforeEach(async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: { status: 'ready', indexName: 'gsiString1', type: 'string' },
+          },
+        })
+        .where({ id: dummyColumnIds[0] })
+    })
+
+    it('should update row with GSI', async () => {
+      await expect(updateRowAction.run($)).resolves.toBeUndefined()
+      expect(patchTableRowSpy).toHaveBeenCalledWith({
+        tableId: dummyTable.id,
+        rowId: $.step.parameters.rowId,
+        patchData: {
+          subtract: {},
+          add: {},
+          set: ($.step.parameters.rowData as any[]).reduce((acc, row) => {
+            acc[row.columnId] = row.cellValue
+            return acc
+          }, {} as Record<string, string>),
+        },
+        gsis: [{ indexName: 'gsiString1', columnIdToMap: dummyColumnIds[0] }],
+      })
     })
   })
 })

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -3,6 +3,7 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 import { createTableRow } from '@/models/dynamodb/table-row/functions'
 import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 
 import { CreateRowOutput } from '../../types'
@@ -94,7 +95,9 @@ const action: IRawAction = {
       rowData: { columnId: string; cellValue: string }[]
     }
 
-    const table = await TableMetadata.query().findById(tableId)
+    const table = await TableMetadata.query()
+      .withGraphFetched('columns')
+      .findById(tableId)
     if (!table) {
       throw new StepError(
         'Tile not found',
@@ -124,7 +127,9 @@ const action: IRawAction = {
       )
     }
 
-    const newRow = await createTableRow({ tableId, data: rowDataObject })
+    const gsis = TableColumnMetadata.getGsisFromColumns(table.columns)
+
+    const newRow = await createTableRow({ tableId, data: rowDataObject, gsis })
 
     $.setActionItem({
       raw: {

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -137,6 +137,7 @@ const action: IRawAction = {
      */
     const columns = await TableColumnMetadata.getColumns(tableId, $)
     const columnIds = columns.map((c) => c.id)
+    const gsis = TableColumnMetadata.getGsisFromColumns(columns)
 
     await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
@@ -166,7 +167,10 @@ const action: IRawAction = {
 
     const patchData = {
       ...rowData.reduce(
-        (acc, { columnId, cellValue, operator }) => {
+        (
+          acc: PatchRowInput['patchData'],
+          { columnId, cellValue, operator },
+        ) => {
           // Check that the column still exists
           if (columnIds.includes(columnId)) {
             switch (operator) {
@@ -195,6 +199,7 @@ const action: IRawAction = {
         tableId,
         rowId,
         patchData,
+        gsis,
       })
 
       const updatedRowData = stripInvalidKeys({

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import createRows from '@/graphql/mutations/tiles/create-rows'
-import { getTableRows } from '@/models/dynamodb/table-row/functions'
+import * as tableFunctions from '@/models/dynamodb/table-row/functions'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -14,6 +15,7 @@ import {
   generateMockTableRowData,
 } from './table.mock'
 
+const createTableRowsSpy = vi.spyOn(tableFunctions, 'createTableRows')
 describe('create row mutation', () => {
   let context: Context
   let dummyTable: TableMetadata
@@ -56,7 +58,7 @@ describe('create row mutation', () => {
       context,
     )
 
-    const { rows } = await getTableRows({
+    const { rows } = await tableFunctions.getTableRows({
       tableId: dummyTable.id,
       columnIds: dummyColumnIds,
     })
@@ -81,7 +83,7 @@ describe('create row mutation', () => {
       context,
     )
 
-    const { rows } = await getTableRows({
+    const { rows } = await tableFunctions.getTableRows({
       tableId: dummyTable.id,
       columnIds: dummyColumnIds,
     })
@@ -120,5 +122,42 @@ describe('create row mutation', () => {
         context,
       ),
     ).rejects.toThrow(ForbiddenError)
+  })
+
+  describe('GSI', () => {
+    beforeEach(async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: { status: 'ready', indexName: 'gsiString1', type: 'string' },
+          },
+        })
+        .where({ id: dummyColumnIds[0] })
+    })
+    it('should call createTableRows with gsis', async () => {
+      await createRows(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            dataArray: [
+              { [dummyColumnIds[0]]: null },
+              { [dummyColumnIds[0]]: '' },
+              { [dummyColumnIds[0]]: 'test2' },
+            ],
+          },
+        },
+        context,
+      )
+      expect(createTableRowsSpy).toHaveBeenCalledWith({
+        tableId: dummyTable.id,
+        dataArray: [
+          { [dummyColumnIds[0]]: null },
+          { [dummyColumnIds[0]]: '' },
+          { [dummyColumnIds[0]]: 'test2' },
+        ],
+        gsis: [{ indexName: 'gsiString1', columnIdToMap: dummyColumnIds[0] }],
+      })
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-row.ts
@@ -1,5 +1,6 @@
 import { createTableRow } from '@/models/dynamodb/table-row'
 import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
@@ -13,13 +14,18 @@ const createRow: MutationResolvers['createRow'] = async (
 
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+  const table = await TableMetadata.query()
+    .withGraphFetched('columns')
+    .findById(tableId)
+    .throwIfNotFound()
 
   if (!(await table.validateRows([data]))) {
     throw new Error('Invalid column id')
   }
 
-  const row = await createTableRow({ tableId, data })
+  const gsis = TableColumnMetadata.getGsisFromColumns(table.columns)
+
+  const row = await createTableRow({ tableId, data, gsis })
 
   return row.rowId
 }

--- a/packages/backend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-rows.ts
@@ -1,5 +1,6 @@
 import { createTableRows } from '@/models/dynamodb/table-row'
 import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
@@ -13,13 +14,18 @@ const createRows: MutationResolvers['createRows'] = async (
 
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+  const table = await TableMetadata.query()
+    .withGraphFetched('columns')
+    .findById(tableId)
+    .throwIfNotFound()
 
   if (!(await table.validateRows(dataArray))) {
     throw new Error('Invalid column id')
   }
 
-  await createTableRows({ tableId, dataArray })
+  const gsis = TableColumnMetadata.getGsisFromColumns(table.columns)
+
+  await createTableRows({ tableId, dataArray, gsis })
 
   return true
 }

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -1,5 +1,6 @@
 import { updateTableRow } from '@/models/dynamodb/table-row'
 import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
@@ -13,13 +14,18 @@ const updateRow: MutationResolvers['updateRow'] = async (
 
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+  const table = await TableMetadata.query()
+    .withGraphFetched('columns')
+    .findById(tableId)
+    .throwIfNotFound()
 
   if (!(await table.validateRows([data]))) {
     throw new Error('Invalid column id')
   }
 
-  await updateTableRow({ tableId, rowId, data })
+  const gsis = TableColumnMetadata.getGsisFromColumns(table.columns)
+
+  await updateTableRow({ tableId, rowId, data, gsis })
 
   return rowId
 }

--- a/packages/backend/src/models/__tests__/table-column-metadata.test.ts
+++ b/packages/backend/src/models/__tests__/table-column-metadata.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import TableColumnMetadata from '../table-column-metadata'
+
+describe('TableColumnMetadata', () => {
+  describe('getGsisFromColumns', () => {
+    it('returns GSI options for columns with ready GSI status', () => {
+      const columns = [
+        {
+          id: '1',
+          config: { gsi: { status: 'ready', indexName: 'index1' } },
+        },
+        {
+          id: '2',
+          config: { gsi: { status: 'pending', indexName: 'index2' } },
+        },
+        {
+          id: '3',
+          config: { gsi: { status: 'ready', indexName: 'index3' } },
+        },
+      ] as TableColumnMetadata[]
+
+      const result = TableColumnMetadata.getGsisFromColumns(columns)
+
+      expect(result).toEqual([
+        {
+          indexName: 'index1',
+          columnIdToMap: '1',
+        },
+        {
+          indexName: 'index3',
+          columnIdToMap: '3',
+        },
+      ])
+    })
+
+    it('returns empty array when no columns have ready GSI status', () => {
+      const columns = [
+        {
+          id: '1',
+          config: {
+            gsi: { status: 'pending', indexName: 'gsi1', type: 'string' },
+          },
+        },
+        {
+          id: '2',
+          config: {},
+        },
+      ] as TableColumnMetadata[]
+
+      const result = TableColumnMetadata.getGsisFromColumns(columns)
+
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/packages/backend/src/models/__tests__/table-column-metadata.test.ts
+++ b/packages/backend/src/models/__tests__/table-column-metadata.test.ts
@@ -4,7 +4,7 @@ import TableColumnMetadata from '../table-column-metadata'
 
 describe('TableColumnMetadata', () => {
   describe('getGsisFromColumns', () => {
-    it('returns GSI options for columns with ready GSI status', () => {
+    it('returns GSI options for columns of any status', () => {
       const columns = [
         {
           id: '1',
@@ -28,18 +28,22 @@ describe('TableColumnMetadata', () => {
           columnIdToMap: '1',
         },
         {
+          indexName: 'index2',
+          columnIdToMap: '2',
+        },
+        {
           indexName: 'index3',
           columnIdToMap: '3',
         },
       ])
     })
 
-    it('returns empty array when no columns have ready GSI status', () => {
+    it('returns empty array when no columns have GSI of any status', () => {
       const columns = [
         {
           id: '1',
           config: {
-            gsi: { status: 'pending', indexName: 'gsi1', type: 'string' },
+            width: 120,
           },
         },
         {

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -15,6 +15,7 @@ import {
   type CreateRowInput,
   type CreateRowsInput,
   type DeleteRowsInput,
+  GSIS,
   type PatchRowInput,
   type TableRowFilter,
   TableRowFilterOperator,
@@ -95,10 +96,11 @@ const generateProjectionExpressions = ({
   ProjectionExpression: string
   ExpressionAttributeNames: Record<string, string>
 } => {
+  const gsiUsed = GSIS.find((g) => g.gsi === indexUsed)
   const ProjectionExpression = [
     'rowId',
     ...columnIds.map((_id, i) => `#data.#col${i}`),
-    ...(indexUsed === 'gsiString1' ? ['skString1'] : []),
+    ...(gsiUsed ? [gsiUsed.sk] : []),
     ...(includeTimestamps ? ['createdAt', 'updatedAt'] : []),
   ].join(',')
   // #pk has to be mapped since it's used by electrodb
@@ -111,8 +113,8 @@ const generateProjectionExpressions = ({
   if (indexUsed === 'byRowId') {
     ExpressionAttributeNames['#sk1'] = 'rowId'
   }
-  if (indexUsed === 'gsiString1') {
-    ExpressionAttributeNames['#sk1'] = 'skString1'
+  if (gsiUsed) {
+    ExpressionAttributeNames['#sk1'] = gsiUsed.sk
   }
   // Add attribute name mapping for column name projection
   columnIds.forEach((id: string, i: number) => {

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -4,7 +4,7 @@ import client, { tableName } from '@/config/dynamodb'
 
 import { autoMarshallDataObj } from '../helpers'
 
-import type { GsiOptions } from './types'
+import { GsiOptions, GSIS, TableRowSortKeyName } from './types'
 
 export const TableRow = new Entity(
   {
@@ -126,12 +126,10 @@ export function constructDataWithGsis(
 export function getGsiSortKey(
   gsis: GsiOptions[],
   columnId: string,
-): 'skString1' | undefined {
+): TableRowSortKeyName | undefined {
   const correspondingGsi = gsis.find((gsi) => gsi.columnIdToMap === columnId)
-  switch (correspondingGsi?.indexName) {
-    case 'gsiString1':
-      return 'skString1'
-    default:
-      return undefined
-  }
+  const correspondingSk = GSIS.find(
+    (g) => g.gsi === correspondingGsi?.indexName,
+  )
+  return correspondingSk?.sk
 }

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -61,7 +61,7 @@ class TableColumnMetadata extends Base {
   ): GsiOptions[] => {
     return columns
       .map((column) => {
-        if (column.config?.gsi?.status === 'ready') {
+        if (column.config?.gsi) {
           return {
             indexName: column.config.gsi.indexName as TableRowIndexName,
             columnIdToMap: column.id,

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -2,6 +2,7 @@ import { IGlobalVariable, ITableColumnConfig } from '@plumber/types'
 
 import StepError from '@/errors/step'
 
+import type { GsiOptions, TableRowIndexName } from './dynamodb/table-row/types'
 import Base from './base'
 import TableMetadata from './table-metadata'
 
@@ -53,6 +54,21 @@ class TableColumnMetadata extends Base {
       )
     }
     return columns
+  }
+
+  static getGsisFromColumns = (
+    columns: TableColumnMetadata[],
+  ): GsiOptions[] => {
+    return columns
+      .map((column) => {
+        if (column.config?.gsi?.status === 'ready') {
+          return {
+            indexName: column.config.gsi.indexName as TableRowIndexName,
+            columnIdToMap: column.id,
+          }
+        }
+      })
+      .filter(Boolean)
   }
 }
 


### PR DESCRIPTION
## Changes
Added support for GSI in actions and mutations

### What changed?

- Enhanced `createRow`, `createRows`, and `updateRow` operations to support GSIs
- Added a new utility method `getGsisFromColumns` to `TableColumnMetadata` to extract GSI configurations from table columns
