### PR TITLE
[SIDE-DRAWER-30]: update for e2e test

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -31,7 +31,14 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
   }
 
   return (
-    <Flex flexDir="column" w="100%" py="4" overflowY="auto" h="100%">
+    <Flex
+      data-test="editor-right-drawer"
+      flexDir="column"
+      w="100%"
+      py="4"
+      overflowY="auto"
+      h="100%"
+    >
       <StepHeader step={step} />
       <Flex {...styles.stepContentsWrapper} pt={hasConnection ? 0 : 4}>
         <Step step={step} isLastStep={index === steps.length - 1} />

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -21,6 +21,7 @@ export default function EmptyFlowStepHeader(
 
   return (
     <Flex
+      data-test="flow-step"
       borderWidth="1px"
       borderColor="base.divider.medium"
       borderRadius="lg"

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -210,6 +210,7 @@ export default function FlowStep(
             </Box>
           )}
           <Flex
+            data-test="flow-step"
             {...flowStepStyles.container}
             borderTopWidth={hasInfoBox ? 0 : '1px'}
             borderColor={


### PR DESCRIPTION
## TL;DR
Update frontend for e2e tests:
* add back `data-test="flow-step"` which was mistakenly deleted during revamp
* added `data-test="editor-right-drawer"` for the new side drawer