### PR TITLE
PLU-416 [GSI-6]: ensure partial update of table column metadata config

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import updateTable from '@/graphql/mutations/tiles/update-table'
+import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -159,6 +160,42 @@ describe('update table mutation', () => {
         context,
       )
       expect(updatedTable.columns[0].config.width).toBe(100)
+    })
+
+    it('should modify column widths without overwriting other config', async () => {
+      await TableColumnMetadata.query()
+        .patch({
+          config: {
+            gsi: {
+              indexName: 'gsiString1',
+              type: 'string',
+              status: 'pending',
+            },
+          },
+        })
+        .where({ id: dummyColumnId })
+      const updatedTable = await updateTable(
+        null,
+        {
+          input: {
+            id: dummyTable.id,
+            addedColumns: [],
+            modifiedColumns: [
+              {
+                id: dummyColumnId,
+                name: 'New Column Name',
+                config: {
+                  width: 100,
+                },
+              },
+            ],
+            deletedColumns: [],
+          },
+        },
+        context,
+      )
+      expect(updatedTable.columns[0].config.width).toBe(100)
+      expect(updatedTable.columns[0].config.gsi.indexName).toBe('gsiString1')
     })
 
     it('should fail if column does not exist', async () => {

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -1,3 +1,4 @@
+import { DataPropertyNames } from 'objection'
 import pLimit from 'p-limit'
 import { z } from 'zod'
 
@@ -75,11 +76,15 @@ const updateTable: MutationResolvers['updateTable'] = async (
       // we're setting a concurrency limit of 5.
       await Promise.all(
         modifiedColumns.map(async (column) => {
-          const { id, ...rest } = column
+          const { id, config, ...rest } = column
           return limit(() =>
             table
               .$relatedQuery('columns', trx)
-              .patchAndFetchById(id, rest)
+              .patchAndFetchById(id, {
+                ...rest,
+                ['config:width' as DataPropertyNames<TableColumnMetadata>]:
+                  config?.width,
+              })
               .throwIfNotFound(),
           )
         }),


### PR DESCRIPTION
## Problem
Currently, update-table mutation, replaces the entire config column in table column metadata. This will be a problem once we add gsis into the config.

## Solution
Only patch the `width` key