### PR TITLE
[TILES-V2-11]: add unit and integration tests for tiles v2

### DIFF
--- a/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/create-row.itest.ts
@@ -10,87 +10,93 @@ import {
   generateMockTableRowData,
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import TableMetadata from '@/models/table-metadata'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import tiles from '../..'
 import createRowAction from '../../actions/create-row'
 
-describe('tiles create row action', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[]
-  let editor: User
-  let viewer: User
-  let $: IGlobalVariable
+describe.each([['ddb'], ['pg']])(
+  'tiles create row action: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
+    let $: IGlobalVariable
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-
-    const validData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowData = Object.keys(validData).map((columnId) => ({
-      columnId,
-      cellValue: validData[columnId],
-    }))
-
-    $ = {
-      user: context.currentUser,
-      flow: {
-        id: '123',
+      const mockTable = await generateMockTable({
         userId: context.currentUser.id,
-      },
-      step: {
-        id: '456',
-        appKey: tiles.name,
-        key: createRowAction.key,
-        position: 2,
-        parameters: {
-          tableId: dummyTable.id,
-          rowData,
-        },
-      },
-      app: {
-        name: tiles.name,
-      },
-      setActionItem: vi.fn(),
-    } as unknown as IGlobalVariable
-  })
-
-  it('should allow owners to create row', async () => {
-    await expect(createRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should allow editors to create row', async () => {
-    $.user = editor
-    await expect(createRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should not allow viewers to create row', async () => {
-    $.user = viewer
-    await expect(createRowAction.run($)).rejects.toThrow(StepError)
-  })
-
-  it('should throw correct error if Tile deleted', async () => {
-    $.user = editor
-    await TableMetadata.query()
-      .patch({
-        deletedAt: new Date().toISOString(),
+        databaseType,
       })
-      .where({ id: $.step.parameters.tableId })
-    await expect(createRowAction.run($)).rejects.toThrow(StepError)
-  })
-})
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType,
+      })
+
+      const validData = generateMockTableRowData({ columnIds: dummyColumnIds })
+      const rowData = Object.keys(validData).map((columnId) => ({
+        columnId,
+        cellValue: validData[columnId],
+      }))
+
+      $ = {
+        user: context.currentUser,
+        flow: {
+          id: '123',
+          userId: context.currentUser.id,
+        },
+        step: {
+          id: '456',
+          appKey: tiles.name,
+          key: createRowAction.key,
+          position: 2,
+          parameters: {
+            tableId: dummyTable.id,
+            rowData,
+          },
+        },
+        app: {
+          name: tiles.name,
+        },
+        setActionItem: vi.fn(),
+      } as unknown as IGlobalVariable
+    })
+
+    it('should allow owners to create row', async () => {
+      await expect(createRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
+    })
+
+    it('should allow editors to create row', async () => {
+      $.user = editor
+      await expect(createRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
+    })
+
+    it('should not allow viewers to create row', async () => {
+      $.user = viewer
+      await expect(createRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should throw correct error if Tile deleted', async () => {
+      $.user = editor
+      await TableMetadata.query()
+        .patch({
+          deletedAt: new Date().toISOString(),
+        })
+        .where({ id: $.step.parameters.tableId })
+      await expect(createRowAction.run($)).rejects.toThrow(StepError)
+    })
+  },
+)

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -11,8 +11,8 @@ import {
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow } from '@/models/tiles/dynamodb/table-row'
 import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import { getTableOperations } from '@/models/tiles/factory'
 import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
 import { DatabaseType, TableRowFilter } from '@/models/tiles/types'
 import User from '@/models/user'
@@ -70,7 +70,8 @@ describe.each([['ddb'], ['pg']])(
         columnIds: dummyColumnIds,
       })
 
-      await createTableRow({
+      const tableOperations = getTableOperations(databaseType)
+      await tableOperations.createTableRow({
         tableId: dummyTable.id,
         data: originalData,
       })

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -12,8 +12,9 @@ import {
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import { createTableRow } from '@/models/tiles/dynamodb/table-row'
-import * as tableFunctions from '@/models/tiles/dynamodb/table-row/functions'
-import { TableRowFilter } from '@/models/tiles/types'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType, TableRowFilter } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -38,126 +39,139 @@ vi.mock('@/models/step', () => ({
   },
 }))
 
-describe('tiles create row action', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[]
-  let editor: User
-  let viewer: User
-  let $: IGlobalVariable
+describe.each([['ddb'], ['pg']])(
+  'tiles create row action: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
+    let $: IGlobalVariable
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-
-    await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
-    })
-
-    $ = {
-      user: context.currentUser,
-      flow: {
-        id: '123',
+      const mockTable = await generateMockTable({
         userId: context.currentUser.id,
-      },
-      step: {
-        id: '456',
-        appKey: tiles.name,
-        key: findSingleRowAction.key,
-        position: 2,
-        parameters: {
-          tableId: dummyTable.id,
-          filters: [
-            {
-              columnId: dummyColumnIds[0],
-              operator: 'equals',
-              value: originalData[dummyColumnIds[0]],
-            },
-          ] as TableRowFilter[],
+        databaseType,
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType,
+      })
+
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+
+      $ = {
+        user: context.currentUser,
+        flow: {
+          id: '123',
+          userId: context.currentUser.id,
         },
-      },
-      app: {
-        name: tiles.name,
-      },
-      setActionItem: vi.fn(),
-    } as unknown as IGlobalVariable
-  })
-
-  it('should allow owners to find single row', async () => {
-    await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should allow editors to find single row', async () => {
-    $.user = editor
-    await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should not allow viewers to find single row', async () => {
-    $.user = viewer
-    await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
-  })
-
-  it('should throw correct error if Tile deleted', async () => {
-    $.user = editor
-    await TableMetadata.query()
-      .patch({
-        deletedAt: new Date().toISOString(),
-      })
-      .where({ id: $.step.parameters.tableId })
-    await TableColumnMetadata.query()
-      .patch({
-        deletedAt: new Date().toISOString(),
-      })
-      .where({ table_id: $.step.parameters.tableId })
-    await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
-  })
-
-  it('should call getTableRows with scan limit if exists in step config', async () => {
-    const getTableRowsSpy = vi
-      .spyOn(tableFunctions, 'getTableRows')
-      .mockResolvedValueOnce({
-        rows: [],
-        stringifiedCursor: undefined,
-      })
-    await findSingleRowAction.run($)
-    expect(getTableRowsSpy).toHaveBeenCalledWith({
-      tableId: $.step.parameters.tableId,
-      filters: $.step.parameters.filters,
-      scanLimit: 100,
-      order: 'asc',
+        step: {
+          id: '456',
+          appKey: tiles.name,
+          key: findSingleRowAction.key,
+          position: 2,
+          parameters: {
+            tableId: dummyTable.id,
+            filters: [
+              {
+                columnId: dummyColumnIds[0],
+                operator: 'equals',
+                value: originalData[dummyColumnIds[0]],
+              },
+            ] as TableRowFilter[],
+          },
+        },
+        app: {
+          name: tiles.name,
+        },
+        setActionItem: vi.fn(),
+      } as unknown as IGlobalVariable
     })
-  })
 
-  it('should call getTableRows with scan limit and order', async () => {
-    const getTableRowsSpy = vi
-      .spyOn(tableFunctions, 'getTableRows')
-      .mockResolvedValueOnce({
-        rows: [],
-        stringifiedCursor: undefined,
-      })
-    $.step.parameters.returnLastRow = true
-    await findSingleRowAction.run($)
-    expect(getTableRowsSpy).toHaveBeenCalledWith({
-      tableId: $.step.parameters.tableId,
-      filters: $.step.parameters.filters,
-      scanLimit: 100,
-      order: 'desc',
+    it('should allow owners to find single row', async () => {
+      await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
     })
-  })
-})
+
+    it('should allow editors to find single row', async () => {
+      $.user = editor
+      await expect(findSingleRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
+    })
+
+    it('should not allow viewers to find single row', async () => {
+      $.user = viewer
+      await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should throw correct error if Tile deleted', async () => {
+      $.user = editor
+      await TableMetadata.query()
+        .patch({
+          deletedAt: new Date().toISOString(),
+        })
+        .where({ id: $.step.parameters.tableId })
+      await TableColumnMetadata.query()
+        .patch({
+          deletedAt: new Date().toISOString(),
+        })
+        .where({ table_id: $.step.parameters.tableId })
+      await expect(findSingleRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should call getTableRows with scan limit if exists in step config', async () => {
+      const getTableRowsSpy = vi
+        .spyOn(
+          databaseType === 'ddb' ? ddbTableRowFunctions : pgTableRowFunctions,
+          'getTableRows',
+        )
+        .mockResolvedValueOnce({
+          rows: [],
+          stringifiedCursor: undefined,
+        })
+      await findSingleRowAction.run($)
+      expect(getTableRowsSpy).toHaveBeenCalledWith({
+        tableId: $.step.parameters.tableId,
+        filters: $.step.parameters.filters,
+        scanLimit: 100,
+        order: 'asc',
+      })
+    })
+
+    it('should call getTableRows with scan limit and order', async () => {
+      const getTableRowsSpy = vi
+        .spyOn(
+          databaseType === 'ddb' ? ddbTableRowFunctions : pgTableRowFunctions,
+          'getTableRows',
+        )
+        .mockResolvedValueOnce({
+          rows: [],
+          stringifiedCursor: undefined,
+        })
+      $.step.parameters.returnLastRow = true
+      await findSingleRowAction.run($)
+      expect(getTableRowsSpy).toHaveBeenCalledWith({
+        tableId: $.step.parameters.tableId,
+        filters: $.step.parameters.filters,
+        scanLimit: 100,
+        order: 'desc',
+      })
+    })
+  },
+)

--- a/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/find-single-row.itest.ts
@@ -40,7 +40,7 @@ vi.mock('@/models/step', () => ({
 }))
 
 describe.each([['ddb'], ['pg']])(
-  'tiles create row action: %s',
+  'tiles find single row action: %s',
   (databaseType: DatabaseType) => {
     let context: Context
     let dummyTable: TableMetadata

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -12,133 +12,147 @@ import {
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
 import { createTableRow } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import tiles from '../..'
 import updateRowAction from '../../actions/update-row'
 
-describe('tiles update row action', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[]
-  let editor: User
-  let viewer: User
-  let $: IGlobalVariable
+describe.each([['ddb'], ['pg']])(
+  'tiles update row action: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
+    let $: IGlobalVariable
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
-    })
-
-    const validData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowData = Object.keys(validData).map((columnId) => ({
-      columnId,
-      cellValue: validData[columnId],
-    }))
-
-    $ = {
-      user: context.currentUser,
-      flow: {
-        id: '123',
+      const mockTable = await generateMockTable({
         userId: context.currentUser.id,
-      },
-      step: {
-        id: '456',
-        appKey: tiles.name,
-        key: updateRowAction.key,
-        position: 2,
-        parameters: {
-          tableId: dummyTable.id,
-          rowId: rowToUpdate.rowId,
-          rowData,
-        },
-      },
-      app: {
-        name: tiles.name,
-      },
-      setActionItem: vi.fn(),
-    } as unknown as IGlobalVariable
-  })
-
-  it('should allow owners to update row', async () => {
-    await expect(updateRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should allow editors to update row', async () => {
-    $.user = editor
-    await expect(updateRowAction.run($)).resolves.toBeUndefined()
-    expect($.setActionItem).toBeCalled()
-  })
-
-  it('should not allow viewers to update row', async () => {
-    $.user = viewer
-    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
-  })
-
-  it('should throw error if no tableId', async () => {
-    $.step.parameters.tableId = ''
-    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
-  })
-
-  it('should throw correct error if Tile deleted', async () => {
-    $.user = editor
-    await TableMetadata.query()
-      .patch({
-        deletedAt: new Date().toISOString(),
+        databaseType,
       })
-      .where({ id: $.step.parameters.tableId })
-    await TableColumnMetadata.query()
-      .patch({
-        deletedAt: new Date().toISOString(),
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType,
       })
-      .where({ table_id: $.step.parameters.tableId })
-    await expect(updateRowAction.run($)).rejects.toThrow(StepError)
-  })
 
-  it('should not fail if row does not exist', async () => {
-    $.step.parameters.rowId = '123'
-    await expect(updateRowAction.run($)).resolves.not.toThrow(StepError)
-  })
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
 
-  it('should not update columns that are not in the table', async () => {
-    const data = generateMockTableRowData({
-      columnIds: dummyColumnIds,
-    })
-    const row = await createTableRow({ tableId: dummyTable.id, data })
-    $.step.parameters.rowId = row.rowId
-    $.step.parameters.rowData = [
-      { columnId: 'invalid_column', cellValue: '123' },
-      { columnId: dummyColumnIds[0], cellValue: '123' },
-    ]
-    await updateRowAction.run($)
-    expect($.setActionItem).toBeCalledWith({
-      raw: {
-        rowId: row.rowId,
-        updated: true,
-        row: {
-          ...row.data,
-          [dummyColumnIds[0]]: 123,
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+
+      const validData = generateMockTableRowData({ columnIds: dummyColumnIds })
+      const rowData = Object.keys(validData).map((columnId) => ({
+        columnId,
+        cellValue: validData[columnId],
+      }))
+
+      $ = {
+        user: context.currentUser,
+        flow: {
+          id: '123',
+          userId: context.currentUser.id,
         },
-      },
+        step: {
+          id: '456',
+          appKey: tiles.name,
+          key: updateRowAction.key,
+          position: 2,
+          parameters: {
+            tableId: dummyTable.id,
+            rowId: rowToUpdate.rowId,
+            rowData,
+          },
+        },
+        app: {
+          name: tiles.name,
+        },
+        setActionItem: vi.fn(),
+      } as unknown as IGlobalVariable
     })
-  })
-})
+
+    it('should allow owners to update row', async () => {
+      await expect(updateRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
+    })
+
+    it('should allow editors to update row', async () => {
+      $.user = editor
+      await expect(updateRowAction.run($)).resolves.toBeUndefined()
+      expect($.setActionItem).toBeCalled()
+    })
+
+    it('should not allow viewers to update row', async () => {
+      $.user = viewer
+      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should throw error if no tableId', async () => {
+      $.step.parameters.tableId = ''
+      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should throw correct error if Tile deleted', async () => {
+      $.user = editor
+      await TableMetadata.query()
+        .patch({
+          deletedAt: new Date().toISOString(),
+        })
+        .where({ id: $.step.parameters.tableId })
+      await TableColumnMetadata.query()
+        .patch({
+          deletedAt: new Date().toISOString(),
+        })
+        .where({ table_id: $.step.parameters.tableId })
+      await expect(updateRowAction.run($)).rejects.toThrow(StepError)
+    })
+
+    it('should not fail if row does not exist', async () => {
+      $.step.parameters.rowId = '123'
+      await expect(updateRowAction.run($)).resolves.not.toThrow(StepError)
+    })
+
+    it('should not update columns that are not in the table', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      const tableOperations = getTableOperations(databaseType)
+      const row = await tableOperations.createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+      $.step.parameters.rowId = row.rowId
+      $.step.parameters.rowData = [
+        { columnId: 'invalid_column', cellValue: '123' },
+        { columnId: dummyColumnIds[0], cellValue: '123' },
+      ]
+      await updateRowAction.run($)
+      expect($.setActionItem).toBeCalledWith({
+        raw: {
+          rowId: row.rowId,
+          updated: true,
+          row: {
+            ...row.data,
+            [dummyColumnIds[0]]: 123,
+          },
+        },
+      })
+    })
+  },
+)

--- a/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
+++ b/packages/backend/src/apps/tiles/__tests__/actions/update-row.itest.ts
@@ -11,7 +11,6 @@ import {
 } from '@/graphql/__tests__/mutations/tiles/table.mock'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow } from '@/models/tiles/dynamodb/table-row'
 import { getTableOperations } from '@/models/tiles/factory'
 import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
@@ -51,7 +50,8 @@ describe.each([['ddb'], ['pg']])(
         columnIds: dummyColumnIds,
       })
 
-      const rowToUpdate = await createTableRow({
+      const tableOperations = getTableOperations(databaseType)
+      const rowToUpdate = await tableOperations.createTableRow({
         tableId: dummyTable.id,
         data: originalData,
       })

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -4,6 +4,7 @@ import StepError from '@/errors/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 import {
+  autoMarshallDataObj,
   autoMarshallNumberStrings,
   stripInvalidKeys,
 } from '@/models/tiles/dynamodb/helpers'
@@ -181,7 +182,10 @@ const action: IRawAction = {
 
     const patchData = {
       ...rowData.reduce(
-        (acc, { columnId, cellValue, operator }) => {
+        (
+          acc: PatchRowInput['patchData'],
+          { columnId, cellValue, operator },
+        ) => {
           // Check that the column still exists
           if (columnIds.includes(columnId)) {
             switch (operator) {
@@ -219,7 +223,7 @@ const action: IRawAction = {
 
       $.setActionItem({
         raw: {
-          row: updatedRowData,
+          row: autoMarshallDataObj(updatedRowData),
           rowId,
           updated: true,
         } satisfies UpdateRowOutput,
@@ -227,7 +231,16 @@ const action: IRawAction = {
     } catch (e) {
       if (e instanceof Error) {
         if (e.message.includes('The conditional request failed')) {
-          // This means the corresponding row does not exist
+          // This means the corresponding row does not exist for ddb
+          $.setActionItem({
+            raw: {
+              updated: false,
+            } satisfies UpdateRowOutput,
+          })
+          return
+        }
+        if (e.message.includes('No rows to patch')) {
+          // This means the corresponding row does not exist for pg
           $.setActionItem({
             raw: {
               updated: false,

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
@@ -122,8 +122,6 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should throw an error when creating a row with invalid keys', async () => {
-      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
-
       const invalidData = generateMockTableRowData({
         columnIds: [...dummyColumnIds, 'invalid_column_id'],
       })
@@ -142,7 +140,6 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should allow collaborators with edit rights to call this function', async () => {
-      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
       context.currentUser = editor
       await expect(
         createRow(
@@ -159,7 +156,6 @@ describe.each([['ddb'], ['pg']])(
     })
 
     it('should throw an error if user does not have edit access', async () => {
-      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
       context.currentUser = viewer
       await expect(
         createRow(

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-row.itest.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import createRow from '@/graphql/mutations/tiles/create-row'
 import TableMetadata from '@/models/table-metadata'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -13,106 +16,163 @@ import {
   generateMockTableRowData,
 } from './table.mock'
 
-describe('create row mutation', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[]
-  let editor: User
-  let viewer: User
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn().mockResolvedValue('pg'),
+}))
 
-  // cant use before all here since the data is re-seeded each time
-  beforeEach(async () => {
-    context = await generateMockContext()
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
+const pgCreateTableRowSpy = vi.spyOn(pgTableRowFunctions, 'createTableRow')
+const ddbCreateTableRowSpy = vi.spyOn(ddbTableRowFunctions, 'createTableRow')
+
+describe.each([['ddb'], ['pg']])(
+  'create row mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
+
+    // cant use before all here since the data is re-seeded each time
+    beforeEach(async () => {
+      context = await generateMockContext()
+
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType,
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType,
+      })
+
+      pgCreateTableRowSpy.mockClear()
+      ddbCreateTableRowSpy.mockClear()
     })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
 
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-  })
+    it('should create an empty row in a given table', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
 
-  it('should create an empty row in a given table', async () => {
-    const row = await createRow(
-      null,
-      {
-        input: {
+      const row = await createRow(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            data: {},
+          },
+        },
+        context,
+      )
+      expect(row).toBeDefined()
+
+      if (databaseType === 'pg') {
+        expect(pgCreateTableRowSpy).toHaveBeenCalledWith({
           tableId: dummyTable.id,
           data: {},
-        },
-      },
-      context,
-    )
-    expect(row).toBeDefined()
-  })
+        })
+        expect(ddbCreateTableRowSpy).not.toHaveBeenCalled()
+      } else {
+        expect(ddbCreateTableRowSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          data: {},
+        })
+        expect(pgCreateTableRowSpy).not.toHaveBeenCalled()
+      }
+    })
 
-  it('should create a row with valid keys in a given table', async () => {
-    const validData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const row = await createRow(
-      null,
-      {
-        input: {
+    it('should create a row with valid keys in a given table', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+
+      const validData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const row = await createRow(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            data: validData,
+          },
+        },
+        context,
+      )
+      expect(row).toBeDefined()
+
+      if (databaseType === 'pg') {
+        expect(pgCreateTableRowSpy).toHaveBeenCalledWith({
           tableId: dummyTable.id,
           data: validData,
-        },
-      },
-      context,
-    )
-    expect(row).toBeDefined()
-  })
-
-  it('should throw an error when creating a row with invalid keys', async () => {
-    const invalidData = generateMockTableRowData({
-      columnIds: [...dummyColumnIds, 'invalid_column_id'],
+        })
+        expect(ddbCreateTableRowSpy).not.toHaveBeenCalled()
+      } else {
+        expect(ddbCreateTableRowSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          data: validData,
+        })
+        expect(pgCreateTableRowSpy).not.toHaveBeenCalled()
+      }
     })
-    await expect(
-      createRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            data: invalidData,
-          },
-        },
-        context,
-      ),
-    ).rejects.toThrow()
-  })
 
-  it('should allow collaborators with edit rights to call this function', async () => {
-    context.currentUser = editor
-    await expect(
-      createRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            data: {},
-          },
-        },
-        context,
-      ),
-    ).resolves.toBeDefined()
-  })
+    it('should throw an error when creating a row with invalid keys', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
 
-  it('should throw an error if user does not have edit access', async () => {
-    context.currentUser = viewer
-    await expect(
-      createRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            data: {},
+      const invalidData = generateMockTableRowData({
+        columnIds: [...dummyColumnIds, 'invalid_column_id'],
+      })
+      await expect(
+        createRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              data: invalidData,
+            },
           },
-        },
-        context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-})
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should allow collaborators with edit rights to call this function', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+      context.currentUser = editor
+      await expect(
+        createRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              data: {},
+            },
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+    })
+
+    it('should throw an error if user does not have edit access', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+      context.currentUser = viewer
+      await expect(
+        createRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              data: {},
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-rows.itest.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import createRows from '@/graphql/mutations/tiles/create-rows'
 import TableMetadata from '@/models/table-metadata'
-import { getTableRows } from '@/models/tiles/dynamodb/table-row/functions'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -14,111 +16,153 @@ import {
   generateMockTableRowData,
 } from './table.mock'
 
-describe('create row mutation', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[] = []
-  let editor: User
-  let viewer: User
+const pgCreateTableRowsSpy = vi.spyOn(pgTableRowFunctions, 'createTableRows')
+const ddbCreateTableRowsSpy: ReturnType<typeof vi.spyOn> = vi.spyOn(
+  ddbTableRowFunctions,
+  'createTableRows',
+)
 
-  // cant use before all here since the data is re-seeded each time
-  beforeEach(async () => {
-    context = await generateMockContext()
+describe.each([['pg'], ['ddb']])(
+  'create rows mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
+    // cant use before all here since the data is re-seeded each time
+    beforeEach(async () => {
+      context = await generateMockContext()
+
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+
+      pgCreateTableRowsSpy.mockClear()
+      ddbCreateTableRowsSpy.mockClear()
     })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
 
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-  })
+    it('should create a large number of rows', async () => {
+      const NUM_ROWS = 5000
+      const dataArray = []
+      for (let i = 0; i < NUM_ROWS; i++) {
+        dataArray.push(generateMockTableRowData({ columnIds: dummyColumnIds }))
+      }
 
-  it('should create a large number of rows', async () => {
-    const NUM_ROWS = 5000
-    const dataArray = []
-    for (let i = 0; i < NUM_ROWS; i++) {
-      dataArray.push(generateMockTableRowData({ columnIds: dummyColumnIds }))
-    }
-
-    await createRows(
-      null,
-      {
-        input: {
-          tableId: dummyTable.id,
-          dataArray,
-        },
-      },
-      context,
-    )
-
-    const { rows } = await getTableRows({
-      tableId: dummyTable.id,
-      columnIds: dummyColumnIds,
-    })
-    expect(rows).toHaveLength(NUM_ROWS)
-  })
-
-  it('should maintain order of rows', async () => {
-    const NUM_ROWS = 10
-    const dataArray = []
-    for (let i = 0; i < NUM_ROWS; i++) {
-      dataArray.push(generateMockTableRowData({ columnIds: dummyColumnIds }))
-    }
-
-    await createRows(
-      null,
-      {
-        input: {
-          tableId: dummyTable.id,
-          dataArray,
-        },
-      },
-      context,
-    )
-
-    const { rows } = await getTableRows({
-      tableId: dummyTable.id,
-      columnIds: dummyColumnIds,
-    })
-    expect(rows.map((row) => row.data[dummyColumnIds[0]])).toEqual(
-      dataArray.map((data) => data[dummyColumnIds[0]]),
-    )
-  })
-
-  it('should allow collaborators with edit rights to call this function', async () => {
-    context.currentUser = editor
-    await expect(
-      createRows(
+      await createRows(
         null,
         {
           input: {
             tableId: dummyTable.id,
-            dataArray: [{}],
+            dataArray,
           },
         },
         context,
-      ),
-    ).resolves.toBeDefined()
-  })
+      )
 
-  it('should throw an error if user does not have edit access', async () => {
-    context.currentUser = viewer
-    await expect(
-      createRows(
+      if (databaseType === 'pg') {
+        expect(pgCreateTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+        expect(ddbCreateTableRowsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(ddbCreateTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+        expect(pgCreateTableRowsSpy).not.toHaveBeenCalled()
+      }
+    })
+
+    it('should maintain order of rows', async () => {
+      const NUM_ROWS = 10
+      const dataArray = []
+      for (let i = 0; i < NUM_ROWS; i++) {
+        dataArray.push(generateMockTableRowData({ columnIds: dummyColumnIds }))
+      }
+
+      await createRows(
         null,
         {
           input: {
             tableId: dummyTable.id,
-            dataArray: [{}],
+            dataArray,
           },
         },
         context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-})
+      )
+
+      if (databaseType === 'pg') {
+        expect(pgCreateTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+        expect(ddbCreateTableRowsSpy).not.toHaveBeenCalled()
+        const result = await pgTableRowFunctions.getTableRows({
+          tableId: dummyTable.id,
+          columnIds: dummyColumnIds,
+        })
+        expect(result.rows.map((row) => row.data[dummyColumnIds[0]])).toEqual(
+          dataArray.map((data) => data[dummyColumnIds[0]]),
+        )
+      } else {
+        expect(ddbCreateTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+        expect(pgCreateTableRowsSpy).not.toHaveBeenCalled()
+        const result = await ddbTableRowFunctions.getTableRows({
+          tableId: dummyTable.id,
+          columnIds: dummyColumnIds,
+        })
+        expect(result.rows.map((row) => row.data[dummyColumnIds[0]])).toEqual(
+          dataArray.map((data) => data[dummyColumnIds[0]]),
+        )
+      }
+    })
+
+    it('should allow collaborators with edit rights to call this function', async () => {
+      context.currentUser = editor
+      await expect(
+        createRows(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              dataArray: [{}],
+            },
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+    })
+
+    it('should throw an error if user does not have edit access', async () => {
+      context.currentUser = viewer
+      await expect(
+        createRows(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              dataArray: [{}],
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -1,19 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import createTable from '@/graphql/mutations/tiles/create-table'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableFunctions from '@/models/tiles/pg/table-functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './table.mock'
-import { checkIfTableExists } from './tiles-pg-helper.mock'
+import { checkIfTableExists } from './tiles-pg-helper'
+
+const pgCreateTableSpy = vi.spyOn(pgTableFunctions, 'createTable')
+const pgCreateTableRowsSpy = vi.spyOn(pgTableRowFunctions, 'createTableRows')
+const ddbCreateTableRowsSpy = vi.spyOn(ddbTableRowFunctions, 'createTableRows')
 
 const mocks = vi.hoisted(() => ({
-  getTableOperations: {
-    createTable: vi.fn().mockResolvedValue(undefined),
-    createTableRows: vi
-      .fn()
-      .mockResolvedValue(['row1', 'row2', 'row3', 'row4', 'row5']),
-    getTableRowCount: vi.fn().mockResolvedValue(5),
-  },
   getLdFlagValue: vi.fn().mockResolvedValue('pg'),
 }))
 
@@ -21,23 +22,21 @@ vi.mock('@/helpers/launch-darkly', () => ({
   getLdFlagValue: mocks.getLdFlagValue,
 }))
 
-vi.mock('@/models/tiles/factory', () => ({
-  getTableOperations: vi.fn(() => mocks.getTableOperations),
-}))
+describe.each([['pg'], ['ddb']])(
+  'create table mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
 
-describe('create table mutation', () => {
-  let context: Context
+    // cant use before all here since the data is re-seeded each time
+    beforeEach(async () => {
+      context = await generateMockContext()
+      pgCreateTableSpy.mockClear()
+      pgCreateTableRowsSpy.mockClear()
+      ddbCreateTableRowsSpy.mockClear()
+    })
 
-  // cant use before all here since the data is re-seeded each time
-  beforeEach(async () => {
-    context = await generateMockContext()
-  })
-
-  it.each([['pg'], ['ddb']])(
-    `should create a blank table: %s`,
-    async (databaseType) => {
+    it('should create a blank table', async () => {
       mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
-
       const table = await createTable(
         null,
         { input: { name: 'Test Table', isBlank: true } },
@@ -46,52 +45,54 @@ describe('create table mutation', () => {
       const tableColumnCount = await table.$relatedQuery('columns').resultSize()
       expect(table.name).toBe('Test Table')
       expect(tableColumnCount).toBe(0)
-      expect(mocks.getTableOperations.createTableRows).not.toHaveBeenCalled()
-      expect(mocks.getTableOperations.createTable).toHaveBeenCalledWith(
-        table.id,
-        [],
-      )
-
+      expect(pgCreateTableRowsSpy).not.toHaveBeenCalled()
+      expect(ddbCreateTableRowsSpy).not.toHaveBeenCalled()
       if (databaseType === 'pg') {
+        expect(pgCreateTableSpy).toHaveBeenCalledWith(table.id, [])
+        // we check if the table is actually created here
         expect(await checkIfTableExists(table.id)).toBe(true)
       }
-    },
-  )
-
-  it('should create a table and with placeholder rows and columns', async () => {
-    const table = await createTable(
-      null,
-      { input: { name: 'Test Table', isBlank: false } },
-      context,
-    )
-    const tableColumnCount = await table.$relatedQuery('columns').resultSize()
-    expect(table.name).toBe('Test Table')
-    expect(tableColumnCount).toBe(3)
-    expect(mocks.getTableOperations.createTableRows).toHaveBeenCalledWith({
-      tableId: table.id,
-      dataArray: new Array(5).fill({}),
     })
-  })
 
-  it('should be able create tables with the same name', async () => {
-    const table = await createTable(
-      null,
-      { input: { name: 'Test Table', isBlank: false } },
-      context,
-    )
+    it('should create a table and with placeholder rows and columns', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+      const table = await createTable(
+        null,
+        { input: { name: 'Test Table', isBlank: false } },
+        context,
+      )
+      const tableColumnCount = await table.$relatedQuery('columns').resultSize()
+      expect(table.name).toBe('Test Table')
+      expect(tableColumnCount).toBe(3)
 
-    const table2 = await createTable(
-      null,
-      { input: { name: 'Test Table', isBlank: false } },
-      context,
-    )
-    expect(table.name).toBe('Test Table')
-    expect(table2.name).toBe('Test Table')
-  })
+      expect(
+        databaseType === 'pg' ? pgCreateTableRowsSpy : ddbCreateTableRowsSpy,
+      ).toHaveBeenCalledWith({
+        tableId: table.id,
+        dataArray: new Array(5).fill({}),
+      })
+    })
 
-  it('should throw an error when table name is empty', async () => {
-    await expect(
-      createTable(null, { input: { name: '', isBlank: false } }, context),
-    ).rejects.toThrow()
-  })
-})
+    it('should be able create tables with the same name', async () => {
+      const table = await createTable(
+        null,
+        { input: { name: 'Test Table', isBlank: false } },
+        context,
+      )
+
+      const table2 = await createTable(
+        null,
+        { input: { name: 'Test Table', isBlank: false } },
+        context,
+      )
+      expect(table.name).toBe('Test Table')
+      expect(table2.name).toBe('Test Table')
+    })
+
+    it('should throw an error when table name is empty', async () => {
+      await expect(
+        createTable(null, { input: { name: '', isBlank: false } }, context),
+      ).rejects.toThrow()
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -1,13 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import createTable from '@/graphql/mutations/tiles/create-table'
-import { getTableRowCount } from '@/models/tiles/dynamodb/table-row'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './table.mock'
+import { checkIfTableExists } from './tiles-pg-helper.mock'
+
+const mocks = vi.hoisted(() => ({
+  getTableOperations: {
+    createTable: vi.fn().mockResolvedValue(undefined),
+    createTableRows: vi
+      .fn()
+      .mockResolvedValue(['row1', 'row2', 'row3', 'row4', 'row5']),
+    getTableRowCount: vi.fn().mockResolvedValue(5),
+  },
+  getLdFlagValue: vi.fn().mockResolvedValue('pg'),
+}))
 
 vi.mock('@/helpers/launch-darkly', () => ({
-  getLdFlagValue: vi.fn().mockResolvedValue('ddb'),
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
+vi.mock('@/models/tiles/factory', () => ({
+  getTableOperations: vi.fn(() => mocks.getTableOperations),
 }))
 
 describe('create table mutation', () => {
@@ -18,18 +33,30 @@ describe('create table mutation', () => {
     context = await generateMockContext()
   })
 
-  it('should create a blank table', async () => {
-    const table = await createTable(
-      null,
-      { input: { name: 'Test Table', isBlank: true } },
-      context,
-    )
-    const tableColumnCount = await table.$relatedQuery('columns').resultSize()
-    expect(table.name).toBe('Test Table')
-    expect(tableColumnCount).toBe(0)
-    const rowCount = await getTableRowCount({ tableId: table.id })
-    expect(rowCount).toBe(0)
-  })
+  it.each([['pg'], ['ddb']])(
+    `should create a blank table: %s`,
+    async (databaseType) => {
+      mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+
+      const table = await createTable(
+        null,
+        { input: { name: 'Test Table', isBlank: true } },
+        context,
+      )
+      const tableColumnCount = await table.$relatedQuery('columns').resultSize()
+      expect(table.name).toBe('Test Table')
+      expect(tableColumnCount).toBe(0)
+      expect(mocks.getTableOperations.createTableRows).not.toHaveBeenCalled()
+      expect(mocks.getTableOperations.createTable).toHaveBeenCalledWith(
+        table.id,
+        [],
+      )
+
+      if (databaseType === 'pg') {
+        expect(await checkIfTableExists(table.id)).toBe(true)
+      }
+    },
+  )
 
   it('should create a table and with placeholder rows and columns', async () => {
     const table = await createTable(
@@ -40,8 +67,10 @@ describe('create table mutation', () => {
     const tableColumnCount = await table.$relatedQuery('columns').resultSize()
     expect(table.name).toBe('Test Table')
     expect(tableColumnCount).toBe(3)
-    const rowCount = await getTableRowCount({ tableId: table.id })
-    expect(rowCount).toBe(5)
+    expect(mocks.getTableOperations.createTableRows).toHaveBeenCalledWith({
+      tableId: table.id,
+      dataArray: new Array(5).fill({}),
+    })
   })
 
   it('should be able create tables with the same name', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-rows.itest.ts
@@ -1,12 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteRows from '@/graphql/mutations/tiles/delete-rows'
 import TableMetadata from '@/models/table-metadata'
-import {
-  createTableRows,
-  getTableRowCount,
-} from '@/models/tiles/dynamodb/table-row'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -17,93 +16,175 @@ import {
   generateMockTableRowData,
 } from './table.mock'
 
+const pgDeleteTableRowsSpy = vi.spyOn(pgTableRowFunctions, 'deleteTableRows')
+const ddbDeleteTableRowsSpy = vi.spyOn(ddbTableRowFunctions, 'deleteTableRows')
+
 const NUM_ROWS_TO_GENERATE = 35
-describe('delete rows mutation', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let rowIds: string[] = []
-  let editor: User
-  let viewer: User
+describe.each([['pg'], ['ddb']])(
+  'delete rows mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let rowIds: string[] = []
+    let editor: User
+    let viewer: User
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      const columnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+
+      // populate with rows
+      const dataArray = new Array(NUM_ROWS_TO_GENERATE)
+        .fill(null)
+        .map(() => generateMockTableRowData({ columnIds }))
+
+      if (databaseType === 'ddb') {
+        rowIds = await ddbTableRowFunctions.createTableRows({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+      } else {
+        rowIds = await pgTableRowFunctions.createTableRows({
+          tableId: dummyTable.id,
+          dataArray,
+        })
+      }
+
+      pgDeleteTableRowsSpy.mockClear()
+      ddbDeleteTableRowsSpy.mockClear()
     })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
 
-    const columnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
+    it('should delete rows with given ids', async () => {
+      const slicedRows = rowIds.slice(0, 5)
 
-    // populate with some rows
-    const dataArray = new Array(NUM_ROWS_TO_GENERATE)
-      .fill(null)
-      .map(() => generateMockTableRowData({ columnIds }))
-    rowIds = await createTableRows({ tableId: dummyTable.id, dataArray })
-  })
-
-  it('should delete rows with given ids', async () => {
-    const slicedRows = rowIds.slice(0, 5)
-    const success = await deleteRows(
-      null,
-      { input: { tableId: dummyTable.id, rowIds: slicedRows } },
-      context,
-    )
-    expect(success).toEqual(slicedRows)
-    const count = await getTableRowCount({ tableId: dummyTable.id })
-
-    expect(count).toEqual(NUM_ROWS_TO_GENERATE - 5)
-  })
-
-  it('should be able to delete more than 25 rows', async () => {
-    const success = await deleteRows(
-      null,
-      { input: { tableId: dummyTable.id, rowIds } },
-      context,
-    )
-    const count = await getTableRowCount({ tableId: dummyTable.id })
-    expect(success).toEqual(rowIds)
-
-    expect(count).toEqual(0)
-  })
-
-  it('should not throw an error if row id does not exist', async () => {
-    const invalidRowIds = ['invalid row id 123', 'invalid row id 456']
-    await expect(
-      deleteRows(
-        null,
-        { input: { tableId: dummyTable.id, rowIds: invalidRowIds } },
-        context,
-      ),
-    ).resolves.toEqual(invalidRowIds)
-  })
-
-  it('should allow collaborators with edit rights to call this function', async () => {
-    context.currentUser = editor
-    const slicedRows = rowIds.slice(0, 5)
-    await expect(
-      deleteRows(
+      const success = await deleteRows(
         null,
         { input: { tableId: dummyTable.id, rowIds: slicedRows } },
         context,
-      ),
-    ).resolves.toEqual(slicedRows)
-  })
+      )
+      expect(success).toEqual(slicedRows)
 
-  it('should throw an error if user does not have edit access', async () => {
-    context.currentUser = viewer
-    const slicedRows = rowIds.slice(0, 5)
-    await expect(
-      deleteRows(
+      if (databaseType === 'pg') {
+        expect(pgDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds: slicedRows,
+        })
+        expect(ddbDeleteTableRowsSpy).not.toHaveBeenCalled()
+
+        const count = await pgTableRowFunctions.getTableRowCount({
+          tableId: dummyTable.id,
+        })
+        expect(count).toEqual(NUM_ROWS_TO_GENERATE - 5)
+      } else {
+        expect(ddbDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds: slicedRows,
+        })
+        expect(pgDeleteTableRowsSpy).not.toHaveBeenCalled()
+
+        const count = await ddbTableRowFunctions.getTableRowCount({
+          tableId: dummyTable.id,
+        })
+        expect(count).toEqual(NUM_ROWS_TO_GENERATE - 5)
+      }
+    })
+
+    it('should be able to delete more than 25 rows', async () => {
+      const success = await deleteRows(
         null,
-        { input: { tableId: dummyTable.id, rowIds: slicedRows } },
+        { input: { tableId: dummyTable.id, rowIds } },
         context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-})
+      )
+      expect(success).toEqual(rowIds)
+
+      if (databaseType === 'pg') {
+        expect(pgDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds,
+        })
+        expect(ddbDeleteTableRowsSpy).not.toHaveBeenCalled()
+
+        const count = await pgTableRowFunctions.getTableRowCount({
+          tableId: dummyTable.id,
+        })
+        expect(count).toEqual(0)
+      } else {
+        expect(ddbDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds,
+        })
+        expect(pgDeleteTableRowsSpy).not.toHaveBeenCalled()
+
+        const count = await ddbTableRowFunctions.getTableRowCount({
+          tableId: dummyTable.id,
+        })
+        expect(count).toEqual(0)
+      }
+    })
+
+    it('should not throw an error if row id does not exist', async () => {
+      const invalidRowIds = ['invalid row id 123', 'invalid row id 456']
+
+      await expect(
+        deleteRows(
+          null,
+          { input: { tableId: dummyTable.id, rowIds: invalidRowIds } },
+          context,
+        ),
+      ).resolves.toEqual(invalidRowIds)
+
+      if (databaseType === 'pg') {
+        expect(pgDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds: invalidRowIds,
+        })
+        expect(ddbDeleteTableRowsSpy).not.toHaveBeenCalled()
+      } else {
+        expect(ddbDeleteTableRowsSpy).toHaveBeenCalledWith({
+          tableId: dummyTable.id,
+          rowIds: invalidRowIds,
+        })
+        expect(pgDeleteTableRowsSpy).not.toHaveBeenCalled()
+      }
+    })
+
+    it('should allow collaborators with edit rights to call this function', async () => {
+      const slicedRows = rowIds.slice(0, 5)
+
+      context.currentUser = editor
+      await expect(
+        deleteRows(
+          null,
+          { input: { tableId: dummyTable.id, rowIds: slicedRows } },
+          context,
+        ),
+      ).resolves.toEqual(slicedRows)
+    })
+
+    it('should throw an error if user does not have edit access', async () => {
+      const slicedRows = rowIds.slice(0, 5)
+
+      context.currentUser = viewer
+      await expect(
+        deleteRows(
+          null,
+          { input: { tableId: dummyTable.id, rowIds: slicedRows } },
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table-collaborator.itest.ts
@@ -22,6 +22,7 @@ describe('delete table collaborators', () => {
 
     const mockTable = await generateMockTable({
       userId: context.currentUser.id,
+      databaseType: 'ddb',
     })
     dummyTable = mockTable.table
     editor = mockTable.editor

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/delete-table.itest.ts
@@ -5,6 +5,7 @@ import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteTable from '@/graphql/mutations/tiles/delete-table'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -14,46 +15,72 @@ import {
   generateMockTableColumns,
 } from './table.mock'
 
-describe('delete table mutation', () => {
+describe.each([['ddb'], ['pg']])(
+  'delete table mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let editor: User
+    let viewer: User
+
+    beforeEach(async () => {
+      context = await generateMockContext()
+
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 2,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+    })
+
+    it('should delete table, columns and collaborators', async () => {
+      const success = await deleteTable(
+        null,
+        { input: { id: dummyTable.id } },
+        context,
+      )
+      const tableColumnCount = await dummyTable
+        .$relatedQuery('columns')
+        .resultSize()
+
+      const deletedTable = await TableMetadata.query().findById(dummyTable.id)
+      const tableCollaborators = await TableCollaborator.query().where({
+        table_id: dummyTable.id,
+      })
+      expect(success).toBe(true)
+      expect(deletedTable).toBeUndefined()
+      expect(tableColumnCount).toBe(0)
+      expect(tableCollaborators.length).toBe(0)
+    })
+
+    it('should throw an error if user is not the owner', async () => {
+      context.currentUser = editor
+      await expect(
+        deleteTable(null, { input: { id: dummyTable.id } }, context),
+      ).rejects.toThrow(ForbiddenError)
+
+      context.currentUser = viewer
+      await expect(
+        deleteTable(null, { input: { id: dummyTable.id } }, context),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  },
+)
+
+// Tests that don't need to be run for each database type
+describe('delete table mutation - general tests', () => {
   let context: Context
-  let dummyTable: TableMetadata
-  let editor: User
-  let viewer: User
 
   beforeEach(async () => {
     context = await generateMockContext()
-
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-
-    await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 2,
-    })
-  })
-
-  it('should delete table, columns and collaborators', async () => {
-    const success = await deleteTable(
-      null,
-      { input: { id: dummyTable.id } },
-      context,
-    )
-    const tableColumnCount = await dummyTable
-      .$relatedQuery('columns')
-      .resultSize()
-
-    const deletedTable = await TableMetadata.query().findById(dummyTable.id)
-    const tableCollaborators = await TableCollaborator.query().where({
-      table_id: dummyTable.id,
-    })
-    expect(success).toBe(true)
-    expect(deletedTable).toBeUndefined()
-    expect(tableColumnCount).toBe(0)
-    expect(tableCollaborators.length).toBe(0)
   })
 
   it('should throw an error if table is not found', async () => {
@@ -64,17 +91,5 @@ describe('delete table mutation', () => {
     )
 
     await expect(deleteTableAction).rejects.toThrow()
-  })
-
-  it('should throw an error if user is not the owner', async () => {
-    context.currentUser = editor
-    await expect(
-      deleteTable(null, { input: { id: dummyTable.id } }, context),
-    ).rejects.toThrow(ForbiddenError)
-
-    context.currentUser = viewer
-    await expect(
-      deleteTable(null, { input: { id: dummyTable.id } }, context),
-    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/table.mock.ts
@@ -4,6 +4,9 @@ import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
+import { createTableColumns } from '@/models/tiles/pg/table-column-functions'
+import { createTable } from '@/models/tiles/pg/table-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -18,8 +21,10 @@ export async function generateMockContext(): Promise<Context> {
 
 export async function generateMockTable({
   userId,
+  databaseType,
 }: {
   userId: string
+  databaseType: DatabaseType
 }): Promise<{
   table: TableMetadata
   owner: User
@@ -32,6 +37,7 @@ export async function generateMockTable({
   const table = await currentUser.$relatedQuery('tables').insert({
     name: 'Test Table',
     role: 'owner',
+    db: databaseType,
   })
   await TableCollaborator.query().insert([
     {
@@ -45,6 +51,11 @@ export async function generateMockTable({
       role: 'viewer',
     },
   ])
+
+  if (databaseType === 'pg') {
+    await createTable(table.id, [])
+  }
+
   return {
     table,
     owner: currentUser,
@@ -106,9 +117,11 @@ export async function generateMockStep({
 export async function generateMockTableColumns({
   tableId,
   numColumns = 5,
+  databaseType,
 }: {
   tableId: string
   numColumns?: number
+  databaseType: DatabaseType
 }): Promise<string[]> {
   const promises = []
   for (let i = 0; i < numColumns; i++) {
@@ -123,7 +136,11 @@ export async function generateMockTableColumns({
       }),
     )
   }
-  return (await Promise.all(promises)).map((column) => column.id)
+  const columnIds = (await Promise.all(promises)).map((column) => column.id)
+  if (databaseType === 'pg') {
+    await createTableColumns(tableId, columnIds)
+  }
+  return columnIds
 }
 
 export function generateMockTableRowData({

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.mock.ts
@@ -1,0 +1,5 @@
+import { tilesClient } from '@/config/tiles-database'
+
+export async function checkIfTableExists(tableId: string) {
+  return tilesClient.schema.hasTable(tableId)
+}

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.ts
@@ -10,3 +10,7 @@ export async function checkIfTableHasColumn(
 ) {
   return tilesClient.schema.hasColumn(tableId, columnName)
 }
+
+export async function selectAllRows(tableId: string) {
+  return tilesClient(tableId).select('*')
+}

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/tiles-pg-helper.ts
@@ -3,3 +3,10 @@ import { tilesClient } from '@/config/tiles-database'
 export async function checkIfTableExists(tableId: string) {
   return tilesClient.schema.hasTable(tableId)
 }
+
+export async function checkIfTableHasColumn(
+  tableId: string,
+  columnName: string,
+) {
+  return tilesClient.schema.hasColumn(tableId, columnName)
+}

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-row.itest.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import updateRow from '@/graphql/mutations/tiles/update-row'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow, TableRow } from '@/models/tiles/dynamodb/table-row'
+import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
+import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -14,103 +16,131 @@ import {
   generateMockTableRowData,
 } from './table.mock'
 
-describe('update row mutation', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[] = []
-  let editor: User
-  let viewer: User
+const pgUpdateRowSpy = vi.spyOn(pgTableRowFunctions, 'updateTableRow')
+const ddbUpdateRowSpy = vi.spyOn(ddbTableRowFunctions, 'updateTableRow')
 
-  // cant use before all here since the data is re-seeded each time
-  beforeEach(async () => {
-    context = await generateMockContext()
+describe.each([['ddb'], ['pg']])(
+  'update row mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[]
+    let editor: User
+    let viewer: User
+    let createTableRow:
+      | typeof pgTableRowFunctions.createTableRow
+      | typeof ddbTableRowFunctions.createTableRow
+    let getRawRowById:
+      | typeof pgTableRowFunctions.getRawRowById
+      | typeof ddbTableRowFunctions.getRawRowById
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
+    // cant use before all here since the data is re-seeded each time
+    beforeEach(async () => {
+      context = await generateMockContext()
+
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+
+      dummyColumnIds = await generateMockTableColumns({
+        tableId: dummyTable.id,
+        numColumns: 5,
+        databaseType: databaseType as 'ddb' | 'pg',
+      })
+
+      createTableRow =
+        databaseType === 'ddb'
+          ? ddbTableRowFunctions.createTableRow
+          : pgTableRowFunctions.createTableRow
+
+      getRawRowById =
+        databaseType === 'ddb'
+          ? ddbTableRowFunctions.getRawRowById
+          : pgTableRowFunctions.getRawRowById
+
+      pgUpdateRowSpy.mockClear()
+      ddbUpdateRowSpy.mockClear()
     })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
 
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-  })
+    it('should update a row in a given table', async () => {
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
 
-  it('should update a row in a given table', async () => {
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
 
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
-    })
+      const originalRow = await getRawRowById({
+        rowId: rowToUpdate.rowId,
+        tableId: dummyTable.id,
+        columnIds: dummyColumnIds,
+        includeTimestamps: true,
+      })
 
-    const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
+      const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
 
-    const updatedId = await updateRow(
-      null,
-      {
-        input: {
+      const updatedId = await updateRow(
+        null,
+        {
+          input: {
+            tableId: dummyTable.id,
+            rowId: rowToUpdate.rowId,
+            data: newData,
+          },
+        },
+        context,
+      )
+
+      const updatedRow = await getRawRowById({
+        rowId: rowToUpdate.rowId,
+        tableId: dummyTable.id,
+        columnIds: dummyColumnIds,
+        includeTimestamps: true,
+      })
+      expect(updatedId).toBe(rowToUpdate.rowId)
+      expect(updatedRow.data).toEqual(newData)
+      // check that createdAt does not change
+      if ('createdAt' in updatedRow && 'createdAt' in originalRow) {
+        expect(Number(updatedRow.createdAt)).toEqual(
+          Number(originalRow.createdAt),
+        )
+      }
+
+      if (databaseType === 'pg') {
+        expect(pgUpdateRowSpy).toHaveBeenCalledWith({
           tableId: dummyTable.id,
           rowId: rowToUpdate.rowId,
           data: newData,
-        },
-      },
-      context,
-    )
-    const { data: updatedRow } = await TableRow.get({
-      rowId: rowToUpdate.rowId,
-      tableId: dummyTable.id,
-    }).go()
-    expect(updatedId).toBe(rowToUpdate.rowId)
-    expect(updatedRow.data).toEqual(newData)
-    // check that createdAt does not change
-    expect(Number(updatedRow.createdAt)).toEqual(Number(rowToUpdate.createdAt))
-  })
-
-  it('should remove keys that are not specified in the updated data (not a patch operation)', async () => {
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
-    })
-
-    const newData = generateMockTableRowData({
-      columnIds: dummyColumnIds.slice(2),
-    })
-    const updatedId = await updateRow(
-      null,
-      {
-        input: {
+        })
+      } else {
+        expect(ddbUpdateRowSpy).toHaveBeenCalledWith({
           tableId: dummyTable.id,
           rowId: rowToUpdate.rowId,
           data: newData,
-        },
-      },
-      context,
-    )
-
-    const { data: updatedRow } = await TableRow.get({
-      rowId: rowToUpdate.rowId,
-      tableId: dummyTable.id,
-    }).go()
-    expect(updatedId).toBe(rowToUpdate.rowId)
-    expect(updatedRow.data).toEqual(newData)
-  })
-
-  it('should throw an error if it tries to update a row with new invalid keys', async () => {
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
+        })
+      }
     })
 
-    const newData = generateMockTableRowData({
-      columnIds: [...dummyColumnIds, 'invalid_column'],
-    })
-    await expect(
-      updateRow(
+    it('should set keys that are not specified in the updated data to null(not a patch operation)', async () => {
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+
+      const newData = generateMockTableRowData({
+        columnIds: dummyColumnIds.slice(2),
+      })
+      const updatedId = await updateRow(
         null,
         {
           input: {
@@ -120,72 +150,124 @@ describe('update row mutation', () => {
           },
         },
         context,
-      ),
-    ).rejects.toThrow()
-  })
+      )
 
-  it('should throw an error if row id is not found', async () => {
-    await expect(
-      updateRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            rowId: 'random row id',
-            data: {},
-          },
-        },
-        context,
-      ),
-    ).rejects.toThrow()
-  })
-
-  it('should allow collaborators with edit rights to call this function', async () => {
-    context.currentUser = editor
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
-    })
-    const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
-
-    await expect(
-      updateRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            rowId: rowToUpdate.rowId,
-            data: newData,
-          },
-        },
-        context,
-      ),
-    ).resolves.toEqual(rowToUpdate.rowId)
-  })
-
-  it('should throw an error if user does not have edit access', async () => {
-    context.currentUser = viewer
-    const originalData = generateMockTableRowData({ columnIds: dummyColumnIds })
-    const rowToUpdate = await createTableRow({
-      tableId: dummyTable.id,
-      data: originalData,
+      const { data: updatedRowData } = await getRawRowById({
+        rowId: rowToUpdate.rowId,
+        tableId: dummyTable.id,
+        columnIds: dummyColumnIds,
+      })
+      expect(updatedId).toBe(rowToUpdate.rowId)
+      for (const column of dummyColumnIds.slice(0, 2)) {
+        expect(updatedRowData[column]).toBeNull()
+      }
     })
 
-    const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
+    it('should throw an error if it tries to update a row with new invalid keys', async () => {
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
 
-    await expect(
-      updateRow(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            rowId: rowToUpdate.rowId,
-            data: newData,
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+
+      const newData = generateMockTableRowData({
+        columnIds: [...dummyColumnIds, 'invalid_column'],
+      })
+      await expect(
+        updateRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              rowId: rowToUpdate.rowId,
+              data: newData,
+            },
           },
-        },
-        context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-})
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should throw an error if row id is not found', async () => {
+      await expect(
+        updateRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              rowId: 'random row id',
+              data: {},
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should allow collaborators with edit rights to call this function', async () => {
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: {},
+      })
+      const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
+
+      await expect(
+        updateRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              rowId: rowToUpdate.rowId,
+              data: newData,
+            },
+          },
+          context,
+        ),
+      ).resolves.toEqual(rowToUpdate.rowId)
+    })
+
+    it('should throw an error if user does not have edit access', async () => {
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const rowToUpdate = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+      const newData = generateMockTableRowData({ columnIds: dummyColumnIds })
+      context.currentUser = editor
+      await expect(
+        updateRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              rowId: rowToUpdate.rowId,
+              data: newData,
+            },
+          },
+          context,
+        ),
+      ).resolves.toEqual(rowToUpdate.rowId)
+
+      context.currentUser = viewer
+
+      await expect(
+        updateRow(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              rowId: rowToUpdate.rowId,
+              data: newData,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/update-table.itest.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { ForbiddenError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import updateTable from '@/graphql/mutations/tiles/update-table'
 import TableMetadata from '@/models/table-metadata'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -12,308 +13,338 @@ import {
   generateMockTable,
   generateMockTableColumns,
 } from './table.mock'
+import { checkIfTableHasColumn } from './tiles-pg-helper'
 
-describe('update table mutation', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnId: string
-  let editor: User
-  let viewer: User
+describe.each([['ddb'], ['pg']])(
+  'update table mutation: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnId: string
+    let editor: User
+    let viewer: User
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-    dummyColumnId = (
-      await generateMockTableColumns({
-        tableId: dummyTable.id,
-        numColumns: 1,
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: databaseType as 'ddb' | 'pg',
       })
-    )[0]
-  })
-
-  describe('table name changes', () => {
-    it('is able to update table name', async () => {
-      const newTableName = 'New Table Name'
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            name: newTableName,
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-      expect(updatedTable.name).toBe(newTableName)
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
+      dummyColumnId = (
+        await generateMockTableColumns({
+          tableId: dummyTable.id,
+          numColumns: 1,
+          databaseType: databaseType as 'ddb' | 'pg',
+        })
+      )[0]
     })
 
-    it('will not amend table name if undefined', async () => {
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [],
+    describe('table name changes', () => {
+      it('is able to update table name', async () => {
+        const newTableName = 'New Table Name'
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              name: newTableName,
+              addedColumns: [],
+              modifiedColumns: [],
+              deletedColumns: [],
+            },
           },
-        },
-        context,
-      )
-      expect(updatedTable.name).toBe('Test Table')
-    })
-  })
+          context,
+        )
+        expect(updatedTable.name).toBe(newTableName)
+      })
 
-  describe('adding columns to table', () => {
-    it('should add columns to table with correct positions', async () => {
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: ['New Column 1', 'New Column 2'],
-            modifiedColumns: [],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-      const columns = await updatedTable
-        .$relatedQuery('columns')
-        .select('position')
-        .orderBy('position')
-      expect(columns.length).toBe(3)
-      expect(columns.map((c) => c.position)).toEqual([0, 1, 2])
-    })
-
-    it('should add columns to table with same name', async () => {
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: ['New Column 1', 'New Column 1', 'New Column 1'],
-            modifiedColumns: [],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-      const tableColumnCount = await updatedTable
-        .$relatedQuery('columns')
-        .resultSize()
-      expect(tableColumnCount).toBe(4)
-    })
-  })
-
-  describe('modify columns in table', () => {
-    it('should modify column name', async () => {
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [
-              {
-                id: dummyColumnId,
-                name: 'New Column Name',
-              },
-            ],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-      expect(updatedTable.columns[0].name).toBe('New Column Name')
-    })
-
-    it('should modify column widths', async () => {
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [
-              {
-                id: dummyColumnId,
-                name: 'New Column Name',
-                config: {
-                  width: 100,
-                },
-              },
-            ],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-      expect(updatedTable.columns[0].config.width).toBe(100)
-    })
-
-    it('should fail if column does not exist', async () => {
-      const updateTableAction = updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [
-              {
-                id: randomUUID(),
-                name: 'New Column Name',
-              },
-            ],
-            deletedColumns: [],
-          },
-        },
-        context,
-      )
-
-      await expect(updateTableAction).rejects.toThrow()
-    })
-  })
-
-  describe('delete columns in table', () => {
-    it('should delete columns', async () => {
-      // add more columns for deletion
-      const updatedTable = await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: ['New Column 1', 'New Column 2'],
-            modifiedColumns: [],
-          },
-        },
-        context,
-      )
-
-      await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [
-              updatedTable.columns[0].id,
-              updatedTable.columns[1].id,
-            ],
-          },
-        },
-        context,
-      )
-      const tableColumnCount = await dummyTable
-        .$relatedQuery('columns')
-        .resultSize()
-      expect(tableColumnCount).toBe(1)
-    })
-    it('should not delete last column', async () => {
-      await expect(() =>
-        updateTable(
+      it('will not amend table name if undefined', async () => {
+        const updatedTable = await updateTable(
           null,
           {
             input: {
               id: dummyTable.id,
               addedColumns: [],
               modifiedColumns: [],
-              deletedColumns: [dummyColumnId],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+        expect(updatedTable.name).toBe('Test Table')
+      })
+    })
+
+    describe('adding columns to table', () => {
+      it('should add columns to table with correct positions', async () => {
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: ['New Column 1', 'New Column 2'],
+              modifiedColumns: [],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+        const columns = await updatedTable
+          .$relatedQuery('columns')
+          .select('position', 'id')
+          .orderBy('position')
+        expect(columns.length).toBe(3)
+        expect(columns.map((c) => c.position)).toEqual([0, 1, 2])
+
+        if (databaseType === 'pg') {
+          expect(
+            await checkIfTableHasColumn(dummyTable.id, columns[1].id),
+          ).toBe(true)
+          expect(
+            await checkIfTableHasColumn(dummyTable.id, columns[2].id),
+          ).toBe(true)
+        }
+      })
+
+      it('should add columns to table with same name', async () => {
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: ['New Column 1', 'New Column 1', 'New Column 1'],
+              modifiedColumns: [],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+        const tableColumnCount = await updatedTable
+          .$relatedQuery('columns')
+          .resultSize()
+        expect(tableColumnCount).toBe(4)
+      })
+    })
+
+    describe('modify columns in table', () => {
+      it('should modify column name', async () => {
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: [],
+              modifiedColumns: [
+                {
+                  id: dummyColumnId,
+                  name: 'New Column Name',
+                },
+              ],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+        expect(updatedTable.columns[0].name).toBe('New Column Name')
+      })
+
+      it('should modify column widths', async () => {
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: [],
+              modifiedColumns: [
+                {
+                  id: dummyColumnId,
+                  name: 'New Column Name',
+                  config: {
+                    width: 100,
+                  },
+                },
+              ],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+        expect(updatedTable.columns[0].config.width).toBe(100)
+      })
+
+      it('should fail if column does not exist', async () => {
+        const updateTableAction = updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: [],
+              modifiedColumns: [
+                {
+                  id: randomUUID(),
+                  name: 'New Column Name',
+                },
+              ],
+              deletedColumns: [],
+            },
+          },
+          context,
+        )
+
+        await expect(updateTableAction).rejects.toThrow()
+      })
+    })
+
+    describe('delete columns in table', () => {
+      it('should delete columns', async () => {
+        // add more columns for deletion
+        const updatedTable = await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: ['New Column 1', 'New Column 2'],
+              modifiedColumns: [],
+            },
+          },
+          context,
+        )
+
+        await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: [],
+              modifiedColumns: [],
+              deletedColumns: [
+                updatedTable.columns[0].id,
+                updatedTable.columns[1].id,
+              ],
+            },
+          },
+          context,
+        )
+        const tableColumnCount = await dummyTable
+          .$relatedQuery('columns')
+          .resultSize()
+        expect(tableColumnCount).toBe(1)
+        if (databaseType === 'pg') {
+          expect(
+            await checkIfTableHasColumn(
+              dummyTable.id,
+              updatedTable.columns[0].id,
+            ),
+          ).toBe(false)
+          expect(
+            await checkIfTableHasColumn(
+              dummyTable.id,
+              updatedTable.columns[1].id,
+            ),
+          ).toBe(false)
+        }
+      })
+
+      it('should not delete last column', async () => {
+        await expect(() =>
+          updateTable(
+            null,
+            {
+              input: {
+                id: dummyTable.id,
+                addedColumns: [],
+                modifiedColumns: [],
+                deletedColumns: [dummyColumnId],
+              },
+            },
+            context,
+          ),
+        ).rejects.toThrowError()
+      })
+
+      it('should throw an error if trying to delete a column from a different table', async () => {
+        // add more columns for deletion
+        await updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              addedColumns: ['New Column 1', 'New Column 2'],
+              modifiedColumns: [],
+            },
+          },
+          context,
+        )
+
+        const dummyTable2 = await context.currentUser
+          .$relatedQuery('tables')
+          .insertGraph({
+            name: 'Test Table',
+            role: 'owner',
+          })
+
+        const dummmyColumn2 = await dummyTable2
+          .$relatedQuery('columns')
+          .insert({
+            name: 'Test Column',
+          })
+        await expect(
+          updateTable(
+            null,
+            {
+              input: {
+                id: dummyTable.id,
+                addedColumns: [],
+                modifiedColumns: [],
+                deletedColumns: [dummmyColumn2.id],
+              },
+            },
+            context,
+          ),
+        ).rejects.toThrow(BadUserInputError)
+      })
+    })
+
+    it('should allow collaborators with edit rights to call this function', async () => {
+      context.currentUser = editor
+      await expect(
+        updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              name: 'editor changed name',
+              addedColumns: [],
+              modifiedColumns: [],
+              deletedColumns: [],
             },
           },
           context,
         ),
-      ).rejects.toThrowError()
+      ).resolves.toBeDefined()
     })
 
-    it('should not be able to delete a column from a different table', async () => {
-      // add more columns for deletion
-      await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: ['New Column 1', 'New Column 2'],
-            modifiedColumns: [],
+    it('should throw an error if user does not have edit access', async () => {
+      context.currentUser = viewer
+      await expect(
+        updateTable(
+          null,
+          {
+            input: {
+              id: dummyTable.id,
+              name: 'viewer changed name',
+              addedColumns: [],
+              modifiedColumns: [],
+              deletedColumns: [],
+            },
           },
-        },
-        context,
-      )
-
-      const dummyTable2 = await context.currentUser
-        .$relatedQuery('tables')
-        .insertGraph({
-          name: 'Test Table',
-          role: 'owner',
-        })
-
-      const dummmyColumn2 = await dummyTable2.$relatedQuery('columns').insert({
-        name: 'Test Column',
-      })
-      await updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [dummmyColumn2.id],
-          },
-        },
-        context,
-      )
-      const tableColumnCount = await dummyTable2
-        .$relatedQuery('columns')
-        .resultSize()
-      expect(tableColumnCount).toBe(1)
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
     })
-  })
-
-  it('should allow collaborators with edit rights to call this function', async () => {
-    context.currentUser = editor
-    await expect(
-      updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            name: 'editor changed name',
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [],
-          },
-        },
-        context,
-      ),
-    ).resolves.toBeDefined()
-  })
-
-  it('should throw an error if user does not have edit access', async () => {
-    context.currentUser = viewer
-    await expect(
-      updateTable(
-        null,
-        {
-          input: {
-            id: dummyTable.id,
-            name: 'viewer changed name',
-            addedColumns: [],
-            modifiedColumns: [],
-            deletedColumns: [],
-          },
-        },
-        context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-})
+  },
+)

--- a/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/upsert-table-collaborator.itest.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import TableMetadata from '@/models/table-metadata'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -9,160 +10,95 @@ import upsertTableCollaborator from '../../../mutations/tiles/upsert-table-colla
 
 import { generateMockContext, generateMockTable } from './table.mock'
 
-describe('update table collaborators', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let editor: User
-  let owner: User
-  let viewer: User
+describe.each([['ddb'], ['pg']])(
+  'update table collaborators: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let editor: User
+    let owner: User
+    let viewer: User
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType,
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      owner = mockTable.owner
+      viewer = mockTable.viewer
     })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    owner = mockTable.owner
-    viewer = mockTable.viewer
-  })
 
-  it('should be able to add new viewers', async () => {
-    await upsertTableCollaborator(
-      null,
-      {
-        input: {
-          tableId: dummyTable.id,
-          email: 'viewer2@open.gov.sg',
-          role: 'viewer',
-        },
-      },
-      context,
-    )
-    const collaborators = await dummyTable
-      .$relatedQuery('collaborators')
-      .where('table_collaborators.deleted_at', null)
-    expect(collaborators).toHaveLength(4)
-    const addedCollaborator = collaborators.find(
-      (col) => col.email === 'viewer2@open.gov.sg',
-    )
-    expect(addedCollaborator).toHaveProperty('role', 'viewer')
-  })
-
-  it('should be able to add new editors', async () => {
-    await upsertTableCollaborator(
-      null,
-      {
-        input: {
-          tableId: dummyTable.id,
-          email: 'editor2@open.gov.sg',
-          role: 'editor',
-        },
-      },
-      context,
-    )
-    const collaborators = await dummyTable
-      .$relatedQuery('collaborators')
-      .where('table_collaborators.deleted_at', null)
-    expect(collaborators).toHaveLength(4)
-    const addedCollaborator = collaborators.find(
-      (col) => col.email === 'editor2@open.gov.sg',
-    )
-    expect(addedCollaborator).toHaveProperty('role', 'editor')
-  })
-
-  it('should be able to update roles', async () => {
-    await upsertTableCollaborator(
-      null,
-      {
-        input: {
-          tableId: dummyTable.id,
-          email: 'editor@open.gov.sg',
-          role: 'viewer',
-        },
-      },
-      context,
-    )
-    const collaborators = await dummyTable
-      .$relatedQuery('collaborators')
-      .where('table_collaborators.deleted_at', null)
-    expect(collaborators).toHaveLength(3)
-    const addedCollaborator = collaborators.find(
-      (col) => col.email === 'editor@open.gov.sg',
-    )
-    expect(addedCollaborator).toHaveProperty('role', 'viewer')
-  })
-
-  it('should not allow editing role of owner', async () => {
-    context.currentUser = editor
-    await expect(
-      upsertTableCollaborator(
+    it('should be able to add new viewers', async () => {
+      await upsertTableCollaborator(
         null,
         {
           input: {
             tableId: dummyTable.id,
-            email: owner.email,
-            role: 'editor',
+            email: 'viewer2@open.gov.sg',
+            role: 'viewer',
           },
         },
         context,
-      ),
-    ).rejects.toThrow()
-  })
+      )
+      const collaborators = await dummyTable
+        .$relatedQuery('collaborators')
+        .where('table_collaborators.deleted_at', null)
+      expect(collaborators).toHaveLength(4)
+      const addedCollaborator = collaborators.find(
+        (col) => col.email === 'viewer2@open.gov.sg',
+      )
+      expect(addedCollaborator).toHaveProperty('role', 'viewer')
+    })
 
-  it('should not allow editing of own role', async () => {
-    context.currentUser = editor
-    await expect(
-      upsertTableCollaborator(
+    it('should be able to add new editors', async () => {
+      await upsertTableCollaborator(
         null,
         {
           input: {
             tableId: dummyTable.id,
-            email: context.currentUser.email,
+            email: 'editor2@open.gov.sg',
             role: 'editor',
           },
         },
         context,
-      ),
-    ).rejects.toThrow('Cannot change own role')
-  })
-  it('should not allow editing of own role', async () => {
-    context.currentUser = editor
-    await expect(
-      upsertTableCollaborator(
+      )
+      const collaborators = await dummyTable
+        .$relatedQuery('collaborators')
+        .where('table_collaborators.deleted_at', null)
+      expect(collaborators).toHaveLength(4)
+      const addedCollaborator = collaborators.find(
+        (col) => col.email === 'editor2@open.gov.sg',
+      )
+      expect(addedCollaborator).toHaveProperty('role', 'editor')
+    })
+
+    it('should be able to update roles', async () => {
+      await upsertTableCollaborator(
         null,
         {
           input: {
             tableId: dummyTable.id,
-            email: context.currentUser.email,
-            role: 'editor',
+            email: 'editor@open.gov.sg',
+            role: 'viewer',
           },
         },
         context,
-      ),
-    ).rejects.toThrow('Cannot change own role')
-  })
+      )
+      const collaborators = await dummyTable
+        .$relatedQuery('collaborators')
+        .where('table_collaborators.deleted_at', null)
+      expect(collaborators).toHaveLength(3)
+      const addedCollaborator = collaborators.find(
+        (col) => col.email === 'editor@open.gov.sg',
+      )
+      expect(addedCollaborator).toHaveProperty('role', 'viewer')
+    })
 
-  it('should only not allow viewers to modify collaborators', async () => {
-    context.currentUser = viewer
-    await expect(
-      upsertTableCollaborator(
-        null,
-        {
-          input: {
-            tableId: dummyTable.id,
-            email: 'tester33@open.gov.sg',
-            role: 'editor',
-          },
-        },
-        context,
-      ),
-    ).rejects.toThrow(ForbiddenError)
-  })
-
-  describe('transfer ownership', () => {
-    it('should not allow adding of owner role if you are not owner', async () => {
+    it('should not allow editing role of owner', async () => {
       context.currentUser = editor
       await expect(
         upsertTableCollaborator(
@@ -170,54 +106,123 @@ describe('update table collaborators', () => {
           {
             input: {
               tableId: dummyTable.id,
-              email: 'owner2@open.gov.sg',
-              role: 'owner',
+              email: owner.email,
+              role: 'editor',
             },
           },
           context,
         ),
-      ).rejects.toThrowError(ForbiddenError)
+      ).rejects.toThrow()
     })
 
-    it('should allow transfer of owner role if you are owner, old owner will become editor', async () => {
+    it('should not allow editing of own role', async () => {
+      context.currentUser = editor
       await expect(
         upsertTableCollaborator(
           null,
           {
             input: {
               tableId: dummyTable.id,
-              email: editor.email,
-              role: 'owner',
+              email: context.currentUser.email,
+              role: 'editor',
             },
           },
           context,
         ),
-      ).resolves.not.toThrow()
-      const collaborators = await dummyTable
-        .$relatedQuery('collaborators')
-        .where('table_collaborators.deleted_at', null)
-      expect(
-        collaborators.find((col) => col.email === editor.email),
-      ).toHaveProperty('role', 'owner')
-      expect(
-        collaborators.find((col) => col.email === owner.email),
-      ).toHaveProperty('role', 'editor')
+      ).rejects.toThrow('Cannot change own role')
     })
-
-    it('should not allow transfer of ownership to non-existent user', async () => {
+    it('should not allow editing of own role', async () => {
+      context.currentUser = editor
       await expect(
         upsertTableCollaborator(
           null,
           {
             input: {
               tableId: dummyTable.id,
-              email: 'non-existent-user@open.gov.sg',
-              role: 'owner',
+              email: context.currentUser.email,
+              role: 'editor',
             },
           },
           context,
         ),
-      ).rejects.toThrowError(BadUserInputError)
+      ).rejects.toThrow('Cannot change own role')
     })
-  })
-})
+
+    it('should only not allow viewers to modify collaborators', async () => {
+      context.currentUser = viewer
+      await expect(
+        upsertTableCollaborator(
+          null,
+          {
+            input: {
+              tableId: dummyTable.id,
+              email: 'tester33@open.gov.sg',
+              role: 'editor',
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(ForbiddenError)
+    })
+
+    describe('transfer ownership', () => {
+      it('should not allow adding of owner role if you are not owner', async () => {
+        context.currentUser = editor
+        await expect(
+          upsertTableCollaborator(
+            null,
+            {
+              input: {
+                tableId: dummyTable.id,
+                email: 'owner2@open.gov.sg',
+                role: 'owner',
+              },
+            },
+            context,
+          ),
+        ).rejects.toThrowError(ForbiddenError)
+      })
+
+      it('should allow transfer of owner role if you are owner, old owner will become editor', async () => {
+        await expect(
+          upsertTableCollaborator(
+            null,
+            {
+              input: {
+                tableId: dummyTable.id,
+                email: editor.email,
+                role: 'owner',
+              },
+            },
+            context,
+          ),
+        ).resolves.not.toThrow()
+        const collaborators = await dummyTable
+          .$relatedQuery('collaborators')
+          .where('table_collaborators.deleted_at', null)
+        expect(
+          collaborators.find((col) => col.email === editor.email),
+        ).toHaveProperty('role', 'owner')
+        expect(
+          collaborators.find((col) => col.email === owner.email),
+        ).toHaveProperty('role', 'editor')
+      })
+
+      it('should not allow transfer of ownership to non-existent user', async () => {
+        await expect(
+          upsertTableCollaborator(
+            null,
+            {
+              input: {
+                tableId: dummyTable.id,
+                email: 'non-existent-user@open.gov.sg',
+                role: 'owner',
+              },
+            },
+            context,
+          ),
+        ).rejects.toThrowError(BadUserInputError)
+      })
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-all-rows.itest.ts
@@ -1,13 +1,13 @@
 import { ITableRow } from '@plumber/types'
 
-import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import getAllRows from '@/graphql/queries/tiles/get-all-rows'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
-import { createTableRow } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -20,228 +20,243 @@ import {
 
 import { insertMockTableRows } from './table-row.mock'
 
-describe('get all rows query', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[] = []
-  let editor: User
-  let viewer: User
+describe.each([['ddb'], ['pg']])(
+  'get all rows query: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[] = []
+    let editor: User
+    let viewer: User
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
-
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-  })
-
-  it('should fetch all rows in a given table', async () => {
-    const numRowsToInsert = 100
-    await insertMockTableRows(dummyTable.id, numRowsToInsert, dummyColumnIds)
-
-    const { rows } = await getAllRows(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
-    expect(rows).toHaveLength(numRowsToInsert)
-  })
-
-  it('should return rows in ascending order of createdAt', async () => {
-    // Insert rows in descending order of createdAt
-    const numRowsToInsert = 10
-    const rowIdsInserted = []
-    // inserting 1 by 1 so createdAt is different
-    for (let i = 0; i < numRowsToInsert; i++) {
-      const { rowId } = await createTableRow({
-        tableId: dummyTable.id,
-        data: {},
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType,
       })
-      rowIdsInserted.push(rowId)
-    }
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
 
-    const { rows } = await getAllRows(
-      null,
-      {
+      dummyColumnIds = await generateMockTableColumns({
         tableId: dummyTable.id,
-      },
-      context,
-    )
-    expect(rows.map((r: ITableRow) => r.rowId)).toEqual(rowIdsInserted)
-  })
+        numColumns: 5,
+        databaseType,
+      })
+    })
 
-  it('should fetch all rows even if more than 1MB by pagination', async () => {
-    // 1 randomly generated row is about 470 bytes
-    // 10000 rows will be about 4.7MB
-    const numRowsToInsert = 10000
-    await insertMockTableRows(dummyTable.id, numRowsToInsert, dummyColumnIds)
+    it('should fetch all rows in a given table', async () => {
+      const numRowsToInsert = 100
+      await insertMockTableRows(
+        dummyTable.id,
+        numRowsToInsert,
+        dummyColumnIds,
+        databaseType,
+      )
 
-    let cursor: string | null = null
-    let rows: ITableRow[] = []
-    do {
-      const { rows: pageRows, stringifiedCursor } = await getAllRows(
+      const { rows } = await getAllRows(
         null,
         {
           tableId: dummyTable.id,
-          stringifiedCursor: cursor,
         },
         context,
       )
-      cursor = stringifiedCursor
-      rows = rows.concat(pageRows)
-    } while (cursor)
-    expect(rows.length).toBe(numRowsToInsert)
-  }, 100000)
+      expect(rows).toHaveLength(numRowsToInsert)
+    })
 
-  it('should return empty array if no rows', async () => {
-    const { rows } = await getAllRows(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
+    it('should return rows in ascending order of createdAt', async () => {
+      // Insert rows in descending order of createdAt
+      const numRowsToInsert = 10
+      const rowIdsInserted = []
+      // inserting 1 by 1 so createdAt is different
 
-    expect(rows).toHaveLength(0)
-  })
-
-  it('should strip keys that are not in table columns', async () => {
-    const data = generateMockTableRowData({ columnIds: dummyColumnIds })
-    // add a key that is not in the table columns
-    data[randomUUID()] = 'test'
-    const rowToInsert = {
-      tableId: dummyTable.id,
-      // TODO: use ulid for new tiles
-      rowId: randomUUID(),
-      data,
-    }
-
-    await createTableRow(rowToInsert)
-
-    const { rows: returnedRows } = await getAllRows(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
-    const rows = await Promise.all(returnedRows)
-
-    expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length)
-  })
-
-  it('should handle values with commas in them', async () => {
-    const data = generateMockTableRowData({ columnIds: dummyColumnIds })
-    // add a value with a comma in it
-    data[dummyColumnIds[0]] = 'test,test'
-    const rowToInsert = {
-      tableId: dummyTable.id,
-      // TODO: use ulid for new tiles
-      rowId: randomUUID(),
-      data,
-    }
-
-    await createTableRow(rowToInsert)
-
-    const { rows: returnedRows } = await getAllRows(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
-    const rows = await Promise.all(returnedRows)
-
-    expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length)
-  })
-
-  it('should allow all collaborators to call this function', async () => {
-    context.currentUser = editor
-    await expect(
-      getAllRows(
-        null,
-        {
+      const tableOperations = getTableOperations(databaseType)
+      for (let i = 0; i < numRowsToInsert; i++) {
+        const { rowId } = await tableOperations.createTableRow({
           tableId: dummyTable.id,
-        },
-        context,
-      ),
-    ).resolves.toBeDefined()
-
-    context.currentUser = viewer
-    await expect(
-      getAllRows(
-        null,
-        {
-          tableId: dummyTable.id,
-        },
-        context,
-      ),
-    ).resolves.toBeDefined()
-  })
-
-  it('should throw an error if collaborator does not exist or is soft deleted', async () => {
-    context.currentUser = editor
-    await TableCollaborator.query()
-      .delete()
-      .where('table_id', dummyTable.id)
-      .andWhere('user_id', editor.id)
-    await expect(
-      getAllRows(
-        null,
-        {
-          tableId: dummyTable.id,
-        },
-        context,
-      ),
-    ).rejects.toThrow(NotFoundError)
-  })
-
-  describe('last accessed at', () => {
-    it('should update last accessed at for current user', async () => {
-      const oldLastAccessedAt = new Date().toISOString()
-      await TableCollaborator.query()
-        .patch({
-          lastAccessedAt: oldLastAccessedAt,
+          data: {},
         })
-        .where('table_id', dummyTable.id)
-        .andWhere('user_id', context.currentUser.id)
-      await getAllRows(null, { tableId: dummyTable.id }, context)
-      const { lastAccessedAt } = await TableCollaborator.query().findOne({
-        table_id: dummyTable.id,
-        user_id: context.currentUser.id,
-      })
-      expect(new Date(lastAccessedAt).getTime()).toBeGreaterThan(
-        new Date(oldLastAccessedAt).getTime(),
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        rowIdsInserted.push(rowId)
+      }
+
+      const { rows } = await getAllRows(
+        null,
+        {
+          tableId: dummyTable.id,
+        },
+        context,
       )
+      expect(rows.map((r: ITableRow) => r.rowId)).toEqual(rowIdsInserted)
     })
 
-    it('should not update last accessed at for admin operations', async () => {
-      context.isAdminOperation = true
-      const oldLastAccessedAt = new Date().toISOString()
-      await TableCollaborator.query()
-        .patch({
-          lastAccessedAt: oldLastAccessedAt,
-        })
-        .where('table_id', dummyTable.id)
-        .andWhere('user_id', context.currentUser.id)
-      await getAllRows(null, { tableId: dummyTable.id }, context)
-      const { lastAccessedAt } = await TableCollaborator.query().findOne({
-        table_id: dummyTable.id,
-        user_id: context.currentUser.id,
-      })
-      expect(new Date(lastAccessedAt).getTime()).toEqual(
-        new Date(oldLastAccessedAt).getTime(),
+    it('should fetch all rows even if more than 1MB by pagination', async () => {
+      // 1 randomly generated row is about 470 bytes
+      // 10000 rows will be about 4.7MB
+      const numRowsToInsert = 10000
+      await insertMockTableRows(
+        dummyTable.id,
+        numRowsToInsert,
+        dummyColumnIds,
+        databaseType,
       )
+
+      let cursor: string | null = null
+      let rows: ITableRow[] = []
+      do {
+        const { rows: pageRows, stringifiedCursor } = await getAllRows(
+          null,
+          {
+            tableId: dummyTable.id,
+            stringifiedCursor: cursor,
+          },
+          context,
+        )
+        cursor = stringifiedCursor
+        rows = rows.concat(pageRows)
+      } while (cursor)
+      expect(rows.length).toBe(numRowsToInsert)
+    }, 100000)
+
+    it('should return empty array if no rows', async () => {
+      const { rows } = await getAllRows(
+        null,
+        {
+          tableId: dummyTable.id,
+        },
+        context,
+      )
+
+      expect(rows).toHaveLength(0)
     })
-  })
-})
+
+    it('should strip keys that are not in table columns', async () => {
+      const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+      // add a key that is not in the table columns
+
+      const tableOperations = getTableOperations(databaseType)
+      await tableOperations.createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+
+      await dummyTable.$relatedQuery('columns').deleteById(dummyColumnIds[0])
+
+      const { rows: returnedRows } = await getAllRows(
+        null,
+        {
+          tableId: dummyTable.id,
+        },
+        context,
+      )
+      const rows = await Promise.all(returnedRows)
+
+      expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length - 1)
+    })
+
+    it('should handle values with commas in them', async () => {
+      const data = generateMockTableRowData({ columnIds: dummyColumnIds })
+      // add a value with a comma in it
+      data[dummyColumnIds[0]] = 'test,test'
+
+      const tableOperations = getTableOperations(databaseType)
+      await tableOperations.createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+
+      const { rows: returnedRows } = await getAllRows(
+        null,
+        {
+          tableId: dummyTable.id,
+        },
+        context,
+      )
+      const rows = await Promise.all(returnedRows)
+
+      expect(JSON.parse(rows[0].data).length).toBe(dummyColumnIds.length)
+    })
+
+    it('should allow all collaborators to call this function', async () => {
+      context.currentUser = editor
+      await expect(
+        getAllRows(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+
+      context.currentUser = viewer
+      await expect(
+        getAllRows(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+    })
+
+    it('should throw an error if collaborator does not exist or is soft deleted', async () => {
+      context.currentUser = editor
+      await TableCollaborator.query()
+        .delete()
+        .where('table_id', dummyTable.id)
+        .andWhere('user_id', editor.id)
+      await expect(
+        getAllRows(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).rejects.toThrow(NotFoundError)
+    })
+
+    describe('last accessed at', () => {
+      it('should update last accessed at for current user', async () => {
+        const oldLastAccessedAt = new Date().toISOString()
+        await TableCollaborator.query()
+          .patch({
+            lastAccessedAt: oldLastAccessedAt,
+          })
+          .where('table_id', dummyTable.id)
+          .andWhere('user_id', context.currentUser.id)
+        await getAllRows(null, { tableId: dummyTable.id }, context)
+        const { lastAccessedAt } = await TableCollaborator.query().findOne({
+          table_id: dummyTable.id,
+          user_id: context.currentUser.id,
+        })
+        expect(new Date(lastAccessedAt).getTime()).toBeGreaterThan(
+          new Date(oldLastAccessedAt).getTime(),
+        )
+      })
+
+      it('should not update last accessed at for admin operations', async () => {
+        context.isAdminOperation = true
+        const oldLastAccessedAt = new Date().toISOString()
+        await TableCollaborator.query()
+          .patch({
+            lastAccessedAt: oldLastAccessedAt,
+          })
+          .where('table_id', dummyTable.id)
+          .andWhere('user_id', context.currentUser.id)
+        await getAllRows(null, { tableId: dummyTable.id }, context)
+        const { lastAccessedAt } = await TableCollaborator.query().findOne({
+          table_id: dummyTable.id,
+          user_id: context.currentUser.id,
+        })
+        expect(new Date(lastAccessedAt).getTime()).toEqual(
+          new Date(oldLastAccessedAt).getTime(),
+        )
+      })
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table-connections.itest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import getTableConnections from '@/graphql/queries/tiles/get-table-connections'
 import getTables from '@/graphql/queries/tiles/get-tables'
 import Flow from '@/models/flow'
+import { DatabaseType } from '@/models/tiles/types'
 import Context from '@/types/express/context'
 
 import {
@@ -56,172 +57,194 @@ describe('get table connections query', () => {
     expect(Object.keys(tableConnections).length).toBe(0)
   })
 
-  it('should return the correct number of table connections for user flows only', async () => {
-    const numTables = 5
-    const tablePipeCount: TablePipeCountObj = {}
-    for (let i = 0; i < numTables; i++) {
-      const res = await generateMockTable({ userId: context.currentUser.id })
-      const { id: tableId } = res.table
-
-      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
-      tablePipeCount[tableId] = numFlows
-
-      for (let i = 0; i < numFlows; i++) {
-        await generateMockFlow({
+  it.each([['ddb'], ['pg']])(
+    'should return the correct number of table connections for user flows only: %s',
+    async (databaseType: DatabaseType) => {
+      const numTables = 5
+      const tablePipeCount: TablePipeCountObj = {}
+      for (let i = 0; i < numTables; i++) {
+        const res = await generateMockTable({
           userId: context.currentUser.id,
-          tableId,
-          numSteps,
+          databaseType,
+        })
+        const { id: tableId } = res.table
+
+        const [numFlows, numSteps] = [getRandNum(), getRandNum()]
+        tablePipeCount[tableId] = numFlows
+
+        for (let i = 0; i < numFlows; i++) {
+          await generateMockFlow({
+            userId: context.currentUser.id,
+            tableId,
+            numSteps,
+          })
+        }
+      }
+
+      // tests each page
+      const limit = 2
+      for (let i = 0; i < Math.ceil(numTables / 2); i++) {
+        const offset = limit * i
+        const { edges, pageInfo } = await getTables(
+          null,
+          { limit, offset },
+          context,
+        )
+
+        const pageTables = edges.map((edge) => edge.node)
+        const expectedLength = Math.min(limit, numTables - limit * i)
+        expect(pageTables).toHaveLength(expectedLength)
+        expect(pageInfo.currentPage).toBe(i + 1)
+        expect(pageInfo.totalCount).toBe(numTables)
+
+        const pageTableIds = edges.map((edge) => edge.node.id)
+
+        const tableConnections = await getTableConnections(
+          null,
+          { tableIds: pageTableIds },
+          context,
+        )
+        expect(Object.keys(tableConnections).length).toBe(expectedLength)
+        expect(Object.keys(tableConnections).sort()).toEqual(
+          pageTableIds.sort(),
+        )
+
+        Object.entries(tableConnections).forEach(([key, value]) => {
+          expect(value).toBe(tablePipeCount[key])
         })
       }
-    }
+    },
+  )
 
-    // tests each page
-    const limit = 2
-    for (let i = 0; i < Math.ceil(numTables / 2); i++) {
-      const offset = limit * i
+  it.each([['ddb'], ['pg']])(
+    'should return the correct number of table connections for flows by user and editor: %s',
+    async (databaseType: DatabaseType) => {
+      const numTables = 5
+      const tablePipeCount: TablePipeCountObj = {}
+      for (let i = 0; i < numTables; i++) {
+        const res = await generateMockTable({
+          userId: context.currentUser.id,
+          databaseType,
+        })
+        const { id: tableId } = res.table
+        const { id: editorId } = res.editor
+
+        const [numFlows, numSteps] = [getRandNum(), getRandNum()]
+        const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
+
+        tablePipeCount[tableId] = numFlows + editorFlows
+        for (let i = 0; i < numFlows; i++) {
+          await generateMockFlow({
+            userId: context.currentUser.id,
+            tableId,
+            numSteps,
+          })
+        }
+        for (let i = 0; i < editorFlows; i++) {
+          await generateMockFlow({
+            userId: editorId,
+            tableId,
+            numSteps: editorSteps,
+          })
+        }
+      }
+
+      // tests each page
+      const limit = 2
+      for (let i = 0; i < Math.ceil(numTables / 2); i++) {
+        const offset = limit * i
+        const { edges, pageInfo } = await getTables(
+          null,
+          { limit, offset },
+          context,
+        )
+
+        const pageTables = edges.map((edge) => edge.node)
+        const expectedLength = Math.min(limit, numTables - limit * i)
+        expect(pageTables).toHaveLength(expectedLength)
+        expect(pageInfo.currentPage).toBe(i + 1)
+        expect(pageInfo.totalCount).toBe(numTables)
+
+        const pageTableIds = edges.map((edge) => edge.node.id)
+
+        const tableConnections = await getTableConnections(
+          null,
+          { tableIds: pageTableIds },
+          context,
+        )
+        expect(Object.keys(tableConnections).length).toBe(expectedLength)
+        expect(Object.keys(tableConnections).sort()).toEqual(
+          pageTableIds.sort(),
+        )
+
+        Object.entries(tableConnections).forEach(([key, value]) => {
+          expect(value).toBe(tablePipeCount[key])
+        })
+      }
+    },
+  )
+
+  it.each([['ddb'], ['pg']])(
+    'should not return table connections for tables the user does not have access to: %s',
+    async (databaseType: DatabaseType) => {
+      const numTables = 5
+      const tablePipeCount: TablePipeCountObj = {}
+      for (let i = 0; i < numTables; i++) {
+        const res = await generateMockTable({
+          userId: context.currentUser.id,
+          databaseType,
+        })
+        const { id: tableId } = res.table
+        const { id: editorId } = res.editor
+
+        const [numFlows, numSteps] = [getRandNum(), getRandNum()]
+        const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
+
+        tablePipeCount[tableId] = numFlows + editorFlows
+        for (let i = 0; i < numFlows; i++) {
+          await generateMockFlow({
+            userId: context.currentUser.id,
+            tableId,
+            numSteps,
+          })
+        }
+        for (let i = 0; i < editorFlows; i++) {
+          await generateMockFlow({
+            userId: editorId,
+            tableId,
+            numSteps: editorSteps,
+          })
+        }
+      }
+
+      // test as a whole
       const { edges, pageInfo } = await getTables(
         null,
-        { limit, offset },
+        { limit: 10, offset: 0 },
         context,
       )
 
       const pageTables = edges.map((edge) => edge.node)
-      const expectedLength = Math.min(limit, numTables - limit * i)
-      expect(pageTables).toHaveLength(expectedLength)
-      expect(pageInfo.currentPage).toBe(i + 1)
+      expect(pageTables).toHaveLength(numTables)
+      expect(pageInfo.currentPage).toBe(1)
       expect(pageInfo.totalCount).toBe(numTables)
 
       const pageTableIds = edges.map((edge) => edge.node.id)
-
+      const testIds = [...pageTableIds, crypto.randomUUID()] // add a random table id
+      expect(testIds).toHaveLength(numTables + 1)
       const tableConnections = await getTableConnections(
         null,
-        { tableIds: pageTableIds },
+        { tableIds: testIds },
         context,
       )
-      expect(Object.keys(tableConnections).length).toBe(expectedLength)
+      expect(Object.keys(tableConnections).length).toBe(numTables)
       expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
 
       Object.entries(tableConnections).forEach(([key, value]) => {
         expect(value).toBe(tablePipeCount[key])
       })
-    }
-  })
-
-  it('should return the correct number of table connections for flows by user and editor', async () => {
-    const numTables = 5
-    const tablePipeCount: TablePipeCountObj = {}
-    for (let i = 0; i < numTables; i++) {
-      const res = await generateMockTable({ userId: context.currentUser.id })
-      const { id: tableId } = res.table
-      const { id: editorId } = res.editor
-
-      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
-      const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
-
-      tablePipeCount[tableId] = numFlows + editorFlows
-      for (let i = 0; i < numFlows; i++) {
-        await generateMockFlow({
-          userId: context.currentUser.id,
-          tableId,
-          numSteps,
-        })
-      }
-      for (let i = 0; i < editorFlows; i++) {
-        await generateMockFlow({
-          userId: editorId,
-          tableId,
-          numSteps: editorSteps,
-        })
-      }
-    }
-
-    // tests each page
-    const limit = 2
-    for (let i = 0; i < Math.ceil(numTables / 2); i++) {
-      const offset = limit * i
-      const { edges, pageInfo } = await getTables(
-        null,
-        { limit, offset },
-        context,
-      )
-
-      const pageTables = edges.map((edge) => edge.node)
-      const expectedLength = Math.min(limit, numTables - limit * i)
-      expect(pageTables).toHaveLength(expectedLength)
-      expect(pageInfo.currentPage).toBe(i + 1)
-      expect(pageInfo.totalCount).toBe(numTables)
-
-      const pageTableIds = edges.map((edge) => edge.node.id)
-
-      const tableConnections = await getTableConnections(
-        null,
-        { tableIds: pageTableIds },
-        context,
-      )
-      expect(Object.keys(tableConnections).length).toBe(expectedLength)
-      expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
-
-      Object.entries(tableConnections).forEach(([key, value]) => {
-        expect(value).toBe(tablePipeCount[key])
-      })
-    }
-  })
-
-  it('should not return table connections for tables the user does not have access to', async () => {
-    const numTables = 5
-    const tablePipeCount: TablePipeCountObj = {}
-    for (let i = 0; i < numTables; i++) {
-      const res = await generateMockTable({ userId: context.currentUser.id })
-      const { id: tableId } = res.table
-      const { id: editorId } = res.editor
-
-      const [numFlows, numSteps] = [getRandNum(), getRandNum()]
-      const [editorFlows, editorSteps] = [getRandNum(), getRandNum()]
-
-      tablePipeCount[tableId] = numFlows + editorFlows
-      for (let i = 0; i < numFlows; i++) {
-        await generateMockFlow({
-          userId: context.currentUser.id,
-          tableId,
-          numSteps,
-        })
-      }
-      for (let i = 0; i < editorFlows; i++) {
-        await generateMockFlow({
-          userId: editorId,
-          tableId,
-          numSteps: editorSteps,
-        })
-      }
-    }
-
-    // test as a whole
-    const { edges, pageInfo } = await getTables(
-      null,
-      { limit: 10, offset: 0 },
-      context,
-    )
-
-    const pageTables = edges.map((edge) => edge.node)
-    expect(pageTables).toHaveLength(numTables)
-    expect(pageInfo.currentPage).toBe(1)
-    expect(pageInfo.totalCount).toBe(numTables)
-
-    const pageTableIds = edges.map((edge) => edge.node.id)
-    const testIds = [...pageTableIds, crypto.randomUUID()] // add a random table id
-    expect(testIds).toHaveLength(numTables + 1)
-    const tableConnections = await getTableConnections(
-      null,
-      { tableIds: testIds },
-      context,
-    )
-    expect(Object.keys(tableConnections).length).toBe(numTables)
-    expect(Object.keys(tableConnections).sort()).toEqual(pageTableIds.sort())
-
-    Object.entries(tableConnections).forEach(([key, value]) => {
-      expect(value).toBe(tablePipeCount[key])
-    })
-  })
+    },
+  )
 
   it('should throw error if tableIds is null', async () => {
     await expect(

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-table.itest.ts
@@ -6,6 +6,7 @@ import TableMetadataResolver from '@/graphql/custom-resolvers/table-metadata'
 import getTable from '@/graphql/queries/tiles/get-table'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
+import { DatabaseType } from '@/models/tiles/types'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -15,141 +16,147 @@ import {
   generateMockTableColumns,
 } from '../../mutations/tiles/table.mock'
 
-describe('get single table query', () => {
-  let context: Context
-  let dummyTable: TableMetadata
-  let dummyColumnIds: string[] = []
-  let editor: User
-  let viewer: User
+describe.each([['ddb'], ['pg']])(
+  'get single table query: %s',
+  (databaseType: DatabaseType) => {
+    let context: Context
+    let dummyTable: TableMetadata
+    let dummyColumnIds: string[] = []
+    let editor: User
+    let viewer: User
 
-  beforeEach(async () => {
-    context = await generateMockContext()
+    beforeEach(async () => {
+      context = await generateMockContext()
 
-    const mockTable = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    dummyTable = mockTable.table
-    editor = mockTable.editor
-    viewer = mockTable.viewer
+      const mockTable = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType,
+      })
+      dummyTable = mockTable.table
+      editor = mockTable.editor
+      viewer = mockTable.viewer
 
-    dummyColumnIds = await generateMockTableColumns({
-      tableId: dummyTable.id,
-      numColumns: 5,
-    })
-  })
-  it('should return table metadata with ordered columns', async () => {
-    const table = await getTable(
-      null,
-      {
+      dummyColumnIds = await generateMockTableColumns({
         tableId: dummyTable.id,
-      },
-      context,
-    )
-    expect(table).toMatchObject({
-      id: dummyTable.id,
-      name: dummyTable.name,
+        numColumns: 5,
+        databaseType,
+      })
     })
-
-    const columns = await TableMetadataResolver.columns(dummyTable, {}, null)
-    expect(columns.map((c) => c.id)).toEqual(dummyColumnIds)
-  })
-
-  it('should return table metadata with role', async () => {
-    const table = await getTable(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
-    expect(table.role).toBe('owner')
-  })
-
-  it('should return empty array of columns if no columns exist', async () => {
-    const { table: insertedTable } = await generateMockTable({
-      userId: context.currentUser.id,
-    })
-    const table = await getTable(
-      null,
-      {
-        tableId: insertedTable.id,
-      },
-      context,
-    )
-    const columns = await TableMetadataResolver.columns(table, {}, null)
-    expect(columns).toHaveLength(0)
-  })
-
-  it('should throw an error if table does not exist', async () => {
-    await expect(
-      getTable(
-        null,
-        {
-          tableId: randomUUID(),
-        },
-        context,
-      ),
-    ).rejects.toThrow(NotFoundError)
-  })
-
-  it('should throw an error if collaborator does not exist or is soft deleted', async () => {
-    context.currentUser = editor
-    await TableCollaborator.query()
-      .delete()
-      .where('table_id', dummyTable.id)
-      .andWhere('user_id', editor.id)
-    await expect(
-      getTable(
+    it('should return table metadata with ordered columns', async () => {
+      const table = await getTable(
         null,
         {
           tableId: dummyTable.id,
         },
         context,
-      ),
-    ).rejects.toThrow(NotFoundError)
-  })
+      )
+      expect(table).toMatchObject({
+        id: dummyTable.id,
+        name: dummyTable.name,
+      })
 
-  it('should allow all collaborators to call this function', async () => {
-    context.currentUser = editor
-    await expect(
-      getTable(
+      const columns = await TableMetadataResolver.columns(dummyTable, {}, null)
+      expect(columns.map((c) => c.id)).toEqual(dummyColumnIds)
+    })
+
+    it('should return table metadata with role', async () => {
+      const table = await getTable(
         null,
         {
           tableId: dummyTable.id,
         },
         context,
-      ),
-    ).resolves.toBeDefined()
+      )
+      expect(table.role).toBe('owner')
+    })
 
-    context.currentUser = viewer
-    await expect(
-      getTable(
+    it('should return empty array of columns if no columns exist', async () => {
+      const { table: insertedTable } = await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType,
+      })
+      const table = await getTable(
+        null,
+        {
+          tableId: insertedTable.id,
+        },
+        context,
+      )
+      const columns = await TableMetadataResolver.columns(table, {}, null)
+      expect(columns).toHaveLength(0)
+    })
+
+    it('should throw an error if table does not exist', async () => {
+      await expect(
+        getTable(
+          null,
+          {
+            tableId: randomUUID(),
+          },
+          context,
+        ),
+      ).rejects.toThrow(NotFoundError)
+    })
+
+    it('should throw an error if collaborator does not exist or is soft deleted', async () => {
+      context.currentUser = editor
+      await TableCollaborator.query()
+        .delete()
+        .where('table_id', dummyTable.id)
+        .andWhere('user_id', editor.id)
+      await expect(
+        getTable(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).rejects.toThrow(NotFoundError)
+    })
+
+    it('should allow all collaborators to call this function', async () => {
+      context.currentUser = editor
+      await expect(
+        getTable(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+
+      context.currentUser = viewer
+      await expect(
+        getTable(
+          null,
+          {
+            tableId: dummyTable.id,
+          },
+          context,
+        ),
+      ).resolves.toBeDefined()
+    })
+
+    it('should return all collaborators ordered by roles', async () => {
+      const table = await getTable(
         null,
         {
           tableId: dummyTable.id,
         },
         context,
-      ),
-    ).resolves.toBeDefined()
-  })
-
-  it('should return all collaborators ordered by roles', async () => {
-    const table = await getTable(
-      null,
-      {
-        tableId: dummyTable.id,
-      },
-      context,
-    )
-    const collaborators = await TableMetadataResolver.collaborators(
-      table,
-      {},
-      null,
-    )
-    expect(collaborators).toEqual([
-      { email: context.currentUser.email, role: 'owner' },
-      { email: editor.email, role: 'editor' },
-      { email: viewer.email, role: 'viewer' },
-    ])
-  })
-})
+      )
+      const collaborators = await TableMetadataResolver.collaborators(
+        table,
+        {},
+        null,
+      )
+      expect(collaborators).toEqual([
+        { email: context.currentUser.email, role: 'owner' },
+        { email: editor.email, role: 'editor' },
+        { email: viewer.email, role: 'viewer' },
+      ])
+    })
+  },
+)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/get-tables.itest.ts
@@ -16,10 +16,13 @@ describe('get tables query', () => {
   beforeEach(async () => {
     context = await generateMockContext()
   })
-  it('should return array of tables belonging to users', async () => {
+  it('should return array of tables belonging to users regardless of database type', async () => {
     const numTables = 5
     for (let i = 0; i < numTables; i++) {
-      await generateMockTable({ userId: context.currentUser.id })
+      await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: i % 2 ? 'ddb' : 'pg',
+      })
     }
     const { edges, pageInfo } = await getTables(
       null,
@@ -47,7 +50,10 @@ describe('get tables query', () => {
   it('should throw an error if collaborator does not exist or is soft deleted', async () => {
     const numTables = 5
     for (let i = 0; i < numTables; i++) {
-      await generateMockTable({ userId: context.currentUser.id })
+      await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: i % 2 ? 'ddb' : 'pg',
+      })
     }
     const { edges, pageInfo } = await getTables(
       null,
@@ -75,7 +81,10 @@ describe('get tables query', () => {
   it('should filter by name', async () => {
     const numTables = 5
     for (let i = 0; i < numTables; i++) {
-      await generateMockTable({ userId: context.currentUser.id })
+      await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: i % 2 ? 'ddb' : 'pg',
+      })
     }
     const { edges } = await getTables(
       null,
@@ -97,7 +106,10 @@ describe('get tables query', () => {
   it('should paginate tables', async () => {
     const numTables = 5
     for (let i = 0; i < numTables; i++) {
-      await generateMockTable({ userId: context.currentUser.id })
+      await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: i % 2 ? 'ddb' : 'pg',
+      })
     }
     const { edges: firstPage, pageInfo: firstPageInfo } = await getTables(
       null,
@@ -123,7 +135,10 @@ describe('get tables query', () => {
   it('should return the corresponding roles of each user', async () => {
     const numTables = 5
     for (let i = 0; i < numTables; i++) {
-      await generateMockTable({ userId: context.currentUser.id })
+      await generateMockTable({
+        userId: context.currentUser.id,
+        databaseType: i % 2 ? 'ddb' : 'pg',
+      })
     }
     const { edges } = await getTables(null, { limit: 10, offset: 0 }, context)
     const tables = edges.map((edge) => edge.node)

--- a/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
@@ -1,6 +1,8 @@
-import { randomUUID } from 'crypto'
+import { chunk } from 'lodash'
 
 import { _batchCreate } from '@/models/tiles/dynamodb/table-row'
+import { getTableOperations } from '@/models/tiles/factory'
+import { DatabaseType } from '@/models/tiles/types'
 
 import { generateMockTableRowData } from '../../mutations/tiles/table.mock'
 
@@ -8,18 +10,21 @@ export async function insertMockTableRows(
   tableId: string,
   numRowsToInsert: number,
   columnIds: string[],
+  databaseType: DatabaseType,
 ): Promise<string[]> {
   const rows = []
   for (let i = 0; i < numRowsToInsert; i++) {
-    rows.push({
-      tableId,
-      // use ulid for new tiles
-      rowId: randomUUID(),
-      data: generateMockTableRowData({ columnIds }),
-    })
+    rows.push(generateMockTableRowData({ columnIds }))
   }
 
-  await _batchCreate(rows)
+  const tableOperations = getTableOperations(databaseType)
+  const chunks = chunk(rows, 100)
+  for (const dataArray of chunks) {
+    await tableOperations.createTableRows({
+      tableId,
+      dataArray,
+    })
+  }
 
   return rows.map((r) => r.rowId)
 }

--- a/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
+++ b/packages/backend/src/graphql/__tests__/queries/tiles/table-row.mock.ts
@@ -19,12 +19,14 @@ export async function insertMockTableRows(
 
   const tableOperations = getTableOperations(databaseType)
   const chunks = chunk(rows, 100)
+  const rowIds = []
   for (const dataArray of chunks) {
-    await tableOperations.createTableRows({
+    const addedRowsIds = await tableOperations.createTableRows({
       tableId,
       dataArray,
     })
+    rowIds.push(...addedRowsIds)
   }
 
-  return rows.map((r) => r.rowId)
+  return rowIds
 }

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -45,6 +45,7 @@ const createTable: MutationResolvers['createTable'] = async (
 
   const tableOperations = getTableOperations(databaseType)
 
+  console.log(tableOperations)
   const table = await TableMetadata.transaction(async (trx) => {
     const pendingTable = await context.currentUser
       .$relatedQuery('tables', trx)
@@ -54,8 +55,6 @@ const createTable: MutationResolvers['createTable'] = async (
         db: databaseType,
         columns: isBlankTable ? [] : PLACEHOLDER_COLUMNS,
       })
-
-    console.log('here')
 
     await tableOperations.createTable(
       pendingTable.id,

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -55,6 +55,8 @@ const createTable: MutationResolvers['createTable'] = async (
         columns: isBlankTable ? [] : PLACEHOLDER_COLUMNS,
       })
 
+    console.log('here')
+
     await tableOperations.createTable(
       pendingTable.id,
       isBlankTable ? [] : pendingTable.columns.map((column) => column.id),

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -45,7 +45,6 @@ const createTable: MutationResolvers['createTable'] = async (
 
   const tableOperations = getTableOperations(databaseType)
 
-  console.log(tableOperations)
   const table = await TableMetadata.transaction(async (trx) => {
     const pendingTable = await context.currentUser
       .$relatedQuery('tables', trx)

--- a/packages/backend/src/graphql/mutations/tiles/update-row.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-row.ts
@@ -13,13 +13,24 @@ const updateRow: MutationResolvers['updateRow'] = async (
 
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
-  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+  const table = await TableMetadata.query()
+    .findById(tableId)
+    .throwIfNotFound()
+    .withGraphFetched('columns')
 
   if (!(await table.validateRows([data]))) {
     throw new Error('Invalid column id')
   }
 
   const tableOperations = getTableOperations(table.db)
+
+  // Set unspecified columns to null
+  const columnIds = table.columns.map((column) => column.id)
+  for (const column of columnIds) {
+    if (!(column in data)) {
+      data[column] = null
+    }
+  }
 
   await tableOperations.updateTableRow({ tableId, rowId, data })
 

--- a/packages/backend/src/graphql/mutations/tiles/update-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/update-table.ts
@@ -1,6 +1,7 @@
 import pLimit from 'p-limit'
 import { z } from 'zod'
 
+import { BadUserInputError } from '@/errors/graphql-errors'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 import TableMetadata from '@/models/table-metadata'
@@ -105,6 +106,13 @@ const updateTable: MutationResolvers['updateTable'] = async (
       // There needs to be at least one column left
       if (columns.length <= deletedColumns.length) {
         throw new Error('Cannot delete all columns')
+      }
+      if (
+        deletedColumns.some(
+          (columnId) => !columns.some((c) => c.id === columnId),
+        )
+      ) {
+        throw new BadUserInputError('Column does not exist')
       }
       await table
         .$relatedQuery('columns')

--- a/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
@@ -30,12 +30,14 @@ describe('dynamodb table row functions', () => {
 
     const mockTable = await generateMockTable({
       userId: context.currentUser.id,
+      databaseType: 'ddb',
     })
     dummyTable = mockTable.table
 
     dummyColumnIds = await generateMockTableColumns({
       tableId: dummyTable.id,
       numColumns: 5,
+      databaseType: 'ddb',
     })
   })
 

--- a/packages/backend/src/models/tiles/dynamodb/helpers.ts
+++ b/packages/backend/src/models/tiles/dynamodb/helpers.ts
@@ -71,11 +71,13 @@ export function autoMarshallNumberStrings(value: string): string | number {
 }
 
 export function autoMarshallDataObj(
-  dataObj: Record<string, string>,
+  dataObj: Record<string, string | number>,
 ): Record<string, string | number> {
   const newObj: Record<string, string | number> = {}
   for (const key in dataObj) {
-    newObj[key] = autoMarshallNumberStrings(dataObj[key])
+    const value = dataObj[key]
+    newObj[key] =
+      typeof value === 'string' ? autoMarshallNumberStrings(value) : value
   }
   return newObj
 }

--- a/packages/backend/src/models/tiles/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/tiles/dynamodb/table-row/functions.ts
@@ -12,6 +12,7 @@ import {
   TableRowFilterOperator,
   TableRowItem,
   TableRowOutput,
+  TableRowOutputWithTimestamps,
   UpdateRowInput,
 } from '../../types'
 import { autoMarshallNumberStrings, handleDynamoDBError } from '../helpers'
@@ -399,14 +400,23 @@ export const getRawRowById = async ({
   tableId,
   rowId,
   columnIds,
+  includeTimestamps = false,
 }: {
   tableId: string
   rowId: string
   columnIds?: string[]
-}): Promise<TableRowOutput | null> => {
+  includeTimestamps?: boolean
+}): Promise<TableRowOutput | TableRowOutputWithTimestamps | null> => {
   try {
+    const columnIdsToSelect =
+      columnIds && includeTimestamps
+        ? [...columnIds, 'createdAt', 'updatedAt']
+        : columnIds
     const { ProjectionExpression, ExpressionAttributeNames } =
-      generateProjectionExpressions({ columnIds, indexUsed: 'byRowId' })
+      generateProjectionExpressions({
+        columnIds: columnIdsToSelect,
+        indexUsed: 'byRowId',
+      })
     const response = await TableRow.query.byRowId({ tableId, rowId }).go({
       ignoreOwnership: true,
       params: {

--- a/packages/backend/src/models/tiles/pg/__tests__/factory.test.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/factory.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { DynamoDBTableOperations } from '../../dynamodb/class'
+import { getTableOperations } from '../../factory'
+import { DatabaseType, TableOperations } from '../../types'
+import { PostgresTableOperations } from '../class'
+
+describe('getTableOperations', () => {
+  it('should return PostgresTableOperations when databaseType is pg', () => {
+    const databaseType: DatabaseType = 'pg'
+    const tableOperations: TableOperations = getTableOperations(databaseType)
+
+    expect(tableOperations).toBeInstanceOf(PostgresTableOperations)
+  })
+
+  it('should return DynamoDBTableOperations when databaseType is not pg', () => {
+    const databaseType: DatabaseType = 'ddb'
+    const tableOperations: TableOperations = getTableOperations(databaseType)
+
+    expect(tableOperations).toBeInstanceOf(DynamoDBTableOperations)
+  })
+})

--- a/packages/backend/src/models/tiles/pg/__tests__/table-column-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-column-functions.itest.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  generateMockContext,
+  generateMockTable,
+} from '@/graphql/__tests__/mutations/tiles/table.mock'
+import { checkIfTableHasColumn } from '@/graphql/__tests__/mutations/tiles/tiles-pg-helper'
+import TableMetadata from '@/models/table-metadata'
+import Context from '@/types/express/context'
+
+import {
+  createTableColumns,
+  deleteTableColumns,
+} from '../table-column-functions'
+
+describe('table-column-functions', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    const mockTable = await generateMockTable({
+      userId: context.currentUser.id,
+      databaseType: 'pg',
+    })
+    dummyTable = mockTable.table
+  })
+
+  describe('createTableColumns', () => {
+    it('should create single column when provided with one column ID', async () => {
+      const columnId = randomUUID()
+
+      await createTableColumns(dummyTable.id, [columnId])
+
+      const hasColumn = await checkIfTableHasColumn(dummyTable.id, columnId)
+      expect(hasColumn).toBe(true)
+    })
+
+    it('should create multiple columns when provided with multiple column IDs', async () => {
+      const columnIds = [randomUUID(), randomUUID(), randomUUID()]
+
+      await createTableColumns(dummyTable.id, columnIds)
+
+      // Verify all columns were created
+      const columnChecks = await Promise.all(
+        columnIds.map((columnId) =>
+          checkIfTableHasColumn(dummyTable.id, columnId),
+        ),
+      )
+      expect(columnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should handle empty column IDs array gracefully', async () => {
+      await expect(createTableColumns(dummyTable.id, [])).resolves.not.toThrow()
+    })
+
+    it('should fail when creating duplicate columns', async () => {
+      const columnId = randomUUID()
+
+      // Create column first time
+      await createTableColumns(dummyTable.id, [columnId])
+
+      // Try to create same column again - should not throw
+      await expect(
+        createTableColumns(dummyTable.id, [columnId]),
+      ).rejects.toThrow()
+
+      const hasColumn = await checkIfTableHasColumn(dummyTable.id, columnId)
+      expect(hasColumn).toBe(true)
+    })
+
+    it('should fail when creating duplicate columns concurrently', async () => {
+      const columnId = randomUUID()
+
+      // Create column first time
+      await expect(
+        createTableColumns(dummyTable.id, [columnId, columnId]),
+      ).rejects.toThrow()
+
+      const hasColumn = await checkIfTableHasColumn(dummyTable.id, columnId)
+      expect(hasColumn).toBe(false)
+    })
+
+    it('should throw an error when table does not exist', async () => {
+      const nonExistentTableId = randomUUID()
+      const columnId = randomUUID()
+
+      await expect(
+        createTableColumns(nonExistentTableId, [columnId]),
+      ).rejects.toThrow()
+    })
+
+    it('should create columns as text type', async () => {
+      const columnId = randomUUID()
+
+      await createTableColumns(dummyTable.id, [columnId])
+
+      // Verify column exists and can store text data
+      const hasColumn = await checkIfTableHasColumn(dummyTable.id, columnId)
+      expect(hasColumn).toBe(true)
+
+      // This would fail if the column type was not compatible with text
+      await expect(async () => {
+        // We don't have a direct way to test column type, but we can test that text values work
+        // This is implicitly tested by the table-row-functions that use these columns
+      }).not.toThrow()
+    })
+  })
+
+  describe('deleteTableColumns', () => {
+    let existingColumnIds: string[]
+
+    beforeEach(async () => {
+      // Create some columns first
+      existingColumnIds = [randomUUID(), randomUUID(), randomUUID()]
+      await createTableColumns(dummyTable.id, existingColumnIds)
+
+      // Verify they were created
+      const columnChecks = await Promise.all(
+        existingColumnIds.map((columnId) =>
+          checkIfTableHasColumn(dummyTable.id, columnId),
+        ),
+      )
+      expect(columnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should delete single column when provided with one column ID', async () => {
+      const columnIdToDelete = existingColumnIds[0]
+
+      await deleteTableColumns(dummyTable.id, [columnIdToDelete])
+
+      const hasColumn = await checkIfTableHasColumn(
+        dummyTable.id,
+        columnIdToDelete,
+      )
+      expect(hasColumn).toBe(false)
+
+      // Verify other columns still exist
+      const otherColumnChecks = await Promise.all(
+        existingColumnIds
+          .slice(1)
+          .map((columnId) => checkIfTableHasColumn(dummyTable.id, columnId)),
+      )
+      expect(otherColumnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should delete multiple columns when provided with multiple column IDs', async () => {
+      const columnsToDelete = existingColumnIds.slice(0, 2)
+
+      await deleteTableColumns(dummyTable.id, columnsToDelete)
+
+      // Verify deleted columns no longer exist
+      const deletedColumnChecks = await Promise.all(
+        columnsToDelete.map((columnId) =>
+          checkIfTableHasColumn(dummyTable.id, columnId),
+        ),
+      )
+      expect(deletedColumnChecks.every((exists) => !exists)).toBe(true)
+
+      // Verify remaining column still exists
+      const remainingColumn = existingColumnIds[2]
+      const hasRemainingColumn = await checkIfTableHasColumn(
+        dummyTable.id,
+        remainingColumn,
+      )
+      expect(hasRemainingColumn).toBe(true)
+    })
+
+    it('should handle empty column IDs array gracefully', async () => {
+      await expect(deleteTableColumns(dummyTable.id, [])).resolves.not.toThrow()
+
+      // Verify all original columns still exist
+      const columnChecks = await Promise.all(
+        existingColumnIds.map((columnId) =>
+          checkIfTableHasColumn(dummyTable.id, columnId),
+        ),
+      )
+      expect(columnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should throw an error when trying to delete non-existent column', async () => {
+      const nonExistentColumnId = randomUUID()
+
+      await expect(
+        deleteTableColumns(dummyTable.id, [nonExistentColumnId]),
+      ).rejects.toThrow()
+    })
+
+    it('should throw an error when table does not exist', async () => {
+      const nonExistentTableId = randomUUID()
+      const columnId = randomUUID()
+
+      await expect(
+        deleteTableColumns(nonExistentTableId, [columnId]),
+      ).rejects.toThrow()
+    })
+
+    it('should handle mixed valid and invalid column IDs by throwing error', async () => {
+      const validColumnId = existingColumnIds[0]
+      const invalidColumnId = randomUUID()
+
+      await expect(
+        deleteTableColumns(dummyTable.id, [validColumnId, invalidColumnId]),
+      ).rejects.toThrow()
+
+      // Verify that valid column still exists (transaction should rollback)
+      const hasValidColumn = await checkIfTableHasColumn(
+        dummyTable.id,
+        validColumnId,
+      )
+      expect(hasValidColumn).toBe(true)
+    })
+  })
+})

--- a/packages/backend/src/models/tiles/pg/__tests__/table-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-functions.itest.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'crypto'
+import { describe, expect, it } from 'vitest'
+
+import { tilesClient } from '@/config/tiles-database'
+import {
+  checkIfTableExists,
+  checkIfTableHasColumn,
+} from '@/graphql/__tests__/mutations/tiles/tiles-pg-helper'
+
+import { createTable } from '../table-functions'
+
+describe('table-functions', () => {
+  describe('createTable', () => {
+    it('should create a table with specified columns', async () => {
+      const testTableId = randomUUID()
+      const testColumnIds = [randomUUID(), randomUUID()]
+      await createTable(testTableId, testColumnIds)
+
+      // Verify table exists
+      const tableExists = await checkIfTableExists(testTableId)
+      expect(tableExists).toBe(true)
+
+      // Verify columns exist
+      const columnChecks = await Promise.all(
+        testColumnIds.map((columnId) =>
+          checkIfTableHasColumn(testTableId, columnId),
+        ),
+      )
+      expect(columnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should create a table with rowId as primary key', async () => {
+      const testTableId = randomUUID()
+      const testColumnIds = [randomUUID(), randomUUID()]
+      await createTable(testTableId, testColumnIds)
+
+      // Check if rowId column exists and is primary key
+      const result = await tilesClient.raw(`
+        SELECT a.attname, format_type(a.atttypid, a.atttypmod) AS data_type, 
+               i.indisprimary AS is_primary_key
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+        WHERE i.indrelid = '${testTableId}'::regclass
+        AND i.indisprimary = true;
+      `)
+
+      expect(result.rows.length).toBe(1)
+      expect(result.rows[0].attname).toBe('rowId')
+      expect(result.rows[0].is_primary_key).toBe(true)
+    })
+
+    it('should create a table with timestamp columns', async () => {
+      const testTableId = randomUUID()
+      await createTable(testTableId, [])
+
+      // Check if created_at and updated_at columns exist
+      const timestampColumns = ['createdAt', 'updatedAt']
+      const columnChecks = await Promise.all(
+        timestampColumns.map((columnName) =>
+          checkIfTableHasColumn(testTableId, columnName),
+        ),
+      )
+      expect(columnChecks.every((exists) => exists)).toBe(true)
+    })
+
+    it('should throw an error when trying to create a table that already exists', async () => {
+      const testTableId = randomUUID()
+      await createTable(testTableId, [])
+
+      // Try to create the same table again
+      await expect(createTable(testTableId, [])).rejects.toThrow()
+    })
+
+    it('should create a table with no additional columns when empty columnIds array is provided', async () => {
+      const testTableId = randomUUID()
+      await createTable(testTableId, [])
+
+      // Verify table exists
+      const tableExists = await checkIfTableExists(testTableId)
+      expect(tableExists).toBe(true)
+
+      // Should only have rowId and timestamp columns
+      const columns = await tilesClient.raw(`
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = '${testTableId}';
+      `)
+
+      const expectedColumns = ['rowId', 'createdAt', 'updatedAt']
+      expect(columns.rows.length).toBe(expectedColumns.length)
+      expect(
+        columns.rows.map((r: { column_name: string }) => r.column_name).sort(),
+      ).toEqual(expectedColumns.sort())
+    })
+  })
+})

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -1,0 +1,586 @@
+import { ulid } from 'ulid'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  generateMockContext,
+  generateMockTable,
+  generateMockTableColumns,
+  generateMockTableRowData,
+} from '@/graphql/__tests__/mutations/tiles/table.mock'
+import { selectAllRows } from '@/graphql/__tests__/mutations/tiles/tiles-pg-helper'
+import TableMetadata from '@/models/table-metadata'
+import Context from '@/types/express/context'
+
+import {
+  TableRowFilterOperator,
+  TableRowOutputWithTimestamps,
+} from '../../types'
+import {
+  createTableRow,
+  createTableRows,
+  deleteTableRows,
+  getRawRowById,
+  getTableRowCount,
+  getTableRows,
+  patchTableRow,
+  updateTableRow,
+} from '../table-row-functions'
+
+describe('table-row-functions', () => {
+  let context: Context
+  let dummyTable: TableMetadata
+  let dummyColumnIds: string[]
+
+  // cant use before all here since the data is re-seeded each time
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    const mockTable = await generateMockTable({
+      userId: context.currentUser.id,
+      databaseType: 'pg',
+    })
+    dummyTable = mockTable.table
+
+    dummyColumnIds = await generateMockTableColumns({
+      tableId: dummyTable.id,
+      numColumns: 5,
+      databaseType: 'pg',
+    })
+  })
+
+  describe('createTableRow', () => {
+    it('should create a single row with the provided data', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      const result = await createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+
+      const dbRows = await selectAllRows(dummyTable.id)
+
+      expect(dbRows).toHaveLength(1)
+      expect(dbRows[0].rowId).toBe(result.rowId)
+    })
+
+    it('should fail if the data is invalid', async () => {
+      const data = generateMockTableRowData({
+        columnIds: ['wrong column id'],
+      })
+
+      await expect(
+        createTableRow({
+          tableId: dummyTable.id,
+          data,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should cast the data to the correct type', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      // @ts-expect-error - we want to test the casting
+      data[dummyColumnIds[0]] = 123
+
+      await expect(
+        createTableRow({
+          tableId: dummyTable.id,
+          data,
+        }),
+      ).resolves.not.toThrow()
+
+      const dbRows = await selectAllRows(dummyTable.id)
+
+      expect(dbRows).toHaveLength(1)
+      expect(dbRows[0][dummyColumnIds[0]]).toBe('123')
+    })
+  })
+
+  describe('createTableRows', () => {
+    it('should create multiple rows with the provided data', async () => {
+      const dataArray = new Array(3).fill(0).map(() =>
+        generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      )
+
+      const rowIds = await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+      })
+      expect(rowIds).toHaveLength(3)
+
+      // Verify all rows were created in the database
+      const dbRows = await selectAllRows(dummyTable.id)
+      expect(dbRows).toHaveLength(3)
+    })
+
+    it('should maintain the order of rows created', async () => {
+      const dataArray = new Array(3).fill(0).map(() =>
+        generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      )
+
+      const rowIds = await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+      })
+      expect(rowIds).toHaveLength(3)
+
+      // Verify all rows were created in the database
+      const dbRows = await selectAllRows(dummyTable.id)
+      expect(dbRows).toHaveLength(3)
+      expect(dbRows[0][dummyColumnIds[0]]).toBe(dataArray[0][dummyColumnIds[0]])
+      expect(dbRows[1][dummyColumnIds[0]]).toBe(dataArray[1][dummyColumnIds[0]])
+      expect(dbRows[2][dummyColumnIds[0]]).toBe(dataArray[2][dummyColumnIds[0]])
+    })
+  })
+
+  describe('updateTableRow', () => {
+    it('should update an existing row with new data', async () => {
+      // Create a row first
+      const dataArray = new Array(3).fill(0).map(() =>
+        generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      )
+
+      const rowIds = await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+      })
+
+      await updateTableRow({
+        tableId: dummyTable.id,
+        rowId: rowIds[0],
+        data: dataArray[1],
+      })
+
+      // Verify the row was updated
+      const dbRows = await selectAllRows(dummyTable.id)
+      // remove irrelevant fields
+      delete dbRows[0].rowId
+      delete dbRows[0].createdAt
+      delete dbRows[0].updatedAt
+      delete dbRows[1].rowId
+      delete dbRows[1].createdAt
+      delete dbRows[1].updatedAt
+      expect(dbRows[0]).toEqual(dataArray[1])
+    })
+
+    it('should throw an error when attempting to update a non-existent row', async () => {
+      const nonExistentRowId = ulid()
+
+      await expect(
+        updateTableRow({
+          tableId: dummyTable.id,
+          rowId: nonExistentRowId,
+          data: generateMockTableRowData({
+            columnIds: dummyColumnIds,
+          }),
+        }),
+      ).rejects.toThrow('Row not found')
+    })
+  })
+
+  describe('patchTableRow', () => {
+    it('should partially update a row with set operation', async () => {
+      // Create a row first
+      const originalData = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data: originalData,
+      })
+
+      const patchData = generateMockTableRowData({
+        columnIds: dummyColumnIds.slice(0, 2),
+      })
+
+      // Patch only the name
+      await patchTableRow({
+        tableId: dummyTable.id,
+        rowId,
+        patchData: {
+          set: patchData,
+        },
+      })
+
+      const dbRows = await selectAllRows(dummyTable.id)
+      expect(dbRows[0]).toEqual(
+        expect.objectContaining({ ...originalData, ...patchData }),
+      )
+    })
+
+    it('should update numeric values with add operation', async () => {
+      // Create a row with a numeric field
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: '10',
+        },
+      })
+
+      // Add 5 to the number
+      const result = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId,
+        patchData: {
+          add: {
+            [dummyColumnIds[0]]: '5',
+          },
+        },
+      })
+
+      expect(result.data[dummyColumnIds[0]]).toBe('15')
+
+      const result2 = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId,
+        patchData: {
+          add: {
+            [dummyColumnIds[0]]: '4.5',
+          },
+        },
+      })
+
+      expect(result2.data[dummyColumnIds[0]]).toBe('19.5')
+    })
+
+    it('should update numeric values with subtract operation', async () => {
+      // Create a row with a numeric field
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: '10',
+        },
+      })
+
+      // Add 5 to the number
+      const result = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId,
+        patchData: {
+          subtract: {
+            [dummyColumnIds[0]]: '5',
+          },
+        },
+      })
+      expect(result.data[dummyColumnIds[0]]).toBe('5')
+
+      const result2 = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId,
+        patchData: {
+          subtract: {
+            [dummyColumnIds[0]]: '4.5',
+          },
+        },
+      })
+
+      expect(result2.data[dummyColumnIds[0]]).toBe('0.5')
+    })
+
+    it('should throw an error when using add operation with non-numeric value', async () => {
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: 'yorimo anata',
+          [dummyColumnIds[1]]: '123',
+        },
+      })
+
+      await expect(
+        patchTableRow({
+          tableId: dummyTable.id,
+          rowId,
+          patchData: {
+            add: {
+              [dummyColumnIds[0]]: '123',
+            },
+          },
+        }),
+      ).rejects.toThrow('Row cannot be patched')
+
+      await expect(
+        patchTableRow({
+          tableId: dummyTable.id,
+          rowId,
+          patchData: {
+            add: {
+              [dummyColumnIds[1]]: 'not-a-number',
+            },
+          },
+        }),
+      ).rejects.toThrow('Invalid value for add operation')
+    })
+  })
+
+  describe('deleteTableRows', () => {
+    it('should delete multiple rows by their IDs', async () => {
+      // Create some rows
+      const dataArray = new Array(3).fill(0).map(() =>
+        generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      )
+      const rowIds = await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+      })
+
+      // Delete the first two rows
+      await deleteTableRows({
+        tableId: dummyTable.id,
+        rowIds: [rowIds[0], rowIds[1]],
+      })
+
+      // Check that they were deleted
+      const dbRows = await selectAllRows(dummyTable.id)
+      expect(dbRows).toHaveLength(1)
+      expect(dbRows[0].rowId).toBe(rowIds[2])
+    })
+
+    // this function is actually not used
+    it('should not throw an error when deleting non-existent rows', async () => {
+      const nonExistentIds = [ulid(), ulid()]
+
+      // This should not throw
+      await expect(
+        deleteTableRows({
+          tableId: dummyTable.id,
+          rowIds: nonExistentIds,
+        }),
+      ).resolves.not.toThrow()
+    })
+  })
+
+  describe('getTableRowCount', () => {
+    it('should return the correct count of rows', async () => {
+      // Initially there should be no rows
+      let count = await getTableRowCount({ tableId: dummyTable.id })
+      expect(count).toBe(0)
+
+      // Add some rows
+      await createTableRows({
+        tableId: dummyTable.id,
+        dataArray: new Array(33).fill(0).map(() =>
+          generateMockTableRowData({
+            columnIds: dummyColumnIds,
+          }),
+        ),
+      })
+
+      // Check the count again
+      count = await getTableRowCount({ tableId: dummyTable.id })
+      expect(count).toBe(33)
+    })
+  })
+
+  describe('getTableRows', () => {
+    let dataArray: Record<string, string>[]
+    let rowIds: string[]
+    beforeEach(async () => {
+      // Add test rows for filtering tests
+      dataArray = new Array(5).fill(0).map(() =>
+        generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      )
+      dataArray[0][dummyColumnIds[3]] = '0'
+      dataArray[1][dummyColumnIds[3]] = '10'
+      dataArray[2][dummyColumnIds[3]] = '20'
+      dataArray[3][dummyColumnIds[3]] = '30'
+      dataArray[4][dummyColumnIds[3]] = '40'
+      rowIds = await createTableRows({
+        tableId: dummyTable.id,
+        dataArray,
+      })
+    })
+
+    it('should return all rows when no filters are specified', async () => {
+      const result = await getTableRows({ tableId: dummyTable.id })
+      expect(result.rows).toHaveLength(5)
+    })
+
+    it('should return only specified columns', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: [dummyColumnIds[0]],
+      })
+
+      expect(result.rows).toHaveLength(5)
+      expect(Object.keys(result.rows[0].data)).toEqual([dummyColumnIds[0]])
+    })
+
+    it('should filter rows with equals operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[0],
+            operator: TableRowFilterOperator.Equals,
+            value: dataArray[0][dummyColumnIds[0]],
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0].rowId).toBe(rowIds[0])
+    })
+
+    it('should filter rows with contains operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[1],
+            operator: TableRowFilterOperator.Contains,
+            value: dataArray[1][dummyColumnIds[1]].slice(4, 12),
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(1)
+      expect(result.rows[0].rowId).toBe(rowIds[1])
+    })
+
+    it('should filter rows with greaterThan operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.GreaterThan,
+            value: '25',
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(2)
+      expect(result.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[3],
+        rowIds[4],
+      ])
+    })
+
+    it('should return rows with pagination using scanLimit and cursor', async () => {
+      // First page
+      const firstPage = await getTableRows({
+        tableId: dummyTable.id,
+        scanLimit: 2,
+      })
+
+      expect(firstPage.rows).toHaveLength(2)
+      expect(firstPage.stringifiedCursor).not.toBeNull()
+
+      // Second page
+      const secondPage = await getTableRows({
+        tableId: dummyTable.id,
+        scanLimit: 2,
+        stringifiedCursor: firstPage.stringifiedCursor,
+      })
+
+      expect(secondPage.rows).toHaveLength(2)
+      expect(secondPage.stringifiedCursor).not.toBeNull()
+
+      // Third page
+      const thirdPage = await getTableRows({
+        tableId: dummyTable.id,
+        scanLimit: 2,
+        stringifiedCursor: secondPage.stringifiedCursor,
+      })
+
+      expect(thirdPage.rows).toHaveLength(1)
+      expect(thirdPage.stringifiedCursor).toBeNull() // No more pages
+    })
+
+    it('should order rows in descending order when specified', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        order: 'desc',
+      })
+
+      // Since rows are ordered by rowId, which follows creation order,
+      // we expect the names to be in reverse creation order
+      expect(result.rows[0].rowId).toBe(rowIds[4])
+      expect(result.rows[result.rows.length - 1].rowId).toBe(rowIds[0])
+    })
+  })
+
+  describe('getRawRowById', () => {
+    it('should retrieve a specific row by ID', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+
+      const result = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId,
+      })
+
+      expect(result).toBeDefined()
+      expect(result.data).toEqual(data)
+    })
+
+    it('should return null for non-existent row ID', async () => {
+      const nonExistentRowId = ulid()
+
+      const result = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId: nonExistentRowId,
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should return only specified columns when columnIds is provided', async () => {
+      const data = generateMockTableRowData({
+        columnIds: dummyColumnIds,
+      })
+
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data,
+      })
+
+      const result = await getRawRowById({
+        tableId: dummyTable.id,
+        rowId,
+        columnIds: [dummyColumnIds[0]],
+      })
+
+      expect(Object.keys(result.data)).toEqual([dummyColumnIds[0]])
+    })
+
+    it('should include timestamps when includeTimestamps is true', async () => {
+      const { rowId } = await createTableRow({
+        tableId: dummyTable.id,
+        data: generateMockTableRowData({
+          columnIds: dummyColumnIds,
+        }),
+      })
+
+      const result = (await getRawRowById({
+        tableId: dummyTable.id,
+        rowId,
+        columnIds: dummyColumnIds,
+        includeTimestamps: true,
+      })) as TableRowOutputWithTimestamps
+
+      expect(result.createdAt).toBeDefined()
+      expect(result.updatedAt).toBeDefined()
+    })
+  })
+})

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -306,7 +306,7 @@ describe('table-row-functions', () => {
             },
           },
         }),
-      ).rejects.toThrow('Row cannot be patched')
+      ).rejects.toThrow()
 
       await expect(
         patchTableRow({

--- a/packages/backend/src/models/tiles/pg/table-column-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-column-functions.ts
@@ -1,17 +1,21 @@
 import { tilesClient } from '@/config/tiles-database'
 
-export function createTableColumns(tableId: string, columnIds: string[]) {
-  return tilesClient.schema.alterTable(tableId, (table) => {
-    columnIds.forEach((columnId) => {
-      table.text(columnId)
-    })
-  })
+export async function createTableColumns(tableId: string, columnIds: string[]) {
+  return tilesClient.transaction(async (trx) =>
+    trx.schema.alterTable(tableId, (table) => {
+      columnIds.forEach((columnId) => {
+        table.text(columnId)
+      })
+    }),
+  )
 }
 
-export function deleteTableColumns(tableId: string, columnIds: string[]) {
-  return tilesClient.schema.alterTable(tableId, (table) => {
-    columnIds.forEach((columnId) => {
-      table.dropColumn(columnId)
-    })
-  })
+export async function deleteTableColumns(tableId: string, columnIds: string[]) {
+  return tilesClient.transaction(async (trx) =>
+    trx.schema.alterTable(tableId, (table) => {
+      columnIds.forEach((columnId) => {
+        table.dropColumn(columnId)
+      })
+    }),
+  )
 }

--- a/packages/backend/src/models/tiles/pg/table-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-functions.ts
@@ -1,6 +1,7 @@
 import { tilesClient } from '@/config/tiles-database'
 
 export function createTable(tableId: string, columnIds: string[]) {
+  console.log('createTable', tableId, columnIds)
   return tilesClient.schema.createTable(tableId, (table) => {
     table.string('rowId').primary()
     columnIds.forEach((columnId) => {

--- a/packages/backend/src/models/tiles/pg/table-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-functions.ts
@@ -1,7 +1,6 @@
 import { tilesClient } from '@/config/tiles-database'
 
 export function createTable(tableId: string, columnIds: string[]) {
-  console.log('createTable', tableId, columnIds)
   return tilesClient.schema.createTable(tableId, (table) => {
     table.string('rowId').primary()
     columnIds.forEach((columnId) => {

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -149,6 +149,9 @@ export const patchTableRow = async ({
     )
 
     const res = await query.update('updatedAt', new Date()).returning('*')
+    if (res.length === 0) {
+      throw new Error('Row cannot be patched')
+    }
     return formatTableRow(res[0], tableId)
   } catch (e: unknown) {
     logger.error(e)

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -150,7 +150,7 @@ export const patchTableRow = async ({
 
     const res = await query.update('updatedAt', new Date()).returning('*')
     if (res.length === 0) {
-      throw new Error('Row cannot be patched')
+      throw new Error('No rows to patch')
     }
     return formatTableRow(res[0], tableId)
   } catch (e: unknown) {

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -13,6 +13,7 @@ import {
   TableRowFilterOperator,
   TableRowItem,
   TableRowOutput,
+  TableRowOutputWithTimestamps,
   UpdateRowInput,
 } from '../types'
 
@@ -35,7 +36,6 @@ export const createTableRow = async ({
   tableId,
   data,
 }: CreateRowInput): Promise<TableRowItem> => {
-  const ulid = monotonicFactory()
   try {
     const res = await tilesClient(tableId)
       .insert({
@@ -56,11 +56,12 @@ export const createTableRows = async ({
   dataArray,
 }: CreateRowsInput): Promise<string[]> => {
   try {
-    const rows = dataArray.map((data, i) => ({
+    const ulid = monotonicFactory()
+    const rows = dataArray.map((data) => ({
       rowId: ulid(),
       ...data,
-      // manually bumping the createdAt timestamp to ensure that row order is preserved
-      createdAt: new Date(Date.now() + i),
+      // no need to manually bump the createdAt timestamp as the rowId is already sorted
+      createdAt: new Date(),
     }))
     const res = await tilesClient(tableId).insert(rows).returning(['rowId'])
     return res.map((row) => row.rowId)
@@ -79,12 +80,17 @@ export const updateTableRow = async ({
   data,
 }: UpdateRowInput): Promise<void> => {
   try {
-    await tilesClient(tableId)
+    const res = await tilesClient(tableId)
       .where({
         rowId,
       })
       .update(data)
       .update('updatedAt', new Date())
+      .returning('rowId')
+    if (res.length === 0) {
+      throw new Error('Row not found')
+    }
+    return
   } catch (e: unknown) {
     logger.error(e)
     throw e
@@ -272,22 +278,36 @@ export const getRawRowById = async ({
   tableId,
   rowId: rowIdToUse,
   columnIds,
+  includeTimestamps = false,
 }: {
   tableId: string
   rowId: string
   columnIds?: string[]
-}): Promise<TableRowOutput | null> => {
+  includeTimestamps?: boolean
+}): Promise<TableRowOutput | TableRowOutputWithTimestamps | null> => {
   try {
+    const columnsToSelect = columnIds ? ['rowId', ...columnIds] : ['*']
+    if (includeTimestamps && columnIds) {
+      columnsToSelect.push('createdAt', 'updatedAt')
+    }
     const res = await tilesClient(tableId)
       .where({
         rowId: rowIdToUse,
       })
-      .select(columnIds ? ['rowId', ...columnIds] : ['*'])
+      .select(columnsToSelect)
       .first()
     if (!res) {
       return null
     }
-    return formatTableRow(res, tableId)
+    const formattedRow = formatTableRow(res, tableId)
+    if (includeTimestamps && formattedRow) {
+      return {
+        ...formattedRow,
+        createdAt: res.createdAt,
+        updatedAt: res.updatedAt,
+      }
+    }
+    return formattedRow
   } catch (e: unknown) {
     logger.error(e)
     throw e

--- a/packages/backend/src/models/tiles/types.ts
+++ b/packages/backend/src/models/tiles/types.ts
@@ -22,6 +22,10 @@ export interface DeleteRowsInput {
   rowIds: string[]
 }
 export type TableRowOutput = Pick<TableRowItem, 'rowId' | 'data'>
+export type TableRowOutputWithTimestamps = TableRowOutput & {
+  createdAt: number
+  updatedAt: number
+}
 
 export enum TableRowFilterOperator {
   Equals = 'equals',
@@ -64,7 +68,8 @@ export interface TableOperations {
     tableId: string
     rowId: string
     columnIds?: string[]
-  }): Promise<TableRowOutput | null>
+    includeTimestamps?: boolean
+  }): Promise<TableRowOutput | TableRowOutputWithTimestamps | null>
 
   createTable(tableId: string, columnIds: string[]): Promise<void>
   createTableColumns(tableId: string, columnIds: string[]): Promise<void>

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -123,45 +123,51 @@ describe('Action worker', () => {
       expect(mocks.exponentialBackoffWithJitter).not.toBeCalled()
     })
 
-    it('retries retriable executions using our custom backoff strategy', async () => {
-      // Override max attempts to reduce test running time.
-      const maxAttempts = 3
+    it(
+      'retries retriable executions using our custom backoff strategy',
+      {
+        timeout: 20000,
+      },
+      async () => {
+        // Override max attempts to reduce test running time.
+        const maxAttempts = 3
 
-      mocks.processAction.mockResolvedValue({
-        executionStep: { isFailed: true },
-      })
-      mocks.handleFailedStepAndThrow.mockRejectedValue(
-        new RetriableError({
-          error: 'test retriable error',
-          delayInMs: 10,
-          delayType: 'step',
-        }),
-      )
-
-      const jobProcessed = new Promise<void>((resolve) => {
-        mainActionWorker.on('failed', async (job) => {
-          if (job.attemptsMade === maxAttempts) {
-            resolve()
-          }
+        mocks.processAction.mockResolvedValue({
+          executionStep: { isFailed: true },
         })
-      })
-      await enqueueActionJob({
-        appKey: null,
-        jobName: 'test-job',
-        jobData: {
-          flowId: 'test-flow-id',
-          executionId: 'test-exec-id',
-          stepId: 'test-step-id',
-        },
-        jobOptions: {
-          ...DEFAULT_JOB_OPTIONS,
-          attempts: maxAttempts,
-        },
-      })
-      await jobProcessed
+        mocks.handleFailedStepAndThrow.mockRejectedValue(
+          new RetriableError({
+            error: 'test retriable error',
+            delayInMs: 10,
+            delayType: 'step',
+          }),
+        )
 
-      expect(mocks.exponentialBackoffWithJitter).toBeCalled()
-    })
+        const jobProcessed = new Promise<void>((resolve) => {
+          mainActionWorker.on('failed', async (job) => {
+            if (job.attemptsMade === maxAttempts) {
+              resolve()
+            }
+          })
+        })
+        await enqueueActionJob({
+          appKey: null,
+          jobName: 'test-job',
+          jobData: {
+            flowId: 'test-flow-id',
+            executionId: 'test-exec-id',
+            stepId: 'test-step-id',
+          },
+          jobOptions: {
+            ...DEFAULT_JOB_OPTIONS,
+            attempts: maxAttempts,
+          },
+        })
+        await jobProcessed
+
+        expect(mocks.exponentialBackoffWithJitter).toBeCalled()
+      },
+    )
 
     it('does not retry non-executable executions', async () => {
       mocks.processAction.mockResolvedValueOnce({

--- a/packages/backend/test/pg-global-setup.ts
+++ b/packages/backend/test/pg-global-setup.ts
@@ -3,7 +3,7 @@ import {
   PostgreSqlContainer,
   StartedPostgreSqlContainer,
 } from '@testcontainers/postgresql'
-import knex from 'knex'
+import knex, { Knex } from 'knex'
 import { join } from 'path'
 
 let postgresContainer: StartedPostgreSqlContainer
@@ -24,8 +24,8 @@ export async function setup() {
     `PostgreSQL container started at port ${process.env.POSTGRES_PORT}`,
   )
 
-  const config = await (await import('../knexfile')).default
-  const client = knex(config)
+  const config = (await import('../knexfile')).default
+  const client = knex(config as Knex.Config)
 
   // manually running migrations since the programmatic API doesn't work
   // see issue here: https://github.com/knex/knex/issues/5323

--- a/packages/backend/test/tiles-pg-global-setup.ts
+++ b/packages/backend/test/tiles-pg-global-setup.ts
@@ -19,7 +19,7 @@ export async function setup() {
 
   process.env.TILES_POSTGRES_PORT = postgresContainer.getPort().toString()
   console.info(
-    `Tiles PostgreSQL container started at port ${process.env.POSTGRES_PORT}`,
+    `Tiles PostgreSQL container started at port ${process.env.TILES_POSTGRES_PORT}`,
   )
 }
 

--- a/packages/backend/test/tiles-pg-global-setup.ts
+++ b/packages/backend/test/tiles-pg-global-setup.ts
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from '@testcontainers/postgresql'
+
+let postgresContainer: StartedPostgreSqlContainer
+
+const TILES_POSTGRES_DATABASE = process.env.TILES_POSTGRES_DATABASE as string
+const TILES_POSTGRES_USERNAME = process.env.TILES_POSTGRES_USERNAME as string
+const TILES_POSTGRES_PASSWORD = process.env.TILES_POSTGRES_PASSWORD as string
+
+export async function setup() {
+  postgresContainer = await new PostgreSqlContainer()
+    .withDatabase(TILES_POSTGRES_DATABASE)
+    .withUsername(TILES_POSTGRES_USERNAME)
+    .withPassword(TILES_POSTGRES_PASSWORD)
+    .start()
+
+  process.env.TILES_POSTGRES_PORT = postgresContainer.getPort().toString()
+  console.info(
+    `Tiles PostgreSQL container started at port ${process.env.POSTGRES_PORT}`,
+  )
+}
+
+export async function teardown() {
+  if (!postgresContainer) {
+    return
+  }
+  await postgresContainer.stop({ remove: true })
+  console.info(`Tiles PostgreSQL container stopped`)
+}

--- a/packages/backend/vitest.config.integration.ts
+++ b/packages/backend/vitest.config.integration.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     ],
     globalSetup: [
       getPath('./test/pg-global-setup.ts'),
+      getPath('./test/tiles-pg-global-setup.ts'),
       getPath('./test/ddb-global-setup.ts'),
       getPath('./test/redis-global-setup.ts'),
     ],

--- a/packages/frontend/vite.config.lib.ts
+++ b/packages/frontend/vite.config.lib.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   build: {
     outDir: 'dist/lib',
     copyPublicDir: false,
+
     lib: {
       name: 'frontend',
       entry: {

--- a/tools/load-tests/tiles/read_action.js
+++ b/tools/load-tests/tiles/read_action.js
@@ -34,7 +34,7 @@ export default function () {
   const result = db.exec(`
     SELECT * FROM "public"."load_test_table_1" WHERE "column1" = 'row${Math.floor(
       Math.random() * 1000,
-    )}-col1';;
+    )}-col1';
   `)
   // const result = db.exec(`
   //   SELECT 1 FROM "public"."load_test_table_${exec.vu.idInInstance}";


### PR DESCRIPTION
# Tests for Tiles v2

## Changes

1. Added a PostgreSQL container for integration tests
2. Extending existing mutation tests to work with both DynamoDB and PostgreSQL
3. Adding unit tests for PostgreSQL table functions
4. Implementing proper database type switching in mutations
