### PR TITLE
PLU-343 [FIND-SINGLE-ROW-1]: tiles find-single-row should return all columns + row id even if no rows found

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -159,4 +159,21 @@ describe('tiles create row action', () => {
       order: 'desc',
     })
   })
+
+  it('should return an empty columns if no rows are found', async () => {
+    const filters = $.step.parameters.filters as TableRowFilter[]
+    filters[0].value = 'not a valid value'
+    await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+    const emptyRow = dummyColumnIds.reduce((acc, c) => {
+      acc[c] = ''
+      return acc
+    }, {} as Record<string, string>)
+    expect($.setActionItem).toBeCalledWith({
+      raw: {
+        rowsFound: 0,
+        rowId: '',
+        row: emptyRow,
+      },
+    })
+  })
 })

--- a/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/get-data-out-metadata.ts
@@ -18,9 +18,11 @@ async function getDataOutMetadata(
   const metadata: IDataOutMetadata = {
     rowId: {
       label: 'Row ID',
+      order: 2,
     },
     rowsFound: {
       label: 'Rows found',
+      order: 1,
     },
   }
   const rowData = (dataOut as FindSingleRowOutput).row

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -190,9 +190,16 @@ const action: IRawAction = {
     })
 
     if (!rows || !rows.length) {
+      const emptyRow = columns.reduce((acc, c) => {
+        acc[c.id] = ''
+        return acc
+      }, {} as Record<string, string>)
+
       $.setActionItem({
         raw: {
           rowsFound: 0,
+          rowId: '',
+          row: emptyRow,
         } satisfies FindSingleRowOutput,
       })
       return

--- a/packages/backend/src/apps/tiles/common/column-name-metadata.ts
+++ b/packages/backend/src/apps/tiles/common/column-name-metadata.ts
@@ -22,7 +22,8 @@ export async function generateColumnNameMetadata(
   columns.forEach((column) => {
     columnMetadata[column.id] = {
       label: column.name,
-      order: column.position,
+      // + 2 to ensure that the rowId an rowCount come first
+      order: column.position + 2,
     }
   })
   return { [parentKey]: columnMetadata }


### PR DESCRIPTION
### Problem

"Find Single Row" action does not return columns and row ID when no rows are found, making it difficult for users to set up the "Update Row" step.

### Solution
- Modified the `find-single-row` action to return an empty row ID and an empty row object with all columns set to empty strings when no rows are found
- Added ordering for `rowsFound` and `rowId` to appear before column data
- Added a test case to verify the behaviour when no rows are found

### How to test?

1. Create a "Find Single Row" action with filters that won't match any rows
2. Run the action and verify that:
   - `Row Found` is set to 0
   - `Row ID` is an empty string
   - All column values are empty strings
   - The metadata fields are properly ordered
