### PR TITLE
PLU-442 [SIDE-DRAWER-7]: Convert MultiRow to MultiRow-MultiCol

### DIFF
--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
@@ -49,7 +49,7 @@ export const fields: TransformSpec['fields'] = [
   {
     label: 'Specify the amount of time you want to add or subtract',
     key: ensureZodObjectKey(fieldSchema.sourceType(), 'addSubtractDateTimeOps'),
-    type: 'multirow' as const,
+    type: 'multirow-multicol' as const,
     required: true,
     subFields: [
       {
@@ -63,6 +63,7 @@ export const fields: TransformSpec['fields'] = [
           label: sentenceCase(op),
           value: op,
         })),
+        customStyle: { flex: 1 },
       },
       {
         placeholder: 'Amount of time to add or subtract (number)',
@@ -70,6 +71,7 @@ export const fields: TransformSpec['fields'] = [
         type: 'string' as const,
         required: true,
         variables: true,
+        customStyle: { flex: 2 },
       },
       {
         placeholder: 'Unit of time to add or subtract',
@@ -82,6 +84,7 @@ export const fields: TransformSpec['fields'] = [
           label: sentenceCase(unit),
           value: unit,
         })),
+        customStyle: { flex: 2 },
       },
     ],
   },

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -68,7 +68,7 @@ const action: IRawAction = {
     {
       label: 'Personalised fields',
       key: 'letterParams',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       description:
         'Specify values for each personalised field in your template.',
@@ -95,6 +95,7 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 2 },
         },
         {
           placeholder: 'Value',
@@ -102,6 +103,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -88,7 +88,7 @@ const action: IRawAction = {
     {
       label: 'New row data',
       key: 'columnValues',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       subFields: [
         {
@@ -116,6 +116,7 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 2 },
         },
         {
           key: 'value' as const,
@@ -123,6 +124,7 @@ const action: IRawAction = {
           required: true,
           variables: true,
           placeholder: 'Value',
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -38,7 +38,7 @@ const action: IRawAction = {
       label: 'Row data',
       description:
         'Enter the data to update the row with. Columns not specified will not be updated',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       subFields: [
         {
@@ -66,6 +66,7 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 2 },
         },
         {
           key: 'value' as const,
@@ -73,6 +74,7 @@ const action: IRawAction = {
           required: true,
           variables: true,
           placeholder: 'Value to write',
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
@@ -61,7 +61,7 @@ const action: IRawAction = {
     {
       label: 'Values',
       key: 'cells',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       // We need to make 1 separate request for each cell, so limit to 3 as a
       // balance between convenience and API quota usage.
@@ -74,6 +74,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 1 },
         },
         {
           label: 'Value',
@@ -81,6 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
+          customStyle: { flex: 1 },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -103,7 +103,7 @@ const action: IRawAction = {
       label: 'Additional responses',
       description: 'These will be included in reports exported from PaySG',
       key: 'responses',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: false,
       subFields: [
         {
@@ -112,6 +112,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 1 },
         },
         {
           placeholder: 'Answer',
@@ -119,6 +120,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 1 },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -75,7 +75,7 @@ const action: IRawAction = {
       label: 'Additional responses',
       description: 'These will be included in reports exported from PaySG',
       key: 'responses',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: false,
       subFields: [
         {
@@ -84,6 +84,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 1 },
         },
         {
           placeholder: 'Answer',
@@ -91,6 +92,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 1 },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/index.ts
@@ -81,7 +81,7 @@ const action: IRawAction = {
     {
       label: 'Metadata',
       key: 'metadata',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: false,
       subFields: [
         {
@@ -90,6 +90,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 2 },
         },
         {
           placeholder: 'Value',
@@ -97,6 +98,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -41,7 +41,7 @@ const action: IRawAction = {
     {
       label: 'New row data',
       key: 'rowData',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',
@@ -74,6 +74,7 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 2 },
         },
         {
           placeholder: 'Value',
@@ -81,6 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -74,7 +74,7 @@ const action: IRawAction = {
               },
             ],
           },
-          customStyle: { flex: 3 },
+          customStyle: { flex: 2 },
         },
         {
           placeholder: 'Value',
@@ -82,7 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 5 },
+          customStyle: { flex: 3 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -49,7 +49,7 @@ const action: IRawAction = {
       },
       subFields: [
         {
-          placeholder: 'Select a column or type to create one',
+          placeholder: 'Select or type to create a column',
           key: 'columnId',
           type: 'dropdown' as const,
           required: true,
@@ -74,7 +74,7 @@ const action: IRawAction = {
               },
             ],
           },
-          customStyle: { flex: 2 },
+          customStyle: { flex: 3 },
         },
         {
           placeholder: 'Value',
@@ -82,7 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 5 },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -46,7 +46,7 @@ const action: IRawAction = {
       description:
         'If multiple rows meet the conditions, the oldest entry will be returned',
       key: 'filters',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',
@@ -74,6 +74,7 @@ const action: IRawAction = {
               },
             ],
           },
+          customStyle: { flex: 1 },
         },
         {
           placeholder: 'Condition',
@@ -104,6 +105,7 @@ const action: IRawAction = {
               value: TableRowFilterOperator.IsEmpty,
             },
           ],
+          customStyle: { flex: 1 },
         },
         {
           placeholder: 'Value',
@@ -116,6 +118,7 @@ const action: IRawAction = {
             op: 'equals',
             fieldValue: TableRowFilterOperator.IsEmpty,
           },
+          customStyle: { flex: 2 },
         },
       ],
     },

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -45,7 +45,7 @@ const action: IRawAction = {
     {
       label: 'Conditions',
       key: 'conditions',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       description:
         'Every condition has to be satisfied for this branch to be taken.',

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -1,4 +1,4 @@
-import type { IField } from '@plumber/types'
+import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 interface GetConditionArgsOptions {
   usePlaceholders: boolean
@@ -8,7 +8,7 @@ interface GetConditionArgsOptions {
 // onlyContinueIf.
 export default function getConditionArgs({
   usePlaceholders,
-}: GetConditionArgsOptions): IField[] {
+}: GetConditionArgsOptions): IFieldMultiRowMultiColSubField[] {
   const labelPropName = usePlaceholders ? 'placeholder' : 'label'
 
   return [
@@ -18,6 +18,7 @@ export default function getConditionArgs({
       type: 'string' as const,
       required: true,
       variables: true,
+      customStyle: { flex: 3 },
     },
     {
       [labelPropName]: 'Is or is not',
@@ -30,6 +31,7 @@ export default function getConditionArgs({
         { label: 'Is', value: 'is' },
         { label: 'Is not', value: 'not' },
       ],
+      customStyle: { flex: 2 },
     },
     {
       [labelPropName]: 'Condition',
@@ -73,6 +75,7 @@ export default function getConditionArgs({
           description: 'Used for dates',
         },
       ],
+      customStyle: { flex: 2 },
     },
     {
       [labelPropName]: 'Value',
@@ -85,6 +88,7 @@ export default function getConditionArgs({
         op: 'equals',
         fieldValue: 'empty',
       },
+      customStyle: { flex: 3 },
     },
   ]
 }

--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -32,7 +32,7 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
     <Flex
       flexDir="column"
       position="relative"
-      width={isDrawerOpen ? (isMobile ? '100vw' : '55%') : '0'}
+      width={isDrawerOpen ? (isMobile ? '100vw' : '60%') : '0'}
       bg="white"
       py="4"
       borderRadius="lg"

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -137,6 +137,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           variablesEnabled
           tooltipText={tooltipText}
           variableTypes={schema.variableTypes}
+          parentType={parentType}
         />
       )
     }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -28,7 +28,7 @@ export default function MultiCol(props: MultiColProps) {
 
   const isMobile = useBreakpointValue({ base: true, sm: false })
   return (
-    <Flex flexDir={isMobile ? 'column' : 'row'} gap={2}>
+    <Flex flexDir={isMobile ? 'column' : 'row'} gap={2} alignItems="center">
       {subFields.map((subF) => {
         return (
           <div

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -41,7 +41,11 @@ import { MenuBar } from './MenuBar'
 import ImageResize from './ResizableImageExtension'
 import { StepVariable } from './StepVariablePlugin'
 import Suggestions from './Suggestions'
-import { genVariableInfoMap, substituteOldTemplates } from './utils'
+import {
+  genVariableInfoMap,
+  getPopoverPlacement,
+  substituteOldTemplates,
+} from './utils'
 
 const RICH_TEXT_EXTENSIONS = [
   Document.configure({
@@ -86,6 +90,7 @@ interface EditorProps {
   isRich?: boolean
   isSingleLine?: boolean
   variableTypes?: TDataOutMetadatumType[]
+  parentType?: string
 }
 const Editor = ({
   onChange,
@@ -96,6 +101,7 @@ const Editor = ({
   isRich,
   isSingleLine,
   variableTypes,
+  parentType,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
@@ -216,11 +222,12 @@ const Editor = ({
     <Popover
       autoFocus={false}
       gutter={0}
-      matchWidth={true}
+      matchWidth={parentType === 'multicol' ? false : true}
       isLazy
       lazyBehavior="unmount"
       onClose={closeSuggestions}
       isOpen={isSuggestionsOpen && variablesEnabled}
+      placement={getPopoverPlacement(editor)}
     >
       <div
         className="editor"
@@ -240,6 +247,7 @@ const Editor = ({
             <EditorContent className="editor__content" editor={editor} />
             <PopoverContent
               w="100%"
+              maxWidth={parentType === 'multicol' ? 'fit-content' : undefined}
               motionProps={POPOVER_MOTION_PROPS}
               onFocus={(e) => {
                 // Go back to previous focus when clicking on suggestions to resume typing
@@ -273,6 +281,7 @@ interface RichTextEditorProps {
   isSingleLine?: boolean
   tooltipText?: string
   variableTypes?: TDataOutMetadatumType[]
+  parentType?: string
 }
 const RichTextEditor = ({
   required,
@@ -287,6 +296,7 @@ const RichTextEditor = ({
   isSingleLine,
   tooltipText,
   variableTypes,
+  parentType,
 }: RichTextEditorProps) => {
   const { control } = useFormContext()
 
@@ -318,6 +328,7 @@ const RichTextEditor = ({
             isRich={isRich}
             isSingleLine={isSingleLine}
             variableTypes={variableTypes}
+            parentType={parentType}
           />
         )}
       />

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -1,3 +1,5 @@
+import { PlacementWithLogical } from '@chakra-ui/react'
+import { Editor } from '@tiptap/react'
 import { HTMLElement, Node, parse, TextNode } from 'node-html-parser'
 
 import type { StepWithVariables } from '@/helpers/variables'
@@ -127,4 +129,24 @@ export function substituteOldTemplates(
   const originalElem = parse(original)
   const substitutedDom = recursiveSubstitute(originalElem, varInfo)
   return substitutedDom.outerHTML
+}
+
+export function getPopoverPlacement(
+  editor: Editor | null,
+): PlacementWithLogical {
+  if (typeof window === 'undefined' || editor == null) {
+    return 'bottom-start'
+  }
+
+  const editorElement = editor?.view.dom as globalThis.HTMLElement
+  if (!editorElement) {
+    return 'bottom-start'
+  }
+
+  const rect = editorElement.getBoundingClientRect()
+  const spaceBelow = window.innerHeight - rect.bottom
+  const spaceAbove = rect.top
+
+  // If there's more space above than below, show the popover above
+  return spaceAbove > spaceBelow ? 'top-start' : 'bottom-start'
 }


### PR DESCRIPTION
## TL;DR
This PR converts several form field types from `multirow` to `multirow-multicol`, placing input fields side-by-side instead of stacking them vertically.

It also makes the right drawer wider to allow more space for side-by-side inputs.

## What changed?
- Converts date-time add/subtract operations to use multi-column layout with flex styling
- Updates LetterSG's personalized fields to use multi-column layout with proportional spacing
- Converts Microsoft 365 Excel actions (create/update table rows, write cell values) to multi-column layout
- Updates PaySG actions (payment form submissions, create payment) with multi-column layout
- Enhances Tiles actions (create row, find single row) with better column proportions
- Converts Toolbox's if-then conditions to multi-column layout with flex styling
- Widens the right drawer from 55% to 60% to accommodate the multi-column layout
- Adds center alignment to multi-column items for better visual appearance

## How to test?
Make sure that actions and input fields are saved and applied correctly; this should only be a UI change.

Apps and actions to test:
- Formatter
  - [ ] Add / subtract date time
- LetterSG
  - [ ] Create letter (personalised fields)
- M365
  - [ ] Create table row (new row data)
  - [ ] Update table row (row data)
  - [ ] Write cell values (values)
- PaySG
  - [ ] Create payment form submission subscriptions (metadata)
  - [ ] Create payment form submission (additional responses)
  - [ ] Create payment (metadata)
- Tiles
  - [ ] Create row (new row data)
  - [ ] Find single row (lookup conditions)
- Toolbox
  - [ ] If-then (branch conditions)
