### PR TITLE
[FOR-EACH-5] PLU-447: Execute actions within for-each

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -1,0 +1,312 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isCheckboxItems,
+  processItems,
+} from '@/apps/toolbox/common/get-for-each-variables'
+import StepError from '@/errors/step'
+
+import action from '../../../actions/for-each'
+import {
+  FOR_EACH_INPUT_SOURCE,
+  FOR_EACH_ITERATION_KEY,
+} from '../../../common/constants'
+
+const mocks = vi.hoisted(() => ({
+  setActionItem: vi.fn(),
+}))
+
+vi.mock('@/apps/toolbox/common/get-for-each-variables', () => ({
+  isCheckboxItems: vi.fn(),
+  processItems: vi.fn(),
+}))
+
+const mockedIsCheckboxItems = vi.mocked(isCheckboxItems)
+const mockedProcessItems = vi.mocked(processItems)
+
+const MOCK_FLOW = [
+  {
+    id: 'trigger',
+    appKey: 'formsg',
+    key: 'newSubmission',
+    position: 1,
+  },
+  {
+    id: 'test-step',
+    appKey: 'tiles',
+    key: 'findMultipleRows',
+    position: 2,
+  },
+  {
+    id: 'for-each',
+    appKey: 'toolbox',
+    key: action.key,
+    position: 3,
+  },
+  {
+    id: 'for-each-action',
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+    position: 4,
+  },
+]
+
+describe('For each action', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    $ = {
+      flow: {
+        id: 'fake-pipe',
+        steps: MOCK_FLOW,
+      },
+      step: {
+        id: 'for-each',
+        appKey: 'toolbox',
+        key: action.key,
+        position: 3,
+        parameters: {},
+      },
+      app: {
+        name: 'Toolbox',
+      },
+      setActionItem: mocks.setActionItem,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('checkbox input', () => {
+    it('should handle valid checkbox input', async () => {
+      const checkboxItems = ['item1', 'item2', 'item3']
+      $.step.parameters.items = 'item1,item2,item3'
+
+      mockedIsCheckboxItems.mockReturnValue(true)
+
+      const result = await action.run($)
+
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 3,
+          items: checkboxItems,
+          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          item: `items.${FOR_EACH_ITERATION_KEY}`,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle checkbox input with whitespace', async () => {
+      const checkboxItems = ['item1', 'item2', 'item3']
+      $.step.parameters.items = '  item1,item2,item3  '
+
+      mockedIsCheckboxItems.mockReturnValue(true)
+
+      await action.run($)
+
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 3,
+          items: checkboxItems,
+          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          item: `items.${FOR_EACH_ITERATION_KEY}`,
+        },
+      })
+    })
+
+    it('should handle single checkbox item', async () => {
+      const checkboxItems = ['single-item']
+      $.step.parameters.items = 'single-item'
+
+      mockedIsCheckboxItems.mockReturnValue(true)
+
+      await action.run($)
+
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 1,
+          items: checkboxItems,
+          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          item: `items.${FOR_EACH_ITERATION_KEY}`,
+        },
+      })
+    })
+
+    it('should throw error when checkbox items validation fails', async () => {
+      $.step.parameters.items = ''
+
+      await expect(action.run($)).rejects.toThrow(StepError)
+      await expect(action.run($)).rejects.toThrow('Invalid input list')
+    })
+  })
+
+  describe('table input', () => {
+    const validTableData = {
+      rows: [
+        {
+          data: {
+            col1: 'value1',
+            col2: 'value2',
+          },
+          rowId: 'row-1',
+        },
+        {
+          data: {
+            col1: 'value3',
+            col2: 'value4',
+          },
+          rowId: 'row-2',
+        },
+      ],
+      columns: [
+        {
+          id: 'col1',
+          name: 'Column 1',
+          value: 'col1-value',
+        },
+        {
+          id: 'col2',
+          name: 'Column 2',
+          value: 'col2-value',
+        },
+      ],
+    }
+
+    it('should handle valid table input (Tiles)', async () => {
+      $.step.parameters.items = JSON.stringify(validTableData)
+
+      const processedResult = {
+        processedItems: {
+          rows: validTableData.rows,
+          columns: validTableData.columns,
+        },
+        iterations: 2,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      const result = await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 2,
+          items: processedResult.processedItems,
+          inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+        },
+      })
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle valid table input (M365 Excel)', async () => {
+      const excelData = {
+        ...validTableData,
+        rows: validTableData.rows.map((row) => ({ data: row.data })), // No rowId for Excel
+      }
+
+      $.step.parameters.items = JSON.stringify(excelData)
+
+      const processedResult = {
+        processedItems: {
+          rows: excelData.rows,
+          columns: validTableData.columns,
+        },
+        iterations: 2,
+        inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 2,
+          items: processedResult.processedItems,
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+        },
+      })
+    })
+
+    it('should handle table input with empty rows', async () => {
+      const emptyTableData = {
+        rows: [] as any[],
+        columns: validTableData.columns,
+      }
+
+      $.step.parameters.items = JSON.stringify(emptyTableData)
+
+      const processedResult = {
+        processedItems: {
+          rows: [] as any[],
+          columns: validTableData.columns,
+        },
+        iterations: 0,
+        inputSource: null as any,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      await action.run($)
+
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iterations: 0,
+          items: processedResult.processedItems,
+          inputSource: null,
+        },
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('should throw StepError for empty input', async () => {
+      $.step.parameters.items = ''
+
+      await expect(action.run($)).rejects.toThrow(StepError)
+      await expect(action.run($)).rejects.toThrow('Invalid input list')
+    })
+
+    it('should throw StepError for whitespace-only input', async () => {
+      $.step.parameters.items = '   '
+
+      await expect(action.run($)).rejects.toThrow(StepError)
+      await expect(action.run($)).rejects.toThrow('Invalid input list')
+    })
+
+    it('should throw StepError for invalid JSON', async () => {
+      $.step.parameters.items = '{ invalid json'
+
+      await expect(action.run($)).rejects.toThrow(StepError)
+      await expect(action.run($)).rejects.toThrow('Invalid input list')
+    })
+
+    it('should throw StepError for JSON missing required fields', async () => {
+      $.step.parameters.items = JSON.stringify({
+        invalidField: 'value',
+      })
+
+      await expect(action.run($)).rejects.toThrow(StepError)
+      await expect(action.run($)).rejects.toThrow('Invalid input list')
+    })
+  })
+})

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -98,7 +98,7 @@ describe('For each action', () => {
         raw: {
           iterations: 3,
           items: checkboxItems,
-          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
           item: `items.${FOR_EACH_ITERATION_KEY}`,
         },
       })
@@ -123,7 +123,7 @@ describe('For each action', () => {
         raw: {
           iterations: 3,
           items: checkboxItems,
-          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
           item: `items.${FOR_EACH_ITERATION_KEY}`,
         },
       })
@@ -141,7 +141,7 @@ describe('For each action', () => {
         raw: {
           iterations: 1,
           items: checkboxItems,
-          inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
+          inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
           item: `items.${FOR_EACH_ITERATION_KEY}`,
         },
       })
@@ -192,17 +192,15 @@ describe('For each action', () => {
           value: 'col2-value',
         },
       ],
+      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
     }
 
     it('should handle valid table input (Tiles)', async () => {
       $.step.parameters.items = validTableData
 
       const processedResult = {
-        processedItems: {
-          rows: validTableData.rows,
-          columns: validTableData.columns,
-        },
-        iterations: 2,
+        rows: validTableData.rows,
+        columns: validTableData.columns,
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
@@ -214,7 +212,7 @@ describe('For each action', () => {
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iterations: 2,
-          items: processedResult.processedItems,
+          items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.TILES,
         },
       })
@@ -230,16 +228,14 @@ describe('For each action', () => {
       const excelData = {
         ...validTableData,
         rows: validTableData.rows.map((row) => ({ data: row.data })), // No rowId for Excel
+        inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
       $.step.parameters.items = excelData
 
       const processedResult = {
-        processedItems: {
-          rows: excelData.rows,
-          columns: validTableData.columns,
-        },
-        iterations: 2,
+        rows: excelData.rows,
+        columns: validTableData.columns,
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
@@ -251,7 +247,7 @@ describe('For each action', () => {
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iterations: 2,
-          items: processedResult.processedItems,
+          items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
         },
       })
@@ -268,17 +264,15 @@ describe('For each action', () => {
       const emptyTableData = {
         rows: [] as any[],
         columns: validTableData.columns,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
       $.step.parameters.items = emptyTableData
 
       const processedResult = {
-        processedItems: {
-          rows: [] as any[],
-          columns: validTableData.columns,
-        },
-        iterations: 0,
-        inputSource: null as any,
+        rows: [] as any[],
+        columns: validTableData.columns,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
       mockedProcessItems.mockReturnValue(processedResult)
@@ -288,8 +282,8 @@ describe('For each action', () => {
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iterations: 0,
-          items: processedResult.processedItems,
-          inputSource: null,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.TILES,
         },
       })
 

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -85,7 +85,7 @@ describe('For each action', () => {
   describe('checkbox input', () => {
     it('should handle valid checkbox input', async () => {
       const checkboxItems = ['item1', 'item2', 'item3']
-      $.step.parameters.items = 'item1,item2,item3'
+      $.step.parameters.items = ['item1', 'item2', 'item3']
 
       mockedIsCheckboxItems.mockReturnValue(true)
 
@@ -109,8 +109,8 @@ describe('For each action', () => {
     })
 
     it('should handle checkbox input with whitespace', async () => {
-      const checkboxItems = ['item1', 'item2', 'item3']
-      $.step.parameters.items = '  item1,item2,item3  '
+      const checkboxItems = ['   item1', 'item2', 'item3']
+      $.step.parameters.items = ['   item1', 'item2', 'item3']
 
       mockedIsCheckboxItems.mockReturnValue(true)
 
@@ -128,7 +128,7 @@ describe('For each action', () => {
 
     it('should handle single checkbox item', async () => {
       const checkboxItems = ['single-item']
-      $.step.parameters.items = 'single-item'
+      $.step.parameters.items = ['single-item']
 
       mockedIsCheckboxItems.mockReturnValue(true)
 
@@ -145,7 +145,7 @@ describe('For each action', () => {
     })
 
     it('should throw error when checkbox items validation fails', async () => {
-      $.step.parameters.items = ''
+      $.step.parameters.items = 'item1,item2,item3'
 
       await expect(action.run($)).rejects.toThrow(StepError)
       await expect(action.run($)).rejects.toThrow('Invalid input list')
@@ -185,7 +185,7 @@ describe('For each action', () => {
     }
 
     it('should handle valid table input (Tiles)', async () => {
-      $.step.parameters.items = JSON.stringify(validTableData)
+      $.step.parameters.items = validTableData
 
       const processedResult = {
         processedItems: {
@@ -222,7 +222,7 @@ describe('For each action', () => {
         rows: validTableData.rows.map((row) => ({ data: row.data })), // No rowId for Excel
       }
 
-      $.step.parameters.items = JSON.stringify(excelData)
+      $.step.parameters.items = excelData
 
       const processedResult = {
         processedItems: {
@@ -253,7 +253,7 @@ describe('For each action', () => {
         columns: validTableData.columns,
       }
 
-      $.step.parameters.items = JSON.stringify(emptyTableData)
+      $.step.parameters.items = emptyTableData
 
       const processedResult = {
         processedItems: {

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -74,6 +74,9 @@ describe('For each action', () => {
       app: {
         name: 'Toolbox',
       },
+      execution: {
+        testRun: false,
+      },
       setActionItem: mocks.setActionItem,
     } as unknown as IGlobalVariable
   })

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -132,7 +132,7 @@ describe('For each action', () => {
 
       mockedIsCheckboxItems.mockReturnValue(true)
 
-      await action.run($)
+      const result = await action.run($)
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
@@ -140,6 +140,13 @@ describe('For each action', () => {
           items: checkboxItems,
           inputSource: FOR_EACH_INPUT_SOURCE.CHECKBOX,
           item: `items.${FOR_EACH_ITERATION_KEY}`,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
         },
       })
     })
@@ -235,7 +242,7 @@ describe('For each action', () => {
 
       mockedProcessItems.mockReturnValue(processedResult)
 
-      await action.run($)
+      const result = await action.run($)
 
       expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
@@ -243,6 +250,13 @@ describe('For each action', () => {
           iterations: 2,
           items: processedResult.processedItems,
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
         },
       })
     })
@@ -266,13 +280,20 @@ describe('For each action', () => {
 
       mockedProcessItems.mockReturnValue(processedResult)
 
-      await action.run($)
+      const result = await action.run($)
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iterations: 0,
           items: processedResult.processedItems,
           inputSource: null,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'stop-execution',
+          stepId: 'for-each',
         },
       })
     })

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/schema.test.ts
@@ -7,134 +7,164 @@ import { inputSchema } from '../../../actions/for-each/schema'
 
 describe('inputSchema', () => {
   describe('table input format', () => {
-    it('should handle valid table input', () => {
-      const validTableInput = {
-        rows: [
-          {
-            data: { name: 'John', age: 25 },
-            rowId: 'row1',
-          },
-          {
-            data: { name: 'Jane', age: 30 },
-          },
-        ],
-        columns: [
-          { id: 'name', name: 'Name', value: 'name' },
-          { id: 'age', name: 'Age', value: 'age' },
-        ],
-        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
-      }
-
-      const result = inputSchema.safeParse(validTableInput)
-
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-
-        if (inputSource === FOR_EACH_INPUT_SOURCE.TILES) {
-          expect((items as MultipleRowObject).rows).toHaveLength(2)
-          expect((items as MultipleRowObject).columns).toHaveLength(2)
-          expect((items as MultipleRowObject).rows[0].data.name).toBe('John')
-          expect((items as MultipleRowObject).rows[0].rowId).toBe('row1')
-          expect((items as MultipleRowObject).rows[1].rowId).toBeUndefined()
+    it.each([true, false])(
+      'should handle valid table input for testRun: %s',
+      (testRun) => {
+        const validTableInput = {
+          rows: [
+            {
+              data: { name: 'John', age: 25 },
+              rowId: 'row1',
+            },
+            {
+              data: { name: 'Jane', age: 30 },
+            },
+          ],
+          columns: [
+            { id: 'name', name: 'Name', value: 'name' },
+            { id: 'age', name: 'Age', value: 'age' },
+          ],
+          inputSource: FOR_EACH_INPUT_SOURCE.TILES,
         }
-      }
-    })
 
-    it('should handle table input without rowId', () => {
-      const validTableInput = {
-        rows: [
-          {
-            data: { name: 'Alice', score: 95.5 },
-          },
-        ],
-        columns: [
-          { id: 'name', name: 'Name', value: 'name' },
-          { id: 'score', name: 'Score', value: 'score' },
-        ],
-        inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
-      }
+        const result = inputSchema.safeParse({ data: validTableInput, testRun })
 
-      const result = inputSchema.safeParse(validTableInput)
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
-        if (inputSource === FOR_EACH_INPUT_SOURCE.M365_EXCEL) {
-          expect((items as MultipleRowObject).rows[0].data.score).toBe(95.5)
+          if (inputSource === FOR_EACH_INPUT_SOURCE.TILES) {
+            expect((items as MultipleRowObject).rows).toHaveLength(2)
+            expect((items as MultipleRowObject).columns).toHaveLength(2)
+            expect((items as MultipleRowObject).rows[0].data.name).toBe('John')
+            expect((items as MultipleRowObject).rows[0].rowId).toBe('row1')
+            expect((items as MultipleRowObject).rows[1].rowId).toBeUndefined()
+          }
         }
-      }
-    })
+      },
+    )
 
-    it('should reject table input with missing rows', () => {
-      const invalidTableInput = {
-        columns: [{ id: 'name', name: 'Name', value: 'name' }],
-      }
+    it.each([true, false])(
+      'should handle table input without rowId for testRun: %s',
+      (testRun) => {
+        const validTableInput = {
+          rows: [
+            {
+              data: { name: 'Alice', score: 95.5 },
+            },
+          ],
+          columns: [
+            { id: 'name', name: 'Name', value: 'name' },
+            { id: 'score', name: 'Score', value: 'score' },
+          ],
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+        }
 
-      const result = inputSchema.safeParse(invalidTableInput)
+        const result = inputSchema.safeParse({ data: validTableInput, testRun })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
+          if (inputSource === FOR_EACH_INPUT_SOURCE.M365_EXCEL) {
+            expect((items as MultipleRowObject).rows[0].data.score).toBe(95.5)
+          }
+        }
+      },
+    )
 
-    it('should reject table input with missing columns', () => {
-      const invalidTableInput = {
-        rows: [
-          {
-            data: { name: 'John' },
-          },
-        ],
-      }
+    it.each([true, false])(
+      'should reject table input with missing rows for testRun: %s',
+      (testRun) => {
+        const invalidTableInput = {
+          columns: [{ id: 'name', name: 'Name', value: 'name' }],
+        }
 
-      const result = inputSchema.safeParse(invalidTableInput)
+        const result = inputSchema.safeParse({
+          data: invalidTableInput,
+          testRun,
+        })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
 
-    it('should reject table input with invalid row structure', () => {
-      const invalidTableInput = {
-        rows: [
-          {
-            invalidField: 'test',
-          },
-        ],
-        columns: [{ id: 'name', name: 'Name', value: 'name' }],
-      }
+    it.each([true, false])(
+      'should reject table input with missing columns for testRun: %s',
+      (testRun) => {
+        const invalidTableInput = {
+          rows: [
+            {
+              data: { name: 'John' },
+            },
+          ],
+        }
 
-      const result = inputSchema.safeParse(invalidTableInput)
+        const result = inputSchema.safeParse({
+          data: invalidTableInput,
+          testRun,
+        })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
 
-    it('should reject table input with invalid column structure', () => {
-      const invalidTableInput = {
-        rows: [
-          {
-            data: { name: 'John' },
-          },
-        ],
-        columns: [
-          { id: 'name', name: 'Name' }, // missing 'value' field
-        ],
-      }
+    it.each([true, false])(
+      'should reject table input with invalid row structure for testRun: %s',
+      (testRun) => {
+        const invalidTableInput = {
+          rows: [
+            {
+              invalidField: 'test',
+            },
+          ],
+          columns: [{ id: 'name', name: 'Name', value: 'name' }],
+        }
 
-      const result = inputSchema.safeParse(invalidTableInput)
+        const result = inputSchema.safeParse({
+          data: invalidTableInput,
+          testRun,
+        })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
+
+    it.each([true, false])(
+      'should reject table input with invalid column structure for testRun: %s',
+      (testRun) => {
+        const invalidTableInput = {
+          rows: [
+            {
+              data: { name: 'John' },
+            },
+          ],
+          columns: [
+            { id: 'name', name: 'Name' }, // missing 'value' field
+          ],
+        }
+
+        const result = inputSchema.safeParse({
+          data: invalidTableInput,
+          testRun,
+        })
+
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
 
     it.each([
       {
@@ -149,12 +179,22 @@ describe('inputSchema', () => {
         input: 'item1,item2}',
         error: 'Invalid input',
       },
-    ])('should reject malformed JSON', ({ input, error }) => {
-      const result = inputSchema.safeParse(input)
+    ])('should reject malformed JSON for testRun: %s', ({ input, error }) => {
+      const resTestRun = inputSchema.safeParse({ data: input, testRun: true })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe(error)
+      expect(resTestRun.success).toBe(false)
+      if (resTestRun.success === false) {
+        expect(resTestRun.error.issues[0].message).toBe(error)
+      }
+
+      const resActual = inputSchema.safeParse({
+        data: input,
+        testRun: false,
+      })
+
+      expect(resActual.success).toBe(false)
+      if (resActual.success === false) {
+        expect(resActual.error.issues[0].message).toBe(error)
       }
     })
 
@@ -178,88 +218,144 @@ describe('inputSchema', () => {
   })
 
   describe('checkbox input format', () => {
-    it('should handle single item', () => {
-      const result = inputSchema.safeParse(['item1'])
+    it.each([true, false])(
+      'should handle single item for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({ data: ['item1'], testRun })
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
-        expect(items).toEqual(['item1'])
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+          expect(items).toEqual(['item1'])
+        }
+      },
+    )
 
-    it('should handle multiple comma-separated items', () => {
-      const result = inputSchema.safeParse(['item1', 'item2', 'item3'])
+    it.each([true, false])(
+      'should handle multiple comma-separated items for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({
+          data: ['item1', 'item2', 'item3'],
+          testRun,
+        })
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
-        expect(items).toEqual(['item1', 'item2', 'item3'])
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+          expect(items).toEqual(['item1', 'item2', 'item3'])
+        }
+      },
+    )
 
-    it('should handle items with spaces', () => {
-      const result = inputSchema.safeParse(['item 1', ' item 2 ', ' item 3'])
+    it.each([true, false])(
+      'should handle items with spaces for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({
+          data: ['item 1', ' item 2 ', ' item 3'],
+          testRun,
+        })
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
-        expect(items).toEqual(['item 1', ' item 2 ', ' item 3'])
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+          expect(items).toEqual(['item 1', ' item 2 ', ' item 3'])
+        }
+      },
+    )
 
-    it('should handle empty items in comma-separated list', () => {
-      const result = inputSchema.safeParse(['item1', '', 'item3'])
+    it.each([true, false])(
+      'should handle empty items in comma-separated list for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({
+          data: ['item1', '', 'item3'],
+          testRun,
+        })
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
-        expect(items).toEqual(['item1', '', 'item3'])
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+          expect(items).toEqual(['item1', '', 'item3'])
+        }
+      },
+    )
 
-    it('should not trim whitespace for checkbox items', () => {
-      const result = inputSchema.safeParse(['  item1', 'item2  '])
+    it.each([true, false])(
+      'should not trim whitespace for checkbox items for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({
+          data: ['  item1', 'item2  '],
+          testRun,
+        })
 
-      expect(result.success).toBe(true)
-      if (result.success) {
-        const { inputSource, items } = result.data
-        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
-        expect(items).toEqual(['  item1', 'item2  '])
-      }
-    })
+        expect(result.success).toBe(true)
+        if (result.success) {
+          const { inputSource, items } = result.data
+          expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+          expect(items).toEqual(['  item1', 'item2  '])
+        }
+      },
+    )
 
-    it('should reject single comma', () => {
-      const result = inputSchema.safeParse(',')
+    it.each([true, false])(
+      'should reject single comma for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({ data: ',', testRun })
+
+        expect(result.success).toBe(false)
+        if (result.success == false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
+
+    it('should reject empty array on test run', () => {
+      const result = inputSchema.safeParse({ data: [], testRun: true })
 
       expect(result.success).toBe(false)
       if (result.success == false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
+        expect(result.error.issues[0].message).toBe('Input cannot be empty')
+      }
+    })
+
+    it('should handle empty array on actual run', () => {
+      const result = inputSchema.safeParse({ data: [], testRun: false })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        const { inputSource, items } = result.data
+        expect(inputSource).toBe(FOR_EACH_INPUT_SOURCE.STRING_ARRAY)
+        expect(items).toEqual([])
       }
     })
   })
 
   describe('edge cases and validation', () => {
-    it('should reject empty string', () => {
-      const result = inputSchema.safeParse('')
+    it.each([true, false])(
+      'should reject empty string for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({ data: '', testRun })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
 
-    it('should reject whitespace-only string', () => {
-      const result = inputSchema.safeParse('   ')
+    it.each([true, false])(
+      'should reject whitespace-only string for testRun: %s',
+      (testRun) => {
+        const result = inputSchema.safeParse({ data: '   ', testRun })
 
-      expect(result.success).toBe(false)
-      if (result.success === false) {
-        expect(result.error.issues[0].message).toBe('Invalid input')
-      }
-    })
+        expect(result.success).toBe(false)
+        if (result.success === false) {
+          expect(result.error.issues[0].message).toBe('Invalid input')
+        }
+      },
+    )
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -50,8 +50,17 @@ const action: IRawAction = {
     }
 
     try {
-      let output = {}
       const { items, inputSource, iterations } = parsedResult.data
+      let output: {
+        iterations: number
+        items: any[]
+        inputSource: string
+        item?: string
+      } = {
+        iterations: 0,
+        items: [],
+        inputSource: '',
+      }
       if (
         inputSource === FOR_EACH_INPUT_SOURCE.STRING_ARRAY &&
         Array.isArray(items) &&
@@ -62,7 +71,7 @@ const action: IRawAction = {
           items: items,
           inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
           // NOTE: this is specifically for checkboxes
-          // table data is handled differently in processInput
+          // table data is handled differently in processItems
           item: `items.${FOR_EACH_ITERATION_KEY}`,
         }
         return
@@ -80,6 +89,16 @@ const action: IRawAction = {
       }
 
       $.setActionItem({ raw: output })
+
+      if (output?.iterations === 0) {
+        return {
+          nextStep: {
+            command: 'stop-execution',
+            stepId: $.step.id,
+          },
+        }
+      }
+
       return {
         nextStep: {
           command: 'start-for-each',

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -75,7 +75,6 @@ const action: IRawAction = {
           // table data is handled differently in processItems
           item: `items.${FOR_EACH_ITERATION_KEY}`,
         }
-        return
       } else if (
         inputSource === FOR_EACH_INPUT_SOURCE.M365_EXCEL ||
         inputSource === FOR_EACH_INPUT_SOURCE.TILES

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -37,8 +37,9 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    const { testRun } = $.execution
     const { items: rawItems } = $.step.parameters
-    const parsedResult = inputSchema.safeParse(rawItems)
+    const parsedResult = inputSchema.safeParse({ data: rawItems, testRun })
 
     if (parsedResult.success === false) {
       throw new StepError(

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -50,22 +50,21 @@ const action: IRawAction = {
     }
 
     try {
+      let output = {}
       const { items, inputSource, iterations } = parsedResult.data
       if (
         inputSource === FOR_EACH_INPUT_SOURCE.STRING_ARRAY &&
         Array.isArray(items) &&
         isCheckboxItems(items)
       ) {
-        $.setActionItem({
-          raw: {
-            iterations: items.length,
-            items: items,
-            inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
-            // NOTE: this is specifically for checkboxes
-            // table data is handled differently in processInput
-            item: `items.${FOR_EACH_ITERATION_KEY}`,
-          },
-        })
+        output = {
+          iterations: items.length,
+          items: items,
+          inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
+          // NOTE: this is specifically for checkboxes
+          // table data is handled differently in processInput
+          item: `items.${FOR_EACH_ITERATION_KEY}`,
+        }
         return
       } else if (
         inputSource === FOR_EACH_INPUT_SOURCE.M365_EXCEL ||
@@ -73,13 +72,19 @@ const action: IRawAction = {
       ) {
         const processedItems = processItems(items as MultipleRowObject)
 
-        $.setActionItem({
-          raw: {
-            iterations: iterations,
-            items: processedItems,
-            inputSource,
-          },
-        })
+        output = {
+          iterations: iterations,
+          items: processedItems,
+          inputSource,
+        }
+      }
+
+      $.setActionItem({ raw: output })
+      return {
+        nextStep: {
+          command: 'start-for-each',
+          stepId: $.step.id,
+        },
       }
     } catch (err) {
       console.error(err)

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -30,10 +30,17 @@ const baseDataOutSchema = z.object({
   iterations: z.number(),
 })
 
+const dataSchema = z.union([z.array(z.any()), tableSchema])
+
 export const inputSchema = z
-  .union([z.array(z.any()), tableSchema])
-  .transform((data, ctx) => {
-    if (!data || (Array.isArray(data) && data.length === 0)) {
+  .object({
+    data: dataSchema,
+    testRun: z.boolean(),
+  })
+  .transform(({ data, testRun }, ctx) => {
+    // we allow empty arrays in non-test runs as the checkboxes may be empty
+    // however test runs should not be empty as values are needed to set up subsequent steps
+    if (!data || (testRun && Array.isArray(data) && data.length === 0)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Input cannot be empty',

--- a/packages/backend/src/apps/toolbox/common/constants.ts
+++ b/packages/backend/src/apps/toolbox/common/constants.ts
@@ -4,3 +4,11 @@ export enum FOR_EACH_INPUT_SOURCE {
   TILES = 'tiles',
   STRING_ARRAY = 'string-array',
 }
+
+export const FOR_EACH_ITERATION_DELAY = 2000 // in ms
+export const FOR_EACH_MAX_ITERATIONS = 500
+export const TOOLBOX_APP_KEY = 'toolbox'
+export enum TOOLBOX_ACTIONS {
+  FOR_EACH = 'forEach',
+  IF_THEN = 'ifThen',
+}

--- a/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
+++ b/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
@@ -1,4 +1,7 @@
-import { FOR_EACH_INPUT_SOURCE, FOR_EACH_ITERATION_KEY } from './constants'
+import {
+  FOR_EACH_INPUT_SOURCE,
+  FOR_EACH_ITERATION_KEY,
+} from '@/apps/toolbox/common/constants'
 
 interface ProcessedColumn {
   id: string

--- a/packages/backend/src/db/migrations/20250606072418_add_execution_steps_key.ts
+++ b/packages/backend/src/db/migrations/20250606072418_add_execution_steps_key.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('execution_steps', (table) => {
+    table.string('key').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('execution_steps', (table) => {
+    table.dropColumn('key')
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import cronTimes from '@/apps/scheduler/common/cron-times'
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
 import updateFlowStatus from '@/graphql/mutations/update-flow-status'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
@@ -85,6 +89,21 @@ describe('updateFlowStatus', () => {
 
     await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
       'Step positions are out of order. Please contact support@plumber.gov.sg for help.',
+    )
+  })
+
+  it('throws an error when activating a flow with more than one for-each step', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { position: 1 },
+      { position: 2, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
+      { position: 3, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
+    ]
+
+    const params = { input: { id: fakeFlow.id, active: true } }
+
+    await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+      'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
     )
   })
 

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -1,13 +1,37 @@
 import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
 import flowQueue from '@/queues/flow'
 
-import type { MutationResolvers } from '../__generated__/types.generated'
+import type { MutationResolvers, Step } from '../__generated__/types.generated'
 
 const JOB_NAME = 'flow'
 const EVERY_15_MINUTES_CRON = '*/15 * * * *'
+
+const validateFlowSteps = (steps: Step[]) => {
+  if (!steps.every((step, index) => step.position === index + 1)) {
+    throw new Error(
+      'Step positions are out of order. Please contact support@plumber.gov.sg for help.',
+    )
+  }
+
+  if (
+    steps.filter(
+      (step) =>
+        step.appKey === TOOLBOX_APP_KEY &&
+        step.key === TOOLBOX_ACTIONS.FOR_EACH,
+    ).length > 1
+  ) {
+    throw new Error(
+      'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
+    )
+  }
+}
 
 const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   _parent,
@@ -28,14 +52,8 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
     return flow
   }
 
-  // Check that step positions are contiguous when publishing
-  if (
-    params.input.active &&
-    !flow.steps.every((step, index) => step.position === index + 1)
-  ) {
-    throw new Error(
-      'Step positions are out of order. Please contact support@plumber.gov.sg for help.',
-    )
+  if (params.input.active) {
+    validateFlowSteps(flow.steps)
   }
 
   await flow.$query().patch({

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -328,6 +328,8 @@ type ExecutionStep {
 type ExecutionStepMetadata {
   isMock: Boolean
   iteration: Int
+  isLastIteration: Boolean
+  isLastStep: Boolean
 }
 
 type Field {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -327,6 +327,7 @@ type ExecutionStep {
 
 type ExecutionStepMetadata {
   isMock: Boolean
+  iteration: Int
 }
 
 type Field {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -322,6 +322,7 @@ type ExecutionStep {
   createdAt: String
   updatedAt: String
   metadata: ExecutionStepMetadata!
+  key: String
 }
 
 type ExecutionStepMetadata {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -328,6 +328,8 @@ type ExecutionStep {
 type ExecutionStepMetadata {
   isMock: Boolean
   iteration: Int
+  iterations: Int
+  iterationStatus: JSONObject
   isLastIteration: Boolean
   isLastStep: Boolean
 }

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -8,13 +8,12 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
-import Flow from '@/models/flow'
-
 import {
   computeForEachParameters,
   ForEachContext,
   getForEachContext,
-} from '../compute-for-each-parameters'
+} from '@/helpers/compute-for-each-parameters'
+import Flow from '@/models/flow'
 
 const triggerId = randomUUID()
 const randomForEachStepId = randomUUID()
@@ -298,12 +297,16 @@ describe('getForEachContext', () => {
       ],
     } as unknown as Flow
 
-    const context = getForEachContext(flowWithoutForEach)
+    const context = getForEachContext(
+      flowWithoutForEach,
+      flowWithoutForEach.steps[0],
+    )
 
     expect(context).toEqual({
       forEachStepIndex: -1,
       stepPositions: {},
       lastStepId: '',
+      isForEachStep: false,
     })
   })
 
@@ -331,7 +334,10 @@ describe('getForEachContext', () => {
       ],
     } as unknown as Flow
 
-    const context = getForEachContext(flowWithMultipleForEach)
+    const context = getForEachContext(
+      flowWithMultipleForEach,
+      flowWithMultipleForEach.steps[1],
+    )
 
     expect(context.forEachStepIndex).toBe(2)
     expect(context.stepPositions).toEqual({
@@ -340,22 +346,24 @@ describe('getForEachContext', () => {
       [flowWithMultipleForEach.steps[2].id]: 3,
     })
     expect(context.lastStepId).toBe(flowWithMultipleForEach.steps[2].id)
+    expect(context.isForEachStep).toBe(true)
   })
 
   it('should return correct context when step is before for-each', () => {
-    const context = getForEachContext(mockFlow)
+    const context = getForEachContext(mockFlow, mockFlow.steps[0])
 
     expect(context.forEachStepIndex).toBe(2)
   })
 
   it('should return correct context when step is after for-each', () => {
-    const context = getForEachContext(mockFlow)
+    const context = getForEachContext(mockFlow, mockFlow.steps[2])
 
     expect(context.forEachStepIndex).toBe(2)
+    expect(context.isForEachStep).toBe(false)
   })
 
   it('should return correct step positions', () => {
-    const context = getForEachContext(mockFlow)
+    const context = getForEachContext(mockFlow, mockFlow.steps[1])
 
     expect(context.stepPositions).toEqual({
       [mockFlow.steps[0].id]: 1,
@@ -364,6 +372,19 @@ describe('getForEachContext', () => {
       [mockFlow.steps[3].id]: 4,
     })
   })
+
+  it.each([
+    { step: mockFlow.steps[0], expected: false },
+    { step: mockFlow.steps[1], expected: true },
+    { step: mockFlow.steps[2], expected: false },
+    { step: mockFlow.steps[3], expected: false },
+  ])(
+    'should return correct isForEachStep for step %s',
+    ({ step, expected }) => {
+      const context = getForEachContext(mockFlow, step)
+      expect(context.isForEachStep).toBe(expected)
+    },
+  )
 })
 
 describe('computeForEachParameters', () => {
@@ -378,6 +399,7 @@ describe('computeForEachParameters', () => {
       [mockFlow.steps[2].id]: 3,
       [mockFlow.steps[3].id]: 4,
     },
+    isForEachStep: false,
   }
 
   it.each([

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -1,0 +1,499 @@
+import { IExecutionStep, IJSONObject } from '@plumber/types'
+
+import { randomUUID } from 'crypto'
+import { describe, expect, it } from 'vitest'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import Flow from '@/models/flow'
+
+import {
+  computeForEachParameters,
+  ForEachContext,
+  getForEachContext,
+} from '../compute-for-each-parameters'
+
+const triggerId = randomUUID()
+const randomForEachStepId = randomUUID()
+const randomAction1StepId = randomUUID()
+const randomAction2StepId = randomUUID()
+
+const mockTriggerExecutionStep = {
+  stepId: triggerId,
+  appKey: 'test-app',
+  key: 'test-action',
+  dataOut: {
+    stringProp: 'test string',
+    numberProp: 42,
+    arrayProp: ['item1', 'item2', 'item3'],
+    checkboxProp: [
+      { name: 'option1', value: true },
+      { name: 'option2', value: false },
+      { name: 'option3', value: true },
+    ],
+    tableProp: {
+      rows: [
+        { data: { id: 1, name: 'John', age: 25 } },
+        { data: { id: 2, name: 'Jane', age: 30 } },
+      ],
+      columns: [
+        { id: 'id', name: 'ID', value: 'id' },
+        { id: 'name', name: 'Name', value: 'name' },
+        { id: 'age', name: 'Age', value: 'age' },
+      ],
+    },
+  },
+} as unknown as IExecutionStep
+
+const mockForEachCheckboxExecutionStep = {
+  stepId: randomForEachStepId,
+  appKey: TOOLBOX_APP_KEY,
+  key: TOOLBOX_ACTIONS.FOR_EACH,
+  dataOut: {
+    item: 'items.__ITERATION__',
+    items: ['Option 4', 'Option 3', 'Option 2', 'Option 1'],
+    iterations: 4,
+    inputSource: 'checkbox',
+  },
+} as unknown as IExecutionStep
+
+const mockForEachTableExecutionStep = {
+  stepId: randomForEachStepId,
+  appKey: TOOLBOX_APP_KEY,
+  key: TOOLBOX_ACTIONS.FOR_EACH,
+  dataOut: {
+    items: {
+      rows: [
+        {
+          data: {
+            '11167042-c7dc-447c-a08c-9694d44e7cab': 'Yes',
+            '4d847712-89f4-4339-bbca-b5fc066a7bf8': 'T7822950K',
+            '6d673eaa-fa43-4a5e-bd0f-cd5737ed6538':
+              'Block 97 Ang Mo Kio Avenue #1-846',
+            'a7e29b3c-ef08-4016-964f-9226ce85325e': 'Li Hua',
+            'adde3dbe-d88c-4ca3-96a8-9c0b0122b8a6': 'hello',
+            'b3313cc9-27cc-465f-83c4-20fee42d59c1': 'lihua.lim957@outlook.com',
+            'e6269e93-d869-4384-9e1d-fdd127e4287f': 109480,
+            'f7d2cc56-672a-4485-8bd6-b359b3ac8343': 'Lim',
+          },
+          rowId: 'dc8984b2-7521-412d-8698-c0c21f754922',
+        },
+        {
+          data: {
+            '11167042-c7dc-447c-a08c-9694d44e7cab': 'Yes',
+            '4d847712-89f4-4339-bbca-b5fc066a7bf8': 'S7586967P',
+            '6d673eaa-fa43-4a5e-bd0f-cd5737ed6538':
+              'Block 422 Raffles Place #2-545',
+            'a7e29b3c-ef08-4016-964f-9226ce85325e': 'Isaac',
+            'b3313cc9-27cc-465f-83c4-20fee42d59c1': 'john.goh704@gmail.com',
+            'e6269e93-d869-4384-9e1d-fdd127e4287f': 278127,
+            'f7d2cc56-672a-4485-8bd6-b359b3ac8343': 'Goh',
+          },
+          rowId: '98040a94-5c10-4eab-ae4b-587c79ae5ed0',
+        },
+        {
+          data: {
+            '11167042-c7dc-447c-a08c-9694d44e7cab': 'Yes',
+            '4d847712-89f4-4339-bbca-b5fc066a7bf8': 'S4654108U',
+            '6d673eaa-fa43-4a5e-bd0f-cd5737ed6538':
+              'Block 771 Holland Road #47-552',
+            'a7e29b3c-ef08-4016-964f-9226ce85325e': 'Wei Ming',
+            'b3313cc9-27cc-465f-83c4-20fee42d59c1':
+              'weiming.singh717@hotmail.com',
+            'e6269e93-d869-4384-9e1d-fdd127e4287f': 805877,
+            'f7d2cc56-672a-4485-8bd6-b359b3ac8343': 'Singh',
+          },
+          rowId: '88464fa3-acb5-454c-904f-bb72dc153a5d',
+        },
+        {
+          data: {
+            '11167042-c7dc-447c-a08c-9694d44e7cab': 'Yes',
+            '4d847712-89f4-4339-bbca-b5fc066a7bf8': 'S3257627G',
+            '6d673eaa-fa43-4a5e-bd0f-cd5737ed6538':
+              'Block 775 Jurong West Street #35-435',
+            'a7e29b3c-ef08-4016-964f-9226ce85325e': 'Kumar',
+            'adde3dbe-d88c-4ca3-96a8-9c0b0122b8a6': 'bye',
+            'b3313cc9-27cc-465f-83c4-20fee42d59c1': 'kumar.chen803@gmail.com',
+            'e6269e93-d869-4384-9e1d-fdd127e4287f': 813351,
+            'f7d2cc56-672a-4485-8bd6-b359b3ac8343': 'Chen',
+          },
+          rowId: '13628595-dd01-4cb8-a6bd-fac80373441a',
+        },
+      ],
+      columns: [
+        {
+          id: 'a7e29b3c-ef08-4016-964f-9226ce85325e',
+          name: 'First Name',
+          value:
+            'items.rows.__ITERATION__.data.a7e29b3c-ef08-4016-964f-9226ce85325e',
+        },
+        {
+          id: 'f7d2cc56-672a-4485-8bd6-b359b3ac8343',
+          name: 'Last Name',
+          value:
+            'items.rows.__ITERATION__.data.f7d2cc56-672a-4485-8bd6-b359b3ac8343',
+        },
+        {
+          id: '4d847712-89f4-4339-bbca-b5fc066a7bf8',
+          name: 'NRIC',
+          value:
+            'items.rows.__ITERATION__.data.4d847712-89f4-4339-bbca-b5fc066a7bf8',
+        },
+        {
+          id: '6d673eaa-fa43-4a5e-bd0f-cd5737ed6538',
+          name: 'Address',
+          value:
+            'items.rows.__ITERATION__.data.6d673eaa-fa43-4a5e-bd0f-cd5737ed6538',
+        },
+        {
+          id: 'e6269e93-d869-4384-9e1d-fdd127e4287f',
+          name: 'Postal Code',
+          value:
+            'items.rows.__ITERATION__.data.e6269e93-d869-4384-9e1d-fdd127e4287f',
+        },
+        {
+          id: 'b3313cc9-27cc-465f-83c4-20fee42d59c1',
+          name: 'Email Address',
+          value:
+            'items.rows.__ITERATION__.data.b3313cc9-27cc-465f-83c4-20fee42d59c1',
+        },
+        {
+          id: '11167042-c7dc-447c-a08c-9694d44e7cab',
+          name: 'RSVP-ed?',
+          value:
+            'items.rows.__ITERATION__.data.11167042-c7dc-447c-a08c-9694d44e7cab',
+        },
+        {
+          id: 'adde3dbe-d88c-4ca3-96a8-9c0b0122b8a6',
+          name: 'Test',
+          value:
+            'items.rows.__ITERATION__.data.adde3dbe-d88c-4ca3-96a8-9c0b0122b8a6',
+        },
+        {
+          id: '62ead552-d117-48c4-930a-9fe7a110e2ec',
+          name: 'Test',
+          value:
+            'items.rows.__ITERATION__.data.62ead552-d117-48c4-930a-9fe7a110e2ec',
+        },
+      ],
+    },
+    iterations: 4,
+    inputSource: 'tiles',
+  },
+} as unknown as IExecutionStep
+
+const mockExecutionStepsAfterForEach = [
+  {
+    stepId: randomAction1StepId,
+    appKey: 'test-app',
+    key: 'test-action',
+    dataOut: {
+      stringProp: 'iteration 1 step 3 string',
+      numberProp: 84,
+      objectProp: {
+        stringProp: 'iteration 1 step 3 string in object',
+        numberProp: 840,
+      },
+    },
+    metadata: { iteration: 1 },
+  },
+  {
+    stepId: randomAction1StepId,
+    appKey: 'test-app',
+    key: 'test-action',
+    dataOut: {
+      stringProp: 'iteration 2 step 3 string',
+      numberProp: 84,
+      objectProp: {
+        stringProp: 'iteration 2 step 3 string in object',
+        numberProp: 840,
+      },
+    },
+    metadata: { iteration: 2 },
+  },
+  {
+    stepId: randomAction2StepId,
+    appKey: 'test-app',
+    key: 'test-action',
+    dataOut: {
+      stringProp: 'iteration 2 step 4 string',
+      numberProp: 126,
+      objectProp: {
+        stringProp: 'iteration 2 step 4 string in object',
+        numberProp: 1260,
+      },
+    },
+    metadata: { iteration: 2 },
+  },
+  {
+    stepId: randomAction2StepId,
+    appKey: 'test-app',
+    key: 'test-action',
+    dataOut: {
+      stringProp: 'iteration 3 step 4 string',
+      numberProp: 126,
+      objectProp: {
+        stringProp: 'iteration 3 step 4 string in object',
+        numberProp: 1260,
+      },
+    },
+    metadata: { iteration: 3 },
+  },
+] as unknown as IExecutionStep[]
+
+const mockExecutionStepsCheckbox: IExecutionStep[] = [
+  mockTriggerExecutionStep,
+  mockForEachCheckboxExecutionStep,
+  ...mockExecutionStepsAfterForEach,
+]
+
+const mockExecutionStepsTable: IExecutionStep[] = [
+  mockTriggerExecutionStep,
+  mockForEachTableExecutionStep,
+  ...mockExecutionStepsAfterForEach,
+]
+
+const mockFlow = {
+  steps: [
+    {
+      id: triggerId,
+      position: 1,
+      appKey: 'test-app',
+      key: 'test-action',
+    },
+    {
+      id: randomForEachStepId,
+      position: 2,
+      appKey: TOOLBOX_APP_KEY,
+      key: TOOLBOX_ACTIONS.FOR_EACH,
+    },
+    {
+      id: randomAction1StepId,
+      position: 3,
+      appKey: 'test-app',
+      key: 'test-action-after-foreach',
+    },
+    {
+      id: randomAction2StepId,
+      position: 4,
+      appKey: 'test-app',
+      key: 'test-action-after-foreach',
+    },
+  ],
+} as unknown as Flow
+
+describe('getForEachContext', () => {
+  it('should return correct context when no for-each step exists', () => {
+    const flowWithoutForEach = {
+      steps: [
+        {
+          id: triggerId,
+          position: 1,
+          appKey: 'test-app',
+          key: 'test-action',
+        },
+      ],
+    } as unknown as Flow
+
+    const context = getForEachContext(flowWithoutForEach, 1)
+
+    expect(context).toEqual({
+      forEachStepIndex: -1,
+      stepIsInForEach: false,
+      stepPositions: {},
+    })
+  })
+
+  it('should return correct context when step is in for-each', () => {
+    const flowWithMultipleForEach = {
+      steps: [
+        {
+          id: randomUUID(),
+          position: 1,
+          appKey: 'formsg',
+          key: 'newSubmission',
+        },
+        {
+          id: randomUUID(),
+          position: 2,
+          appKey: TOOLBOX_APP_KEY,
+          key: TOOLBOX_ACTIONS.FOR_EACH,
+        },
+        {
+          id: randomUUID(),
+          position: 3,
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+        },
+      ],
+    } as unknown as Flow
+
+    const context = getForEachContext(flowWithMultipleForEach, 3)
+
+    expect(context.forEachStepIndex).toBe(2)
+    expect(context.stepIsInForEach).toBe(true)
+  })
+
+  it('should return correct context when step is before for-each', () => {
+    const context = getForEachContext(mockFlow, 1)
+
+    expect(context.forEachStepIndex).toBe(2)
+    expect(context.stepIsInForEach).toBe(false)
+  })
+
+  it('should return correct context when step is after for-each', () => {
+    const context = getForEachContext(mockFlow, 3)
+
+    expect(context.forEachStepIndex).toBe(2)
+    expect(context.stepIsInForEach).toBe(true)
+  })
+
+  it('should return correct step positions', () => {
+    const context = getForEachContext(mockFlow, 1)
+
+    expect(context.stepPositions).toEqual({
+      [mockFlow.steps[0].id]: 1,
+      [mockFlow.steps[1].id]: 2,
+      [mockFlow.steps[2].id]: 3,
+      [mockFlow.steps[3].id]: 4,
+    })
+  })
+})
+
+describe('computeForEachParameters', () => {
+  const baseIteration = 2
+  const baseForEachContext: ForEachContext = {
+    testRun: false,
+    executionStepMetadata: { iteration: baseIteration },
+    forEachStepIndex: 2,
+    stepIsInForEach: true,
+    stepPositions: {
+      [mockFlow.steps[0].id]: 1,
+      [mockFlow.steps[1].id]: 2,
+      [mockFlow.steps[2].id]: 3,
+      [mockFlow.steps[3].id]: 4,
+    },
+  }
+
+  it.each([
+    { iteration: 1, expected: 'Option 4' },
+    { iteration: 2, expected: 'Option 3' },
+    { iteration: 3, expected: 'Option 2' },
+    { iteration: 4, expected: 'Option 1' },
+    { iteration: 5, expected: '' },
+  ])(
+    'should handle checkbox data retrieval from for-each step %s',
+    ({ iteration, expected }) => {
+      const keyPath = `item`
+
+      const executionStep = mockExecutionStepsCheckbox[1] // for-each step
+
+      const result = computeForEachParameters({
+        data: executionStep.dataOut,
+        keyPath,
+        executionSteps: mockExecutionStepsCheckbox,
+        executionStep,
+        stepId: randomForEachStepId,
+        forEachContext: {
+          ...baseForEachContext,
+          executionStepMetadata: { iteration },
+        },
+      })
+      expect(result).toEqual(expected)
+    },
+  )
+
+  it.each([
+    { keyPath: `items.columns.0.value`, iteration: 1, expected: 'Li Hua' },
+    { keyPath: `items.columns.0.value`, iteration: 2, expected: 'Isaac' },
+    { keyPath: `items.columns.0.value`, iteration: 3, expected: 'Wei Ming' },
+    { keyPath: `items.columns.0.value`, iteration: 4, expected: 'Kumar' },
+    { keyPath: `items.columns.1.value`, iteration: 1, expected: 'Lim' },
+    { keyPath: `items.columns.1.value`, iteration: 2, expected: 'Goh' },
+    { keyPath: `items.columns.1.value`, iteration: 3, expected: 'Singh' },
+    { keyPath: `items.columns.1.value`, iteration: 4, expected: 'Chen' },
+    { keyPath: `items.columns.4.value`, iteration: 1, expected: 109480 },
+    { keyPath: `items.columns.4.value`, iteration: 2, expected: 278127 },
+    { keyPath: `items.columns.4.value`, iteration: 3, expected: 805877 },
+    { keyPath: `items.columns.4.value`, iteration: 4, expected: 813351 },
+    { keyPath: `items.columns.7.value`, iteration: 1, expected: 'hello' },
+    { keyPath: `items.columns.7.value`, iteration: 2, expected: '' },
+    { keyPath: `items.columns.7.value`, iteration: 3, expected: '' },
+    { keyPath: `items.columns.7.value`, iteration: 4, expected: 'bye' },
+  ])(
+    'should handle table data retrieval from for-each step',
+    ({ keyPath, iteration, expected }) => {
+      const executionStep = mockExecutionStepsTable[1] // for-each step
+      const result = computeForEachParameters({
+        data: executionStep.dataOut,
+        keyPath,
+        executionSteps: mockExecutionStepsTable,
+        executionStep,
+        stepId: randomForEachStepId,
+        forEachContext: {
+          ...baseForEachContext,
+          executionStepMetadata: { iteration },
+        },
+      })
+      // console.log('result', result)
+      expect(result).toEqual(expected)
+    },
+  )
+
+  it.each([
+    { keyPath: 'stringProp', expected: 'iteration 2 step 3 string' },
+    { keyPath: 'numberProp', expected: 84 },
+    {
+      keyPath: 'objectProp.stringProp',
+      expected: 'iteration 2 step 3 string in object',
+    },
+    { keyPath: 'objectProp.numberProp', expected: 840 },
+  ])(
+    'should handle data retrieval from the correct iteration for an action step inside the for-each step',
+    ({ keyPath, expected }) => {
+      const executionStep = mockExecutionStepsAfterForEach[0]
+      const result = computeForEachParameters({
+        data: executionStep.dataOut,
+        keyPath,
+        executionSteps: mockExecutionStepsTable,
+        executionStep,
+        stepId: randomAction1StepId,
+        forEachContext: baseForEachContext,
+      })
+      expect(result).toEqual(expected)
+    },
+  )
+
+  it('should handle non-existent step id', () => {
+    const executionStep = mockExecutionStepsAfterForEach[0]
+    const result = computeForEachParameters({
+      data: executionStep.dataOut,
+      keyPath: 'stringProp',
+      executionSteps: mockExecutionStepsAfterForEach,
+      executionStep: mockExecutionStepsAfterForEach[0],
+      stepId: 'non-existent-step-id',
+      forEachContext: baseForEachContext,
+    })
+    expect(result).toEqual('')
+  })
+
+  it('should handle missing forEachContext gracefully', () => {
+    const data: IJSONObject = {
+      stringProp: 'test string',
+    }
+    const keyPath = 'stringProp'
+    const executionStep = mockExecutionStepsCheckbox[2]
+    const result = computeForEachParameters({
+      data,
+      keyPath,
+      executionSteps: mockExecutionStepsCheckbox,
+      executionStep,
+      stepId: randomAction1StepId,
+      forEachContext: undefined as any,
+    })
+
+    expect(result).toBe(keyPath) // returns keyPath when context is missing
+  })
+})

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -1,9 +1,10 @@
-import { IExecutionStep, IJSONObject } from '@plumber/types'
+import { IExecutionStep } from '@plumber/types'
 
 import { randomUUID } from 'crypto'
 import { describe, expect, it } from 'vitest'
 
 import {
+  FOR_EACH_ITERATION_KEY,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
@@ -480,13 +481,10 @@ describe('computeForEachParameters', () => {
   })
 
   it('should handle missing forEachContext gracefully', () => {
-    const data: IJSONObject = {
-      stringProp: 'test string',
-    }
-    const keyPath = 'stringProp'
+    const keyPath = `items.columns.${FOR_EACH_ITERATION_KEY}.value`
     const executionStep = mockExecutionStepsCheckbox[2]
     const result = computeForEachParameters({
-      data,
+      data: executionStep.dataOut,
       keyPath,
       executionSteps: mockExecutionStepsCheckbox,
       executionStep,
@@ -495,5 +493,24 @@ describe('computeForEachParameters', () => {
     })
 
     expect(result).toBe(keyPath) // returns keyPath when context is missing
+  })
+
+  it('should handle undefined metadata.iteration gracefully', () => {
+    const keyPath = `items.columns.${FOR_EACH_ITERATION_KEY}.value`
+    const executionStep = mockExecutionStepsTable[1] // for-each step
+
+    const result = computeForEachParameters({
+      data: executionStep.dataOut,
+      keyPath,
+      executionSteps: mockExecutionStepsTable,
+      executionStep,
+      stepId: randomForEachStepId,
+      forEachContext: {
+        ...baseForEachContext,
+        executionStepMetadata: {},
+      },
+    })
+
+    expect(result).toBe('')
   })
 })

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -11,7 +11,7 @@ import {
 import {
   computeForEachParameters,
   ForEachContext,
-  getForEachContext,
+  getStepContext,
 } from '@/helpers/compute-for-each-parameters'
 import Flow from '@/models/flow'
 
@@ -284,7 +284,7 @@ const mockFlow = {
   ],
 } as unknown as Flow
 
-describe('getForEachContext', () => {
+describe('getStepContext', () => {
   it('should return correct context when no for-each step exists', () => {
     const flowWithoutForEach = {
       steps: [
@@ -297,7 +297,7 @@ describe('getForEachContext', () => {
       ],
     } as unknown as Flow
 
-    const context = getForEachContext(
+    const context = getStepContext(
       flowWithoutForEach,
       flowWithoutForEach.steps[0],
     )
@@ -311,7 +311,7 @@ describe('getForEachContext', () => {
   })
 
   it('should return correct context when step is in for-each', () => {
-    const context = getForEachContext(mockFlow, mockFlow.steps[1])
+    const context = getStepContext(mockFlow, mockFlow.steps[1])
 
     expect(context.forEachStepPosition).toBe(2)
     expect(context.stepPositions).toEqual({
@@ -325,7 +325,7 @@ describe('getForEachContext', () => {
   })
 
   it('should return correct context when step is the last step in for-each', () => {
-    const context = getForEachContext(mockFlow, mockFlow.steps[3])
+    const context = getStepContext(mockFlow, mockFlow.steps[3])
 
     expect(context.forEachStepPosition).toBe(2)
     expect(context.stepPositions).toEqual({
@@ -339,20 +339,20 @@ describe('getForEachContext', () => {
   })
 
   it('should return correct context when step is before for-each', () => {
-    const context = getForEachContext(mockFlow, mockFlow.steps[0])
+    const context = getStepContext(mockFlow, mockFlow.steps[0])
 
     expect(context.forEachStepPosition).toBe(2)
   })
 
-  it('should return correct context when step is after for-each', () => {
-    const context = getForEachContext(mockFlow, mockFlow.steps[2])
+  it('should return correct context when step is af qqqqer for-each', () => {
+    const context = getStepContext(mockFlow, mockFlow.steps[2])
 
     expect(context.forEachStepPosition).toBe(2)
     expect(context.isForEachStep).toBe(false)
   })
 
   it('should return correct step positions', () => {
-    const context = getForEachContext(mockFlow, mockFlow.steps[1])
+    const context = getStepContext(mockFlow, mockFlow.steps[1])
 
     expect(context.stepPositions).toEqual({
       [mockFlow.steps[0].id]: 1,
@@ -370,7 +370,7 @@ describe('getForEachContext', () => {
   ])(
     'should return correct isForEachStep for step %s',
     ({ step, expected }) => {
-      const context = getForEachContext(mockFlow, step)
+      const context = getStepContext(mockFlow, step)
       expect(context.isForEachStep).toBe(expected)
     },
   )
@@ -379,7 +379,6 @@ describe('getForEachContext', () => {
 describe('computeForEachParameters', () => {
   const baseIteration = 2
   const baseForEachContext: ForEachContext = {
-    testRun: false,
     executionStepMetadata: { iteration: baseIteration },
     forEachStepPosition: 2,
     stepPositions: {

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -298,11 +298,10 @@ describe('getForEachContext', () => {
       ],
     } as unknown as Flow
 
-    const context = getForEachContext(flowWithoutForEach, 1)
+    const context = getForEachContext(flowWithoutForEach)
 
     expect(context).toEqual({
       forEachStepIndex: -1,
-      stepIsInForEach: false,
       stepPositions: {},
     })
   })
@@ -331,28 +330,26 @@ describe('getForEachContext', () => {
       ],
     } as unknown as Flow
 
-    const context = getForEachContext(flowWithMultipleForEach, 3)
+    const context = getForEachContext(flowWithMultipleForEach)
 
     expect(context.forEachStepIndex).toBe(2)
-    expect(context.stepIsInForEach).toBe(true)
+    // expect(context.stepIsInForEach).toBe(true)
   })
 
   it('should return correct context when step is before for-each', () => {
-    const context = getForEachContext(mockFlow, 1)
+    const context = getForEachContext(mockFlow)
 
     expect(context.forEachStepIndex).toBe(2)
-    expect(context.stepIsInForEach).toBe(false)
   })
 
   it('should return correct context when step is after for-each', () => {
-    const context = getForEachContext(mockFlow, 3)
+    const context = getForEachContext(mockFlow)
 
     expect(context.forEachStepIndex).toBe(2)
-    expect(context.stepIsInForEach).toBe(true)
   })
 
   it('should return correct step positions', () => {
-    const context = getForEachContext(mockFlow, 1)
+    const context = getForEachContext(mockFlow)
 
     expect(context.stepPositions).toEqual({
       [mockFlow.steps[0].id]: 1,
@@ -369,7 +366,6 @@ describe('computeForEachParameters', () => {
     testRun: false,
     executionStepMetadata: { iteration: baseIteration },
     forEachStepIndex: 2,
-    stepIsInForEach: true,
     stepPositions: {
       [mockFlow.steps[0].id]: 1,
       [mockFlow.steps[1].id]: 2,

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -303,6 +303,7 @@ describe('getForEachContext', () => {
     expect(context).toEqual({
       forEachStepIndex: -1,
       stepPositions: {},
+      lastStepId: '',
     })
   })
 
@@ -333,7 +334,12 @@ describe('getForEachContext', () => {
     const context = getForEachContext(flowWithMultipleForEach)
 
     expect(context.forEachStepIndex).toBe(2)
-    // expect(context.stepIsInForEach).toBe(true)
+    expect(context.stepPositions).toEqual({
+      [flowWithMultipleForEach.steps[0].id]: 1,
+      [flowWithMultipleForEach.steps[1].id]: 2,
+      [flowWithMultipleForEach.steps[2].id]: 3,
+    })
+    expect(context.lastStepId).toBe(flowWithMultipleForEach.steps[2].id)
   })
 
   it('should return correct context when step is before for-each', () => {

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -303,62 +303,51 @@ describe('getForEachContext', () => {
     )
 
     expect(context).toEqual({
-      forEachStepIndex: -1,
+      forEachStepPosition: -1,
       stepPositions: {},
-      lastStepId: '',
       isForEachStep: false,
+      isLastStep: false,
     })
   })
 
   it('should return correct context when step is in for-each', () => {
-    const flowWithMultipleForEach = {
-      steps: [
-        {
-          id: randomUUID(),
-          position: 1,
-          appKey: 'formsg',
-          key: 'newSubmission',
-        },
-        {
-          id: randomUUID(),
-          position: 2,
-          appKey: TOOLBOX_APP_KEY,
-          key: TOOLBOX_ACTIONS.FOR_EACH,
-        },
-        {
-          id: randomUUID(),
-          position: 3,
-          appKey: 'postman',
-          key: 'sendTransactionalEmail',
-        },
-      ],
-    } as unknown as Flow
+    const context = getForEachContext(mockFlow, mockFlow.steps[1])
 
-    const context = getForEachContext(
-      flowWithMultipleForEach,
-      flowWithMultipleForEach.steps[1],
-    )
-
-    expect(context.forEachStepIndex).toBe(2)
+    expect(context.forEachStepPosition).toBe(2)
     expect(context.stepPositions).toEqual({
-      [flowWithMultipleForEach.steps[0].id]: 1,
-      [flowWithMultipleForEach.steps[1].id]: 2,
-      [flowWithMultipleForEach.steps[2].id]: 3,
+      [mockFlow.steps[0].id]: 1,
+      [mockFlow.steps[1].id]: 2,
+      [mockFlow.steps[2].id]: 3,
+      [mockFlow.steps[3].id]: 4,
     })
-    expect(context.lastStepId).toBe(flowWithMultipleForEach.steps[2].id)
     expect(context.isForEachStep).toBe(true)
+    expect(context.isLastStep).toBe(false)
+  })
+
+  it('should return correct context when step is the last step in for-each', () => {
+    const context = getForEachContext(mockFlow, mockFlow.steps[3])
+
+    expect(context.forEachStepPosition).toBe(2)
+    expect(context.stepPositions).toEqual({
+      [mockFlow.steps[0].id]: 1,
+      [mockFlow.steps[1].id]: 2,
+      [mockFlow.steps[2].id]: 3,
+      [mockFlow.steps[3].id]: 4,
+    })
+    expect(context.isForEachStep).toBe(false)
+    expect(context.isLastStep).toBe(true)
   })
 
   it('should return correct context when step is before for-each', () => {
     const context = getForEachContext(mockFlow, mockFlow.steps[0])
 
-    expect(context.forEachStepIndex).toBe(2)
+    expect(context.forEachStepPosition).toBe(2)
   })
 
   it('should return correct context when step is after for-each', () => {
     const context = getForEachContext(mockFlow, mockFlow.steps[2])
 
-    expect(context.forEachStepIndex).toBe(2)
+    expect(context.forEachStepPosition).toBe(2)
     expect(context.isForEachStep).toBe(false)
   })
 
@@ -392,7 +381,7 @@ describe('computeForEachParameters', () => {
   const baseForEachContext: ForEachContext = {
     testRun: false,
     executionStepMetadata: { iteration: baseIteration },
-    forEachStepIndex: 2,
+    forEachStepPosition: 2,
     stepPositions: {
       [mockFlow.steps[0].id]: 1,
       [mockFlow.steps[1].id]: 2,

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -344,7 +344,7 @@ describe('getStepContext', () => {
     expect(context.forEachStepPosition).toBe(2)
   })
 
-  it('should return correct context when step is af qqqqer for-each', () => {
+  it('should return correct context when step is after for-each', () => {
     const context = getStepContext(mockFlow, mockFlow.steps[2])
 
     expect(context.forEachStepPosition).toBe(2)

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -207,7 +207,7 @@ describe('compute parameters', () => {
       const result = computeParameters(params, executionSteps, undefined, {
         testRun: false,
         executionStepMetadata: { iteration: 1 },
-        forEachStepIndex: 0,
+        forEachStepPosition: 0,
         stepPositions: {},
         isForEachStep: true,
       })

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -205,7 +205,6 @@ describe('compute parameters', () => {
       expected: Record<string, any>
     }) => {
       const result = computeParameters(params, executionSteps, undefined, {
-        testRun: false,
         executionStepMetadata: { iteration: 1 },
         forEachStepPosition: 0,
         stepPositions: {},

--- a/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-parameters.test.ts
@@ -204,7 +204,13 @@ describe('compute parameters', () => {
       params: Record<string, any>
       expected: Record<string, any>
     }) => {
-      const result = computeParameters(params, executionSteps, undefined, true)
+      const result = computeParameters(params, executionSteps, undefined, {
+        testRun: false,
+        executionStepMetadata: { iteration: 1 },
+        forEachStepIndex: 0,
+        stepPositions: {},
+        isForEachStep: true,
+      })
       expect(result).toEqual(expected)
     },
   )

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -101,11 +101,21 @@ export function computeForEachParameters({
   let forEachKeyPath = get(data, keyPath)
   const currentStepIndex = stepPositions?.[executionStep?.stepId] || -1
 
-  // handling of checkboxes which is just a flat array
-  forEachKeyPath = String(forEachKeyPath).replace(
-    FOR_EACH_ITERATION_KEY,
-    `${testRun ? 0 : metadata?.iteration - 1}`,
-  )
+  if (testRun) {
+    forEachKeyPath = String(forEachKeyPath).replace(FOR_EACH_ITERATION_KEY, '0')
+  } else if (metadata?.iteration) {
+    forEachKeyPath = String(forEachKeyPath).replace(
+      FOR_EACH_ITERATION_KEY,
+      `${metadata.iteration - 1}`,
+    )
+  }
+
+  if (testRun || metadata?.iteration) {
+    forEachKeyPath = String(forEachKeyPath).replace(
+      FOR_EACH_ITERATION_KEY,
+      `${testRun ? 0 : metadata.iteration - 1}`,
+    )
+  }
 
   if (
     executionStep.appKey === TOOLBOX_APP_KEY &&

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -20,7 +20,7 @@ export type ForEachContext = {
   executionStepMetadata: NextStepMetadata
   forEachStepIndex: number
   isForEachStep: boolean
-  stepIsInForEach: boolean
+
   stepPositions: Record<string, number>
 }
 
@@ -29,12 +29,9 @@ export function getForEachContext(
   step: IStep,
 ): {
   forEachStepIndex: number
-  stepIsInForEach: boolean
   stepPositions: Record<string, number>
   isForEachStep: boolean
 } {
-  let stepIsInForEach = false
-  const stepPosition = step.position
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
   const forEachSteps = flow.steps.filter(
@@ -45,14 +42,9 @@ export function getForEachContext(
   if (forEachSteps.length === 0 || forEachSteps.length > 1) {
     return {
       forEachStepIndex: -1,
-      stepIsInForEach,
       stepPositions: {},
       isForEachStep,
     }
-  }
-
-  if (stepPosition > forEachSteps[0].position) {
-    stepIsInForEach = true
   }
 
   const stepPositions = flow.steps.reduce((acc, step) => {
@@ -62,7 +54,6 @@ export function getForEachContext(
 
   return {
     forEachStepIndex: forEachSteps[0].position,
-    stepIsInForEach,
     stepPositions,
     isForEachStep,
   }
@@ -121,5 +112,6 @@ export function computeForEachParameters({
     )
     dataValue = get(iterationExecutionStep?.dataOut, keyPath) || ''
   }
+
   return dataValue
 }

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -101,15 +101,6 @@ export function computeForEachParameters({
   let forEachKeyPath = get(data, keyPath)
   const currentStepIndex = stepPositions?.[executionStep?.stepId] || -1
 
-  if (testRun) {
-    forEachKeyPath = String(forEachKeyPath).replace(FOR_EACH_ITERATION_KEY, '0')
-  } else if (metadata?.iteration) {
-    forEachKeyPath = String(forEachKeyPath).replace(
-      FOR_EACH_ITERATION_KEY,
-      `${metadata.iteration - 1}`,
-    )
-  }
-
   if (testRun || metadata?.iteration) {
     forEachKeyPath = String(forEachKeyPath).replace(
       FOR_EACH_ITERATION_KEY,

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -18,7 +18,7 @@ import Flow from '@/models/flow'
 export type ForEachContext = {
   testRun: boolean
   executionStepMetadata: NextStepMetadata
-  forEachStepIndex: number
+  forEachStepPosition: number
   isForEachStep: boolean
 
   stepPositions: Record<string, number>
@@ -28,10 +28,10 @@ export function getForEachContext(
   flow: Flow,
   step: IStep,
 ): {
-  forEachStepIndex: number
+  forEachStepPosition: number
   stepPositions: Record<string, number>
   isForEachStep: boolean
-  lastStepId: string
+  isLastStep: boolean
 } {
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
@@ -42,10 +42,10 @@ export function getForEachContext(
   // NOTE: do not allow multiple for-each steps in a flow
   if (forEachSteps.length === 0 || forEachSteps.length > 1) {
     return {
-      forEachStepIndex: -1,
+      forEachStepPosition: -1,
       stepPositions: {},
       isForEachStep,
-      lastStepId: '',
+      isLastStep: false,
     }
   }
 
@@ -66,10 +66,10 @@ export function getForEachContext(
   )
 
   return {
-    forEachStepIndex: forEachSteps[0].position,
+    forEachStepPosition: forEachSteps[0].position,
     stepPositions,
     isForEachStep,
-    lastStepId,
+    isLastStep: lastStepId === step.id,
   }
 }
 
@@ -98,13 +98,13 @@ export function computeForEachParameters({
   const {
     testRun,
     executionStepMetadata: metadata,
-    forEachStepIndex,
+    forEachStepPosition,
     stepPositions,
   } = forEachContext || {}
 
   let dataValue: IJSONValue = keyPath
   let forEachKeyPath = get(data, keyPath)
-  const currentStepIndex = stepPositions?.[executionStep?.stepId] || -1
+  const currentStepPosition = stepPositions?.[executionStep?.stepId] || -1
 
   if (testRun || metadata?.iteration) {
     forEachKeyPath = String(forEachKeyPath).replace(
@@ -118,7 +118,7 @@ export function computeForEachParameters({
     executionStep?.key === TOOLBOX_ACTIONS.FOR_EACH
   ) {
     dataValue = get(data, forEachKeyPath as string) || ''
-  } else if (currentStepIndex > forEachStepIndex) {
+  } else if (currentStepPosition > forEachStepPosition) {
     // find the specific execution step for the same iteration
     const iterationExecutionStep = executionSteps.find(
       (es) =>

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -114,8 +114,8 @@ export function computeForEachParameters({
   }
 
   if (
-    executionStep.appKey === TOOLBOX_APP_KEY &&
-    executionStep.key === TOOLBOX_ACTIONS.FOR_EACH
+    executionStep?.appKey === TOOLBOX_APP_KEY &&
+    executionStep?.key === TOOLBOX_ACTIONS.FOR_EACH
   ) {
     dataValue = get(data, forEachKeyPath as string) || ''
   } else if (currentStepIndex > forEachStepIndex) {

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -16,15 +16,21 @@ import {
 import Flow from '@/models/flow'
 
 export type ForEachContext = {
-  testRun: boolean
   executionStepMetadata: NextStepMetadata
   forEachStepPosition: number
   isForEachStep: boolean
-
   stepPositions: Record<string, number>
 }
 
-export function getForEachContext(
+/**
+ * gets the context for the step within the pipe
+ * returns:
+ * - forEachStepPosition: position of the for-each step in the pipe
+ * - stepPositions: map of step ids and their corresponding positions
+ * - isForEachStep: whether the step is a for-each step
+ * - isLastStep: whether the step is the last step in the pipe
+ */
+export function getStepContext(
   flow: Flow,
   step: IStep,
 ): {
@@ -40,7 +46,7 @@ export function getForEachContext(
       step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH,
   )
   // NOTE: do not allow multiple for-each steps in a flow
-  if (forEachSteps.length === 0 || forEachSteps.length > 1) {
+  if (forEachSteps.length !== 1) {
     return {
       forEachStepPosition: -1,
       stepPositions: {},
@@ -49,6 +55,15 @@ export function getForEachContext(
     }
   }
 
+  /**
+   * stepPositions: map of step ids and their corresponding positions
+   *   used in for-each to determine whether the variable is from an action before the for-each step
+   *   or within the for-each loop.
+   *   if variables are from steps within the loop, it will be used to find the specific execution step for the same iteration
+   *
+   * lastStepId: id of the last step in the pipe
+   *   used in for each to terminate an iteration within the loop
+   */
   const { stepPositions, lastStepId } = flow.steps.reduce(
     (acc, step) => {
       acc.stepPositions[step.id] = step.position
@@ -96,7 +111,6 @@ export function computeForEachParameters({
   forEachContext: ForEachContext
 }): IJSONValue {
   const {
-    testRun,
     executionStepMetadata: metadata,
     forEachStepPosition,
     stepPositions,
@@ -106,12 +120,11 @@ export function computeForEachParameters({
   let forEachKeyPath = get(data, keyPath)
   const currentStepPosition = stepPositions?.[executionStep?.stepId] || -1
 
-  if (testRun || metadata?.iteration) {
-    forEachKeyPath = String(forEachKeyPath).replace(
-      FOR_EACH_ITERATION_KEY,
-      `${testRun ? 0 : metadata.iteration - 1}`,
-    )
-  }
+  forEachKeyPath = String(forEachKeyPath).replace(
+    FOR_EACH_ITERATION_KEY,
+    // test runs will not have metadata.iteration, and defaults to the first iteration
+    String(metadata?.iteration ? metadata.iteration - 1 : 0),
+  )
 
   if (
     executionStep?.appKey === TOOLBOX_APP_KEY &&

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -1,0 +1,124 @@
+import {
+  IExecutionStep,
+  IJSONObject,
+  IJSONValue,
+  IStep,
+  NextStepMetadata,
+} from '@plumber/types'
+
+import get from 'lodash.get'
+
+import {
+  FOR_EACH_ITERATION_KEY,
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import Flow from '@/models/flow'
+
+export type ForEachContext = {
+  testRun: boolean
+  executionStepMetadata: NextStepMetadata
+  forEachStepIndex: number
+  isForEachStep: boolean
+  stepIsInForEach: boolean
+  stepPositions: Record<string, number>
+}
+
+export function getForEachContext(
+  flow: Flow,
+  step: IStep,
+): {
+  forEachStepIndex: number
+  stepIsInForEach: boolean
+  stepPositions: Record<string, number>
+  isForEachStep: boolean
+} {
+  let stepIsInForEach = false
+  const stepPosition = step.position
+  const isForEachStep =
+    step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
+  const forEachSteps = flow.steps.filter(
+    (step) =>
+      step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH,
+  )
+  // NOTE: do not allow multiple for-each steps in a flow
+  if (forEachSteps.length === 0 || forEachSteps.length > 1) {
+    return {
+      forEachStepIndex: -1,
+      stepIsInForEach,
+      stepPositions: {},
+      isForEachStep,
+    }
+  }
+
+  if (stepPosition > forEachSteps[0].position) {
+    stepIsInForEach = true
+  }
+
+  const stepPositions = flow.steps.reduce((acc, step) => {
+    acc[step.id] = step.position
+    return acc
+  }, {} as Record<string, number>)
+
+  return {
+    forEachStepIndex: forEachSteps[0].position,
+    stepIsInForEach,
+    stepPositions,
+    isForEachStep,
+  }
+}
+
+/**
+ * NOTE: special handling for for-each
+ * data can come from multiple sources:
+ * 1. from steps before the for-each
+ * 2. from the for-each step itself (i.e., checkbox or table data)
+ * 3. from a step within for-each
+ */
+export function computeForEachParameters({
+  data,
+  keyPath,
+  executionSteps,
+  executionStep,
+  stepId,
+  forEachContext,
+}: {
+  data: IJSONObject
+  keyPath: string
+  executionSteps: IExecutionStep[]
+  executionStep: IExecutionStep
+  stepId: string
+  forEachContext: ForEachContext
+}): IJSONValue {
+  const {
+    testRun,
+    executionStepMetadata: metadata,
+    forEachStepIndex,
+    stepPositions,
+  } = forEachContext || {}
+
+  let dataValue: IJSONValue = keyPath
+  let forEachKeyPath = get(data, keyPath)
+  const currentStepIndex = stepPositions[executionStep?.stepId]
+
+  // handling of checkboxes which is just a flat array
+  forEachKeyPath = String(forEachKeyPath).replace(
+    FOR_EACH_ITERATION_KEY,
+    `${testRun ? 0 : metadata?.iteration - 1}`,
+  )
+
+  if (
+    executionStep.appKey === TOOLBOX_APP_KEY &&
+    executionStep.key === TOOLBOX_ACTIONS.FOR_EACH
+  ) {
+    dataValue = get(data, forEachKeyPath as string)
+  } else if (currentStepIndex > forEachStepIndex) {
+    // find the specific execution step for the same iteration
+    const iterationExecutionStep = executionSteps.find(
+      (es) =>
+        es.stepId === stepId && es.metadata.iteration === metadata?.iteration,
+    )
+    dataValue = get(iterationExecutionStep?.dataOut, keyPath)
+  }
+  return dataValue
+}

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -31,6 +31,7 @@ export function getForEachContext(
   forEachStepIndex: number
   stepPositions: Record<string, number>
   isForEachStep: boolean
+  lastStepId: string
 } {
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
@@ -44,18 +45,31 @@ export function getForEachContext(
       forEachStepIndex: -1,
       stepPositions: {},
       isForEachStep,
+      lastStepId: '',
     }
   }
 
-  const stepPositions = flow.steps.reduce((acc, step) => {
-    acc[step.id] = step.position
-    return acc
-  }, {} as Record<string, number>)
+  const { stepPositions, lastStepId } = flow.steps.reduce(
+    (acc, step) => {
+      acc.stepPositions[step.id] = step.position
+      if (step.position > acc.maxPosition) {
+        acc.maxPosition = step.position
+        acc.lastStepId = step.id
+      }
+      return acc
+    },
+    {
+      stepPositions: {} as Record<string, number>,
+      maxPosition: -1,
+      lastStepId: '',
+    },
+  )
 
   return {
     forEachStepIndex: forEachSteps[0].position,
     stepPositions,
     isForEachStep,
+    lastStepId,
   }
 }
 

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -99,7 +99,7 @@ export function computeForEachParameters({
 
   let dataValue: IJSONValue = keyPath
   let forEachKeyPath = get(data, keyPath)
-  const currentStepIndex = stepPositions[executionStep?.stepId]
+  const currentStepIndex = stepPositions?.[executionStep?.stepId] || -1
 
   // handling of checkboxes which is just a flat array
   forEachKeyPath = String(forEachKeyPath).replace(
@@ -111,14 +111,14 @@ export function computeForEachParameters({
     executionStep.appKey === TOOLBOX_APP_KEY &&
     executionStep.key === TOOLBOX_ACTIONS.FOR_EACH
   ) {
-    dataValue = get(data, forEachKeyPath as string)
+    dataValue = get(data, forEachKeyPath as string) || ''
   } else if (currentStepIndex > forEachStepIndex) {
     // find the specific execution step for the same iteration
     const iterationExecutionStep = executionSteps.find(
       (es) =>
         es.stepId === stepId && es.metadata.iteration === metadata?.iteration,
     )
-    dataValue = get(iterationExecutionStep?.dataOut, keyPath)
+    dataValue = get(iterationExecutionStep?.dataOut, keyPath) || ''
   }
   return dataValue
 }

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -2,16 +2,16 @@ import type { IAction } from '@plumber/types'
 
 import get from 'lodash.get'
 
+import {
+  computeForEachParameters,
+  ForEachContext,
+} from '@/helpers/compute-for-each-parameters'
 import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
 const variableRegExp =
   /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
-import {
-  computeForEachParameters,
-  ForEachContext,
-} from './compute-for-each-parameters'
 
 function findAndSubstituteVariables(
   // i.e. the `key` corresponding to this variable's form field in defineAction

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -8,6 +8,10 @@ import Step from '../models/step'
 
 const variableRegExp =
   /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
+import {
+  computeForEachParameters,
+  ForEachContext,
+} from './compute-for-each-parameters'
 
 function findAndSubstituteVariables(
   // i.e. the `key` corresponding to this variable's form field in defineAction
@@ -16,7 +20,7 @@ function findAndSubstituteVariables(
   rawValue: unknown,
   executionSteps: ExecutionStep[],
   preprocessVariable?: IAction['preprocessVariable'],
-  isForEachStep?: boolean,
+  forEachContext?: ForEachContext,
 ): unknown {
   if (Array.isArray(rawValue)) {
     return rawValue.map((element) =>
@@ -25,7 +29,7 @@ function findAndSubstituteVariables(
         element,
         executionSteps,
         preprocessVariable,
-        isForEachStep,
+        forEachContext,
       ),
     )
   }
@@ -40,7 +44,7 @@ function findAndSubstituteVariables(
           v,
           executionSteps,
           preprocessVariable,
-          isForEachStep,
+          forEachContext,
         ),
       }),
       {},
@@ -52,6 +56,7 @@ function findAndSubstituteVariables(
   }
 
   const parts = rawValue.split(variableRegExp)
+  const { isForEachStep, stepIsInForEach } = forEachContext || {}
 
   const substitutedParts = parts.map((part: string) => {
     const isVariable = part.match(variableRegExp)
@@ -64,7 +69,17 @@ function findAndSubstituteVariables(
       const data = executionStep?.dataOut
 
       const keyPath = keyPaths.join('.') // for lodash get to work
-      const dataValue = get(data, keyPath)
+      let dataValue = get(data, keyPath)
+      if (stepIsInForEach) {
+        dataValue = computeForEachParameters({
+          data,
+          keyPath,
+          executionSteps,
+          executionStep,
+          stepId,
+          forEachContext,
+        })
+      }
 
       // NOTE: dataValue could be an array if it is not processed on variables.ts
       // which is the case for formSG checkbox only, this is to deal with forEach next time
@@ -108,13 +123,13 @@ export default function computeParameters(
   parameters: Step['parameters'],
   executionSteps: ExecutionStep[],
   preprocessVariable?: IAction['preprocessVariable'],
-  isForEachStep?: boolean,
+  forEachContext?: ForEachContext,
 ): Step['parameters'] {
   return findAndSubstituteVariables(
     '', // Dummy initial value; will never be used.
     parameters,
     executionSteps,
     preprocessVariable,
-    isForEachStep,
+    forEachContext,
   ) as Step['parameters']
 }

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -56,7 +56,8 @@ function findAndSubstituteVariables(
   }
 
   const parts = rawValue.split(variableRegExp)
-  const { isForEachStep, stepIsInForEach } = forEachContext || {}
+  const { forEachStepIndex, stepPositions, isForEachStep } =
+    forEachContext || {}
 
   const substitutedParts = parts.map((part: string) => {
     const isVariable = part.match(variableRegExp)
@@ -67,6 +68,8 @@ function findAndSubstituteVariables(
         return executionStep.stepId === stepId
       })
       const data = executionStep?.dataOut
+      const stepIsInForEach =
+        forEachStepIndex > -1 && stepPositions?.[stepId] >= forEachStepIndex
 
       const keyPath = keyPaths.join('.') // for lodash get to work
       let dataValue = get(data, keyPath)

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -56,7 +56,7 @@ function findAndSubstituteVariables(
   }
 
   const parts = rawValue.split(variableRegExp)
-  const { forEachStepIndex, stepPositions, isForEachStep } =
+  const { forEachStepPosition, stepPositions, isForEachStep } =
     forEachContext || {}
 
   const substitutedParts = parts.map((part: string) => {
@@ -69,7 +69,8 @@ function findAndSubstituteVariables(
       })
       const data = executionStep?.dataOut
       const stepIsInForEach =
-        forEachStepIndex > -1 && stepPositions?.[stepId] >= forEachStepIndex
+        forEachStepPosition > -1 &&
+        stepPositions?.[stepId] >= forEachStepPosition
 
       const keyPath = keyPaths.join('.') // for lodash get to work
       let dataValue = get(data, keyPath)

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -85,38 +85,27 @@ class ExecutionStep extends Base {
   }
 
   static async getForEachExecutionSteps(executionId: string) {
+    // TESTING
     return ExecutionStep.query()
+      .select('execution_steps.*', 'latest_steps.min_created_at')
       .with('latest_steps', (builder) => {
-        /**
-         * NOTE: there is a known issue with knex where 'groupBy' are placed at the end of the 'unionAll' query.
-         * the workaround is to unionAll both queries with 'true' to wrap the subequery.
-         */
         builder
-          .unionAll((qb) => {
-            qb.select(
-              'step_id',
-              raw('max(created_at) as max_created_at'),
-              raw('min(created_at) as min_created_at'),
-            )
-              .from('execution_steps')
-              .groupBy('step_id')
-              .where('execution_id', '=', executionId)
-              .where(raw("metadata = '{}'::jsonb"))
-              .withSoftDeleted()
-          }, true)
-          .unionAll((qb) => {
-            qb.select(
-              'step_id',
-              raw('max(created_at) as max_created_at'),
-              raw('min(created_at) as min_created_at'),
-            )
-              .from('execution_steps')
-              .groupBy('step_id', raw("metadata->>'iteration'"))
-              .where('execution_id', '=', executionId)
-              .where(raw("metadata != '{}'::jsonb"))
-              .withSoftDeleted()
-          }, true)
-          .withSoftDeleted()
+          .select(
+            'step_id',
+            raw('MAX(created_at) as max_created_at'),
+            raw('MIN(created_at) as min_created_at'),
+          )
+          .from('execution_steps')
+          .where('execution_id', executionId)
+          .groupBy('step_id')
+          .groupBy(
+            raw(`
+              CASE
+                WHEN metadata = '{}'::jsonb THEN NULL
+                ELSE metadata ->> 'iteration'
+              END
+            `),
+          )
       })
       .join('latest_steps', (builder) => {
         builder
@@ -127,9 +116,53 @@ class ExecutionStep extends Base {
             'latest_steps.max_created_at',
           )
       })
-      .select('execution_steps.*', 'min_created_at')
-      .withSoftDeleted()
-      .orderBy('min_created_at', 'asc')
+      .where('execution_steps.execution_id', executionId)
+      .orderBy('latest_steps.min_created_at', 'asc')
+    // return ExecutionStep.query()
+    //   .with('latest_steps', (builder) => {
+    //     /**
+    //      * NOTE: there is a known issue with knex where 'groupBy' are placed at the end of the 'unionAll' query.
+    //      * the workaround is to unionAll both queries with 'true' to wrap the subequery.
+    //      */
+    //     builder
+    //       .unionAll((qb) => {
+    //         qb.select(
+    //           'step_id',
+    //           raw('max(created_at) as max_created_at'),
+    //           raw('min(created_at) as min_created_at'),
+    //         )
+    //           .from('execution_steps')
+    //           .groupBy('step_id')
+    //           .where('execution_id', '=', executionId)
+    //           .where(raw("metadata = '{}'::jsonb"))
+    //           .withSoftDeleted()
+    //       }, true)
+    //       .unionAll((qb) => {
+    //         qb.select(
+    //           'step_id',
+    //           raw('max(created_at) as max_created_at'),
+    //           raw('min(created_at) as min_created_at'),
+    //         )
+    //           .from('execution_steps')
+    //           .groupBy('step_id', raw("metadata->>'iteration'"))
+    //           .where('execution_id', '=', executionId)
+    //           .where(raw("metadata != '{}'::jsonb"))
+    //           .withSoftDeleted()
+    //       }, true)
+    //       .withSoftDeleted()
+    //   })
+    //   .join('latest_steps', (builder) => {
+    //     builder
+    //       .on('execution_steps.step_id', '=', 'latest_steps.step_id')
+    //       .andOn(
+    //         'execution_steps.created_at',
+    //         '=',
+    //         'latest_steps.max_created_at',
+    //       )
+    //   })
+    //   .select('execution_steps.*', 'min_created_at')
+    //   .withSoftDeleted()
+    //   .orderBy('min_created_at', 'asc')
   }
 
   static async getForEachExecutionState(executionId: string) {

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -1,5 +1,7 @@
 import { IExecutionStepMetadata, IJSONObject } from '@plumber/types'
 
+import { raw } from 'objection'
+
 import appConfig from '@/config/app'
 
 import Base from './base'
@@ -80,6 +82,68 @@ class ExecutionStep extends Base {
     }
 
     return `${appConfig.baseUrl}/apps/${this.appKey}/assets/favicon.svg`
+  }
+
+  static async getForEachExecutionSteps(executionId: string) {
+    return ExecutionStep.query()
+      .with('latest_steps', (builder) => {
+        /**
+         * NOTE: there is a known issue with knex where 'groupBy' are placed at the end of the 'unionAll' query.
+         * the workaround is to unionAll both queries with 'true' to wrap the subequery.
+         */
+        builder
+          .unionAll((qb) => {
+            qb.select(
+              'step_id',
+              raw('max(created_at) as max_created_at'),
+              raw('min(created_at) as min_created_at'),
+            )
+              .from('execution_steps')
+              .groupBy('step_id')
+              .where('execution_id', '=', executionId)
+              .where(raw("metadata = '{}'::jsonb"))
+              .withSoftDeleted()
+          }, true)
+          .unionAll((qb) => {
+            qb.select(
+              'step_id',
+              raw('max(created_at) as max_created_at'),
+              raw('min(created_at) as min_created_at'),
+            )
+              .from('execution_steps')
+              .groupBy('step_id', raw("metadata->>'iteration'"))
+              .where('execution_id', '=', executionId)
+              .where(raw("metadata != '{}'::jsonb"))
+              .withSoftDeleted()
+          }, true)
+          .withSoftDeleted()
+      })
+      .join('latest_steps', (builder) => {
+        builder
+          .on('execution_steps.step_id', '=', 'latest_steps.step_id')
+          .andOn(
+            'execution_steps.created_at',
+            '=',
+            'latest_steps.max_created_at',
+          )
+      })
+      .select('execution_steps.*', 'min_created_at')
+      .withSoftDeleted()
+      .orderBy('min_created_at', 'asc')
+  }
+
+  static async getForEachExecutionState(executionId: string) {
+    const executionSteps = await ExecutionStep.getForEachExecutionSteps(
+      executionId,
+    )
+    return {
+      hasLastIterationRun: executionSteps.some(
+        (step) => step.metadata?.isLastIteration && step.metadata?.isLastStep,
+      ),
+      areAllStepsSuccessful: executionSteps.every(
+        (step) => step.status === 'success',
+      ),
+    }
   }
 }
 

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -85,7 +85,6 @@ class ExecutionStep extends Base {
   }
 
   static async getForEachExecutionSteps(executionId: string) {
-    // TESTING
     return ExecutionStep.query()
       .select('execution_steps.*', 'latest_steps.min_created_at')
       .with('latest_steps', (builder) => {
@@ -118,51 +117,6 @@ class ExecutionStep extends Base {
       })
       .where('execution_steps.execution_id', executionId)
       .orderBy('latest_steps.min_created_at', 'asc')
-    // return ExecutionStep.query()
-    //   .with('latest_steps', (builder) => {
-    //     /**
-    //      * NOTE: there is a known issue with knex where 'groupBy' are placed at the end of the 'unionAll' query.
-    //      * the workaround is to unionAll both queries with 'true' to wrap the subequery.
-    //      */
-    //     builder
-    //       .unionAll((qb) => {
-    //         qb.select(
-    //           'step_id',
-    //           raw('max(created_at) as max_created_at'),
-    //           raw('min(created_at) as min_created_at'),
-    //         )
-    //           .from('execution_steps')
-    //           .groupBy('step_id')
-    //           .where('execution_id', '=', executionId)
-    //           .where(raw("metadata = '{}'::jsonb"))
-    //           .withSoftDeleted()
-    //       }, true)
-    //       .unionAll((qb) => {
-    //         qb.select(
-    //           'step_id',
-    //           raw('max(created_at) as max_created_at'),
-    //           raw('min(created_at) as min_created_at'),
-    //         )
-    //           .from('execution_steps')
-    //           .groupBy('step_id', raw("metadata->>'iteration'"))
-    //           .where('execution_id', '=', executionId)
-    //           .where(raw("metadata != '{}'::jsonb"))
-    //           .withSoftDeleted()
-    //       }, true)
-    //       .withSoftDeleted()
-    //   })
-    //   .join('latest_steps', (builder) => {
-    //     builder
-    //       .on('execution_steps.step_id', '=', 'latest_steps.step_id')
-    //       .andOn(
-    //         'execution_steps.created_at',
-    //         '=',
-    //         'latest_steps.max_created_at',
-    //       )
-    //   })
-    //   .select('execution_steps.*', 'min_created_at')
-    //   .withSoftDeleted()
-    //   .orderBy('min_created_at', 'asc')
   }
 
   static async getForEachExecutionState(executionId: string) {

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -38,10 +38,23 @@ class ExecutionStep extends Base {
       errorDetails: { type: ['object', 'null'] },
       appKey: { type: ['string', 'null'] },
       jobId: { type: ['string', 'null'] },
+      key: { type: ['string', 'null'] },
       metadata: {
         type: 'object',
         properties: {
           isMock: {
+            type: 'boolean',
+          },
+          iteration: {
+            type: 'number',
+          },
+          iterationStatus: {
+            type: 'object',
+          },
+          isLastIteration: {
+            type: 'boolean',
+          },
+          isLastStep: {
             type: 'boolean',
           },
         },
@@ -84,6 +97,32 @@ class ExecutionStep extends Base {
     return `${appConfig.baseUrl}/apps/${this.appKey}/assets/favicon.svg`
   }
 
+  static async patchIterationStatus(
+    executionId: string,
+    iteration: number,
+    status: 'success' | 'failure' | null,
+  ) {
+    const updateData =
+      status !== null
+        ? {
+            metadata: raw(
+              `jsonb_set(metadata, '{iterationStatus,iteration_${iteration}}', to_jsonb(?::text), true)`,
+              [status],
+            ),
+          }
+        : {
+            metadata: raw(
+              `jsonb_set(metadata, '{iterationStatus,iteration_${iteration}}', 'null'::jsonb, true)`,
+            ),
+          }
+
+    return ExecutionStep.query()
+      .where('execution_id', executionId)
+      .where('app_key', 'toolbox')
+      .where('key', 'forEach')
+      .patch(updateData)
+  }
+
   static async getForEachExecutionSteps(executionId: string) {
     return ExecutionStep.query()
       .select('execution_steps.*', 'latest_steps.min_created_at')
@@ -119,17 +158,30 @@ class ExecutionStep extends Base {
       .orderBy('latest_steps.min_created_at', 'asc')
   }
 
+  /**
+   * checks the state of the for-each execution by looking at the iterationStatus
+   * metadata field
+   *
+   * returns:
+   * - hasLastIterationRun: boolean
+   *   mainly used during retry to determine whether to set the execution to status to success
+   * - areAllStepsSuccessful: boolean
+   */
   static async getForEachExecutionState(executionId: string) {
-    const executionSteps = await ExecutionStep.getForEachExecutionSteps(
-      executionId,
-    )
+    const forEachStep = await ExecutionStep.query()
+      .where('execution_id', executionId)
+      .where('app_key', 'toolbox')
+      .where('key', 'forEach')
+      .first()
+    const iterationStatus = forEachStep?.metadata?.iterationStatus
+
     return {
-      hasLastIterationRun: executionSteps.some(
-        (step) => step.metadata?.isLastIteration && step.metadata?.isLastStep,
-      ),
-      areAllStepsSuccessful: executionSteps.every(
-        (step) => step.status === 'success',
-      ),
+      hasLastIterationRun:
+        iterationStatus &&
+        Object.values(iterationStatus).every((value) => value !== null),
+      areAllStepsSuccessful:
+        iterationStatus &&
+        Object.values(iterationStatus).every((value) => value === 'success'),
     }
   }
 }

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -18,6 +18,7 @@ class ExecutionStep extends Base {
   jobId: string
   step: Step
   metadata: IExecutionStepMetadata
+  key: string
   execution?: Execution
 
   static tableName = 'execution_steps'

--- a/packages/backend/src/services/__tests__/helpers.get-for-each-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/helpers.get-for-each-metadata.test.ts
@@ -1,0 +1,413 @@
+import { IActionRunResult, IJSONObject, NextStepMetadata } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { ForEachContext } from '@/helpers/compute-for-each-parameters'
+
+import getForEachMetadata from '../helpers/get-for-each-metadata'
+
+describe('getForEachMetadata', () => {
+  const mockForEachContext: ForEachContext = {
+    testRun: false,
+    executionStepMetadata: {},
+    forEachStepPosition: 2,
+    stepPositions: {
+      'step-1': 1,
+      'step-2': 2,
+      'step-3': 3,
+      'step-4': 4,
+    },
+    isForEachStep: false,
+  }
+
+  const mockDataOut: IJSONObject = {
+    iterations: 3,
+    items: ['item1', 'item2', 'item3'],
+    inputSource: 'checkbox',
+  }
+
+  const mockRunResult: IActionRunResult = {
+    nextStep: undefined,
+  }
+
+  describe('when nextStep command is stop-execution', () => {
+    it('should set isLastStep to true in metadata', () => {
+      const metadata: NextStepMetadata = {}
+      const runResult: IActionRunResult = {
+        nextStep: {
+          command: 'stop-execution',
+        },
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, forEachStepPosition: 1 },
+        metadata,
+        dataOut: mockDataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBe(true)
+    })
+
+    it('should not set isLastStep when there is no for-each step', () => {
+      const metadata: NextStepMetadata = {}
+      const runResult: IActionRunResult = {
+        nextStep: {
+          command: 'stop-execution',
+        },
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, forEachStepPosition: -1 },
+        metadata,
+        dataOut: mockDataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBeUndefined()
+    })
+
+    it('should not set isLastStep when nextStep command is not stop-execution', () => {
+      const metadata: NextStepMetadata = {}
+      const runResult: IActionRunResult = {
+        nextStep: {
+          command: 'jump-to-step',
+          stepId: 'step-3',
+        },
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, forEachStepPosition: 1 },
+        metadata,
+        dataOut: mockDataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBeUndefined()
+    })
+
+    it('should not set isLastStep when nextStep is undefined', () => {
+      const metadata: NextStepMetadata = {}
+      const runResult: IActionRunResult = {
+        nextStep: undefined,
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, forEachStepPosition: 1 },
+        metadata,
+        dataOut: mockDataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBeUndefined()
+    })
+  })
+
+  describe('when isForEachStep is true', () => {
+    it('should initialize iterations and iterationStatus when iterations > 0', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 3,
+        items: ['item1', 'item2', 'item3'],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBe(3)
+      expect(metadata.iterationStatus).toEqual({
+        iteration_1: null,
+        iteration_2: null,
+        iteration_3: null,
+      })
+    })
+
+    it('should not initialize when iterations is 0', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 0,
+        items: [],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should not initialize when iterations is undefined', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        items: [],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should cap iterations at FOR_EACH_MAX_ITERATIONS', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 1000, // Should be capped at FOR_EACH_MAX_ITERATIONS
+        items: Array.from({ length: 1000 }, (_, i) => `item${i}`),
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBe(500) // FOR_EACH_MAX_ITERATIONS
+      expect(Object.keys(metadata.iterationStatus || {}).length).toBe(500)
+    })
+
+    it('should handle negative iterations by treating as 0', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: -5,
+        items: ['item1'],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should handle non-numeric iterations by treating as 0', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 'invalid',
+        items: ['item1'],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+  })
+
+  describe('when isForEachStep is false', () => {
+    it('should not initialize iterations or iterationStatus', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 3,
+        items: ['item1', 'item2', 'item3'],
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: false },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty metadata object', () => {
+      const metadata: NextStepMetadata = {}
+
+      getForEachMetadata({
+        forEachContext: mockForEachContext,
+        metadata,
+        dataOut: mockDataOut,
+        runResult: mockRunResult,
+      })
+
+      // Should not throw and should not modify metadata
+      expect(metadata).toEqual({})
+    })
+
+    it('should handle null dataOut', () => {
+      const metadata: NextStepMetadata = {}
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut: null as any,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should handle undefined dataOut', () => {
+      const metadata: NextStepMetadata = {}
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut: undefined as any,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should preserve existing metadata properties', () => {
+      const metadata: NextStepMetadata = {
+        isMock: true,
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut: mockDataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.isMock).toBe(true)
+      expect(metadata.iterations).toBe(3)
+      expect(metadata.iterationStatus).toBeDefined()
+    })
+  })
+
+  describe('tests with realistic dataOut', () => {
+    it('should handle checkbox data', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 4,
+        items: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        inputSource: 'checkbox',
+        item: 'items.__ITERATION__',
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBe(4)
+      expect(metadata.iterationStatus).toEqual({
+        iteration_1: null,
+        iteration_2: null,
+        iteration_3: null,
+        iteration_4: null,
+      })
+    })
+
+    it('should handle no data', () => {
+      const dataOut: IJSONObject = {
+        iterations: 0,
+        items: [],
+        inputSource: 'checkbox',
+        item: 'items.__ITERATION__',
+      }
+      const metadata: NextStepMetadata = {}
+      const runResult: IActionRunResult = {
+        nextStep: {
+          command: 'stop-execution',
+        },
+      }
+
+      getForEachMetadata({
+        forEachContext: {
+          ...mockForEachContext,
+          forEachStepPosition: 1,
+          isForEachStep: true,
+        },
+        metadata,
+        dataOut: dataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBe(true)
+      expect(metadata.iterations).toBeUndefined()
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+
+    it('should handle real-world for-each with table data', () => {
+      const metadata: NextStepMetadata = {}
+      const dataOut: IJSONObject = {
+        iterations: 2,
+        items: {
+          rows: [
+            { data: { name: 'John', age: 25 } },
+            { data: { name: 'Jane', age: 30 } },
+          ],
+          columns: [
+            { id: 'name', name: 'Name', value: 'name' },
+            { id: 'age', name: 'Age', value: 'age' },
+          ],
+        },
+        inputSource: 'tiles',
+      }
+
+      getForEachMetadata({
+        forEachContext: { ...mockForEachContext, isForEachStep: true },
+        metadata,
+        dataOut,
+        runResult: mockRunResult,
+      })
+
+      expect(metadata.iterations).toBe(2)
+      expect(metadata.iterationStatus).toEqual({
+        iteration_1: null,
+        iteration_2: null,
+      })
+    })
+
+    it('should handle if-then with stop-execution in for-each context', () => {
+      const metadata: NextStepMetadata = {
+        iteration: 3,
+      }
+      const runResult: IActionRunResult = {
+        nextStep: {
+          command: 'stop-execution',
+        },
+      }
+
+      getForEachMetadata({
+        forEachContext: {
+          ...mockForEachContext,
+          forEachStepPosition: 2,
+          isForEachStep: false,
+        },
+        metadata,
+        dataOut: mockDataOut,
+        runResult,
+      })
+
+      expect(metadata.isLastStep).toBe(true)
+      expect(metadata.iteration).toBe(3)
+      expect(metadata.iterationStatus).toBeUndefined()
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/helpers.get-for-each-metadata.test.ts
+++ b/packages/backend/src/services/__tests__/helpers.get-for-each-metadata.test.ts
@@ -8,7 +8,6 @@ import getForEachMetadata from '../helpers/get-for-each-metadata'
 
 describe('getForEachMetadata', () => {
   const mockForEachContext: ForEachContext = {
-    testRun: false,
     executionStepMetadata: {},
     forEachStepPosition: 2,
     stepPositions: {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -91,10 +91,11 @@ export const processAction = async (options: ProcessActionOptions) => {
     .findById(executionId)
     .throwIfNotFound()
 
-  const { forEachStepIndex, stepPositions, isForEachStep } = getForEachContext(
-    flow,
-    step,
-  )
+  const { forEachStepIndex, stepPositions, lastStepId, isForEachStep } =
+    getForEachContext(flow, step)
+  if (forEachStepIndex > -1 && lastStepId === stepId) {
+    metadata.isLastStep = true
+  }
 
   const $ = await globalVariable({
     flow,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -172,6 +172,20 @@ export const processAction = async (options: ProcessActionOptions) => {
       ? 'success'
       : 'failure'
 
+  /**
+   * FOR-EACH + IF-THEN SPECIAL CASE
+   * when there are if-then actions in the for-each, not all steps may run so the lastStep check may not work
+   * if-then uses stop-execution to terminate the flow, so we need to set the isLastStep to true
+   * so that the execution status is set to success
+   */
+  if (
+    !testRun &&
+    forEachStepIndex > -1 &&
+    runResult.nextStep?.command === 'stop-execution'
+  ) {
+    metadata.isLastStep = true
+  }
+
   const executionStep = await execution
     .$relatedQuery('executionSteps')
     .insertAndFetch({

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -18,6 +18,8 @@ import Flow from '@/models/flow'
 import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 
+import getForEachMetadata from './helpers/get-for-each-metadata'
+
 type ProcessActionOptions = {
   flowId: string
   executionId: string
@@ -40,6 +42,11 @@ async function enqueueFirstForEachStep({
   flowId: string
   metadata?: NextStepMetadata
 }): Promise<void> {
+  // remove unnecessary metadata from steps within the for-each
+  const filteredMetadata = { ...metadata }
+  delete filteredMetadata?.iterations
+  delete filteredMetadata?.iterationStatus
+
   const results = await Promise.allSettled(
     Array.from({ length: iterations }, (_, i) =>
       enqueueActionJob({
@@ -50,7 +57,7 @@ async function enqueueFirstForEachStep({
           executionId: executionId,
           stepId: firstStepInForEach.id,
           metadata: {
-            ...metadata,
+            ...filteredMetadata,
             iteration: i + 1,
             ...(i === iterations - 1 && { isLastIteration: true }),
           },
@@ -91,9 +98,11 @@ export const processAction = async (options: ProcessActionOptions) => {
     .findById(executionId)
     .throwIfNotFound()
 
-  const { forEachStepIndex, stepPositions, lastStepId, isForEachStep } =
+  const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
     getForEachContext(flow, step)
-  if (!testRun && forEachStepIndex > -1 && lastStepId === stepId && metadata) {
+
+  // we use this to indicate an iteration in the for-each is complete
+  if (!testRun && forEachStepPosition > -1 && isLastStep && metadata) {
     metadata.isLastStep = true
   }
 
@@ -113,18 +122,19 @@ export const processAction = async (options: ProcessActionOptions) => {
   })
 
   const actionCommand = await step.getActionCommand()
+  const forEachContext = {
+    testRun,
+    executionStepMetadata: metadata,
+    forEachStepPosition,
+    stepPositions,
+    isForEachStep,
+  }
 
   const computedParameters = computeParameters(
     $.step.parameters,
     priorExecutionSteps,
     actionCommand.preprocessVariable,
-    {
-      testRun,
-      executionStepMetadata: metadata,
-      forEachStepIndex,
-      stepPositions,
-      isForEachStep,
-    },
+    forEachContext,
   )
 
   $.step.parameters = computedParameters
@@ -172,19 +182,14 @@ export const processAction = async (options: ProcessActionOptions) => {
       ? 'success'
       : 'failure'
 
-  /**
-   * FOR-EACH + IF-THEN SPECIAL CASE
-   * when there are if-then actions in the for-each, not all steps may run so the lastStep check may not work
-   * if-then uses stop-execution to terminate the flow, so we need to set the isLastStep to true
-   * so that the execution status is set to success
-   */
-  if (
-    !testRun &&
-    forEachStepIndex > -1 &&
-    runResult.nextStep?.command === 'stop-execution' &&
-    metadata
-  ) {
-    metadata.isLastStep = true
+  // update metadata specially for for-each
+  if (!testRun) {
+    getForEachMetadata({
+      forEachContext,
+      metadata,
+      dataOut: $.actionOutput.data?.raw ?? null,
+      runResult,
+    })
   }
 
   const executionStep = await execution

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -93,7 +93,7 @@ export const processAction = async (options: ProcessActionOptions) => {
 
   const { forEachStepIndex, stepPositions, lastStepId, isForEachStep } =
     getForEachContext(flow, step)
-  if (!testRun && forEachStepIndex > -1 && lastStepId === stepId) {
+  if (!testRun && forEachStepIndex > -1 && lastStepId === stepId && metadata) {
     metadata.isLastStep = true
   }
 
@@ -181,7 +181,8 @@ export const processAction = async (options: ProcessActionOptions) => {
   if (
     !testRun &&
     forEachStepIndex > -1 &&
-    runResult.nextStep?.command === 'stop-execution'
+    runResult.nextStep?.command === 'stop-execution' &&
+    metadata
   ) {
     metadata.isLastStep = true
   }

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -212,7 +212,7 @@ export const processAction = async (options: ProcessActionOptions) => {
       const firstStepInForEach = await step.getNextStep()
 
       // testing for-each step should not enqueue any jobs
-      if (!testRun) {
+      if (!testRun && firstStepInForEach) {
         await enqueueFirstForEachStep({
           iterations,
           firstStepInForEach,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -49,7 +49,11 @@ async function enqueueFirstForEachStep({
           flowId: flowId,
           executionId: executionId,
           stepId: firstStepInForEach.id,
-          metadata: { ...metadata, iteration: i + 1 },
+          metadata: {
+            ...metadata,
+            iteration: i + 1,
+            ...(i === iterations - 1 && { isLastIteration: true }),
+          },
         },
         jobOptions: {
           ...DEFAULT_JOB_OPTIONS,
@@ -201,7 +205,7 @@ export const processAction = async (options: ProcessActionOptions) => {
       const dataOut = $.actionOutput.data?.raw ?? null
       const iterations = Math.min(
         FOR_EACH_MAX_ITERATIONS,
-        Number(dataOut.iterations ?? 0),
+        Number(dataOut?.iterations ?? 0),
       )
 
       // NOTE: unlikely that iterations will be negative, but just in case

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -7,7 +7,10 @@ import {
 import HttpError from '@/errors/http'
 import PartialStepError from '@/errors/partial-error'
 import StepError from '@/errors/step'
-import { getForEachContext } from '@/helpers/compute-for-each-parameters'
+import {
+  ForEachContext,
+  getStepContext,
+} from '@/helpers/compute-for-each-parameters'
 import computeParameters from '@/helpers/compute-parameters'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import globalVariable from '@/helpers/global-variable'
@@ -99,7 +102,7 @@ export const processAction = async (options: ProcessActionOptions) => {
     .throwIfNotFound()
 
   const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
-    getForEachContext(flow, step)
+    getStepContext(flow, step)
 
   // we use this to indicate an iteration in the for-each is complete
   if (!testRun && forEachStepPosition > -1 && isLastStep && metadata) {
@@ -122,8 +125,7 @@ export const processAction = async (options: ProcessActionOptions) => {
   })
 
   const actionCommand = await step.getActionCommand()
-  const forEachContext = {
-    testRun,
+  const forEachContext: ForEachContext = {
     executionStepMetadata: metadata,
     forEachStepPosition,
     stepPositions,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -91,8 +91,10 @@ export const processAction = async (options: ProcessActionOptions) => {
     .findById(executionId)
     .throwIfNotFound()
 
-  const { forEachStepIndex, isForEachStep, stepIsInForEach, stepPositions } =
-    getForEachContext(flow, step)
+  const { forEachStepIndex, stepPositions, isForEachStep } = getForEachContext(
+    flow,
+    step,
+  )
 
   const $ = await globalVariable({
     flow,
@@ -118,7 +120,6 @@ export const processAction = async (options: ProcessActionOptions) => {
     {
       testRun,
       executionStepMetadata: metadata,
-      stepIsInForEach,
       forEachStepIndex,
       stepPositions,
       isForEachStep,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,15 +1,22 @@
 import { type IActionRunResult, NextStepMetadata } from '@plumber/types'
 
+import {
+  FOR_EACH_ITERATION_DELAY,
+  FOR_EACH_MAX_ITERATIONS,
+} from '@/apps/toolbox/common/constants'
 import HttpError from '@/errors/http'
 import PartialStepError from '@/errors/partial-error'
 import StepError from '@/errors/step'
+import { getForEachContext } from '@/helpers/compute-for-each-parameters'
 import computeParameters from '@/helpers/compute-parameters'
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
+import { enqueueActionJob } from '@/queues/action'
 
 type ProcessActionOptions = {
   flowId: string
@@ -18,6 +25,46 @@ type ProcessActionOptions = {
   jobId?: string
   testRun?: boolean
   metadata?: NextStepMetadata
+}
+
+async function enqueueFirstForEachStep({
+  iterations,
+  firstStepInForEach,
+  executionId,
+  flowId,
+  metadata,
+}: {
+  iterations: number
+  firstStepInForEach: Step
+  executionId: string
+  flowId: string
+  metadata?: NextStepMetadata
+}): Promise<void> {
+  const results = await Promise.allSettled(
+    Array.from({ length: iterations }, (_, i) =>
+      enqueueActionJob({
+        appKey: firstStepInForEach.appKey,
+        jobName: `${executionId}-${firstStepInForEach.id}-${i + 1}`,
+        jobData: {
+          flowId: flowId,
+          executionId: executionId,
+          stepId: firstStepInForEach.id,
+          metadata: { ...metadata, iteration: i + 1 },
+        },
+        jobOptions: {
+          ...DEFAULT_JOB_OPTIONS,
+          delay: i * FOR_EACH_ITERATION_DELAY,
+        },
+      }),
+    ),
+  )
+
+  const failures = results.filter((r) => r.status === 'rejected')
+  if (failures.length > 0) {
+    logger.error(`Failed to enqueue ${failures.length} for-each jobs`, {
+      failures,
+    })
+  }
 }
 
 export const processAction = async (options: ProcessActionOptions) => {
@@ -34,10 +81,14 @@ export const processAction = async (options: ProcessActionOptions) => {
   const flow = await Flow.query()
     .findById(flowId)
     .withGraphJoined('user')
+    .withGraphFetched('steps')
     .throwIfNotFound()
   const execution = await Execution.query()
     .findById(executionId)
     .throwIfNotFound()
+
+  const { forEachStepIndex, isForEachStep, stepIsInForEach, stepPositions } =
+    getForEachContext(flow, step)
 
   const $ = await globalVariable({
     flow,
@@ -60,7 +111,14 @@ export const processAction = async (options: ProcessActionOptions) => {
     $.step.parameters,
     priorExecutionSteps,
     actionCommand.preprocessVariable,
-    step.appKey === 'toolbox' && step.key === 'forEach',
+    {
+      testRun,
+      executionStepMetadata: metadata,
+      stepIsInForEach,
+      forEachStepIndex,
+      stepPositions,
+      isForEachStep,
+    },
   )
 
   $.step.parameters = computedParameters
@@ -118,6 +176,8 @@ export const processAction = async (options: ProcessActionOptions) => {
       errorDetails: $.actionOutput.error ?? null,
       appKey: $.app.key,
       jobId,
+      key: step.key,
+      metadata,
     })
 
   let nextStep = null
@@ -128,6 +188,42 @@ export const processAction = async (options: ProcessActionOptions) => {
         .findById(runResult.nextStep.stepId)
         .throwIfNotFound()
       break
+
+    case 'start-for-each': {
+      /**
+       * FOR-EACH:
+       * we do not have a next step because we enqueue the next step here
+       * each iteration of the for-each step will have its own job.
+       * we also intentionally add a delay between each iteration to avoid
+       * overwhelming the workers.
+       */
+      nextStep = null
+      const dataOut = $.actionOutput.data?.raw ?? null
+      const iterations = Math.min(
+        FOR_EACH_MAX_ITERATIONS,
+        Number(dataOut.iterations ?? 0),
+      )
+
+      // NOTE: unlikely that iterations will be negative, but just in case
+      if (!iterations || iterations <= 0) {
+        break
+      }
+
+      const firstStepInForEach = await step.getNextStep()
+
+      // testing for-each step should not enqueue any jobs
+      if (!testRun) {
+        await enqueueFirstForEachStep({
+          iterations,
+          firstStepInForEach,
+          executionId,
+          flowId,
+          metadata,
+        })
+      }
+
+      break
+    }
     case 'stop-execution':
       // Nothing to do, nextStep is already null.
       break
@@ -142,7 +238,10 @@ export const processAction = async (options: ProcessActionOptions) => {
     executionStep,
     computedParameters,
     nextStep,
-    nextStepMetadata: runResult.nextStepMetadata,
+    nextStepMetadata: {
+      ...runResult.nextStepMetadata,
+      ...metadata,
+    },
     executionError,
   }
 }

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -93,7 +93,7 @@ export const processAction = async (options: ProcessActionOptions) => {
 
   const { forEachStepIndex, stepPositions, lastStepId, isForEachStep } =
     getForEachContext(flow, step)
-  if (forEachStepIndex > -1 && lastStepId === stepId) {
+  if (!testRun && forEachStepIndex > -1 && lastStepId === stepId) {
     metadata.isLastStep = true
   }
 

--- a/packages/backend/src/services/helpers/get-for-each-metadata.ts
+++ b/packages/backend/src/services/helpers/get-for-each-metadata.ts
@@ -1,0 +1,56 @@
+import { IActionRunResult, IJSONObject, NextStepMetadata } from '@plumber/types'
+
+import { FOR_EACH_MAX_ITERATIONS } from '@/apps/toolbox/common/constants'
+import { ForEachContext } from '@/helpers/compute-for-each-parameters'
+
+export default function getForEachMetadata({
+  forEachContext,
+  metadata,
+  dataOut,
+  runResult,
+}: {
+  forEachContext: ForEachContext
+  metadata: NextStepMetadata
+  dataOut: IJSONObject
+  runResult: IActionRunResult
+}) {
+  const { forEachStepPosition, isForEachStep } = forEachContext
+
+  /**
+   * SPECIAL CASE
+   * these are the instances where this is needed:
+   * 1. if-then
+   *    when there are if-then actions in the for-each, not all steps may run so the lastStep check may not work
+   *    if-then uses stop-execution to terminate the flow, so we need to set the isLastStep to true
+   *    so that the execution status is set to success
+   * 2. only continue if
+   *    it uses stop-execution to terminate the flow, so we need to set the isLastStep to true
+   *    so that the execution status is set to success
+   * 3. when there are no iterations to run.
+   *    terminate the flow at the for-each step and mark as success immediately
+   */
+  if (
+    forEachStepPosition > -1 &&
+    runResult.nextStep?.command === 'stop-execution' &&
+    metadata
+  ) {
+    metadata.isLastStep = true
+  }
+
+  if (isForEachStep) {
+    const iterations = Math.min(
+      FOR_EACH_MAX_ITERATIONS,
+      Number(dataOut?.iterations ?? 0),
+    )
+
+    // create object to track status of each iteration
+    // set default status to null so that we have a 'waiting' status
+    if (iterations && iterations > 0) {
+      metadata.iterations = iterations
+      metadata.iterationStatus = {}
+      for (let i = 0; i < iterations; i++) {
+        metadata.iterationStatus[`iteration_${i + 1}`] = null
+      }
+    }
+  }
+}

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -89,6 +89,7 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
       errorDetails: error,
       appKey: step.appKey,
       metadata: triggerItem?.isMock ? { isMock: true } : {},
+      key: step.key,
     })
 
   return {

--- a/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
+++ b/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
@@ -1,0 +1,437 @@
+import { IExecutionStepMetadata } from '@plumber/types'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import logger from '@/helpers/logger'
+import Step from '@/models/step'
+
+import processForEachStatus from '../helpers/for-each-status-manager'
+
+const mocks = vi.hoisted(() => ({
+  patchIterationStatus: vi.fn(),
+  getForEachExecutionState: vi.fn(),
+  setStatus: vi.fn(),
+}))
+
+vi.mock('@/models/execution-step', () => ({
+  default: {
+    patchIterationStatus: mocks.patchIterationStatus,
+    getForEachExecutionState: mocks.getForEachExecutionState,
+  },
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    setStatus: mocks.setStatus,
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}))
+
+describe('processForEachStatus', () => {
+  const mockExecutionId = 'execution-123'
+  const mockForEachStep: Step = {
+    id: 'step-1',
+    appKey: TOOLBOX_APP_KEY,
+    key: TOOLBOX_ACTIONS.FOR_EACH,
+  } as Step
+
+  const mockRegularStep: Step = {
+    id: 'step-2',
+    appKey: 'postman',
+    key: 'sendEmail',
+  } as Step
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when step is a for-each step', () => {
+    it('should return false if isLastStep is undefined', async () => {
+      const metadata: IExecutionStepMetadata = {}
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false if iteration is not provided', async () => {
+      const metadata: IExecutionStepMetadata = {}
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false even with iterations and iterationStatus', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iterations: 5,
+        iterationStatus: {
+          iteration_1: null,
+          iteration_2: null,
+          iteration_3: null,
+          iteration_4: null,
+          iteration_5: null,
+        },
+      }
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false for null nextStepMetadata', async () => {
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: null as any,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false for undefined nextStepMetadata', async () => {
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: undefined as any,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when step is not a for-each step', () => {
+    it('should return true if iteration is not provided', async () => {
+      const metadata: IExecutionStepMetadata = {}
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockRegularStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false if isLastStep is not provided', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+      }
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockRegularStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
+      expect(mocks.getForEachExecutionState).not.toHaveBeenCalled()
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when processing iteration with isLastStep true', () => {
+    it('should return true when all steps are successful', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+        isLastStep: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        1,
+        'success',
+      )
+    })
+
+    it('should log error if patchIterationStatus fails but continue processing', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+        isLastStep: true,
+      }
+
+      const error = new Error('Database error')
+      mocks.patchIterationStatus.mockRejectedValue(error)
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to patch iteration status',
+        {
+          err: error,
+          executionId: mockExecutionId,
+          iteration: 1,
+        },
+      )
+    })
+
+    it('should continue processing even if patchIterationStatus fails', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+        isLastStep: true,
+      }
+
+      mocks.patchIterationStatus.mockRejectedValue(new Error('Database error'))
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.getForEachExecutionState).toHaveBeenCalledWith(
+        mockExecutionId,
+      )
+    })
+  })
+
+  describe('when isLastIteration is true', () => {
+    it('should return false and set execution status to failure if not all steps are successful', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 3,
+        isLastStep: true,
+        isLastIteration: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: false,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        3,
+        'success',
+      )
+      expect(mocks.setStatus).toHaveBeenCalledWith(mockExecutionId, 'failure')
+    })
+
+    it('should return true if all steps are successful', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 3,
+        isLastStep: true,
+        isLastIteration: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      // NOTE: we don't call setStatus to set 'success' in the manager
+      // we let the action worker set to success
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when checking execution state', () => {
+    it('should return false if last iteration has not run', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 2,
+        isLastStep: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: false,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        2,
+        'success',
+      )
+      // NOTE: we do not prematurely set to success
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false and set execution status to failure if not all steps are successful', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 2,
+        isLastStep: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: false,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.setStatus).toHaveBeenCalledWith(mockExecutionId, 'failure')
+    })
+
+    it('should handle successful for-each completion', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 3,
+        isLastStep: true,
+        isLastIteration: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        3,
+        'success',
+      )
+      expect(mocks.setStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return false for failed for-each completion', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 3,
+        isLastStep: true,
+        isLastIteration: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: false,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(false)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        3,
+        'success',
+      )
+      expect(mocks.setStatus).toHaveBeenCalledWith(mockExecutionId, 'failure')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return true for null currStep when processing iteration', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+        isLastStep: true,
+      }
+
+      mocks.getForEachExecutionState.mockResolvedValue({
+        hasLastIterationRun: true,
+        areAllStepsSuccessful: true,
+      })
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: null as any,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        1,
+        'success',
+      )
+    })
+  })
+})

--- a/packages/backend/src/workers/helpers/for-each-status-manager.ts
+++ b/packages/backend/src/workers/helpers/for-each-status-manager.ts
@@ -1,0 +1,93 @@
+import { IExecutionStepMetadata } from '@plumber/types'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Step from '@/models/step'
+
+/**
+ * this function helps to patch the execution status of steps in a pipe with for-each
+ * it returns a boolean to decide whether to set the execution status to success
+ */
+export default async function processForEachStatus({
+  executionId,
+  currStep,
+  nextStepMetadata,
+}: {
+  executionId: string
+  currStep: Step
+  nextStepMetadata: IExecutionStepMetadata
+}): Promise<boolean> {
+  const isForEach =
+    currStep?.appKey === TOOLBOX_APP_KEY &&
+    currStep?.key === TOOLBOX_ACTIONS.FOR_EACH
+
+  const { isLastIteration, isLastStep, iteration } = nextStepMetadata ?? {}
+
+  /**
+   * nextStep is always null for the for-each execution step,
+   * return early so that we do not prematurely set the execution status to success
+   * and it can be reflected accurately as waiting.
+   *
+   * if there are no iterations, the nextStepMetadata isLastStep will be set to true
+   * to signal that this is the end of the execution.
+   */
+  if (isForEach && !isLastStep) {
+    return false
+  }
+
+  if (iteration) {
+    /**
+     * default state is null (waiting for all iterations to execute)
+     * if any iteration fails, the execution is immediately set to failure
+     * if all iterations are successful, the execution is set to success
+     */
+    // only need to check at the last step to set the execution status
+    if (isLastStep) {
+      try {
+        await ExecutionStep.patchIterationStatus(
+          executionId,
+          iteration,
+          'success',
+        )
+      } catch (err) {
+        logger.error('Failed to patch iteration status', {
+          err,
+          executionId,
+          iteration,
+        })
+      }
+
+      const { hasLastIterationRun, areAllStepsSuccessful } =
+        await ExecutionStep.getForEachExecutionState(executionId)
+
+      // signals end of the execution: all iterations ran successfully up to the last iteration and last step
+      if (isLastIteration) {
+        if (!areAllStepsSuccessful) {
+          await Execution.setStatus(executionId, 'failure')
+          return false // Status was set to failure
+        }
+      }
+
+      // if the last iteration has not run, it means this flow is still executing
+      // we return early to preserve the waiting state of the execution
+      if (!hasLastIterationRun) {
+        return false // No status was set, still waiting
+      }
+
+      // if all steps are successful, return to let the action worker set to success
+      if (!areAllStepsSuccessful) {
+        await Execution.setStatus(executionId, 'failure')
+        return false
+      }
+    } else {
+      return false // No status was set
+    }
+  }
+
+  return true
+}

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -162,16 +162,23 @@ export function makeActionWorker(
           })
         }
 
-        /**
-         * FOR-EACH SPECIAL CASE
-         * 1. nextStep is null for the for-each execution step
-         * 2. execution with for-each is only a success if all iterations are a success
-         */
         const isForEach =
           currStep.appKey === TOOLBOX_APP_KEY &&
           currStep.key === TOOLBOX_ACTIONS.FOR_EACH
 
-        if (!nextStep && !isForEach) {
+        /**
+         * FOR-EACH SPECIAL CASE
+         * 1. nextStep is null for the for-each execution step, return if its not the last iteration
+         *    so that we do not prematurely set the execution status to success and it can be
+         *    reflected accurately as waiting
+         * 2. if any iteration fails, the execution is set to failed
+         * 3. if all iterations are successful, the execution is set to success
+         */
+        if (!nextStep && isForEach) {
+          return
+        }
+
+        if (!nextStep) {
           if (nextStepMetadata?.isLastIteration) {
             const executionSteps = await ExecutionStep.query().where({
               execution_id: executionId,

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -168,35 +168,50 @@ export function makeActionWorker(
 
         /**
          * FOR-EACH SPECIAL CASE
-         * 1. nextStep is null for the for-each execution step, return if its not the last iteration
-         *    so that we do not prematurely set the execution status to success and it can be
-         *    reflected accurately as waiting
-         * 2. if any iteration fails, the execution is set to failed
-         * 3. if all iterations are successful, the execution is set to success
+         * nextStep is null for the for-each execution step, return if its not the last iteration
+         * so that we do not prematurely set the execution status to success and it can be
+         * reflected accurately as waiting
          */
         if (!nextStep && isForEach) {
           return
         }
 
         if (!nextStep) {
+          /**
+           * FOR-EACH SPECIAL CASE
+           * default state is null (waiting for all iterations to execute)
+           * if any iteration fails, the execution is immediately set to failure
+           * if all iterations are successful, the execution is set to success
+           */
           if (nextStepMetadata?.iteration) {
+            const { hasLastIterationRun, areAllStepsSuccessful } =
+              await ExecutionStep.getForEachExecutionState(executionId)
+
+            // end of the execution: all iterations ran successfully up to the last iteration and last step
             if (
               nextStepMetadata?.isLastIteration &&
               nextStepMetadata?.isLastStep
             ) {
-              const executionSteps = await ExecutionStep.query().where({
-                execution_id: executionId,
-              })
-
-              const areAllStepsSuccessful = executionSteps.every(
-                (step) => step.status === 'success',
-              )
               if (!areAllStepsSuccessful) {
                 await Execution.setStatus(executionId, 'failure')
                 return
               }
             } else {
-              return
+              // handle failures and retries
+              if (nextStepMetadata?.isLastStep) {
+                if (!areAllStepsSuccessful) {
+                  await Execution.setStatus(executionId, 'failure')
+                  return
+                }
+
+                // if the last iteration has not run, it means this flow is still executing
+                // we return early to preserve the waiting state of the execution
+                if (!hasLastIterationRun) {
+                  return
+                }
+              } else {
+                return
+              }
             }
           }
 

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -6,6 +6,10 @@ import {
   type WorkerProOptions,
 } from '@taskforcesh/bullmq-pro'
 
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
@@ -23,6 +27,7 @@ import {
 import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import { enqueueActionJob, makeActionJobId } from '@/queues/action'
@@ -157,7 +162,30 @@ export function makeActionWorker(
           })
         }
 
-        if (!nextStep) {
+        /**
+         * FOR-EACH SPECIAL CASE
+         * 1. nextStep is null for the for-each execution step
+         * 2. execution with for-each is only a success if all iterations are a success
+         */
+        const isForEach =
+          currStep.appKey === TOOLBOX_APP_KEY &&
+          currStep.key === TOOLBOX_ACTIONS.FOR_EACH
+
+        if (!nextStep && !isForEach) {
+          if (nextStepMetadata?.isLastIteration) {
+            const executionSteps = await ExecutionStep.query().where({
+              execution_id: executionId,
+            })
+
+            const areAllStepsSuccessful = executionSteps.every(
+              (step) => step.status === 'success',
+            )
+            if (!areAllStepsSuccessful) {
+              await Execution.setStatus(executionId, 'failure')
+              return
+            }
+          }
+
           await Execution.setStatus(executionId, 'success')
           return
         }

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -171,8 +171,11 @@ export function makeActionWorker(
          * nextStep is null for the for-each execution step, return if its not the last iteration
          * so that we do not prematurely set the execution status to success and it can be
          * reflected accurately as waiting
+         *
+         * NOTE: if there are no iterations, the nextStepMetadata isLastStep will be set to true
+         * to signal that this is the end of the execution
          */
-        if (!nextStep && isForEach) {
+        if (!nextStep && isForEach && !nextStepMetadata?.isLastStep) {
           return
         }
 

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -163,8 +163,8 @@ export function makeActionWorker(
         }
 
         const isForEach =
-          currStep.appKey === TOOLBOX_APP_KEY &&
-          currStep.key === TOOLBOX_ACTIONS.FOR_EACH
+          currStep?.appKey === TOOLBOX_APP_KEY &&
+          currStep?.key === TOOLBOX_ACTIONS.FOR_EACH
 
         /**
          * FOR-EACH SPECIAL CASE

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -179,7 +179,10 @@ export function makeActionWorker(
         }
 
         if (!nextStep) {
-          if (nextStepMetadata?.isLastIteration) {
+          if (
+            nextStepMetadata?.isLastIteration &&
+            nextStepMetadata?.isLastStep
+          ) {
             const executionSteps = await ExecutionStep.query().where({
               execution_id: executionId,
             })

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -184,34 +184,26 @@ export function makeActionWorker(
            * if all iterations are successful, the execution is set to success
            */
           if (nextStepMetadata?.iteration) {
-            const { hasLastIterationRun, areAllStepsSuccessful } =
-              await ExecutionStep.getForEachExecutionState(executionId)
+            // only need to check at the last step to set the execution status
+            if (nextStepMetadata?.isLastStep) {
+              const { hasLastIterationRun, areAllStepsSuccessful } =
+                await ExecutionStep.getForEachExecutionState(executionId)
 
-            // end of the execution: all iterations ran successfully up to the last iteration and last step
-            if (
-              nextStepMetadata?.isLastIteration &&
-              nextStepMetadata?.isLastStep
-            ) {
-              if (!areAllStepsSuccessful) {
-                await Execution.setStatus(executionId, 'failure')
-                return
-              }
-            } else {
-              // handle failures and retries
-              if (nextStepMetadata?.isLastStep) {
+              // end of the execution: all iterations ran successfully up to the last iteration and last step
+              if (nextStepMetadata?.isLastIteration) {
                 if (!areAllStepsSuccessful) {
                   await Execution.setStatus(executionId, 'failure')
                   return
                 }
+              }
 
-                // if the last iteration has not run, it means this flow is still executing
-                // we return early to preserve the waiting state of the execution
-                if (!hasLastIterationRun) {
-                  return
-                }
-              } else {
+              // if the last iteration has not run, it means this flow is still executing
+              // we return early to preserve the waiting state of the execution
+              if (!hasLastIterationRun) {
                 return
               }
+            } else {
+              return
             }
           }
 

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -6,10 +6,6 @@ import {
   type WorkerProOptions,
 } from '@taskforcesh/bullmq-pro'
 
-import {
-  TOOLBOX_ACTIONS,
-  TOOLBOX_APP_KEY,
-} from '@/apps/toolbox/common/constants'
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
@@ -32,6 +28,8 @@ import Flow from '@/models/flow'
 import Step from '@/models/step'
 import { enqueueActionJob, makeActionJobId } from '@/queues/action'
 import { processAction } from '@/services/action'
+
+import processForEachStatus from './for-each-status-manager'
 
 function convertParamsToBullMqOptions(
   params: MakeActionWorkerParams,
@@ -150,6 +148,13 @@ export function makeActionWorker(
         })
 
         if (executionStep.isFailed) {
+          if (nextStepMetadata?.iteration) {
+            await ExecutionStep.patchIterationStatus(
+              executionId,
+              nextStepMetadata.iteration,
+              'failure',
+            )
+          }
           return handleFailedStepAndThrow({
             errorDetails: executionStep.errorDetails,
             executionError,
@@ -162,52 +167,15 @@ export function makeActionWorker(
           })
         }
 
-        const isForEach =
-          currStep?.appKey === TOOLBOX_APP_KEY &&
-          currStep?.key === TOOLBOX_ACTIONS.FOR_EACH
-
-        /**
-         * FOR-EACH SPECIAL CASE
-         * nextStep is null for the for-each execution step, return if its not the last iteration
-         * so that we do not prematurely set the execution status to success and it can be
-         * reflected accurately as waiting
-         *
-         * NOTE: if there are no iterations, the nextStepMetadata isLastStep will be set to true
-         * to signal that this is the end of the execution
-         */
-        if (!nextStep && isForEach && !nextStepMetadata?.isLastStep) {
-          return
-        }
-
         if (!nextStep) {
-          /**
-           * FOR-EACH SPECIAL CASE
-           * default state is null (waiting for all iterations to execute)
-           * if any iteration fails, the execution is immediately set to failure
-           * if all iterations are successful, the execution is set to success
-           */
-          if (nextStepMetadata?.iteration) {
-            // only need to check at the last step to set the execution status
-            if (nextStepMetadata?.isLastStep) {
-              const { hasLastIterationRun, areAllStepsSuccessful } =
-                await ExecutionStep.getForEachExecutionState(executionId)
+          const shouldContinue = await processForEachStatus({
+            executionId,
+            currStep,
+            nextStepMetadata,
+          })
 
-              // end of the execution: all iterations ran successfully up to the last iteration and last step
-              if (nextStepMetadata?.isLastIteration) {
-                if (!areAllStepsSuccessful) {
-                  await Execution.setStatus(executionId, 'failure')
-                  return
-                }
-              }
-
-              // if the last iteration has not run, it means this flow is still executing
-              // we return early to preserve the waiting state of the execution
-              if (!hasLastIterationRun) {
-                return
-              }
-            } else {
-              return
-            }
+          if (!shouldContinue) {
+            return
           }
 
           await Execution.setStatus(executionId, 'success')

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -179,19 +179,23 @@ export function makeActionWorker(
         }
 
         if (!nextStep) {
-          if (
-            nextStepMetadata?.isLastIteration &&
-            nextStepMetadata?.isLastStep
-          ) {
-            const executionSteps = await ExecutionStep.query().where({
-              execution_id: executionId,
-            })
+          if (nextStepMetadata?.iteration) {
+            if (
+              nextStepMetadata?.isLastIteration &&
+              nextStepMetadata?.isLastStep
+            ) {
+              const executionSteps = await ExecutionStep.query().where({
+                execution_id: executionId,
+              })
 
-            const areAllStepsSuccessful = executionSteps.every(
-              (step) => step.status === 'success',
-            )
-            if (!areAllStepsSuccessful) {
-              await Execution.setStatus(executionId, 'failure')
+              const areAllStepsSuccessful = executionSteps.every(
+                (step) => step.status === 'success',
+              )
+              if (!areAllStepsSuccessful) {
+                await Execution.setStatus(executionId, 'failure')
+                return
+              }
+            } else {
               return
             }
           }

--- a/packages/frontend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-execution-steps.ts
@@ -23,6 +23,14 @@ export const GET_EXECUTION_STEPS = gql`
           updatedAt
           jobId
           appKey
+          key
+          metadata {
+            iteration
+            iterations
+            isLastIteration
+            iterationStatus
+            isLastStep
+          }
         }
       }
     }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -118,6 +118,7 @@ export interface IExecutionStep {
   createdAt: string
   updatedAt: string
   metadata: IExecutionStepMetadata
+  key: string
 
   // Only resolved on the front end via GraphQL.
   dataOutMetadata?: IDataOutMetadata

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -126,6 +126,7 @@ export interface IExecutionStep {
 
 export interface IExecutionStepMetadata {
   isMock?: boolean
+  iteration?: number
 }
 
 export interface IExecution {
@@ -715,6 +716,7 @@ export interface IActionRunResult {
   nextStep?:
     | { command: 'jump-to-step'; stepId: IStep['id'] }
     | { command: 'stop-execution' }
+    | { command: 'start-for-each'; stepId: IStep['id'] }
   nextStepMetadata?: NextStepMetadata
 }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -127,6 +127,8 @@ export interface IExecutionStep {
 export interface IExecutionStepMetadata {
   isMock?: boolean
   iteration?: number
+  iterations?: number
+  iterationStatus?: Record<string, 'success' | 'failure' | null>
   isLastIteration?: boolean
   isLastStep?: boolean
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -127,6 +127,8 @@ export interface IExecutionStep {
 export interface IExecutionStepMetadata {
   isMock?: boolean
   iteration?: number
+  isLastIteration?: boolean
+  isLastStep?: boolean
 }
 
 export interface IExecution {


### PR DESCRIPTION
## TL;DR
Implements functionality to execute steps within the for-each action with variables:
* Variable from the for-each step
* Variable from before the for-each step
* Variable from within the for-each step (note this refers to iteration-specific variable)

## Changes
- Add `key` column to `execution_steps` table to track step types
- Add the following to execution steps `metadata` to track progress of the for-each action
  - the for-each step:
    - `iterations`: number of iterations
    - `iterationStatus`: object where key is iteration (`iteration_x`) and value is the status (`success`, `failure`, `null`). this is introduced to enable easy checking of execution state and for retrieving iteration-specific execution steps in the executions page.
   - steps within the for-each:
     - `iteration`: iteration number
     - `isLastStep`: whether its the last step of the iteration. this is mainly used during retries to check whether to update the status of the entire execution
     - `isLastIteration`: whether this is the last iteration. this is mainly used during the execution itself to determine whether to update teh status of the entire execution
- Add validation to ensure flows have at most one For-Each step before allowing user to publish the pipe
- Add constants for For-Each configuration (max iterations, delay between iterations)
- Add tests for For-Each parameter computation

## How to test?
- [ ] Only one for-each step allowed
  - Manually modify `steps` in the DB to have more than 1 for-each action in an unpublished pipe
  - Attempt to publish via frontend, should see error message
- [ ] Check for-each action steps
  - Create actions within the for-each, verify that check step only tests with the first checkbox item or first row of data
- [ ] Execute for-each actions by publishing pipe
  - Create actions within the for-each that use a mix of variables from the for-each step and steps within the for-each
  - Verify that each iteration uses the correct data:
    - [ ] using for-each variable, it should use the correct checkbox item or row data
    - [ ] using variable from step within the action, it should use the data from the correct iteration
  - Verify that status is updated correctly:
    - [ ] `success`: all iterations succeeded
    - [ ] `failure`: any iteration failed, regardless of whether all iterations have run
    - [ ] `waiting`: execution has not completed, may include successful iterations
  - [ ] Pipe still succeeds if no checkbox items are selected
  - [ ] Pipe still succeeds if no rows are found by find multiple rows

## Screenshots

![Screenshot 2025-06-09 at 10.43.40 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/33630896-5088-4377-b464-2822339c06a4.png)

![Screenshot 2025-06-09 at 10.43.58 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/1f18cce5-5e25-4492-8db5-b473e24356a7.png)

![Screenshot 2025-06-09 at 10.44.14 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/d1fac486-ce73-4d80-b4e6-0eed2f218fec.png)

![Screenshot 2025-06-09 at 10.44.33 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/8792a49b-f0a0-4373-a7b7-f47a65bb831f.png)

