### PR TITLE
[SIDE-DRAWER-9] Warn on unsaved changes

### DIFF
--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -1,9 +1,14 @@
+import { useContext, useRef } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Box, Divider, useDisclosure } from '@chakra-ui/react'
 import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
+
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
+
+import UnsavedChangesAlert from './UnsavedChangesAlert'
 
 interface AddStepButtonProps {
   isHidden: boolean
@@ -15,7 +20,22 @@ interface AddStepButtonProps {
 
 export function AddStepButton(props: AddStepButtonProps): JSX.Element {
   const { isHidden, isLastStep, stepId, isDisabled, showEmptyAction } = props
+  const cancelRef = useRef(null)
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
+  const { shouldWarnOnLeave } = useContext(EditorContext)
+
+  const handleOpen = () => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      onOpen()
+    }
+  }
 
   return (
     <Box
@@ -42,7 +62,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
                 borderColor="base.divider.strong"
                 h={20}
               />
-              <EmptyFlowStepHeader isTrigger={false} onModalOpen={onOpen} />
+              <EmptyFlowStepHeader isTrigger={false} onModalOpen={handleOpen} />
             </>
           )}
           {/* Top vertical line */}
@@ -56,7 +76,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
             marginX="auto"
           >
             <IconButton
-              onClick={onOpen}
+              onClick={handleOpen}
               aria-label="Add Step"
               isDisabled={isDisabled || showEmptyAction}
               icon={<BiPlus />}
@@ -95,6 +115,13 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
           )}
         </>
       )}
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={onOpen}
+      />
     </Box>
   )
 }

--- a/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
+++ b/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
@@ -13,7 +13,6 @@ export interface UnsavedChangesAlertProps {
   isOpen: boolean
   onClose: () => void
   onLeave?: () => void
-  onStay?: () => void
 }
 
 export default function UnsavedChangesAlert({
@@ -21,15 +20,9 @@ export default function UnsavedChangesAlert({
   isOpen,
   onClose,
   onLeave,
-  onStay,
 }: UnsavedChangesAlertProps): React.ReactElement {
   const handleLeave = () => {
     onLeave?.()
-    onClose()
-  }
-
-  const handleStay = () => {
-    onStay?.()
     onClose()
   }
 
@@ -50,7 +43,7 @@ export default function UnsavedChangesAlert({
           <AlertDialogFooter>
             <Button
               ref={cancelRef}
-              onClick={handleStay}
+              onClick={onClose}
               variant="clear"
               colorScheme="secondary"
             >

--- a/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
+++ b/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
@@ -1,0 +1,67 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+} from '@chakra-ui/react'
+
+export interface UnsavedChangesAlertProps {
+  cancelRef: React.RefObject<HTMLButtonElement>
+  isOpen: boolean
+  onClose: () => void
+  onLeave?: () => void
+  onStay?: () => void
+}
+
+export default function UnsavedChangesAlert({
+  cancelRef,
+  isOpen,
+  onClose,
+  onLeave,
+  onStay,
+}: UnsavedChangesAlertProps): React.ReactElement {
+  const handleLeave = () => {
+    onLeave?.()
+    onClose()
+  }
+
+  const handleStay = () => {
+    onStay?.()
+    onClose()
+  }
+
+  return (
+    <AlertDialog
+      isOpen={isOpen}
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+    >
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader>Unsaved changes</AlertDialogHeader>
+
+          <AlertDialogBody>
+            You have unsaved changes. Are you sure you want to navigate away?
+          </AlertDialogBody>
+
+          <AlertDialogFooter>
+            <Button
+              ref={cancelRef}
+              onClick={handleStay}
+              variant="clear"
+              colorScheme="secondary"
+            >
+              Stay
+            </Button>
+            <Button colorScheme="critical" onClick={handleLeave} ml={3}>
+              Leave
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  )
+}

--- a/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
+++ b/packages/frontend/src/components/Editor/UnsavedChangesAlert.tsx
@@ -41,10 +41,10 @@ export default function UnsavedChangesAlert({
     >
       <AlertDialogOverlay>
         <AlertDialogContent>
-          <AlertDialogHeader>Unsaved changes</AlertDialogHeader>
+          <AlertDialogHeader>You have unsaved changes</AlertDialogHeader>
 
           <AlertDialogBody>
-            You have unsaved changes. Are you sure you want to navigate away?
+            Are you sure you want to leave? Your changes will be lost.
           </AlertDialogBody>
 
           <AlertDialogFooter>
@@ -54,10 +54,10 @@ export default function UnsavedChangesAlert({
               variant="clear"
               colorScheme="secondary"
             >
-              Stay
+              Continue editing
             </Button>
             <Button colorScheme="critical" onClick={handleLeave} ml={3}>
-              Leave
+              Discard changes
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -34,10 +34,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
     currentStepId,
     currentStepIndex,
     flow,
-    onDrawerClose,
-    onDrawerOpen,
-    setCurrentStepId,
-    setCurrentStepIndex,
   } = useContext(EditorContext)
 
   const rawSteps = flow.steps
@@ -177,18 +173,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
               <FlowStep
                 step={step}
                 isDeletable={true}
+                index={index}
                 isLastStep={index === steps.length - 1}
                 isNested={isNested}
-                onOpen={() => {
-                  setCurrentStepId(step.id)
-                  setCurrentStepIndex(index)
-                  onDrawerOpen()
-                }}
-                onClose={() => {
-                  setCurrentStepId(null)
-                  setCurrentStepIndex(null)
-                  onDrawerClose()
-                }}
               />
               <AddStepButton
                 // hide all add button steps if is readonly

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,10 +1,18 @@
 import type { IFlow } from '@plumber/types'
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { BiChevronLeft, BiCog, BiInfoCircle } from 'react-icons/bi'
-import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ApolloError, useMutation, useQuery } from '@apollo/client'
-import { Box, Flex, HStack, Icon, Skeleton, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  HStack,
+  Icon,
+  Skeleton,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
 import {
   Button,
   IconButton,
@@ -25,18 +33,28 @@ import { GET_FLOW } from '@/graphql/queries/get-flow'
 import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
 
 import { EDITOR_MARGIN_TOP } from '../Editor/constants'
+import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 
 import EditorSnackbar from './EditorSnackbar'
 import { LensSurvey } from './LensSurvey'
 
 export default function EditorLayout() {
+  const cancelRef = useRef(null)
   const { flowId } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
   const isMobile = useIsMobile()
   const [updateFlow] = useMutation(UPDATE_FLOW)
   const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS, {
     refetchQueries: [GET_FLOW],
   })
+  const [shouldWarnOnLeave, setShouldWarnOnLeave] = useState(false)
+  const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
+
   const { data, loading, error } = useQuery(GET_FLOW, {
     variables: { id: flowId },
   })
@@ -136,7 +154,18 @@ export default function EditorLayout() {
           borderColor="base.divider.subtle"
         >
           <Flex flex={1} alignItems="center">
-            <Box as={Link} to={URLS.FLOWS} mt={1} mr={3}>
+            <Box
+              as={Link}
+              to={URLS.FLOWS}
+              mt={1}
+              mr={3}
+              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                if (shouldWarnOnLeave) {
+                  e.preventDefault()
+                  onWarningOpen()
+                }
+              }}
+            >
               <Icon
                 boxSize={6}
                 color="interaction.support.disabled-content"
@@ -222,7 +251,12 @@ export default function EditorLayout() {
           flex={1}
           overflowY="auto"
         >
-          <EditorProvider readOnly={isEditorReadOnly} flow={flow}>
+          <EditorProvider
+            readOnly={isEditorReadOnly}
+            flow={flow}
+            shouldWarnOnLeave={shouldWarnOnLeave}
+            setShouldWarnOnLeave={setShouldWarnOnLeave}
+          >
             <Editor />
             {flow.active && flow.config?.showSurvey && <LensSurvey />}
           </EditorProvider>
@@ -240,6 +274,13 @@ export default function EditorLayout() {
           demoVideoDetails={demoVideoDetails}
         />
       )}
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={() => navigate(URLS.FLOWS)}
+      />
     </>
   )
 }

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -49,6 +49,7 @@ export default function EditorLayout() {
     refetchQueries: [GET_FLOW],
   })
   const [shouldWarnOnLeave, setShouldWarnOnLeave] = useState(false)
+  const [leaveToUrl, setLeaveToUrl] = useState(URLS.FLOWS)
   const {
     isOpen: isWarningOpen,
     onOpen: onWarningOpen,
@@ -109,6 +110,16 @@ export default function EditorLayout() {
       })
     },
     [flow?.id, flowId, updateFlowStatus],
+  )
+
+  const handleWarnOnLeave = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+      if (shouldWarnOnLeave) {
+        e.preventDefault()
+        onWarningOpen()
+      }
+    },
+    [shouldWarnOnLeave, onWarningOpen],
   )
 
   // disallow user from publishing pipe if any step is incomplete
@@ -173,12 +184,7 @@ export default function EditorLayout() {
               to={URLS.FLOWS}
               mt={1}
               mr={3}
-              onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                if (shouldWarnOnLeave) {
-                  e.preventDefault()
-                  onWarningOpen()
-                }
-              }}
+              onClick={handleWarnOnLeave}
             >
               <Icon
                 boxSize={6}
@@ -228,6 +234,10 @@ export default function EditorLayout() {
               _hover={{
                 color: 'primary.500',
                 bg: 'interaction.muted.main.hover',
+              }}
+              onClick={(e) => {
+                setLeaveToUrl(URLS.FLOW_EDITOR_NOTIFICATIONS(flowId))
+                handleWarnOnLeave(e)
               }}
             />
           </TouchableTooltip>
@@ -293,7 +303,7 @@ export default function EditorLayout() {
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={() => navigate(URLS.FLOWS)}
+        onLeave={() => navigate(leaveToUrl)}
       />
     </>
   )

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,6 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { BiChevronLeft, BiCog, BiInfoCircle } from 'react-icons/bi'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ApolloError, useMutation, useQuery } from '@apollo/client'
@@ -116,6 +116,20 @@ export default function EditorLayout() {
     () => flow?.steps.some((step) => step.status === 'incomplete'),
     [flow?.steps],
   )
+
+  // warn user of unsaved changes when they try to close or reload the browser
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!shouldWarnOnLeave) {
+        return
+      }
+      e.preventDefault()
+      e.returnValue = '' // legacy but still required by some browsers
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [shouldWarnOnLeave])
 
   // navigate user to not found page if flow does not belong to the user
   if (

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -1,11 +1,13 @@
 import { IStep } from '@plumber/types'
 
-import { useContext } from 'react'
-import { CloseButton, Flex, Text } from '@chakra-ui/react'
+import { useContext, useRef } from 'react'
+import { CloseButton, Flex, Text, useDisclosure } from '@chakra-ui/react'
 
 import EditableInput from '@/components/EditableInput'
 import { EditorContext } from '@/contexts/Editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
+
+import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 
 interface StepHeaderProps {
   step: IStep
@@ -13,16 +15,38 @@ interface StepHeaderProps {
 
 export default function StepHeader(props: StepHeaderProps) {
   const { step } = props
+  const cancelRef = useRef(null)
+  const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
 
   const {
     allApps,
     readOnly: isReadOnlyEditor,
+    shouldWarnOnLeave,
     onDrawerClose,
     onUpdateStep,
     setCurrentStepId,
+    setShouldWarnOnLeave,
   } = useContext(EditorContext)
 
   const { position, stepName: initialStepName } = useStepMetadata(allApps, step)
+
+  const handleClose = () => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      handleLeave()
+    }
+  }
+
+  const handleLeave = () => {
+    onDrawerClose()
+    setCurrentStepId(null)
+    setShouldWarnOnLeave(false)
+  }
 
   const onSave = async (value: string) => {
     await onUpdateStep({
@@ -57,13 +81,12 @@ export default function StepHeader(props: StepHeaderProps) {
         />
       </Flex>
 
-      <CloseButton
-        onClick={() => {
-          onDrawerClose()
-          setCurrentStepId(null)
-        }}
-        position="absolute"
-        right="4"
+      <CloseButton onClick={handleClose} position="absolute" right="4" />
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={handleLeave}
       />
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepDeleteButton.tsx
@@ -1,31 +1,38 @@
 import { IStep } from '@plumber/types'
 
-import { MouseEventHandler, useCallback, useRef } from 'react'
+import { MouseEventHandler, useCallback, useContext, useRef } from 'react'
 import { BiTrash } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import { Flex, useDisclosure } from '@chakra-ui/react'
-import { IconButton, useIsMobile } from '@opengovsg/design-system-react'
+import { IconButton } from '@opengovsg/design-system-react'
 
 import MenuAlertDialog from '@/components/MenuAlertDialog'
+import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 
 interface StepDeleteButtonProps {
   isNested?: boolean
-  onClose: () => void
   isDeletingStep?: boolean
   step: IStep
 }
 
 export default function StepDeleteButton(props: StepDeleteButtonProps) {
-  const { isNested, onClose, step } = props
+  const { isNested, step } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
   const {
     isOpen: isDialogOpen,
     onOpen: onDialogOpen,
     onClose: onDialogClose,
   } = useDisclosure()
-  const isMobile = useIsMobile()
+
+  const {
+    isMobile,
+    onDrawerClose,
+    setCurrentStepId,
+    setCurrentStepIndex,
+    setShouldWarnOnLeave,
+  } = useContext(EditorContext)
 
   const [deleteStep, { loading: isDeletingStep }] = useMutation(DELETE_STEP, {
     refetchQueries: [GET_FLOW],
@@ -37,9 +44,19 @@ export default function StepDeleteButton(props: StepDeleteButtonProps) {
       await deleteStep({ variables: { input: { ids: [step.id] } } })
       // NOTE: this ensures that the drawer is closed and step headers
       // return to the original width when the drawer is closed
-      onClose()
+      setCurrentStepId(null)
+      setCurrentStepIndex(null)
+      setShouldWarnOnLeave(false)
+      onDrawerClose()
     },
-    [deleteStep, step.id, onClose],
+    [
+      step.id,
+      deleteStep,
+      onDrawerClose,
+      setCurrentStepId,
+      setCurrentStepIndex,
+      setShouldWarnOnLeave,
+    ],
   )
 
   if (!step.id) {

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -65,6 +65,7 @@ export default function FlowStep(
     onDrawerOpen,
     setCurrentStepId,
     setCurrentStepIndex,
+    setShouldWarnOnLeave,
   } = useContext(EditorContext)
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
   const { app, caption, isCompleted, isTrigger, selectedActionOrTrigger } =
@@ -130,6 +131,21 @@ export default function FlowStep(
     setCurrentStepIndex,
   ])
 
+  const handleLeave = () => {
+    if (currentStepId === step.id) {
+      setCurrentStepId(null)
+      setCurrentStepIndex(null)
+      setShouldWarnOnLeave(false)
+      onDrawerClose()
+    } else if (!app || !selectedActionOrTrigger) {
+      setShouldWarnOnLeave(false)
+      onModalOpen()
+    } else {
+      setCurrentStepId(step.id)
+      setCurrentStepIndex(index)
+    }
+  }
+
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
 
   // generate help message only if template config exists
@@ -160,7 +176,13 @@ export default function FlowStep(
         <EmptyFlowStepHeader
           isNested={isNested}
           isTrigger={isTrigger}
-          onModalOpen={onModalOpen}
+          onModalOpen={() => {
+            if (shouldWarnOnLeave) {
+              onWarningOpen()
+            } else {
+              onModalOpen()
+            }
+          }}
         />
       ) : (
         <>
@@ -241,10 +263,7 @@ export default function FlowStep(
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={() => {
-          setCurrentStepId(step.id)
-          setCurrentStepIndex(index)
-        }}
+        onLeave={handleLeave}
       />
     </FlowStepWrapper>
   )

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,6 +1,6 @@
 import type { IStep } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo, useRef } from 'react'
 import { BiInfoCircle } from 'react-icons/bi'
 import { Box, CircularProgress, Flex, useDisclosure } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
@@ -12,6 +12,7 @@ import { getFlowStepHeaderWidth } from '@/helpers/editor'
 import { replacePlaceholdersForHelpMessage } from '@/helpers/flow-templates'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
+import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
 import { matchParamsToDataIn } from '../FlowStepTestController/utils'
@@ -26,17 +27,17 @@ import { flowStepStyles } from './styles'
 
 type FlowStepProps = {
   step: IStep
+  index: number
   isDeletable?: boolean
   isLastStep: boolean
   isNested?: boolean
-  onOpen: () => void
-  onClose: () => void
 }
 
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, isLastStep, isNested, onOpen, onClose } = props
+  const { step, index, isLastStep, isNested } = props
+  const cancelRef = useRef(null)
 
   const {
     isOpen: isModalOpen,
@@ -45,14 +46,25 @@ export default function FlowStep(
   } = useDisclosure()
 
   const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
+
+  const {
     allApps,
     currentStepId,
+    flow,
     isDrawerOpen,
     isMobile,
-    flow,
     readOnly,
+    shouldWarnOnLeave,
     testExecutionSteps,
     varInfoMap,
+    onDrawerClose,
+    onDrawerOpen,
+    setCurrentStepId,
+    setCurrentStepIndex,
   } = useContext(EditorContext)
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
   const { app, caption, isCompleted, isTrigger, selectedActionOrTrigger } =
@@ -88,12 +100,35 @@ export default function FlowStep(
       onModalOpen()
       return
     }
-    if (isDrawerOpen && currentStepId === step.id) {
-      onClose()
-    } else {
-      onOpen()
+
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+      return
     }
-  }, [app, isDrawerOpen, currentStepId, step.id, onModalOpen, onClose, onOpen])
+
+    if (isDrawerOpen && currentStepId === step.id) {
+      setCurrentStepId(null)
+      setCurrentStepIndex(null)
+      onDrawerClose()
+    } else {
+      setCurrentStepId(step.id)
+      setCurrentStepIndex(index)
+      onDrawerOpen()
+    }
+  }, [
+    app,
+    currentStepId,
+    index,
+    isDrawerOpen,
+    shouldWarnOnLeave,
+    step.id,
+    onDrawerClose,
+    onDrawerOpen,
+    onModalOpen,
+    onWarningOpen,
+    setCurrentStepId,
+    setCurrentStepIndex,
+  ])
 
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
 
@@ -185,11 +220,7 @@ export default function FlowStep(
               />
               <StepCaptionAndDemo app={app} caption={caption} />
               {isDeletable && (
-                <StepDeleteButton
-                  isNested={isNested}
-                  onClose={onClose}
-                  step={step}
-                />
+                <StepDeleteButton isNested={isNested} step={step} />
               )}
             </Flex>
           </Flex>
@@ -205,6 +236,16 @@ export default function FlowStep(
           event={selectedActionOrTrigger}
         />
       )}
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={() => {
+          setCurrentStepId(step.id)
+          setCurrentStepIndex(index)
+        }}
+      />
     </FlowStepWrapper>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -46,9 +46,7 @@ export default function Branch(props: BranchProps) {
     isMobile,
     readOnly: isEditorReadOnly,
     onDrawerClose,
-    onDrawerOpen,
     setCurrentStepId,
-    setCurrentStepIndex,
   } = useContext(EditorContext)
 
   // Handle branch deletion
@@ -137,19 +135,10 @@ export default function Branch(props: BranchProps) {
           <Fragment key={`${step.id}-${stepsBeforeGroup.length + index}`}>
             <FlowStep
               step={step}
+              index={stepsBeforeGroup.length + index}
               isDeletable={index !== 0}
               isNested={true}
               isLastStep={index === branchSteps.length - 1}
-              onOpen={() => {
-                setCurrentStepId(step.id)
-                setCurrentStepIndex(stepsBeforeGroup.length + index)
-                onDrawerOpen()
-              }}
-              onClose={() => {
-                setCurrentStepId(null)
-                setCurrentStepIndex(null)
-                onDrawerClose()
-              }}
             />
             <HoverAddStepButton
               isDisabled={isEditorReadOnly}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useContext, useRef, useState } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Divider, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 
+import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
+import { EditorContext } from '@/contexts/Editor'
 
 import { hoverAddStepButtonStyles as styles } from './styles'
 
@@ -17,8 +19,23 @@ export function HoverAddStepButton(
   props: HoverAddStepButtonProps,
 ): JSX.Element {
   const { isDisabled, isLastStep, prevStepId } = props
+  const cancelRef = useRef(null)
+  const { shouldWarnOnLeave } = useContext(EditorContext)
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
+
+  const handleOpen = () => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      onOpen()
+    }
+  }
 
   return (
     <>
@@ -40,7 +57,8 @@ export function HoverAddStepButton(
           <IconButton
             {...styles.button}
             aria-label="Add Step"
-            onClick={onOpen}
+            className="add-button"
+            onClick={handleOpen}
             isDisabled={isDisabled}
             icon={<BiPlus />}
           />
@@ -55,6 +73,13 @@ export function HoverAddStepButton(
           prevStepId={prevStepId}
         />
       )}
+
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={onOpen}
+      />
     </>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -57,7 +57,6 @@ export function HoverAddStepButton(
           <IconButton
             {...styles.button}
             aria-label="Add Step"
-            className="add-button"
             onClick={handleOpen}
             isDisabled={isDisabled}
             icon={<BiPlus />}

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -24,7 +24,8 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const { isTrigger, substep, step, selectedActionOrTrigger } = props
   const { flags } = useContext(LaunchDarklyContext)
   const formContext = useFormContext()
-  const { readOnly, executeTestStep, onUpdateStep } = useContext(EditorContext)
+  const { readOnly, executeTestStep, onUpdateStep, setShouldWarnOnLeave } =
+    useContext(EditorContext)
   const {
     isOpen: isTestResultOpen,
     onOpen: onTestResultOpen,
@@ -46,6 +47,9 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
    */
   const { dirtyFields } = formContext.formState
   const isDirty = Object.keys(dirtyFields).length > 0
+  useEffect(() => {
+    setShouldWarnOnLeave(isDirty)
+  }, [isDirty, setShouldWarnOnLeave])
 
   // filter inputs hidden behind feature flags based on timestamp
   const argsToDisplay = useMemo(

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -48,6 +48,7 @@ interface IEditorContextValue {
   isDrawerOpen: boolean
   isMobile: boolean
   isTestExecuting: boolean
+  shouldWarnOnLeave: boolean
   stepsWithVars: StepWithVariables[]
   varInfoMap: VariableInfoMap
   executeTestStep: () => Promise<void>
@@ -55,6 +56,7 @@ interface IEditorContextValue {
   onDrawerClose: () => void
   setCurrentStepId: (stepId: string | null) => void
   setCurrentStepIndex: (stepIndex: number | null) => void
+  setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
   onCreateStep: (
     previousStepId: string,
     appKey: string,
@@ -75,6 +77,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   isDrawerOpen: false,
   isMobile: false,
   isTestExecuting: false,
+  shouldWarnOnLeave: false,
   stepsWithVars: [],
   readOnly: false,
   testExecutionSteps: [],
@@ -86,6 +89,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   executeTestStep: () => Promise.resolve(),
   setCurrentStepId: () => null,
   setCurrentStepIndex: () => null,
+  setShouldWarnOnLeave: () => null,
   allApps: [],
 })
 
@@ -93,6 +97,8 @@ type EditorProviderProps = {
   children: ReactNode
   readOnly: boolean
   flow: IFlow
+  shouldWarnOnLeave: boolean
+  setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
 }
 
 /**
@@ -140,6 +146,8 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
 export const EditorProvider = ({
   readOnly,
   flow,
+  shouldWarnOnLeave,
+  setShouldWarnOnLeave,
   children,
 }: EditorProviderProps) => {
   // TODO: remove this kill switch once Single Step Testing is stable
@@ -364,6 +372,7 @@ export const EditorProvider = ({
         currentTestExecutionStep,
         isTestExecuting,
         readOnly,
+        shouldWarnOnLeave,
         stepsWithVars,
         testExecutionSteps,
         varInfoMap,
@@ -374,6 +383,7 @@ export const EditorProvider = ({
         onUpdateStep,
         setCurrentStepId,
         setCurrentStepIndex,
+        setShouldWarnOnLeave,
       }}
     >
       {children}


### PR DESCRIPTION


## TL;DR
This PR adds a warning dialog when users attempt to navigate away from the editor with unsaved changes. 

## What changed?
- Adds a new `UnsavedChangesAlert` component that displays a confirmation dialog
- Tracks unsaved changes state with a `shouldWarnOnLeave` flag in the EditorContext
- Warns users when they try to:
  - Navigate back to the Pipes page
  - Close or reload the browser
  - Add a new step while having unsaved changes
  - Close the step drawer with unsaved changes

The warning gives users the option to stay on the page to save their changes or leave and discard them.

## How to test?
- [ ] Edit a Step, attempt to close right drawer with 'X' icon, should see the alert
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the Alert and the right drawer with changes lost
- [ ] Edit a Step, attempt to choose another Step from the left panel, should see the alert
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the Alert and the right drawer shows the Step that was selected
- [ ] Edit a Step, attempt to close the drawer by clicking on the same Step, should see the alert
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the Alert and the right drawer with changes lost
- [ ] Edit a Step, attempt to add a new Step, should see the alert
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the Alert and opens the Add step modal
- [ ] Edit a Step, attempt to add a new If-Then Step, should see the alert
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the Alert and opens the Add step modal
- [ ] Edit a Step, attempt to close the browser
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' closes the browser
- [ ] Edit a Step, attempt to reload the page
  - [ ] 'Stay' closes the Alert with changes preserved
  - [ ] 'Leave' refreshes the page with changes lost

## Screenshots
### 'X' button to close side drawer

[Screen Recording 2025-05-07 at 9.09.13 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/cb725631-11e4-44b5-bd8c-45fe449a64b3.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/cb725631-11e4-44b5-bd8c-45fe449a64b3.mov)

### Selecting another step from left panel

[Screen Recording 2025-05-07 at 9.13.30 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/b1beb3b3-d859-49fe-b2f4-8a3e14393585.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/b1beb3b3-d859-49fe-b2f4-8a3e14393585.mov)


### Closing side drawer by clicking on the same step

[Screen Recording 2025-05-07 at 9.14.15 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/8e7e19fe-ac40-485e-a9e2-0a5c01b5c484.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/8e7e19fe-ac40-485e-a9e2-0a5c01b5c484.mov)

### Adding a new Step

[Screen Recording 2025-05-07 at 9.14.51 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/6e31aacb-cea9-402d-9b9e-9437c2ae7163.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/6e31aacb-cea9-402d-9b9e-9437c2ae7163.mov)

### Adding a new If-Then Step

[Screen Recording 2025-05-07 at 9.15.40 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/8227deab-ad4a-46a1-93a8-aa3d8bca3f63.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/8227deab-ad4a-46a1-93a8-aa3d8bca3f63.mov)

### Closing the window

[Screen Recording 2025-05-07 at 9.16.24 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/22fdea62-5df9-4f79-8588-90b2231eff12.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/22fdea62-5df9-4f79-8588-90b2231eff12.mov)

### Reloading the page

[Screen Recording 2025-05-07 at 9.16.50 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/c3a74d6f-165c-48d4-9ce1-ee3906cff565.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/c3a74d6f-165c-48d4-9ce1-ee3906cff565.mov)

