### PR TITLE
[SIDE-DRAWER-18] Allow reset to default step name

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -253,6 +253,24 @@ describe('updateStep mutation', () => {
     })
   })
 
+  it('should allow for empty step name', async () => {
+    const input = {
+      ...genericInputParams,
+      config: { stepName: '' },
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      connectionId: mockConnectionId,
+      parameters: { testParam: 'value' },
+      status: 'completed',
+      config: { stepName: '' },
+    })
+  })
+
   it('updating step name should not update template config', async () => {
     // Override the steps query to return template config
     context.currentUser.$relatedQuery = vi
@@ -312,6 +330,68 @@ describe('updateStep mutation', () => {
     })
     expect(patchAndFetchByIdSpy.mock.results[0].value.config.stepName).toEqual(
       'Updated Step Name',
+    )
+  })
+
+  it('updating empty step name should not update template config', async () => {
+    // Override the steps query to return template config
+    context.currentUser.$relatedQuery = vi
+      .fn()
+      .mockImplementation((relation) => {
+        if (relation === 'steps') {
+          return {
+            findOne: vi.fn().mockResolvedValue({
+              id: mockStepId,
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              status: 'completed',
+              connection: { id: mockConnectionId },
+              config: {
+                stepName: 'some-step-name',
+                templateConfig: { appEventKey: 'existingAppEventKey' },
+              },
+            }),
+          }
+        }
+        if (relation === 'connections') {
+          return {
+            findOne: vi
+              .fn()
+              .mockResolvedValue({ id: mockConnectionId, key: 'postman' }),
+          }
+        }
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      })
+
+    const input = {
+      ...genericInputParams,
+      config: { stepName: '' },
+    }
+
+    await updateStep(null, { input }, context)
+
+    expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      connectionId: mockConnectionId,
+      parameters: { testParam: 'value' },
+      status: 'completed',
+      config: {
+        stepName: '',
+        templateConfig: { appEventKey: 'existingAppEventKey' },
+      },
+    })
+
+    // Verify the existing templateConfig was preserved in the result
+    expect(
+      patchAndFetchByIdSpy.mock.results[0].value.config.templateConfig,
+    ).toEqual({
+      appEventKey: 'existingAppEventKey',
+    })
+    expect(patchAndFetchByIdSpy.mock.results[0].value.config.stepName).toEqual(
+      '',
     )
   })
 })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -47,7 +47,8 @@ const updateStep: MutationResolvers['updateStep'] = async (
         status: shouldInvalidate ? 'incomplete' : step.status,
         config: {
           ...existingConfig,
-          ...(stepName ? { stepName } : {}),
+          // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
+          ...(stepName !== undefined ? { stepName } : {}),
         },
       })
       .withGraphFetched('connection')

--- a/packages/frontend/src/components/EditableInput/index.tsx
+++ b/packages/frontend/src/components/EditableInput/index.tsx
@@ -13,6 +13,8 @@ interface EditableInputProps {
   editModeWrapper?: (children: React.ReactNode) => React.ReactNode
   readOnlyWrapper?: (children: React.ReactNode) => React.ReactNode
   componentWrapper?: (children: React.ReactNode) => React.ReactNode
+  allowEmpty?: boolean
+  placeholder?: string
 }
 
 export default function EditableInput({
@@ -24,6 +26,8 @@ export default function EditableInput({
   editModeWrapper,
   readOnlyWrapper,
   componentWrapper,
+  placeholder,
+  allowEmpty = false,
 }: EditableInputProps) {
   const isMobile = useIsMobile()
 
@@ -38,11 +42,15 @@ export default function EditableInput({
 
   const handleSave = async () => {
     const trimmedValue = inputValue.trim()
-    if (!trimmedValue.length || trimmedValue.length > maxLength) {
+    if (
+      !allowEmpty &&
+      (!trimmedValue.length || trimmedValue.length > maxLength)
+    ) {
       resetField()
     } else {
+      const valueToSave = trimmedValue === '' ? '' : trimmedValue
       setIsUpdating(true)
-      await onSave(inputValue)
+      await onSave(valueToSave)
       setIsUpdating(false)
       setIsEditing(false)
     }
@@ -67,6 +75,7 @@ export default function EditableInput({
         value={inputValue}
         onKeyDown={handleKeyDown}
         onChange={(e) => setInputValue(e.target.value)}
+        placeholder={placeholder}
       />
       <IconButton
         ml={3}

--- a/packages/frontend/src/components/EditableInput/index.tsx
+++ b/packages/frontend/src/components/EditableInput/index.tsx
@@ -48,9 +48,8 @@ export default function EditableInput({
     ) {
       resetField()
     } else {
-      const valueToSave = trimmedValue === '' ? '' : trimmedValue
       setIsUpdating(true)
-      await onSave(valueToSave)
+      await onSave(trimmedValue)
       setIsUpdating(false)
       setIsEditing(false)
     }

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -32,7 +32,11 @@ export default function StepHeader(props: StepHeaderProps) {
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
 
-  const { position, stepName: initialStepName } = useStepMetadata(allApps, step)
+  const {
+    defaultCaption,
+    position,
+    stepName: initialStepName,
+  } = useStepMetadata(allApps, step)
 
   const handleClose = () => {
     if (shouldWarnOnLeave) {
@@ -78,6 +82,8 @@ export default function StepHeader(props: StepHeaderProps) {
           value={initialStepName}
           onSave={onSave}
           readOnly={isReadOnlyEditor}
+          placeholder={defaultCaption}
+          allowEmpty={true}
         />
       </Flex>
 

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -292,7 +292,10 @@ export const EditorProvider = ({
           id: flowId,
         },
         config: {
-          stepName: step.config?.stepName,
+          // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
+          ...(step.config?.stepName !== undefined && {
+            stepName: step.config?.stepName,
+          }),
         },
         ...(step.status !== undefined && { status: step.status }),
       }

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -8,6 +8,7 @@ interface UseStepMetadataResult {
   app: IApp | undefined
   selectedActionOrTrigger: IAction | ITrigger | undefined
   caption: string
+  defaultCaption?: string
   hasConnection: boolean
   isCompleted: boolean
   isIfThenStep: boolean
@@ -46,12 +47,11 @@ export function useStepMetadata(
 
   // define caption description based on app and step
   let caption = ''
+  let defaultCaption = selectedActionOrTrigger?.name
   if (step?.config?.stepName) {
     caption = `${step.position}. ${step.config.stepName}`
-  } else if (selectedActionOrTrigger?.name) {
-    caption = `${step?.position ? `${step.position}. ` : ''}${
-      selectedActionOrTrigger?.name
-    }`
+  } else if (defaultCaption) {
+    caption = `${step?.position ? `${step.position}. ` : ''}${defaultCaption}`
 
     if (isIfThenStep) {
       caption = `${step?.position}. Condition`
@@ -66,6 +66,10 @@ export function useStepMetadata(
     caption = 'This step happens after the previous step'
   }
 
+  if (isIfThenStep) {
+    defaultCaption = 'Condition'
+  }
+
   const substeps = selectedActionOrTrigger?.substeps || []
   const hasConnection = substeps?.some(
     (substep: ISubstep) => substep.key === 'chooseConnection',
@@ -75,12 +79,16 @@ export function useStepMetadata(
     app,
     selectedActionOrTrigger,
     caption,
+    defaultCaption,
     hasConnection,
     isCompleted,
     isIfThenStep,
     isTrigger,
     position: step?.position ?? 0,
-    stepName: step?.config?.stepName ?? selectedActionOrTrigger?.name ?? '',
+    stepName:
+      step?.config?.stepName && step?.config?.stepName !== ''
+        ? step.config.stepName
+        : defaultCaption ?? '',
     substeps,
   }
 }

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -85,10 +85,9 @@ export function useStepMetadata(
     isIfThenStep,
     isTrigger,
     position: step?.position ?? 0,
-    stepName:
-      step?.config?.stepName && step?.config?.stepName !== ''
-        ? step.config.stepName
-        : defaultCaption ?? '',
+    stepName: step?.config?.stepName
+      ? step.config.stepName
+      : defaultCaption ?? '',
     substeps,
   }
 }


### PR DESCRIPTION
## TL;DR
This PR allows users to reset a step name to its default by saving an empty step name.
**Note**: only allowed for steps

## Why make this change?
When users rename steps, they may lose track of the action being performed—especially in workflows involving multiple events (e.g., Tiles or M365 Excel).
Restoring the default step name when an empty name is saved helps maintain clarity and reduces confusion.

## How to test?
- [ ] Rename a step, clear the input, placeholder should be the default step name
- [ ] Rename a step, clear the input and save, step name should now show the default name

**Existing functionality**
- [ ] Rename a pipe, saving empty returns to the original pipe name
- [ ] Rename a tile, saving empty returns to the original tile name

## Screenshots

[Screen Recording 2025-05-14 at 11.47.26 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/58a49ba2-8606-4203-89a0-2fa662f48544.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/58a49ba2-8606-4203-89a0-2fa662f48544.mov)

