### PR TITLE
chore: retry Postman SMS on Cloudflare errors

### DIFF
--- a/packages/backend/src/apps/postman-sms/__tests__/request-error-handler.test.ts
+++ b/packages/backend/src/apps/postman-sms/__tests__/request-error-handler.test.ts
@@ -73,7 +73,7 @@ describe('Postman SMS request error handler', () => {
   })
 
   describe('Other errors', () => {
-    it.each([500, 502, 503])('should retry on %s', async (status) => {
+    it.each([500, 502, 503, 520, 524])('should retry on %s', async (status) => {
       const axiosError = {
         isAxiosError: true,
         name: 'AxiosError',

--- a/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
+++ b/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
@@ -21,7 +21,7 @@ const handle429: ThrowingHandler = (_, error): never => {
   })
 }
 
-const handle500and502and503: ThrowingHandler = (_, error): never => {
+const handle5xxErrors: ThrowingHandler = (_, error): never => {
   const status = error.response.status
   throw new RetriableError({
     error: `Retrying HTTP ${status} from Postman SMS`,
@@ -40,7 +40,9 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
     case 500:
     case 502:
     case 503:
-      return handle500and502and503($, error)
+    case 520: // Cloudflare-specific error
+    case 524: // Cloudflare-specific error
+      return handle5xxErrors($, error)
     default:
       if (error.message === 'read ETIMEDOUT') {
         throw new RetriableError({


### PR DESCRIPTION
## Problem
Postman SMS actions face intermittent errors when calling the API due to 520 / 524, which are Cloudflare-specific HTTP status codes indicating issues between Cloudflare and the origin server.
current implementation leads to failures and require manual retries, when there is in fact nothing wrong with the user's set up or input data

## Solution
Enable auto-retries for postman sms when encountering 520 or 524 status codes.

## How to test?
Set up Postman SMS action first, modify to call 520 or 524 
(use https://status-codes-eight.vercel.app/api/520, since mock.codes does not have 520 or 524)
- [ ] Verify that action is retried when 520 / 524 is returned
- [ ] Verify that action fails after the default number of retries (10)
