### PR TITLE
fix: dedupe form submissions with internal id

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -12,6 +12,16 @@ import { NricFilter } from '../../triggers/new-submission'
 LuxonSettings.defaultZone = 'Asia/Singapore'
 LuxonSettings.defaultLocale = 'en-SG'
 
+const SUCCESS_DECRYPT_RESPONSE = {
+  verified: true,
+  internalId: 'submissionId',
+}
+
+const FAILED_DECRYPT_RESPONSE = {
+  verified: false,
+  internalId: null as string | null,
+}
+
 // mocks hoisted here so that they can be used in import mocks
 const mocks = vi.hoisted(() => {
   const webhooksAuthenticate = vi.fn()
@@ -128,7 +138,9 @@ describe('decrypt form response', () => {
 
     it('should fail if no request in global variable', async () => {
       delete $.request
-      await expect(decryptFormResponse($)).resolves.toEqual(false)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        FAILED_DECRYPT_RESPONSE,
+      )
       expect(mocks.consoleError).toHaveBeenCalledWith(
         'No trigger item provided',
       )
@@ -138,7 +150,9 @@ describe('decrypt form response', () => {
       mocks.webhooksAuthenticate.mockImplementationOnce(() => {
         throw new Error('error')
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(false)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        FAILED_DECRYPT_RESPONSE,
+      )
       expect(mocks.webhooksAuthenticate).toHaveBeenCalledTimes(1)
       expect(mocks.consoleError).toHaveBeenCalledWith(
         'Unable to verify formsg signature',
@@ -147,7 +161,9 @@ describe('decrypt form response', () => {
 
     it('should fail and give warning if no connection exists', async () => {
       delete $.auth.data
-      await expect(decryptFormResponse($)).resolves.toEqual(false)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        FAILED_DECRYPT_RESPONSE,
+      )
       expect(mocks.consoleWarn).toHaveBeenCalledWith(
         'Form is not connected to any pipe after pipe is transferred',
         {
@@ -161,7 +177,9 @@ describe('decrypt form response', () => {
 
     it('should fail if unable to decrypt form response', async () => {
       mockDecryptedSubmission(null)
-      await expect(decryptFormResponse($)).resolves.toEqual(false)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        FAILED_DECRYPT_RESPONSE,
+      )
       expect(decryptMock).toHaveBeenCalledTimes(1)
       expect(mocks.consoleError).toHaveBeenCalledWith(
         'Unable to decrypt formsg response',
@@ -170,7 +188,9 @@ describe('decrypt form response', () => {
 
     it('should extract submission ID', async () => {
       mockDecryptedSubmission({ responses: [] })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           submissionId: 'submissionId',
@@ -180,7 +200,9 @@ describe('decrypt form response', () => {
 
     it('should extract submission time as a ISO 8601 SGT formatted string', async () => {
       mockDecryptedSubmission({ responses: [] })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           submissionTime: '2023-07-06T18:26:27.505+08:00',
@@ -205,7 +227,9 @@ describe('decrypt form response', () => {
           },
         ],
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           fields: {
@@ -260,7 +284,9 @@ describe('decrypt form response', () => {
       })
 
       it('should handle nric filter - do nothing', async () => {
-        await expect(decryptFormResponse($)).resolves.toEqual(true)
+        await expect(decryptFormResponse($)).resolves.toEqual(
+          SUCCESS_DECRYPT_RESPONSE,
+        )
         expect($.request.body).toEqual(
           expect.objectContaining({
             fields: {
@@ -294,7 +320,9 @@ describe('decrypt form response', () => {
 
       it('it should handle nric filter - remove', async () => {
         $.step.parameters.nricFilter = NricFilter.Remove
-        await expect(decryptFormResponse($)).resolves.toEqual(true)
+        await expect(decryptFormResponse($)).resolves.toEqual(
+          SUCCESS_DECRYPT_RESPONSE,
+        )
         expect($.request.body).toEqual(
           expect.objectContaining({
             fields: {
@@ -314,7 +342,9 @@ describe('decrypt form response', () => {
 
       it('it should handle nric filter - hash', async () => {
         $.step.parameters.nricFilter = NricFilter.Hash
-        await expect(decryptFormResponse($)).resolves.toEqual(true)
+        await expect(decryptFormResponse($)).resolves.toEqual(
+          SUCCESS_DECRYPT_RESPONSE,
+        )
         expect($.request.body).toEqual(
           expect.objectContaining({
             fields: {
@@ -348,7 +378,9 @@ describe('decrypt form response', () => {
 
       it('it should handle nric filter - mask', async () => {
         $.step.parameters.nricFilter = NricFilter.Mask
-        await expect(decryptFormResponse($)).resolves.toEqual(true)
+        await expect(decryptFormResponse($)).resolves.toEqual(
+          SUCCESS_DECRYPT_RESPONSE,
+        )
         expect($.request.body).toEqual(
           expect.objectContaining({
             fields: {
@@ -398,7 +430,9 @@ describe('decrypt form response', () => {
           cpUen: '987654321Z',
         },
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           verifiedSubmitterInfo: {
@@ -428,7 +462,9 @@ describe('decrypt form response', () => {
           },
         ],
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           fields: {
@@ -474,7 +510,9 @@ describe('decrypt form response', () => {
           },
         ],
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           fields: {
@@ -508,7 +546,9 @@ describe('decrypt form response', () => {
     it('attachment decryption function not called if pipe does not process files', async () => {
       $.flow.hasFileProcessingActions = false
       mocks.cryptoDecrypt.mockReturnValueOnce({ responses: [] })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect(mocks.cryptoDecryptWithAttachments).not.toBeCalled()
     })
 
@@ -518,7 +558,9 @@ describe('decrypt form response', () => {
         attachments: {},
         content: { responses: [] },
       })
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect(mocks.cryptoDecrypt).not.toBeCalled()
     })
   })
@@ -529,7 +571,9 @@ describe('decrypt form response', () => {
       mocks.cryptoDecrypt.mockReturnValueOnce({ responses: [] })
       mocks.parseFormEnv.mockReturnValue('staging')
 
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
 
       expect(mocks.parseFormEnv).toBeCalled()
       expect(mocks.getSdk).toBeCalledWith('staging')
@@ -563,7 +607,9 @@ describe('decrypt form response', () => {
         ],
       })
 
-      await expect(decryptFormResponse($)).resolves.toEqual(true)
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
       expect($.request.body).toEqual(
         expect.objectContaining({
           fields: {

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -57,10 +57,10 @@ export function filterNric($: IGlobalVariable, value: string): string | null {
 
 export async function decryptFormResponse(
   $: IGlobalVariable,
-): Promise<boolean> {
+): Promise<{ verified: boolean; internalId: string | null }> {
   if (!$.request) {
     logger.error('No trigger item provided')
-    return false
+    return { verified: false, internalId: null }
   }
 
   // Note: this could occur due to pipe transfer since connection becomes null
@@ -71,7 +71,7 @@ export async function decryptFormResponse(
       stepId: $.step.id,
       userId: $.user.id,
     })
-    return false
+    return { verified: false, internalId: null }
   }
 
   const formSgSdk = getSdk(parseFormEnv($))
@@ -88,7 +88,7 @@ export async function decryptFormResponse(
     )
   } catch (e) {
     logger.error('Unable to verify formsg signature')
-    return false
+    return { verified: false, internalId: null }
   }
 
   const formSecretKey = $.auth.data.privateKey as string
@@ -187,10 +187,10 @@ export async function decryptFormResponse(
     delete $.request.headers
     delete $.request.query
 
-    return true
+    return { verified: true, internalId: data.submissionId }
   } else {
     // Could not decrypt the submission
     logger.error('Unable to decrypt formsg response')
-    return false
+    return { verified: false, internalId: null }
   }
 }

--- a/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
+++ b/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
@@ -29,7 +29,10 @@ const mocks = vi.hoisted(() => {
         })),
       })),
     },
-    processTrigger: vi.fn(() => ({ executionId: 'execution-id' })),
+    processTrigger: vi.fn(() => ({
+      executionId: 'execution-id',
+      shouldExecute: true,
+    })),
     enqueueActionJob: vi.fn(),
   }
 })
@@ -200,5 +203,19 @@ describe('webhook handler', () => {
         expect(mocks.response.sendStatus).toHaveReturnedWith(200)
       },
     )
+
+    it('should not enqueue job when processTrigger returns shouldExecute: false', async () => {
+      mocks.flow.active = true
+      mocks.processTrigger.mockResolvedValueOnce({
+        executionId: 'execution-id',
+        shouldExecute: false,
+      })
+
+      await webhookHandler(request, mocks.response)
+
+      expect(mocks.processTrigger).toHaveBeenCalledOnce()
+      expect(mocks.enqueueActionJob).not.toHaveBeenCalled()
+      expect(mocks.response.sendStatus).toHaveReturnedWith(200)
+    })
   })
 })

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -70,6 +70,7 @@ export default async (request: IRequest, response: Response) => {
     }
   }
 
+  let internalId: string = randomUUID()
   const testRun = !flow.active
   const triggerStep = await flow.getTriggerStep()
 
@@ -106,11 +107,13 @@ export default async (request: IRequest, response: Response) => {
       request,
     })
 
-    const verified = await triggerApp.auth.verifyWebhook($)
+    const { verified, internalId: newInternalId } =
+      await triggerApp.auth.verifyWebhook($)
 
     if (!verified) {
       return response.sendStatus(401)
     }
+    internalId = newInternalId
   }
 
   // in case trigger type is 'webhook'
@@ -127,10 +130,7 @@ export default async (request: IRequest, response: Response) => {
   const triggerItem: ITriggerItem = {
     raw: payload,
     meta: {
-      internalId:
-        isFormsgApp && payload?.submissionId
-          ? payload.submissionId
-          : randomUUID(),
+      internalId,
     },
   }
 

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -80,8 +80,8 @@ export default async (request: IRequest, response: Response) => {
     return response.sendStatus(404)
   }
 
-  const isWebhookApp =
-    triggerApp.key === 'webhook' || triggerApp.key === 'formsg'
+  const isFormsgApp = triggerApp.key === 'formsg'
+  const isWebhookApp = triggerApp.key === 'webhook' || isFormsgApp
 
   if (!isWebhookApp) {
     logger.info(`Invalid trigger app for flow${flowId}`)
@@ -127,11 +127,19 @@ export default async (request: IRequest, response: Response) => {
   const triggerItem: ITriggerItem = {
     raw: payload,
     meta: {
-      internalId: randomUUID(),
+      internalId:
+        isFormsgApp && payload?.submissionId
+          ? payload.submissionId
+          : randomUUID(),
     },
   }
 
-  const { executionId } = await processTrigger({
+  /**
+   * NOTE: special case for when FormSG calls Plumber's webhook twice for payment forms.
+   * Plumber will still return a 200 status code, so that FormSG does not auto-retry,
+   * but Plumber not enqueue the job.
+   */
+  const { executionId, shouldExecute } = await processTrigger({
     flowId,
     stepId: triggerStep.id,
     triggerItem,
@@ -146,7 +154,7 @@ export default async (request: IRequest, response: Response) => {
     testRun,
   })
 
-  if (testRun) {
+  if (testRun || !shouldExecute) {
     return response.sendStatus(200)
   }
 

--- a/packages/backend/src/db/migrations/20250430111845_add_executions_flow_id_test_run_internal_id_index.ts
+++ b/packages/backend/src/db/migrations/20250430111845_add_executions_flow_id_test_run_internal_id_index.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  // Add index for flow_id, test_run, internal_id in executions table
+  await knex.schema.table('executions', (table) => {
+    table.index(['flow_id', 'test_run', 'internal_id'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('executions', (table) => {
+    table.dropIndex(['flow_id', 'test_run', 'internal_id'])
+  })
+}

--- a/packages/backend/src/services/__tests__/trigger.itest.ts
+++ b/packages/backend/src/services/__tests__/trigger.itest.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'crypto'
+import { describe, expect, it, vi } from 'vitest'
+
+import Execution from '@/models/execution'
+import Step from '@/models/step'
+
+import { processTrigger } from '../trigger'
+
+describe('processTrigger', () => {
+  it('should prevent duplicate executions from concurrent requests', async () => {
+    // Setup test data
+    const flowId = randomUUID()
+    const stepId = randomUUID()
+    const internalId = randomUUID()
+    const triggerItem = {
+      raw: { formId: 'test-form-id' },
+      meta: { internalId },
+    }
+
+    // Mock Step query
+    const mockStep = {
+      id: stepId,
+      appKey: 'formsg',
+      parameters: {},
+    }
+    vi.spyOn(Step, 'query').mockReturnValue({
+      findById: vi.fn().mockReturnValue({
+        throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+      }),
+    } as any)
+
+    // Mock Execution query
+    const mockExecution = {
+      id: randomUUID(),
+      flowId,
+      internalId,
+      testRun: false,
+      $relatedQuery: vi.fn().mockReturnValue({
+        insertAndFetch: vi.fn().mockResolvedValue({
+          id: randomUUID(),
+          stepId,
+          status: 'success',
+          dataIn: {},
+          dataOut: triggerItem.raw,
+          errorDetails: null,
+          appKey: 'formsg',
+          metadata: {},
+        }),
+      }),
+    }
+
+    // Mock knex raw query for advisory lock
+    let lockAcquired = true
+    vi.spyOn(Execution, 'knex').mockReturnValue({
+      raw: vi.fn().mockImplementation(() => {
+        // First call gets the lock, second call fails
+        const result = { rows: [{ acquired: lockAcquired }] }
+        lockAcquired = false
+        return Promise.resolve(result)
+      }),
+    } as any)
+
+    vi.spyOn(Execution, 'query').mockReturnValue({
+      insert: vi.fn().mockResolvedValue(mockExecution),
+      where: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(null),
+      }),
+    } as any)
+
+    const options = {
+      flowId,
+      stepId,
+      triggerItem,
+      testRun: false,
+    }
+
+    // Create two concurrent requests
+    const request1 = processTrigger(options)
+
+    const request2 = processTrigger(options)
+
+    // Wait for both requests to complete
+    const [result1, result2] = await Promise.all([request1, request2])
+
+    // Verify that only one execution was created
+    expect(Execution.query().insert).toHaveBeenCalledTimes(1)
+
+    // Verify that one request got the execution and the other was rejected
+    expect(result1.shouldExecute).not.toBe(result2.shouldExecute)
+
+    // Verify that the execution IDs match for the successful request
+    const successfulResult = result1.shouldExecute ? result1 : result2
+    expect(successfulResult.executionId).toBe(mockExecution.id)
+    expect(successfulResult.executionStep).toBeDefined()
+
+    // Verify that the rejected request has no execution step
+    const rejectedResult = result1.shouldExecute ? result2 : result1
+    expect(rejectedResult.executionStep).toBeNull()
+  })
+})

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -18,7 +18,7 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
 
-  if (step.appKey === 'formsg' && !testRun) {
+  if (!testRun && step.appKey === 'formsg' && triggerItem?.meta.internalId) {
     /**
      * NOTE: we use an advisory lock to prevent race conditions and ensure idempotency
      * when handling concurrent requests.
@@ -26,7 +26,7 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
      * ensuring that only one execution is created per FormSG submission.
      */
     const formId = triggerItem?.raw.formId
-    const submissionId = triggerItem?.meta.internalId
+    const submissionId = triggerItem.meta.internalId
 
     const lockAcquired = await Execution.knex()
       .raw(

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -18,32 +18,60 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
 
-  let shouldExecute = true
   if (step.appKey === 'formsg' && !testRun) {
-    const execution = await Execution.query()
-      .where({
-        flow_id: flowId,
-        test_run: false,
-        internal_id: triggerItem?.meta.internalId,
-      })
-      .first()
+    /**
+     * NOTE: we use an advisory lock to prevent race conditions and ensure idempotency
+     * when handling concurrent requests.
+     * The lock is based on a composite key: flowId and internalId (FormSG submissionId),
+     * ensuring that only one execution is created per FormSG submission.
+     */
+    const formId = triggerItem?.raw.formId
+    const submissionId = triggerItem?.meta.internalId
 
-    if (execution && execution.internalId === triggerItem?.meta.internalId) {
-      logger.error(
-        `FormSG: ${triggerItem?.raw.formId} - submissionId: ${triggerItem?.meta.internalId} already exists in execution: ${execution.id}`,
+    const lockAcquired = await Execution.knex()
+      .raw(
+        'SELECT pg_try_advisory_xact_lock(hashtext(?), hashtext(?)) as acquired',
+        [flowId, submissionId || ''],
       )
-      shouldExecute = false
+      .then((result) => result.rows[0].acquired)
 
+    if (lockAcquired) {
+      const execution = await Execution.query()
+        .where({
+          flow_id: flowId,
+          test_run: false,
+          internal_id: submissionId,
+        })
+        .first()
+
+      if (execution && execution.internalId === submissionId) {
+        logger.error(
+          `FormSG: ${formId} - submissionId: ${submissionId} already exists in execution: ${execution.id}`,
+        )
+
+        return {
+          flowId,
+          stepId,
+          executionId: execution.id,
+          executionStep: null,
+          shouldExecute: false,
+        }
+      }
+    } else {
+      logger.error(
+        `FormSG: ${formId} - submissionId: ${submissionId} is already being processed`,
+      )
       return {
         flowId,
         stepId,
-        executionId: execution.id,
+        executionId: null,
         executionStep: null,
-        shouldExecute,
+        shouldExecute: false,
       }
     }
   }
 
+  // non-FormSG triggers or test runs proceed without advisory lock
   const execution = await Execution.query().insert({
     flowId,
     testRun,
@@ -68,6 +96,6 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
     stepId,
     executionId: execution.id,
     executionStep,
-    shouldExecute,
+    shouldExecute: true,
   }
 }

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,5 +1,6 @@
 import { IJSONObject, ITriggerItem } from '@plumber/types'
 
+import logger from '@/helpers/logger'
 import Execution from '@/models/execution'
 import Step from '@/models/step'
 
@@ -16,6 +17,32 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
   const { flowId, stepId, triggerItem, error, testRun } = options
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
+
+  let shouldExecute = true
+  if (step.appKey === 'formsg' && !testRun) {
+    const execution = await Execution.query()
+      .where({
+        flow_id: flowId,
+        test_run: false,
+        internal_id: triggerItem?.meta.internalId,
+      })
+      .first()
+
+    if (execution && execution.internalId === triggerItem?.meta.internalId) {
+      logger.error(
+        `FormSG: ${triggerItem?.raw.formId} - submissionId: ${triggerItem?.meta.internalId} already exists in execution: ${execution.id}`,
+      )
+      shouldExecute = false
+
+      return {
+        flowId,
+        stepId,
+        executionId: execution.id,
+        executionStep: null,
+        shouldExecute,
+      }
+    }
+  }
 
   const execution = await Execution.query().insert({
     flowId,
@@ -36,5 +63,11 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
       metadata: triggerItem?.isMock ? { isMock: true } : {},
     })
 
-  return { flowId, stepId, executionId: execution.id, executionStep }
+  return {
+    flowId,
+    stepId,
+    executionId: execution.id,
+    executionStep,
+    shouldExecute,
+  }
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -589,7 +589,9 @@ interface IBaseAuth {
   verifyCredentials?($: IGlobalVariable): Promise<void>
   isStillVerified?($: IGlobalVariable): Promise<boolean>
   refreshToken?($: IGlobalVariable): Promise<void>
-  verifyWebhook?($: IGlobalVariable): Promise<boolean>
+  verifyWebhook?(
+    $: IGlobalVariable,
+  ): Promise<{ verified: boolean; internalId: string | null }>
   isRefreshTokenRequested?: boolean
   authenticationSteps?: IAuthenticationStep[]
   reconnectionSteps?: IAuthenticationStep[]


### PR DESCRIPTION
## Problem
FormSG may call Plumber's webhook more than once, which results in duplicate executions.


## Solution
* Saves the FormSG Submission ID in the `internal_id` column
* Every FormSG call to Plumber's webhook will check for the submission ID, if an execution has executed with the submission ID, it will not execute again
* Use an advisory lock to prevent race conditions when FormSG concurrently triggers Plumber’s webhook with the same submission ID

## Tests
- [ ] Existing Pipes with FormSG work as intended
- [ ] New Pipes with FormSG work as intended
- [ ] Call Plumber webhook with a prior form submission and ensure that Pipe does not execute again

## Deploy Notes
* Run migration to add new index to `Executions` table: `flow_id`, `test_run`, `internal_id`
