### PR TITLE
PLU-467 [HOTFIX]: slow GetFlows query when query planner does a poor job

### DIFF
--- a/packages/backend/src/graphql/queries/get-flows.ts
+++ b/packages/backend/src/graphql/queries/get-flows.ts
@@ -1,4 +1,5 @@
 import paginate from '@/helpers/pagination'
+import Flow from '@/models/flow'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -7,31 +8,55 @@ const getFlows: QueryResolvers['getFlows'] = async (
   params,
   context,
 ) => {
-  const flowsQuery = context.currentUser
-    .$relatedQuery('flows')
-    .joinRelated({
-      steps: true,
+  const filteredFlowIds = (
+    await context.currentUser
+      .$relatedQuery('flows')
+      .distinct('id')
+      .where((builder) => {
+        if (params.name) {
+          builder.where('name', 'ilike', `%${params.name}%`)
+        }
+      })
+  ).map((f) => f.id)
+
+  if (!filteredFlowIds.length) {
+    return {
+      pageInfo: {
+        currentPage: 1,
+        totalCount: 0,
+      },
+      edges: [],
+    }
+  }
+
+  const flowsQuery = Flow.query()
+    .with('filtered_steps', (builder) => {
+      builder
+        .distinct('flow_id')
+        .from('steps')
+        .where((stepBuilder) => {
+          if (params.connectionId) {
+            stepBuilder.where('connection_id', params.connectionId)
+          }
+
+          if (params.appKey) {
+            stepBuilder.where('app_key', params.appKey)
+          }
+
+          stepBuilder.withSoftDeleted()
+        })
+        .whereNull('deleted_at')
+        .whereIn('flow_id', filteredFlowIds)
+        .withSoftDeleted()
     })
+    .innerJoin('filtered_steps', 'id', 'filtered_steps.flow_id')
     .withGraphFetched({
       steps: {
         connection: true,
       },
       pendingTransfer: true,
     })
-    .where((builder) => {
-      if (params.connectionId) {
-        builder.where('steps.connection_id', params.connectionId)
-      }
-
-      if (params.name) {
-        builder.where('flows.name', 'ilike', `%${params.name}%`)
-      }
-
-      if (params.appKey) {
-        builder.where('steps.app_key', params.appKey)
-      }
-    })
-    .groupBy('flows.id')
+    .groupBy('id')
     .orderBy('active', 'desc')
     .orderBy('updated_at', 'desc')
 


### PR DESCRIPTION
## Problem

GetFlows endpoint and db query is slow for some users (e.g. myself)

## Solution

Fetch the filtered slows and steps first to make it more deliberate. See notion: https://www.notion.so/opengov/GetFlows-query-slow-1df77dbba788808d9c9fe1f1f9be5bc7?pvs=4 for more details.

## What to test
- [ ] Retrieving all pipes works
- [ ] Filtering and paginate pipes work
- [ ] Able to view all pipes for a given app
- [ ] Able to view all pipes for a given connection