### PR TITLE
[SIDE-DRAWER-8] Post bugbash UI fixes - Part 1

### DIFF
--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -74,7 +74,7 @@ const action: IRawAction = {
               },
             ],
           },
-          customStyle: { flex: 2 },
+          customStyle: { flex: 3 },
         },
         {
           placeholder: 'Value',
@@ -82,7 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 5 },
         },
       ],
     },

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -145,7 +145,7 @@ function ChooseConnectionSubstep(
   ])
 
   return (
-    <Flex w="100%" p="1rem 1rem 1.5rem" flexDir="column" gap={4}>
+    <Flex w="100%" p="16px 0px" flexDir="column" gap={4}>
       <Flex justifyContent="space-between" alignItems="baseline">
         <Flex alignItems="baseline" gap={2}>
           <Icon

--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -20,7 +20,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
   // If in between add button is disabled, we hide it
   if (isHidden || (isDisabled && !isLastStep)) {
     return (
-      <Box pos="relative" h={24} display="flex" justifyContent="center">
+      <Box pos="relative" h={20} display="flex" justifyContent="center">
         {/* dont show line if last step, leave box for padding */}
         {!isLastStep && (
           <Divider orientation="vertical" borderColor="base.divider.strong" />
@@ -37,6 +37,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
         flexDir="column"
         alignItems="center"
         alignSelf="stretch"
+        h={20}
       >
         {/* Show empty action instead of add button */}
         {showEmptyAction && (
@@ -45,13 +46,13 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
             <Divider
               orientation="vertical"
               borderColor="base.divider.strong"
-              h={20}
+              h={24}
             />
             <EmptyFlowStepHeader isTrigger={false} onModalOpen={onOpen} />
           </>
         )}
         {/* Top vertical line */}
-        <Box h={5}>
+        <Box h={6}>
           <Divider orientation="vertical" borderColor="base.divider.strong" />
         </Box>
         <TouchableTooltip
@@ -81,7 +82,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
         </TouchableTooltip>
         {/* Bottom vertical line */}
         {!isLastStep && (
-          <Box h={5}>
+          <Box h={6}>
             <Divider orientation="vertical" borderColor="base.divider.strong" />
           </Box>
         )}

--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -17,85 +17,84 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
   const { isHidden, isLastStep, stepId, isDisabled, showEmptyAction } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  // If in between add button is disabled, we hide it
-  if (isHidden || (isDisabled && !isLastStep)) {
-    return (
-      <Box pos="relative" h={20} display="flex" justifyContent="center">
-        {/* dont show line if last step, leave box for padding */}
-        {!isLastStep && (
-          <Divider orientation="vertical" borderColor="base.divider.strong" />
-        )}
-      </Box>
-    )
-  }
-
   return (
-    <>
-      <Box
-        pos="relative"
-        display="flex"
-        flexDir="column"
-        alignItems="center"
-        alignSelf="stretch"
-        h={20}
-      >
-        {/* Show empty action instead of add button */}
-        {showEmptyAction && (
-          <>
-            {/* Top vertical line */}
-            <Divider
-              orientation="vertical"
-              borderColor="base.divider.strong"
-              h={24}
-            />
-            <EmptyFlowStepHeader isTrigger={false} onModalOpen={onOpen} />
-          </>
-        )}
-        {/* Top vertical line */}
-        <Box h={6}>
+    <Box
+      pos="relative"
+      display="flex"
+      flexDir="column"
+      alignItems="center"
+      alignSelf="stretch"
+      h={showEmptyAction ? undefined : 20}
+    >
+      {isHidden || (isDisabled && !isLastStep) ? (
+        !isLastStep && (
+          // If in between add button is disabled, we hide it
           <Divider orientation="vertical" borderColor="base.divider.strong" />
-        </Box>
-        <TouchableTooltip
-          label={isDisabled ? '' : 'Add step'}
-          placement="right"
-          display={isDisabled && !isLastStep ? 'none' : 'flex'}
-          marginX="auto"
-        >
-          <IconButton
-            onClick={onOpen}
-            aria-label="Add Step"
-            isDisabled={isDisabled || showEmptyAction}
-            icon={<BiPlus />}
-            variant={isLastStep ? 'outline' : 'clear'}
-            size="xs"
-            color="interaction.sub.default"
-            borderRadius="full"
-            pointerEvents={isDisabled ? 'none' : 'auto'}
-            _hover={{
-              bg: 'interaction.muted.neutral.hover',
-            }}
-            _active={{
-              bg: 'interaction.muted.neutral.active',
-            }}
-            borderColor={isLastStep ? 'interaction.sub.default' : undefined}
-          />
-        </TouchableTooltip>
-        {/* Bottom vertical line */}
-        {!isLastStep && (
+        )
+      ) : (
+        <>
+          {/* Show empty action instead of add button */}
+          {showEmptyAction && (
+            <>
+              {/* Top vertical line */}
+              <Divider
+                orientation="vertical"
+                borderColor="base.divider.strong"
+                h={20}
+              />
+              <EmptyFlowStepHeader isTrigger={false} onModalOpen={onOpen} />
+            </>
+          )}
+          {/* Top vertical line */}
           <Box h={6}>
             <Divider orientation="vertical" borderColor="base.divider.strong" />
           </Box>
-        )}
-      </Box>
+          <TouchableTooltip
+            label={isDisabled ? '' : 'Add step'}
+            placement="right"
+            display={isDisabled && !isLastStep ? 'none' : 'flex'}
+            marginX="auto"
+          >
+            <IconButton
+              onClick={onOpen}
+              aria-label="Add Step"
+              isDisabled={isDisabled || showEmptyAction}
+              icon={<BiPlus />}
+              variant={isLastStep ? 'outline' : 'clear'}
+              size="xs"
+              color="interaction.sub.default"
+              borderRadius="full"
+              pointerEvents={isDisabled ? 'none' : 'auto'}
+              _hover={{
+                bg: 'interaction.muted.neutral.hover',
+              }}
+              _active={{
+                bg: 'interaction.muted.neutral.active',
+              }}
+              borderColor={isLastStep ? 'interaction.sub.default' : undefined}
+              h={8}
+            />
+          </TouchableTooltip>
+          {/* Bottom vertical line */}
+          {!isLastStep && (
+            <Box h={6}>
+              <Divider
+                orientation="vertical"
+                borderColor="base.divider.strong"
+              />
+            </Box>
+          )}
 
-      {isOpen && (
-        <FlowStepConfigurationModal
-          onClose={onClose}
-          isTrigger={false} // Can only add an action all the time
-          isLastStep={isLastStep}
-          prevStepId={stepId}
-        />
+          {isOpen && (
+            <FlowStepConfigurationModal
+              onClose={onClose}
+              isTrigger={false} // Can only add an action all the time
+              isLastStep={isLastStep}
+              prevStepId={stepId}
+            />
+          )}
+        </>
       )}
-    </>
+    </Box>
   )
 }

--- a/packages/frontend/src/components/Editor/styles.ts
+++ b/packages/frontend/src/components/Editor/styles.ts
@@ -12,7 +12,7 @@ export const editorStyles = {
     minH: '100%',
     maxW: 'full',
     overflowY: 'auto' as FlexProps['overflowY'],
-    py: '40px',
+    py: 10,
     px: 0,
     transition: 'width 0.3s ease-in-out, transform 0.3s ease-in-out',
     w: '100%',

--- a/packages/frontend/src/components/Editor/styles.ts
+++ b/packages/frontend/src/components/Editor/styles.ts
@@ -12,7 +12,7 @@ export const editorStyles = {
     minH: '100%',
     maxW: 'full',
     overflowY: 'auto' as FlexProps['overflowY'],
-    py: 3,
+    py: '40px',
     px: 0,
     transition: 'width 0.3s ease-in-out, transform 0.3s ease-in-out',
     w: '100%',

--- a/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
@@ -1,7 +1,7 @@
 import { IStep } from '@plumber/types'
 
 import { MouseEventHandler, useCallback, useRef } from 'react'
-import { BiTrashAlt } from 'react-icons/bi'
+import { BiTrash } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import { Flex, useDisclosure } from '@chakra-ui/react'
 import { IconButton, useIsMobile } from '@opengovsg/design-system-react'
@@ -58,7 +58,7 @@ export default function StepDeleteButton(props: StepDeleteButtonProps) {
           variant="clear"
           aria-label="Delete Step"
           colorScheme="secondary"
-          icon={<BiTrashAlt />}
+          icon={<BiTrash />}
           minHeight={isNested ? 6 : 8}
           minWidth={isNested ? 6 : 8}
           className={isMobile ? undefined : 'hover-remove-button'}

--- a/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
@@ -50,7 +50,7 @@ export default function StepDeleteButton(props: StepDeleteButtonProps) {
     <>
       <Flex ml="auto">
         <IconButton
-          boxSize={isNested ? 8 : 10}
+          boxSize={isNested ? 6 : 8}
           onClick={(event) => {
             onDialogOpen()
             event.stopPropagation()

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -7,7 +7,7 @@ import {
   useContext,
   useRef,
 } from 'react'
-import { BiTrashAlt } from 'react-icons/bi'
+import { BiTrash } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import {
   AlertDialog,
@@ -124,7 +124,7 @@ export default function Branch(props: BranchProps) {
                 variant="clear"
                 aria-label="Delete branch"
                 colorScheme="secondary"
-                icon={<BiTrashAlt />}
+                icon={<BiTrash />}
                 isLoading={isDeletingBranch}
                 isDisabled={isDeletingBranch}
               />

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -106,7 +106,7 @@ export default function Branch(props: BranchProps) {
         mb={2}
         role="group"
       >
-        <Flex alignItems="center" borderRadius="inherit" w="full">
+        <Flex alignItems="center" borderRadius="inherit" w="full" h={8}>
           {/* Branch name */}
           <Text textStyle="subhead-1" color="base.content.default">
             {branchSteps[0].parameters.branchName as string}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -150,12 +150,10 @@ export default function FlowStepTestController(
                         : onTestResultOpen()
                     }
                   >
-                    <Flex alignItems="center" cursor="pointer">
-                      <Text color="base.content.default">{infoBoxText}</Text>
-                      <Box ml={2} color="base.content.default">
-                        {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
-                      </Box>
-                    </Flex>
+                    <Text color="base.content.default">{infoBoxText}</Text>
+                    <Box ml={2} color="base.content.default">
+                      {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
+                    </Box>
                   </Button>
                   {shouldShowSaveButton ? (
                     <Flex gap={2}>

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -140,20 +140,23 @@ export default function FlowStepTestController(
                   alignItems="center"
                   w="100%"
                 >
-                  <Flex
-                    alignItems="center"
+                  <Button
+                    variant="clear"
+                    colorScheme="green"
+                    size="sm"
                     onClick={() =>
                       isTestResultOpen
                         ? onTestResultClose()
                         : onTestResultOpen()
                     }
-                    cursor="pointer"
                   >
-                    <Text>{infoBoxText}</Text>
-                    <Box ml={2}>
-                      {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
-                    </Box>
-                  </Flex>
+                    <Flex alignItems="center" cursor="pointer">
+                      <Text color="base.content.default">{infoBoxText}</Text>
+                      <Box ml={2} color="base.content.default">
+                        {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
+                      </Box>
+                    </Flex>
+                  </Button>
                   {shouldShowSaveButton ? (
                     <Flex gap={2}>
                       <Button

--- a/packages/frontend/src/components/FlowStepTestController/styles.ts
+++ b/packages/frontend/src/components/FlowStepTestController/styles.ts
@@ -4,7 +4,7 @@ export const flowStepTestControllerStyles = {
   container: {
     direction: 'row' as StackProps['direction'],
     spacing: 4,
-    py: '16px',
+    py: 4,
     justify: 'flex-end',
     borderTop: '1px solid',
     borderTopColor: 'base.divider.medium',

--- a/packages/frontend/src/components/FlowStepTestController/styles.ts
+++ b/packages/frontend/src/components/FlowStepTestController/styles.ts
@@ -4,7 +4,7 @@ export const flowStepTestControllerStyles = {
   container: {
     direction: 'row' as StackProps['direction'],
     spacing: 4,
-    p: '1rem',
+    py: '16px',
     justify: 'flex-end',
     borderTop: '1px solid',
     borderTopColor: 'base.divider.medium',

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -110,7 +110,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   return (
     <Box position="relative" display="flex" flexDirection="column">
       {(!isTrigger || argsToDisplay.length > 0) && (
-        <Box flex="1" p={0} pb="16px">
+        <Box flex="1" p={0} pb={4}>
           <Stack w="100%" spacing={4}>
             {argsToDisplay.map((argument) => (
               <InputCreator

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -110,7 +110,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   return (
     <Box position="relative" display="flex" flexDirection="column">
       {(!isTrigger || argsToDisplay.length > 0) && (
-        <Box flex="1" p="16px 0px">
+        <Box flex="1" p={0} pb="16px">
           <Stack w="100%" spacing={4}>
             {argsToDisplay.map((argument) => (
               <InputCreator

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -110,7 +110,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   return (
     <Box position="relative" display="flex" flexDirection="column">
       {(!isTrigger || argsToDisplay.length > 0) && (
-        <Box flex="1" p="1rem 1rem">
+        <Box flex="1" p="16px 0px">
           <Stack w="100%" spacing={4}>
             {argsToDisplay.map((argument) => (
               <InputCreator

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -51,6 +51,7 @@ export default function MultiCol(props: MultiColProps) {
           icon={<BiTrash />}
           isDisabled={isEditorReadOnly}
           onClick={() => remove?.(index)}
+          colorScheme="secondary"
         />
       )}
     </Flex>

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -138,6 +138,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                             icon={<BiTrash />}
                             isDisabled={isEditorReadOnly}
                             onClick={() => remove(index)}
+                            colorScheme="secondary"
                           />
                         )}
                       </Flex>

--- a/packages/frontend/src/theme/index.ts
+++ b/packages/frontend/src/theme/index.ts
@@ -24,6 +24,9 @@ export const theme = extendTheme(
             transform: 'scale(0.9)',
           },
         },
+        body: {
+          fontFeatureSettings: 'inherit',
+        },
       },
     },
     Form: {


### PR DESCRIPTION
## TL;DR
This PR addresses issues found during the bug bash

## What was fixed?
* Padding inconsistencies between published and unpublished state
* Step header and add step button positions
* Standardised delete buttons
* Use a button to open test step result
* Font inconsistency between readonly and edit modes
* Padding of Step from navbar
* Padding of Side Drawer contents

## How to test?
- [ ] Publish a Pipe + Unpublish a Pipe, padding should be the same for both states, including step header and add step button positions
- [ ] Delete buttons are the same across the Editor, and delete functionality still works
  - [ ] Delete step
  - [ ] Delete branch
  - [ ] Delete "And" data in set up step
- [ ] Button shadow should show when hovering over 'Step was set up successfully' or 'Previous result'
  - [ ] Collapse opens / closes correctly when clicking on the button
- [ ] Rename Step / Pipe: font is the same in readonly and edit mode
- [ ] First Step is 40px from the navbar
- [ ] Left-right padding of items in the right drawer is consistent at 16px

