### PR TITLE
[PLU-493]: Remove uploaded attachments on duplicate Pipe

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-flow-helpers.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-flow-helpers.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  updateStepIdForKey,
+  updateStepVariables,
+} from '@/helpers/update-duplicated-steps'
+
+describe('duplicate flow helper functions', () => {
+  describe('updateStepIdForKey', () => {
+    const stepIdMap = {
+      'old-step-1': 'new-step-1',
+      'old-step-2': 'new-step-2',
+      'old-step-3': 'new-step-3',
+    }
+
+    it('should replace step IDs in simple variable references', () => {
+      const input = '{{step.old-step-1.fields.name}}'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('{{step.new-step-1.fields.name}}')
+    })
+
+    it('should replace multiple step IDs in the same string', () => {
+      const input =
+        'Hello {{step.old-step-1.output.name}} and {{step.old-step-2.fields.email}}'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe(
+        'Hello {{step.new-step-1.output.name}} and {{step.new-step-2.fields.email}}',
+      )
+    })
+
+    it('should handle complex variable paths', () => {
+      const input = '{{step.old-step-1.fields.123.answer}}'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('{{step.new-step-1.fields.123.answer}}')
+    })
+
+    it('should not affect non-step variables', () => {
+      const input = 'Hello {{user.name}} and {{config.setting}}'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('Hello {{user.name}} and {{config.setting}}')
+    })
+
+    it('should handle data-id attributes in HTML/XML', () => {
+      const input = '<div data-id="step.old-step-1.output">Content</div>'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('<div data-id="step.new-step-1.output">Content</div>')
+    })
+
+    it('should handle mixed content with variables and plain text', () => {
+      const input =
+        'Subject: {{step.old-step-1.fields.subject}} - Reply to {{step.old-step-2.email}}'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe(
+        'Subject: {{step.new-step-1.fields.subject}} - Reply to {{step.new-step-2.email}}',
+      )
+    })
+
+    it('should not replace partial matches', () => {
+      const input = 'step.old-step-12.field should not change'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('step.old-step-12.field should not change')
+    })
+
+    it('should handle empty string', () => {
+      const result = updateStepIdForKey('', stepIdMap)
+      expect(result).toBe('')
+    })
+
+    it('should handle string with no step references', () => {
+      const input = 'This is just plain text'
+      const result = updateStepIdForKey(input, stepIdMap)
+      expect(result).toBe('This is just plain text')
+    })
+
+    it('should handle empty step ID map', () => {
+      const input = '{{step.old-step-1.fields.name}}'
+      const result = updateStepIdForKey(input, {})
+      expect(result).toBe('{{step.old-step-1.fields.name}}')
+    })
+  })
+
+  describe('updateStepVariables', () => {
+    const stepIdMap = {
+      'old-step-1': 'new-step-1',
+      'old-step-2': 'new-step-2',
+    }
+
+    it('should update string parameters', () => {
+      const parameters = {
+        subject: '{{step.old-step-1.fields.title}}',
+        body: 'Static text',
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        subject: '{{step.new-step-1.fields.title}}',
+        body: 'Static text',
+      })
+    })
+
+    it('should update nested object parameters', () => {
+      const parameters = {
+        config: {
+          url: '{{step.old-step-1.output.url}}',
+          headers: {
+            auth: '{{step.old-step-2.token}}',
+          },
+        },
+        static: 'value',
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        config: {
+          url: '{{step.new-step-1.output.url}}',
+          headers: {
+            auth: '{{step.new-step-2.token}}',
+          },
+        },
+        static: 'value',
+      })
+    })
+
+    it('should filter out S3 object keys from arrays', () => {
+      const parameters = {
+        attachments: [
+          's3:bucket:file1.pdf',
+          's3:another-bucket:file2.pdf',
+          '{{step.old-step-1.attachment}}',
+        ],
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        attachments: ['{{step.new-step-1.attachment}}'],
+      })
+    })
+
+    it('should update step variables in array of objects', () => {
+      const parameters = {
+        conditions: [
+          {
+            field: 'status',
+            value: '{{step.old-step-1.status}}',
+          },
+          {
+            field: 'email',
+            value: '{{step.old-step-2.email}}',
+          },
+        ],
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        conditions: [
+          {
+            field: 'status',
+            value: '{{step.new-step-1.status}}',
+          },
+          {
+            field: 'email',
+            value: '{{step.new-step-2.email}}',
+          },
+        ],
+      })
+    })
+
+    it('should handle array with only S3 attachments', () => {
+      const parameters = {
+        files: ['s3:bucket:file1.pdf', 's3:bucket:file2.pdf'],
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        files: [],
+      })
+    })
+
+    it('should handle mixed array with strings and objects', () => {
+      const parameters = {
+        mixed: [
+          '{{step.old-step-1.value}}',
+          's3:bucket:file.pdf',
+          {
+            type: 'condition',
+            value: '{{step.old-step-2.condition}}',
+          },
+          'static-string',
+        ],
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        mixed: [
+          '{{step.new-step-1.value}}',
+          {
+            type: 'condition',
+            value: '{{step.new-step-2.condition}}',
+          },
+          'static-string',
+        ],
+      })
+    })
+
+    it('should handle deeply nested structures', () => {
+      const parameters = {
+        level1: {
+          level2: {
+            level3: {
+              value: '{{step.old-step-1.deep.value}}',
+              array: [
+                {
+                  nested: '{{step.old-step-2.nested}}',
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            level3: {
+              value: '{{step.new-step-1.deep.value}}',
+              array: [
+                {
+                  nested: '{{step.new-step-2.nested}}',
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+
+    it('should handle empty parameters object', () => {
+      const result = updateStepVariables({}, stepIdMap)
+      expect(result).toEqual({})
+    })
+
+    it('should handle parameters with null and undefined values', () => {
+      const parameters: Record<string, any> = {
+        nullValue: null,
+        undefinedValue: undefined,
+        stringValue: '{{step.old-step-1.value}}',
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        nullValue: null,
+        undefinedValue: undefined,
+        stringValue: '{{step.new-step-1.value}}',
+      })
+    })
+
+    it('should handle parameters with number and boolean values', () => {
+      const parameters = {
+        number: 42,
+        boolean: true,
+        string: '{{step.old-step-1.value}}',
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        number: 42,
+        boolean: true,
+        string: '{{step.new-step-1.value}}',
+      })
+    })
+
+    it('should handle empty arrays', () => {
+      const parameters: Record<string, any> = {
+        emptyArray: [],
+        stringValue: '{{step.old-step-1.value}}',
+      }
+
+      const result = updateStepVariables(parameters, stepIdMap)
+
+      expect(result).toEqual({
+        emptyArray: [],
+        stringValue: '{{step.new-step-1.value}}',
+      })
+    })
+  })
+})

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -1,70 +1,10 @@
-import type { IJSONObject } from '@plumber/types'
-
 import { isEmpty } from 'lodash'
 
 import logger from '@/helpers/logger'
+import { updateStepVariables } from '@/helpers/update-duplicated-steps'
 import Flow from '@/models/flow'
-import Step from '@/models/step'
 
 import { MutationResolvers } from '../__generated__/types.generated'
-
-function updateStepIdForKey(
-  value: string,
-  oldToNewStepIdsMap: Record<string, string>,
-) {
-  /**
-   * Example: this step position 3 has a key: "subject" and
-   * a value of "{{step.123.fields.111.answer}} blah {{step.456.fields.222.answer}}"
-   * 123 and 456 belongs to the previous 2 steps, so the mapping will be the old steps to new steps
-   * */
-  let newValue = value
-  for (const stepIdMapping of Object.entries(oldToNewStepIdsMap)) {
-    const [oldStepId, newStepId] = stepIdMapping
-    // Replaces data-id in postman also and all step variables with the curly braces notation
-    const partialOldVariable = `step.${oldStepId}.`
-    const partialNewVariable = `step.${newStepId}.`
-
-    newValue = newValue.replaceAll(partialOldVariable, partialNewVariable)
-  }
-  return newValue
-}
-
-function updateStepVariables(
-  parameters: Step['parameters'],
-  oldToNewStepIdsMap: Record<string, string>,
-): Step['parameters'] {
-  const entries = Object.entries(parameters)
-  return entries.reduce((result, [key, value]) => {
-    if (typeof value === 'string') {
-      return {
-        ...result,
-        [key]: updateStepIdForKey(value, oldToNewStepIdsMap),
-      }
-    }
-
-    if (Array.isArray(value)) {
-      return {
-        ...result,
-        [key]: value.flatMap((item) => {
-          // HACKFIX (kevinkim-ogp): remove uploaded attachments from the duplicated flow
-          if (typeof item === 'string' && item.startsWith('s3:')) {
-            return []
-          }
-          // could be a string or an object: attachments array would contain strings but conditions would contain objects
-          if (typeof item === 'string') {
-            return [updateStepIdForKey(item, oldToNewStepIdsMap)]
-          }
-          return updateStepVariables(item as IJSONObject, oldToNewStepIdsMap)
-        }),
-      }
-    }
-
-    return {
-      ...result,
-      [key]: value,
-    }
-  }, {})
-}
 
 // transaction does 2 things: update duplicate count for flow + duplicate flow + steps
 const duplicateFlow: MutationResolvers['duplicateFlow'] = async (

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -45,10 +45,14 @@ function updateStepVariables(
     if (Array.isArray(value)) {
       return {
         ...result,
-        [key]: value.map((item) => {
+        [key]: value.flatMap((item) => {
+          // HACKFIX (kevinkim-ogp): remove uploaded attachments from the duplicated flow
+          if (typeof item === 'string' && item.startsWith('s3:')) {
+            return []
+          }
           // could be a string or an object: attachments array would contain strings but conditions would contain objects
           if (typeof item === 'string') {
-            return updateStepIdForKey(item, oldToNewStepIdsMap)
+            return [updateStepIdForKey(item, oldToNewStepIdsMap)]
           }
           return updateStepVariables(item as IJSONObject, oldToNewStepIdsMap)
         }),
@@ -92,6 +96,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     delete prevConfig['duplicateCount']
     delete prevConfig['templateConfig']
     delete prevConfig['showSurvey']
+    delete prevConfig['attachments']
 
     const duplicatedFlow = await context.currentUser
       .$relatedQuery('flows', trx)

--- a/packages/backend/src/helpers/update-duplicated-steps.ts
+++ b/packages/backend/src/helpers/update-duplicated-steps.ts
@@ -1,0 +1,68 @@
+import { IJSONObject } from '@plumber/types'
+
+import { Step } from '@/graphql/__generated__/types.generated'
+
+export function updateStepIdForKey(
+  value: string,
+  oldToNewStepIdsMap: Record<string, string>,
+) {
+  /**
+   * Example: this step position 3 has a key: "subject" and
+   * a value of "{{step.123.fields.111.answer}} blah {{step.456.fields.222.answer}}"
+   * 123 and 456 belongs to the previous 2 steps, so the mapping will be the old steps to new steps
+   * */
+  let newValue = value
+  for (const stepIdMapping of Object.entries(oldToNewStepIdsMap)) {
+    const [oldStepId, newStepId] = stepIdMapping
+    // Replaces data-id in postman also and all step variables with the curly braces notation
+    const partialOldVariable = `step.${oldStepId}.`
+    const partialNewVariable = `step.${newStepId}.`
+
+    newValue = newValue.replaceAll(partialOldVariable, partialNewVariable)
+  }
+  return newValue
+}
+
+export function updateStepVariables(
+  parameters: Step['parameters'],
+  oldToNewStepIdsMap: Record<string, string>,
+): Step['parameters'] {
+  const entries = Object.entries(parameters)
+  return entries.reduce((result, [key, value]) => {
+    if (typeof value === 'string') {
+      return {
+        ...result,
+        [key]: updateStepIdForKey(value, oldToNewStepIdsMap),
+      }
+    }
+
+    if (Array.isArray(value)) {
+      return {
+        ...result,
+        [key]: value.flatMap((item) => {
+          // HACKFIX (kevinkim-ogp): remove uploaded attachments from the duplicated flow
+          if (typeof item === 'string' && item.startsWith('s3:')) {
+            return []
+          }
+          // could be a string or an object: attachments array would contain strings but conditions would contain objects
+          if (typeof item === 'string') {
+            return [updateStepIdForKey(item, oldToNewStepIdsMap)]
+          }
+          return updateStepVariables(item as IJSONObject, oldToNewStepIdsMap)
+        }),
+      }
+    }
+
+    if (typeof value === 'object' && value !== null) {
+      return {
+        ...result,
+        [key]: updateStepVariables(value as IJSONObject, oldToNewStepIdsMap),
+      }
+    }
+
+    return {
+      ...result,
+      [key]: value,
+    }
+  }, {})
+}


### PR DESCRIPTION
## Problem
Manually uploaded attachments in the Email by Postman step are not handled properly when duplicating Pipe as it is not copied to a new S3 bucket and step parameters are still referencing the old attachment. 
It causes the following error:
![image](https://github.com/user-attachments/assets/a2618398-ee85-4a0a-b40d-ccaf89999b60)

**How to replicate**
1. Create a Pipe with Email by Postman action
2. Upload your own attachment
3. Check step
4. Duplicate the pipe
5. Delete attachment from the action in the duplicated Pipe
6. Check step
7. See the error

## Solution
This is a short-term solution to address the issue when duplicating a Pipe:
* Remove all manually uploaded attachments from the Pipe's config
* Remove all manually uploaded attachments from the Email by Postman's step parameters
  * Does a check to remove step parameter values that start with `s3:`
  * Confirmed that only manually uploaded attachments have this prefix in their value

**NOTE**: The long-term solution to follow in the future would be to duplicate the attachments in the S3 bucket and update the step parameters in the Email by Postman actions.

## What changed?
* Remove `attachments` from the config of the newly duplicated Pipe
* Remove all manually uploaded attachments from the Email by Postman's step parameters
* Refactor to helper function
* Add functionality to handle nested objects
* Add tests for the helper functions

## How to test?
1. Create a Pipe with both FormSG and manually uploaded attachments
2. Duplicate this Pipe
3. Open the duplicated Pipe
4. Run 'Check step' on the FormSG step
5. Check that Postman step ONLY contains the FormSG attachments and does not contain the manually uploaded attachment
6. Manually upload an attachment and 'Check step'
7. Verify that email is sent with both form and manually uploaded attachments

## Screenshots

https://github.com/user-attachments/assets/7463e2c7-122f-4f8c-9a9f-f865ae767db4






