### PR TITLE
fix: dedupe multiple cc repeated emails

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -134,15 +134,26 @@ describe('postman transactional email schema zod validation', () => {
     expect(result.data.body).toBe('hello<br>hihi')
   })
 
-  it('should validate multiple valid CC emails', () => {
+  it('should validate and lowercase multiple valid CC emails', () => {
     validPayload.destinationEmailCc =
       'recipientCc@example.com, recipientCc2@example.com,recipientCc3@example.com'
     const result = transactionalEmailSchema.safeParse(validPayload)
     assert(result.success === true) // using assert here for type assertion
     expect(result.data.destinationEmailCc).toEqual([
-      'recipientCc@example.com',
-      'recipientCc2@example.com',
-      'recipientCc3@example.com',
+      'recipientcc@example.com',
+      'recipientcc2@example.com',
+      'recipientcc3@example.com',
+    ])
+  })
+
+  it('should dedupe repeated multiple valid CC emails', () => {
+    validPayload.destinationEmailCc =
+      'recipientCc@example.com, recipientCc2@example.com,recipientCc@example.com'
+    const result = transactionalEmailSchema.safeParse(validPayload)
+    assert(result.success === true) // using assert here for type assertion
+    expect(result.data.destinationEmailCc).toEqual([
+      'recipientcc@example.com',
+      'recipientcc2@example.com',
     ])
   })
 

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -11,6 +11,7 @@ function recipientStringToArray(value: string) {
     .split(',')
     .map((e) => e.trim())
     .filter((e) => e?.length > 0)
+    .map((e) => e.toLowerCase())
   // dedupe the array
   return uniq(recipientArray)
 }

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -9,9 +9,8 @@ import { parseS3Id } from '@/helpers/s3'
 function recipientStringToArray(value: string) {
   const recipientArray = value
     .split(',')
-    .map((e) => e.trim())
+    .map((e) => e.trim().toLowerCase())
     .filter((e) => e?.length > 0)
-    .map((e) => e.toLowerCase())
   // dedupe the array
   return uniq(recipientArray)
 }


### PR DESCRIPTION
## Problem

User wanted to send emails with the CC functionality but her emails were of different case and it was giving an error because we don't dedupe it properly.

## Solution

Lowercase the emails since they are no case-sensitive

## Tests
- [x] Multiple repeated cc emails of different casing are deduped and does not throw an error
- [x] Multiple repeated destination emails of different casing are also deduped now so it won't be sent more than once to the same user email

