### PR TITLE
fix(tiles): remove deleted column keys when updating row

### DIFF
--- a/packages/frontend/src/graphql/cache.ts
+++ b/packages/frontend/src/graphql/cache.ts
@@ -10,6 +10,17 @@ export const cacheConfig = {
     App: {
       keyFields: ['key'],
     },
+    // prevent apollo client from complaining about cache data loss
+    // for use when updating table (columns/names/etc)
+    TableMetadata: {
+      fields: {
+        columns: {
+          merge(_existing = [], incoming: any[]) {
+            return incoming // Replace existing with incoming
+          },
+        },
+      },
+    },
     Mutation: {
       mutationType: true,
       fields: {

--- a/packages/frontend/src/pages/Tile/hooks/useUpdateRow.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useUpdateRow.tsx
@@ -21,7 +21,7 @@ interface UpdateRowOutput {
 export function useUpdateRow(
   setData: Dispatch<SetStateAction<GenericRowData[]>>,
 ) {
-  const { tableId } = useTableContext()
+  const { tableId, tableColumns } = useTableContext()
   const [rowsUpdating, setRowsUpdating] = useState<Record<string, boolean>>({})
 
   const [updateRowMutation] = useMutation<UpdateRowOutput, UpdateRowInput>(
@@ -45,6 +45,12 @@ export function useUpdateRow(
   const updateRow = useCallback(
     async (updatedRow: GenericRowData) => {
       const { rowId, ...data } = updatedRow
+      // delete keys from data that are not in the table (recently deleted columns)
+      Object.keys(data).forEach((key) => {
+        if (!tableColumns.some((column) => column.id === key)) {
+          delete data[key]
+        }
+      })
       setRowsUpdating((oldState) => {
         oldState[rowId] = true
         return { ...oldState }
@@ -64,7 +70,7 @@ export function useUpdateRow(
         },
       })
     },
-    [setData, tableId, updateRowMutation],
+    [setData, tableId, tableColumns, updateRowMutation],
   )
   return {
     rowsUpdating,

--- a/packages/frontend/src/pages/Tile/hooks/useUpdateTable.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useUpdateTable.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { type SetOptional } from 'type-fest'
 
+import { UpdateTableMutation } from '@/graphql/__generated__/graphql'
 import { UPDATE_TABLE } from '@/graphql/mutations/tiles/update-table'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 
@@ -22,10 +23,6 @@ interface UpdateTableInput {
   }
 }
 
-interface UpdateTableOutput {
-  createRow: string
-}
-
 export function useUpdateTable() {
   const { tableId } = useTableContext()
   const [isUpdatingTableName, setIsUpdatingTableName] = useState(false)
@@ -33,7 +30,7 @@ export function useUpdateTable() {
   const [isUpdatingColumns, setIsUpdatingColumns] = useState(false)
   const [isDeletingColumns, setIsDeletingColumns] = useState(false)
 
-  const [updateTable] = useMutation<UpdateTableOutput, UpdateTableInput>(
+  const [updateTable] = useMutation<UpdateTableMutation, UpdateTableInput>(
     UPDATE_TABLE,
     {
       awaitRefetchQueries: true,


### PR DESCRIPTION
## Problem
After deleting a column, users cannot update rows as it tries to store a row with non-existent column keys

## Solution
Remove deleted column keys from data before writing.

Also specify cache merge strategy for TableMetadata.columns