### PR TITLE
PLU-489 [FIND-MULTIPLE-ROWS-7]: Compute parameters with wildcard

### DIFF
--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -349,4 +349,82 @@ describe('compute parameters', () => {
     const result = computeParameters(params, executionStep)
     expect(result).toEqual(expected)
   })
+
+  it.each([
+    {
+      testDescription: 'wildcard on empty array',
+      params: `empty!! {{step.${randomStepID}.emptyArrayProp.*}}`,
+      expected: 'empty!! ',
+    },
+    {
+      testDescription: 'wildcard on array of values',
+      params: `{{step.${randomStepID}.arrayProp.*}}`,
+      expected: 'array value 1, hehe, array value 3',
+    },
+    {
+      testDescription: 'wildcard on array of objects to get strings',
+      params: `wildcard get strings {{step.${randomStepID}.arrayOfObjectsProp.*.stringProp}}`,
+      expected:
+        'wildcard get strings string value 1 in array of objects, string value 2 in array of objects',
+    },
+    {
+      testDescription: 'wildcard on array of objects to get numbers',
+      params: `wildcard get numbers {{step.${randomStepID}.arrayOfObjectsProp.*.numberProp}}`,
+      expected: 'wildcard get numbers 456, 789',
+    },
+    {
+      testDescription: 'wildcard on both strings and numbers',
+      params: `wildcard get strings and numbers {{step.${randomStepID}.arrayOfObjectsProp.*.stringProp}} {{step.${randomStepID}.arrayOfObjectsProp.*.numberProp}}`,
+      expected:
+        'wildcard get strings and numbers string value 1 in array of objects, string value 2 in array of objects 456, 789',
+    },
+    {
+      testDescription: 'wildcard on non-existent key',
+      params: `non-existent key! {{step.${randomStepID}.non-existent-key.*}}`,
+      expected: 'non-existent key! ',
+    },
+    {
+      testDescription: 'prop name with wildcard',
+      params: `prop with wildcard {{step.${randomStepID}.stringWith*}}`,
+      expected: 'prop with wildcard string value',
+    },
+    {
+      testDescription: 'prop name with space and wildcard',
+      params: `prop with space and wildcard! {{step.${randomStepID}.string with *}}`,
+      expected: `prop with space and wildcard! string value 2`,
+    },
+    {
+      testDescription: 'wildcard on a string',
+      params: `wildcard on a string!! {{step.${randomStepID}.stringProp.*}}`,
+      expected: 'wildcard on a string!! string value',
+    },
+  ])('should handle $testDescription', ({ params, expected }) => {
+    const executionSteps = [
+      {
+        stepId: randomStepID,
+        dataOut: {
+          stringProp: 'string value',
+          numberProp: 123,
+          'space separated prop': 'space separated value',
+          arrayProp: ['array value 1', 'hehe', 'array value 3'],
+          emptyArrayProp: [],
+          arrayOfObjectsProp: [
+            {
+              stringProp: 'string value 1 in array of objects',
+              numberProp: 456,
+            },
+            {
+              stringProp: 'string value 2 in array of objects',
+              numberProp: 789,
+            },
+          ],
+          'stringWith*': 'string value',
+          'string with *': 'string value 2',
+        },
+      } as unknown as ExecutionStep,
+    ]
+
+    const result = computeParameters({ params }, executionSteps)
+    expect(result).toEqual({ params: expected })
+  })
 })

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -352,53 +352,48 @@ describe('compute parameters', () => {
 
   it.each([
     {
-      testDescription: 'wildcard on empty array',
-      params: `empty!! {{step.${randomStepID}.emptyArrayProp.*}}`,
-      expected: 'empty!! ',
-    },
-    {
-      testDescription: 'wildcard on array of values',
-      params: `{{step.${randomStepID}.arrayProp.*}}`,
-      expected: 'array value 1, hehe, array value 3',
-    },
-    {
-      testDescription: 'wildcard on array of objects to get strings',
+      testDescription: 'compute wildcard on array of objects to get strings',
       params: `wildcard get strings {{step.${randomStepID}.arrayOfObjectsProp.*.stringProp}}`,
       expected:
         'wildcard get strings string value 1 in array of objects, string value 2 in array of objects',
     },
     {
-      testDescription: 'wildcard on array of objects to get numbers',
+      testDescription: 'compute wildcard on array of objects to get numbers',
       params: `wildcard get numbers {{step.${randomStepID}.arrayOfObjectsProp.*.numberProp}}`,
       expected: 'wildcard get numbers 456, 789',
     },
     {
-      testDescription: 'wildcard on both strings and numbers',
+      testDescription: 'compute wildcard on both strings and numbers',
       params: `wildcard get strings and numbers {{step.${randomStepID}.arrayOfObjectsProp.*.stringProp}} {{step.${randomStepID}.arrayOfObjectsProp.*.numberProp}}`,
       expected:
         'wildcard get strings and numbers string value 1 in array of objects, string value 2 in array of objects 456, 789',
     },
     {
-      testDescription: 'wildcard on non-existent key',
-      params: `non-existent key! {{step.${randomStepID}.non-existent-key.*}}`,
+      testDescription: 'compute wildcard on non-existent key',
+      params: `non-existent key! {{step.${randomStepID}.non-existent-key.*.id}}`,
       expected: 'non-existent key! ',
     },
     {
-      testDescription: 'prop name with wildcard',
-      params: `prop with wildcard {{step.${randomStepID}.stringWith*}}`,
-      expected: 'prop with wildcard string value',
-    },
-    {
-      testDescription: 'prop name with space and wildcard',
-      params: `prop with space and wildcard! {{step.${randomStepID}.string with *}}`,
-      expected: `prop with space and wildcard! string value 2`,
-    },
-    {
-      testDescription: 'wildcard on a string',
-      params: `wildcard on a string!! {{step.${randomStepID}.stringProp.*}}`,
+      testDescription: 'compute wildcard on a string',
+      params: `wildcard on a string!! {{step.${randomStepID}.stringProp.*.id}}`,
       expected: 'wildcard on a string!! string value',
     },
-  ])('should handle $testDescription', ({ params, expected }) => {
+    {
+      testDescription: 'ignore wildcard at end of variable',
+      params: `empty!! {{step.${randomStepID}.emptyArrayProp.*}}`,
+      expected: `empty!! {{step.${randomStepID}.emptyArrayProp.*}}`,
+    },
+    {
+      testDescription: 'ignore wildcard inside the key',
+      params: `wildcard inside the key {{step.${randomStepID}.stringProp*}}`,
+      expected: `wildcard inside the key {{step.${randomStepID}.stringProp*}}`,
+    },
+    {
+      testDescription: 'ignore more than one wildcard inside the variable',
+      params: `two wildcards inside the key {{step.${randomStepID}.*.stringProp.*}}`,
+      expected: `two wildcards inside the key {{step.${randomStepID}.*.stringProp.*}}`,
+    },
+  ])('should $testDescription', ({ params, expected }) => {
     const executionSteps = [
       {
         stepId: randomStepID,
@@ -418,8 +413,6 @@ describe('compute parameters', () => {
               numberProp: 789,
             },
           ],
-          'stringWith*': 'string value',
-          'string with *': 'string value 2',
         },
       } as unknown as ExecutionStep,
     ]

--- a/packages/backend/src/helpers/check-step-parameters.ts
+++ b/packages/backend/src/helpers/check-step-parameters.ts
@@ -1,7 +1,7 @@
 import { IJSONObject } from '@plumber/types'
 
 const VARIABLE_REGEX =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\w* -]+)+}})/
 const GLOBAL_VARIABLE_REGEX = new RegExp(VARIABLE_REGEX, 'g')
 
 /**

--- a/packages/backend/src/helpers/check-step-parameters.ts
+++ b/packages/backend/src/helpers/check-step-parameters.ts
@@ -1,7 +1,7 @@
 import { IJSONObject } from '@plumber/types'
 
-const VARIABLE_REGEX =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\w* -]+)+}})/
+import { VARIABLE_REGEX } from './compute-parameters'
+
 const GLOBAL_VARIABLE_REGEX = new RegExp(VARIABLE_REGEX, 'g')
 
 /**

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -9,11 +9,31 @@ import Step from '../models/step'
 
 const GET_ALL_SEPARATOR = ','
 
-const variableRegExp =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\w* -]+)+}})/g
+export const VARIABLE_REGEX =
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.(?:[\w -]+|\*))+}})/
+
+function isVariableValid(path: string) {
+  const rawPath = path.replace(/^{{step\.[^}]+?\./, '').replace(/}}$/, '')
+  const segments = rawPath.split('.')
+  const wildcardCount = segments.filter((s) => s === '*').length
+
+  if (
+    wildcardCount > 1 ||
+    segments[0] === '*' ||
+    segments[segments.length - 1] === '*'
+  ) {
+    return false
+  }
+
+  return true
+}
 
 function splitAndJoinAroundWildcard(arr: string[]) {
   const wildcardIndex = arr.indexOf('*')
+  if (wildcardIndex === -1) {
+    console.error("Wildcard '*' not found in array")
+    return { before: arr.join('.'), after: '' }
+  }
   return {
     before: arr.slice(0, wildcardIndex).join('.'),
     after: arr.slice(wildcardIndex + 1).join('.'),
@@ -59,11 +79,15 @@ function findAndSubstituteVariables(
     return rawValue
   }
 
-  const parts = rawValue.split(variableRegExp)
+  const parts = rawValue.split(VARIABLE_REGEX)
 
   return parts
     .map((part: string) => {
-      const isVariable = part.match(variableRegExp)
+      if (!isVariableValid(part)) {
+        return part
+      }
+
+      const isVariable = part.match(VARIABLE_REGEX)
       if (isVariable) {
         const stepIdAndKeyPath = part.replace(/{{step.|}}/g, '') as string
         const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
@@ -79,6 +103,9 @@ function findAndSubstituteVariables(
 
           if (!base) {
             return ''
+          }
+          if (typeof base === 'string') {
+            return base
           }
 
           const values = after

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -1,13 +1,24 @@
 import type { IAction } from '@plumber/types'
 
+import { map } from 'lodash'
 import get from 'lodash.get'
 
 import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
+const GET_ALL_SEPARATOR = ','
+
 const variableRegExp =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\w* -]+)+}})/g
+
+function splitAndJoinAroundWildcard(arr: string[]) {
+  const wildcardIndex = arr.indexOf('*')
+  return {
+    before: arr.slice(0, wildcardIndex).join('.'),
+    after: arr.slice(wildcardIndex + 1).join('.'),
+  }
+}
 
 function findAndSubstituteVariables(
   // i.e. the `key` corresponding to this variable's form field in defineAction
@@ -60,6 +71,24 @@ function findAndSubstituteVariables(
           return executionStep.stepId === stepId
         })
         const data = executionStep?.dataOut
+
+        // wildcard intent is to get values from an array in dataOut
+        if (keyPaths.includes('*')) {
+          const { before, after } = splitAndJoinAroundWildcard(keyPaths)
+          const base = get(data, before)
+
+          if (!base) {
+            return ''
+          }
+
+          const values = after
+            ? map(base as Record<string, unknown>, after)
+            : Array.isArray(base)
+            ? base
+            : [base]
+
+          return values.join(`${GET_ALL_SEPARATOR} `)
+        }
 
         const keyPath = keyPaths.join('.') // for lodash get to work
         const dataValue = get(data, keyPath)

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -1,7 +1,7 @@
 import type { IAction } from '@plumber/types'
 
-import { map } from 'lodash'
 import get from 'lodash.get'
+import map from 'lodash/map'
 
 import ExecutionStep from '@/models/execution-step'
 

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -19,8 +19,9 @@ export type VariableInfoMap = Map<
 >
 
 const VARIABLE_REGEX =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\w* -]+)+}})/
 export const GLOBAL_VARIABLE_REGEX = new RegExp(VARIABLE_REGEX, 'g')
+
 /**
  * Used to generate substituted string for hyperlink checking
  */


### PR DESCRIPTION
## TL;DR
This PR adds support for wildcard syntax in parameter computation, allowing users to use column values from find multiple rows / get table rows steps in subsequent steps.

## What changed?
- Get all values from an array: `{{step.id.arrayProp.*}}`
- Get specific properties from objects in an array: `{{step.id.arrayOfObjects.*.propertyName}}`

The implementation includes:
- Updated regex patterns to recognise wildcards in variable paths
- Added logic to handle wildcard substitution in `compute-parameters.ts`
- Comprehensive test cases for various wildcard scenarios

This enhancement provides more flexibility when working with array data in workflow steps.

## How to test?
**Setup**
* Create a Tile find multiple row step and an Excel get table rows step successfully
* Create another step e.g., Postman / Telegram / Slack

**Test**
- [ ] Use variable for column values in your action, test the step and verify that the output uses the correct values
- [ ] Update the Tile or Excel sheet, re-run the action, verify output uses the updated values


## Screenshots

[Screen Recording 2025-06-02 at 6.25.58 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/41b3b533-1ee9-4bb7-80df-1bd94edb402a.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/41b3b533-1ee9-4bb7-80df-1bd94edb402a.mov)

