### PR TITLE
[SIDE-DRAWER-25]: Fix PaySG schema

### DIFF
--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
@@ -83,16 +83,18 @@ export const requestSchema = z.object({
     .max(500, { message: 'Description cannot be more than 500 characters' })
     .transform((value) => value || undefined)
     .optional(),
-  responses: z.array(
-    z.object({
-      question: z
-        .string({ invalid_type_error: 'Empty question' })
-        .trim()
-        .min(1, { message: 'Empty question' }),
-      answer: z
-        .string({ invalid_type_error: 'Empty answer' })
-        .trim()
-        .min(1, { message: 'Empty answer' }),
-    }),
-  ),
+  responses: z
+    .array(
+      z.object({
+        question: z
+          .string({ invalid_type_error: 'Empty question' })
+          .trim()
+          .min(1, { message: 'Empty question' }),
+        answer: z
+          .string({ invalid_type_error: 'Empty answer' })
+          .trim()
+          .min(1, { message: 'Empty answer' }),
+      }),
+    )
+    .default([]),
 })


### PR DESCRIPTION
## TL;DR
Made the `responses` field optional in the payment form submission schema by adding a default empty array.

## How to test?
- [ ] Payment form for subscription
  1. Create a payment form submission without including the 'Additional responses'
  2. Verify that the submission is accepted and processed correctly
  3. Check that the `responses` field is set to an empty array in the stored submission
- [ ] Payment form for one-time payment
  1. Create a payment form submission without including the 'Additional responses'
  2. Verify that the submission is accepted and processed correctly
  3. Check that the `responses` field is set to an empty array in the stored submission


## Screenshots

[Screen Recording 2025-05-20 at 8.58.03 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/8eebb861-a018-4d3a-bc4e-f849da6df99b.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/8eebb861-a018-4d3a-bc4e-f849da6df99b.mov)

![Screenshot 2025-05-20 at 8.58.29 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/f531939e-f17b-4983-a23f-ccf56abd2f56.png)

