### PR TITLE
chore: add additional logging for worker status

### DIFF
--- a/packages/backend/src/config/redis.ts
+++ b/packages/backend/src/config/redis.ts
@@ -1,5 +1,7 @@
 import ioRedis from 'ioredis'
 
+import logger from '@/helpers/logger'
+
 import appConfig from './app'
 
 // Maximum of 16; be careful when adding!
@@ -13,6 +15,7 @@ export const REDIS_DB_INDEX = {
 
 function reconnectOnError(err: Error) {
   const targetError = 'READONLY'
+  logger.error('Redis connection error', err)
   if (err.message.includes(targetError)) {
     // Only reconnect when the error contains "READONLY"
     // during node failover, this is thrown: 149: -READONLY You can't write against a read only replica.

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -67,6 +67,14 @@ worker.on('failed', (job, err) => {
   )
 })
 
+worker.on('ready', () => {
+  logger.info('Flow worker is ready!')
+})
+
+worker.on('closed', () => {
+  logger.info('Flow worker is closed!')
+})
+
 worker.on('error', (err) => {
   if (!err) {
     logger.error('Worker undefined error')

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -278,6 +278,14 @@ export function makeActionWorker(
     }
   })
 
+  worker.on('ready', () => {
+    logger.info(`[${queueName}] Worker is ready!`)
+  })
+
+  worker.on('closed', () => {
+    logger.info(`[${queueName}] Worker is closed!`)
+  })
+
   worker.on('error', (err) => {
     if (!err) {
       logger.error(`[${queueName}] Worker had undefined error`)

--- a/packages/backend/src/workers/trigger.ts
+++ b/packages/backend/src/workers/trigger.ts
@@ -66,6 +66,14 @@ worker.on('failed', (job, err) => {
   )
 })
 
+worker.on('ready', () => {
+  logger.info('Trigger worker is ready!')
+})
+
+worker.on('closed', () => {
+  logger.info('Trigger worker is closed!')
+})
+
 worker.on('error', (err) => {
   if (!err) {
     logger.error('Worker undefined error')


### PR DESCRIPTION
## Changes

Adding additional logging for redis connection error and worker status for `closed` and `ready`.

For debugging `failed to refresh slots cache` error.