### PR TITLE
chore: remove postman upload attachment flag

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
@@ -15,7 +15,6 @@ import { reformatToCheckboxVariables } from '../utils'
 
 export function useAttachmentOptions(
   flowData: GetFlowQuery,
-  hideUploadAttachments: boolean,
   priorExecutionSteps: IExecutionStep[],
   variableTypes: TDataOutMetadatumType[] | null,
 ) {
@@ -51,20 +50,14 @@ export function useAttachmentOptions(
 
     return [
       ...filteredVars,
-      !hideUploadAttachments && {
+      {
         id: 'uploaded',
         name: 'Uploaded attachments',
         output: uploadedItems,
         addNew: true,
       },
     ].filter(Boolean) as StepWithVariables[]
-  }, [
-    setOptions,
-    hideUploadAttachments,
-    priorExecutionSteps,
-    uploadedItems,
-    variableTypes,
-  ])
+  }, [setOptions, priorExecutionSteps, uploadedItems, variableTypes])
 
   return {
     options,

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -7,8 +7,6 @@ import { useQuery } from '@apollo/client'
 import { FormControl, useDisclosure, useOutsideClick } from '@chakra-ui/react'
 import { FormErrorMessage, FormLabel } from '@opengovsg/design-system-react'
 
-import { HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG } from '@/config/flags'
-import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { type Variable } from '@/helpers/variables'
@@ -44,15 +42,9 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const wrapperRef = useRef(null)
   const { control, setError, getValues } = useFormContext()
   const [currentTab, setCurrentTab] = useState<number>(0)
-
-  // TODO (kevinkim-ogp): remove this after we confirm that upload is stable
-  const launchDarkly = useContext(LaunchDarklyContext)
-  const hideUploadAttachments =
-    launchDarkly.flags?.[HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG]
+  const [selectedFile, setSelectedFile] = useState<Variable | null>(null)
 
   const flowId = getValues('flowId')
-
-  const [selectedFile, setSelectedFile] = useState<Variable | null>(null)
 
   const {
     isOpen: isDialogOpen,
@@ -102,7 +94,6 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
 
   const { options, suggestions, uploadedItems } = useAttachmentOptions(
     flowData,
-    hideUploadAttachments,
     priorExecutionSteps,
     variableTypes,
   )

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -16,8 +16,6 @@ export const SINGLE_STEP_TEST_KILL_SWITCH = 'single_step_test_kill_switch'
 export const BULK_RETRY_EXECUTIONS_FLAG = 'bulk-retry-failed-executions-v1'
 export const SGID_FEATURE_FLAG = 'sgid-login'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
-export const HIDE_POSTMAN_UPLOAD_ATTACHMENT_FLAG =
-  'hide-postman-upload-attachment'
 
 /**
  * App/events flags


### PR DESCRIPTION
## TL;DR
Removing the Postman upload attachment flag now that the feature is stable.

## How to test?
- [ ] Attachment dropdown still show option to upload attachments
- [ ] Existing email actions with uploaded attachments work as expected
- [ ] New email actions allow uploading of attachments

## Post-release
- [ ] Archive flag on launchdarkly: `hide-postman-upload-attachment`
