### PR TITLE
[SIDE-DRAWER-26]: Disable vertical scroll for multirow-multicol RTE

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -71,7 +71,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 3, minWidth: 0 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
@@ -71,7 +71,7 @@ export const fields: TransformSpec['fields'] = [
         type: 'string' as const,
         required: true,
         variables: true,
-        customStyle: { flex: 4 },
+        customStyle: { flex: 4, minWidth: 0, maxWidth: '44%' },
       },
       {
         placeholder: 'Unit of time to add or subtract',

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -103,7 +103,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -124,7 +124,7 @@ const action: IRawAction = {
           required: true,
           variables: true,
           placeholder: 'Value',
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -74,7 +74,7 @@ const action: IRawAction = {
           required: true,
           variables: true,
           placeholder: 'Value to write',
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
@@ -74,7 +74,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
         {
           label: 'Value',
@@ -82,7 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -112,7 +112,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
         {
           placeholder: 'Answer',
@@ -120,7 +120,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -84,7 +84,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
         {
           placeholder: 'Answer',
@@ -92,7 +92,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 1 },
+          customStyle: { flex: 1, minWidth: 0, maxWidth: '50%' },
         },
       ],
     },

--- a/packages/backend/src/apps/paysg/actions/create-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/index.ts
@@ -90,7 +90,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 2 },
+          customStyle: { flex: 2, minWidth: 0, maxWidth: '40%' },
         },
         {
           placeholder: 'Value',
@@ -98,7 +98,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -82,7 +82,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 5 },
+          customStyle: { flex: 5, minWidth: 0, maxWidth: '62.5%' },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -118,7 +118,7 @@ const action: IRawAction = {
             op: 'equals',
             fieldValue: TableRowFilterOperator.IsEmpty,
           },
-          customStyle: { flex: 2 },
+          customStyle: { flex: 2, minWidth: 0, maxWidth: '50%' },
         },
       ],
     },

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -110,7 +110,7 @@ const action: IRawAction = {
           type: 'string' as const,
           required: false,
           variables: true,
-          customStyle: { flex: 3, minWidth: 0 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '50%' },
         },
       ],
     },

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -18,7 +18,7 @@ export default function getConditionArgs({
       type: 'string' as const,
       required: true,
       variables: true,
-      customStyle: { flex: 3 },
+      customStyle: { flex: 3, minWidth: 0, maxWidth: '30%' },
     },
     {
       [labelPropName]: 'Is or is not',
@@ -88,7 +88,7 @@ export default function getConditionArgs({
         op: 'equals',
         fieldValue: 'empty',
       },
-      customStyle: { flex: 3 },
+      customStyle: { flex: 3, minWidth: 0, maxWidth: '30%' },
     },
   ]
 }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -34,7 +34,7 @@ export default function MultiCol(props: MultiColProps) {
         return (
           <div
             key={`${name}.${subF.key}`}
-            style={isMobile ? { flex: 1 } : subF.customStyle}
+            style={isMobile ? { flex: 1, width: '100%' } : subF.customStyle}
           >
             <InputCreator
               schema={subF}

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -284,3 +284,31 @@
     }
   }
 }
+
+.single-line-editor {
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  // NOTE: below is to make sure the scrollbar adopts the editor's border radius
+  border-radius: inherit;
+  mask-image: linear-gradient(to right, black 100%, black 100%);
+  -webkit-mask-image: linear-gradient(to right, black 100%, black 100%);
+
+  // NOTE: forcefully hide the scrollbar so that it does not
+  // cause misalignment with the height of the multirow
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .editor__content {
+    min-width: min-content;
+  }
+
+  .ProseMirror {
+    width: 100%;
+    white-space: nowrap;
+  }
+}

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -197,6 +197,14 @@ const Editor = ({
       transformPastedHTML: (html) => {
         return substituteOldTemplates(html, varInfo)
       },
+      handleKeyDown: (view, event) => {
+        // Prevent new lines in single line mode
+        if (isSingleLine && event.key === 'Enter') {
+          event.preventDefault()
+          return true
+        }
+        return false
+      },
     },
   })
   useEffect(() => {

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -252,8 +252,10 @@ const Editor = ({
         onBlur={(e) => {
           // Focus might shift to menu bar or other children, where we do _not_
           // want to close our popper.
+          const editorContainer =
+            e.currentTarget.closest('.single-line-editor') || e.currentTarget
           if (
-            e.currentTarget.contains(e.relatedTarget) ||
+            editorContainer.contains(e.relatedTarget) ||
             e.relatedTarget?.closest('.chakra-popover__content')
           ) {
             return

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -255,7 +255,7 @@ const Editor = ({
         }}
       >
         <PopoverTrigger>
-          <Box>
+          <Box className={isMulticol ? 'single-line-editor' : undefined}>
             {isRich && <MenuBar editor={editor} variableMap={varInfo} />}
             <EditorContent className="editor__content" editor={editor} />
             <Portal>

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -218,7 +218,9 @@ const Editor = ({
       editor?.commands.focus()
 
       if (isMulticol && editor) {
-        singleLineEditorScroll(editor)
+        requestAnimationFrame(() => {
+          singleLineEditorScroll(editor)
+        })
       }
     },
     [editor, isMulticol],

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -197,14 +197,6 @@ const Editor = ({
       transformPastedHTML: (html) => {
         return substituteOldTemplates(html, varInfo)
       },
-      handleKeyDown: (view, event) => {
-        // Prevent new lines in single line mode
-        if (isSingleLine && event.key === 'Enter') {
-          event.preventDefault()
-          return true
-        }
-        return false
-      },
     },
   })
   useEffect(() => {

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -46,6 +46,7 @@ import {
   checkAutoFocus,
   genVariableInfoMap,
   getPopoverPlacement,
+  singleLineEditorScroll,
   substituteOldTemplates,
 } from './utils'
 
@@ -215,8 +216,12 @@ const Editor = ({
         },
       })
       editor?.commands.focus()
+
+      if (isMulticol && editor) {
+        singleLineEditorScroll(editor)
+      }
     },
-    [editor],
+    [editor, isMulticol],
   )
 
   const {

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -1,7 +1,12 @@
 import { FieldValues, UseFormGetValues } from 'react-hook-form'
 import { PlacementWithLogical } from '@chakra-ui/react'
 import { Editor } from '@tiptap/react'
-import { HTMLElement, Node, parse, TextNode } from 'node-html-parser'
+import {
+  HTMLElement as NodeHTMLElement,
+  Node,
+  parse,
+  TextNode,
+} from 'node-html-parser'
 
 import type { StepWithVariables } from '@/helpers/variables'
 
@@ -59,12 +64,12 @@ export function genVariableInfoMap(
 function constructVariableSpanElement(
   varInfo: VariableInfoMap,
   id: string,
-): HTMLElement {
+): NodeHTMLElement {
   const idComponents = id.split('.')
   const varInfoForNode = varInfo.get(`{{${id}}}`)
   const value = varInfoForNode?.testRunValue || ''
   const label = varInfoForNode?.label || idComponents[idComponents.length - 1]
-  const span = new HTMLElement('span', {})
+  const span = new NodeHTMLElement('span', {})
   span.setAttribute('data-type', 'variable')
   span.setAttribute('data-id', id)
   span.setAttribute('data-label', label)
@@ -93,9 +98,9 @@ function substituteTemplateStringWithSpan(
 }
 
 function recursiveSubstitute(
-  el: HTMLElement,
+  el: NodeHTMLElement,
   varInfo: VariableInfoMap,
-): HTMLElement {
+): NodeHTMLElement {
   const dataIdAttr = el.getAttribute('data-id')
   const dataTypeAttr = el.getAttribute('data-type')
   if (dataTypeAttr === 'variable' && dataIdAttr != null) {
@@ -105,7 +110,7 @@ function recursiveSubstitute(
   }
   const newChildNodes: Node[] = []
   el.childNodes.forEach((n) => {
-    if (n instanceof HTMLElement) {
+    if (n instanceof NodeHTMLElement) {
       newChildNodes.push(recursiveSubstitute(n, varInfo))
     } else if (n instanceof TextNode) {
       // We cannot use n.textContent here because it will unescape all HTML tags
@@ -139,7 +144,7 @@ export function getPopoverPlacement(
     return 'bottom-start'
   }
 
-  const editorElement = editor?.view.dom as globalThis.HTMLElement
+  const editorElement = editor?.view.dom as HTMLElement
   if (!editorElement) {
     return 'bottom-start'
   }
@@ -162,4 +167,87 @@ export const checkAutoFocus = (
   const rowData = getValues(fieldParentPath)
   const isNewRow = rowData?.isNew
   return { shouldAutoFocus: isNewRow && autoFocusProp, isNewRow, rowData }
+}
+
+// Add scrolling behavior for single-line mode
+export const singleLineEditorScroll = (editor: Editor) => {
+  if (!editor) {
+    return
+  }
+
+  setTimeout(() => {
+    const singleLineEditor = editor.view.dom.closest(
+      '.single-line-editor',
+    ) as HTMLElement
+    if (singleLineEditor) {
+      // Get the current cursor position
+      const pos = editor.state.selection.$head.pos
+      let targetVariable = findClosestVariableNode(
+        editor,
+        pos,
+        singleLineEditor,
+      )
+
+      // If we still haven't found it, fall back to the last variable
+      if (!targetVariable) {
+        const variables = Array.from(
+          singleLineEditor.getElementsByClassName('node-variable'),
+        ) as HTMLElement[]
+        if (variables.length > 0) {
+          targetVariable = variables[variables.length - 1]
+        }
+      }
+
+      // Scroll to the target variable if found
+      if (targetVariable) {
+        scrollVariableIntoView(targetVariable, singleLineEditor)
+      }
+    }
+  }, 10)
+}
+
+export function findClosestVariableNode(
+  editor: any,
+  pos: number,
+  container: HTMLElement,
+): HTMLElement | null {
+  for (let offset = -1; offset <= 1; offset++) {
+    const checkPos = Math.max(0, pos + offset)
+    const domInfo = editor.view.domAtPos(checkPos)
+    const node = domInfo.node as HTMLElement
+
+    if (node.classList?.contains('node-variable')) {
+      return node
+    }
+
+    const prevSibling = node.previousElementSibling as HTMLElement
+    if (prevSibling?.classList?.contains('node-variable')) {
+      return prevSibling
+    }
+
+    const nextSibling = node.nextElementSibling as HTMLElement
+    if (nextSibling?.classList?.contains('node-variable')) {
+      return nextSibling
+    }
+  }
+
+  // Fallback: last variable in the container
+  const variables = container.getElementsByClassName('node-variable')
+  return variables.length > 0
+    ? (variables[variables.length - 1] as HTMLElement)
+    : null
+}
+
+export function scrollVariableIntoView(
+  target: HTMLElement,
+  container: HTMLElement,
+) {
+  const targetDiv = target
+  const containerWidth = container.clientWidth
+  const scrollLeft =
+    targetDiv.offsetLeft - containerWidth + targetDiv.offsetWidth + 20
+  container.scrollTo({
+    left: Math.max(0, scrollLeft),
+    behavior: 'smooth',
+  })
 }

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -175,35 +175,29 @@ export const singleLineEditorScroll = (editor: Editor) => {
     return
   }
 
-  setTimeout(() => {
-    const singleLineEditor = editor.view.dom.closest(
-      '.single-line-editor',
-    ) as HTMLElement
-    if (singleLineEditor) {
-      // Get the current cursor position
-      const pos = editor.state.selection.$head.pos
-      let targetVariable = findClosestVariableNode(
-        editor,
-        pos,
-        singleLineEditor,
-      )
+  const singleLineEditor = editor.view.dom.closest(
+    '.single-line-editor',
+  ) as HTMLElement
+  if (singleLineEditor) {
+    // Get the current cursor position
+    const pos = editor.state.selection.$head.pos
+    let targetVariable = findClosestVariableNode(editor, pos, singleLineEditor)
 
-      // If we still haven't found it, fall back to the last variable
-      if (!targetVariable) {
-        const variables = Array.from(
-          singleLineEditor.getElementsByClassName('node-variable'),
-        ) as HTMLElement[]
-        if (variables.length > 0) {
-          targetVariable = variables[variables.length - 1]
-        }
-      }
-
-      // Scroll to the target variable if found
-      if (targetVariable) {
-        scrollVariableIntoView(targetVariable, singleLineEditor)
+    // If we still haven't found it, fall back to the last variable
+    if (!targetVariable) {
+      const variables = Array.from(
+        singleLineEditor.getElementsByClassName('node-variable'),
+      ) as HTMLElement[]
+      if (variables.length > 0) {
+        targetVariable = variables[variables.length - 1]
       }
     }
-  }, 10)
+
+    // Scroll to the target variable if found
+    if (targetVariable) {
+      scrollVariableIntoView(targetVariable, singleLineEditor)
+    }
+  }
 }
 
 export function findClosestVariableNode(


### PR DESCRIPTION
## TL;DR
This PR adds an option for a single-line RTE for the MultiRow-MultiCol input fields.
Previous implementation causes variables/text to overflow along the y-axis, making it difficult to edit the inputs.

## How to test?
- [ ] Add multiple variables or text that will overflow the input, verify that it overflows along the x-axis and you can scroll horizontally in the input
  - [ ] Verify that there is no vertical or horizontal scrollbar shown
  - [ ] Verify that input sizes for different input lengths remain the same


- [ ] Existing non-single line RTE fields behave as intended
  - [ ] Text overflows along the y-axis and the rte editor grows downwards

## Where was this changed?
All multirow-multicol field types:
* Custom API
* Formatter: add / subtract datetime
* LetterSG
* M365-Excel: Create table row, update table row, write cell values
* PaySG: Create payment, create payment form for one-time payment, create payment form for subscription
* Tiles: create row, find single row, update row
* If-then

## Screenshots
**If-then condition**

[Screen Recording 2025-05-21 at 12.01.13 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/46c38d2f-6c7b-4f42-9c4d-23a99b4f2254.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/46c38d2f-6c7b-4f42-9c4d-23a99b4f2254.mov)

**Custom api**

[Screen Recording 2025-05-21 at 12.02.02 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/3bbcae23-1d24-46df-a8cb-4254b62f2e03.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/3bbcae23-1d24-46df-a8cb-4254b62f2e03.mov)

