### PR TITLE
fix: open drawer after adding new form

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -28,13 +28,8 @@ export default function Step(props: StepProps): React.ReactElement | null {
     onClose: onModalClose,
   } = useDisclosure()
 
-  const {
-    allApps,
-    onDrawerClose,
-    onUpdateStep,
-    testExecutionSteps,
-    resetTimestamp,
-  } = useContext(EditorContext)
+  const { allApps, onUpdateStep, testExecutionSteps, resetTimestamp } =
+    useContext(EditorContext)
 
   // This includes all steps that run even after the current step, but within the same branch.
   const stepExecutionsToInclude = useContext(StepExecutionsToIncludeContext)
@@ -62,11 +57,6 @@ export default function Step(props: StepProps): React.ReactElement | null {
     () => generateValidationSchema(substeps),
     [substeps],
   )
-
-  // this ensures that we do not have an empty drawer
-  if (!step.appKey && !step.key) {
-    onDrawerClose()
-  }
 
   if (!allApps) {
     return <CircularProgress isIndeterminate my={2} />

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -140,7 +140,7 @@ export default function ChooseAndAddConnection(
             },
           })
           newStepId = updatedStep.id
-          newStepIndex = updatedStep.position - 1
+          newStepIndex = Math.max(1, updatedStep.position - 1)
         }
         onClose()
       } finally {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -140,7 +140,7 @@ export default function ChooseAndAddConnection(
             },
           })
           newStepId = updatedStep.id
-          newStepIndex = Math.max(1, updatedStep.position - 1)
+          newStepIndex = updatedStep.position - 1
         }
         onClose()
       } finally {

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -10,6 +10,7 @@ export const UPDATE_STEP = graphql(`
       webhookUrl
       parameters
       status
+      position
       connection {
         id
       }


### PR DESCRIPTION
## Problem
BUG: side drawer does not open when adding a new form
* noted in multiple users' pipes
* sample RUM session: https://ogp.datadoghq.com/rum/replay/sessions/de402c74-935f-43f5-9de3-df2c71b0f75b?applicationId=3bd09f62-dad8-4107-a907-1242dda9ee4d&seed=796b2f87-33fc-4ab6-bdcb-752b3509b0f2&ts=1748920230148

## Solution
**Bug Fixes**:
- Return the step position after updating the step

## Other changes
- Removed the unnecessary closure of the side drawer in the Step since it is already handled by the flow step, which shows Add step if the step only has `appKey` and not a `key` (this is for old pipes where users selected the app, but not the event)

## How to test?
- [ ] Create a new Pipe and connect a **NEW** form
  - Or use an existing form, but delete the webhook url in form admin and delete the connection from apps
- [ ] Open an existing Pipe, delete the trigger and connect a **NEW** form
- [ ] Open an existing FormSG step and change the connection
- [ ] Adding a new Step works as expected

## Before & After Screenshots

**BEFORE**:
sample RUM session: https://ogp.datadoghq.com/rum/replay/sessions/de402c74-935f-43f5-9de3-df2c71b0f75b?applicationId=3bd09f62-dad8-4107-a907-1242dda9ee4d&seed=796b2f87-33fc-4ab6-bdcb-752b3509b0f2&ts=1748920230148

**AFTER**:

https://github.com/user-attachments/assets/55ab81f1-a0f1-4bce-84b2-d03d8d9bee2a



