### PR TITLE
feat: use RDS proxy

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -43,10 +43,6 @@
     {
       "name": "ENABLE_BULLMQ_DASHBOARD",
       "value": "true"
-    },
-    {
-      "name": "POSTMAN_SMS_QPS_LIMIT_PER_CAMPAIGN",
-      "value": "5"
     }
   ],
   "secrets": [
@@ -217,6 +213,10 @@
     {
       "name": "ONBOARDING_EMAIL_WEBHOOK_URL",
       "valueFrom": "plumber-onboarding-email-webhook-url"
+    },
+    {
+      "name": "POSTMAN_SMS_QPS_LIMIT_PER_CAMPAIGN",
+      "valueFrom": "plumber-<ENVIRONMENT>-postman-sms-qps"
     }
   ]
 }

--- a/ecs/env.json
+++ b/ecs/env.json
@@ -217,6 +217,10 @@
     {
       "name": "POSTMAN_SMS_QPS_LIMIT_PER_CAMPAIGN",
       "valueFrom": "plumber-<ENVIRONMENT>-postman-sms-qps"
+    },
+    {
+      "name": "RDS_PROXY_HOST",
+      "valueFrom": "plumber-<ENVIRONMENT>-rds-proxy-host"
     }
   ]
 }

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -69,7 +69,8 @@ const appConfig: AppConfig = {
   version: process.env.npm_package_version,
   postgresDatabase: process.env.POSTGRES_DATABASE || 'plumber_dev',
   postgresPort: parseInt(process.env.POSTGRES_PORT || '5432'),
-  postgresHost: process.env.POSTGRES_HOST || 'localhost',
+  postgresHost:
+    process.env.RDS_PROXY_HOST || process.env.POSTGRES_HOST || 'localhost',
   postgresUsername: process.env.POSTGRES_USERNAME,
   postgresPassword: process.env.POSTGRES_PASSWORD,
   postgresEnableSsl: process.env.POSTGRES_ENABLE_SSL === 'true',


### PR DESCRIPTION
## Changes
- use rds proxy host if exists. else, fallback to rds cluster host
- move postman-sms qps rate limit to env var instead of hardcoding


## To test
- Check that postman sms qps env var is set
  - [x] Prod
  - [x] Staging
  - [x] UAT
- [x] Check that RDS Proxy on Prod is accessible before merging