### PR TITLE
PLU-477: fix slack bot display name should be optional

### DIFF
--- a/gql-codegen.ts
+++ b/gql-codegen.ts
@@ -37,10 +37,10 @@ const config: CodegenConfig = {
             output: 'type-fest#JsonObject',
           },
         },
-        JSON: {
+        JSONPrimitive: {
           type: {
-            input: 'type-fest#JsonValue',
-            output: 'type-fest#JsonValue',
+            input: 'type-fest#JsonPrimitive',
+            output: 'type-fest#JsonPrimitive',
           },
         },
         Any: {
@@ -117,7 +117,7 @@ const config: CodegenConfig = {
         scalars: {
           // Use type-fest's JSON types in generated code, as they're nice.
           JSONObject: 'type-fest#JsonObject',
-          JSON: 'type-fest#JsonValue',
+          JSONPrimitive: 'type-fest#JsonPrimitive',
           Any: 'any',
         },
       },

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/index.ts
@@ -38,7 +38,7 @@ const action: IRawAction = {
       label: 'Send as a bot?',
       key: 'sendAsBot',
       type: 'boolean-radio' as const,
-      required: false,
+      required: true,
       value: false,
       description:
         'If you choose no, this message will appear to come from you. Direct messages are always sent by bots.',
@@ -47,11 +47,16 @@ const action: IRawAction = {
       label: 'Bot name',
       key: 'botName',
       type: 'string' as const,
-      required: true,
+      required: false,
       value: 'Plumber',
       description:
         'Specify the bot name which appears as a bold username above the message inside Slack. Defaults to Plumber.',
       variables: true,
+      hiddenIf: {
+        fieldKey: 'sendAsBot',
+        op: 'equals',
+        fieldValue: false,
+      },
     },
     {
       label: 'Bot icon',
@@ -61,6 +66,11 @@ const action: IRawAction = {
       description:
         'Either an image url or an emoji available to your team (surrounded by :). For example, https://example.com/icon_256.png or :robot_face:',
       variables: true,
+      hiddenIf: {
+        fieldKey: 'sendAsBot',
+        op: 'equals',
+        fieldValue: false,
+      },
     },
   ],
 

--- a/packages/backend/src/apps/slack/actions/send-a-message-to-channel/post-message.ts
+++ b/packages/backend/src/apps/slack/actions/send-a-message-to-channel/post-message.ts
@@ -24,7 +24,8 @@ const postMessage = async ($: IGlobalVariable) => {
   }
 
   if (sendAsBot) {
-    data.username = botName
+    // somehow slack doesn't recognise '0' as a valid username
+    data.username = !botName || botName === '0' ? 'Plumber' : botName
     try {
       // challenging the input to check if it is a URL!
       new URL(botIcon)

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -137,7 +137,7 @@ enum FieldVisibilityOp {
 type FieldVisibilityCondition {
   op: FieldVisibilityOp!
   fieldKey: String
-  fieldValue: String
+  fieldValue: JSONPrimitive
 }
 
 enum SetupMessageVariant {
@@ -559,6 +559,7 @@ input BulkRetryExecutionsInput {
 The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSONObject
+scalar JSONPrimitive
 scalar Any
 
 input PreviousStepInput {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -247,7 +247,7 @@ interface IFieldComparativeVisibilityCondition {
   op: Extract<FieldVisibilityOp, 'equals' | 'not_equals'>
 
   fieldKey: string
-  fieldValue: string
+  fieldValue?: IJSONPrimitive
 }
 
 export type IFieldVisibilityCondition =


### PR DESCRIPTION
## Problem

Bot name is set as required, but description shows 'Defaults to Plumber. -> counter-intuitive

## Solution
1. Hide Bot Name and Bot Icon fields if Send as Bot is False
2. Make Bot Name and Bot Icon fields optional
3. If Bot Name is optional, default to 'Plumber'

Replace graphql schema scalar `JSON` (currently unused) with `JSONPrimitive` which represents `string | number | boolean | null`
https://github.com/sindresorhus/type-fest/blob/main/source/json-value.d.ts