### PR TITLE
[SIDE-DRAWER-19] Backward compability of variable validation

### DIFF
--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -61,8 +61,14 @@ export default function FlowStep(
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
-  const { app, caption, isCompleted, isTrigger, selectedActionOrTrigger } =
-    useStepMetadata(allApps, step)
+  const {
+    app,
+    caption,
+    isCompleted,
+    isTrigger,
+    selectedActionOrTrigger,
+    substeps,
+  } = useStepMetadata(allApps, step)
 
   const {
     cancelRef,
@@ -81,8 +87,8 @@ export default function FlowStep(
       : !readOnly && props.isDeletable
 
   const { shouldTestStepAgain, isTestSuccessful } = useMemo(
-    () => validateStepParams(step, testExecutionSteps),
-    [step, testExecutionSteps],
+    () => validateStepParams(step, testExecutionSteps, substeps),
+    [step, substeps, testExecutionSteps],
   )
 
   const shouldHighlight = currentStepId === step.id

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -59,10 +59,8 @@ export default function FlowStepTestController(
   } = useContext(EditorContext)
   const formContext = useFormContext()
 
-  const { isIfThenStep, isTrigger, selectedActionOrTrigger } = useStepMetadata(
-    allApps,
-    step,
-  )
+  const { isIfThenStep, isTrigger, selectedActionOrTrigger, substeps } =
+    useStepMetadata(allApps, step)
   const {
     isTestSuccessful,
     lastErrorDetails,
@@ -94,8 +92,8 @@ export default function FlowStepTestController(
   })
 
   const { shouldTestStepAgain } = useMemo(() => {
-    return validateStepParams(step, testExecutionSteps)
-  }, [testExecutionSteps, step])
+    return validateStepParams(step, testExecutionSteps, substeps)
+  }, [testExecutionSteps, step, substeps])
 
   const shouldShowSaveButton =
     !isLastTestExecutionCurrent || (isTestSuccessful && isDirty)

--- a/packages/frontend/src/helpers/validateStepParams.ts
+++ b/packages/frontend/src/helpers/validateStepParams.ts
@@ -1,4 +1,4 @@
-import { IExecutionStep, IJSONObject, IStep } from '@plumber/types'
+import { IExecutionStep, IJSONObject, IStep, ISubstep } from '@plumber/types'
 
 import { GLOBAL_VARIABLE_REGEX } from '@/components/RichTextEditor/utils'
 
@@ -38,6 +38,7 @@ function hasMissingStepReference(obj: IJSONObject, stepMap: Set<string>) {
 export const validateStepParams = (
   step: IStep,
   testExecutionSteps: IExecutionStep[],
+  substeps: ISubstep[],
 ) => {
   const testResult = testExecutionSteps.find((ts) => ts.stepId === step.id)
   if (!testResult) {
@@ -46,8 +47,23 @@ export const validateStepParams = (
       isTestSuccessful: testResult,
     }
   }
+
+  /**
+   * FOR BACKWARD COMPATIBILITY
+   * old UI allowed users to change events without changing the app
+   * which resulted in additional parameters being stored in the step parameters.
+   * we need to filter out these additional parameters to avoid validation errors.
+   */
+  const stepArgs = substeps.find((s) => s.key === 'setUpAction')?.arguments
+  const stepParamKeys = stepArgs?.map((arg) => arg.key) || []
+  const filteredParams = Object.fromEntries(
+    Object.entries(step.parameters).filter(([key]) =>
+      stepParamKeys.includes(key),
+    ),
+  )
+
   const shouldTestStepAgain = hasMissingStepReference(
-    step.parameters,
+    filteredParams,
     new Set(testExecutionSteps.map((ts) => ts.stepId)),
   )
 


### PR DESCRIPTION
## TL;DR
This PR ensures backward compatibility in validating variables used in step parameters.

**Note to reviewer**: this backward compatibility is done purely on the frontend.

### Problem
In the previous UI, users could change the action type (e.g., from Find single row to Update single row) without deleting and recreating the step. As a result, parameters from the old action could remain stored alongside the new action’s parameters.

Some of these leftover parameters reference variables from deleted steps, leading to validation errors or unexpected behaviour.

### Solution
This update adds checks to gracefully handle outdated parameters referencing deleted variables, ensuring that legacy steps continue to function without breaking existing workflows.

## How to test?
If you do not have an old Pipe where you modified the event without deleting the Step, you will need to modify the DB.
### Set up
1. Create 4 steps: Step 1 and 2 can be anything, Step 3 and 4 should be the same app but different events
1. Use variable(s) from Step 1 in Step 3, and variable(s) from Step 2 in Step 4
1. In your DB, copy some parameter(s) from Step 4 to Step 3
1. Delete Step 2 and Step 4 in the UI
- [ ] Verify that there should not be the 'Update step with the latest data' message at Step 3
 