### PR TITLE
PLU-416 [GSI-8]: admin mutation to patch rows for GSI population

### DIFF
--- a/packages/backend/src/graphql/admin/mutations/index.ts
+++ b/packages/backend/src/graphql/admin/mutations/index.ts
@@ -1,7 +1,9 @@
 import type { AdminMutationResolvers } from '../../__generated__/types.generated'
 
 import addGsi from './add-gsi'
+import patchGsiRows from './patch-gsi-rows'
 
 export default {
   addGsi,
+  patchGsiRows,
 } satisfies AdminMutationResolvers

--- a/packages/backend/src/graphql/admin/mutations/patch-gsi-rows.ts
+++ b/packages/backend/src/graphql/admin/mutations/patch-gsi-rows.ts
@@ -1,0 +1,188 @@
+import { DataPropertyNames } from 'objection'
+import pLimit from 'p-limit'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { castGsiValue, GSIS, TableRow } from '@/models/dynamodb/table-row'
+import TableCollaborator from '@/models/table-collaborators'
+import TableColumnMetadata from '@/models/table-column-metadata'
+
+import type { AdminMutationResolvers } from '../../__generated__/types.generated'
+
+const DEFAULT_PATCH_LIMIT = 1000
+
+/**
+ * This function patches the relevant column into the sort key for a given GSI
+ *
+ * @input
+ * tableId: string - ID of table to patch
+ * columnId: string - ID of column to patch from
+ * limit: number - Maximum number of rows to patch
+ * returnCount: boolean - Whether to return the number of rows left to patch
+ * (this will usually be set to true for the first call)
+ *
+ * @output
+ * numRowsPatched: number - Number of rows patched
+ * numRowsLeftToPatch: number - Number of rows left to patch (only returned if returnCount is true)
+ * hasMore: boolean - Whether there are more rows to patch
+ */
+
+const patchGsiRows: AdminMutationResolvers['patchGsiRows'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { tableId, columnId, limit: limitInput, returnCount } = params.input
+
+  /**
+   * Default limit is 1000
+   */
+  const limit = limitInput ?? DEFAULT_PATCH_LIMIT
+
+  if (!tableId || !columnId || limit <= 0) {
+    throw new BadUserInputError('Invalid input')
+  }
+
+  /**
+   * Checks that the admin is access the table from an editor or above account
+   */
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+
+  /**
+   * Gets the gsi config for the column to patch from
+   */
+  const { config } = await TableColumnMetadata.query()
+    .findById(columnId)
+    .throwIfNotFound()
+
+  if (!config.gsi) {
+    throw new BadUserInputError('Column does not have a GSI')
+  }
+
+  /**
+   * GSI MUST be a valid GSI
+   * status MUST be pending
+   * patchFrom MUST be set
+   */
+  const correspondingGsi = GSIS.find((gsi) => gsi.gsi === config.gsi.indexName)
+  if (
+    config.gsi.status !== 'pending' ||
+    !config.gsi.patchFrom ||
+    !correspondingGsi
+  ) {
+    throw new BadUserInputError('GSI status is invalid or no patchFrom date')
+  }
+
+  /**
+   * Gets the rows to patch in descending order of createdAt
+   * Only rows before the patchFrom date are included
+   */
+  const { data: rowsToPatch, cursor } = await TableRow.query
+    .byCreatedAt({
+      tableId,
+    })
+    .lt({ createdAt: new Date(config.gsi.patchFrom).getTime() })
+    .go({
+      order: 'desc',
+      limit,
+      ignoreOwnership: true,
+    })
+
+  /**
+   * We update with a concurrency of 10 to prevent overloading the partition
+   * and server
+   */
+  const updateLimit = pLimit(100)
+
+  await Promise.all(
+    /**
+     * For each row, we update the GSI sort key with the value of the column
+     * to patch from
+     */
+    rowsToPatch.map(async (item) => {
+      await updateLimit(async () => {
+        /**
+         * 1. Read original value of column to patch from
+         * 2. Cast the original value to a string (since our sort key is a string for now)
+         * 3. Update the GSI sort key with the casted value
+         * PS: Since this is not an atomic operation, we need to ensure that
+         * the original value is still the same when we update the GSI sort key
+         * If not, this throws an error and the whole batch has to be re-run
+         */
+        const row = await TableRow.get({
+          tableId,
+          rowId: item.rowId,
+        }).go({
+          ignoreOwnership: true,
+        })
+        if (!row) {
+          throw new Error('Row not found')
+        }
+
+        const originalValue = row.data.data[columnId]
+        const valueToPatch = castGsiValue(originalValue)
+
+        return TableRow.update({ tableId, rowId: item.rowId })
+          .data((row, { set, remove }) => {
+            /**
+             * If undefined/nullish or empty string, remove the sort key
+             * Otherwise, set the sort key to the value to patch
+             */
+            if (valueToPatch != null) {
+              set(row[correspondingGsi.sk], valueToPatch)
+            } else {
+              remove(row[correspondingGsi.sk])
+            }
+          })
+          .where(({ data }, { eq }) => eq(data[columnId], originalValue))
+          .go({
+            ignoreOwnership: true,
+          })
+      })
+    }),
+  )
+
+  const hasMore = rowsToPatch.length === 0 || !!cursor
+
+  /**
+   * We get the last(earliest) createdAt of the rows to patch
+   * This will be used to update the patchFrom date
+   */
+  const lastPatchedCreatedAt = rowsToPatch[rowsToPatch.length - 1].createdAt
+
+  await TableColumnMetadata.query()
+    .patch({
+      ['config:gsi' as DataPropertyNames<TableColumnMetadata>]: {
+        ...config.gsi,
+        status: hasMore ? 'pending' : 'ready',
+        patchFrom: hasMore
+          ? new Date(lastPatchedCreatedAt).toISOString()
+          : undefined,
+      },
+    })
+    .where({ id: columnId })
+
+  /**
+   * If returnCount is true, we get the number of rows left to patch
+   */
+  let numRowsLeftToPatch
+  if (returnCount) {
+    const numRowsLeftToPatchRes = await TableRow.query
+      .byCreatedAt({
+        tableId,
+      })
+      .lt({ createdAt: lastPatchedCreatedAt })
+      .go({
+        pages: 'all',
+        attributes: ['rowId'],
+      })
+    numRowsLeftToPatch = numRowsLeftToPatchRes.data.length
+  }
+
+  return {
+    numRowsPatched: rowsToPatch.length,
+    numRowsLeftToPatch,
+    hasMore,
+  }
+}
+
+export default patchGsiRows

--- a/packages/backend/src/graphql/admin/mutations/patch-gsi-rows.ts
+++ b/packages/backend/src/graphql/admin/mutations/patch-gsi-rows.ts
@@ -91,7 +91,7 @@ const patchGsiRows: AdminMutationResolvers['patchGsiRows'] = async (
    * We update with a concurrency of 10 to prevent overloading the partition
    * and server
    */
-  const updateLimit = pLimit(100)
+  const updateLimit = pLimit(10)
 
   await Promise.all(
     /**

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -120,7 +120,8 @@ type Mutation {
 }
 
 type AdminMutation {
-  addGsi(input: AddGsiInput!): Boolean
+  addGsi(input: AddGsiInput!): Boolean!
+  patchGsiRows(input: PatchGsiRowsInput!): PatchGsiRowsResult!
 }
 
 """
@@ -852,6 +853,19 @@ input AddGsiInput {
   tableId: ID!
   columnId: ID!
   indexName: String!
+}
+
+input PatchGsiRowsInput {
+  tableId: ID!
+  columnId: ID!
+  limit: Int
+  returnCount: Boolean
+}
+
+type PatchGsiRowsResult {
+  numRowsPatched: Int!
+  numRowsLeftToPatch: Int
+  hasMore: Boolean!
 }
 
 # End Tiles row types

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -856,6 +856,12 @@ describe('dynamodb table row functions', () => {
         const originalRow = await createTableRow({
           tableId: dummyTable.id,
           data,
+          gsis: [
+            {
+              indexName: 'gsiString1',
+              columnIdToMap: dummyColumnIds[0],
+            },
+          ],
         })
         const patchData = {
           set: {
@@ -896,8 +902,7 @@ describe('dynamodb table row functions', () => {
         const data = generateMockTableRowData({
           columnIds: dummyColumnIds,
         })
-        const row = await createTableRow({ tableId: dummyTable.id, data })
-        await createTableRow({
+        const row = await createTableRow({
           tableId: dummyTable.id,
           data: { ...data, [dummyColumnIds[0]]: value },
           gsis: [
@@ -930,7 +935,11 @@ describe('dynamodb table row functions', () => {
         const data = generateMockTableRowData({
           columnIds: dummyColumnIds,
         })
-        const row = await createTableRow({ tableId: dummyTable.id, data })
+        const row = await createTableRow({
+          tableId: dummyTable.id,
+          data,
+          gsis: [{ indexName: 'gsiString1', columnIdToMap: dummyColumnIds[0] }],
+        })
         await updateTableRow({
           tableId: dummyTable.id,
           rowId: row.rowId,

--- a/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/dynamodb/__tests__/table-row/functions.itest.ts
@@ -543,7 +543,7 @@ describe('dynamodb table row functions', () => {
       const updatedRow = await patchTableRow({
         tableId: dummyTable.id,
         rowId: row.rowId,
-        patchData: { [dummyColumnIds[0]]: '123' },
+        patchData: { set: { [dummyColumnIds[0]]: '123' } },
       })
       expect(updatedRow.updatedAt).toBeGreaterThan(row.updatedAt)
     })

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -288,7 +288,7 @@ export const patchTableRow = async ({
           set(row.data[key], value ? autoMarshallNumberStrings(value) : null)
           const sortKey = getGsiSortKey(gsis, key)
           if (sortKey) {
-            if (castGsiValue(value)) {
+            if (castGsiValue(value) != null) {
               set(row[sortKey], castGsiValue(value))
             } else {
               remove(row[sortKey])

--- a/packages/backend/src/models/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/dynamodb/table-row/functions.ts
@@ -22,6 +22,7 @@ import {
   type TableRowIndexName,
   type TableRowItem,
   type TableRowOutput,
+  TableRowSortKeyName,
   type UpdateRowInput,
 } from './types'
 
@@ -255,11 +256,26 @@ export const updateTableRow = async ({
   gsis = [],
 }: UpdateRowInput): Promise<void> => {
   try {
+    const { data: dataWithoutNullish, ...rest } = constructDataWithGsis(
+      data,
+      gsis,
+    )
     await TableRow.patch({
       tableId,
       rowId,
     })
-      .set(constructDataWithGsis(data, gsis))
+      .data((row, { set, remove }) => {
+        set(row.data, dataWithoutNullish)
+        Object.entries(rest || {}).forEach(
+          ([sortKey, value]: [TableRowSortKeyName, string]) => {
+            if (value != null) {
+              set(row[sortKey], value)
+            } else {
+              remove(row[sortKey])
+            }
+          },
+        )
+      })
       .go({
         ignoreOwnership: true,
       })
@@ -301,6 +317,11 @@ export const patchTableRow = async ({
       Object.entries(patchData.add || {}).forEach(
         ([key, value]: [string, string]) => {
           add(row.data[key], autoMarshallNumberStrings(value))
+          // since we only support string sks for now, we need to remove the sort key
+          const sortKey = getGsiSortKey(gsis, key)
+          if (sortKey) {
+            remove(row[sortKey])
+          }
         },
       )
 
@@ -308,6 +329,11 @@ export const patchTableRow = async ({
       Object.entries(patchData.subtract || {}).forEach(
         ([key, value]: [string, string]) => {
           subtract(row.data[key], autoMarshallNumberStrings(value))
+          // since we only support string sks for now, we need to remove the sort key
+          const sortKey = getGsiSortKey(gsis, key)
+          if (sortKey) {
+            remove(row[sortKey])
+          }
         },
       )
     })

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -36,10 +36,19 @@ export const TableRow = new Entity(
       },
       updatedAt: {
         type: 'number',
-        watch: ['data'],
+        watch: '*',
         required: true,
         default: () => Date.now(),
-        set: () => Date.now(),
+        set: (_, changeObject) => {
+          /**
+           * We only update the updatedAt if the data is being updated
+           * This is to prevent updating the updatedAt when patching GSI
+           */
+          const keys = Object.keys(changeObject)
+          if (keys.some((key) => key === 'data' || key.startsWith('data.'))) {
+            return Date.now()
+          }
+        },
       },
       skString1: {
         type: 'string',

--- a/packages/backend/src/models/dynamodb/table-row/model.ts
+++ b/packages/backend/src/models/dynamodb/table-row/model.ts
@@ -36,7 +36,7 @@ export const TableRow = new Entity(
       },
       updatedAt: {
         type: 'number',
-        watch: '*',
+        watch: ['data'],
         required: true,
         default: () => Date.now(),
         set: () => Date.now(),

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -886,6 +886,7 @@ export interface ITableColumnConfig {
     indexName: string
     type: 'string' | 'number'
     status: 'pending' | 'ready' | 'error'
+    patchFrom?: string
   }
 }
 


### PR DESCRIPTION
## Changes

Added a new `patchGsiRows` mutation for admins to patch the sort key for the new GSI

- new `patchGsiRows` mutation that patches the column value to the sort key
  - casts the value to string
  - ensures that the original value has not been updated during the patch (prevent race condition)
  - removes sort key if the value is nullish / empty
  - does this in batches of 1000
- Extended the `ITableColumnConfig` interface to include an optional `patchFrom` field. This `patchFrom` acts as a cursor to patch the rows in batches.
- Modified the `updatedAt` watch property in TableRow model to only watch 'data' changes. This is to prevent the updatedAt from changing when we patch the rows.

### How to test?

1. Use an existing tile (> 1k rows)
2. Use the admin portal to add a GSI
3. Use the admin portal to patch the rows
4. Verify that the sort keys are updated correctly
