### PR TITLE
chore: add dropdown to select model type

### DIFF
--- a/packages/backend/src/apps/aisay/__tests__/common/schema.test.ts
+++ b/packages/backend/src/apps/aisay/__tests__/common/schema.test.ts
@@ -1,4 +1,4 @@
-import { assert, beforeEach, describe, it } from 'vitest'
+import { assert, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   generalisedModelSchema,
@@ -51,6 +51,36 @@ describe('AISAY schema', () => {
       generalisedModelPayload.file = '123'
       const result = generalisedModelSchema.safeParse(generalisedModelPayload)
       assert(result.success === false)
+    })
+
+    describe('should validate the model type', () => {
+      it('should return null if is default model type', () => {
+        generalisedModelPayload.modelType = 'standard'
+        const result = generalisedModelSchema.safeParse(generalisedModelPayload)
+        assert(result.success === true)
+        expect(result.data.modelType).toBeNull()
+      })
+
+      it('should return the model type if is not default model type', () => {
+        generalisedModelPayload.modelType = 'DOC_EXTRACTION_V2'
+        const result = generalisedModelSchema.safeParse(generalisedModelPayload)
+        assert(result.success === true)
+        expect(result.data.modelType).toEqual({ DOC_EXTRACTION_V2: {} })
+      })
+
+      it('should return null if model type is not a valid model type', () => {
+        generalisedModelPayload.modelType = 'INVALID_MODEL_TYPE'
+        const result = generalisedModelSchema.safeParse(generalisedModelPayload)
+        assert(result.success === true)
+        expect(result.data.modelType).toBeNull()
+      })
+
+      it('should return null if no model type provided (for backward compatibility)', () => {
+        delete generalisedModelPayload.modelType
+        const result = generalisedModelSchema.safeParse(generalisedModelPayload)
+        assert(result.success === true)
+        expect(result.data.modelType).toBeNull()
+      })
     })
   })
 

--- a/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
+++ b/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
@@ -5,6 +5,10 @@ import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
 import { getToken } from '../../auth/get-token'
+import {
+  DEFAULT_GENERALISED_MODEL_TYPE,
+  GENERALISED_MODEL_OPTIONS,
+} from '../../common/constants'
 import { parseError } from '../../common/error-parser'
 import { generalisedModelSchema } from '../../common/schema'
 import { getAttachmentFromS3, getValidationError } from '../../common/utils'
@@ -16,6 +20,16 @@ const action: IRawAction = {
   key: 'useGeneralisedModel',
   description: 'Optimised for standard and non-standard documents',
   arguments: [
+    {
+      label: 'Model type',
+      key: 'modelType',
+      type: 'dropdown',
+      required: true,
+      variables: false,
+      showOptionValue: false,
+      options: GENERALISED_MODEL_OPTIONS,
+      value: DEFAULT_GENERALISED_MODEL_TYPE,
+    },
     {
       label: 'File',
       key: 'file',
@@ -50,21 +64,7 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
-    const { file, prompts } = $.step.parameters as {
-      file: string
-      prompts: Array<{ prompt: string }>
-    }
-
-    if (!$.auth.data?.clientId || !$.auth.data?.clientSecret) {
-      throw new StepError(
-        'Missing client ID or client secret',
-        'Please check the client ID and client secret',
-        $.step.position,
-        $.app.name,
-      )
-    }
-
-    const result = generalisedModelSchema.safeParse({ file, prompts })
+    const result = generalisedModelSchema.safeParse($.step.parameters)
     if (!result.success) {
       const { stepErrorName, stepErrorSolution } = getValidationError(result)
 
@@ -76,9 +76,20 @@ const action: IRawAction = {
       )
     }
 
+    if (!$.auth.data?.clientId || !$.auth.data?.clientSecret) {
+      throw new StepError(
+        'Missing client ID or client secret',
+        'Please check the client ID and client secret',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
     try {
+      const { file, prompts, modelType } = result.data
+
       // get attachment from S3 first
-      const attachment = await getAttachmentFromS3(result.data.file, $.flow.id)
+      const attachment = await getAttachmentFromS3(file, $.flow.id)
 
       // Step 1: get AWS Cognito access token
       const token = await getToken($)
@@ -93,7 +104,8 @@ const action: IRawAction = {
           Authorization: `Bearer ${token}`,
         },
         data: {
-          gpt_query: result.data.prompts,
+          ...(modelType && { additional_features: modelType }),
+          gpt_query: prompts,
           image: attachment.data,
         },
       })

--- a/packages/backend/src/apps/aisay/common/constants.ts
+++ b/packages/backend/src/apps/aisay/common/constants.ts
@@ -8,6 +8,6 @@ export const DOCUMENT_TYPES = [
 
 export const DEFAULT_GENERALISED_MODEL_TYPE = 'standard'
 export const GENERALISED_MODEL_OPTIONS = [
-  { label: 'Standard', value: DEFAULT_GENERALISED_MODEL_TYPE },
-  { label: 'Vision', value: 'DOC_EXTRACTION_V2' },
+  { label: 'Standard', value: DEFAULT_GENERALISED_MODEL_TYPE }, // LLM
+  { label: 'Vision', value: 'DOC_EXTRACTION_V2' }, // VLM
 ]

--- a/packages/backend/src/apps/aisay/common/constants.ts
+++ b/packages/backend/src/apps/aisay/common/constants.ts
@@ -5,3 +5,9 @@ export const DOCUMENT_TYPES = [
   'PASSPORT',
   'RECEIPT',
 ]
+
+export const DEFAULT_GENERALISED_MODEL_TYPE = 'standard'
+export const GENERALISED_MODEL_OPTIONS = [
+  { label: 'Standard', value: DEFAULT_GENERALISED_MODEL_TYPE },
+  { label: 'Vision', value: 'DOC_EXTRACTION_V2' },
+]

--- a/packages/backend/src/apps/aisay/common/schema.ts
+++ b/packages/backend/src/apps/aisay/common/schema.ts
@@ -2,7 +2,11 @@ import { z } from 'zod'
 
 import { parseS3Id } from '@/helpers/s3'
 
-import { DOCUMENT_TYPES } from './constants'
+import {
+  DEFAULT_GENERALISED_MODEL_TYPE,
+  DOCUMENT_TYPES,
+  GENERALISED_MODEL_OPTIONS,
+} from './constants'
 
 export const fileSchema = z.string().transform((value, context) => {
   if (!value) {
@@ -36,6 +40,23 @@ export const generalisedModelSchema = z.object({
     })
     return result
   }),
+  modelType: z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (!value) {
+        return null
+      }
+
+      const allowedValues = GENERALISED_MODEL_OPTIONS.map(
+        (option) => option.value,
+      ).filter((value) => value !== DEFAULT_GENERALISED_MODEL_TYPE)
+
+      if (!allowedValues.includes(value)) {
+        return null
+      }
+      return { [value]: {} }
+    }),
 })
 
 export const documentTypeEnum = z.enum(DOCUMENT_TYPES as [string, ...string[]])

--- a/packages/backend/src/apps/aisay/common/schema.ts
+++ b/packages/backend/src/apps/aisay/common/schema.ts
@@ -40,17 +40,23 @@ export const generalisedModelSchema = z.object({
     })
     return result
   }),
+  /**
+   * NOTE: the custom model type is indicated by the 'additonal_features' field in the request body
+   * 1. this function returns null when using the standard model as it is not required by default.
+   * 2. it is only included when using the vision generalised model.
+   * API doc: https://app.swaggerhub.com/apis-docs/DAMIENSKTWORK/bgp-aisay_document_extraction_api/1.0.11#/DocumentParserRequestS3GenericV2
+   */
   modelType: z
     .string()
     .optional()
     .transform((value) => {
-      if (!value) {
+      if (!value || value === DEFAULT_GENERALISED_MODEL_TYPE) {
         return null
       }
 
       const allowedValues = GENERALISED_MODEL_OPTIONS.map(
         (option) => option.value,
-      ).filter((value) => value !== DEFAULT_GENERALISED_MODEL_TYPE)
+      )
 
       if (!allowedValues.includes(value)) {
         return null


### PR DESCRIPTION
## TL;DR
Adds dropdown to select the type of generalised model to use for AISAY action.
Context: AISAY added a new model type called 'Vision' to their generalised model.

AISAY's API doc: https://app.swaggerhub.com/apis-docs/DAMIENSKTWORK/bgp-aisay_document_extraction_api/1.0.11#/DocumentParserResponse

## Solution
**Improvements**:
- Add dropdown to select generalised model: `Standard` (default) or `Vision` (new) 

## How to test?
- [ ] Existing AISAY actions work as intended without making any changes
  - [ ] Show the model type as `Standard` by default 
- [ ] Existing AISAY action can be updated to use new `Vision` model
- [ ] Create new AISAY action with `Vision` model and runs as intended
- [ ] Create new AISAY action with `Standard` model and runs as intended

## What changed?
* Additional dropdown field called `Model type` with the following options: `Standard` (default), `Vision` (new) 
* Add tests to validate the model type selection
* Add model type to api call as `additional_features`

## Before & After Screenshots

**BEFORE**:
<img width="975" alt="Screenshot 2025-06-06 at 2 49 19 PM" src="https://github.com/user-attachments/assets/9063c9ef-7770-4e96-af14-7fa6e0f750a8" />


**AFTER**:
<img width="968" alt="Screenshot 2025-06-06 at 2 52 50 PM" src="https://github.com/user-attachments/assets/24103909-31da-4b01-be8f-7f0c49cc4d2e" />

https://github.com/user-attachments/assets/b0b0093f-75d6-4457-9552-02ffe80fa348

