### PR TITLE
[FOR-EACH-3.5]: Refactor if-then branch deletion

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -10,7 +10,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog'
-import useDeleteConfirmation from '../../hooks/useDeleteConfirmation'
+import useDeleteStepConfirmation from '../../hooks/useDeleteStepConfirmation'
 import { allowAddStep } from '../utils'
 
 import { HoverAddStepButton } from './HoverAddStepButton'
@@ -41,7 +41,11 @@ export default function Branch(props: BranchProps) {
     onClose: closeDeleteConfirmation,
     onDelete: deleteBranch,
     cancelRef,
-  } = useDeleteConfirmation(TOOLBOX_ACTIONS.IfThen, groupedSteps, branchSteps)
+  } = useDeleteStepConfirmation(
+    TOOLBOX_ACTIONS.IfThen,
+    groupedSteps,
+    branchSteps,
+  )
 
   const handleDeleteBranch = useCallback(async () => {
     await deleteBranch()

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -1,35 +1,16 @@
 import { IStep } from '@plumber/types'
 
-import {
-  Fragment,
-  MouseEventHandler,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-} from 'react'
+import { Fragment, useCallback, useContext, useMemo } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { useMutation } from '@apollo/client'
-import {
-  AlertDialog,
-  AlertDialogBody,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogOverlay,
-  Box,
-  Button,
-  Flex,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react'
+import { Box, Flex, Text } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import FlowStep from '@/components/FlowStep'
 import { EditorContext } from '@/contexts/Editor'
-import { DELETE_STEP } from '@/graphql/mutations/delete-step'
-import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
+import DeleteConfirmationDialog from '../../components/DeleteConfirmationDialog'
+import useDeleteConfirmation from '../../hooks/useDeleteConfirmation'
 import { allowAddStep } from '../utils'
 
 import { HoverAddStepButton } from './HoverAddStepButton'
@@ -42,7 +23,7 @@ interface BranchProps {
 }
 
 export default function Branch(props: BranchProps) {
-  const { branchSteps, stepsBeforeGroup } = props
+  const { branchSteps, groupedSteps, stepsBeforeGroup } = props
 
   const {
     isDrawerOpen,
@@ -54,37 +35,21 @@ export default function Branch(props: BranchProps) {
 
   // Handle branch deletion
   const {
-    isOpen: deleteConfirmationIsOpen,
-    onOpen: openDeleteConfirmationImpl,
+    isDeletingBranch,
+    isOpen: isDeleteConfirmationOpen,
+    onOpen: openDeleteConfirmation,
     onClose: closeDeleteConfirmation,
-  } = useDisclosure()
-  const cancelDeleteButton = useRef<HTMLButtonElement>(null)
-  const [deleteStep, { loading: isDeletingBranch }] = useMutation(DELETE_STEP, {
-    refetchQueries: [GET_FLOW],
-  })
-  const openDeleteConfirmation = useCallback<MouseEventHandler>(
-    (e) => {
-      e.stopPropagation()
-      openDeleteConfirmationImpl()
-    },
-    [openDeleteConfirmationImpl],
-  )
-  const deleteBranch = useCallback(async () => {
-    const idsToDelete = branchSteps.map((step) => step.id)
-    await deleteStep({
-      variables: { input: { ids: idsToDelete } },
-    })
+    onDelete: deleteBranch,
+    cancelRef,
+  } = useDeleteConfirmation(TOOLBOX_ACTIONS.IfThen, groupedSteps, branchSteps)
+
+  const handleDeleteBranch = useCallback(async () => {
+    await deleteBranch()
 
     setCurrentStepId(null)
     closeDeleteConfirmation()
     onDrawerClose()
-  }, [
-    branchSteps,
-    deleteStep,
-    setCurrentStepId,
-    closeDeleteConfirmation,
-    onDrawerClose,
-  ])
+  }, [deleteBranch, setCurrentStepId, closeDeleteConfirmation, onDrawerClose])
 
   const canAddStep = useMemo(() => allowAddStep(branchSteps), [branchSteps])
 
@@ -115,7 +80,7 @@ export default function Branch(props: BranchProps) {
               <IconButton
                 boxSize={8}
                 onClick={(event) => {
-                  openDeleteConfirmation(event)
+                  openDeleteConfirmation()
                   event.stopPropagation()
                 }}
                 variant="clear"
@@ -150,36 +115,14 @@ export default function Branch(props: BranchProps) {
       })}
 
       {/* Delete Confirmation Modal */}
-      <AlertDialog
-        isOpen={deleteConfirmationIsOpen}
-        leastDestructiveRef={cancelDeleteButton}
+      <DeleteConfirmationDialog
+        name={branchSteps[0].parameters.branchName as string}
+        cancelRef={cancelRef}
+        isOpen={isDeleteConfirmationOpen}
         onClose={closeDeleteConfirmation}
-      >
-        <AlertDialogOverlay>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              Delete {branchSteps[0].parameters.branchName as string}
-            </AlertDialogHeader>
-            <AlertDialogBody>
-              Are you sure you want to delete this branch? This action cannot be
-              undone.
-            </AlertDialogBody>
-            <AlertDialogFooter>
-              <Button
-                colorScheme="neutral"
-                variant="clear"
-                ref={cancelDeleteButton}
-                onClick={closeDeleteConfirmation}
-              >
-                Cancel
-              </Button>
-              <Button colorScheme="critical" onClick={deleteBranch} ml={3}>
-                Yes, delete branch
-              </Button>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialogOverlay>
-      </AlertDialog>
+        onDelete={handleDeleteBranch}
+        onCancel={closeDeleteConfirmation}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteConfirmation.ts
+++ b/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteConfirmation.ts
@@ -8,7 +8,11 @@ import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
-const useDeleteConfirmation = (type: string, groupedSteps: IStep[][]) => {
+const useDeleteConfirmation = (
+  type: string,
+  groupedSteps: IStep[][],
+  branchSteps?: IStep[],
+) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef<HTMLButtonElement>(null)
 
@@ -35,11 +39,17 @@ const useDeleteConfirmation = (type: string, groupedSteps: IStep[][]) => {
       await deleteStep({
         variables: { input: { ids: idsToDelete } },
       })
-    } else {
-      // TODO: refactor branch deletion
+    } else if (type === TOOLBOX_ACTIONS.IfThen) {
+      if (!branchSteps) {
+        return
+      }
+      const idsToDelete = branchSteps.map((step) => step.id)
+      await deleteStep({
+        variables: { input: { ids: idsToDelete } },
+      })
     }
     onClose()
-  }, [deleteStep, groupedSteps, onClose, type])
+  }, [branchSteps, deleteStep, groupedSteps, onClose, type])
 
   return {
     cancelRef,

--- a/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteConfirmation.ts
+++ b/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteConfirmation.ts
@@ -39,10 +39,7 @@ const useDeleteConfirmation = (
       await deleteStep({
         variables: { input: { ids: idsToDelete } },
       })
-    } else if (type === TOOLBOX_ACTIONS.IfThen) {
-      if (!branchSteps) {
-        return
-      }
+    } else if (type === TOOLBOX_ACTIONS.IfThen && branchSteps) {
       const idsToDelete = branchSteps.map((step) => step.id)
       await deleteStep({
         variables: { input: { ids: idsToDelete } },

--- a/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
+++ b/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
@@ -8,7 +8,7 @@ import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
-const useDeleteConfirmation = (
+const useDeleteStepConfirmation = (
   type: string,
   groupedSteps: IStep[][],
   branchSteps?: IStep[],
@@ -59,4 +59,4 @@ const useDeleteConfirmation = (
   }
 }
 
-export default useDeleteConfirmation
+export default useDeleteStepConfirmation

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -68,7 +68,6 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
       alignItems="center"
       justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
     >
-      {/* FIXME (kevinkim-ogp): above is a temporary wrapper to ensure the flow step group is centered when drawer is closed */}
       <Flex
         {...flowStepGroupStyles.container}
         display={isMobile ? 'block' : 'flex'}

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -15,7 +15,7 @@ import DeleteConfirmationDialog from './components/DeleteConfirmationDialog'
 import Error from './Content/Error'
 import ForEach from './Content/ForEach'
 import IfThen from './Content/IfThen'
-import useDeleteConfirmation from './hooks/useDeleteConfirmation'
+import useDeleteStepConfirmation from './hooks/useDeleteStepConfirmation'
 import { flowStepGroupStyles } from './styles'
 
 interface FlowStepGroupProps {
@@ -55,7 +55,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
     onClose: closeDeleteConfirmation,
     onDelete: deleteForEach,
     cancelRef,
-  } = useDeleteConfirmation(stepGroupType ?? '', groupedSteps)
+  } = useDeleteStepConfirmation(stepGroupType ?? '', groupedSteps)
 
   const handleForEachDelete = useCallback(async () => {
     await deleteForEach()


### PR DESCRIPTION
## TL;DR
Not related to for-each, just a refactor of branch deletion since the previous PR created a generic component and hook to perform flow step group deletion.

## What changed?
Use the new generic component and hook to handle group deletion.

## How to test?
- [ ] Delete If-then branch
- [ ] Delete if-then branch within a for-each group

## Screenshots
**If-then**

[Screen Recording 2025-06-04 at 4.05.03 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/358acdc9-95c1-4bc9-9695-b71e492ad961.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/358acdc9-95c1-4bc9-9695-b71e492ad961.mov)

**If-then inside for-each**

[Screen Recording 2025-06-04 at 4.04.33 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/64a2f167-b039-4d61-b513-565eb05f19c3.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/64a2f167-b039-4d61-b513-565eb05f19c3.mov)

