### PR TITLE
[TILES-V2-9]: store database type in TableContext on frontend

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -1,10 +1,14 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import createTable from '@/graphql/mutations/tiles/create-table'
 import { getTableRowCount } from '@/models/tiles/dynamodb/table-row'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './table.mock'
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: vi.fn().mockResolvedValue('ddb'),
+}))
 
 describe('create table mutation', () => {
   let context: Context
@@ -17,7 +21,7 @@ describe('create table mutation', () => {
   it('should create a blank table', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: true, databaseType: 'ddb' } },
+      { input: { name: 'Test Table', isBlank: true } },
       context,
     )
     const tableColumnCount = await table.$relatedQuery('columns').resultSize()
@@ -30,7 +34,7 @@ describe('create table mutation', () => {
   it('should create a table and with placeholder rows and columns', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
+      { input: { name: 'Test Table', isBlank: false } },
       context,
     )
     const tableColumnCount = await table.$relatedQuery('columns').resultSize()
@@ -43,13 +47,13 @@ describe('create table mutation', () => {
   it('should be able create tables with the same name', async () => {
     const table = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
+      { input: { name: 'Test Table', isBlank: false } },
       context,
     )
 
     const table2 = await createTable(
       null,
-      { input: { name: 'Test Table', isBlank: false, databaseType: 'ddb' } },
+      { input: { name: 'Test Table', isBlank: false } },
       context,
     )
     expect(table.name).toBe('Test Table')

--- a/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
+++ b/packages/backend/src/graphql/custom-resolvers/table-metadata.ts
@@ -4,6 +4,10 @@ import type { Resolvers } from '../__generated__/types.generated'
 
 type TableMetadataResolver = Resolvers['TableMetadata']
 
+const databaseType: TableMetadataResolver['databaseType'] = async (parent) => {
+  return parent.db
+}
+
 const columns: TableMetadataResolver['columns'] = async (parent) => {
   const columns = await parent
     .$relatedQuery('columns')
@@ -33,4 +37,5 @@ const collaborators: TableMetadataResolver['collaborators'] = async (
 export default {
   columns,
   collaborators,
+  databaseType,
 } satisfies TableMetadataResolver

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -1,7 +1,8 @@
+import { MutationResolvers } from '@/graphql/__generated__/types.generated'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import TableMetadata from '@/models/table-metadata'
 import { getTableOperations } from '@/models/tiles/factory'
-
-import type { MutationResolvers } from '../../__generated__/types.generated'
+import { type DatabaseType } from '@/models/tiles/types'
 
 const PLACEHOLDER_COLUMNS = [
   {
@@ -19,20 +20,28 @@ const PLACEHOLDER_COLUMNS = [
 ]
 const PLACEHOLDER_ROWS = new Array(5).fill({})
 
+// DELETE THIS FLAG ONCE IT'S NO LONGER IN USE
+const DATABASE_TYPE_LD_FLAG_KEY = 'tiles-database-type'
+
 const createTable: MutationResolvers['createTable'] = async (
   _parent,
   params,
   context,
 ) => {
-  const {
-    name: tableName,
-    isBlank: isBlankTable,
-    databaseType = 'ddb',
-  } = params.input
+  const { name: tableName, isBlank: isBlankTable } = params.input
 
   if (!tableName) {
     throw new Error('Table name is required')
   }
+
+  /**
+   * Check which database type user is allowed to create
+   */
+  const databaseType = (await getLdFlagValue(
+    DATABASE_TYPE_LD_FLAG_KEY,
+    context.currentUser.email,
+    'ddb',
+  )) as DatabaseType
 
   const tableOperations = getTableOperations(databaseType)
 

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -15,7 +15,7 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
   params,
   context,
 ) => {
-  const { tableId } = params
+  const { tableId, stringifiedCursor } = params
 
   try {
     const table = context.tilesViewKey
@@ -43,10 +43,15 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
 
     const columnIds = table.columns.map((column) => column.id)
 
-    const { rows } = await tableOperations.getTableRows({
-      tableId,
-      columnIds,
-    })
+    const { rows, stringifiedCursor: newStringifiedCursor } =
+      await tableOperations.getTableRows({
+        tableId,
+        columnIds,
+        // If table is postgres, we set pagination limit
+        // If table is dynamodb, the pagination size is based on dynamodb query limits
+        scanLimit: table.db === 'pg' ? 10000 : undefined,
+        stringifiedCursor,
+      })
 
     // Convert data object to csv to minimize payload size
     rows.forEach((row) => {
@@ -56,6 +61,7 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
     return {
       rows,
       columnIds,
+      stringifiedCursor: newStringifiedCursor,
     }
   } catch (e) {
     logger.error(e)

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -807,6 +807,7 @@ input DeleteTableCollaboratorInput {
 
 type TableMetadata {
   id: ID!
+  databaseType: DatabaseType!
   name: String!
   columns: [TableColumnMetadata!]
   lastAccessedAt: String!

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -752,7 +752,6 @@ enum DatabaseType {
 input CreateTableInput {
   name: String!
   isBlank: Boolean!
-  databaseType: DatabaseType
 }
 
 input TableColumnConfigInput {

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -221,6 +221,7 @@ export const getTableRows = async ({
   filters,
   order = 'asc',
   scanLimit,
+  stringifiedCursor,
 }: {
   tableId: string
   columnIds?: string[]
@@ -230,8 +231,10 @@ export const getTableRows = async ({
    * Optional limit on the total number of rows scanned.
    */
   scanLimit?: number
+  stringifiedCursor?: string
 }): Promise<{
   rows: TableRowOutput[]
+  stringifiedCursor: string | null
 }> => {
   const query = tilesClient(tableId).select(['rowId', ...(columnIds ?? [])])
   if (filters) {
@@ -239,6 +242,10 @@ export const getTableRows = async ({
   }
   if (scanLimit) {
     query.limit(scanLimit)
+  }
+  const offset = stringifiedCursor ? +stringifiedCursor : 0
+  if (offset) {
+    query.offset(offset)
   }
   try {
     const tableRows = []
@@ -249,6 +256,8 @@ export const getTableRows = async ({
     }
     return {
       rows: tableRows,
+      stringifiedCursor:
+        tableRows.length === scanLimit ? (offset + scanLimit).toString() : null,
     }
   } catch (e: unknown) {
     logger.error(e)

--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -13,7 +13,6 @@ import {
 } from '@chakra-ui/react'
 import { Button, FormLabel, Input } from '@opengovsg/design-system-react'
 
-import { DatabaseType } from '@/graphql/__generated__/graphql'
 import client from '@/graphql/client'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
 import { UPDATE_TABLE } from '@/graphql/mutations/tiles/update-table'
@@ -50,7 +49,6 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
                 input: {
                   name: inputValue.trim(),
                   isBlank: true,
-                  databaseType: DatabaseType.Pg,
                 },
               },
             })

--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react'
 import { Button, FormLabel, Input } from '@opengovsg/design-system-react'
 
+import { DatabaseType } from '@/graphql/__generated__/graphql'
 import client from '@/graphql/client'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
 import { UPDATE_TABLE } from '@/graphql/mutations/tiles/update-table'
@@ -49,6 +50,7 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
                 input: {
                   name: inputValue.trim(),
                   isBlank: true,
+                  databaseType: DatabaseType.Pg,
                 },
               },
             })

--- a/packages/frontend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table.ts
@@ -6,6 +6,7 @@ export const GET_TABLE = gql`
       id
       name
       viewOnlyKey
+      databaseType
       columns {
         id
         name

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -47,8 +47,11 @@ type IMPORT_STATUS =
   | 'completed'
   | 'error'
 
-// 2 MB in bytes
-const MAX_FILE_SIZE = 2 * 1000 * 1000
+// 5 MB in bytes
+const MAX_FILE_SIZE = {
+  [DatabaseType.Pg]: 5 * 1000 * 1000,
+  [DatabaseType.Ddb]: 2 * 1000 * 1000,
+}
 // Add row chunk size
 const CHUNK_SIZE = {
   [DatabaseType.Pg]: 1000,
@@ -322,7 +325,7 @@ export const ImportCsvModalContent = ({
           existing values.
         </Text>
         <Attachment
-          maxSize={MAX_FILE_SIZE}
+          maxSize={MAX_FILE_SIZE[databaseType]}
           onChange={setFile}
           title="Upload CSV"
           name="file-upload"

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ImportCsvButton.tsx
@@ -29,6 +29,7 @@ import Papa, { ParseMeta, ParseResult } from 'papaparse'
 import { SetRequired } from 'type-fest'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
+import { DatabaseType } from '@/graphql/__generated__/graphql'
 import { CREATE_ROWS } from '@/graphql/mutations/tiles/create-rows'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 
@@ -49,7 +50,10 @@ type IMPORT_STATUS =
 // 2 MB in bytes
 const MAX_FILE_SIZE = 2 * 1000 * 1000
 // Add row chunk size
-const CHUNK_SIZE = 100
+const CHUNK_SIZE = {
+  [DatabaseType.Pg]: 1000,
+  [DatabaseType.Ddb]: 100,
+}
 
 const ImportStatus = ({
   columnsToCreate,
@@ -134,7 +138,7 @@ export const ImportCsvModalContent = ({
   onPostImport?: () => void
   onBack?: () => void
 }) => {
-  const { tableId, tableColumns, refetch } = useTableContext()
+  const { tableId, tableColumns, refetch, databaseType } = useTableContext()
   const { createColumns } = useUpdateTable()
   const [createRows] = useMutation(CREATE_ROWS)
   const [getTableData] = useLazyQuery<{
@@ -255,7 +259,7 @@ export const ImportCsvModalContent = ({
         setImportStatus('importing')
         setRowsToImport(mappedData.length)
         setRowsImported(0)
-        const chunkedData = chunk(mappedData, CHUNK_SIZE)
+        const chunkedData = chunk(mappedData, CHUNK_SIZE[databaseType])
 
         for (let i = 0; i < chunkedData.length; i++) {
           await createRows({
@@ -269,7 +273,7 @@ export const ImportCsvModalContent = ({
           if (i === chunkedData.length - 1 && !onPreImport) {
             await refetch()
           }
-          setRowsImported((i + 1) * CHUNK_SIZE)
+          setRowsImported((i + 1) * CHUNK_SIZE[databaseType])
         }
       }
       setImportStatus('completed')
@@ -291,6 +295,7 @@ export const ImportCsvModalContent = ({
     onPreImport,
     refetch,
     result,
+    databaseType,
     tableColumns,
     tableId,
   ])

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -13,12 +13,15 @@ import React, {
   useState,
 } from 'react'
 
+import { DatabaseType } from '@/graphql/__generated__/graphql'
+
 import { flattenRows } from '../helpers/flatten-rows'
 import { EditMode, GenericRowData } from '../types'
 
 interface TableContextProps {
   tableId: string
   tableName: string
+  databaseType: DatabaseType
   flattenedData: GenericRowData[]
   tableColumns: ITableColumnMetadata[]
   filteredDataRef: MutableRefObject<GenericRowData[]>
@@ -49,6 +52,7 @@ export const useTableContext = () => {
 interface TableContextProviderProps {
   tableId: string
   tableName: string
+  databaseType: DatabaseType
   tableColumns: ITableColumnMetadata[]
   tableRows: ITableRow[]
   children: React.ReactNode
@@ -64,6 +68,7 @@ interface TableContextProviderProps {
 export const TableContextProvider = ({
   tableId,
   tableName,
+  databaseType,
   tableColumns,
   tableRows,
   children,
@@ -86,6 +91,7 @@ export const TableContextProvider = ({
       value={{
         tableId,
         tableName,
+        databaseType,
         flattenedData,
         tableColumns,
         allDataRef,

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -80,13 +80,14 @@ export default function Tile(): JSX.Element | null {
     return null
   }
 
-  const { id, name, columns, viewOnlyKey, collaborators } =
+  const { id, name, columns, viewOnlyKey, collaborators, databaseType } =
     getTableData.getTable
 
   return (
     <TableContextProvider
       tableName={name}
       tableId={id}
+      databaseType={databaseType}
       tableColumns={columns}
       tableRows={rows}
       viewOnlyKey={viewOnlyKey}

--- a/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
+++ b/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
 import {
   Flex,
+  FormControl,
   Modal,
   ModalBody,
   ModalContent,
@@ -16,6 +17,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import {
+  Badge,
   Button,
   FormLabel,
   Input,
@@ -23,7 +25,9 @@ import {
   Tile,
 } from '@opengovsg/design-system-react'
 
+import { SingleSelect } from '@/components/SingleSelect'
 import * as URLS from '@/config/urls'
+import { DatabaseType } from '@/graphql/__generated__/graphql'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
 import { ImportCsvModalContent } from '@/pages/Tile/components/TableBanner/ImportCsvButton'
 import { TableContextProvider } from '@/pages/Tile/contexts/TableContext'
@@ -33,12 +37,16 @@ type TILE_CREATE_MODE = 'import' | 'new'
 const CreateTileForm = ({
   tableName,
   setTableName,
+  databaseType,
+  setDatabaseType,
   onSubmit,
   isSubmitting,
   onImportNext,
 }: {
   tableName: string
   setTableName: (tableName: string) => void
+  databaseType: DatabaseType
+  setDatabaseType: (databaseType: DatabaseType) => void
   onSubmit: () => Promise<void>
   isSubmitting: boolean
   onImportNext: () => void
@@ -49,41 +57,55 @@ const CreateTileForm = ({
     <>
       <ModalHeader>Create a Tile</ModalHeader>
       <ModalCloseButton />
-      <ModalBody>
-        <FormLabel isRequired>Enter a name for your new tile</FormLabel>
-        <Input
-          value={tableName}
-          onChange={(e) => setTableName(e.target.value)}
-        />
-        <FormLabel mt={8} isRequired>
-          How do you want to start?
-        </FormLabel>
-        <Flex gap={4}>
-          <Tile
-            icon={BiSpreadsheet}
-            flex={1}
-            onClick={() => setCreateMode('import')}
-            isSelected={createMode === 'import'}
-          >
-            <Text textStyle="h5" mt={4}>
-              Import CSV
-            </Text>
-            <Text textStyle="body-2">
-              Start with data that you have already collected
-            </Text>
-          </Tile>
-          <Tile
-            icon={BiTable}
-            flex={1}
-            onClick={() => setCreateMode('new')}
-            isSelected={createMode === 'new'}
-          >
-            <Text textStyle="h5" mt={4}>
-              Start from scratch
-            </Text>
-            <Text textStyle="body-2">Start with a blank database</Text>
-          </Tile>
-        </Flex>
+      <ModalBody gap={8} display="flex" flexDirection="column">
+        <FormControl>
+          <FormLabel isRequired>Enter a name for your new tile</FormLabel>
+          <Input
+            value={tableName}
+            onChange={(e) => setTableName(e.target.value)}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Select version</FormLabel>
+          <SingleSelect
+            items={[
+              {
+                label: 'Tiles v2 (PostgreSQL)',
+                value: DatabaseType.Pg,
+                badge: <Badge>NEW</Badge>,
+              },
+              { label: 'Tiles v1 (DynamoDB)', value: DatabaseType.Ddb },
+            ]}
+            value={databaseType}
+            onChange={(value) => setDatabaseType(value as DatabaseType)}
+            name="databaseType"
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel isRequired>How do you want to start?</FormLabel>
+          <Flex gap={4} direction={{ base: 'column', sm: 'row' }}>
+            <Tile
+              icon={BiSpreadsheet}
+              flex={1}
+              onClick={() => setCreateMode('import')}
+              isSelected={createMode === 'import'}
+            >
+              <Text textStyle="h5">Import CSV</Text>
+              <Text textStyle="body-2">
+                Start with data that you have already collected
+              </Text>
+            </Tile>
+            <Tile
+              icon={BiTable}
+              flex={1}
+              onClick={() => setCreateMode('new')}
+              isSelected={createMode === 'new'}
+            >
+              <Text textStyle="h5">Start from scratch</Text>
+              <Text textStyle="body-2">Start with a blank database</Text>
+            </Tile>
+          </Flex>
+        </FormControl>
       </ModalBody>
       <ModalFooter>
         <Button
@@ -104,6 +126,9 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
   const [tableName, setTableName] = useState('')
   const [showImportModal, setShowImportModal] = useState(false)
   const [tableData, setTableData] = useState<ITableMetadata | null>(null)
+  const [databaseType, setDatabaseType] = useState<DatabaseType>(
+    DatabaseType.Pg,
+  )
 
   const [createTableMutation, { loading }] = useMutation<{
     createTable: ITableMetadata
@@ -116,6 +141,7 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
           input: {
             name: tableName,
             isBlank,
+            databaseType,
           },
         },
       })
@@ -125,7 +151,7 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
       setTableData(data.createTable)
       return data.createTable
     },
-    [createTableMutation, tableName],
+    [createTableMutation, databaseType, tableName],
   )
 
   const navigateToTile = useCallback(
@@ -155,6 +181,7 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
       <ModalContent>
         {showImportModal ? (
           <TableContextProvider
+            databaseType={databaseType}
             tableName={tableName}
             tableId={tableData ? tableData.id : ''}
             tableColumns={[]}
@@ -174,6 +201,8 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
           <CreateTileForm
             tableName={tableName}
             setTableName={setTableName}
+            setDatabaseType={setDatabaseType}
+            databaseType={databaseType}
             onSubmit={onSubmit}
             isSubmitting={loading}
             onImportNext={() => setShowImportModal(true)}

--- a/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
+++ b/packages/frontend/src/pages/Tiles/components/CreateTileButton.tsx
@@ -17,7 +17,6 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import {
-  Badge,
   Button,
   FormLabel,
   Input,
@@ -25,7 +24,6 @@ import {
   Tile,
 } from '@opengovsg/design-system-react'
 
-import { SingleSelect } from '@/components/SingleSelect'
 import * as URLS from '@/config/urls'
 import { DatabaseType } from '@/graphql/__generated__/graphql'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
@@ -37,16 +35,12 @@ type TILE_CREATE_MODE = 'import' | 'new'
 const CreateTileForm = ({
   tableName,
   setTableName,
-  databaseType,
-  setDatabaseType,
   onSubmit,
   isSubmitting,
   onImportNext,
 }: {
   tableName: string
   setTableName: (tableName: string) => void
-  databaseType: DatabaseType
-  setDatabaseType: (databaseType: DatabaseType) => void
   onSubmit: () => Promise<void>
   isSubmitting: boolean
   onImportNext: () => void
@@ -63,22 +57,6 @@ const CreateTileForm = ({
           <Input
             value={tableName}
             onChange={(e) => setTableName(e.target.value)}
-          />
-        </FormControl>
-        <FormControl>
-          <FormLabel>Select version</FormLabel>
-          <SingleSelect
-            items={[
-              {
-                label: 'Tiles v2 (PostgreSQL)',
-                value: DatabaseType.Pg,
-                badge: <Badge>NEW</Badge>,
-              },
-              { label: 'Tiles v1 (DynamoDB)', value: DatabaseType.Ddb },
-            ]}
-            value={databaseType}
-            onChange={(value) => setDatabaseType(value as DatabaseType)}
-            name="databaseType"
           />
         </FormControl>
         <FormControl>
@@ -126,9 +104,6 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
   const [tableName, setTableName] = useState('')
   const [showImportModal, setShowImportModal] = useState(false)
   const [tableData, setTableData] = useState<ITableMetadata | null>(null)
-  const [databaseType, setDatabaseType] = useState<DatabaseType>(
-    DatabaseType.Pg,
-  )
 
   const [createTableMutation, { loading }] = useMutation<{
     createTable: ITableMetadata
@@ -141,7 +116,6 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
           input: {
             name: tableName,
             isBlank,
-            databaseType,
           },
         },
       })
@@ -151,7 +125,7 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
       setTableData(data.createTable)
       return data.createTable
     },
-    [createTableMutation, databaseType, tableName],
+    [createTableMutation, tableName],
   )
 
   const navigateToTile = useCallback(
@@ -181,8 +155,9 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
       <ModalContent>
         {showImportModal ? (
           <TableContextProvider
-            databaseType={databaseType}
             tableName={tableName}
+            // this doesnt matter for empty tables
+            databaseType={DatabaseType.Ddb}
             tableId={tableData ? tableData.id : ''}
             tableColumns={[]}
             tableRows={[]}
@@ -201,8 +176,6 @@ const CreateTileModal = ({ onClose }: { onClose: () => void }): JSX.Element => {
           <CreateTileForm
             tableName={tableName}
             setTableName={setTableName}
-            setDatabaseType={setDatabaseType}
-            databaseType={databaseType}
             onSubmit={onSubmit}
             isSubmitting={loading}
             onImportNext={() => setShowImportModal(true)}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -903,6 +903,7 @@ export interface ITableColumnMetadata {
 export interface ITableMetadata {
   id: string
   name: string
+  databaseType: DatabaseType
   columns: ITableColumnMetadata[]
   lastAccessedAt: string
   viewOnlyKey?: string


### PR DESCRIPTION
### TL;DR

Removed the explicit database type selection when creating tables, instead using LaunchDarkly flags to determine the database type.

### What changed?

- Removed `databaseType` from the `CreateTableInput` in GraphQL schema
- Added LaunchDarkly integration to determine database type when creating tables
- Added `databaseType` field to `TableMetadata` resolver to expose the database type to clients
- Updated tests to mock LaunchDarkly flag values
- Enhanced CSV import functionality with database-specific limits:
  - Increased max file size to 5MB for PostgreSQL (vs 2MB for DynamoDB)
  - Increased chunk size to 1000 rows for PostgreSQL (vs 100 for DynamoDB)
- Added pagination support for table rows with `stringifiedCursor` parameter

### How to test?

1. Create a new table and verify it uses the database type determined by LaunchDarkly
2. Import CSV files of different sizes to verify the database-specific limits
3. Test pagination by loading large tables and checking that rows load correctly
