### PR TITLE
[SIDE-DRAWER-17] Reset fields properly on discard change

### DIFF
--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -1,9 +1,8 @@
-import { useContext, useRef } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Box, Divider, useDisclosure } from '@chakra-ui/react'
 import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
 
-import { EditorContext } from '@/contexts/Editor'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
@@ -20,22 +19,17 @@ interface AddStepButtonProps {
 
 export function AddStepButton(props: AddStepButtonProps): JSX.Element {
   const { isHidden, isLastStep, stepId, isDisabled, showEmptyAction } = props
-  const cancelRef = useRef(null)
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const {
-    isOpen: isWarningOpen,
-    onOpen: onWarningOpen,
-    onClose: onWarningClose,
-  } = useDisclosure()
-  const { shouldWarnOnLeave } = useContext(EditorContext)
 
-  const handleOpen = () => {
-    if (shouldWarnOnLeave) {
-      onWarningOpen()
-    } else {
-      onOpen()
-    }
-  }
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave,
+  } = useUnsavedChanges({
+    onProceed: onOpen,
+  })
 
   return (
     <Box
@@ -62,7 +56,10 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
                 borderColor="base.divider.strong"
                 h={20}
               />
-              <EmptyFlowStepHeader isTrigger={false} onModalOpen={handleOpen} />
+              <EmptyFlowStepHeader
+                isTrigger={false}
+                onModalOpen={handleProceed}
+              />
             </>
           )}
           {/* Top vertical line */}
@@ -76,7 +73,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
             marginX="auto"
           >
             <IconButton
-              onClick={handleOpen}
+              onClick={handleProceed}
               aria-label="Add Step"
               isDisabled={isDisabled || showEmptyAction}
               icon={<BiPlus />}
@@ -120,7 +117,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={onOpen}
+        onLeave={handleLeave}
       />
     </Box>
   )

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -28,8 +28,13 @@ export default function Step(props: StepProps): React.ReactElement | null {
     onClose: onModalClose,
   } = useDisclosure()
 
-  const { allApps, onDrawerClose, onUpdateStep, testExecutionSteps } =
-    useContext(EditorContext)
+  const {
+    allApps,
+    onDrawerClose,
+    onUpdateStep,
+    testExecutionSteps,
+    resetTimestamp,
+  } = useContext(EditorContext)
 
   // This includes all steps that run even after the current step, but within the same branch.
   const stepExecutionsToInclude = useContext(StepExecutionsToIncludeContext)
@@ -72,7 +77,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
       <Flex w="100%" flexDir="column">
         <StepExecutionsProvider priorExecutionSteps={priorExecutionSteps}>
           <Form
-            key={step.id}
+            key={`${step.id}-${resetTimestamp}`}
             defaultValues={step}
             onSubmit={handleSubmit}
             resolver={stepValidationSchema}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,6 +1,6 @@
 import type { IStep } from '@plumber/types'
 
-import { useCallback, useContext, useMemo, useRef } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { BiInfoCircle } from 'react-icons/bi'
 import { Box, CircularProgress, Flex, useDisclosure } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
@@ -12,6 +12,7 @@ import { getFlowStepHeaderWidth } from '@/helpers/editor'
 import { replacePlaceholdersForHelpMessage } from '@/helpers/flow-templates'
 import { validateStepParams } from '@/helpers/validateStepParams'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
@@ -37,18 +38,11 @@ export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
   const { step, index, isLastStep, isNested } = props
-  const cancelRef = useRef(null)
 
   const {
     isOpen: isModalOpen,
     onOpen: onModalOpen,
     onClose: onModalClose,
-  } = useDisclosure()
-
-  const {
-    isOpen: isWarningOpen,
-    onOpen: onWarningOpen,
-    onClose: onWarningClose,
   } = useDisclosure()
 
   const {
@@ -69,6 +63,17 @@ export default function FlowStep(
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
   const { app, caption, isCompleted, isTrigger, selectedActionOrTrigger } =
     useStepMetadata(allApps, step)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: onModalOpen,
+  })
 
   const isDeletable =
     displayOverrides?.disableDelete === true
@@ -117,7 +122,7 @@ export default function FlowStep(
     setCurrentStepIndex,
   ])
 
-  const handleLeave = () => {
+  const onLeave = () => {
     if (currentStepId === step.id) {
       setCurrentStepId(null)
       setCurrentStepIndex(null)
@@ -125,7 +130,7 @@ export default function FlowStep(
       onDrawerClose()
     } else if (!app || !selectedActionOrTrigger) {
       setShouldWarnOnLeave(false)
-      onModalOpen()
+      discardChanges()
     } else {
       setCurrentStepId(step.id)
       setCurrentStepIndex(index)
@@ -162,13 +167,7 @@ export default function FlowStep(
         <EmptyFlowStepHeader
           isNested={isNested}
           isTrigger={isTrigger}
-          onModalOpen={() => {
-            if (shouldWarnOnLeave) {
-              onWarningOpen()
-            } else {
-              onModalOpen()
-            }
-          }}
+          onModalOpen={handleProceed}
         />
       ) : (
         <>
@@ -250,7 +249,7 @@ export default function FlowStep(
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={handleLeave}
+        onLeave={onLeave}
       />
     </FlowStepWrapper>
   )

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -1,10 +1,10 @@
-import { useContext, useRef, useState } from 'react'
+import { useState } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Divider, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 
 import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
-import { EditorContext } from '@/contexts/Editor'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import { hoverAddStepButtonStyles as styles } from './styles'
 
@@ -19,23 +19,18 @@ export function HoverAddStepButton(
   props: HoverAddStepButtonProps,
 ): JSX.Element {
   const { isDisabled, isLastStep, prevStepId } = props
-  const cancelRef = useRef(null)
-  const { shouldWarnOnLeave } = useContext(EditorContext)
   const { isOpen, onOpen, onClose } = useDisclosure()
-  const {
-    isOpen: isWarningOpen,
-    onOpen: onWarningOpen,
-    onClose: onWarningClose,
-  } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
 
-  const handleOpen = () => {
-    if (shouldWarnOnLeave) {
-      onWarningOpen()
-    } else {
-      onOpen()
-    }
-  }
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave,
+  } = useUnsavedChanges({
+    onProceed: onOpen,
+  })
 
   return (
     <>
@@ -57,7 +52,7 @@ export function HoverAddStepButton(
           <IconButton
             {...styles.button}
             aria-label="Add Step"
-            onClick={handleOpen}
+            onClick={handleProceed}
             isDisabled={isDisabled}
             icon={<BiPlus />}
           />
@@ -77,7 +72,7 @@ export function HoverAddStepButton(
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={onOpen}
+        onLeave={handleLeave}
       />
     </>
   )

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -49,8 +49,9 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const { dirtyFields } = formContext.formState
   const isDirty = Object.keys(dirtyFields).length > 0
   useEffect(() => {
+    onTestResultClose()
     setShouldWarnOnLeave(isDirty)
-  }, [isDirty, setShouldWarnOnLeave])
+  }, [isDirty, onTestResultClose, setShouldWarnOnLeave])
 
   // filter inputs hidden behind feature flags based on timestamp
   const argsToDisplay = useMemo(

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -65,6 +65,8 @@ interface IEditorContextValue {
   ) => Promise<IStep>
   onUpdateStep: (step: IStep) => Promise<IStep>
   allApps: IApp[]
+  resetForm: () => void
+  resetTimestamp: number
 }
 
 export const EditorContext = createContext<IEditorContextValue>({
@@ -91,6 +93,8 @@ export const EditorContext = createContext<IEditorContextValue>({
   setCurrentStepIndex: () => null,
   setShouldWarnOnLeave: () => null,
   allApps: [],
+  resetForm: () => null,
+  resetTimestamp: 0,
 })
 
 type EditorProviderProps = {
@@ -159,6 +163,7 @@ export const EditorProvider = ({
   const flowId = flow.id
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
   const [currentStepIndex, setCurrentStepIndex] = useState<number | null>(0)
+  const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
   const hasIfThen = flow?.steps.some(
@@ -350,6 +355,11 @@ export const EditorProvider = ({
     }
   }, [executeStep, currentStepId])
 
+  // Force the Form to remount by changing its key when discarding changes
+  const resetForm = useCallback(() => {
+    setResetTimestamp(Date.now())
+  }, [])
+
   if (isLoadingAllApps) {
     return (
       <Center height="100vh" position="fixed" width="full" top={0} left={0}>
@@ -384,6 +394,8 @@ export const EditorProvider = ({
         setCurrentStepId,
         setCurrentStepIndex,
         setShouldWarnOnLeave,
+        resetForm,
+        resetTimestamp,
       }}
     >
       {children}

--- a/packages/frontend/src/hooks/useUnsavedChanges.ts
+++ b/packages/frontend/src/hooks/useUnsavedChanges.ts
@@ -1,0 +1,54 @@
+import { useContext, useRef } from 'react'
+import { useDisclosure } from '@chakra-ui/react'
+
+import { EditorContext } from '@/contexts/Editor'
+
+interface UseUnsavedChangesProps {
+  onProceed: () => void
+}
+
+interface UseUnsavedChangesReturn {
+  cancelRef: React.RefObject<HTMLButtonElement>
+  isWarningOpen: boolean
+  onWarningOpen: () => void
+  onWarningClose: () => void
+  handleProceed: () => void
+  handleLeave: () => void
+}
+
+export function useUnsavedChanges({
+  onProceed,
+}: UseUnsavedChangesProps): UseUnsavedChangesReturn {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const {
+    isOpen: isWarningOpen,
+    onOpen: onWarningOpen,
+    onClose: onWarningClose,
+  } = useDisclosure()
+
+  const { shouldWarnOnLeave, resetForm, setShouldWarnOnLeave } =
+    useContext(EditorContext)
+
+  const handleProceed = () => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      onProceed()
+    }
+  }
+
+  const handleLeave = () => {
+    onProceed()
+    resetForm()
+    setShouldWarnOnLeave(false)
+  }
+
+  return {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave,
+  }
+}


### PR DESCRIPTION
## TL;DR
This PR addresses 2 key issues:
1. Closing the Collapse when user starts editing after testing the step
1. Discarding changes properly when user makes edits and attempts to add a new step
1. Minor refactor
   * Introduced a new `useUnsavedChanges` hook to centralise the logic for handling unsaved changes when navigating between step

## How to test
- [ ] Collapse closes on edit
  - [ ] Test a step, Collapse opens, start making edits, Collapse should close
- [ ] Discarding changes properly
  - [ ] Edit a step, attempt to add a step using + icon, click 'Discard', but do not actually add a step, close the Add step modal, changes should have been discarded
  - [ ] Edit a step, attempt to add a step using the empty flow step header, click 'Discard', but do not actually add a step, close the Add step modal, changes should have been discarded