### PR TITLE
PLU-488 [FIND-MULTIPLE-ROWS-5]: Get Excel column values dynamically

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows-metadata.test.ts
@@ -4,6 +4,40 @@ import { describe, expect, it, vi } from 'vitest'
 
 import getDataOutMetadata from '../../actions/get-table-rows/get-data-out-metadata'
 
+const DEFAULT_SUCCESS_EXECUTION_STEP = {
+  dataOut: {
+    rowsFound: 2,
+    data: {
+      rows: [
+        {
+          data: {
+            '436f6c756d6e31': 'value1',
+            '436f6c756d6e32': 'value2',
+          },
+        },
+        {
+          data: {
+            '436f6c756d6e31': 'value3',
+            '436f6c756d6e32': 'value4',
+          },
+        },
+      ],
+      columns: [
+        {
+          id: '436f6c756d6e31',
+          name: 'Column1',
+          value: `data.rows.*.${Buffer.from('Column1').toString('hex')}`,
+        },
+        {
+          id: '436f6c756d6e32',
+          name: 'Column2',
+          value: `data.rows.*.${Buffer.from('Column2').toString('hex')}`,
+        },
+      ],
+    },
+  },
+} as unknown as IExecutionStep
+
 describe('getTableRows getDataOutMetadata', () => {
   it('should return null if no dataOut is provided', async () => {
     const executionStep = { dataOut: null } as unknown as IExecutionStep
@@ -15,93 +49,48 @@ describe('getTableRows getDataOutMetadata', () => {
     const executionStep = {
       dataOut: {
         rowsFound: 0,
+        data: {
+          rows: [],
+          columns: [
+            {
+              id: '436f6c756d6e31',
+              name: 'Column1',
+              value: `data.rows.*.${Buffer.from('Column1').toString('hex')}`,
+            },
+          ],
+        },
       },
     } as unknown as IExecutionStep
-
     const result = await getDataOutMetadata(executionStep)
 
     expect(result).toEqual({
-      rows: {
-        label: 'List of row(s) found',
-        displayedValue: 'Preview 0 row(s)',
-        order: 1,
-        type: 'array',
-      },
       rowsFound: {
         label: 'Number of rows found',
         order: 2,
       },
-      columns: [],
+      data: {
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 0 row(s)',
+        order: 1,
+        type: 'multiple-row-object',
+      },
     })
   })
 
   it('should return metadata for foundRows: true with row data', async () => {
-    const executionStep = {
-      dataOut: {
-        rowsFound: 2,
-        rowData: [
-          {
-            tableRowIndex: 0,
-            sheetRowNumber: 2,
-            row: {
-              '436f6c756d6e31': { value: 'value1', columnName: 'Column1' },
-              '436f6c756d6e32': { value: 'value2', columnName: 'Column2' },
-            },
-          },
-          {
-            tableRowIndex: 1,
-            sheetRowNumber: 3,
-            row: {
-              '436f6c756d6e31': { value: 'value3', columnName: 'Column1' },
-              '436f6c756d6e32': { value: 'value4', columnName: 'Column2' },
-            },
-          },
-        ],
-        columns: [
-          {
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: 'value1, value3',
-          },
-          {
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: 'value2, value4',
-          },
-        ],
-        numRows: 2,
-      },
-    } as unknown as IExecutionStep
-
-    const result = await getDataOutMetadata(executionStep)
+    const result = await getDataOutMetadata(DEFAULT_SUCCESS_EXECUTION_STEP)
 
     expect(result).toEqual({
-      rows: {
-        label: 'List of row(s) found',
-        displayedValue: 'Preview 2 row(s)',
-        order: 1,
-        type: 'array',
-      },
       rowsFound: {
         label: 'Number of rows found',
         order: 2,
       },
-      columns: [
-        {
-          id: { isHidden: true },
-          name: { isHidden: true },
-          value: {
-            label: 'Column1',
-          },
-        },
-        {
-          id: { isHidden: true },
-          name: { isHidden: true },
-          value: {
-            label: 'Column2',
-          },
-        },
-      ],
+      data: {
+        label: 'List of row(s) found',
+        displayedValue: 'Preview 2 row(s)',
+        order: 1,
+        type: 'multiple-row-object',
+      },
     })
   })
 
@@ -109,26 +98,14 @@ describe('getTableRows getDataOutMetadata', () => {
     const executionStep = {
       dataOut: {
         rowsFound: 0,
-        rows: [],
-        // columns is missing
+        data: {
+          rows: [],
+          // columns is missing
+        },
       },
     } as unknown as IExecutionStep
 
-    const result = await getDataOutMetadata(executionStep)
-
-    expect(result).toEqual({
-      rows: {
-        label: 'List of row(s) found',
-        displayedValue: 'Preview 0 row(s)',
-        order: 1,
-        type: 'array',
-      },
-      rowsFound: {
-        label: 'Number of rows found',
-        order: 2,
-      },
-      columns: [],
-    })
+    await expect(getDataOutMetadata(executionStep)).rejects.toThrow()
   })
 
   it('should handle invalid dataOut format gracefully', async () => {

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -8,6 +8,10 @@ import Context from '@/types/express/context'
 
 import m365Excel from '../..'
 import getTableRowsAction from '../../actions/get-table-rows'
+import { HexEncodedRowObject } from '../../common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record'
+
+const getHexEncodedColumnName = (columnName: string) =>
+  Buffer.from(columnName).toString('hex')
 
 // Mock dependencies
 const mocks = vi.hoisted(() => ({
@@ -16,7 +20,7 @@ const mocks = vi.hoisted(() => ({
     request: vi.fn(),
   },
   getTopNTableRows: vi.fn(),
-  convertRowToHexEncodedRowRecord: vi.fn(),
+  convertRowToHexKeyedObject: vi.fn(),
   validateDynamicFieldsAndThrowError: vi.fn(),
 }))
 
@@ -83,17 +87,19 @@ describe('getTableRowsAction', () => {
     })
 
     // Setup hex-encoded row record mock
-    mocks.convertRowToHexEncodedRowRecord.mockImplementation(
+    mocks.convertRowToHexKeyedObject.mockImplementation(
       ({ row, columns }: { row: string[]; columns: string[] }) => {
         // Create a simple mock implementation that converts the row to a record
-        const result: Record<string, { value: string; columnName: string }> = {}
-        columns.forEach((col: string, index: number) => {
-          const hexKey = Buffer.from(col).toString('hex')
-          result[hexKey] = {
-            value: row[index],
-            columnName: col,
-          }
-        })
+        const result: HexEncodedRowObject = Object.create(null)
+
+        for (const [cellIndex, cell] of row.entries()) {
+          const cellColumnName = columns[cellIndex]
+          const hexEncodedColumnName =
+            Buffer.from(cellColumnName).toString('hex')
+
+          result[hexEncodedColumnName] = cell
+        }
+
         return result
       },
     )
@@ -121,19 +127,21 @@ describe('getTableRowsAction', () => {
 
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: expect.arrayContaining([
-          expect.objectContaining({
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: '',
-          }),
-          expect.objectContaining({
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: '',
-          }),
-        ]),
-        rows: [],
+        data: {
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            }),
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            }),
+          ]),
+          rows: [],
+        },
         rowsFound: 0,
       },
     })
@@ -145,31 +153,50 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 2, // Two rows match 'test-value'
-        columns: expect.arrayContaining([
-          expect.objectContaining({
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: 'test-value, test-value',
-          }),
-          expect.objectContaining({
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: 'data2, data3',
-          }),
-        ]),
-        rows: expect.any(Array),
+        data: {
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            }),
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            }),
+          ]),
+          rows: expect.arrayContaining([
+            expect.objectContaining({
+              data: {
+                [getHexEncodedColumnName('Column1')]: 'test-value',
+                [getHexEncodedColumnName('Column2')]: 'data2',
+              },
+            }),
+            expect.objectContaining({
+              data: {
+                [getHexEncodedColumnName('Column1')]: 'test-value',
+                [getHexEncodedColumnName('Column2')]: 'data3',
+              },
+            }),
+          ]),
+        },
       }),
     })
 
     // Verify the rowData contains the expected rows
     const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    const rowData = call.raw.rows
+    const rowData = call.raw.data.rows
 
     expect(rowData).toHaveLength(2)
-    expect(rowData[0].tableRowIndex).toBe(1)
-    expect(rowData[0].sheetRowNumber).toBe(3) // headerSheetRowIndex(0) + rowIndex(1) + 2
-    expect(rowData[1].tableRowIndex).toBe(2)
-    expect(rowData[1].sheetRowNumber).toBe(4) // headerSheetRowIndex(0) + rowIndex(2) + 2
+    expect(rowData[0].data[getHexEncodedColumnName('Column1')]).toBe(
+      'test-value',
+    )
+    expect(rowData[0].data[getHexEncodedColumnName('Column2')]).toBe('data2')
+    expect(rowData[1].data[getHexEncodedColumnName('Column1')]).toBe(
+      'test-value',
+    )
+    expect(rowData[1].data[getHexEncodedColumnName('Column2')]).toBe('data3')
   })
 
   it('should handle invalid parameters', async () => {
@@ -189,19 +216,22 @@ describe('getTableRowsAction', () => {
     // Should not find any matches due to case sensitivity
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        columns: [
-          {
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: '',
-          },
-          {
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: '',
-          },
-        ],
-        rows: [],
+        data: {
+          columns: [
+            {
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            },
+            {
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            },
+          ],
+          rows: [],
+        },
+
         rowsFound: 0,
       },
     })
@@ -226,19 +256,28 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 1,
-        columns: expect.arrayContaining([
-          expect.objectContaining({
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: 'TEST-VALUE',
-          }),
-          expect.objectContaining({
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: 'data2',
-          }),
-        ]),
-        rows: expect.any(Array),
+        data: {
+          rows: expect.arrayContaining([
+            expect.objectContaining({
+              data: {
+                [getHexEncodedColumnName('Column1')]: 'TEST-VALUE',
+                [getHexEncodedColumnName('Column2')]: 'data2',
+              },
+            }),
+          ]),
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            }),
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            }),
+          ]),
+        },
       }),
     })
   })
@@ -260,44 +299,48 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: expect.objectContaining({
         rowsFound: 500, // Should be limited to 500 rows
-        columns: expect.arrayContaining([
-          expect.objectContaining({
-            id: Buffer.from('Column1').toString('hex'),
-            name: 'Column1',
-            value: `test-value, ${Array.from(
-              { length: 499 },
-              (_) => `test-value`,
-            ).join(', ')}`,
-          }),
-          expect.objectContaining({
-            id: Buffer.from('Column2').toString('hex'),
-            name: 'Column2',
-            value: `data1, ${Array.from(
-              { length: 499 },
-              (_, i) => `data${i + 2}`,
-            ).join(', ')}`,
-          }),
-        ]),
-        rows: expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(String),
-            rowData: expect.any(Object),
-            sheetRowNumber: expect.any(Number),
-            tableRowIndex: expect.any(Number),
-          }),
-        ]),
+        data: {
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            }),
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            }),
+          ]),
+          rows: expect.arrayContaining(
+            Array.from({ length: 500 }, (_, i) =>
+              expect.objectContaining({
+                data: {
+                  [getHexEncodedColumnName('Column1')]: 'test-value',
+                  [getHexEncodedColumnName('Column2')]: `data${i + 1}`,
+                },
+              }),
+            ),
+          ),
+        },
       }),
     })
 
     // Verify the rowData contains exactly 500 rows
     const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
-    const rowData = call.raw.rows
+    const rowData = call.raw.data.rows
     expect(rowData).toHaveLength(500)
 
     // Verify the first and last rows are correct
-    expect(rowData[0].tableRowIndex).toBe(0)
-    expect(rowData[0].sheetRowNumber).toBe(2) // headerSheetRowIndex(0) + rowIndex(0) + 2
-    expect(rowData[499].tableRowIndex).toBe(499)
-    expect(rowData[499].sheetRowNumber).toBe(501) // headerSheetRowIndex(0) + rowIndex(499) + 2
+    expect(rowData[0].data[getHexEncodedColumnName('Column1')]).toBe(
+      'test-value',
+    )
+    expect(rowData[0].data[getHexEncodedColumnName('Column2')]).toBe('data1')
+    expect(rowData[499].data[getHexEncodedColumnName('Column1')]).toBe(
+      'test-value',
+    )
+    expect(rowData[499].data[getHexEncodedColumnName('Column2')]).toBe(
+      'data500',
+    )
   })
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/get-data-out-metadata.ts
@@ -17,34 +17,111 @@ async function getDataOutMetadata(
       label: 'Number of rows found',
       order: 2,
     },
+    data: {
+      label: 'List of row(s) found',
+      displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
+      type: 'multiple-row-object',
+      order: 1,
+    },
   }
 
-  metadata.rows = {
-    label: 'List of row(s) found',
-    displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
-    type: 'array',
-    order: 1,
-  }
-
-  const columnMetadata: IDataOutMetadata = []
-  if ('columns' in dataOut) {
-    dataOut.columns.forEach(({ name }) => {
-      columnMetadata.push({
-        id: { isHidden: true },
-        name: { isHidden: true },
-        value: { label: name },
-      })
-    })
-  }
-
-  return { ...metadata, columns: columnMetadata }
+  return { ...metadata }
 }
 
 export default getDataOutMetadata
 
-// Example dataOut: {
-//   // rows is an array of objects, where each object is a row of data
-//   rows: [{"id": "0-2","tableRowIndex":0,"sheetRowNumber":2,"row":{"436f6c756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"123","columnName":"Column2"}}},{"id": "3-5","tableRowIndex":3,"sheetRowNumber":5,"row":{"436F6C756D6E31":{"value":"abc","columnName":"Column1"},"436F6C756D6E32":{"value":"111","columnName":"Column2"}}}],
-//   columns: {"Column1": {"id": "Column1", "order":1, value: "Column1"}, "Column2": {"id": "Column2", "order":2, value: "Column2"}},
-//   rowsFound: 2
+// Example dataOut:
+// {
+//   "data": {
+//     "rows": [
+//       {
+//         "data": {
+//           "4e524943": "S7032796N",
+//           "41646472657373": "Block 161 Victoria Street #41-21",
+//           "525356502d6564": "Yes",
+//           "4164647265737332": "",
+//           "4c617374204e616d65": "Lee",
+//           "4669727374204e616d65": "Jane",
+//           "506f7374616c20436f6465": "753105",
+//           "4e657720436f6c756d6e2033": "2025-04-07T10:19:39.920Z",
+//           "4e657720436f6c756d6e2034": "400",
+//           "456d61696c2041646472657373": "meiling.lee179@gmail.com",
+//           "456d61696c204164647265737332": ""
+//         }
+//       },
+//       {
+//         "data": {
+//           "4e524943": "S2645644U",
+//           "41646472657373": "Block 535 Bedok North Road #38-325",
+//           "525356502d6564": "Yes",
+//           "4164647265737332": "",
+//           "4c617374204e616d65": "Abdullah",
+//           "4669727374204e616d65": "Ivan",
+//           "506f7374616c20436f6465": "557687",
+//           "4e657720436f6c756d6e2033": "",
+//           "4e657720436f6c756d6e2034": "",
+//           "456d61696c2041646472657373": "",
+//           "456d61696c204164647265737332": ""
+//         }
+//       }
+//     ],
+//     "columns": [
+//       {
+//         "id": "525356502d6564",
+//         "name": "RSVP-ed",
+//         "value": "data.rows.*.data.525356502d6564"
+//       },
+//       {
+//         "id": "4669727374204e616d65",
+//         "name": "First Name",
+//         "value": "data.rows.*.data.4669727374204e616d65"
+//       },
+//       {
+//         "id": "4c617374204e616d65",
+//         "name": "Last Name",
+//         "value": "data.rows.*.data.4c617374204e616d65"
+//       },
+//       {
+//         "id": "4e524943",
+//         "name": "NRIC",
+//         "value": "data.rows.*.data.4e524943"
+//       },
+//       {
+//         "id": "41646472657373",
+//         "name": "Address",
+//         "value": "data.rows.*.data.41646472657373"
+//       },
+//       {
+//         "id": "506f7374616c20436f6465",
+//         "name": "Postal Code",
+//         "value": "data.rows.*.data.506f7374616c20436f6465"
+//       },
+//       {
+//         "id": "456d61696c2041646472657373",
+//         "name": "Email Address",
+//         "value": "data.rows.*.data.456d61696c2041646472657373"
+//       },
+//       {
+//         "id": "456d61696c204164647265737332",
+//         "name": "Email Address2",
+//         "value": "data.rows.*.data.456d61696c204164647265737332"
+//       },
+//       {
+//         "id": "4164647265737332",
+//         "name": "Address2",
+//         "value": "data.rows.*.data.4164647265737332"
+//       },
+//       {
+//         "id": "4e657720436f6c756d6e2033",
+//         "name": "New Column 3",
+//         "value": "data.rows.*.data.4e657720436f6c756d6e2033"
+//       },
+//       {
+//         "id": "4e657720436f6c756d6e2034",
+//         "name": "New Column 4",
+//         "value": "data.rows.*.data.4e657720436f6c756d6e2034"
+//       }
+//     ]
+//   },
+//   "rowsFound": 6
 // }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -7,7 +7,7 @@ import StepError from '@/errors/step'
 import { GET_TABLE_ROWS_LIMIT } from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
 import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
-import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
+import { convertRowToHexKeyedObject } from '../../common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record'
 import WorkbookSession from '../../common/workbook-session'
 import { MAX_ROWS } from '../get-table-row/implementation'
 
@@ -132,14 +132,14 @@ const action: IRawAction = {
     })
 
     const session = await WorkbookSession.acquire($, fileId)
-    const { columns, rows, headerSheetRowIndex } = await getTopNTableRows(
+    const { columns: rawColumns, rows } = await getTopNTableRows(
       $,
       session,
       tableId,
       MAX_ROWS,
     )
 
-    const columnIndex = columns.indexOf(lookupColumn)
+    const columnIndex = rawColumns.indexOf(lookupColumn)
     if (columnIndex === -1) {
       throw new StepError(
         `Column "${lookupColumn}" does not exist in your table.`,
@@ -149,23 +149,12 @@ const action: IRawAction = {
       )
     }
 
-    const rowsToReturn: {
-      id: string
-      tableRowIndex: number
-      sheetRowNumber: number
-      rowData: Record<string, { value?: string; columnName?: string }>
-    }[] = []
+    const rowsToReturn: { data: Record<string, string> }[] = []
 
-    for (const [rowIndex, row] of rows.entries()) {
+    for (const [_, row] of rows.entries()) {
       if (row[columnIndex] === lookupValue) {
         rowsToReturn.push({
-          id: `${rowIndex}-${rowIndex + headerSheetRowIndex + 2}`,
-          tableRowIndex: rowIndex,
-          sheetRowNumber: rowIndex + headerSheetRowIndex + 2,
-          rowData: convertRowToHexEncodedRowRecord({
-            row,
-            columns,
-          }),
+          data: convertRowToHexKeyedObject({ row, columns: rawColumns }),
         })
       }
     }
@@ -173,36 +162,20 @@ const action: IRawAction = {
     // Max limit of 500 rows
     const slicedRows = rowsToReturn.slice(0, GET_TABLE_ROWS_LIMIT)
 
-    const consolidatedColumns = columns.reduce((acc, column) => {
-      const values: string[] = []
-      for (const row of slicedRows) {
-        const rowData = Object.entries(row.rowData).find(([_, value]) => {
-          if (value.columnName === column) {
-            return value.value
-          }
-        })
-
-        const value = rowData?.[1].value
-        if (value) {
-          values.push(value)
-        }
-      }
-
-      acc.push({
-        // NOTE: convert column to hex to avoid special characters
-        // such as '.' that may affect lodash get
-        id: Buffer.from(column).toString('hex'),
-        name: column,
-        value: values.join(', '),
-      })
-      return acc
-    }, [])
-
     $.setActionItem({
       raw: {
         rowsFound: slicedRows.length,
-        rows: slicedRows,
-        columns: consolidatedColumns,
+        data: {
+          rows: slicedRows,
+          columns: rawColumns.map((c) => {
+            const hexEncodedColumnName = Buffer.from(c).toString('hex')
+            return {
+              id: hexEncodedColumnName,
+              name: c,
+              value: `data.rows.*.data.${hexEncodedColumnName}`,
+            }
+          }),
+        },
       } satisfies DataOut,
     })
   },

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -20,29 +20,8 @@ export const parametersSchema = z.object({
 
 export const dataOutSchema = z.object({
   rowsFound: z.number(),
-  columns: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        value: z.string(),
-      }),
-    )
-    .optional(),
-  rows: z
-    .array(
-      z.object({
-        id: z.string(),
-        tableRowIndex: z.number(),
-        sheetRowNumber: z.number(),
-        rowData: z.record(
-          z.string(),
-          z.object({
-            value: z.string(),
-            columnName: z.string(),
-          }),
-        ),
-      }),
-    )
-    .optional(),
+  data: z.object({
+    rows: z.array(z.object({ data: z.record(z.string(), z.string()) })),
+    columns: z.array(z.object({ id: z.string(), name: z.string() })),
+  }),
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -22,6 +22,8 @@ export const dataOutSchema = z.object({
   rowsFound: z.number(),
   data: z.object({
     rows: z.array(z.object({ data: z.record(z.string(), z.string()) })),
-    columns: z.array(z.object({ id: z.string(), name: z.string() })),
+    columns: z.array(
+      z.object({ id: z.string(), name: z.string(), value: z.string() }),
+    ),
   }),
 })

--- a/packages/backend/src/apps/m365-excel/common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record.ts
+++ b/packages/backend/src/apps/m365-excel/common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record.ts
@@ -13,6 +13,7 @@ export type HexEncodedRowRecord = z.infer<typeof hexEncodedRowRecordSchema>
 export function convertRowToHexEncodedRowRecord(args: {
   row: string[]
   columns: string[]
+  includeColumnName?: boolean
 }): HexEncodedRowRecord {
   const { row, columns } = args
   const result: HexEncodedRowRecord = Object.create(null)
@@ -25,6 +26,30 @@ export function convertRowToHexEncodedRowRecord(args: {
       value: cell,
       columnName: cellColumnName,
     }
+  }
+
+  return result
+}
+
+export const hexEncodedRowObjectSchema = z.record(
+  z.string().regex(/[\da-f]/i),
+  z.string(),
+)
+
+export type HexEncodedRowObject = z.infer<typeof hexEncodedRowObjectSchema>
+
+export function convertRowToHexKeyedObject(args: {
+  row: string[]
+  columns: string[]
+}): HexEncodedRowObject {
+  const { row, columns } = args
+  const result: HexEncodedRowObject = Object.create(null)
+
+  for (const [cellIndex, cell] of row.entries()) {
+    const cellColumnName = columns[cellIndex]
+    const hexEncodedColumnName = Buffer.from(cellColumnName).toString('hex')
+
+    result[hexEncodedColumnName] = cell
   }
 
   return result


### PR DESCRIPTION
## TL;DR
Refactored to dynamically obtain column values for the `getTableRows` action instead of storing them in the execution step’s `dataOut`, to avoid duplicate data — since the values are already stored in the row data.

**Note to reviewers**
The modal that displays the list of rows in table format will be updated in a subsequent PR. As of now, the test result can still be verified in the output after testing the step.

## What changed?
* Restructured output to align with Tiles multiple row output:
  * `rows.rowData` to `data.rows` for better semantic clarity\
  * Removed unnecessary consolidated column metadata as it is already available within the `data`
  * Removed unnecessary `tableRowIndex` and `sheetRowNumber`
* Added explicit value paths (`data.rows.*.data.<hex-encoded-column-name>`) to column definitions for dynamic data access
* Changed the type in metadata from 'array' to 'multiple-row-object' to better represent the data structure

## How to test?
Set up the find table rows action and test the following:
- [ ] Number of rows returned is correct
- [ ] Test result shows the correct number of columns with:
  - `id`: Tile column id (uuid)
  - `name`: Tile column name
  - `value`: step variable-like string in this format `data.rows.*.data.<hex-encoded-column-name>`


## Screenshots

![Screenshot 2025-06-02 at 9.47.25 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/03295d11-07dc-47dd-8e91-2f764d210330.png)

![Screenshot 2025-06-02 at 9.47.36 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/45d33307-5712-4da2-af52-ee77c789b5b9.png)

![Screenshot 2025-06-02 at 9.47.43 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/0b208bd5-5ad4-4359-a67c-e7337acb2c12.png)

