### PR TITLE
PLU-462 [FIX]: too many sigterm listeners on process

### DIFF
--- a/packages/backend/src/queues/action.ts
+++ b/packages/backend/src/queues/action.ts
@@ -7,6 +7,7 @@ import {
 } from '@taskforcesh/bullmq-pro'
 
 import apps from '@/apps'
+import logger from '@/helpers/logger'
 import { makeActionQueue } from '@/queues/helpers/make-action-queue'
 
 //
@@ -133,3 +134,10 @@ export async function getActionJob(
   const { queueName, bullMqJobId } = parseActionJobId(actionJobId)
   return await actionQueuesByName[queueName].getJob(bullMqJobId)
 }
+
+process.on('SIGTERM', async () => {
+  logger.info('SIGTERM: gracefully closing all action queues')
+  const allQueues = [mainActionQueue, ...Object.values(actionQueuesByName)]
+  await Promise.all(allQueues.map((q) => q.close()))
+  logger.info('SIGTERM: all action queues closed')
+})

--- a/packages/backend/src/queues/action.ts
+++ b/packages/backend/src/queues/action.ts
@@ -138,6 +138,6 @@ export async function getActionJob(
 process.on('SIGTERM', async () => {
   logger.info('SIGTERM: gracefully closing all action queues')
   const allQueues = [mainActionQueue, ...Object.values(actionQueuesByName)]
-  await Promise.all(allQueues.map((q) => q.close()))
+  await Promise.all(allQueues.map((q) => q?.close()))
   logger.info('SIGTERM: all action queues closed')
 })

--- a/packages/backend/src/queues/helpers/make-action-queue.ts
+++ b/packages/backend/src/queues/helpers/make-action-queue.ts
@@ -31,9 +31,5 @@ export function makeActionQueue(
     }
   })
 
-  process.on('SIGTERM', async () => {
-    await queue.close()
-  })
-
   return queue
 }

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -43,6 +43,6 @@ for (const [appKey, app] of Object.entries(apps)) {
 process.on('SIGTERM', async () => {
   logger.info('SIGTERM: gracefully closing all action workers')
   const allWorkers = [mainActionWorker, ...Object.values(appActionWorkers)]
-  await Promise.all(allWorkers.map((w) => w.close()))
+  await Promise.all(allWorkers.map((w) => w?.close()))
   logger.info('SIGTERM: all action workers closed')
 })

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -1,4 +1,5 @@
 import apps from '@/apps'
+import logger from '@/helpers/logger'
 import {
   appActionQueues,
   MAIN_ACTION_QUEUE_NAME,
@@ -38,3 +39,10 @@ for (const [appKey, app] of Object.entries(apps)) {
     queueConfig: app.queue,
   })
 }
+
+process.on('SIGTERM', async () => {
+  logger.info('SIGTERM: gracefully closing all action workers')
+  const allWorkers = [mainActionWorker, ...Object.values(appActionWorkers)]
+  await Promise.all(allWorkers.map((w) => w.close()))
+  logger.info('SIGTERM: all action workers closed')
+})

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -290,9 +290,5 @@ export function makeActionWorker(
     })
   })
 
-  process.on('SIGTERM', async () => {
-    await worker.close()
-  })
-
   return worker
 }


### PR DESCRIPTION
### Problem

When running `npm run dev`, we see an error:
```
(node:84335) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process]. Use emitter.setMaxListeners() to increase limit
```

This is caused by a SIGTERM listener on every worker and queue that we create. There's a default max of 10 listeners on node processes.

### Context
When an ECS task is stopped, it sends a SIGTERM signal before the SIGKILL signal. (120 seconds apart for our infra)

This allows the workers to complete whatever it's doing before closing and stop picking up new tasks.

Ref: https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/#:~:text=ECS%20task%20definition.-,When%20a%20task%20is,of%20the%20SIGKILL%20signal.,-One%20PID%20to

### Solution

Instead of listening on each worker/queue, we do a bulk listener for all action workers and all action queues.


### To test
1. Run `npm run dev`
2. The error should not happen
3. Run `ps aux | awk '$11 == "node"' | grep worker.ts` to find the worker process
4. Get the pid (find the node one not the nodemon one)
5. Fire a SIGTERM signal with `kill -SIGTERM <PID>`
6. You should see the following logs:
```
SIGTERM: gracefully closing all action queues
SIGTERM: gracefully closing all action workers
SIGTERM: all action queues closed
SIGTERM: all action workers closed
```