### PR TITLE
[TILES-V2-10]: add load testing scripts for tiles database

### DIFF
--- a/tools/load-tests/.env-example
+++ b/tools/load-tests/.env-example
@@ -1,0 +1,1 @@
+POSTGRES_TILES_URL=postgres://postgres:postgres@localhost:5432/tiles

--- a/tools/load-tests/README.md
+++ b/tools/load-tests/README.md
@@ -6,6 +6,23 @@
 then
 `k6 run formsg.js`
 
+### Build k6 with extensions
+Since we are using k6 plugins, we need to use xk6 to build k6 with extensions.
+
+We are using the following extensions:
+- postgres
+- dotenv
+- dashboard
+
+```
+docker run --rm -it -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
+  grafana/xk6 build \
+  --with github.com/grafana/xk6-sql@latest \
+  --with github.com/grafana/xk6-sql-driver-postgres@latest \
+  --with github.com/grafana/xk6-dashboard@latest\
+  --with github.com/szkiba/xk6-dotenv@latest
+```
+
 ### To run with dashboard
 
 `./k6 run --out dashboard=open webhook.js`

--- a/tools/load-tests/package-lock.json
+++ b/tools/load-tests/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@types/k6": "^0.43.2"
+        "@types/k6": "^1.0.2"
       }
     },
     "node_modules/@types/k6": {
-      "version": "0.43.2",
-      "resolved": "https://registry.npmjs.org/@types/k6/-/k6-0.43.2.tgz",
-      "integrity": "sha512-DD24gUZ5Y+tEZZrNt0wW9xZO3U81mWPQWBkcwms+V37GVUeJQpONriKceq5jgcyoORy9Ra6gjXB3wMhMllB+dw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/k6/-/k6-1.0.2.tgz",
+      "integrity": "sha512-bpja1c7OXIJk06aPGN+Aw5f3QhP0PjvgX2Fwfa3rJUaUI+O1ZE3491g9hMjhH21ZlTaAhz7h6veyxaz/RqPUTg==",
       "dev": true
     }
   }

--- a/tools/load-tests/package.json
+++ b/tools/load-tests/package.json
@@ -6,6 +6,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@types/k6": "^0.43.2"
+    "@types/k6": "^1.0.2"
   }
 }

--- a/tools/load-tests/tiles/bulk_read.js
+++ b/tools/load-tests/tiles/bulk_read.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      duration: '5m',
+
+      rate: 100,
+
+      // It should start `rate` iterations per second
+      timeUnit: '10s',
+
+      // It should preallocate 2 VUs before starting the test
+      preAllocatedVUs: 100,
+
+      // It is allowed to spin up to 50 maximum VUs to sustain the defined
+      // constant arrival rate.
+    },
+  },
+}
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const i = Math.floor(Math.random() * 30)
+  db.exec(`
+    SELECT * FROM "public"."load_test_table_${
+      exec.vu.idInInstance
+    }" ORDER BY "rowId" LIMIT 10000 OFFSET ${i * 10000};
+  `)
+  console.log(
+    `read ${i * 10000} rows in load_test_table_${exec.vu.idInInstance}`,
+  )
+
+  db.close()
+}

--- a/tools/load-tests/tiles/bulk_write.js
+++ b/tools/load-tests/tiles/bulk_write.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-undef */
+import { check } from 'k6'
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      duration: '5m',
+
+      rate: 50,
+
+      // It should start `rate` iterations per second
+      timeUnit: '1s',
+
+      // It should preallocate 2 VUs before starting the test
+      preAllocatedVUs: 100,
+
+      // It is allowed to spin up to 50 maximum VUs to sustain the defined
+      // constant arrival rate.
+      maxVUs: 100,
+    },
+  },
+}
+
+const generatedRows = Array.from({ length: 1000 }, (_, i) => {
+  return Array.from({ length: 10 }, (_, j) => {
+    return `'row${i}-col${j}'`
+  }).join(',')
+})
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const result = db.exec(`
+    INSERT INTO "public"."load_test_table_${
+      exec.vu.idInInstance
+    }" ("rowId", "column0", "column1", "column2", "column3", "column4", "column5", "column6", "column7", "column8", "column9") VALUES ${generatedRows
+    .map((row) => `('${crypto.randomUUID()}', ${row})`)
+    .join(',\n')};
+  `)
+  // const result = db.exec(`
+  //   SELECT 1 FROM "public"."load_test_table_${exec.vu.idInInstance}";
+  // `)
+  check(result, 'is added', (r) => r.rowsAffected() === 1000)
+  console.log(
+    `added ${result.rowsAffected()} rows in load_test_table_${
+      exec.vu.idInInstance
+    }`,
+  )
+  db.close()
+}

--- a/tools/load-tests/tiles/read_action.js
+++ b/tools/load-tests/tiles/read_action.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-undef */
+import { check } from 'k6'
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      duration: '10m',
+
+      rate: 20,
+
+      // It should start `rate` iterations per second
+      timeUnit: '1s',
+
+      // It should preallocate 2 VUs before starting the test
+      preAllocatedVUs: 100,
+
+      // It is allowed to spin up to 50 maximum VUs to sustain the defined
+      // constant arrival rate.
+      maxVUs: 100,
+    },
+  },
+}
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+
+  const result = db.exec(`
+    SELECT * FROM "public"."load_test_table_1" WHERE "column1" = 'row${Math.floor(
+      Math.random() * 1000,
+    )}-col1';;
+  `)
+  // const result = db.exec(`
+  //   SELECT 1 FROM "public"."load_test_table_${exec.vu.idInInstance}";
+  // `)
+  check(result, 'is added', (r) => r.rowsAffected() === 1)
+  console.log(
+    `selected ${result.rowsAffected()} row from load_test_table_${
+      exec.vu.idInInstance
+    }`,
+  )
+  db.close()
+}

--- a/tools/load-tests/tiles/seed_table.js
+++ b/tools/load-tests/tiles/seed_table.js
@@ -1,0 +1,27 @@
+/* eslint-disable no-undef */
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  iterations: 1000,
+  vus: 1,
+}
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const tableId = exec.vu.iterationInInstance
+
+  db.exec(`
+      CREATE TABLE IF NOT EXISTS "public"."load_test_table_${tableId}" (
+      "rowId" varchar(255) NOT NULL,
+      "createdAt" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updatedAt" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      ${Array.from({ length: 10 }, (_, i) => `"column${i}" text`).join(',\n')},
+      PRIMARY KEY ("rowId")
+  );
+    `)
+  console.log(`table created: load_test_table_${tableId}`)
+  db.close()
+}

--- a/tools/load-tests/tiles/test.js
+++ b/tools/load-tests/tiles/test.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-undef */
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  iterations: 1,
+  vus: 1,
+}
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const result = db.exec(`SELECT 1 as connection_test`)
+  console.log(result.rowsAffected())
+  db.close()
+}

--- a/tools/load-tests/tiles/update_action.js
+++ b/tools/load-tests/tiles/update_action.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-undef */
+import { check } from 'k6'
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      duration: '10m',
+
+      rate: 50,
+
+      // It should start `rate` iterations per second
+      timeUnit: '1s',
+
+      // It should preallocate 2 VUs before starting the test
+      preAllocatedVUs: 100,
+
+      // It is allowed to spin up to 50 maximum VUs to sustain the defined
+      // constant arrival rate.
+      maxVUs: 100,
+    },
+  },
+}
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const result = db.exec(`
+    UPDATE "public"."load_test_table_${exec.vu.idInInstance}" SET "column2" = 'updated' WHERE "rowId" = 'to update';
+  `)
+
+  check(result, 'is added', (r) => r.rowsAffected() === 1)
+  console.log(
+    `added ${result.rowsAffected()} rows in load_test_table_${
+      exec.vu.idInInstance
+    }`,
+  )
+  db.close()
+}

--- a/tools/load-tests/tiles/write_action.js
+++ b/tools/load-tests/tiles/write_action.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-undef */
+import { check } from 'k6'
+import exec from 'k6/execution'
+import sql from 'k6/x/sql'
+import driver from 'k6/x/sql/driver/postgres'
+
+// Test configuration
+export const options = {
+  discardResponseBodies: true,
+  scenarios: {
+    contacts: {
+      executor: 'constant-arrival-rate',
+
+      duration: '10m',
+
+      rate: 50,
+
+      // It should start `rate` iterations per second
+      timeUnit: '1s',
+
+      // It should preallocate 2 VUs before starting the test
+      preAllocatedVUs: 100,
+
+      // It is allowed to spin up to 50 maximum VUs to sustain the defined
+      // constant arrival rate.
+      maxVUs: 100,
+    },
+  },
+}
+
+const generatedRows = Array.from({ length: 1 }, (_, i) => {
+  return Array.from({ length: 10 }, (_, j) => {
+    return `'row${i}-col${j}'`
+  }).join(',')
+})
+
+export default function () {
+  const db = sql.open(driver, __ENV.POSTGRES_TILES_URL)
+  const result = db.exec(`
+    INSERT INTO "public"."load_test_table_${
+      exec.vu.idInInstance
+    }" ("rowId", "column0", "column1", "column2", "column3", "column4", "column5", "column6", "column7", "column8", "column9") VALUES ${generatedRows
+    .map((row) => `('${crypto.randomUUID()}', ${row})`)
+    .join(',\n')};
+  `)
+  // const result = db.exec(`
+  //   SELECT 1 FROM "public"."load_test_table_${exec.vu.idInInstance}";
+  // `)
+  check(result, 'is added', (r) => r.rowsAffected() === 1)
+  console.log(
+    `added ${result.rowsAffected()} rows in load_test_table_${
+      exec.vu.idInInstance
+    }`,
+  )
+  db.close()
+}


### PR DESCRIPTION
### TL;DR

Added load testing scripts for Postgres database operations with k6 extensions.

### What changed?

- Added a `.env-example` file with Postgres connection string
- Updated the README with instructions for building k6 with extensions (postgres, dotenv, dashboard)
- Updated the k6 binary to support these extensions
- Added several new load testing scripts for Postgres operations:
  - `seed_table.js` - Creates test tables
  - `bulk_write.js` - Tests bulk insert operations
  - `bulk_read.js` - Tests bulk read operations
  - `read_action.js` - Tests single read operations
  - `write_action.js` - Tests single write operations
  - `update_action.js` - Tests update operations
  - `test.js` - Simple connection test

### How to test?

1. Copy `.env-example` to `.env` and update with your Postgres connection details
2. Build k6 with extensions using the Docker command in the README:
   ```
   docker run --rm -it -e GOOS=darwin -u "$(id -u):$(id -g)" -v "${PWD}:/xk6" \
     grafana/xk6 build \
     --with github.com/grafana/xk6-sql@latest \
     --with github.com/grafana/xk6-sql-driver-postgres@latest \
     --with github.com/grafana/xk6-dashboard@latest\
     --with github.com/szkiba/xk6-dotenv@latest
   ```
3. Run the test scripts, for example:
   ```
   ./k6 run tiles/test.js --out dashboard
   ```
