### PR TITLE
[SIDE-DRAWER-12] Post bugbash UI nits - Part 2

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -72,7 +72,7 @@ export default function StepHeader(props: StepHeaderProps) {
       height="2rem"
     >
       <Flex alignItems="center" maxW="100%">
-        {position && <Text whiteSpace="pre-wrap">{position}. </Text>}
+        {position && <Text whiteSpace="pre-wrap">{position}.&nbsp;</Text>}
         <EditableInput
           key={step.id}
           value={initialStepName}

--- a/packages/frontend/src/components/FlowStep/components/StepAppIcon.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepAppIcon.tsx
@@ -1,4 +1,4 @@
-import { IApp } from '@plumber/types'
+import { IApp, IStep } from '@plumber/types'
 
 import {
   BiArrowFromRight,
@@ -6,6 +6,9 @@ import {
   BiSolidErrorCircle,
 } from 'react-icons/bi'
 import { Flex, Icon, Image } from '@chakra-ui/react'
+
+import { getToolboxIcon } from '@/helpers/editor'
+import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 
 import { flowStepStyles } from '../styles'
 
@@ -15,30 +18,52 @@ interface AppIconProps {
   isNested?: boolean
   isTestSuccessful?: boolean
   shouldTestStepAgain?: boolean
+  step?: IStep
 }
 
 export default function StepAppIcon(props: AppIconProps) {
-  const { app, isCompleted, isNested, isTestSuccessful, shouldTestStepAgain } =
-    props
+  const {
+    app,
+    isCompleted,
+    isNested,
+    isTestSuccessful,
+    shouldTestStepAgain,
+    step,
+  } = props
 
   const showBadge =
     isCompleted || shouldTestStepAgain || isTestSuccessful === false
 
+  const boxSize = isNested ? 6 : 8
+  const FallbackIcon = (
+    <Icon
+      boxSize={boxSize}
+      as={BiArrowFromRight}
+      color="base.content.default"
+    />
+  )
+
   return (
-    <Flex {...flowStepStyles.appIconWrapper} boxSize={isNested ? 6 : 8}>
+    <Flex {...flowStepStyles.appIconWrapper} boxSize={boxSize}>
       {/* App icon */}
-      <Image
-        src={app?.iconUrl}
-        boxSize={isNested ? 6 : 8}
-        fit="contain"
-        fallback={
+      {app ? (
+        app?.key === TOOLBOX_APP_KEY ? (
           <Icon
-            boxSize={6}
-            as={BiArrowFromRight}
-            color="base.content.default"
+            boxSize={boxSize}
+            as={getToolboxIcon(step?.key)}
+            color="primary.500"
           />
-        }
-      />
+        ) : (
+          <Image
+            src={app?.iconUrl}
+            boxSize={boxSize}
+            fit="contain"
+            fallback={FallbackIcon}
+          />
+        )
+      ) : (
+        FallbackIcon
+      )}
       {/*
        * Step completion status badge
        */}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -239,6 +239,7 @@ export default function FlowStep(
                 isTestSuccessful={isTestSuccessful}
                 shouldTestStepAgain={shouldTestStepAgain}
                 app={app}
+                step={step}
               />
               <StepCaptionAndDemo app={app} caption={caption} />
               {isDeletable && (

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -1,13 +1,10 @@
 import { IStep } from '@plumber/types'
 
 import { useContext, useMemo } from 'react'
-import { BiQuestionMark } from 'react-icons/bi'
 import { Box, Flex, Icon, Text } from '@chakra-ui/react'
 
 import { EditorContext } from '@/contexts/Editor'
-import { getFlowStepHeaderWidth } from '@/helpers/editor'
-
-import { TOOLBOX_ACTION_TO_ICON_MAP } from '../FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent'
+import { getFlowStepHeaderWidth, getToolboxIcon } from '@/helpers/editor'
 
 import Error from './Content/Error'
 import IfThen from './Content/IfThen'
@@ -55,11 +52,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
               {/* App icon */}
               <Icon
                 boxSize={8}
-                as={
-                  TOOLBOX_ACTION_TO_ICON_MAP[
-                    stepGroupType as keyof typeof TOOLBOX_ACTION_TO_ICON_MAP
-                  ] ?? BiQuestionMark
-                }
+                as={getToolboxIcon(stepGroupType)}
                 color="primary.500"
               />
             </Flex>

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -4,7 +4,6 @@ import { Box, Collapse, Text } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
 
 import VariablesList from '@/components/VariablesList'
-import { isIfThenStep } from '@/helpers/toolbox'
 import type { Variable } from '@/helpers/variables'
 
 function getNoOutputMessage(
@@ -70,35 +69,6 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
           </Box>
         </Infobox>
       )
-    }
-
-    // Edge case for If-then
-    //
-    // FIXME (ogp-weeloong): Revamp UI to allow special handling for
-    // toolbox actions in an isolated codepath.
-    if (isIfThenStep(step)) {
-      const isConditionMet = variables[0].value as boolean
-
-      if (isConditionMet) {
-        return (
-          <Infobox variant="success" w="full">
-            <Text>
-              Based on your sample data, it meets the conditions that you have
-              set up and your pipe <Text as="b">would have</Text> continued.
-            </Text>
-          </Infobox>
-        )
-      } else {
-        return (
-          <Infobox variant="warning" w="full">
-            <Text>
-              Based on your sample data, it does not meet the conditions you
-              have set up and your pipe <Text as="b">would not have</Text>{' '}
-              continued.
-            </Text>
-          </Infobox>
-        )
-      }
     }
 
     return (

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -125,9 +125,9 @@ export default function FlowStepTestController(
           <VStack w="100%">
             <HStack w="100%">
               <Infobox
+                {...flowStepTestControllerStyles.testedInfobox}
                 variant={infoBoxVariant}
                 borderBottomRadius={isTestResultOpen ? 0 : undefined}
-                {...flowStepTestControllerStyles.testedInfobox}
               >
                 <Flex
                   justifyContent="space-between"

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -15,7 +15,7 @@ import WebhookUrlInfo from '../WebhookUrlInfo'
 import { flowStepTestControllerStyles } from './styles'
 import TestResult from './TestResult'
 import { useTestDetails } from './useTestDetails'
-import { matchParamsToDataIn } from './utils'
+import { getInfoBoxDetails, matchParamsToDataIn } from './utils'
 
 const defaultTriggerInstructions: ITriggerInstructions = {
   beforeUrlMsg: `# 1. You'll need to configure your application with this webhook URL.`,
@@ -57,7 +57,10 @@ export default function FlowStepTestController(
   } = useContext(EditorContext)
   const formContext = useFormContext()
 
-  const { selectedActionOrTrigger } = useStepMetadata(allApps, step)
+  const { isIfThenStep, selectedActionOrTrigger } = useStepMetadata(
+    allApps,
+    step,
+  )
   const {
     isTestSuccessful,
     lastErrorDetails,
@@ -90,27 +93,18 @@ export default function FlowStepTestController(
     [handleSaveAndTest, isTestExecuting, isValid],
   )
 
-  const [infoBoxVariant, infoBoxText] = useMemo(() => {
-    if (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty)) {
-      return ['warning', 'Previous result']
-    }
+  const [infoBoxVariant, infoBoxText] = getInfoBoxDetails({
+    isDirty,
+    isIfThenStep,
+    isLastTestExecutionCurrent,
+    isTestSuccessful,
+    stepId: step.id,
+    testVariables,
+  })
 
-    if (isTestSuccessful) {
-      return ['success', 'Step was set up successfully!']
-    }
-
-    return ['error', 'Failed to set up step']
-  }, [isLastTestExecutionCurrent, isTestSuccessful, isDirty])
-
-  const shouldShowSaveButton = useMemo(
-    () => !isLastTestExecutionCurrent || (isTestSuccessful && isDirty),
-    [isLastTestExecutionCurrent, isTestSuccessful, isDirty],
-  )
-
-  const shouldShowTestResults = useMemo(
-    () => currentTestExecutionStep && !lastErrorDetails,
-    [currentTestExecutionStep, lastErrorDetails],
-  )
+  const shouldShowSaveButton =
+    !isLastTestExecutionCurrent || (isTestSuccessful && isDirty)
+  const shouldShowTestResults = currentTestExecutionStep && !lastErrorDetails
 
   return (
     <Stack {...flowStepTestControllerStyles.container}>
@@ -140,21 +134,27 @@ export default function FlowStepTestController(
                   alignItems="center"
                   w="100%"
                 >
-                  <Button
-                    variant="clear"
-                    colorScheme="green"
-                    size="sm"
-                    onClick={() =>
-                      isTestResultOpen
-                        ? onTestResultClose()
-                        : onTestResultOpen()
-                    }
-                  >
-                    <Text color="base.content.default">{infoBoxText}</Text>
-                    <Box ml={2} color="base.content.default">
-                      {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
-                    </Box>
-                  </Button>
+                  {isIfThenStep ? (
+                    // NOTE: special handling for If-then
+                    // do not need button as there are no variables to display
+                    <Text>{infoBoxText}</Text>
+                  ) : (
+                    <Button
+                      variant="clear"
+                      colorScheme="green"
+                      size="sm"
+                      onClick={() =>
+                        isTestResultOpen
+                          ? onTestResultClose()
+                          : onTestResultOpen()
+                      }
+                    >
+                      <Text color="base.content.default">{infoBoxText}</Text>
+                      <Box ml={2} color="base.content.default">
+                        {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
+                      </Box>
+                    </Button>
+                  )}
                   {shouldShowSaveButton ? (
                     <Flex gap={2}>
                       <Button

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -57,7 +57,7 @@ export default function FlowStepTestController(
   } = useContext(EditorContext)
   const formContext = useFormContext()
 
-  const { isIfThenStep, selectedActionOrTrigger } = useStepMetadata(
+  const { isIfThenStep, isTrigger, selectedActionOrTrigger } = useStepMetadata(
     allApps,
     step,
   )
@@ -130,7 +130,11 @@ export default function FlowStepTestController(
       const spaceBelow = window.innerHeight - 61 - rect.bottom
       const spaceAbove = rect.top + 61 + 32
 
-      // If content is small enough, always collapse downward
+      if (isTrigger) {
+        setCollapseDirection('down')
+        return
+      }
+
       if (contentHeight < minContentHeight) {
         setCollapseDirection('down')
 
@@ -138,6 +142,11 @@ export default function FlowStepTestController(
           setCollapseDirection('up')
           return
         }
+        return
+      }
+
+      if (spaceBelow < 0) {
+        setCollapseDirection('up')
         return
       }
 
@@ -152,7 +161,7 @@ export default function FlowStepTestController(
       window.removeEventListener('resize', updateCollapseDirection)
       window.removeEventListener('scroll', updateCollapseDirection)
     }
-  }, [testVariables])
+  }, [isTrigger, testVariables])
 
   const getChevronIcon = () => {
     if (isTestResultOpen) {

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -1,6 +1,6 @@
 import { IBaseTrigger, IStep, ITriggerInstructions } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { BiChevronDown, BiChevronUp } from 'react-icons/bi'
 import { Box, Flex, HStack, Stack, Text, VStack } from '@chakra-ui/react'
@@ -67,6 +67,10 @@ export default function FlowStepTestController(
     isWebhookSubstep,
     testVariables,
   } = useTestDetails(step, currentTestExecutionStep)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [collapseDirection, setCollapseDirection] = useState<'up' | 'down'>(
+    'down',
+  )
 
   const isLastTestExecutionCurrent = useMemo(() => {
     const formValues = formContext.getValues()
@@ -106,8 +110,59 @@ export default function FlowStepTestController(
     !isLastTestExecutionCurrent || (isTestSuccessful && isDirty)
   const shouldShowTestResults = currentTestExecutionStep && !lastErrorDetails
 
+  useEffect(() => {
+    if (!containerRef.current) {
+      return
+    }
+
+    const updateCollapseDirection = () => {
+      const rect = containerRef.current?.getBoundingClientRect()
+      if (!rect) {
+        return
+      }
+
+      // Get the content height from the test variables
+      const contentHeight = testVariables?.length
+        ? testVariables.length * 40
+        : 0
+      const minContentHeight = 108 // Minimum height to consider for content
+
+      const spaceBelow = window.innerHeight - 61 - rect.bottom
+      const spaceAbove = rect.top + 61 + 32
+
+      // If content is small enough, always collapse downward
+      if (contentHeight < minContentHeight) {
+        setCollapseDirection('down')
+
+        if (spaceBelow < 0) {
+          setCollapseDirection('up')
+          return
+        }
+        return
+      }
+
+      setCollapseDirection(spaceAbove > spaceBelow ? 'up' : 'down')
+    }
+
+    updateCollapseDirection()
+    window.addEventListener('resize', updateCollapseDirection)
+    window.addEventListener('scroll', updateCollapseDirection)
+
+    return () => {
+      window.removeEventListener('resize', updateCollapseDirection)
+      window.removeEventListener('scroll', updateCollapseDirection)
+    }
+  }, [testVariables])
+
+  const getChevronIcon = () => {
+    if (isTestResultOpen) {
+      return collapseDirection === 'up' ? <BiChevronDown /> : <BiChevronUp />
+    }
+    return collapseDirection === 'up' ? <BiChevronUp /> : <BiChevronDown />
+  }
+
   return (
-    <Stack {...flowStepTestControllerStyles.container}>
+    <Stack {...flowStepTestControllerStyles.container} ref={containerRef}>
       <VStack w="100%">
         {isWebhookSubstep && (
           <VStack w="100%">
@@ -151,7 +206,7 @@ export default function FlowStepTestController(
                     >
                       <Text color="base.content.default">{infoBoxText}</Text>
                       <Box ml={2} color="base.content.default">
-                        {isTestResultOpen ? <BiChevronDown /> : <BiChevronUp />}
+                        {getChevronIcon()}
                       </Box>
                     </Button>
                   )}

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -1,6 +1,7 @@
 import { IJSONObject } from '@plumber/types'
 
 import { Text } from '@chakra-ui/react'
+import { InfoboxProps } from '@opengovsg/design-system-react'
 
 import { Variable } from '@/helpers/variables'
 
@@ -135,7 +136,7 @@ export function getInfoBoxDetails({
   isTestSuccessful: boolean
   stepId: string
   testVariables: Variable[] | null
-}): [string, React.ReactNode] {
+}): [InfoboxProps['variant'], React.ReactNode] {
   if (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty)) {
     return ['warning', 'Previous result']
   }

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -1,5 +1,9 @@
 import { IJSONObject } from '@plumber/types'
 
+import { Text } from '@chakra-ui/react'
+
+import { Variable } from '@/helpers/variables'
+
 import { simpleSubstitute, VariableInfoMap } from '../RichTextEditor/utils'
 
 const deepCompare = (a: any, b: any, varInfoMap: VariableInfoMap): boolean => {
@@ -115,4 +119,51 @@ export const matchParamsToDataIn = (
     const substitutedParamValue = simpleSubstitute(paramValue, varInfoMap)
     return substitutedParamValue === lastTest
   })
+}
+
+export function getInfoBoxDetails({
+  isDirty,
+  isIfThenStep,
+  isLastTestExecutionCurrent,
+  isTestSuccessful,
+  stepId,
+  testVariables,
+}: {
+  isDirty: boolean
+  isIfThenStep: boolean
+  isLastTestExecutionCurrent: boolean
+  isTestSuccessful: boolean
+  stepId: string
+  testVariables: Variable[] | null
+}): [string, React.ReactNode] {
+  if (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty)) {
+    return ['warning', 'Previous result']
+  }
+
+  if (isTestSuccessful) {
+    // Edge case for If-then
+    if (isIfThenStep) {
+      const isConditionMet = testVariables?.[0]?.value as boolean
+
+      if (isConditionMet) {
+        return [
+          'success',
+          <Text key={`${stepId}-if-then-success-text`}>
+            Based on your sample data, it meets the conditions that you have set
+            up and your pipe <Text as="b">would have</Text> continued.
+          </Text>,
+        ]
+      }
+      return [
+        'warning',
+        <Text key={`${stepId}-if-then-warning-text`}>
+          Based on your sample data, it does not meet the conditions you have
+          set up and your pipe <Text as="b">would not have</Text> continued.
+        </Text>,
+      ]
+    }
+    return ['success', 'Step was set up successfully!']
+  }
+
+  return ['error', 'Failed to set up step']
 }

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -58,16 +58,18 @@ function VariableTag({
 function VariableItem({
   variable,
   onClick,
+  isLast,
 }: {
   variable: Variable
   onClick?: (variable: Variable) => void
+  isLast?: boolean
 }): JSX.Element {
   return (
     <Box
       key={`suggestion-${variable.name}`}
       data-test="variable-suggestion-item"
       padding={onClick ? '0.5rem 1rem' : '1rem'}
-      borderBottom={onClick ? undefined : '1px solid #EDEDED'}
+      borderBottom={onClick || isLast ? undefined : '1px solid #EDEDED'}
       _hover={
         onClick
           ? {
@@ -133,6 +135,7 @@ export default function VariablesList(props: VariablesListProps) {
           key={`variable-${variable.name}-${index}`}
           variable={variable}
           onClick={onClick}
+          isLast={index === variables.length - 1}
         />
       ))}
     </Box>

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -6,11 +6,13 @@ import {
   ISubstep,
 } from '@plumber/types'
 
+import { BiQuestionMark } from 'react-icons/bi'
 import { yupResolver } from '@hookform/resolvers/yup'
 import type { BaseSchema } from 'yup'
 import * as yup from 'yup'
 import type { ObjectShape } from 'yup/lib/object'
 
+import { TOOLBOX_ACTION_TO_ICON_MAP } from '@/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
 
 export const getFlowStepHeaderWidth = (
@@ -131,4 +133,16 @@ export function generateValidationSchema(substeps: ISubstep[]) {
   })
 
   return yupResolver(validationSchema)
+}
+
+export function getToolboxIcon(key?: string | null) {
+  if (!key) {
+    return BiQuestionMark
+  }
+
+  return (
+    TOOLBOX_ACTION_TO_ICON_MAP[
+      key as keyof typeof TOOLBOX_ACTION_TO_ICON_MAP
+    ] ?? BiQuestionMark
+  )
 }

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -29,7 +29,7 @@ export const getFlowStepHeaderWidth = (
     return '100%'
   }
 
-  return isNested ? 'full' : '55%'
+  return isNested ? 'full' : '600px'
 }
 
 function isValidArgValue(value: IJSONValue): boolean {

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -50,10 +50,6 @@ export function useStepMetadata(
     caption = `${step?.position ? `${step.position}. ` : ''}${
       selectedActionOrTrigger?.name
     }`
-
-    if (selectedActionOrTrigger.key === 'ifThen') {
-      caption = `${step?.position ? `${step.position}. ` : ''} Condition`
-    }
   } else if (app?.name) {
     caption = `${step?.position ? `${step.position}. ` : ''}${app.name}`
   } else if (isTrigger) {


### PR DESCRIPTION
## TL;DR
This PR addresses UI nits from the bug bash:
* adjusts step width when drawer is closed
* remove extra border after last variable
* fix if-then caption and icon
* removed button from if-then test result to show whether step would have continued immediately

## How to test?
Just a sanity check:
- [ ] Drawer opens / closes correctly on clicking of Step
- [ ] Long step names use ellipsis on overflow, icons do not become smaller
- [ ] Renaming if-then step still works and name is reflected correctly in left panel
- [ ] Check step on an if-then condition, ensure that result is shown directly in the infobox and there should not be a button to expand the collapse

## Screenshots
### Step width (600px)

![Screenshot 2025-05-08 at 10.32.29 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/3dc87520-ca08-41cd-a169-542668dffa0a.png)


### Remove extra border after last variable

![Screenshot 2025-05-08 at 10.33.19 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/8e1afefe-1300-4c76-a12b-e155a62ff10e.png)


### Fix if-then caption and icon

![Screenshot 2025-05-08 at 10.33.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/c21be046-9785-4fbd-b9b8-4c7b6d682a8b.png)

### Check step improvement for If-then condition

![Screenshot 2025-05-13 at 9.48.55 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/de249dc9-be51-4230-9523-f22f54e38200.png)

![Screenshot 2025-05-13 at 9.49.06 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/774c6bba-e0a5-4714-9da7-57325ffb44a8.png)

