### PR TITLE
[SIDE-DRAWER-21] Refine save and check step

### DIFF
--- a/packages/backend/src/apps/aisay/common/utils.ts
+++ b/packages/backend/src/apps/aisay/common/utils.ts
@@ -28,7 +28,7 @@ export const getValidationError = (
     fieldName === 'attachments' && stepErrorName.includes('not a S3 ID')
   const stepErrorSolution = isAttachmentNotStoredError
     ? 'This attachment was not stored in the last submission. Please make a new submission with attachments to successfully configure this pipe.'
-    : 'Click on set up action and reconfigure the invalid field.'
+    : 'Reconfigure the invalid field and try again.'
 
   return { stepErrorName, stepErrorSolution }
 }

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -159,7 +159,7 @@ const action: IRawAction = {
       if (err instanceof ZodError) {
         const firstError = fromZodError(err).details[0]
         throw new StepError(
-          `${firstError.message} under set up action`,
+          `${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
           $.step.position,
           $.app.name,

--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -52,7 +52,7 @@ const action: IRawAction = {
     if (isNaN(Number(delayForValue))) {
       throw new StepError(
         'Invalid delay for value entered',
-        'Click on set up action and check that the value is a valid number.',
+        'Check that the value is a valid number.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -47,7 +47,7 @@ const action: IRawAction = {
     if (isNaN(delayTimestamp)) {
       throw new StepError(
         'Invalid timestamp entered',
-        'Click on set up action and check that the date or time entered is of a valid format.',
+        'Check that the date or time entered is of a valid format.',
         $.step.position,
         $.app.name,
       )
@@ -56,7 +56,7 @@ const action: IRawAction = {
     if (delayTimestamp < DateTime.now().toMillis()) {
       throw new StepError(
         'Delay until timestamp entered is in the past',
-        'Click on set up action and check that the date and time entered is not in the past.',
+        'Check that the date and time entered is not in the past.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -147,7 +147,7 @@ const action: IRawAction = {
       if (error instanceof ZodError) {
         const firstError = fromZodError(error).details[0]
         throw new StepError(
-          `${firstError.message} under set up action`,
+          `${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
           $.step.position,
           $.app.name,
@@ -161,7 +161,7 @@ const action: IRawAction = {
             `Personalised field(s) not specified${
               missingFields.length === 0 ? '' : `: ${missingFields.join(', ')}`
             }`,
-            'Click on set up action and check that you have entered all the fields and values in the letter parameters.',
+            'Check that you have entered all the fields and values in the letter parameters.',
             $.step.position,
             $.app.name,
           )

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -61,7 +61,7 @@ const action: IRawAction = {
         fieldName === 'attachments' && stepErrorName.includes('not a S3 ID')
       const stepErrorSolution = isAttachmentNotStoredError
         ? 'This attachment was not stored in the last submission. Please make a new submission with attachments to successfully configure this pipe.'
-        : 'Click on set up action and reconfigure the invalid field.'
+        : 'Reconfigure the invalid field and try again.'
 
       throw new StepError(
         stepErrorName,

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -102,7 +102,7 @@ export function throwPostmanStepError({
     case 'INVALID-ATTACHMENT':
       throw new StepError(
         'Unsupported attachment file type',
-        'Click on set up action and check that the attachment type is supported by postman. Please check the supported types at [this link](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).',
+        'Check that the attachment type is supported by postman. Please check the supported types at [this link](https://guide.postman.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).',
         position,
         appName,
         error,
@@ -110,7 +110,7 @@ export function throwPostmanStepError({
     case 'ATTACHMENT-SIZE-EXCEEDED':
       throw new StepError(
         'Total attachment size exceeded',
-        'Click on set up action and check that the attachments do not exceed 10MB in total.',
+        'Check that the attachments do not exceed 10MB in total.',
         position,
         appName,
         error,

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -70,7 +70,7 @@ const action: IRawAction = {
     if (!messageText) {
       throw new StepError(
         'Empty message text',
-        'Click on set up action and check that the message text is not empty, especially if variables are used.',
+        'Check that the message text is not empty, especially if variables are used.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -79,7 +79,7 @@ export async function throwSendMessageError(
       } else if (errorString.includes('chat not found')) {
         throw new StepError(
           'Incorrect bot configuration',
-          'Click on set up action and check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.',
+          'Check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.',
           position,
           appName,
           err,
@@ -87,7 +87,7 @@ export async function throwSendMessageError(
       } else if (errorString.includes('message thread not found')) {
         throw new StepError(
           'Incorrect topic configuration',
-          'Click on set up action and check that a valid topic ID is used.',
+          'Check that a valid topic ID is used.',
           position,
           appName,
           err,

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -60,7 +60,7 @@ const action: IRawAction = {
     } catch (err) {
       throw new StepError(
         err.message,
-        'Click on set up action and check that the condition has been configured properly.',
+        'Check that the condition has been configured properly.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -19,7 +19,7 @@ const action: IRawAction = {
     } catch (err) {
       throw new StepError(
         err.message,
-        'Click on set up action and check that one of valid options in the condition dropdown is being selected.',
+        'Check that one of valid options in the condition dropdown is being selected.',
         $.step.position,
         $.app.name,
       )

--- a/packages/backend/src/errors/step.ts
+++ b/packages/backend/src/errors/step.ts
@@ -6,7 +6,7 @@ import HttpError from './http'
 // Some generic solutions for common errors
 //
 export enum GenericSolution {
-  ReconfigureInvalidField = 'Click on set up action and reconfigure the invalid field. Error could also result from the variables used in the field.',
+  ReconfigureInvalidField = 'Reconfigure the invalid field and try again. Error could also result from the variables used in the field.',
 }
 
 export default class StepError extends Error {

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -1,3 +1,4 @@
-export const EDITOR_MARGIN_TOP = '61px'
+export const EDITOR_MARGIN_TOP_NUM = 61
+export const EDITOR_MARGIN_TOP = `${EDITOR_MARGIN_TOP_NUM}px`
 export const EDITOR_MAX_HEIGHT = `calc(100vh - ${EDITOR_MARGIN_TOP})`
 export const EDITOR_RIGHT_DRAWER_WIDTH = '60%'

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -68,7 +68,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
             <Text>{getMockDataMessage(selectedActionOrTrigger)}</Text>
           </Infobox>
         )}
-        <VariablesList variables={variables} />
+        <VariablesList variables={variables} customStyles={{ py: 0, px: 2 }} />
       </Box>
     )
   }

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -6,6 +6,8 @@ import { Infobox } from '@opengovsg/design-system-react'
 import VariablesList from '@/components/VariablesList'
 import type { Variable } from '@/helpers/variables'
 
+import { getIfThenOutput } from './utils'
+
 function getNoOutputMessage(
   selectedActionOrTrigger: TestResultsProps['selectedActionOrTrigger'],
 ): string | null {
@@ -43,10 +45,18 @@ interface TestResultsProps {
   variables: Variable[] | null
   isMock?: boolean
   isOpen: boolean
+  isIfThenStep?: boolean
 }
 
 export default function TestResult(props: TestResultsProps): JSX.Element {
-  const { selectedActionOrTrigger, variables, isMock = false, isOpen } = props
+  const {
+    selectedActionOrTrigger,
+    variables,
+    isMock = false,
+    isOpen,
+    isIfThenStep,
+    step,
+  } = props
 
   const Content = () => {
     // No data only happens if user hasn't executed yet, or step returned null.
@@ -57,6 +67,16 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
             <Text fontWeight="600">{`We couldn't find any data from your last test`}</Text>
             <Text mt={0.5}>{getNoOutputMessage(selectedActionOrTrigger)}</Text>
           </Box>
+        </Infobox>
+      )
+    }
+
+    if (isIfThenStep) {
+      const isConditionMet = variables?.[0]?.value as boolean
+      const [variant, message] = getIfThenOutput(isConditionMet, step.id)
+      return (
+        <Infobox variant={variant} width="full">
+          <Box>{message}</Box>
         </Infobox>
       )
     }

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -128,7 +128,7 @@ export default function FlowStepTestController(
     return validateStepParams(step, testExecutionSteps, substeps)
   }, [testExecutionSteps, step, substeps])
 
-  const shouldAllowCheckStep = !(!isValid || readOnly || isSaving)
+  const shouldAllowCheckStep = isValid && !readOnly && !isSaving
   const shouldShowSaveButton =
     !isLastTestExecutionCurrent || (isTestSuccessful && isDirty)
   const shouldShowTestResults =

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -10,6 +10,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { validateStepParams } from '@/helpers/validateStepParams'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
+import { EDITOR_MARGIN_TOP_NUM } from '../Editor/constants'
 import ErrorResult from '../ErrorResult'
 import WebhookUrlInfo from '../WebhookUrlInfo'
 
@@ -68,6 +69,7 @@ export default function FlowStepTestController(
     testVariables,
   } = useTestDetails(step, currentTestExecutionStep)
   const containerRef = useRef<HTMLDivElement>(null)
+  const webhookUrlInfoRef = useRef<HTMLDivElement>(null)
   const [collapseDirection, setCollapseDirection] = useState<'up' | 'down'>(
     'down',
   )
@@ -111,15 +113,16 @@ export default function FlowStepTestController(
         return
       }
 
-      // Get the content height from the test variables
       const contentHeight = testVariables?.length
         ? testVariables.length * 40
         : 0
-      const minContentHeight = 108 // Minimum height to consider for content
+      const minContentHeight = 108
 
-      const spaceBelow = window.innerHeight - 61 - rect.bottom
-      const spaceAbove = rect.top + 61 + 32
+      const spaceBelow =
+        window.innerHeight - EDITOR_MARGIN_TOP_NUM - rect.bottom
+      const spaceAbove = rect.top + EDITOR_MARGIN_TOP_NUM + 32
 
+      // NOTE: all current triggers have a small number of fields
       if (isTrigger) {
         setCollapseDirection('down')
         return
@@ -127,11 +130,6 @@ export default function FlowStepTestController(
 
       if (contentHeight < minContentHeight) {
         setCollapseDirection('down')
-
-        if (spaceBelow < 0) {
-          setCollapseDirection('up')
-          return
-        }
         return
       }
 
@@ -177,119 +175,124 @@ export default function FlowStepTestController(
   )
 
   return (
-    <Stack {...flowStepTestControllerStyles.container} ref={containerRef}>
-      <VStack w="100%">
-        {isWebhookSubstep && (
-          <VStack w="100%">
-            <WebhookUrlInfo
-              webhookUrl={step.webhookUrl}
-              webhookTriggerInstructions={
-                (selectedActionOrTrigger as IBaseTrigger)
-                  .webhookTriggerInstructions || defaultTriggerInstructions
-              }
-              sx={{ mb: 2 }}
-            />
-          </VStack>
-        )}
-        {shouldShowTestResults ? (
-          <VStack w="100%">
-            <HStack w="100%">
-              <Infobox
-                {...flowStepTestControllerStyles.testedInfobox}
-                variant={infoBoxVariant}
-                borderBottomRadius={isTestResultOpen ? 0 : undefined}
-                icon={infoBoxVariant === 'unstyled' ? <></> : null}
-              >
-                <Flex
-                  justifyContent="space-between"
-                  alignItems="center"
-                  w="100%"
+    <>
+      {isWebhookSubstep && (
+        <VStack w="100%" ref={webhookUrlInfoRef}>
+          <WebhookUrlInfo
+            webhookUrl={step.webhookUrl}
+            webhookTriggerInstructions={
+              (selectedActionOrTrigger as IBaseTrigger)
+                .webhookTriggerInstructions || defaultTriggerInstructions
+            }
+            sx={{ mb: 2 }}
+          />
+        </VStack>
+      )}
+      <Stack {...flowStepTestControllerStyles.container} ref={containerRef}>
+        <VStack w="100%">
+          {shouldShowTestResults ? (
+            <VStack w="100%">
+              <HStack w="100%">
+                <Infobox
+                  {...flowStepTestControllerStyles.testedInfobox}
+                  variant={infoBoxVariant}
+                  borderBottomRadius={isTestResultOpen ? 0 : undefined}
+                  icon={infoBoxVariant === 'unstyled' ? <></> : null}
                 >
-                  {isIfThenStep ? (
-                    // NOTE: special handling for If-then
-                    // do not need button as there are no variables to display
-                    <Text>{infoBoxText}</Text>
-                  ) : (
-                    <Button
-                      variant="clear"
-                      colorScheme={
-                        infoBoxVariant === 'unstyled' ? 'black' : 'green'
-                      }
-                      size="sm"
-                      onClick={() =>
-                        isTestResultOpen
-                          ? onTestResultClose()
-                          : onTestResultOpen()
-                      }
-                      isDisabled={isTestExecuting}
-                    >
-                      <Text color="base.content.default">{infoBoxText}</Text>
-                      {!isTestExecuting && (
-                        <Box ml={2} color="base.content.default">
-                          {getChevronIcon()}
-                        </Box>
-                      )}
-                    </Button>
-                  )}
-                  {shouldShowSaveButton ? (
-                    <Flex gap={2}>
+                  <Flex
+                    justifyContent="space-between"
+                    alignItems="center"
+                    w="100%"
+                  >
+                    {isIfThenStep ? (
+                      // NOTE: special handling for If-then
+                      // do not need button as there are no variables to display
+                      <Text>{infoBoxText}</Text>
+                    ) : (
                       <Button
                         variant="clear"
+                        colorScheme={
+                          infoBoxVariant === 'unstyled' ? 'black' : 'green'
+                        }
                         size="sm"
-                        colorScheme="black"
-                        onClick={handleSave}
-                        isDisabled={!isLastTestExecutionCurrent && !isDirty}
+                        onClick={() =>
+                          isTestResultOpen
+                            ? onTestResultClose()
+                            : onTestResultOpen()
+                        }
+                        isDisabled={isTestExecuting}
                       >
-                        {!isLastTestExecutionCurrent && !isDirty
-                          ? 'Saved'
-                          : 'Save without checking'}
+                        <Text color="base.content.default">{infoBoxText}</Text>
+                        {!isTestExecuting && (
+                          <Box ml={2} color="base.content.default">
+                            {getChevronIcon()}
+                          </Box>
+                        )}
                       </Button>
-                      {CheckAgainButton}
-                    </Flex>
-                  ) : (
-                    CheckAgainButton
-                  )}
-                </Flex>
-              </Infobox>
-            </HStack>
-            <TestResult
-              step={step}
-              selectedActionOrTrigger={selectedActionOrTrigger}
-              variables={testVariables}
-              isMock={currentTestExecutionStep?.metadata?.isMock}
-              isOpen={isTestResultOpen}
-            />
-          </VStack>
-        ) : (
-          <VStack w="100%" gap={2}>
-            {lastErrorDetails && (
-              <Box w="100%">
-                <ErrorResult errorDetails={lastErrorDetails} isTestRun={true} />
-              </Box>
-            )}
-            <HStack w="100%" justifyContent="flex-end">
-              {!step.webhookUrl && (
-                <Button
-                  isDisabled={readOnly || isSaving || !isDirty}
-                  isLoading={isSaving}
-                  variant="clear"
-                  onClick={handleSave}
-                >
-                  {isDirty ? 'Save' : 'Saved'}
-                </Button>
+                    )}
+                    {shouldShowSaveButton ? (
+                      <Flex gap={2}>
+                        <Button
+                          variant="clear"
+                          size="sm"
+                          colorScheme="black"
+                          onClick={handleSave}
+                          isDisabled={!isLastTestExecutionCurrent && !isDirty}
+                        >
+                          {!isLastTestExecutionCurrent && !isDirty
+                            ? 'Saved'
+                            : 'Save without checking'}
+                        </Button>
+                        {CheckAgainButton}
+                      </Flex>
+                    ) : (
+                      CheckAgainButton
+                    )}
+                  </Flex>
+                </Infobox>
+              </HStack>
+              <TestResult
+                step={step}
+                selectedActionOrTrigger={selectedActionOrTrigger}
+                variables={testVariables}
+                isMock={currentTestExecutionStep?.metadata?.isMock}
+                isOpen={isTestResultOpen}
+              />
+            </VStack>
+          ) : (
+            <VStack w="100%" gap={2}>
+              {lastErrorDetails && (
+                <Box w="100%">
+                  <ErrorResult
+                    errorDetails={lastErrorDetails}
+                    isTestRun={true}
+                  />
+                </Box>
               )}
-              <Button
-                onClick={handleSaveAndTest}
-                data-test="flow-substep-continue-button"
-                isDisabled={!isValid || readOnly || isSaving}
-                isLoading={isTestExecuting}
-              >
-                Check step
-              </Button>
-            </HStack>
-          </VStack>
-        )}
-      </VStack>
-    </Stack>
+              <HStack w="100%" justifyContent="flex-end">
+                {!step.webhookUrl && (
+                  <Button
+                    isDisabled={readOnly || isSaving || !isDirty}
+                    isLoading={isSaving}
+                    variant="clear"
+                    onClick={handleSave}
+                  >
+                    {isDirty ? 'Save' : 'Saved'}
+                  </Button>
+                )}
+                <Button
+                  onClick={handleSaveAndTest}
+                  data-test="flow-substep-continue-button"
+                  isDisabled={!isValid || readOnly || isSaving}
+                  isLoading={isTestExecuting}
+                >
+                  Check step
+                </Button>
+              </HStack>
+            </VStack>
+          )}
+        </VStack>
+      </Stack>
+    </>
   )
 }

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -241,6 +241,8 @@ export default function FlowStepTestController(
                         colorScheme={
                           infoBoxVariant === 'unstyled' ? 'black' : 'green'
                         }
+                        px={2}
+                        ml={infoBoxVariant === 'unstyled' ? -1 : -0.5}
                         size="sm"
                         onClick={() =>
                           isTestResultOpen

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -3,7 +3,15 @@ import { IBaseTrigger, IStep, ITriggerInstructions } from '@plumber/types'
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { BiChevronDown, BiChevronUp } from 'react-icons/bi'
-import { Box, Flex, HStack, Stack, Text, VStack } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  HStack,
+  Stack,
+  Text,
+  Tooltip,
+  VStack,
+} from '@chakra-ui/react'
 import { Button, Infobox } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
@@ -35,6 +43,22 @@ interface FlowStepTestControllerProps {
   onTestResultOpen: () => void
   onTestResultClose: () => void
 }
+
+type CheckStepTooltipProps = {
+  isDisabled: boolean
+  children: React.ReactNode
+}
+
+const CheckStepTooltip = (props: CheckStepTooltipProps) => (
+  <Tooltip
+    label="Complete required fields to check step"
+    aria-label="check step tooltip"
+    isDisabled={props.isDisabled}
+    hasArrow
+  >
+    {props.children}
+  </Tooltip>
+)
 
 export default function FlowStepTestController(
   props: FlowStepTestControllerProps,
@@ -97,6 +121,7 @@ export default function FlowStepTestController(
     return validateStepParams(step, testExecutionSteps, substeps)
   }, [testExecutionSteps, step, substeps])
 
+  const shouldAllowCheckStep = !(!isValid || readOnly || isSaving)
   const shouldShowSaveButton =
     !isLastTestExecutionCurrent || (isTestSuccessful && isDirty)
   const shouldShowTestResults =
@@ -160,6 +185,7 @@ export default function FlowStepTestController(
 
   const CheckAgainButton = useMemo(
     () => (
+      <CheckStepTooltip isDisabled={!(!isValid || readOnly)}>
       <Button
         variant={infoBoxVariant === 'unstyled' ? undefined : 'clear'}
         onClick={handleSaveAndTest}
@@ -170,6 +196,7 @@ export default function FlowStepTestController(
       >
         Check step again
       </Button>
+      </CheckStepTooltip>
     ),
     [handleSaveAndTest, infoBoxVariant, isTestExecuting, isValid, readOnly],
   )
@@ -280,14 +307,16 @@ export default function FlowStepTestController(
                     {isDirty ? 'Save' : 'Saved'}
                   </Button>
                 )}
+                <CheckStepTooltip isDisabled={shouldAllowCheckStep}>
                 <Button
                   onClick={handleSaveAndTest}
                   data-test="flow-substep-continue-button"
-                  isDisabled={!isValid || readOnly || isSaving}
+                    isDisabled={!shouldAllowCheckStep}
                   isLoading={isTestExecuting}
                 >
                   Check step
                 </Button>
+                </CheckStepTooltip>
               </HStack>
             </VStack>
           )}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -248,7 +248,7 @@ export default function FlowStepTestController(
                     alignItems="center"
                     w="100%"
                   >
-                    {isIfThenStep ? (
+                    {isIfThenStep && isLastTestExecutionCurrent ? (
                       // NOTE: special handling for If-then
                       // do not need button as there are no variables to display
                       <Text>{infoBoxText}</Text>
@@ -303,6 +303,7 @@ export default function FlowStepTestController(
                 variables={testVariables}
                 isMock={currentTestExecutionStep?.metadata?.isMock}
                 isOpen={isTestResultOpen}
+                isIfThenStep={isIfThenStep}
               />
             </VStack>
           ) : (

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -47,24 +47,30 @@ interface FlowStepTestControllerProps {
 
 type CheckStepTooltipProps = {
   isDisabled: boolean
+  isReadOnly: boolean
   hasDeletedVars?: boolean
   children: React.ReactNode
 }
 
-const CheckStepTooltip = (props: CheckStepTooltipProps) => (
-  <Tooltip
-    label={
-      props.hasDeletedVars
-        ? 'Remove variables from deleted steps to check step'
-        : 'Complete required fields to check step'
-    }
-    aria-label="check step tooltip"
-    isDisabled={props.isDisabled}
-    hasArrow
-  >
-    {props.children}
-  </Tooltip>
-)
+const CheckStepTooltip = (props: CheckStepTooltipProps) => {
+  const { children, hasDeletedVars, isDisabled, isReadOnly } = props
+  return (
+    <Tooltip
+      label={
+        isReadOnly
+          ? 'Unpublish your pipe to check step'
+          : hasDeletedVars
+          ? 'Remove variables from deleted steps to check step'
+          : 'Complete required fields to check step'
+      }
+      aria-label="check step tooltip"
+      isDisabled={isDisabled}
+      hasArrow
+    >
+      {children}
+    </Tooltip>
+  )
+}
 
 export default function FlowStepTestController(
   props: FlowStepTestControllerProps,
@@ -194,7 +200,8 @@ export default function FlowStepTestController(
     () => (
       <CheckStepTooltip
         hasDeletedVars={hasDeletedVars}
-        isDisabled={!(!isValid || readOnly)}
+        isDisabled={isValid && !readOnly}
+        isReadOnly={readOnly}
       >
         <Button
           variant={infoBoxVariant === 'unstyled' ? undefined : 'clear'}
@@ -330,6 +337,7 @@ export default function FlowStepTestController(
                 <CheckStepTooltip
                   hasDeletedVars={hasDeletedVars}
                   isDisabled={shouldAllowCheckStep}
+                  isReadOnly={readOnly}
                 >
                   <Button
                     onClick={handleSaveAndTest}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -38,6 +38,7 @@ interface FlowStepTestControllerProps {
   isTestResultOpen: boolean
   isValid: boolean
   step: IStep
+  hasDeletedVars: boolean
   handleSave: () => void
   handleSaveAndTest: () => void
   onTestResultOpen: () => void
@@ -46,12 +47,17 @@ interface FlowStepTestControllerProps {
 
 type CheckStepTooltipProps = {
   isDisabled: boolean
+  hasDeletedVars?: boolean
   children: React.ReactNode
 }
 
 const CheckStepTooltip = (props: CheckStepTooltipProps) => (
   <Tooltip
-    label="Complete required fields to check step"
+    label={
+      props.hasDeletedVars
+        ? 'Remove variables from deleted steps to check step'
+        : 'Complete required fields to check step'
+    }
     aria-label="check step tooltip"
     isDisabled={props.isDisabled}
     hasArrow
@@ -69,6 +75,7 @@ export default function FlowStepTestController(
     isTestResultOpen,
     isValid,
     step,
+    hasDeletedVars,
     handleSave,
     handleSaveAndTest,
     onTestResultOpen,
@@ -185,7 +192,10 @@ export default function FlowStepTestController(
 
   const CheckAgainButton = useMemo(
     () => (
-      <CheckStepTooltip isDisabled={!(!isValid || readOnly)}>
+      <CheckStepTooltip
+        hasDeletedVars={hasDeletedVars}
+        isDisabled={!(!isValid || readOnly)}
+      >
         <Button
           variant={infoBoxVariant === 'unstyled' ? undefined : 'clear'}
           onClick={handleSaveAndTest}
@@ -198,7 +208,14 @@ export default function FlowStepTestController(
         </Button>
       </CheckStepTooltip>
     ),
-    [handleSaveAndTest, infoBoxVariant, isTestExecuting, isValid, readOnly],
+    [
+      handleSaveAndTest,
+      hasDeletedVars,
+      infoBoxVariant,
+      isTestExecuting,
+      isValid,
+      readOnly,
+    ],
   )
 
   return (
@@ -309,7 +326,10 @@ export default function FlowStepTestController(
                     {isDirty ? 'Save' : 'Saved'}
                   </Button>
                 )}
-                <CheckStepTooltip isDisabled={shouldAllowCheckStep}>
+                <CheckStepTooltip
+                  hasDeletedVars={hasDeletedVars}
+                  isDisabled={shouldAllowCheckStep}
+                >
                   <Button
                     onClick={handleSaveAndTest}
                     data-test="flow-substep-continue-button"

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -186,16 +186,16 @@ export default function FlowStepTestController(
   const CheckAgainButton = useMemo(
     () => (
       <CheckStepTooltip isDisabled={!(!isValid || readOnly)}>
-      <Button
-        variant={infoBoxVariant === 'unstyled' ? undefined : 'clear'}
-        onClick={handleSaveAndTest}
-        isLoading={isTestExecuting}
-        colorScheme={infoBoxVariant === 'unstyled' ? 'primary' : 'black'}
-        size="sm"
-        isDisabled={!isValid || readOnly}
-      >
-        Check step again
-      </Button>
+        <Button
+          variant={infoBoxVariant === 'unstyled' ? undefined : 'clear'}
+          onClick={handleSaveAndTest}
+          isLoading={isTestExecuting}
+          colorScheme={infoBoxVariant === 'unstyled' ? 'primary' : 'black'}
+          size="sm"
+          isDisabled={!isValid || readOnly}
+        >
+          Check step again
+        </Button>
       </CheckStepTooltip>
     ),
     [handleSaveAndTest, infoBoxVariant, isTestExecuting, isValid, readOnly],
@@ -308,14 +308,14 @@ export default function FlowStepTestController(
                   </Button>
                 )}
                 <CheckStepTooltip isDisabled={shouldAllowCheckStep}>
-                <Button
-                  onClick={handleSaveAndTest}
-                  data-test="flow-substep-continue-button"
+                  <Button
+                    onClick={handleSaveAndTest}
+                    data-test="flow-substep-continue-button"
                     isDisabled={!shouldAllowCheckStep}
-                  isLoading={isTestExecuting}
-                >
-                  Check step
-                </Button>
+                    isLoading={isTestExecuting}
+                  >
+                    Check step
+                  </Button>
                 </CheckStepTooltip>
               </HStack>
             </VStack>

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -151,26 +151,32 @@ export function getInfoBoxDetails({
     // Edge case for If-then
     if (isIfThenStep) {
       const isConditionMet = testVariables?.[0]?.value as boolean
-
-      if (isConditionMet) {
-        return [
-          'success',
-          <Text key={`${stepId}-if-then-success-text`}>
-            Based on your sample data, it meets the conditions that you have set
-            up and your pipe <Text as="b">would have</Text> continued.
-          </Text>,
-        ]
-      }
-      return [
-        'warning',
-        <Text key={`${stepId}-if-then-warning-text`}>
-          Based on your sample data, it does not meet the conditions you have
-          set up and your pipe <Text as="b">would not have</Text> continued.
-        </Text>,
-      ]
+      return getIfThenOutput(isConditionMet, stepId)
     }
     return ['success', 'Step was set up successfully!']
   }
 
   return ['error', 'Failed to set up step']
+}
+
+export function getIfThenOutput(
+  isConditionMet: boolean,
+  stepId: string,
+): [InfoboxProps['variant'], React.ReactNode] {
+  if (isConditionMet) {
+    return [
+      'success',
+      <Text key={`${stepId}-if-then-success-text`}>
+        Based on your sample data, it meets the conditions that you have set up
+        and your pipe <Text as="b">would have</Text> continued.
+      </Text>,
+    ]
+  }
+  return [
+    'warning',
+    <Text key={`${stepId}-if-then-warning-text`}>
+      Based on your sample data, it does not meet the conditions you have set up
+      and your pipe <Text as="b">would not have</Text> continued.
+    </Text>,
+  ]
 }

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -78,7 +78,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
 
   // NOTE: this is meant to avoid users losing progress
   // we validate the substeps so that the header reflects the correct status
-  const handleSave = useCallback(async () => {
+  const saveStep = useCallback(async () => {
     try {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
@@ -91,12 +91,6 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       if (!result) {
         throw new Error('Failed to save step')
       }
-      toast({
-        title: 'Step saved successfully!',
-        status: 'success',
-        duration: 5000,
-        isClosable: true,
-      })
     } catch (error) {
       toast({
         title: 'Error saving step',
@@ -113,13 +107,23 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     }
   }, [formContext, onUpdateStep, substep, toast])
 
+  const handleSave = useCallback(async () => {
+    await saveStep()
+    toast({
+      title: 'Step saved successfully!',
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+    })
+  }, [saveStep, toast])
+
   const handleSaveAndTest = useCallback(async () => {
-    await handleSave()
+    await saveStep()
     await executeTestStep()
     if (!isIfThenStep(step)) {
       onTestResultOpen()
     }
-  }, [handleSave, executeTestStep, onTestResultOpen, step])
+  }, [saveStep, executeTestStep, step, onTestResultOpen])
 
   return (
     <Box position="relative" display="flex" flexDirection="column">

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -91,6 +91,12 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       if (!result) {
         throw new Error('Failed to save step')
       }
+      toast({
+        title: 'Step saved successfully!',
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      })
     } catch (error) {
       toast({
         title: 'Error saving step',

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -12,7 +12,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { hasDirtyFields, validateSubstep } from '@/helpers/editor'
 import { isIfThenStep } from '@/helpers/toolbox'
-import { hasMissingStepReference } from '@/helpers/validateStepParams'
+import { validateStepParams } from '@/helpers/validateStepParams'
 
 type FlowSubstepProps = {
   hasConnection: boolean
@@ -77,9 +77,10 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     function validate(step: unknown) {
       const typedStep = step as IStep
       const validationResult = validateSubstep(substep, typedStep)
-      const hasMissingRef = hasMissingStepReference(
-        typedStep?.parameters,
-        new Set(testExecutionSteps.map((ts) => ts.stepId)),
+      const { shouldTestStepAgain: hasMissingRef } = validateStepParams(
+        typedStep,
+        testExecutionSteps,
+        [substep],
       )
       setIsValid(validationResult && !hasMissingRef)
       setHasDeletedVars(hasMissingRef)

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -12,6 +12,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { validateSubstep } from '@/helpers/editor'
 import { isIfThenStep } from '@/helpers/toolbox'
+import { hasMissingStepReference } from '@/helpers/validateStepParams'
 
 type FlowSubstepProps = {
   hasConnection: boolean
@@ -25,8 +26,13 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const { isTrigger, substep, step, selectedActionOrTrigger } = props
   const { flags } = useContext(LaunchDarklyContext)
   const formContext = useFormContext()
-  const { readOnly, executeTestStep, onUpdateStep, setShouldWarnOnLeave } =
-    useContext(EditorContext)
+  const {
+    readOnly,
+    executeTestStep,
+    onUpdateStep,
+    setShouldWarnOnLeave,
+    testExecutionSteps,
+  } = useContext(EditorContext)
   const {
     isOpen: isTestResultOpen,
     onOpen: onTestResultOpen,
@@ -39,6 +45,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const [isValid, setIsValid] = useState<boolean>(
     validateSubstep(substep, formContext.getValues() as IStep),
   )
+  const [hasDeletedVars, setHasDeletedVars] = useState(false)
 
   /*
    * NOTE: we use dirtyFields instead of isDirty because dirtyFields only tracks
@@ -68,13 +75,19 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
 
   useEffect(() => {
     function validate(step: unknown) {
-      const validationResult = validateSubstep(substep, step as IStep)
-      setIsValid(validationResult)
+      const typedStep = step as IStep
+      const validationResult = validateSubstep(substep, typedStep)
+      const hasMissingRef = hasMissingStepReference(
+        typedStep?.parameters,
+        new Set(testExecutionSteps.map((ts) => ts.stepId)),
+      )
+      setIsValid(validationResult && !hasMissingRef)
+      setHasDeletedVars(hasMissingRef)
     }
     const subscription = formContext.watch(validate)
 
     return () => subscription.unsubscribe()
-  }, [substep, formContext.watch, formContext])
+  }, [substep, formContext.watch, formContext, testExecutionSteps])
 
   // NOTE: this is meant to avoid users losing progress
   // we validate the substeps so that the header reflects the correct status
@@ -153,6 +166,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
         onTestResultOpen={onTestResultOpen}
         onTestResultClose={onTestResultClose}
         isValid={isValid}
+        hasDeletedVars={hasDeletedVars}
       />
     </Box>
   )

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -10,7 +10,7 @@ import InputCreator from '@/components/InputCreator'
 import { getInputFlag } from '@/config/flags'
 import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
-import { validateSubstep } from '@/helpers/editor'
+import { hasDirtyFields, validateSubstep } from '@/helpers/editor'
 import { isIfThenStep } from '@/helpers/toolbox'
 import { hasMissingStepReference } from '@/helpers/validateStepParams'
 
@@ -54,7 +54,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
    * — even if you change a field back to its original value.
    */
   const { dirtyFields } = formContext.formState
-  const isDirty = Object.keys(dirtyFields).length > 0
+  const isDirty = hasDirtyFields(dirtyFields)
   useEffect(() => {
     onTestResultClose()
     setShouldWarnOnLeave(isDirty)

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -126,7 +126,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     toast({
       title: 'Step saved successfully!',
       status: 'success',
-      duration: 5000,
+      duration: 2000,
       isClosable: true,
     })
   }, [saveStep, toast])

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -1,7 +1,13 @@
 import { TDataOutMetadatumType } from '@plumber/types'
 
 import { useMemo } from 'react'
-import { Box, Tag, Text, Tooltip } from '@chakra-ui/react'
+import {
+  Box,
+  type SystemStyleObject,
+  Tag,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react'
 
 import { type Variable } from '@/helpers/variables'
 import { POPOVER_MOTION_PROPS } from '@/theme/constants'
@@ -114,6 +120,7 @@ function VariableItem({
 interface VariablesListProps {
   variables: Variable[]
   onClick?: (variable: Variable) => void
+  customStyles?: SystemStyleObject
 }
 
 export default function VariablesList(props: VariablesListProps) {
@@ -129,6 +136,7 @@ export default function VariablesList(props: VariablesListProps) {
       maxH={64}
       overflowY="auto"
       p={onClick ? undefined : '1rem'}
+      sx={props.customStyles}
     >
       {variables.map((variable, index) => (
         <VariableItem

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -146,3 +146,20 @@ export function getToolboxIcon(key?: string | null) {
     ] ?? BiQuestionMark
   )
 }
+
+// NOTE: check if any fields are dirty recursively
+// there may be arrays added for multirow inputs that have been deleted
+// and still reside as empty objects in dirtyFields
+export const hasDirtyFields = (fields: Record<string, any>): boolean => {
+  return Object.entries(fields).some(([_, value]) => {
+    // If value is true, the field is dirty
+    if (value === true) {
+      return true
+    }
+    // If value is an object (including arrays), recurse
+    if (value && typeof value === 'object') {
+      return hasDirtyFields(value)
+    }
+    return false
+  })
+}

--- a/packages/frontend/src/helpers/validateStepParams.ts
+++ b/packages/frontend/src/helpers/validateStepParams.ts
@@ -2,7 +2,10 @@ import { IExecutionStep, IJSONObject, IStep, ISubstep } from '@plumber/types'
 
 import { GLOBAL_VARIABLE_REGEX } from '@/components/RichTextEditor/utils'
 
-function hasMissingStepReference(obj: IJSONObject, stepMap: Set<string>) {
+export function hasMissingStepReference(
+  obj: IJSONObject,
+  stepMap: Set<string>,
+) {
   const missing = new Set()
 
   function traverse(value: any) {

--- a/packages/frontend/src/helpers/validateStepParams.ts
+++ b/packages/frontend/src/helpers/validateStepParams.ts
@@ -4,7 +4,7 @@ import { GLOBAL_VARIABLE_REGEX } from '@/components/RichTextEditor/utils'
 
 export function hasMissingStepReference(
   obj: IJSONObject,
-  stepMap: Set<string>,
+  stepIdSet: Set<string>,
 ) {
   const missing = new Set()
 
@@ -20,7 +20,7 @@ export function hasMissingStepReference(
       while ((match = regex.exec(value)) !== null) {
         try {
           const stepId = match[1].split('.')[1]
-          if (!stepMap.has(stepId)) {
+          if (!stepIdSet.has(stepId)) {
             missing.add(stepId)
           }
         } catch (error) {


### PR DESCRIPTION
## TL;DR
This PR focuses on improvements to the save and check step portion of the editor.

**UI changes**
* Add tooltip to the disabled 'Check step' button: `Complete required fields to check step`
* Show success toast when step is saved
* Reposition webhook URL info above the test result and check step buttons to align with other steps
* Removed 'Click on set up action' in error text (no longer relevant as there are no more accordions)
* Adjust padding of infobox icons and collapse buttons
* Adjust padding of test step variables to 24px to align with the side drawer
* Disable the 'Check step' button when there are variables from deleted steps

**Bug fixes**
* Fix bug in MultiRow inputs where dirtyFields are detected wrongly (e.g., adding a new row and deleting a row is detected as dirty but there is no actual change in the fields)
* Fix bug where 'Check step' is not enabled even after deleted step references have been removed from the inputs (was checking additional fields that were present in parameters but not frontend due to old Set up event behaviour)

## How to test?
- [ ] Create a step, hover over the 'Check step' button and verify that tooltip appears
- [ ] Complete and test a step, remove value from a required field, hover over 'Check step again' and verify that tooltip appears
- [ ] Edit a step and save, verify that 'Step saved successfully' toast appears
- [ ] Edit a step and check step, verify that test was executed and no toast appears
- [ ] Create a webhook trigger, verify that the webhook url info appears above the border and the check step result
- [ ] Force a step error, verify that error message no longer has 'set up action' in the message
- [ ] Create a step with variables from previous step, delete the previous step, verify that check step button is disabled and only enabled when variable (from deleted step) is removed
- [ ] Create a step that has multirow inputs and set it up successfully
  - [ ] Add a new row but do not check step, observe that test step changes to previous result 
    - [ ] if-then should show the infobox on whether the step would continue or not)
  - [ ] Delete the row, observe that the test result changes back to 'Step was set up successfully' or the If-then message depending on your step

- [ ] Check step should be enabled after deleted variable is removed (even if there are old variables still present in the DB)
    * If you do not have an old Pipe where you modified the event without deleting the Step, you will need to modify the DB.
    * Set up
      * Create 4 steps: Step 1 and 2 can be anything, Step 3 and 4 should be the same app but different events
      * Use variable(s) from Step 1 in Step 3, and variable(s) from Step 2 in Step 4
      * In your DB, copy some parameter(s) from Step 4 to Step 3
      * Delete Step 2 and Step 4 in the UI
      *  Verify that there should not be the 'Update step with the latest data' message at Step 3

## Screenshots
**Disabled check step with tooltip**
![Screenshot 2025-05-15 at 9.54.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/e85bee7b-483b-4c3a-9adb-e73e7114ea2e.png)
![Screenshot 2025-05-15 at 9.48.53 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/11772a27-c6a7-4b93-84d1-294d0286f6ce.png)



**Webhook info**

![Screenshot 2025-05-15 at 9.49.58 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/c4871335-13d0-4311-9888-5e0ea75328c4.png)

**Saved toast**

![Screenshot 2025-05-15 at 9.50.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/d9078379-92c3-42bd-b32c-8ace01c6d276.png)

**Step error**

![Screenshot 2025-05-15 at 9.50.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/736952dd-30ed-4247-9082-8438789c8d23.png)

**Variable from deleted step**

[Screen Recording 2025-05-19 at 11.11.34 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/3dd9c52c-8f43-4d70-95da-157b801ebede.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/3dd9c52c-8f43-4d70-95da-157b801ebede.mov)

**Multirow test result**

[Screen Recording 2025-05-20 at 10.17.10 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/eafe9a91-f6af-4f00-bf0a-38ca63e99e48.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/eafe9a91-f6af-4f00-bf0a-38ca63e99e48.mov)

[Screen Recording 2025-05-20 at 10.17.36 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/37bdcc0a-3be6-4816-9d99-14b928e7602c.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/37bdcc0a-3be6-4816-9d99-14b928e7602c.mov)

**Enable check step when deleted variables are removed**

[Screen Recording 2025-05-20 at 2.26.00 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/20030b76-6e40-4744-b03f-6ba5b43493ec.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/20030b76-6e40-4744-b03f-6ba5b43493ec.mov)

