### PR TITLE
PLU-487 [FIND-MULTIPLE-ROWS-4]: Get Tiles column values dynamically

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-multiple-row.itest.ts
@@ -172,61 +172,48 @@ describe('findMultipleRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500,
-        rows: expect.objectContaining({
-          rowData: expect.any(Array),
+        data: expect.objectContaining({
+          rows: expect.arrayContaining([
+            expect.objectContaining({
+              data: expect.any(Object),
+              rowId: expect.any(String),
+            }),
+          ]),
           columns: expect.arrayContaining([
             expect.objectContaining({
               id: dummyColumnIds[0],
               name: 'Test Column 0',
+              value: `data.rows.*.data.${dummyColumnIds[0]}`,
             }),
             expect.objectContaining({
               id: dummyColumnIds[1],
               name: 'Test Column 1',
+              value: `data.rows.*.data.${dummyColumnIds[1]}`,
             }),
             expect.objectContaining({
               id: dummyColumnIds[2],
               name: 'Test Column 2',
+              value: `data.rows.*.data.${dummyColumnIds[2]}`,
             }),
             expect.objectContaining({
               id: dummyColumnIds[3],
               name: 'Test Column 3',
+              value: `data.rows.*.data.${dummyColumnIds[3]}`,
             }),
             expect.objectContaining({
               id: dummyColumnIds[4],
               name: 'Test Column 4',
+              value: `data.rows.*.data.${dummyColumnIds[4]}`,
             }),
           ]),
         }),
-        columns: expect.arrayContaining([
-          expect.objectContaining({
-            id: dummyColumnIds[1],
-            name: 'Test Column 1',
-            value: expect.any(String),
-          }),
-          expect.objectContaining({
-            id: dummyColumnIds[2],
-            name: 'Test Column 2',
-            value: expect.any(String),
-          }),
-          expect.objectContaining({
-            id: dummyColumnIds[3],
-            name: 'Test Column 3',
-            value: expect.any(String),
-          }),
-          expect.objectContaining({
-            id: dummyColumnIds[4],
-            name: 'Test Column 4',
-            value: expect.any(String),
-          }),
-        ]),
       }),
     })
 
-    const rows = ($.setActionItem as any).mock.calls[0][0].raw.rows
+    const rows = ($.setActionItem as any).mock.calls[0][0].raw.data.rows
 
-    const rowData = rows.rowData
-    expect(rowData).toHaveLength(500)
-    expect(rowData[0].rowId).toBe('row0')
-    expect(rowData[499].rowId).toBe('row499')
+    expect(rows).toHaveLength(500)
+    expect(rows[0].rowId).toBe('row0')
+    expect(rows[499].rowId).toBe('row499')
   })
 })

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -1,7 +1,5 @@
 import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
-import { TileColumnMetadata } from '../../types'
-
 import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
@@ -15,10 +13,10 @@ async function getDataOutMetadata(
   const dataOut = dataOutSchema.parse(rawDataOut)
 
   const metadata: IDataOutMetadata = {
-    rows: {
+    data: {
       label: 'List of row(s) found',
       displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
-      type: 'array',
+      type: 'multiple-row-object',
       order: 1,
     },
     rowsFound: {
@@ -27,18 +25,7 @@ async function getDataOutMetadata(
     },
   }
 
-  const columnMetadata: IDataOutMetadata = []
-  if (dataOut.columns) {
-    dataOut.columns.forEach((column: TileColumnMetadata) => {
-      columnMetadata.push({
-        id: { isHidden: true },
-        name: { isHidden: true },
-        value: { label: column.name },
-      })
-    })
-  }
-
-  return { ...metadata, columns: columnMetadata }
+  return { ...metadata }
 }
 
 export default getDataOutMetadata

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -189,46 +189,26 @@ const action: IRawAction = {
       scanLimit,
     })
 
-    // NOTE: there are 2 types of column data that we return
-    // 1. column name and id for use in for-each
-    // use an array to preserve the order of the columns
-    const columnData: Record<string, string>[] = []
+    const columnData: TileColumnMetadata[] = []
     columns
       .sort((a, b) => a.position - b.position)
       .forEach((c) => {
         columnData.push({
           id: c.id,
           name: c.name,
+          value: `data.rows.*.data.${c.id}`,
         })
       })
-
-    // 2. column data that combines all the values of all rows into a single string
-    const consolidatedColumns = columns.reduce((acc, column) => {
-      const values: string[] = []
-      for (const row of rows) {
-        const value = row.data[column.id]
-        if (value) {
-          values.push(value)
-        }
-      }
-      acc.push({
-        id: column.id,
-        name: column.name,
-        value: values.join(', '),
-      })
-      return acc
-    }, [] as TileColumnMetadata[])
 
     const slicedRows = rows.slice(0, FIND_MULTIPLE_ROWS_LIMIT)
 
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
-        rows: {
-          rowData: slicedRows,
+        data: {
+          rows: slicedRows,
           columns: columnData,
         },
-        columns: consolidatedColumns,
       } satisfies FindMultipleRowsOutput,
     })
   },

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
@@ -14,6 +14,7 @@ export const dataOutSchema = z.object({
         z.object({
           id: z.string(),
           name: z.string(),
+          value: z.string(),
         }),
       ),
     })

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
@@ -7,18 +7,9 @@ const tableRowOutputSchema = z.object({
 
 export const dataOutSchema = z.object({
   rowsFound: z.number(),
-  columns: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        value: z.string(),
-      }),
-    )
-    .optional(),
-  rows: z
+  data: z
     .object({
-      rowData: z.array(tableRowOutputSchema),
+      rows: z.array(tableRowOutputSchema),
       columns: z.array(
         z.object({
           id: z.string(),

--- a/packages/backend/src/apps/tiles/types/index.ts
+++ b/packages/backend/src/apps/tiles/types/index.ts
@@ -16,10 +16,9 @@ export type TileColumnMetadata = {
 
 export interface FindMultipleRowsOutput extends IJSONObject {
   rowsFound: number
-  columns: TileColumnMetadata[]
-  rows?: {
-    rowData: TableRowOutput[]
-    columns: Record<string, string>[]
+  data?: {
+    rows: TableRowOutput[]
+    columns: TileColumnMetadata[]
   }
 }
 


### PR DESCRIPTION
## TL;DR
Refactored to dynamically obtain column values for the `findMultipleRow` action instead of storing them in the execution step’s `dataOut`, to avoid duplicate data — since the values are already stored in the row data.

**Note to reviewers**
The modal that displays the list of rows in table format will be updated in a subsequent PR. As of now, the test result can still be verified in the output after testing the step.

## What changed?
* Restructured the output format from `rows.rowData` to `data.rows` for better semantic clarity
* Removed unnecessary consolidated column metadata as it is already available within the `data`
* Added explicit value paths (`data.rows.*.data.<columnId>`) to column definitions for dynamic data access
* Changed the type in metadata from 'array' to 'multiple-row-object' to better represent the data structure

## How to test?
Set up the find multiple row action and test the following:
- [ ] Number of rows returned is correct
- [ ] Test result shows the correct number of columns with:
  - `id`: Tile column id (uuid)
  - `name`: Tile column name
  - `value`: step variable-like string in this format `data.rows.*.data.<columnId>`


## Screenshots

![Screenshot 2025-06-02 at 9.23.58 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/01985352-322b-4bf7-ad38-ccc8c48be2b1.png)

![Screenshot 2025-06-02 at 9.25.16 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/87fc45fe-9956-4d6e-91b2-ea4829ef69dc.png)

![Screenshot 2025-06-02 at 9.25.30 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/20135570-2cc1-453e-b21c-e2e25338ab49.png)

