### PR TITLE
fix: change postman guide links

### DIFF
--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -82,7 +82,7 @@ export const transactionalEmailFields: IField[] = [
     label: 'Attachments',
     key: 'attachments',
     description:
-      'Check supported file types [here](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).\nPlease note that the maximum file size for each file is 2MB, and the total size of all attachments cannot exceed 10MB.',
+      'Check supported file types [here](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).\nPlease note that the maximum file size for each file is 2MB, and the total size of all attachments cannot exceed 10MB.',
     type: 'attachment' as const,
     required: false,
     variables: true,

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -102,7 +102,7 @@ export function throwPostmanStepError({
     case 'INVALID-ATTACHMENT':
       throw new StepError(
         'Unsupported attachment file type',
-        'Click on set up action and check that the attachment type is supported by postman. Please check the supported types at [this link](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).',
+        'Click on set up action and check that the attachment type is supported by postman. Please check the supported types at [this link](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).',
         position,
         appName,
         error,

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -17,7 +17,7 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     details: dedent`
       ⚒️ Tiles - you can now choose how to update numbers in Tiles: set as, add by, or subtract by.
 
-      📩 Postman - you can now upload and send your own attachments using the Email by Postman action. Check out the supported file types [here](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).
+      📩 Postman - you can now upload and send your own attachments using the Email by Postman action. Check out the supported file types [here](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).
     `,
   },
   {
@@ -141,7 +141,7 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     title: 'Email attachments for Postman action',
     details: dedent`
       * Email attachments are now supported.
-      * Checkout the supported file types [here](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).
+      * Checkout the supported file types [here](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).
     `,
     multimedia: {
       url: 'https://file.go.gov.sg/clipplumber.png',


### PR DESCRIPTION
## Problem
Postman guide link changed.

## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/f66fae69-03ab-4907-b1c2-83d090f4133d

**AFTER**:

https://github.com/user-attachments/assets/bf15a238-0c5e-4840-8ae5-9a2e8b447a7c


## Tests
- [ ] Verify that Link element for supported file types opens a new tab to Postman's new guide
