### PR TITLE
[SIDE-DRAWER-11] Improve side drawer motion

### DIFF
--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -1,2 +1,3 @@
 export const EDITOR_MARGIN_TOP = '61px'
 export const EDITOR_MAX_HEIGHT = `calc(100vh - ${EDITOR_MARGIN_TOP})`
+export const EDITOR_RIGHT_DRAWER_WIDTH = '60%'

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -17,6 +17,7 @@ import {
 import PrimarySpinner from '../PrimarySpinner'
 
 import { AddStepButton } from './AddStepButton'
+import { EDITOR_RIGHT_DRAWER_WIDTH } from './constants'
 import { editorStyles } from './styles'
 
 type EditorProps = {
@@ -161,12 +162,15 @@ export default function Editor(props: EditorProps): React.ReactElement {
   }
 
   return (
-    <Flex w="full" justifyContent={isDrawerOpen ? 'space-between' : 'center'}>
+    <Flex w="full" justifyContent="center" overflowX="hidden">
       <StepExecutionsToIncludeProvider value={stepExecutionsToInclude}>
         <Flex
           {...editorStyles.container}
           flex={isDrawerOpen ? (isMobile ? 0 : 1) : undefined}
           px={getStepPadding()}
+          maxWidth={`calc(100% - ${
+            isDrawerOpen ? EDITOR_RIGHT_DRAWER_WIDTH : '0px'
+          })`}
         >
           {stepsBeforeGroup.map((step, index) => (
             <Fragment key={`${step.id}-${index}`}>
@@ -200,11 +204,25 @@ export default function Editor(props: EditorProps): React.ReactElement {
           )}
         </Flex>
 
-        <EditorRightDrawer
-          flowStepGroupIconUrl={flowStepGroupIconUrl}
-          index={currentStepIndex}
-          steps={steps}
-        />
+        <Flex
+          {...editorStyles.rightDrawerContainer}
+          w={
+            isDrawerOpen
+              ? isMobile
+                ? '100vw'
+                : EDITOR_RIGHT_DRAWER_WIDTH
+              : '0'
+          }
+          visibility={isDrawerOpen ? 'visible' : 'hidden'}
+          opacity={isDrawerOpen ? 1 : 0}
+          transform={isDrawerOpen ? 'translateX(0)' : 'translateX(100%)'}
+        >
+          <EditorRightDrawer
+            flowStepGroupIconUrl={flowStepGroupIconUrl}
+            index={currentStepIndex}
+            steps={steps}
+          />
+        </Flex>
       </StepExecutionsToIncludeProvider>
     </Flex>
   )

--- a/packages/frontend/src/components/Editor/styles.ts
+++ b/packages/frontend/src/components/Editor/styles.ts
@@ -1,7 +1,6 @@
 import { FlexProps } from '@chakra-ui/react'
 
-export const EDITOR_MARGIN_TOP = '61px'
-export const EDITOR_MAX_HEIGHT = `calc(100vh - ${EDITOR_MARGIN_TOP})`
+import { EDITOR_MAX_HEIGHT } from './constants'
 
 export const editorStyles = {
   container: {
@@ -14,7 +13,19 @@ export const editorStyles = {
     overflowY: 'auto' as FlexProps['overflowY'],
     py: 10,
     px: 0,
-    transition: 'width 0.3s ease-in-out, transform 0.3s ease-in-out',
+    transition: 'transform 0.4s cubic-bezier(0.3, 0, 0.2, 1)',
     w: '100%',
+  },
+  rightDrawerContainer: {
+    flexDir: 'column' as FlexProps['flexDir'],
+    position: 'relative' as FlexProps['position'],
+    bg: 'white',
+    borderRadius: 'lg',
+    boxShadow: 'lg',
+    opacity: 0,
+    maxHeight: EDITOR_MAX_HEIGHT,
+    h: EDITOR_MAX_HEIGHT,
+    overflowY: 'auto' as FlexProps['overflowY'],
+    transition: 'all 0.4s cubic-bezier(0.4, 0, 0.2, 1)',
   },
 }

--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -3,7 +3,6 @@ import { IStep } from '@plumber/types'
 import { useContext, useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
-import { EDITOR_MAX_HEIGHT } from '@/components/Editor/constants'
 import { EditorContext } from '@/contexts/Editor'
 
 import Step from './Step'
@@ -18,7 +17,7 @@ interface EditorRightDrawerProps {
 export default function EditorRightDrawer(props: EditorRightDrawerProps) {
   const { index, steps } = props
 
-  const { currentStepId, isDrawerOpen, isMobile } = useContext(EditorContext)
+  const { currentStepId } = useContext(EditorContext)
 
   const step = useMemo(() => {
     return steps.find((step) => step.id === currentStepId)
@@ -29,24 +28,12 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
   }
 
   return (
-    <Flex
-      flexDir="column"
-      position="relative"
-      width={isDrawerOpen ? (isMobile ? '100vw' : '60%') : '0'}
-      bg="white"
-      py="4"
-      borderRadius="lg"
-      boxShadow="lg"
-      transition="width 0.3s ease-in-out, transform 0.3s ease-in-out"
-      display={isDrawerOpen ? 'block' : 'none'}
-      transform={isDrawerOpen ? 'translateX(0)' : 'translateX(100%)'}
-      maxHeight={EDITOR_MAX_HEIGHT}
-      overflowY="auto"
-    >
+    <Flex flexDir="column" w="100%" py="4" overflowY="auto" h="100%">
       <StepHeader step={step} />
       <Flex
         height="calc(100% - 1.5rem)"
         overflowY="auto"
+        overflowX="hidden"
         position="relative"
         px="4"
         top="2.5rem"


### PR DESCRIPTION
## TL;DR
Improved the Editor's right drawer (open and close) animation and layout with smoother transitions

## What to test?
- [ ] Existing steps open and close with smooth transition
- [ ] New steps can be created and drawer remains open
- [ ] Deleting step closes right drawer smoothly

## Screenshots
### Open / close
[Screen Recording 2025-05-08 at 12.17.17 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/3c236068-2254-4bff-9d2b-cd9c7e14bc63.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/3c236068-2254-4bff-9d2b-cd9c7e14bc63.mov)

### Deleting step
[Screen Recording 2025-05-08 at 12.20.35 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/af6b1b34-5ec9-4c57-94c0-56b94ed18afa.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/af6b1b34-5ec9-4c57-94c0-56b94ed18afa.mov)

