### PR TITLE
[SIDE-DRAWER-15] UI fixes - Part 3

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -4,6 +4,7 @@ import { useContext, useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
 import { EditorContext } from '@/contexts/Editor'
+import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import Step from './Step'
 import StepHeader from './StepHeader'
@@ -17,11 +18,12 @@ interface EditorRightDrawerProps {
 export default function EditorRightDrawer(props: EditorRightDrawerProps) {
   const { index, steps } = props
 
-  const { currentStepId } = useContext(EditorContext)
+  const { allApps, currentStepId } = useContext(EditorContext)
 
   const step = useMemo(() => {
     return steps.find((step) => step.id === currentStepId)
   }, [currentStepId, steps])
+  const { hasConnection } = useStepMetadata(allApps, step)
 
   if (!currentStepId || !step) {
     return null
@@ -36,6 +38,7 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
         overflowX="hidden"
         position="relative"
         px="4"
+        pt={hasConnection ? 0 : 4}
         top="2.5rem"
       >
         <Step step={step} isLastStep={index === steps.length - 1} />

--- a/packages/frontend/src/components/FlowStep/components/StepAppIcon.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepAppIcon.tsx
@@ -44,7 +44,7 @@ export default function StepAppIcon(props: AppIconProps) {
   )
 
   return (
-    <Flex {...flowStepStyles.appIconWrapper} boxSize={boxSize}>
+    <Flex {...flowStepStyles.appIconWrapper} boxSize={boxSize} flexShrink={0}>
       {/* App icon */}
       {app ? (
         app?.key === TOOLBOX_APP_KEY ? (

--- a/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
@@ -51,7 +51,7 @@ export default function StepCaptionAndDemo(props: StepCaptionProps) {
 
   return (
     <>
-      <Flex direction="column" align="start" maxW="80%">
+      <Flex direction="column" align="start" maxW="80%" flexShrink={1}>
         <Flex alignItems="center" gap={2} maxW="100%">
           <Text
             textStyle="subhead-1"

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -45,8 +45,8 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
             alignItems="center"
             borderRadius="inherit"
             w="full"
-            borderLeftWidth={isDrawerOpen ? 0 : '1px'}
-            borderRightWidth={isDrawerOpen ? 0 : '1px'}
+            borderLeftWidth={0}
+            borderRightWidth={0}
           >
             <Flex {...flowStepGroupStyles.iconWrapper}>
               {/* App icon */}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -215,7 +215,7 @@ export default function FlowStepTestController(
                     <Button
                       variant="clear"
                       colorScheme={
-                        infoBoxVariant === 'unstyled' ? 'primary' : 'green'
+                        infoBoxVariant === 'unstyled' ? 'black' : 'green'
                       }
                       size="sm"
                       onClick={() =>

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -2,6 +2,8 @@ import { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import { useMemo } from 'react'
 
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+
 interface UseStepMetadataResult {
   app: IApp | undefined
   selectedActionOrTrigger: IAction | ITrigger | undefined
@@ -50,6 +52,13 @@ export function useStepMetadata(
     caption = `${step?.position ? `${step.position}. ` : ''}${
       selectedActionOrTrigger?.name
     }`
+
+    if (
+      step?.key === TOOLBOX_ACTIONS.IfThen &&
+      step?.appKey === TOOLBOX_APP_KEY
+    ) {
+      caption = `${step.position}. Condition`
+    }
   } else if (app?.name) {
     caption = `${step?.position ? `${step.position}. ` : ''}${app.name}`
   } else if (isTrigger) {

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -2,7 +2,7 @@ import { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import { useMemo } from 'react'
 
-import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+import { isIfThenStep as checkIfThenStep } from '@/helpers/toolbox'
 
 interface UseStepMetadataResult {
   app: IApp | undefined
@@ -23,7 +23,7 @@ export function useStepMetadata(
 ): UseStepMetadataResult {
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'
-  const isIfThenStep = step?.appKey === 'toolbox' && step?.key === 'ifThen'
+  const isIfThenStep = step ? checkIfThenStep(step) : false
 
   const apps: IApp[] = allApps?.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
@@ -53,11 +53,8 @@ export function useStepMetadata(
       selectedActionOrTrigger?.name
     }`
 
-    if (
-      step?.key === TOOLBOX_ACTIONS.IfThen &&
-      step?.appKey === TOOLBOX_APP_KEY
-    ) {
-      caption = `${step.position}. Condition`
+    if (isIfThenStep) {
+      caption = `${step?.position}. Condition`
     }
   } else if (app?.name) {
     caption = `${step?.position ? `${step.position}. ` : ''}${app.name}`


### PR DESCRIPTION
## TL;DR
This PR focuses on UI fixes from the last round of bug bash.

## What changed?
* Fixed app icon shrinking when window is small
* Fixed colour of 'Previous result' button
* Revert to 'Condition' as default step name for If-Then conditions
* Adjust padding between EditableInput and Step for steps without connections
* Removed extra border at If-Then step header

## Screenshots
### Fixed app icon shrinking when window is small

[Screen Recording 2025-05-14 at 9.43.10 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/c5d13806-b147-48c1-916e-cb72080f9d49.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/c5d13806-b147-48c1-916e-cb72080f9d49.mov)

### Fixed colour of 'Previous result' button

![Screenshot 2025-05-14 at 9.42.33 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/daa163b9-b86b-448b-963f-3b88df2ee9ac.png)

### Revert to 'Condition' as default step name for If-Then conditions

![Screenshot 2025-05-14 at 9.42.18 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/a2d3e2b3-09dc-44ef-8994-9d2059ee6b24.png)

### Adjust padding between EditableInput and Step for steps without connections

![Screenshot 2025-05-14 at 9.42.56 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/0c92c535-2bc7-49e3-9e67-2d7a93e3978b.png)

### Removed extra border at If-Then step header

![Screenshot 2025-05-14 at 9.44.01 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/b3cebc68-b417-4b44-8bfd-269aead70fbc.png)

