### PR TITLE
[TILES-V2-6]: use factory class for queries and mutations, minimise getAllRows payload

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -30,7 +30,7 @@ describe('create table mutation', () => {
   it('should create a table and with placeholder rows and columns', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false } },
+      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
       context,
     )
     const tableColumnCount = await table.$relatedQuery('columns').resultSize()

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -17,7 +17,7 @@ describe('create table mutation', () => {
   it('should create a blank table', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: true } },
+      { input: { name: 'Test Table', isBlank: true, databaseType: 'ddb' } },
       context,
     )
     const tableColumnCount = await table.$relatedQuery('columns').resultSize()
@@ -58,11 +58,7 @@ describe('create table mutation', () => {
 
   it('should throw an error when table name is empty', async () => {
     await expect(
-      createTable(
-        null,
-        { input: { name: '', isBlank: false, databaseType: 'ddb' } },
-        context,
-      ),
+      createTable(null, { input: { name: '', isBlank: false } }, context),
     ).rejects.toThrow()
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -43,13 +43,13 @@ describe('create table mutation', () => {
   it('should be able create tables with the same name', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false } },
+      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
       context,
     )
 
     const table2 = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false } },
+      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
       context,
     )
     expect(table.name).toBe('Test Table')
@@ -58,7 +58,11 @@ describe('create table mutation', () => {
 
   it('should throw an error when table name is empty', async () => {
     await expect(
-      createTable(null, { input: { name: '', isBlank: false } }, context),
+      createTable(
+        null,
+        { input: { name: '', isBlank: false, databaseType: 'ddb' } },
+        context,
+      ),
     ).rejects.toThrow()
   })
 })

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -137,7 +137,32 @@ describe('get all rows query', () => {
     )
     const rows = await Promise.all(returnedRows)
 
-    expect(rows[0].data.split(',').length).toBe(dummyColumnIds.length)
+    expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length)
+  })
+
+  it('should handle values with commas in them', async () => {
+    const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+    // add a value with a comma in it
+    data[dummyColumnIds[0]] = 'test,test'
+    const rowToInsert = {
+      tableId: dummyTable.id,
+      // TODO: use ulid for new tiles
+      rowId: randomUUID(),
+      data,
+    }
+
+    await createTableRow(rowToInsert)
+
+    const { rows: returnedRows } = await getAllRows(
+      null,
+      {
+        tableId: dummyTable.id,
+      },
+      context,
+    )
+    const rows = await Promise.all(returnedRows)
+
+    expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length)
   })
 
   it('should allow all collaborators to call this function', async () => {

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -98,7 +98,6 @@ describe('get all rows query', () => {
         context,
       )
       cursor = stringifiedCursor
-      expect(pageRows.length).toBeLessThan(numRowsToInsert)
       rows = rows.concat(pageRows)
     } while (cursor)
     expect(rows.length).toBe(numRowsToInsert)
@@ -138,7 +137,7 @@ describe('get all rows query', () => {
     )
     const rows = await Promise.all(returnedRows)
 
-    expect(Object.keys(rows[0].data).sort()).toEqual(dummyColumnIds.sort())
+    expect(rows[0].data.split(',').length).toBe(dummyColumnIds.length)
   })
 
   it('should allow all collaborators to call this function', async () => {

--- a/packages/backend/src/graphql/mutations/tiles/create-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-row.ts
@@ -1,6 +1,6 @@
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -19,7 +19,9 @@ const createRow: MutationResolvers['createRow'] = async (
     throw new Error('Invalid column id')
   }
 
-  const row = await createTableRow({ tableId, data })
+  const tableOperations = getTableOperations(table.db)
+
+  const row = await tableOperations.createTableRow({ tableId, data })
 
   return row.rowId
 }

--- a/packages/backend/src/graphql/mutations/tiles/create-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-rows.ts
@@ -1,6 +1,6 @@
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRows } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -19,7 +19,9 @@ const createRows: MutationResolvers['createRows'] = async (
     throw new Error('Invalid column id')
   }
 
-  await createTableRows({ tableId, dataArray })
+  const tableOperations = getTableOperations(table.db)
+
+  await tableOperations.createTableRows({ tableId, dataArray })
 
   return true
 }

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -1,3 +1,4 @@
+import TableMetadata from '@/models/table-metadata'
 import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
@@ -35,18 +36,23 @@ const createTable: MutationResolvers['createTable'] = async (
 
   const tableOperations = getTableOperations(databaseType)
 
-  // TODO: should i wrap this in a transaction?
-  const table = await context.currentUser.$relatedQuery('tables').insertGraph({
-    name: tableName,
-    role: 'owner',
-    db: databaseType,
-    columns: isBlankTable ? [] : PLACEHOLDER_COLUMNS,
-  })
+  const table = await TableMetadata.transaction(async (trx) => {
+    const pendingTable = await context.currentUser
+      .$relatedQuery('tables', trx)
+      .insertGraph({
+        name: tableName,
+        role: 'owner',
+        db: databaseType,
+        columns: isBlankTable ? [] : PLACEHOLDER_COLUMNS,
+      })
 
-  await tableOperations.createTable(
-    table.id,
-    isBlankTable ? [] : table.columns.map((column) => column.id),
-  )
+    await tableOperations.createTable(
+      pendingTable.id,
+      isBlankTable ? [] : pendingTable.columns.map((column) => column.id),
+    )
+
+    return pendingTable
+  })
 
   if (!isBlankTable) {
     await tableOperations.createTableRows({

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -1,4 +1,4 @@
-import { createTableRows } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -23,20 +23,36 @@ const createTable: MutationResolvers['createTable'] = async (
   params,
   context,
 ) => {
-  const { name: tableName, isBlank: isBlankTable } = params.input
+  const {
+    name: tableName,
+    isBlank: isBlankTable,
+    databaseType = 'pg',
+  } = params.input
 
   if (!tableName) {
     throw new Error('Table name is required')
   }
 
+  const tableOperations = getTableOperations(databaseType)
+
+  // TODO: should i wrap this in a transaction?
   const table = await context.currentUser.$relatedQuery('tables').insertGraph({
     name: tableName,
     role: 'owner',
+    db: databaseType,
     columns: isBlankTable ? [] : PLACEHOLDER_COLUMNS,
   })
 
+  await tableOperations.createTable(
+    table.id,
+    isBlankTable ? [] : table.columns.map((column) => column.id),
+  )
+
   if (!isBlankTable) {
-    await createTableRows({ tableId: table.id, dataArray: PLACEHOLDER_ROWS })
+    await tableOperations.createTableRows({
+      tableId: table.id,
+      dataArray: PLACEHOLDER_ROWS,
+    })
   }
 
   return table

--- a/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-rows.ts
@@ -1,5 +1,6 @@
 import TableCollaborator from '@/models/table-collaborators'
-import { deleteTableRows } from '@/models/tiles/dynamodb/table-row'
+import TableMetadata from '@/models/table-metadata'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -12,7 +13,10 @@ const deleteRows: MutationResolvers['deleteRows'] = async (
 
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-  await deleteTableRows({ tableId, rowIds })
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+  const tableOperations = getTableOperations(table.db)
+
+  await tableOperations.deleteTableRows({ tableId, rowIds })
 
   return rowIds
 }

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -1,6 +1,6 @@
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
-import { updateTableRow } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -19,7 +19,9 @@ const updateRow: MutationResolvers['updateRow'] = async (
     throw new Error('Invalid column id')
   }
 
-  await updateTableRow({ tableId, rowId, data })
+  const tableOperations = getTableOperations(table.db)
+
+  await tableOperations.updateTableRow({ tableId, rowId, data })
 
   return rowId
 }

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
@@ -45,6 +46,8 @@ const updateTable: MutationResolvers['updateTable'] = async (
 
   const table = await TableMetadata.query().findById(tableId)
 
+  const tableOperations = getTableOperations(table.db)
+
   if (tableName) {
     await table.$query().patch({
       name: tableName.trim(),
@@ -57,11 +60,20 @@ const updateTable: MutationResolvers['updateTable'] = async (
         .$relatedQuery('columns', trx)
         .max('position as position') // aliasing for more convenient typing
       const maxPosition = results[0].position || 0
-      await table.$relatedQuery('columns', trx).insert(
-        addedColumns.map((name, i) => ({
-          name,
-          position: maxPosition + i + 1,
-        })),
+      const tableMetadataColumns = await table
+        .$relatedQuery('columns', trx)
+        .insert(
+          addedColumns.map((name, i) => ({
+            name,
+            position: maxPosition + i + 1,
+          })),
+        )
+        .returning('id')
+
+      // If creation of columns fail, we roll back the creation of table column metadata
+      await tableOperations.createTableColumns(
+        tableId,
+        tableMetadataColumns.map((column) => column.id),
       )
     })
   }
@@ -98,6 +110,8 @@ const updateTable: MutationResolvers['updateTable'] = async (
         .$relatedQuery('columns')
         .delete()
         .whereIn('id', deletedColumns)
+
+      await tableOperations.deleteTableColumns(tableId, deletedColumns)
     })
   }
 

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -50,7 +50,7 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
 
     // Convert data object to csv to minimize payload size
     rows.forEach((row) => {
-      row.data = columnIds.map((columnId) => row.data[columnId]).join(',')
+      row.data = JSON.stringify(columnIds.map((columnId) => row.data[columnId]))
     })
 
     return {

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -6,7 +6,7 @@ import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import logger from '@/helpers/logger'
 import TableMetadata from '@/models/table-metadata'
 import { DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE } from '@/models/tiles/dynamodb/helpers'
-import { getTableRows } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
 
@@ -15,7 +15,7 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
   params,
   context,
 ) => {
-  const { tableId, stringifiedCursor } = params
+  const { tableId } = params
 
   try {
     const table = context.tilesViewKey
@@ -39,14 +39,24 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
       })
     }
 
+    const tableOperations = getTableOperations(table.db)
+
     const columnIds = table.columns.map((column) => column.id)
 
-    return await getTableRows({
+    const { rows } = await tableOperations.getTableRows({
       tableId,
       columnIds,
-      stringifiedCursor: stringifiedCursor ?? 'start',
     })
-    // TODO: remove keys from rows to reduce payload size
+
+    // Convert data object to csv to minimize payload size
+    rows.forEach((row) => {
+      row.data = columnIds.map((columnId) => row.data[columnId]).join(',')
+    })
+
+    return {
+      rows,
+      columnIds,
+    }
   } catch (e) {
     logger.error(e)
     if (e instanceof ObjectionNotFoundError) {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -743,10 +743,16 @@ type PaginatedExecutionSteps {
   pageInfo: PageInfo!
 }
 
+enum DatabaseType {
+  pg
+  ddb
+}
+
 # Tiles types
 input CreateTableInput {
   name: String!
   isBlank: Boolean!
+  databaseType: DatabaseType
 }
 
 input TableColumnConfigInput {
@@ -820,6 +826,7 @@ type PaginatedTables {
 
 type GetTableRowsResult {
   rows: Any!
+  columnIds: [String!]!
   stringifiedCursor: String
 }
 

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -191,6 +191,7 @@ export async function createFlowFromTemplate(
           role: 'owner',
           columns: columnsToInsert,
         })
+
         tableId = table.id
 
         // obtain a map of column name to the column id for easy replacement
@@ -200,6 +201,8 @@ export async function createFlowFromTemplate(
 
         // replace column names with column ids for each row data and create table rows
         const newRowData = replaceColumnNamesWithIds(rowData, columnNameToIdMap)
+
+        // TODO: tiles-v2: use table operations to create rows
         await createTableRows({ tableId, dataArray: newRowData })
       } catch (e) {
         logger.error(e)

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -32,7 +32,7 @@ class TableColumnMetadata extends Base {
       modelClass: TableMetadata,
       join: {
         from: `${this.tableName}.table_id`,
-        to: `${TableColumnMetadata.tableName}.id`,
+        to: `${TableMetadata.tableName}.id`,
       },
     },
   })

--- a/packages/backend/test/pg-global-setup.ts
+++ b/packages/backend/test/pg-global-setup.ts
@@ -25,7 +25,7 @@ export async function setup() {
   )
 
   const config = await import('../knexfile')
-  const client = knex(config.default as any)
+  const client = knex(config.default)
 
   // manually running migrations since the programmatic API doesn't work
   // see issue here: https://github.com/knex/knex/issues/5323

--- a/packages/backend/test/pg-global-setup.ts
+++ b/packages/backend/test/pg-global-setup.ts
@@ -24,8 +24,8 @@ export async function setup() {
     `PostgreSQL container started at port ${process.env.POSTGRES_PORT}`,
   )
 
-  const config = await import('../knexfile')
-  const client = knex(config.default)
+  const config = await (await import('../knexfile')).default
+  const client = knex(config)
 
   // manually running migrations since the programmatic API doesn't work
   // see issue here: https://github.com/knex/knex/issues/5323

--- a/packages/backend/test/pg-reset-db-setup.ts
+++ b/packages/backend/test/pg-reset-db-setup.ts
@@ -8,19 +8,22 @@ import { afterEach, beforeEach } from 'vitest'
 
 import config from '../knexfile'
 
-const client = knex(config as Knex.Config)
-
 beforeEach(async () => {
+  const client = knex(config as Knex.Config)
+
   // manually running seeds for the same reasons
   const seedsToRun = readdirSync(config.seeds.directory)
   for (const seedFile of seedsToRun) {
     const { seed } = await import(join(config.seeds.directory, seedFile))
     await seed(client)
   }
+  await client.destroy()
   console.info(`vite: PostgreSQL seeds run`)
 })
 
 afterEach(async () => {
+  const client = knex(config as Knex.Config)
+
   // truncate all tables
   const tables = await client('pg_catalog.pg_tables')
     .select('tablename')
@@ -31,4 +34,7 @@ afterEach(async () => {
     await client.raw(`TRUNCATE TABLE "${table}" CASCADE`)
   }
   console.info(`vite: PostgreSQL tables truncated`)
+
+  // Close the database connection
+  await client.destroy()
 })

--- a/packages/frontend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-all-rows.ts
@@ -4,6 +4,7 @@ export const GET_ALL_ROWS = graphql(`
   query GetAllRows($tableId: String!, $stringifiedCursor: String) {
     getAllRows(tableId: $tableId, stringifiedCursor: $stringifiedCursor) {
       rows
+      columnIds
       stringifiedCursor
     }
   }

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -19,7 +19,7 @@ const convertCsvRowToObject = (
   row: ITableRowCsv,
   columnIds: string[],
 ): ITableRow => {
-  const dataArray = row.data.split(',')
+  const dataArray = JSON.parse(row.data)
 
   if (dataArray.length !== columnIds.length) {
     console.warn(

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -1,12 +1,58 @@
-import { ITableRow } from '@plumber/types'
+import { ITableRow, ITableRowCsv } from '@plumber/types'
 
 import { useCallback, useRef, useState } from 'react'
 import { ApolloError, useLazyQuery } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
+import { zipObject } from 'lodash'
 
 import { RATE_LIMITED } from '@/config/errors'
 import { GET_ALL_ROWS } from '@/graphql/queries/tiles/get-all-rows'
 import { parseGraphqlError } from '@/helpers/parseGraphqlError'
+
+/**
+ * Converts a CSV row to an object using column IDs as keys
+ * @param row The row to convert
+ * @param columnIds Array of column IDs to use as keys
+ * @returns The converted row
+ */
+const convertCsvRowToObject = (
+  row: ITableRowCsv,
+  columnIds: string[],
+): ITableRow => {
+  const dataArray = row.data.split(',')
+
+  if (dataArray.length !== columnIds.length) {
+    console.warn(
+      `Row data length (${dataArray.length}) doesn't match columnIds length (${columnIds.length})`,
+    )
+    // Create a new ITableRow with empty data object
+    return {
+      rowId: row.rowId,
+      data: {},
+    }
+  }
+
+  return {
+    rowId: row.rowId,
+    data: zipObject(columnIds, dataArray),
+  }
+}
+
+/**
+ * Processes a row, converting it from CSV format if necessary
+ * @param row The row to process
+ * @param columnIds Array of column IDs to use as keys
+ * @returns The processed row
+ */
+const processRow = (
+  row: ITableRowCsv | ITableRow,
+  columnIds: string[],
+): ITableRow => {
+  if (typeof row.data === 'string') {
+    return convertCsvRowToObject(row as ITableRowCsv, columnIds)
+  }
+  return row as ITableRow
+}
 
 export function useFetchAllRows({
   tableId,
@@ -22,7 +68,7 @@ export function useFetchAllRows({
   const cursorToContinueFrom = useRef<string>()
   const startTime = useRef<number>()
 
-  const [fetchAllRowsMutation] = useLazyQuery(GET_ALL_ROWS, {
+  const [fetchAllRowsQuery] = useLazyQuery(GET_ALL_ROWS, {
     context: urlViewOnlyKey
       ? {
           headers: { 'x-tiles-view-key': urlViewOnlyKey },
@@ -39,7 +85,7 @@ export function useFetchAllRows({
       let currentCursor = cursor
       try {
         do {
-          const { data, error } = await fetchAllRowsMutation({
+          const { data, error } = await fetchAllRowsQuery({
             variables: {
               stringifiedCursor: currentCursor,
               tableId: tableId,
@@ -51,8 +97,14 @@ export function useFetchAllRows({
           if (!data?.getAllRows) {
             throw new Error('No data returned from getAllRows')
           }
-          rowCount += data.getAllRows.rows.length
-          setRows((prev) => [...prev, ...data.getAllRows.rows])
+          const { rows, columnIds } = data.getAllRows
+
+          // Process all rows, converting CSV format to objects if needed
+          const processedRows = rows.map((row: ITableRowCsv | ITableRow) =>
+            processRow(row, columnIds),
+          )
+          rowCount += processedRows.length
+          setRows((prev) => [...prev, ...processedRows])
           currentCursor = data?.getAllRows.stringifiedCursor ?? undefined
         } while (currentCursor)
       } catch (e) {
@@ -74,7 +126,7 @@ export function useFetchAllRows({
         setIsFetching(false)
       }
     },
-    [fetchAllRowsMutation, tableId],
+    [fetchAllRowsQuery, tableId],
   )
 
   const refetch = useCallback(async () => {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -915,6 +915,11 @@ export interface ITableCollaborator {
   role: ITableCollabRole
 }
 
+export interface ITableRowCsv {
+  rowId: string
+  data: string
+}
+
 export interface ITableRow {
   rowId: string
   data: Record<string, IJSONPrimitive>


### PR DESCRIPTION
### Changes
Added support for multiple database types in the table system with a factory pattern for database operations.

### What changed?

- Implemented a database type factory pattern with `getTableOperations()` to support multiple database backends
- Added a `databaseType` parameter to the `CreateTableInput` GraphQL type
- Updated all table operations (create, read, update, delete) to use the factory pattern
- Modified row data format to use CSV for network transfer to reduce payload size
- Added conversion logic in the frontend to transform CSV data back to object format
- Fixed table relationship definitions in `TableColumnMetadata`
- Improved database connection handling in tests

### How to test?

1. Create a new table with the DynamoDB backend: `createTable({ name: "Test Table", isBlank: false, databaseType: "ddb" })`
2. Create a new table with the PostgreSQL backend (default): `createTable({ name: "Test Table", isBlank: false })`
3. Verify that operations (adding/updating/deleting rows and columns) work correctly on both table types
4. Check that row data is properly displayed in the frontend despite the CSV transfer format
