### PR TITLE
PLU-416 [GSI-7]: add mutation to allow adding of gsi - admin only

### DIFF
--- a/packages/backend/src/graphql/admin/mutations/add-gsi.ts
+++ b/packages/backend/src/graphql/admin/mutations/add-gsi.ts
@@ -1,0 +1,56 @@
+import { flattenJsonb } from '@/helpers/knex-jsonb-flatten'
+import { GSIS } from '@/models/dynamodb/table-row'
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+import type { AdminMutationResolvers } from '../../__generated__/types.generated'
+
+const createTable: AdminMutationResolvers['addGsi'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { tableId, columnId, indexName } = params.input
+
+  if (!tableId || !columnId) {
+    throw new Error('Table id and column id required')
+  }
+
+  const correspondingGsi = GSIS.find((g) => g.gsi === indexName)
+  if (!correspondingGsi) {
+    throw new Error('Invalid index name')
+  }
+
+  const table = await context.currentUser
+    .$relatedQuery('tables')
+    .findById(tableId)
+    .withGraphFetched('columns')
+    .throwIfNotFound()
+
+  const correspondingColumn = table.columns.find((c) => c.id === columnId)
+  if (!correspondingColumn) {
+    throw new Error('Column not found')
+  }
+
+  const alreadyHasGsi = table.columns.some((c) => !!c.config.gsi)
+  if (alreadyHasGsi) {
+    throw new Error('Table already has a GSI')
+  }
+
+  await TableColumnMetadata.query()
+    .patch(
+      flattenJsonb({
+        config: {
+          gsi: {
+            indexName: correspondingGsi.gsi,
+            type: correspondingGsi.type,
+            status: 'pending',
+          },
+        },
+      }),
+    )
+    .where({ id: columnId })
+
+  return true
+}
+
+export default createTable

--- a/packages/backend/src/graphql/admin/mutations/add-gsi.ts
+++ b/packages/backend/src/graphql/admin/mutations/add-gsi.ts
@@ -1,4 +1,5 @@
-import { flattenJsonb } from '@/helpers/knex-jsonb-flatten'
+import { DataPropertyNames } from 'objection'
+
 import { GSIS } from '@/models/dynamodb/table-row'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
@@ -37,17 +38,14 @@ const createTable: AdminMutationResolvers['addGsi'] = async (
   }
 
   await TableColumnMetadata.query()
-    .patch(
-      flattenJsonb({
-        config: {
-          gsi: {
-            indexName: correspondingGsi.gsi,
-            type: correspondingGsi.type,
-            status: 'pending',
-          },
-        },
-      }),
-    )
+    .patch({
+      ['config:gsi' as DataPropertyNames<TableColumnMetadata>]: {
+        indexName: correspondingGsi.gsi,
+        type: correspondingGsi.type,
+        status: 'pending',
+        patchFrom: new Date().toISOString(),
+      },
+    })
     .where({ id: columnId })
 
   return true

--- a/packages/backend/src/graphql/admin/mutations/index.ts
+++ b/packages/backend/src/graphql/admin/mutations/index.ts
@@ -1,0 +1,7 @@
+import type { AdminMutationResolvers } from '../../__generated__/types.generated'
+
+import addGsi from './add-gsi'
+
+export default {
+  addGsi,
+} satisfies AdminMutationResolvers

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -82,4 +82,9 @@ export default {
   deleteUploadedFile,
   generatePresignedUrl,
   ...tilesMutationResolvers,
+
+  // This is a special stub that enables us to group all our admin-related
+  // mutations into a special AdminMutation object; each "mutations" is handled by field
+  // resolvers defined in @/graphql/admin/mutations.
+  admin: () => ({}),
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -1,4 +1,7 @@
-import type { MutationResolvers } from './__generated__/types.generated'
+import type {
+  AdminMutation,
+  MutationResolvers,
+} from './__generated__/types.generated'
 import bulkRetryExecutions from './mutations/bulk-retry-executions'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
@@ -86,5 +89,5 @@ export default {
   // This is a special stub that enables us to group all our admin-related
   // mutations into a special AdminMutation object; each "mutations" is handled by field
   // resolvers defined in @/graphql/admin/mutations.
-  admin: () => ({}),
+  admin: () => ({} as AdminMutation),
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/resolvers.ts
+++ b/packages/backend/src/graphql/resolvers.ts
@@ -1,4 +1,5 @@
 import type { Resolvers } from './__generated__/types.generated'
+import adminMutationResolvers from './admin/mutations'
 import adminQueryResolvers from './admin/queries'
 import customResolvers from './custom-resolvers'
 import mutationResolvers from './mutation-resolvers'
@@ -8,5 +9,6 @@ export default {
   Query: queryResolvers,
   Mutation: mutationResolvers,
   AdminQuery: adminQueryResolvers,
+  AdminMutation: adminMutationResolvers,
   ...customResolvers,
 } satisfies Resolvers

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -115,6 +115,12 @@ type Mutation {
   # Flow transfers
   createFlowTransfer(input: CreateFlowTransferInput!): FlowTransfer!
   updateFlowTransferStatus(input: UpdateFlowTransferStatusInput): FlowTransfer!
+  # Admin mutations
+  admin: AdminMutation!
+}
+
+type AdminMutation {
+  addGsi(input: AddGsiInput!): Boolean
 }
 
 """
@@ -762,6 +768,13 @@ input DeleteTableInput {
 
 type TableColumnConfig {
   width: Int
+  gsi: TableColumnGsiConfig
+}
+
+type TableColumnGsiConfig {
+  indexName: String!
+  type: String!
+  status: String!
 }
 
 type TableColumnMetadata {
@@ -834,6 +847,13 @@ input DeleteTableRowsInput {
   tableId: ID!
   rowIds: [ID!]!
 }
+
+input AddGsiInput {
+  tableId: ID!
+  columnId: ID!
+  indexName: String!
+}
+
 # End Tiles row types
 
 type AppHealth {

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -103,8 +103,11 @@ const authentication = shield(
       // Not OTP, but no real reason to be looser than OTP.
       loginWithSgid: rateLimitRule({ window: '1s', max: 5 }),
       loginWithSelectedSgid: rateLimitRule({ window: '1s', max: 5 }),
+      // Only admins can access admin mutations, we dont want to default it in '*'
       admin: isAdminOperation,
     },
+    // This is not needed since it's already added above
+    // but adding it here in case we want to make more granular in the future
     AdminMutation: isAdminOperation,
   },
   {

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -103,7 +103,9 @@ const authentication = shield(
       // Not OTP, but no real reason to be looser than OTP.
       loginWithSgid: rateLimitRule({ window: '1s', max: 5 }),
       loginWithSelectedSgid: rateLimitRule({ window: '1s', max: 5 }),
+      admin: isAdminOperation,
     },
+    AdminMutation: isAdminOperation,
   },
   {
     allowExternalErrors: true,


### PR DESCRIPTION
## Changes
A new admin-only mutation `addGsi` that allows admins to add a GSI into the column's config.

- AddGsi mutation - basically adds a gsi object into the config (indexName, status = 'pending', patchFrom and type)
- Add a new resolver group - AdminMutations
- Ensure only admins can call these mutations

## To test
- Ensure that this mutation cannot be called by normal users
- Ensure that a GSI cannot be added if a GSI already exists in the table
- Use the new admin portal to test creation of gsi