### PR TITLE
[TILES-V2-2]: add new column to table_metadata

### DIFF
--- a/packages/backend/src/db/migrations/20250506071427_add_table_metadata_db_column.ts
+++ b/packages/backend/src/db/migrations/20250506071427_add_table_metadata_db_column.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('table_metadata', (table) => {
+    table.string('db').defaultTo('ddb').notNullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('table_metadata', (table) => {
+    table.dropColumn('db')
+  })
+}

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -17,6 +17,7 @@ class TableMetadata extends Base {
    */
   role?: ITableCollabRole
   lastAccessedAt?: Date
+  db: 'pg' | 'ddb'
 
   static tableName = 'table_metadata'
 


### PR DESCRIPTION
### Changes
Added a new `db` column to the `table_metadata` table to distinguish between PostgreSQL and DynamoDB tables.

### What changed?

- Created a new migration file `20250506071427_add_table_metadata_db_column.ts` that adds a `db` column to the `table_metadata` table with a default value of 'ddb' and not nullable constraint
- Updated the `TableMetadata` model to include the new `db` property with type 'pg' | 'ddb'

### How to test?

1. Run the migration
2. Verify the column exists in the database schema
3. Check that existing records have the default 'ddb' value