### PR TITLE
PLU-485: add sanitisation for null characters for formsg submission

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -636,4 +636,186 @@ describe('decrypt form response', () => {
       )
     })
   })
+
+  describe('null character sanitisation', () => {
+    it('should handle normal answer field with null characters', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'textField',
+            fieldType: 'text',
+            question: 'What is your name?',
+            answer: 'John\u0000 Tan\u0000',
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            textField: {
+              fieldType: 'text',
+              question: 'What is your name?',
+              answer: 'John Tan',
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle 1D array field answerArray', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'checkboxField',
+            fieldType: 'checkbox',
+            question: 'What are your hobbies?',
+            answerArray: ['reading', 'gaming', 'coding'],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            checkboxField: {
+              fieldType: 'checkbox',
+              question: 'What are your hobbies?',
+              answerArray: ['reading', 'gaming', 'coding'],
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle 2D array field answerArray', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'tableField',
+            fieldType: 'table',
+            question: 'What are your hobbies and when do you do them?',
+            answerArray: [
+              ['reading', 'night'],
+              ['gaming', 'weekend'],
+              ['coding', 'day'],
+            ],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            tableField: {
+              fieldType: 'table',
+              question: 'What are your hobbies and when do you do them?',
+              answerArray: [
+                ['reading', 'night'],
+                ['gaming', 'weekend'],
+                ['coding', 'day'],
+              ],
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle answerArray with null characters', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'checkboxField',
+            fieldType: 'checkbox',
+            question: 'What are your hobbies?',
+            answerArray: [
+              'reading\u0000',
+              '\u0000gaming\u0000',
+              '\u0000coding',
+            ],
+          },
+          {
+            _id: 'tableField',
+            fieldType: 'table',
+            question: 'What are your hobbies and when do you do them?',
+            answerArray: [
+              ['reading\u0000', 'night\u0000'],
+              ['gaming\u0000', 'weekend\u0000\u0000\u0000'],
+            ],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            checkboxField: {
+              fieldType: 'checkbox',
+              question: 'What are your hobbies?',
+              answerArray: ['reading', 'gaming', 'coding'],
+              order: 1,
+            },
+            tableField: {
+              fieldType: 'table',
+              question: 'What are your hobbies and when do you do them?',
+              answerArray: [
+                ['reading', 'night'],
+                ['gaming', 'weekend'],
+              ],
+              order: 2,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle empty answerArray', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'checkboxField',
+            fieldType: 'checkbox',
+            question: 'What are your hobbies?',
+            answerArray: [],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            checkboxField: {
+              fieldType: 'checkbox',
+              question: 'What are your hobbies?',
+              answerArray: [],
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+  })
 })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -114,6 +114,26 @@ export async function decryptFormResponse(
 
     for (const [index, formField] of submission.responses.entries()) {
       const { _id, ...rest } = formField
+      // perform null character sanitisation for all answer fields so that it can be inserted into the DB
+      if (rest.answer) {
+        rest.answer = rest.answer.replaceAll('\u0000', '')
+      }
+
+      if (rest.answerArray && rest.answerArray.length > 0) {
+        // Could be an array of strings (checkbox/address field) or a 2-D array of strings (table field)
+        if (
+          formField.fieldType === 'table' &&
+          Array.isArray(rest.answerArray[0])
+        ) {
+          rest.answerArray = (rest.answerArray as string[][]).map((row) =>
+            row.map((column) => column.replaceAll('\u0000', '')),
+          )
+        } else {
+          rest.answerArray = (rest.answerArray as string[]).map((answer) =>
+            answer.replaceAll('\u0000', ''),
+          )
+        }
+      }
 
       if (rest.fieldType === 'nric' && !!rest.answer) {
         const filteredAnswer = filterNric($, rest.answer)


### PR DESCRIPTION
## Problem

Null characters are not sanitised when the form submission is made and an error is thrown when inserting into our `ExecutionSteps` table DB

## Solution

Replace `\u0000` characters with empty spaces before inserting the data into our DB

## Tests
- [ ] Check that `\u0000` characters are being sanitised for answer fields e.g. short answer, long answer
- [ ] Check that `\u0000` characters are being sanitised for 1D answerArray fields e.g. checkbox, address
- [ ] Check that `\u0000` characters are being sanitised for 2D answerArray fields e.g. table