### PR TITLE
fix: hide tooltip for empty tiles row id variable

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -171,7 +171,7 @@ describe('tiles create row action', () => {
     expect($.setActionItem).toBeCalledWith({
       raw: {
         rowsFound: 0,
-        rowId: '',
+        rowId: ' ',
         row: emptyRow,
       },
     })

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -198,7 +198,7 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
-          // NOTE: intentionally return whitespace so that a solid pull is shown
+          // NOTE: intentionally return whitespace so that a solid pill is shown
           rowId: ' ',
           row: emptyRow,
         } satisfies FindSingleRowOutput,

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -198,7 +198,8 @@ const action: IRawAction = {
       $.setActionItem({
         raw: {
           rowsFound: 0,
-          rowId: '',
+          // NOTE: intentionally return whitespace so that a solid pull is shown
+          rowId: ' ',
           row: emptyRow,
         } satisfies FindSingleRowOutput,
       })

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -12,16 +12,13 @@ export const VariableBadge = ({ node }: { node: Node }) => {
   const isTemplate = String(node.attrs.id).includes(
     PLACEHOLDER_TEMPLATE_STEP_ID,
   )
-  const isRowId =
-    String(node.attrs.id).split('.').pop() === 'rowId' &&
-    String(node.attrs.label) === 'Row ID'
 
   return (
     <NodeViewWrapper>
       {/* Only show tooltip if value is empty and not a template */}
       <TouchableTooltip
         label={
-          isEmpty && !isTemplate && !isRowId
+          isEmpty && !isTemplate
             ? 'This is a missing variable, check your previous steps and reselect a variable'
             : ''
         }

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -12,13 +12,16 @@ export const VariableBadge = ({ node }: { node: Node }) => {
   const isTemplate = String(node.attrs.id).includes(
     PLACEHOLDER_TEMPLATE_STEP_ID,
   )
+  const isRowId =
+    String(node.attrs.id).split('.').pop() === 'rowId' &&
+    String(node.attrs.label) === 'Row ID'
 
   return (
     <NodeViewWrapper>
       {/* Only show tooltip if value is empty and not a template */}
       <TouchableTooltip
         label={
-          isEmpty && !isTemplate
+          isEmpty && !isTemplate && !isRowId
             ? 'Data is missing for this variable, please test previous steps and reselect the variable'
             : ''
         }

--- a/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
+++ b/packages/frontend/src/components/RichTextEditor/VariableBadge.tsx
@@ -22,7 +22,7 @@ export const VariableBadge = ({ node }: { node: Node }) => {
       <TouchableTooltip
         label={
           isEmpty && !isTemplate && !isRowId
-            ? 'Data is missing for this variable, please test previous steps and reselect the variable'
+            ? 'This is a missing variable, check your previous steps and reselect a variable'
             : ''
         }
         aria-label="variable badge tooltip"


### PR DESCRIPTION
## Problem
Tooltip for empty Row ID is misleading as the intent of showing the empty Row ID is for users to still configure their update row step with the empty variable.

![image](https://github.com/user-attachments/assets/400adba9-83ef-43b4-b2da-2d6d0a01003e)


## Solution
Hide the tooltip specifically for empty Row ID variable:
* Checks both attribute id and label to ensure that it is a Tiles Row ID variable

<img width="862" alt="Screenshot 2025-05-15 at 3 54 25 PM" src="https://github.com/user-attachments/assets/e118ea59-bcc2-4661-93c3-30801f3a19fa" />
