### PR TITLE
[FOR-EACH-1]: Add for-each action to toolbox

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest'
+
+import { inputSchema } from '../../../actions/for-each/schema'
+
+describe('inputSchema', () => {
+  describe('table input format', () => {
+    it('should parse valid table input', () => {
+      const validTableInput = JSON.stringify({
+        rows: [
+          {
+            data: { name: 'John', age: 25 },
+            rowId: 'row1',
+          },
+          {
+            data: { name: 'Jane', age: 30 },
+          },
+        ],
+        columns: [
+          { id: 'name', name: 'Name', value: 'name' },
+          { id: 'age', name: 'Age', value: 'age' },
+        ],
+      })
+
+      const result = inputSchema.safeParse(validTableInput)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        const { type, items } = result.data
+        expect(type).toBe('table')
+        if (type === 'table') {
+          expect(items.rows).toHaveLength(2)
+          expect(items.columns).toHaveLength(2)
+          expect(items.rows[0].data.name).toBe('John')
+          expect(items.rows[0].rowId).toBe('row1')
+          expect(items.rows[1].rowId).toBeUndefined()
+        }
+      }
+    })
+
+    it('should parse table input without rowId', () => {
+      const validTableInput = JSON.stringify({
+        rows: [
+          {
+            data: { name: 'Alice', score: 95.5 },
+          },
+        ],
+        columns: [
+          { id: 'name', name: 'Name', value: 'name' },
+          { id: 'score', name: 'Score', value: 'score' },
+        ],
+      })
+
+      const result = inputSchema.safeParse(validTableInput)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('table')
+        if (result.data.type === 'table') {
+          expect(result.data.items.rows[0].data.score).toBe(95.5)
+        }
+      }
+    })
+
+    it('should trim whitespace before processing', () => {
+      const validTableInput = JSON.stringify({
+        rows: [{ data: { name: 'John' } }],
+        columns: [{ id: 'name', name: 'Name', value: 'name' }],
+      })
+
+      const result = inputSchema.safeParse(`  ${validTableInput}  `)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('table')
+      }
+    })
+
+    it('should reject table input with missing rows', () => {
+      const invalidTableInput = JSON.stringify({
+        columns: [{ id: 'name', name: 'Name', value: 'name' }],
+      })
+
+      const result = inputSchema.safeParse(invalidTableInput)
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe(
+          'Invalid table format: must have rows and columns',
+        )
+      }
+    })
+
+    it('should reject table input with missing columns', () => {
+      const invalidTableInput = JSON.stringify({
+        rows: [
+          {
+            data: { name: 'John' },
+          },
+        ],
+      })
+
+      const result = inputSchema.safeParse(invalidTableInput)
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect((result as any).error.issues[0].message).toBe(
+          'Invalid table format: must have rows and columns',
+        )
+      }
+    })
+
+    it('should reject table input with invalid row structure', () => {
+      const invalidTableInput = JSON.stringify({
+        rows: [
+          {
+            invalidField: 'test',
+          },
+        ],
+        columns: [{ id: 'name', name: 'Name', value: 'name' }],
+      })
+
+      const result = inputSchema.safeParse(invalidTableInput)
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe(
+          'Invalid table format: must have rows and columns',
+        )
+      }
+    })
+
+    it('should reject table input with invalid column structure', () => {
+      const invalidTableInput = JSON.stringify({
+        rows: [
+          {
+            data: { name: 'John' },
+          },
+        ],
+        columns: [
+          { id: 'name', name: 'Name' }, // missing 'value' field
+        ],
+      })
+
+      const result = inputSchema.safeParse(invalidTableInput)
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe(
+          'Invalid table format: must have rows and columns',
+        )
+      }
+    })
+
+    it.each([
+      '{ "rows": [invalid json',
+      '{"item1": value1, "item2": "value2"}',
+      'item1,item2}',
+    ])('should reject malformed JSON', (malformedJson) => {
+      const result = inputSchema.safeParse(malformedJson)
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe('Invalid JSON format')
+      }
+    })
+  })
+
+  describe('checkbox input format', () => {
+    it('should parse single item', () => {
+      const result = inputSchema.safeParse('item1')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['item1'])
+      }
+    })
+
+    it('should parse multiple comma-separated items', () => {
+      const result = inputSchema.safeParse('item1,item2,item3')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['item1', 'item2', 'item3'])
+      }
+    })
+
+    it('should handle items with spaces', () => {
+      const result = inputSchema.safeParse('item 1, item 2 , item 3')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['item 1', ' item 2 ', ' item 3'])
+      }
+    })
+
+    it('should handle empty items in comma-separated list', () => {
+      const result = inputSchema.safeParse('item1,,item3')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['item1', '', 'item3'])
+      }
+    })
+
+    it('should trim whitespace for checkbox input', () => {
+      const result = inputSchema.safeParse('  item1,item2  ')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['item1', 'item2'])
+      }
+    })
+
+    it('should handle single comma (results in two empty items)', () => {
+      const result = inputSchema.safeParse(',')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.type).toBe('checkbox')
+        expect(result.data.items).toEqual(['', ''])
+      }
+    })
+  })
+
+  describe('edge cases and validation', () => {
+    it('should reject empty string', () => {
+      const result = inputSchema.safeParse('')
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe('Input cannot be empty')
+      }
+    })
+
+    it('should reject whitespace-only string', () => {
+      const result = inputSchema.safeParse('   ')
+
+      expect(result.success).toBe(false)
+      if (result.success === false) {
+        expect(result.error.issues[0].message).toBe('Input cannot be empty')
+      }
+    })
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
@@ -4,8 +4,8 @@ import { inputSchema } from '../../../actions/for-each/schema'
 
 describe('inputSchema', () => {
   describe('table input format', () => {
-    it('should parse valid table input', () => {
-      const validTableInput = JSON.stringify({
+    it('should handle valid table input', () => {
+      const validTableInput = {
         rows: [
           {
             data: { name: 'John', age: 25 },
@@ -19,7 +19,7 @@ describe('inputSchema', () => {
           { id: 'name', name: 'Name', value: 'name' },
           { id: 'age', name: 'Age', value: 'age' },
         ],
-      })
+      }
 
       const result = inputSchema.safeParse(validTableInput)
 
@@ -37,8 +37,8 @@ describe('inputSchema', () => {
       }
     })
 
-    it('should parse table input without rowId', () => {
-      const validTableInput = JSON.stringify({
+    it('should handle table input without rowId', () => {
+      const validTableInput = {
         rows: [
           {
             data: { name: 'Alice', score: 95.5 },
@@ -48,7 +48,7 @@ describe('inputSchema', () => {
           { id: 'name', name: 'Name', value: 'name' },
           { id: 'score', name: 'Score', value: 'score' },
         ],
-      })
+      }
 
       const result = inputSchema.safeParse(validTableInput)
 
@@ -61,76 +61,56 @@ describe('inputSchema', () => {
       }
     })
 
-    it('should trim whitespace before processing', () => {
-      const validTableInput = JSON.stringify({
-        rows: [{ data: { name: 'John' } }],
-        columns: [{ id: 'name', name: 'Name', value: 'name' }],
-      })
-
-      const result = inputSchema.safeParse(`  ${validTableInput}  `)
-
-      expect(result.success).toBe(true)
-      if (result.success) {
-        expect(result.data.type).toBe('table')
-      }
-    })
-
     it('should reject table input with missing rows', () => {
-      const invalidTableInput = JSON.stringify({
+      const invalidTableInput = {
         columns: [{ id: 'name', name: 'Name', value: 'name' }],
-      })
+      }
 
       const result = inputSchema.safeParse(invalidTableInput)
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe(
-          'Invalid table format: must have rows and columns',
-        )
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
 
     it('should reject table input with missing columns', () => {
-      const invalidTableInput = JSON.stringify({
+      const invalidTableInput = {
         rows: [
           {
             data: { name: 'John' },
           },
         ],
-      })
+      }
 
       const result = inputSchema.safeParse(invalidTableInput)
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect((result as any).error.issues[0].message).toBe(
-          'Invalid table format: must have rows and columns',
-        )
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
 
     it('should reject table input with invalid row structure', () => {
-      const invalidTableInput = JSON.stringify({
+      const invalidTableInput = {
         rows: [
           {
             invalidField: 'test',
           },
         ],
         columns: [{ id: 'name', name: 'Name', value: 'name' }],
-      })
+      }
 
       const result = inputSchema.safeParse(invalidTableInput)
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe(
-          'Invalid table format: must have rows and columns',
-        )
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
 
     it('should reject table input with invalid column structure', () => {
-      const invalidTableInput = JSON.stringify({
+      const invalidTableInput = {
         rows: [
           {
             data: { name: 'John' },
@@ -139,35 +119,42 @@ describe('inputSchema', () => {
         columns: [
           { id: 'name', name: 'Name' }, // missing 'value' field
         ],
-      })
+      }
 
       const result = inputSchema.safeParse(invalidTableInput)
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe(
-          'Invalid table format: must have rows and columns',
-        )
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
 
     it.each([
-      '{ "rows": [invalid json',
-      '{"item1": value1, "item2": "value2"}',
-      'item1,item2}',
-    ])('should reject malformed JSON', (malformedJson) => {
-      const result = inputSchema.safeParse(malformedJson)
+      {
+        input: '{ "rows": [invalid json',
+        error: 'Invalid input',
+      },
+      {
+        input: '{"item1": value1, "item2": "value2"}',
+        error: 'Invalid input',
+      },
+      {
+        input: 'item1,item2}',
+        error: 'Invalid input',
+      },
+    ])('should reject malformed JSON', ({ input, error }) => {
+      const result = inputSchema.safeParse(input)
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid JSON format')
+        expect(result.error.issues[0].message).toBe(error)
       }
     })
   })
 
   describe('checkbox input format', () => {
-    it('should parse single item', () => {
-      const result = inputSchema.safeParse('item1')
+    it('should handle single item', () => {
+      const result = inputSchema.safeParse(['item1'])
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -176,8 +163,8 @@ describe('inputSchema', () => {
       }
     })
 
-    it('should parse multiple comma-separated items', () => {
-      const result = inputSchema.safeParse('item1,item2,item3')
+    it('should handle multiple comma-separated items', () => {
+      const result = inputSchema.safeParse(['item1', 'item2', 'item3'])
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -187,7 +174,7 @@ describe('inputSchema', () => {
     })
 
     it('should handle items with spaces', () => {
-      const result = inputSchema.safeParse('item 1, item 2 , item 3')
+      const result = inputSchema.safeParse(['item 1', ' item 2 ', ' item 3'])
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -197,7 +184,7 @@ describe('inputSchema', () => {
     })
 
     it('should handle empty items in comma-separated list', () => {
-      const result = inputSchema.safeParse('item1,,item3')
+      const result = inputSchema.safeParse(['item1', '', 'item3'])
 
       expect(result.success).toBe(true)
       if (result.success) {
@@ -206,23 +193,22 @@ describe('inputSchema', () => {
       }
     })
 
-    it('should trim whitespace for checkbox input', () => {
-      const result = inputSchema.safeParse('  item1,item2  ')
+    it('should not trim whitespace for checkbox items', () => {
+      const result = inputSchema.safeParse(['  item1', 'item2  '])
 
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.type).toBe('checkbox')
-        expect(result.data.items).toEqual(['item1', 'item2'])
+        expect(result.data.items).toEqual(['  item1', 'item2  '])
       }
     })
 
-    it('should handle single comma (results in two empty items)', () => {
+    it('should reject single comma', () => {
       const result = inputSchema.safeParse(',')
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        expect(result.data.type).toBe('checkbox')
-        expect(result.data.items).toEqual(['', ''])
+      expect(result.success).toBe(false)
+      if (result.success == false) {
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
   })
@@ -233,7 +219,7 @@ describe('inputSchema', () => {
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Input cannot be empty')
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
 
@@ -242,7 +228,7 @@ describe('inputSchema', () => {
 
       expect(result.success).toBe(false)
       if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Input cannot be empty')
+        expect(result.error.issues[0].message).toBe('Invalid input')
       }
     })
   })

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -1,0 +1,18 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut: rawDataOut } = executionStep
+  if (!rawDataOut) {
+    return null
+  }
+
+  return {
+    iterations: {
+      label: 'Number of items',
+    },
+  }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -1,0 +1,56 @@
+import { IRawAction } from '@plumber/types'
+
+import StepError from '@/errors/step'
+
+import getDataOutMetadata from './get-data-out-metadata'
+
+const action: IRawAction = {
+  name: 'For each',
+  key: 'forEach',
+  description: 'Repeat actions for each item',
+  groupsLaterSteps: true,
+  arguments: [
+    {
+      label: 'Choose items',
+      description:
+        'Supported items include rows in Tiles/M365 Excel and FormSG checkboxes',
+      key: 'forEachInputList',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+      variableTypes: ['array', 'multiple-row-object'],
+    },
+  ],
+
+  getDataOutMetadata,
+
+  async run($) {
+    const { forEachInputList } = $.step.parameters as {
+      forEachInputList: string
+    }
+
+    try {
+      const isJsonString =
+        forEachInputList.includes('[') || forEachInputList.includes('{')
+      const inputList = isJsonString
+        ? JSON.parse(forEachInputList)
+        : forEachInputList.split(',').map((item) => item.trim())
+
+      $.setActionItem({
+        raw: {
+          iterations: isJsonString ? inputList.rows.length : inputList.length,
+        },
+      })
+    } catch (err) {
+      console.error(err)
+      throw new StepError(
+        'Invalid input list',
+        'Select a valid input list',
+        $.step.position,
+        $.app.name,
+      )
+    }
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -6,7 +6,7 @@ import getDataOutMetadata from './get-data-out-metadata'
 import { inputSchema } from './schema'
 
 const action: IRawAction = {
-  name: 'For each',
+  name: 'For each item',
   key: 'forEach',
   description: 'Repeat actions for each item',
   groupsLaterSteps: true,

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -3,6 +3,7 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 
 import getDataOutMetadata from './get-data-out-metadata'
+import { inputSchema } from './schema'
 
 const action: IRawAction = {
   name: 'For each',
@@ -14,35 +15,21 @@ const action: IRawAction = {
       label: 'Choose items',
       description:
         'Supported items include rows in Tiles/M365 Excel and FormSG checkboxes',
-      key: 'forEachInputList',
+      key: 'items',
       type: 'string' as const,
       required: true,
       variables: true,
-      variableTypes: ['array', 'multiple-row-object'],
+      variableTypes: ['array', 'table'],
     },
   ],
 
   getDataOutMetadata,
 
   async run($) {
-    const { forEachInputList } = $.step.parameters as {
-      forEachInputList: string
-    }
+    const { items: rawItems } = $.step.parameters
+    const parsedResult = inputSchema.safeParse(rawItems)
 
-    try {
-      const isJsonString =
-        forEachInputList.includes('[') || forEachInputList.includes('{')
-      const inputList = isJsonString
-        ? JSON.parse(forEachInputList)
-        : forEachInputList.split(',').map((item) => item.trim())
-
-      $.setActionItem({
-        raw: {
-          iterations: isJsonString ? inputList.rows.length : inputList.length,
-        },
-      })
-    } catch (err) {
-      console.error(err)
+    if (!parsedResult.success) {
       throw new StepError(
         'Invalid input list',
         'Select a valid input list',
@@ -50,6 +37,13 @@ const action: IRawAction = {
         $.app.name,
       )
     }
+
+    const { type, items } = parsedResult.data
+    $.setActionItem({
+      raw: {
+        iterations: type === 'checkbox' ? items.length : items.rows.length,
+      },
+    })
   },
 }
 

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -29,7 +29,7 @@ const action: IRawAction = {
     const { items: rawItems } = $.step.parameters
     const parsedResult = inputSchema.safeParse(rawItems)
 
-    if (!parsedResult.success) {
+    if (parsedResult.success === false) {
       throw new StepError(
         'Invalid input list',
         'Select a valid input list',

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+
+// Define specific schemas for each input type
+const tableInputSchema = z.object({
+  rows: z.array(
+    z.object({
+      data: z.record(z.string(), z.string().or(z.number())),
+      rowId: z.string().optional(), // only for tiles
+    }),
+  ),
+  columns: z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      value: z.string(),
+    }),
+  ),
+})
+
+// Create a discriminated union based on input format
+export const inputSchema = z
+  .string()
+  .min(1, 'Input cannot be empty')
+  .transform((str, ctx) => {
+    const trimmed = str.trim()
+
+    if (trimmed.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Input cannot be empty',
+      })
+      return z.NEVER
+    }
+
+    // Handle table input (JSON object)
+    if (trimmed.startsWith('{') || trimmed.endsWith('}')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        const result = tableInputSchema.safeParse(parsed)
+
+        if (!result.success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Invalid table format: must have rows and columns',
+          })
+          return z.NEVER
+        }
+
+        return {
+          type: 'table' as const,
+          items: result.data,
+        }
+      } catch (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Invalid JSON format',
+        })
+        return z.NEVER
+      }
+    }
+
+    // Handle checkbox input (comma-separated values)
+    const items = trimmed.split(',')
+
+    if (items.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'No valid items found in comma-separated input',
+      })
+      return z.NEVER
+    }
+
+    return {
+      type: 'checkbox' as const,
+      items,
+    }
+  })

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -19,12 +19,9 @@ const tableInputSchema = z.object({
 
 // Create a discriminated union based on input format
 export const inputSchema = z
-  .string()
-  .min(1, 'Input cannot be empty')
-  .transform((str, ctx) => {
-    const trimmed = str.trim()
-
-    if (trimmed.length === 0) {
+  .union([z.array(z.any()), tableInputSchema])
+  .transform((data, ctx) => {
+    if (!data || (Array.isArray(data) && data.length === 0)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Input cannot be empty',
@@ -32,36 +29,15 @@ export const inputSchema = z
       return z.NEVER
     }
 
-    // Handle table input (JSON object)
-    if (trimmed.startsWith('{') || trimmed.endsWith('}')) {
-      try {
-        const parsed = JSON.parse(trimmed)
-        const result = tableInputSchema.safeParse(parsed)
-
-        if (!result.success) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Invalid table format: must have rows and columns',
-          })
-          return z.NEVER
-        }
-
-        return {
-          type: 'table' as const,
-          items: result.data,
-        }
-      } catch (error) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Invalid JSON format',
-        })
-        return z.NEVER
+    if (Array.isArray(data)) {
+      return {
+        type: 'checkbox' as const,
+        items: data,
       }
-    }
-
-    // Handle checkbox input (comma-separated values)
-    return {
-      type: 'checkbox' as const,
-      items: trimmed.split(','),
+    } else {
+      return {
+        type: 'table' as const,
+        items: data,
+      }
     }
   })

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -60,18 +60,8 @@ export const inputSchema = z
     }
 
     // Handle checkbox input (comma-separated values)
-    const items = trimmed.split(',')
-
-    if (items.length === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'No valid items found in comma-separated input',
-      })
-      return z.NEVER
-    }
-
     return {
       type: 'checkbox' as const,
-      items,
+      items: trimmed.split(','),
     }
   })

--- a/packages/backend/src/apps/toolbox/actions/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/index.ts
@@ -1,4 +1,5 @@
+import forEach from './for-each'
 import ifThen from './if-then'
 import onlyContinueIf from './only-continue-if'
 
-export default [ifThen, onlyContinueIf]
+export default [forEach, ifThen, onlyContinueIf]

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -15,6 +15,10 @@ const executionSteps = [
       numberProp: 123,
       'space separated prop': 'space separated value',
       arrayProp: ['array value 1', 'hehe', 'array value 3'], // for-each intro
+      tableProp: {
+        rows: [{ data: { name: 'John' } }],
+        columns: [{ id: 'name', name: 'Name', value: 'name' }],
+      },
     },
   } as unknown as ExecutionStep,
 ]
@@ -147,6 +151,15 @@ describe('compute parameters', () => {
             key2: 'array value 1, hehe, array value 3 and more...',
           },
         },
+      },
+    },
+    {
+      testDescription: 'entire object',
+      params: {
+        param1: `{{step.${randomStepID}.tableProp}}`,
+      },
+      expected: {
+        param1: JSON.stringify(executionSteps[0].dataOut.tableProp),
       },
     },
   ])(

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -15,6 +15,12 @@ const executionSteps = [
       numberProp: 123,
       'space separated prop': 'space separated value',
       arrayProp: ['array value 1', 'hehe', 'array value 3'], // for-each intro
+      arrayPropWithCommas: [
+        'array value 1, with, commas',
+        'hehe',
+        'array value 3',
+        'array value 4, with comma',
+      ],
       tableProp: {
         rows: [{ data: { name: 'John' } }],
         columns: [{ id: 'name', name: 'Name', value: 'name' }],
@@ -153,19 +159,52 @@ describe('compute parameters', () => {
         },
       },
     },
+  ])(
+    'performs variable substitution on $testDescription',
+    ({ params, expected }) => {
+      const result = computeParameters(params, executionSteps)
+      expect(result).toEqual(expected)
+    },
+  )
+
+  it.each([
     {
       testDescription: 'entire object',
       params: {
         param1: `{{step.${randomStepID}.tableProp}}`,
       },
       expected: {
-        param1: JSON.stringify(executionSteps[0].dataOut.tableProp),
+        param1: executionSteps[0].dataOut.tableProp,
+      },
+    },
+    {
+      testDescription: 'entire array',
+      params: {
+        param2: `{{step.${randomStepID}.arrayProp}}`,
+      },
+      expected: {
+        param2: executionSteps[0].dataOut.arrayProp,
+      },
+    },
+    {
+      testDescription: 'array with values containing commas',
+      params: {
+        param3: `{{step.${randomStepID}.arrayPropWithCommas}}`,
+      },
+      expected: {
+        param3: executionSteps[0].dataOut.arrayPropWithCommas,
       },
     },
   ])(
-    'performs variable substitution on $testDescription',
-    ({ params, expected }) => {
-      const result = computeParameters(params, executionSteps)
+    'performs for-each variable substitution on $testDescription ',
+    ({
+      params,
+      expected,
+    }: {
+      params: Record<string, any>
+      expected: Record<string, any>
+    }) => {
+      const result = computeParameters(params, executionSteps, undefined, true)
       expect(result).toEqual(expected)
     },
   )

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -68,13 +68,19 @@ function findAndSubstituteVariables(
 
       // NOTE: dataValue could be an array if it is not processed on variables.ts
       // which is the case for formSG checkbox only, this is to deal with forEach next time
-      return preprocessVariable
-        ? preprocessVariable(parameterKey, dataValue)
-        : Array.isArray(dataValue)
-        ? isForEachStep
-          ? dataValue
-          : dataValue.join(', ')
-        : dataValue
+      if (preprocessVariable) {
+        return preprocessVariable(parameterKey, dataValue)
+      }
+
+      if (Array.isArray(dataValue)) {
+        if (isForEachStep) {
+          return dataValue
+        }
+
+        return dataValue.join(', ')
+      }
+
+      return dataValue
     }
 
     return part
@@ -88,9 +94,6 @@ function findAndSubstituteVariables(
    */
   if (isForEachStep) {
     const filteredParts = substitutedParts.filter((part) => part !== '')
-    if (filteredParts.every((part) => typeof part === 'string')) {
-      return filteredParts.flat()
-    }
     return filteredParts[0]
   }
 

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -16,6 +16,7 @@ function findAndSubstituteVariables(
   rawValue: unknown,
   executionSteps: ExecutionStep[],
   preprocessVariable?: IAction['preprocessVariable'],
+  isForEachStep?: boolean,
 ): unknown {
   if (Array.isArray(rawValue)) {
     return rawValue.map((element) =>
@@ -24,6 +25,7 @@ function findAndSubstituteVariables(
         element,
         executionSteps,
         preprocessVariable,
+        isForEachStep,
       ),
     )
   }
@@ -38,6 +40,7 @@ function findAndSubstituteVariables(
           v,
           executionSteps,
           preprocessVariable,
+          isForEachStep,
         ),
       }),
       {},
@@ -50,45 +53,61 @@ function findAndSubstituteVariables(
 
   const parts = rawValue.split(variableRegExp)
 
-  return parts
-    .map((part: string) => {
-      const isVariable = part.match(variableRegExp)
-      if (isVariable) {
-        const stepIdAndKeyPath = part.replace(/{{step.|}}/g, '') as string
-        const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
-        const executionStep = executionSteps.find((executionStep) => {
-          return executionStep.stepId === stepId
-        })
-        const data = executionStep?.dataOut
+  const substitutedParts = parts.map((part: string) => {
+    const isVariable = part.match(variableRegExp)
+    if (isVariable) {
+      const stepIdAndKeyPath = part.replace(/{{step.|}}/g, '') as string
+      const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
+      const executionStep = executionSteps.find((executionStep) => {
+        return executionStep.stepId === stepId
+      })
+      const data = executionStep?.dataOut
 
-        const keyPath = keyPaths.join('.') // for lodash get to work
-        const dataValue = get(data, keyPath)
+      const keyPath = keyPaths.join('.') // for lodash get to work
+      const dataValue = get(data, keyPath)
 
-        // NOTE: dataValue could be an array if it is not processed on variables.ts
-        // which is the case for formSG checkbox only, this is to deal with forEach next time
-        return preprocessVariable
-          ? preprocessVariable(parameterKey, dataValue)
-          : Array.isArray(dataValue)
-          ? dataValue.join(', ')
-          : typeof dataValue === 'object'
-          ? JSON.stringify(dataValue)
-          : dataValue
-      }
+      // NOTE: dataValue could be an array if it is not processed on variables.ts
+      // which is the case for formSG checkbox only, this is to deal with forEach next time
+      return preprocessVariable
+        ? preprocessVariable(parameterKey, dataValue)
+        : Array.isArray(dataValue)
+        ? isForEachStep
+          ? dataValue
+          : dataValue.join(', ')
+        : dataValue
+    }
 
-      return part
-    })
-    .join('')
+    return part
+  })
+
+  /**
+   * FOR-EACH STEP SPECIAL CASE:
+   * for-each step only accepts 1 variable, checkbox or table
+   * checkbox is an array of strings,
+   * table is an object with rows and columns
+   */
+  if (isForEachStep) {
+    const filteredParts = substitutedParts.filter((part) => part !== '')
+    if (filteredParts.every((part) => typeof part === 'string')) {
+      return filteredParts.flat()
+    }
+    return filteredParts[0]
+  }
+
+  return substitutedParts.join('')
 }
 
 export default function computeParameters(
   parameters: Step['parameters'],
   executionSteps: ExecutionStep[],
   preprocessVariable?: IAction['preprocessVariable'],
+  isForEachStep?: boolean,
 ): Step['parameters'] {
   return findAndSubstituteVariables(
     '', // Dummy initial value; will never be used.
     parameters,
     executionSteps,
     preprocessVariable,
+    isForEachStep,
   ) as Step['parameters']
 }

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -70,6 +70,8 @@ function findAndSubstituteVariables(
           ? preprocessVariable(parameterKey, dataValue)
           : Array.isArray(dataValue)
           ? dataValue.join(', ')
+          : typeof dataValue === 'object'
+          ? JSON.stringify(dataValue)
           : dataValue
       }
 

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -73,6 +73,8 @@ function findAndSubstituteVariables(
       }
 
       if (Array.isArray(dataValue)) {
+        // NOTE: we do not stringify the array if its a for each step
+        // to avoid having to parse it back into an array again
         if (isForEachStep) {
           return dataValue
         }
@@ -93,6 +95,8 @@ function findAndSubstituteVariables(
    * table is an object with rows and columns
    */
   if (isForEachStep) {
+    // filter out empty parts as the regex matching creates an array like this:
+    // ['', '{{step-variable}}', '']
     const filteredParts = substitutedParts.filter((part) => part !== '')
     return filteredParts[0]
   }

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -60,6 +60,7 @@ export const processAction = async (options: ProcessActionOptions) => {
     $.step.parameters,
     priorExecutionSteps,
     actionCommand.preprocessVariable,
+    step.appKey === 'toolbox' && step.key === 'forEach',
   )
 
   $.step.parameters = computedParameters

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
@@ -1,6 +1,7 @@
 import type { IAction } from '@plumber/types'
 
 import { BiFilterAlt, BiGitRepoForked, BiQuestionMark } from 'react-icons/bi'
+import { SlLoop } from 'react-icons/sl'
 import { Flex, Icon, Text } from '@chakra-ui/react'
 import { TouchableTooltip } from '@opengovsg/design-system-react'
 
@@ -9,6 +10,7 @@ import { HighlightedText } from './HighlightedText'
 export const TOOLBOX_ACTION_TO_ICON_MAP = {
   onlyContinueIf: BiFilterAlt,
   ifThen: BiGitRepoForked,
+  forEach: SlLoop,
 }
 
 interface ToolboxEventProps {


### PR DESCRIPTION
### TL;DR

Added a new "For each" action to the Toolbox app that allows users to repeat actions for each item in a list.
Refactored parameter computation to return array (FormSG checkboxes) and objects (table object with rows and columns) as is instead of stringifying.

**Note to reviewer**:
* this just shows the app in the list, creating this app will throw an error step in the editor.
* this also does not process the input to get variables for use in subsequent steps (this will come in subsequent PRs).

### What changed?

- Created a new `forEach` action in the Toolbox app that enables users to iterate through items in a list
- Implemented the action's core functionality in `index.ts` with support for arrays and multiple-row objects
- Added metadata handling via `get-data-out-metadata.ts` to display the number of iterations
- Updated the Toolbox actions export to include the new forEach action
- Added the SlLoop icon for the forEach action in the frontend UI
- Refactored `compute-parameters` to not stringify arrays and objects when computing parameters for the for-each step

### How to test?
- [ ] Add step modal shows the For-each action under the Toolbox options

### Screenshots

![Screenshot 2025-06-04 at 12.00.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/9e8ab7c0-e422-43bc-a745-4e621ec63773.png)

