### PR TITLE
[SIDE-DRAWER-20] UI fixes - Part 4

### DIFF
--- a/packages/frontend/src/components/Editor/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/AddStepButton.tsx
@@ -38,7 +38,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
       flexDir="column"
       alignItems="center"
       alignSelf="stretch"
-      h={showEmptyAction ? undefined : 20}
+      h={showEmptyAction ? undefined : isHidden ? 12 : 20}
     >
       {isHidden || (isDisabled && !isLastStep) ? (
         !isLastStep && (

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -176,7 +176,7 @@ export default function EditorLayout() {
           py={2}
           px={8}
           borderBottom="1px solid"
-          borderColor="base.divider.subtle"
+          borderColor="base.divider.medium"
         >
           <Flex flex={1} alignItems="center">
             <Box

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -9,6 +9,8 @@ import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 
+import { editorRightDrawerStyles as styles } from './styles'
+
 interface StepHeaderProps {
   step: IStep
 }
@@ -67,14 +69,7 @@ export default function StepHeader(props: StepHeaderProps) {
   }
 
   return (
-    <Flex
-      alignItems="center"
-      justifyContent="space-between"
-      position="fixed"
-      w="full"
-      px="4"
-      height="2rem"
-    >
+    <Flex {...styles.stepHeader}>
       <Flex alignItems="center" maxW="100%">
         {position && <Text whiteSpace="pre-wrap">{position}.&nbsp;</Text>}
         <EditableInput

--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -8,6 +8,7 @@ import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import Step from './Step'
 import StepHeader from './StepHeader'
+import { editorRightDrawerStyles as styles } from './styles'
 
 interface EditorRightDrawerProps {
   flowStepGroupIconUrl?: string
@@ -32,15 +33,7 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
   return (
     <Flex flexDir="column" w="100%" py="4" overflowY="auto" h="100%">
       <StepHeader step={step} />
-      <Flex
-        height="calc(100% - 1.5rem)"
-        overflowY="auto"
-        overflowX="hidden"
-        position="relative"
-        px="4"
-        pt={hasConnection ? 0 : 4}
-        top="2.5rem"
-      >
+      <Flex {...styles.stepContentsWrapper} pt={hasConnection ? 0 : 4}>
         <Step step={step} isLastStep={index === steps.length - 1} />
       </Flex>
     </Flex>

--- a/packages/frontend/src/components/EditorRightDrawer/styles.ts
+++ b/packages/frontend/src/components/EditorRightDrawer/styles.ts
@@ -1,0 +1,20 @@
+import { FlexProps } from '@chakra-ui/react'
+
+export const editorRightDrawerStyles = {
+  stepHeader: {
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    position: 'fixed' as FlexProps['position'],
+    w: 'full',
+    px: '6',
+    height: '2rem',
+  },
+  stepContentsWrapper: {
+    height: 'calc(100% - 1.5rem)',
+    overflowY: 'auto' as FlexProps['overflowY'],
+    overflowX: 'hidden' as FlexProps['overflowX'],
+    position: 'relative' as FlexProps['position'],
+    px: '6',
+    top: '2.5rem',
+  },
+}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -24,7 +24,6 @@ export default function EmptyFlowStepHeader(
       borderRadius="lg"
       bg="white"
       p={4}
-      pl={8}
       h={isNested ? '48px' : '64px'}
       alignItems="center"
       gap={4}
@@ -38,7 +37,11 @@ export default function EmptyFlowStepHeader(
       }}
       w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)}
     >
-      <Icon as={isTrigger ? BiSolidBolt : BiPlus} boxSize={6} />
+      <Icon
+        as={isTrigger ? BiSolidBolt : BiPlus}
+        boxSize={6}
+        color="interaction.sub.default"
+      />
       <Text textStyle="subhead-1">
         {isTrigger ? 'Choose how you want your workflow to start' : 'Add step'}
       </Text>

--- a/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
@@ -1,54 +1,14 @@
 import { IApp } from '@plumber/types'
 
-import { useCallback, useState } from 'react'
-import { BiHelpCircle } from 'react-icons/bi'
-import {
-  Box,
-  Flex,
-  Icon,
-  Modal,
-  ModalContent,
-  ModalOverlay,
-  Text,
-  Tooltip,
-  useDisclosure,
-} from '@chakra-ui/react'
-
-import DemoVideoModalContent from '../../FlowRow/DemoVideoModalContent'
+import { Flex, Text } from '@chakra-ui/react'
 
 interface StepCaptionProps {
   app?: IApp
   caption: string
 }
 
-const LOCAL_STORAGE_DEMO_TOOLTIP_KEY = 'demo-tooltip-clicked'
-
 export default function StepCaptionAndDemo(props: StepCaptionProps) {
-  const { app, caption } = props
-  // check whether user has opened the demo tooltip previously
-  const [hasSeenDemo, setHasSeenDemo] = useState<boolean>(
-    localStorage.getItem(LOCAL_STORAGE_DEMO_TOOLTIP_KEY) === 'true',
-  )
-
-  // for loading demo modal
-  const {
-    isOpen: isModalOpen,
-    onOpen: onModalOpen,
-    onClose: onModalClose,
-  } = useDisclosure()
-  const hasDemoVideo =
-    !!app?.demoVideoDetails?.url && !!app?.demoVideoDetails?.title
-
-  const handleDemoClick = useCallback(
-    (event: React.MouseEvent<SVGElement>) => {
-      event.stopPropagation()
-      onModalOpen()
-      localStorage.setItem(LOCAL_STORAGE_DEMO_TOOLTIP_KEY, 'true')
-      setHasSeenDemo(true)
-    },
-    [onModalOpen],
-  )
-
+  const { caption } = props
   return (
     <>
       <Flex direction="column" align="start" maxW="80%" flexShrink={1}>
@@ -63,39 +23,94 @@ export default function StepCaptionAndDemo(props: StepCaptionProps) {
           >
             {caption}
           </Text>
-          {hasDemoVideo && (
-            <Tooltip
-              label="Learn how to set this up"
-              placement="top-start"
-              openDelay={300}
-              gutter={0}
-            >
-              <Box boxSize="18px">
-                <Icon
-                  as={BiHelpCircle}
-                  boxSize="inherit"
-                  sx={{
-                    borderRadius: '50%',
-                    animation: hasSeenDemo ? undefined : 'pulse 2s infinite',
-                  }}
-                  onClick={handleDemoClick}
-                />
-              </Box>
-            </Tooltip>
-          )}
         </Flex>
       </Flex>
-      {isModalOpen && hasDemoVideo && (
-        <Modal isCentered isOpen={true} onClose={onModalClose} size="5xl">
-          <ModalOverlay bg="base.canvas.overlay" />
-          <ModalContent p={4} borderRadius={8}>
-            <DemoVideoModalContent
-              src={app?.demoVideoDetails?.url}
-              title={app?.demoVideoDetails?.title}
-            />
-          </ModalContent>
-        </Modal>
-      )}
     </>
   )
 }
+
+// TODO (kevinkim-ogp): revert to below once arcade videos are ready
+
+// interface StepCaptionProps {
+//   app?: IApp
+//   caption: string
+// }
+
+// const LOCAL_STORAGE_DEMO_TOOLTIP_KEY = 'demo-tooltip-clicked'
+
+// export default function StepCaptionAndDemo(props: StepCaptionProps) {
+//   const { app, caption } = props
+//   // check whether user has opened the demo tooltip previously
+//   const [hasSeenDemo, setHasSeenDemo] = useState<boolean>(
+//     localStorage.getItem(LOCAL_STORAGE_DEMO_TOOLTIP_KEY) === 'true',
+//   )
+
+//   // for loading demo modal
+//   const {
+//     isOpen: isModalOpen,
+//     onOpen: onModalOpen,
+//     onClose: onModalClose,
+//   } = useDisclosure()
+//   const hasDemoVideo =
+//     !!app?.demoVideoDetails?.url && !!app?.demoVideoDetails?.title
+
+//   const handleDemoClick = useCallback(
+//     (event: React.MouseEvent<SVGElement>) => {
+//       event.stopPropagation()
+//       onModalOpen()
+//       localStorage.setItem(LOCAL_STORAGE_DEMO_TOOLTIP_KEY, 'true')
+//       setHasSeenDemo(true)
+//     },
+//     [onModalOpen],
+//   )
+
+//   return (
+//     <>
+//       <Flex direction="column" align="start" maxW="80%" flexShrink={1}>
+//         <Flex alignItems="center" gap={2} maxW="100%">
+//           <Text
+//             textStyle="subhead-1"
+//             color="base.content.default"
+//             whiteSpace="nowrap"
+//             overflow="hidden"
+//             textOverflow="ellipsis"
+//             maxW="100%"
+//           >
+//             {caption}
+//           </Text>
+//           {hasDemoVideo && (
+//             <Tooltip
+//               label="Learn how to set this up"
+//               placement="top-start"
+//               openDelay={300}
+//               gutter={0}
+//             >
+//               <Box boxSize="18px">
+//                 <Icon
+//                   as={BiHelpCircle}
+//                   boxSize="inherit"
+//                   sx={{
+//                     borderRadius: '50%',
+//                     animation: hasSeenDemo ? undefined : 'pulse 2s infinite',
+//                   }}
+//                   onClick={handleDemoClick}
+//                 />
+//               </Box>
+//             </Tooltip>
+//           )}
+//         </Flex>
+//       </Flex>
+//       {isModalOpen && hasDemoVideo && (
+//         <Modal isCentered isOpen={true} onClose={onModalClose} size="5xl">
+//           <ModalOverlay bg="base.canvas.overlay" />
+//           <ModalContent p={4} borderRadius={8}>
+//             <DemoVideoModalContent
+//               src={app?.demoVideoDetails?.url}
+//               title={app?.demoVideoDetails?.title}
+//             />
+//           </ModalContent>
+//         </Modal>
+//       )}
+//     </>
+//   )
+// }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/BackButton.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/BackButton.tsx
@@ -1,0 +1,24 @@
+import { BiChevronLeft } from 'react-icons/bi'
+import { Text } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+interface BackButtonProps {
+  onBack: () => void
+}
+
+export default function BackButton(props: BackButtonProps) {
+  const { onBack } = props
+
+  return (
+    <Button
+      variant="clear"
+      colorScheme="secondary"
+      size="xs"
+      onClick={onBack}
+      leftIcon={<BiChevronLeft size={20} />}
+      ml={-4}
+    >
+      <Text textStyle="subhead-1">Back</Text>
+    </Button>
+  )
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -2,7 +2,6 @@ import type { IField, IJSONObject } from '@plumber/types'
 
 import { useCallback, useContext, useEffect, useState } from 'react'
 import { FieldValues, SubmitHandler } from 'react-hook-form'
-import { BiChevronLeft } from 'react-icons/bi'
 import { Flex, ModalBody, ModalHeader, Text } from '@chakra-ui/react'
 import {
   Button,
@@ -18,6 +17,7 @@ import { getOpenerOrigin } from '@/helpers/window'
 
 import Form from '../../Form'
 import { infoboxMdComponents } from '../../MarkdownRenderer/CustomMarkdownComponents'
+import BackButton from '../BackButton'
 import { DEFAULT_ADD_CONNECTION_LABEL } from '../constants'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import { useConnectionVerification } from '../hooks/useConnectionRegistration'
@@ -169,16 +169,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
   return (
     <>
       <ModalHeader pt={0}>
-        <Button
-          variant="clear"
-          colorScheme="secondary"
-          size="xs"
-          onClick={onBack}
-          leftIcon={<BiChevronLeft />}
-          ml={-4}
-        >
-          Back
-        </Button>
+        <BackButton onBack={onBack} />
       </ModalHeader>
       <ConnectionHeader
         selectedApp={selectedApp}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -168,7 +168,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
 
   return (
     <>
-      <ModalHeader pt={0}>
+      <ModalHeader pt={0} mt={-4}>
         <BackButton onBack={onBack} />
       </ModalHeader>
       <ConnectionHeader

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -178,7 +178,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
           DEFAULT_ADD_CONNECTION_LABEL
         }
       />
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
 
       <ModalBody mt={2}>
         {auth?.connectionType !== 'user-added' ? (

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
@@ -1,10 +1,10 @@
 import { useContext } from 'react'
-import { BiChevronLeft } from 'react-icons/bi'
 import { Flex, ModalBody, ModalHeader } from '@chakra-ui/react'
-import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
+import { ModalCloseButton } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 
+import BackButton from '../BackButton'
 import { DEFAULT_CHOOSE_CONNECTION_LABEL } from '../constants'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import InvalidModalScreen from '../InvalidModalScreen'
@@ -70,18 +70,7 @@ export default function ChooseConnection(
     <>
       {/* Hide back button only if step has both the key and appKey */}
       <ModalHeader pt={0}>
-        {(!step?.key || !step?.appKey) && (
-          <Button
-            variant="clear"
-            colorScheme="secondary"
-            size="xs"
-            onClick={onBack}
-            leftIcon={<BiChevronLeft />}
-            ml={-4}
-          >
-            Back
-          </Button>
-        )}
+        {(!step?.key || !step?.appKey) && <BackButton onBack={onBack} />}
         <ConnectionHeader
           selectedApp={selectedApp}
           headerText={

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
@@ -69,7 +69,7 @@ export default function ChooseConnection(
   return (
     <>
       {/* Hide back button only if step has both the key and appKey */}
-      <ModalHeader pt={0}>
+      <ModalHeader pt={0} mt={-4}>
         {(!step?.key || !step?.appKey) && <BackButton onBack={onBack} />}
         <ConnectionHeader
           selectedApp={selectedApp}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnection.tsx
@@ -79,7 +79,7 @@ export default function ChooseConnection(
           }
         />
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
 
       <ModalBody>
         <Flex flexDir="column" alignItems="center" gap={6}>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
@@ -1,7 +1,7 @@
 import type { IApp } from '@plumber/types'
 
 import { useContext, useMemo } from 'react'
-import { BiChevronLeft, BiQuestionMark, BiRightArrowAlt } from 'react-icons/bi'
+import { BiQuestionMark, BiRightArrowAlt } from 'react-icons/bi'
 import {
   Flex,
   Icon,
@@ -15,6 +15,7 @@ import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
 import microsoftFolder from '@/assets/microsoft-folder.svg'
 import useAuthentication from '@/hooks/useAuthentication'
 
+import BackButton from '../BackButton'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import { useConnectionVerification } from '../hooks/useConnectionRegistration'
 
@@ -165,16 +166,7 @@ export default function ConfigureExcelConnection(
     <>
       <ModalHeader pt={0}>
         {!isConnectionValid && (!step?.key || !step?.appKey) && (
-          <Button
-            variant="clear"
-            colorScheme="secondary"
-            size="xs"
-            onClick={onBack}
-            leftIcon={<BiChevronLeft />}
-            ml={-4}
-          >
-            Back
-          </Button>
+          <BackButton onBack={onBack} />
         )}
         {isConnectionValid ? (
           <SuccessfulConnectionHeader iconUrl={selectedApp?.iconUrl ?? ''} />

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
@@ -180,7 +180,7 @@ export default function ConfigureExcelConnection(
           />
         )}
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
 
       <ModalBody>
         {isConnectionValid ? (

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection.tsx
@@ -164,7 +164,7 @@ export default function ConfigureExcelConnection(
 
   return (
     <>
-      <ModalHeader pt={0}>
+      <ModalHeader pt={0} mt={-4}>
         {!isConnectionValid && (!step?.key || !step?.appKey) && (
           <BackButton onBack={onBack} />
         )}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -218,7 +218,7 @@ export default function ChooseApp(props: ChooseAppProps) {
           )}
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
 
       {/* Returns first level modal view of apps: if an app only has one trigger or action,
        * it will be shown as a single item. Else, it will be shown as an expandable item

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -170,7 +170,12 @@ export default function ChooseApp(props: ChooseAppProps) {
   return (
     <>
       <ModalHeader pt={0}>
-        <Flex gap={2} flexDir="column" alignItems="flex-start">
+        <Flex
+          gap={2}
+          flexDir="column"
+          alignItems="flex-start"
+          w={isTrigger ? '90%' : '100%'}
+        >
           <Text textStyle="h3-semibold">
             {isTrigger
               ? 'Choose how you want your workflow to start'

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -1,13 +1,13 @@
 import { type IAction, IApp, ITrigger } from '@plumber/types'
 
 import { useCallback, useContext, useMemo } from 'react'
-import { BiChevronLeft } from 'react-icons/bi'
 import { Box, Flex, ModalBody, ModalHeader, Text } from '@chakra-ui/react'
-import { Button, ModalCloseButton } from '@opengovsg/design-system-react'
+import { ModalCloseButton } from '@opengovsg/design-system-react'
 
 import { getAppActionFlag, getAppTriggerFlag } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 
+import BackButton from '../BackButton'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import InvalidModalScreen from '../InvalidModalScreen'
 
@@ -66,16 +66,17 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
     <>
       <ModalHeader pt={0}>
         <Flex gap={2} flexDir="column" alignItems="flex-start">
-          <Button
+          {/* <Button
             variant="clear"
             colorScheme="secondary"
             size="xs"
             onClick={onBack}
-            leftIcon={<BiChevronLeft />}
+            leftIcon={<BiChevronLeft size={20} />}
             ml={-4}
           >
-            Back
-          </Button>
+            <Text textStyle="subhead-1">Back</Text>
+          </Button> */}
+          <BackButton onBack={onBack} />
           <Text textStyle="h3-semibold">{selectedApp.name}</Text>
           <Text textStyle="body-1">{selectedApp.description}</Text>
         </Flex>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -71,7 +71,7 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
           <Text textStyle="body-1">{selectedApp.description}</Text>
         </Flex>
       </ModalHeader>
-      <ModalCloseButton mt={2} size="xs" />
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
 
       {/* Returns second level modal view of triggers or actions: if an app has multiple
        * triggers or actions, it will be shown as a list of items */}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -64,7 +64,7 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
 
   return (
     <>
-      <ModalHeader pt={0}>
+      <ModalHeader pt={0} mt={-4}>
         <Flex gap={2} flexDir="column" alignItems="flex-start">
           <BackButton onBack={onBack} />
           <Text textStyle="h3-semibold">{selectedApp.name}</Text>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -66,16 +66,6 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
     <>
       <ModalHeader pt={0}>
         <Flex gap={2} flexDir="column" alignItems="flex-start">
-          {/* <Button
-            variant="clear"
-            colorScheme="secondary"
-            size="xs"
-            onClick={onBack}
-            leftIcon={<BiChevronLeft size={20} />}
-            ml={-4}
-          >
-            <Text textStyle="subhead-1">Back</Text>
-          </Button> */}
           <BackButton onBack={onBack} />
           <Text textStyle="h3-semibold">{selectedApp.name}</Text>
           <Text textStyle="body-1">{selectedApp.description}</Text>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -120,7 +120,9 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
           app.key === TOOLBOX_APP_KEY &&
           triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
         ) {
-          await initializeIfThen(step)
+          const ifThen = await initializeIfThen(step)
+          newStepId = ifThen.id
+          newStepIndex = ifThen.position - 1
         } else {
           const updatedStep = await onUpdateStep({
             ...step,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -100,7 +100,11 @@ export default function Branch(props: BranchProps) {
       >
         <Flex alignItems="center" borderRadius="inherit" w="full" h={8}>
           {/* Branch name */}
-          <Text textStyle="subhead-1" color="base.content.default">
+          <Text
+            textStyle="subhead-1"
+            color="base.content.default"
+            noOfLines={1}
+          >
             {branchSteps[0].parameters.branchName as string}
           </Text>
 

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -223,7 +223,7 @@ const Editor = ({
   return (
     <Popover
       autoFocus={false}
-      gutter={0}
+      gutter={2}
       matchWidth={isMulticol ? false : true}
       isLazy
       lazyBehavior="unmount"


### PR DESCRIPTION
## TL;DR
**UI improvements from bug bash and crits from other designers:**
* Border of top nav bar made a darker shade (`base.divider.subtle` to `base.divider.medium`)
* Right drawer left-right padding increased from 16px to 24px
* Back button text size increased to 16px and chevron increased to 20px
* Align the position of back button with the modal close button
* Align connection modal close button colorScheme with back button
* Demo video icon is hidden temporarily as arcade videos have not been made for the new ui
* Align variable popover with input box
* Adjust alignment and colour of add step header
* Reduce line height of step connector in published state (intent is to make it obvious that state is changing, and make it look like the add step button is being hidden)

**Fixes**
* Auto open to if-then step in new pipe

## What to test?
- [ ] Back button at Add step / add connection works as intended
  - [ ] Back button and modal close button are top-aligned
- [ ] Step headers open / close right drawer and unable to view demo videos
- [ ] Side drawer's left-right padding has increased to 24px
- [ ] Variable popover does not overlap with input box, appearance is similar to dropdown
- [ ] Connector line height changes on state change
  - [ ] Connector is still present after deleting all steps to show empty header 
- [ ] Create new pipe, immediately add if-then step, ensure that right drawer opens to first if-then branch condition

## Screenshots
**Back button and close button**

![Screenshot 2025-05-19 at 3.00.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/53e8ecf0-7ce5-4b7d-8fbe-1e7cec345804.png)


![Screenshot 2025-05-19 at 2.58.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/292e02ed-2ef7-44a3-94b5-bd9131ffdb74.png)

![Screenshot 2025-05-19 at 2.58.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/4873f337-459b-487a-8810-f26fc8818d31.png)

![Screenshot 2025-05-19 at 2.57.57 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/373faad8-7695-404b-9595-17299ea1cb37.png)

**No demo video**

![Screenshot 2025-05-15 at 11.30.43 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/cdffd6da-03f1-49d7-a41a-69a84fa2ff98.png)

**Right drawer left-right padding**

![Screenshot 2025-05-15 at 11.30.51 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/bc139c7b-ee76-4740-b4c5-15f69f4ca4cd.png)

**Variable popover alignment**

![Screenshot 2025-05-15 at 2.34.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/5558402c-7a71-4e06-8763-2a8c914e1ab2.png)

**Add step header**

![Screenshot 2025-05-19 at 3.33.29 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/1d1c5155-7f68-427e-8d4c-def0f8aceb4d.png)

![Screenshot 2025-05-19 at 3.33.40 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/0a373faa-bf63-4873-aea6-aa75e6fa16ed.png)

**Connector height**

[Screen Recording 2025-05-19 at 5.02.00 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/8b1b9b21-d195-489f-99a3-cc0cd910512b.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/8b1b9b21-d195-489f-99a3-cc0cd910512b.mov)

**Auto open to if-then branch**

[Screen Recording 2025-05-20 at 11.11.06 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/847fb2d0-d224-4956-a84f-f33bacae7d42.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/847fb2d0-d224-4956-a84f-f33bacae7d42.mov)

