### PR TITLE
[TILES-V2-8]: add env vars

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -217,6 +217,26 @@
     {
       "name": "ONBOARDING_EMAIL_WEBHOOK_URL",
       "valueFrom": "plumber-onboarding-email-webhook-url"
+    },
+    {
+      "name": "TILES_POSTGRES_HOST",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-rds-host"
+    },
+    {
+      "name": "TILES_POSTGRES_DATABASE",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-rds-database"
+    },
+    {
+      "name": "TILES_POSTGRES_USERNAME",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-rds-username"
+    },
+    {
+      "name": "TILES_POSTGRES_PASSWORD",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-rds-password"
+    },
+    {
+      "name": "TILES_POSTGRES_PORT",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-rds-port"
     }
   ]
 }


### PR DESCRIPTION
### TL;DR

Added Tiles Postgres database environment variables to ECS configuration.

### What changed?

Added five new environment variables to the ECS environment configuration:
- `TILES_POSTGRES_HOST`
- `TILES_POSTGRES_DATABASE`
- `TILES_POSTGRES_USERNAME`
- `TILES_POSTGRES_PASSWORD`
- `TILES_POSTGRES_PORT`

Each variable references corresponding parameter store values with the `plumber-<ENVIRONMENT>-tiles-rds-*` pattern.
