### PR TITLE
[SIDE-DRAWER-22] Improve builder guidance

### DIFF
--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -5,6 +5,8 @@ import { Flex, Icon, Text } from '@chakra-ui/react'
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
 
+import { pulsingBoxStyles } from './styles'
+
 interface EmptyFlowStepHeaderProps {
   isTrigger: boolean
   onModalOpen: () => void
@@ -15,7 +17,7 @@ export default function EmptyFlowStepHeader(
   props: EmptyFlowStepHeaderProps,
 ): JSX.Element {
   const { isTrigger, onModalOpen, isNested } = props
-  const { isDrawerOpen, isMobile } = useContext(EditorContext)
+  const { isDrawerOpen, isMobile, isNewPipe } = useContext(EditorContext)
 
   return (
     <Flex
@@ -36,6 +38,7 @@ export default function EmptyFlowStepHeader(
         bg: 'interaction.muted.neutral.active',
       }}
       w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)}
+      sx={isNewPipe && isTrigger ? pulsingBoxStyles : {}}
     >
       <Icon
         as={isTrigger ? BiSolidBolt : BiPlus}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -17,7 +17,7 @@ export default function EmptyFlowStepHeader(
   props: EmptyFlowStepHeaderProps,
 ): JSX.Element {
   const { isTrigger, onModalOpen, isNested } = props
-  const { isDrawerOpen, isMobile, isNewPipe } = useContext(EditorContext)
+  const { isDrawerOpen, isMobile, isEmptyPipe } = useContext(EditorContext)
 
   return (
     <Flex
@@ -38,7 +38,7 @@ export default function EmptyFlowStepHeader(
         bg: 'interaction.muted.neutral.active',
       }}
       w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)}
-      sx={isNewPipe && isTrigger ? pulsingBoxStyles : {}}
+      sx={isEmptyPipe && isTrigger ? pulsingBoxStyles : {}}
     >
       <Icon
         as={isTrigger ? BiSolidBolt : BiPlus}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/styles.ts
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/styles.ts
@@ -1,0 +1,16 @@
+export const pulsingBoxStyles = {
+  animation: 'pulse 2s infinite',
+  '@keyframes pulse': {
+    '0%': {
+      boxShadow: '#f9dde9 0px 0px 0px 0px',
+      transform: 'scale(1)',
+    },
+    '70%': {
+      boxShadow: '#f9dde9 0px 0px 0px 3px',
+      transform: 'scale(1.02)',
+    },
+    '100%': {
+      transform: 'scale(1)',
+    },
+  },
+}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -92,7 +92,6 @@ export default function Branch(props: BranchProps) {
         borderWidth="1px"
         border="none"
         p={0}
-        bg="white"
         overflow="hidden"
         w={isDrawerOpen ? (isMobile ? '0px' : '100%') : '100%'}
         mb={2}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -32,10 +32,8 @@ export const ifThenStyles = {
 export const branchStyles = {
   container: {
     alignItems: 'center',
-    bg: 'white',
-    borderColor: 'base.divider.medium',
+    bg: '#f8f9f9',
     borderRadius: 'lg',
-    borderWidth: '1px',
     direction: 'column' as FlexProps['direction'],
     overflow: 'hidden',
     px: 4,

--- a/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
+++ b/packages/frontend/src/components/RichTextEditor/Suggestions.tsx
@@ -23,7 +23,7 @@ function Suggestions(props: SuggestionsProps) {
   if (isEmpty) {
     return (
       <Text p={4} opacity={0.5} textStyle="body-1" color="base.content.medium">
-        No variables available
+        No variables available - complete earlier steps to use them here
       </Text>
     )
   }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -47,7 +47,7 @@ interface IEditorContextValue {
   currentTestExecutionStep: IExecutionStep | null
   isDrawerOpen: boolean
   isMobile: boolean
-  isNewPipe: boolean
+  isEmptyPipe: boolean
   isTestExecuting: boolean
   shouldWarnOnLeave: boolean
   stepsWithVars: StepWithVariables[]
@@ -79,7 +79,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   currentTestExecutionStep: null,
   isDrawerOpen: false,
   isMobile: false,
-  isNewPipe: false,
+  isEmptyPipe: false,
   isTestExecuting: false,
   shouldWarnOnLeave: false,
   stepsWithVars: [],
@@ -170,9 +170,8 @@ export const EditorProvider = ({
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
 
   const steps = flow?.steps ?? []
-  const isNewPipe =
-    steps.length === 2 &&
-    steps.every((s) => s.key === null && s.appKey === null)
+  const isEmptyPipe =
+    steps.length <= 2 && steps.every((s) => s.key === null && s.appKey === null)
 
   const hasIfThen = flow?.steps.some(
     (step: IStep) => step.key === TOOLBOX_ACTIONS.IfThen,
@@ -388,7 +387,7 @@ export const EditorProvider = ({
         hasIfThen,
         isDrawerOpen,
         isMobile,
-        isNewPipe,
+        isEmptyPipe,
         flow,
         flowId,
         currentTestExecutionStep,

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -47,6 +47,7 @@ interface IEditorContextValue {
   currentTestExecutionStep: IExecutionStep | null
   isDrawerOpen: boolean
   isMobile: boolean
+  isNewPipe: boolean
   isTestExecuting: boolean
   shouldWarnOnLeave: boolean
   stepsWithVars: StepWithVariables[]
@@ -78,6 +79,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   currentTestExecutionStep: null,
   isDrawerOpen: false,
   isMobile: false,
+  isNewPipe: false,
   isTestExecuting: false,
   shouldWarnOnLeave: false,
   stepsWithVars: [],
@@ -166,6 +168,12 @@ export const EditorProvider = ({
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
+
+  const steps = flow?.steps ?? []
+  const isNewPipe =
+    steps.length === 2 &&
+    steps.every((s) => s.key === null && s.appKey === null)
+
   const hasIfThen = flow?.steps.some(
     (step: IStep) => step.key === TOOLBOX_ACTIONS.IfThen,
   )
@@ -380,6 +388,7 @@ export const EditorProvider = ({
         hasIfThen,
         isDrawerOpen,
         isMobile,
+        isNewPipe,
         flow,
         flowId,
         currentTestExecutionStep,


### PR DESCRIPTION
## TL;DR
This PR focuses on improvements to guide users to set up their pipes.

## What changed?
* Trigger step pulses for new pipes (and pipes without any trigger or action) to prompt users to click and add a trigger
* Improved messaging when there are no variables in the variable dropdown
* Adjusted background of If-then branches to make them more "group-like"

## How to test?
- [ ] Create a new Pipe, observe that trigger step pulses
  - [ ] Pulsing disappears once a trigger or an action is set up
- [ ] Empty suggestions dropdown message is changed
- [ ] If-then branches are grouped with the new background colour and does not have a border

## Screenshots
**Trigger step pulsing**

[Screen Recording 2025-05-18 at 11.48.09 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/95763ad7-f04b-4445-a3b5-b4c128b91643.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/95763ad7-f04b-4445-a3b5-b4c128b91643.mov)

**No variables**

![Screenshot 2025-05-18 at 11.49.18 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/2958c4a3-f54c-4f94-801a-6280e938a06d.png)

**If-then branch grouping**

![Screenshot 2025-05-18 at 11.49.57 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/212c9532-3067-402d-a42f-d2fd1324a660.png)

