### PR TITLE
[SIDE-DRAWER-10] Custom step name in Suggestions popover

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -12,7 +12,7 @@ import {
   PopoverTrigger,
   useDisclosure,
 } from '@chakra-ui/react'
-import { FormLabel } from '@opengovsg/design-system-react'
+import { FormLabel, useIsMobile } from '@opengovsg/design-system-react'
 import Document from '@tiptap/extension-document'
 import Hardbreak from '@tiptap/extension-hard-break'
 import Link from '@tiptap/extension-link'
@@ -104,6 +104,8 @@ const Editor = ({
   parentType,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
+  const isMobile = useIsMobile()
+  const isMulticol = parentType === 'multicol'
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
@@ -222,7 +224,7 @@ const Editor = ({
     <Popover
       autoFocus={false}
       gutter={0}
-      matchWidth={parentType === 'multicol' ? false : true}
+      matchWidth={isMulticol ? false : true}
       isLazy
       lazyBehavior="unmount"
       onClose={closeSuggestions}
@@ -246,8 +248,7 @@ const Editor = ({
             {isRich && <MenuBar editor={editor} variableMap={varInfo} />}
             <EditorContent className="editor__content" editor={editor} />
             <PopoverContent
-              w="100%"
-              maxWidth={parentType === 'multicol' ? 'fit-content' : undefined}
+              w={isMobile ? '100%' : isMulticol ? '55vw' : '100%'}
               motionProps={POPOVER_MOTION_PROPS}
               onFocus={(e) => {
                 // Go back to previous focus when clicking on suggestions to resume typing

--- a/packages/frontend/src/components/SuggestionsWrapper/index.tsx
+++ b/packages/frontend/src/components/SuggestionsWrapper/index.tsx
@@ -49,7 +49,7 @@ export default function SuggestionsWrapper(props: SuggestionsWrapperProps) {
   return (
     <Flex w="100%" boxShadow="sm">
       {/* Left Panel --> Step Selector */}
-      <Box flexGrow={1}>
+      <Box flexGrow={1} w="50%">
         <PanelHeader>{headers.left}</PanelHeader>
         <Divider borderColor="base.divider.medium" />
         <Box h={64} overflowY="auto">
@@ -70,6 +70,9 @@ export default function SuggestionsWrapper(props: SuggestionsWrapperProps) {
                 backgroundColor: 'secondary.50',
                 cursor: 'pointer',
               }}
+              textOverflow="ellipsis"
+              overflow="hidden"
+              whiteSpace="nowrap"
             >
               {option.name}
             </Text>

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -15,6 +15,12 @@ export const GET_TEST_EXECUTION_STEPS = gql`
       step {
         id
         position
+        config {
+          templateConfig {
+            appEventKey
+          }
+          stepName
+        }
       }
       status
       appKey

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -160,8 +160,9 @@ export function extractVariables(
         return {
           id: executionStep.stepId,
           name: `${executionStep.step.position}. ${
+            executionStep.step?.config?.stepName ||
             (executionStep.appKey || '').charAt(0)?.toUpperCase() +
-            executionStep.appKey?.slice(1)
+              executionStep.appKey?.slice(1)
           }`,
           output: variables,
         }


### PR DESCRIPTION
## TL;DR
Use custom step names in the variable suggestions popover

## What changed?
- Updated suggestions popover to handle long step names
- Updated the `GET_TEST_EXECUTION_STEPS` GraphQL query to include step configuration data to get custom step names
- Updated the variable extraction logic to display step names from the configuration when available

## How to test?
Pre-test set up: 
* Create a few steps in your Pipe, ensure that they have variables
* Rename some of the steps to custom names

Test:
- [ ] Edit a step that accepts variables, ensure that left panel uses the custom step name


## Screenshots

![Screenshot 2025-05-07 at 11.19.49 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/dacb91f7-d473-45f0-bce1-6462a81b453e.png)

