### PR TITLE
[TILES-V2-7]: update tiles actions to use factory class

### DIFF
--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -3,7 +3,7 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow } from '@/models/tiles/dynamodb/table-row/functions'
+import { getTableOperations } from '@/models/tiles/factory'
 
 import { CreateRowOutput } from '../../types'
 
@@ -124,7 +124,12 @@ const action: IRawAction = {
       )
     }
 
-    const newRow = await createTableRow({ tableId, data: rowDataObject })
+    const tableOperations = getTableOperations(table.db)
+
+    const newRow = await tableOperations.createTableRow({
+      tableId,
+      data: rowDataObject,
+    })
 
     $.setActionItem({
       raw: {

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -4,8 +4,8 @@ import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
-import TableColumnMetadata from '@/models/table-column-metadata'
-import { getRawRowById, getTableRows } from '@/models/tiles/dynamodb/table-row'
+import TableMetadata from '@/models/table-metadata'
+import { getTableOperations } from '@/models/tiles/factory'
 import { TableRowFilter, TableRowFilterOperator } from '@/models/tiles/types'
 
 import { validateFilters } from '../../common/validate-filters'
@@ -150,13 +150,25 @@ const action: IRawAction = {
     /**
      * Check for columns first, there will not be any columns if the tile has been deleted.
      */
-    const columns = await TableColumnMetadata.getColumns(tableId, $)
+
+    const table = await TableMetadata.query()
+      .findById(tableId)
+      .withGraphFetched('columns')
+
+    if (!table) {
+      throw new StepError(
+        'Tile not found',
+        'Tile may have been deleted. Please check your tile.',
+        $.step.position,
+        $.app.name,
+      )
+    }
 
     await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
     // Check that filters are valid
     try {
-      validateFilters(filters, columns)
+      validateFilters(filters, table.columns)
     } catch (e) {
       logger.error({
         message: 'Invalid filters',
@@ -178,7 +190,9 @@ const action: IRawAction = {
     const scanLimitRaw = +step.config?.adminOverride?.tileScanLimit
     const scanLimit = isNaN(scanLimitRaw) ? undefined : scanLimitRaw
 
-    const { rows } = await getTableRows({
+    const tableOperations = getTableOperations(table.db)
+
+    const { rows } = await tableOperations.getTableRows({
       tableId,
       filters,
       order: returnLastRow ? 'desc' : 'asc',
@@ -199,10 +213,10 @@ const action: IRawAction = {
      * We use raw row data instead of mapped column names as we want them to
      * be distinct in data_out
      */
-    const rowToReturn = await getRawRowById({
+    const rowToReturn = await tableOperations.getRawRowById({
       tableId,
       rowId: rowIdToUse,
-      columnIds: columns.map((c) => c.id),
+      columnIds: table.columns.map((c) => c.id),
     })
 
     $.setActionItem({

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -2,12 +2,12 @@ import { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
 import TableCollaborator from '@/models/table-collaborators'
-import TableColumnMetadata from '@/models/table-column-metadata'
+import TableMetadata from '@/models/table-metadata'
 import {
   autoMarshallNumberStrings,
   stripInvalidKeys,
 } from '@/models/tiles/dynamodb/helpers'
-import { patchTableRow } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
 import { PatchRowInput } from '@/models/tiles/types'
 
 import { UpdateRowOutput } from '../../types'
@@ -136,8 +136,20 @@ const action: IRawAction = {
     /**
      * Check for columns first, there will not be any columns if the tile has been deleted.
      */
-    const columns = await TableColumnMetadata.getColumns(tableId, $)
-    const columnIds = columns.map((c) => c.id)
+    const table = await TableMetadata.query()
+      .findById(tableId)
+      .withGraphFetched('columns')
+
+    if (!table) {
+      throw new StepError(
+        'Tile not found',
+        'Tile may have been deleted. Please check your tile.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    const columnIds = table.columns.map((c) => c.id)
 
     await TableCollaborator.hasAccess($.user?.id, tableId, 'editor', $)
 
@@ -164,6 +176,8 @@ const action: IRawAction = {
         )
       }
     }
+
+    const tableOperations = getTableOperations(table.db)
 
     const patchData = {
       ...rowData.reduce(
@@ -192,7 +206,7 @@ const action: IRawAction = {
     }
 
     try {
-      const updatedRow = await patchTableRow({
+      const updatedRow = await tableOperations.patchTableRow({
         tableId,
         rowId,
         patchData,

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -27,7 +27,7 @@ const createTable: MutationResolvers['createTable'] = async (
   const {
     name: tableName,
     isBlank: isBlankTable,
-    databaseType = 'pg',
+    databaseType = 'ddb',
   } = params.input
 
   if (!tableName) {

--- a/packages/backend/src/models/table-column-metadata.ts
+++ b/packages/backend/src/models/table-column-metadata.ts
@@ -1,6 +1,4 @@
-import { IGlobalVariable, ITableColumnConfig } from '@plumber/types'
-
-import StepError from '@/errors/step'
+import { ITableColumnConfig } from '@plumber/types'
 
 import Base from './base'
 import TableMetadata from './table-metadata'
@@ -36,24 +34,6 @@ class TableColumnMetadata extends Base {
       },
     },
   })
-
-  static getColumns = async (tableId: string, $?: IGlobalVariable) => {
-    const columns = await TableColumnMetadata.query()
-      .where({
-        table_id: tableId,
-      })
-      .orderBy('position')
-
-    if (columns.length === 0) {
-      throw new StepError(
-        'Tile not found',
-        'Tile may have been deleted. Please check your tile.',
-        $.step.position,
-        $.app.name,
-      )
-    }
-    return columns
-  }
 }
 
 export default TableColumnMetadata

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -1,6 +1,7 @@
 import { ITableCollabRole } from '@plumber/types'
 
 import Base from './base'
+import ExtendedQueryBuilder from './query-builder'
 import TableCollaborator from './table-collaborators'
 import TableColumnMetadata from './table-column-metadata'
 import User from './user'
@@ -54,6 +55,9 @@ class TableMetadata extends Base {
       join: {
         from: `${this.tableName}.id`,
         to: `${TableColumnMetadata.tableName}.table_id`,
+      },
+      filter(builder: ExtendedQueryBuilder<TableColumnMetadata>) {
+        builder.orderBy('position', 'asc')
       },
     },
   })

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -16,6 +16,17 @@ import {
   UpdateRowInput,
 } from '../types'
 
+function formatTableRow(
+  row: Record<string, string>,
+  tableId: string,
+): TableRowItem | null {
+  if (!row) {
+    return null
+  }
+  const { rowId, createdAt: _createdAt, updatedAt: _updatedAt, ...rest } = row
+  return { rowId, data: rest, tableId }
+}
+
 /**
  * External functions
  */
@@ -32,7 +43,8 @@ export const createTableRow = async ({
         rowId: ulid(),
       })
       .returning('*')
-    return res[0]
+
+    return formatTableRow(res[0], tableId)
   } catch (e: unknown) {
     logger.error(e)
     throw e
@@ -83,12 +95,12 @@ export const updateTableRow = async ({
  * This atomically updates the data object for keys that are changed
  */
 export const patchTableRow = async ({
-  rowId,
+  rowId: rowIdToUse,
   tableId,
   patchData,
 }: PatchRowInput): Promise<TableRowItem> => {
   try {
-    const query = tilesClient(tableId).where({ rowId })
+    const query = tilesClient(tableId).where({ rowId: rowIdToUse })
 
     Object.entries(patchData.set || {}).forEach(
       ([key, value]: [string, string]) => {
@@ -131,7 +143,7 @@ export const patchTableRow = async ({
     )
 
     const res = await query.update('updatedAt', new Date()).returning('*')
-    return res[0]
+    return formatTableRow(res[0], tableId)
   } catch (e: unknown) {
     logger.error(e)
     throw e
@@ -221,9 +233,7 @@ export const getTableRows = async ({
 }): Promise<{
   rows: TableRowOutput[]
 }> => {
-  const query = tilesClient(tableId).select(
-    columnIds ? ['rowId', ...columnIds] : ['*'],
-  )
+  const query = tilesClient(tableId).select(['rowId', ...(columnIds ?? [])])
   if (filters) {
     addFiltersToQuery(query, filters)
   }
@@ -251,7 +261,7 @@ export const getTableRows = async ({
  */
 export const getRawRowById = async ({
   tableId,
-  rowId,
+  rowId: rowIdToUse,
   columnIds,
 }: {
   tableId: string
@@ -261,11 +271,14 @@ export const getRawRowById = async ({
   try {
     const res = await tilesClient(tableId)
       .where({
-        rowId,
+        rowId: rowIdToUse,
       })
       .select(columnIds ? ['rowId', ...columnIds] : ['*'])
       .first()
-    return res
+    if (!res) {
+      return null
+    }
+    return formatTableRow(res, tableId)
   } catch (e: unknown) {
     logger.error(e)
     throw e


### PR DESCRIPTION
###  Changes

Implemented a database abstraction layer for Tiles to support both DynamoDB and PostgreSQL backends.

- Added a factory pattern with `getTableOperations()` to abstract database operations
- Updated Tiles actions (create-row, find-single-row, update-row) to use the new factory pattern
- Changed default database type from 'pg' to 'ddb' in create-table mutation
- Removed the static `getColumns` method from TableColumnMetadata in favor of using relations
- Enhanced TableMetadata to properly fetch columns with ordering
- Improved row formatting in PostgreSQL implementation