### PR TITLE
chore: improve missing pipe page

### DIFF
--- a/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
+++ b/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
@@ -1,21 +1,9 @@
-import { Box, createIcon, Stack, Text, VStack } from '@chakra-ui/react'
+import { Box, Stack, Text, VStack } from '@chakra-ui/react'
 import { Link } from '@opengovsg/design-system-react'
 
+import { PipeIcon } from '@/components/Icons/PipeIcon'
 import * as URLS from '@/config/urls'
 import styles from '@/pages/UnauthorizedTile/UnauthorizedTile.module.css'
-
-const PipeIcon = createIcon({
-  displayName: 'PipeIcon',
-  viewBox: '0 0 20 20',
-  path: (
-    <path
-      d="M15.0704 12.4616V12.4866H15.0954L17.4858 12.4866L17.5108 12.4866V12.4616V7.83483C17.5108 5.15686 15.3294 2.975 12.651 2.975H12.6051C9.92709 2.975 7.74522 5.15644 7.74522 7.83483V11.3509C7.74522 12.682 6.65694 13.7702 5.32584 13.7702H4.49046H4.46546V13.7952V16.1856V16.2106H4.49046H5.32584C8.00381 16.2106 10.1857 14.0292 10.1857 11.3508V7.83477C10.1857 6.50368 11.274 5.41539 12.6051 5.41539H12.651C13.9821 5.41539 15.0704 6.50368 15.0704 7.83477V12.4616ZM17.9151 12.9219H14.6666C14.4406 12.9219 14.2562 13.1064 14.2562 13.3323V14.5661C14.2562 14.7921 14.4407 14.9765 14.6666 14.9765H17.9151C18.1411 14.9765 18.3255 14.792 18.3255 14.5661V13.3323C18.3255 13.1068 18.141 12.9219 17.9151 12.9219ZM4.02961 16.6146V13.3661C4.02961 13.1406 3.84512 12.9557 3.61922 12.9557H2.38539C2.1594 12.9557 1.975 13.1403 1.975 13.3661V16.6146C1.975 16.8401 2.15949 17.025 2.38539 17.025H3.61922C3.84472 17.025 4.02961 16.8405 4.02961 16.6146Z"
-      fill="currentColor"
-      stroke="currentColor"
-      strokeWidth="0.05"
-    />
-  ),
-})
 
 export default function InvalidEditorPage() {
   return (

--- a/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
+++ b/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
@@ -1,10 +1,58 @@
-import { Infobox } from '@opengovsg/design-system-react'
+import { Box, createIcon, Stack, Text, VStack } from '@chakra-ui/react'
+import { Link } from '@opengovsg/design-system-react'
+
+import * as URLS from '@/config/urls'
+import styles from '@/pages/UnauthorizedTile/UnauthorizedTile.module.css'
+
+const PipeIcon = createIcon({
+  displayName: 'PipeIcon',
+  viewBox: '0 0 20 20',
+  path: (
+    <path
+      d="M15.0704 12.4616V12.4866H15.0954L17.4858 12.4866L17.5108 12.4866V12.4616V7.83483C17.5108 5.15686 15.3294 2.975 12.651 2.975H12.6051C9.92709 2.975 7.74522 5.15644 7.74522 7.83483V11.3509C7.74522 12.682 6.65694 13.7702 5.32584 13.7702H4.49046H4.46546V13.7952V16.1856V16.2106H4.49046H5.32584C8.00381 16.2106 10.1857 14.0292 10.1857 11.3508V7.83477C10.1857 6.50368 11.274 5.41539 12.6051 5.41539H12.651C13.9821 5.41539 15.0704 6.50368 15.0704 7.83477V12.4616ZM17.9151 12.9219H14.6666C14.4406 12.9219 14.2562 13.1064 14.2562 13.3323V14.5661C14.2562 14.7921 14.4407 14.9765 14.6666 14.9765H17.9151C18.1411 14.9765 18.3255 14.792 18.3255 14.5661V13.3323C18.3255 13.1068 18.141 12.9219 17.9151 12.9219ZM4.02961 16.6146V13.3661C4.02961 13.1406 3.84512 12.9557 3.61922 12.9557H2.38539C2.1594 12.9557 1.975 13.1403 1.975 13.3661V16.6146C1.975 16.8401 2.15949 17.025 2.38539 17.025H3.61922C3.84472 17.025 4.02961 16.8405 4.02961 16.6146Z"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="0.05"
+    />
+  ),
+})
 
 export default function InvalidEditorPage() {
-  // TODO (mal): check if this needs to be beautified
   return (
-    <Infobox variant="error">
-      Pipe not found, you may have transferred it to someone else 🤔
-    </Infobox>
+    <Stack
+      direction={{ base: 'column', md: 'row' }}
+      maxW="1000px"
+      margin="auto"
+      gap={8}
+      px={8}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box
+        className={styles.flicker}
+        as={PipeIcon}
+        color="primary.300"
+        w="400px"
+        h="200px"
+        maxW="50vw"
+      />
+      <VStack alignItems={{ base: 'center', md: 'start' }} gap={2}>
+        <Text
+          textStyle="h4"
+          textAlign={{ base: 'center', md: 'left' }}
+          fontWeight="normal"
+        >
+          Pipe not found, you may have transferred it to someone else 🤔
+        </Text>
+        <Link
+          textStyle="h6"
+          textAlign={{ base: 'center', md: 'left' }}
+          fontWeight="normal"
+          href={URLS.FLOWS}
+        >
+          Back to your Pipes
+        </Link>
+      </VStack>
+    </Stack>
   )
 }


### PR DESCRIPTION
## TL;DR
Update missing Pipe page to be similar to missing Tile page

## How to test?
- [ ] Navigate to a non-existent Pipe, verify that missing Pipe page is shown and clicking on link redirects to Pipes page

## Screenshots
### Before
<img width="1512" alt="Screenshot 2025-04-28 at 11 17 33 PM" src="https://github.com/user-attachments/assets/ec2400d5-62a8-4785-a86f-11b701b97c2a" />


### After

https://github.com/user-attachments/assets/c1387d13-1e52-4f62-9a77-8baec29bd78b



