### PR TITLE
[FOR-EACH-7]: Bulk retry failed iterations

### DIFF
--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -1,5 +1,6 @@
 import type { MutationResolvers } from './__generated__/types.generated'
 import bulkRetryExecutions from './mutations/bulk-retry-executions'
+import bulkRetryIterations from './mutations/bulk-retry-iterations'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
 import createFlowTransfer from './mutations/create-flow-transfer'
@@ -51,6 +52,7 @@ import verifyOtp from './mutations/verify-otp'
 
 export default {
   bulkRetryExecutions,
+  bulkRetryIterations,
   createConnection,
   generateAuthUrl,
   updateConnection,

--- a/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
@@ -1,17 +1,18 @@
 import { chunk } from 'lodash'
-import { raw } from 'objection'
+import { raw, ref } from 'objection'
 
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import { enqueueActionJob, getActionJob } from '@/queues/action'
+import Context from '@/types/express/context'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
 const CHUNK_SIZE = 100
 
-async function getAllFailedIterations(executionId: string) {
+async function getAllFailedIterations(context: Context, executionId: string) {
   const failedExecutionSteps = await ExecutionStep.query()
     .with('latest_attempts', (builder) => {
       builder
@@ -19,6 +20,12 @@ async function getAllFailedIterations(executionId: string) {
         .select('*')
         .from('execution_steps')
         .where('execution_id', executionId)
+        .whereExists(
+          context.currentUser
+            .$relatedQuery('executions')
+            .select(1)
+            .where('executions.id', ref('execution_steps.execution_id')),
+        )
         .orderBy('step_id')
         .orderBy(raw("metadata->>'iteration'"))
         .orderBy('created_at', 'desc')
@@ -43,12 +50,14 @@ async function getAllFailedIterations(executionId: string) {
 const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
   _parent,
   params,
+  context,
 ) => {
   if (!params.input.executionId) {
     throw new Error('Execution ID is required')
   }
 
   let failedExecutionSteps = await getAllFailedIterations(
+    context,
     params.input.executionId,
   )
 
@@ -57,29 +66,12 @@ const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
    * if there is no job id, we will skip the retry
    */
   failedExecutionSteps = failedExecutionSteps.filter((executionStep) => {
-    const {
-      id: executionStepId,
-      executionId,
-      status,
-      jobId,
-      metadata,
-    } = executionStep
+    const { id: executionStepId, executionId, jobId, metadata } = executionStep
 
     const defaultLoggerMetadata = {
       executionId: executionId,
       executionStepId: executionStepId,
       iteration: metadata.iteration,
-    }
-
-    if (status !== 'failure') {
-      logger.error(
-        'Latest execution step is not failed for a failed execution',
-        {
-          event: 'bulk-retry-iteration-step-status-mismatch',
-          ...defaultLoggerMetadata,
-        },
-      )
-      return false
     }
 
     if (jobId === null || jobId === undefined) {
@@ -88,10 +80,6 @@ const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
         event: 'bulk-retry-iteration-step-no-job-id',
         ...defaultLoggerMetadata,
       })
-      return false
-    }
-
-    if (executionId !== params.input.executionId) {
       return false
     }
 

--- a/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
@@ -192,7 +192,7 @@ const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
           ...defaultLoggerMetadata,
           oldJobData: job.data,
           oldJobId: job.id,
-          newJobId: '123',
+          newJobId: newJob.id,
         })
       } catch (error) {
         logger.error('Bulk retrying iterations - ERROR', {

--- a/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
+++ b/packages/backend/src/graphql/mutations/bulk-retry-iterations.ts
@@ -1,0 +1,237 @@
+import { chunk } from 'lodash'
+import { raw } from 'objection'
+
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import { enqueueActionJob, getActionJob } from '@/queues/action'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const CHUNK_SIZE = 100
+
+async function getAllFailedIterations(executionId: string) {
+  const failedExecutionSteps = await ExecutionStep.query()
+    .with('latest_attempts', (builder) => {
+      builder
+        .distinctOn([raw('step_id'), raw("metadata->>'iteration'")])
+        .select('*')
+        .from('execution_steps')
+        .where('execution_id', executionId)
+        .orderBy('step_id')
+        .orderBy(raw("metadata->>'iteration'"))
+        .orderBy('created_at', 'desc')
+    })
+    .select(
+      'id',
+      'execution_id',
+      'step_id',
+      'status',
+      'job_id',
+      'app_key',
+      'key',
+      'metadata',
+    )
+    .from('latest_attempts')
+    .where('status', '!=', 'success')
+    .withSoftDeleted()
+
+  return failedExecutionSteps
+}
+
+const bulkRetryIterations: MutationResolvers['bulkRetryIterations'] = async (
+  _parent,
+  params,
+) => {
+  if (!params.input.executionId) {
+    throw new Error('Execution ID is required')
+  }
+
+  let failedExecutionSteps = await getAllFailedIterations(
+    params.input.executionId,
+  )
+
+  /**
+   * NOTE: this filters out execution steps that are not failed or have no job id
+   * if there is no job id, we will skip the retry
+   */
+  failedExecutionSteps = failedExecutionSteps.filter((executionStep) => {
+    const {
+      id: executionStepId,
+      executionId,
+      status,
+      jobId,
+      metadata,
+    } = executionStep
+
+    const defaultLoggerMetadata = {
+      executionId: executionId,
+      executionStepId: executionStepId,
+      iteration: metadata.iteration,
+    }
+
+    if (status !== 'failure') {
+      logger.error(
+        'Latest execution step is not failed for a failed execution',
+        {
+          event: 'bulk-retry-iteration-step-status-mismatch',
+          ...defaultLoggerMetadata,
+        },
+      )
+      return false
+    }
+
+    if (jobId === null || jobId === undefined) {
+      // For fresh per-app queues, job ID can be 0.
+      logger.error('Latest execution step does not have a job ID', {
+        event: 'bulk-retry-iteration-step-no-job-id',
+        ...defaultLoggerMetadata,
+      })
+      return false
+    }
+
+    if (executionId !== params.input.executionId) {
+      return false
+    }
+
+    return true
+  })
+
+  // Nothing to do if no steps to retry
+  if (failedExecutionSteps.length === 0) {
+    return {
+      numFailedIterations: 0,
+      allSuccessfullyRetried: true,
+    }
+  }
+
+  // Retry each failed iteration
+  const retryAttempts: PromiseSettledResult<void>[] = []
+  const chunkedIterations = chunk(failedExecutionSteps, CHUNK_SIZE)
+
+  for (const currChunk of chunkedIterations) {
+    const promises = currChunk.map(async (executionStep) => {
+      const {
+        id: executionStepId,
+        executionId,
+        jobId,
+        appKey,
+        metadata,
+      } = executionStep
+
+      const defaultLoggerMetadata = {
+        executionId: executionId,
+        executionStepId: executionStepId,
+        iteration: metadata.iteration,
+      }
+
+      const job = await getActionJob(jobId)
+      if (!job) {
+        // if job cannot be found anymore, remove the job id from the execution step so it cannot be retried again
+        await executionStep.$query().patch({ jobId: null })
+        logger.error('Bulk retrying iteration - no job', {
+          event: 'bulk-retry-iteration-no-job',
+          ...defaultLoggerMetadata,
+          oldJobId: jobId,
+        })
+        throw new Error(
+          `Job for ${executionId}-${executionStepId}-${metadata.iteration} not found or has expired`,
+        )
+      }
+
+      try {
+        const jobState = await job.getState()
+        if (jobState !== 'failed') {
+          logger.warn(
+            `Bulk retrying iteration ${metadata.iteration} - job not failed`,
+            {
+              event: 'bulk-retry-iteration-job-not-failed',
+              ...defaultLoggerMetadata,
+              jobId: jobId,
+              jobState,
+            },
+          )
+          throw new Error(
+            `Job for ${executionId}-${executionStepId}-${metadata.iteration} (JOB: ${jobId}) is not in a failed state`,
+          )
+        }
+      } catch (error) {
+        logger.error('Bulk retrying execution step - job get state error', {
+          event: 'bulk-retry-iteration-job-getstate-error',
+          ...defaultLoggerMetadata,
+          oldJobData: job.data,
+          oldJobId: job.id,
+          error,
+        })
+
+        throw error
+      }
+
+      logger.info('Bulk retrying execution step - start', {
+        event: 'bulk-retry-iteration-start',
+        ...defaultLoggerMetadata,
+        oldJobData: job.data,
+        oldJobId: job.id,
+      })
+
+      try {
+        await job.remove()
+
+        const newJob = await enqueueActionJob({
+          appKey: appKey,
+          jobName: job.name,
+          jobData: job.data,
+          jobOptions: DEFAULT_JOB_OPTIONS,
+        })
+        await Execution.query().findById(executionId).patch({ status: null })
+        await executionStep.$query().patch({ jobId: newJob.id })
+
+        logger.info('Bulk retrying iterations - done', {
+          event: 'bulk-retry-iteration-done',
+          ...defaultLoggerMetadata,
+          oldJobData: job.data,
+          oldJobId: job.id,
+          newJobId: '123',
+        })
+      } catch (error) {
+        logger.error('Bulk retrying iterations - ERROR', {
+          event: 'bulk-retry-iteration-failed',
+          ...defaultLoggerMetadata,
+          oldJobData: job.data,
+          oldJobId: job.id,
+          error,
+        })
+
+        throw error
+      }
+    })
+    const currRetryAttempts = await Promise.allSettled(promises)
+    retryAttempts.push(...currRetryAttempts)
+  }
+
+  const allSuccessfullyRetried = !retryAttempts.find(
+    (attempt) => attempt.status === 'rejected',
+  )
+
+  if (!allSuccessfullyRetried) {
+    // Actually we can do some more processing to see which IDs failed but nvm.
+    logger.warn('Some attempts in bulk iteration retry failed', {
+      event: 'bulk-retry-iteration-some-attempts-failed',
+      executionId: params.input.executionId,
+    })
+  } else {
+    logger.info('Bulk iteration retry succeeded', {
+      event: 'bulk-retry-iteration-success',
+      executionId: params.input.executionId,
+      numRetried: failedExecutionSteps.length,
+    })
+  }
+
+  return {
+    numFailedIterations: failedExecutionSteps.length,
+    allSuccessfullyRetried,
+  }
+}
+
+export default bulkRetryIterations

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -574,7 +574,6 @@ input BulkRetryExecutionsInput {
 }
 
 input BulkRetryIterationsInput {
-  flowId: String!
   executionId: String!
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -91,6 +91,9 @@ type Mutation {
   bulkRetryExecutions(
     input: BulkRetryExecutionsInput
   ): BulkRetryExecutionsResult!
+  bulkRetryIterations(
+    input: BulkRetryIterationsInput
+  ): BulkRetryIterationsResult!
   logout: Boolean
   loginWithSgid(input: LoginWithSgidInput!): LoginWithSgidResult!
   loginWithSelectedSgid(
@@ -416,6 +419,11 @@ type BulkRetryExecutionsResult {
   allSuccessfullyRetried: Boolean!
 }
 
+type BulkRetryIterationsResult {
+  numFailedIterations: Int!
+  allSuccessfullyRetried: Boolean!
+}
+
 input CreateConnectionInput {
   key: String!
   formattedData: JSONObject!
@@ -563,6 +571,11 @@ input RetryPartialStepInput {
 input BulkRetryExecutionsInput {
   flowId: String!
   executionIds: [String!]
+}
+
+input BulkRetryIterationsInput {
+  flowId: String!
+  executionId: String!
 }
 
 """

--- a/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
@@ -5,7 +5,7 @@ import { Flex, Tag } from '@chakra-ui/react'
 
 import { SingleSelect } from '@/components/SingleSelect'
 
-import { RetryAllButton } from '../ExecutionStep/components/RetryAllButton'
+import { RetryAllIterationsButton } from '../ExecutionStep/components/RetryAllIterationsButton'
 import RetryButton from '../ExecutionStep/components/RetryButton'
 
 import { GroupStatusType } from './GroupStatusFilter'
@@ -78,7 +78,6 @@ export default function IterationSelector({
         isClearable={false}
         colorScheme="secondary"
       />
-      {/* TODO: add retry all button */}
       <Flex gap={2}>
         {canRetry && (
           <RetryButton
@@ -87,7 +86,7 @@ export default function IterationSelector({
           />
         )}
         {canRetry && canRetryAll && (
-          <RetryAllButton execution={execution} type="iteration" />
+          <RetryAllIterationsButton execution={execution} />
         )}
       </Flex>
     </Flex>

--- a/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
@@ -1,19 +1,19 @@
-// import { IExecution } from '@plumber/types'
-
-import { IExecutionStep } from '@plumber/types'
+import { IExecution, IExecutionStep } from '@plumber/types'
 
 import { useMemo } from 'react'
 import { Flex, Tag } from '@chakra-ui/react'
 
 import { SingleSelect } from '@/components/SingleSelect'
 
+import { RetryAllButton } from '../ExecutionStep/components/RetryAllButton'
 import RetryButton from '../ExecutionStep/components/RetryButton'
 
-// import { RetryAllButton } from '../ExecutionStep/components/RetryAllButton'
 import { GroupStatusType } from './GroupStatusFilter'
 
 interface IterationSelectorProps {
   iterationMap: Map<number, string>
+  canRetryAll: boolean
+  execution: IExecution
   selectedIteration: string
   setSelectedIteration: (iteration: string) => void
   iterationSteps: IExecutionStep[]
@@ -21,6 +21,8 @@ interface IterationSelectorProps {
 
 export default function IterationSelector({
   iterationMap,
+  canRetryAll,
+  execution,
   selectedIteration,
   setSelectedIteration,
   iterationSteps,
@@ -76,14 +78,18 @@ export default function IterationSelector({
         isClearable={false}
         colorScheme="secondary"
       />
-      {canRetry && (
-        <RetryButton
-          executionStepId={executionStepId}
-          customButtonText="Retry this item"
-        />
-      )}
       {/* TODO: add retry all button */}
-      {/* {canRetryAll && <RetryAllButton execution={execution} type="iteration" />} */}
+      <Flex gap={2}>
+        {canRetry && (
+          <RetryButton
+            executionStepId={executionStepId}
+            customButtonText="Retry this item"
+          />
+        )}
+        {canRetry && canRetryAll && (
+          <RetryAllButton execution={execution} type="iteration" />
+        )}
+      </Flex>
     </Flex>
   )
 }

--- a/packages/frontend/src/components/ExecutionGroup/index.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/index.tsx
@@ -133,6 +133,8 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
             <>
               <IterationSelector
                 iterationMap={iterationMap}
+                canRetryAll={groupStats.failure > 0}
+                execution={execution}
                 selectedIteration={selectedIteration}
                 setSelectedIteration={setSelectedIteration}
                 iterationSteps={iterationSteps}

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -49,14 +49,13 @@ export const RetryAllButton = ({ execution, type }: RetryAllButtonProps) => {
             'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
         }
       } else {
-        if (!flowId || !executionId) {
+        if (!executionId) {
           throw new Error('Flow ID or execution ID is required')
         }
 
         const result = await bulkRetryIterations({
           variables: {
             input: {
-              flowId: flowId,
               executionId: executionId,
             },
           },

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -106,7 +106,7 @@ export const RetryAllButton = ({ execution, type }: RetryAllButtonProps) => {
     >
       {type === 'execution'
         ? 'Retry all failures for this pipe'
-        : 'Retry all failures'}
+        : 'Retry all failed items'}
     </Button>
   )
 }

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -27,6 +27,7 @@ export const RetryAllButton = ({ execution, type }: RetryAllButtonProps) => {
   const [bulkRetryIterations] = useMutation(BULK_RETRY_ITERATIONS)
   const onBulkRetry = useCallback(async () => {
     try {
+      setIsBulkRetrying(true)
       let message = `Plumber has started retrying all ${
         type === 'execution'
           ? 'failures for this pipe'

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -9,35 +9,64 @@ import { Button, Spinner, useToast } from '@opengovsg/design-system-react'
 import { BULK_RETRY_EXECUTIONS_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { BULK_RETRY_EXECUTIONS } from '@/graphql/mutations/bulk-retry-executions'
+import { BULK_RETRY_ITERATIONS } from '@/graphql/mutations/bulk-retry-iterations'
 
 interface RetryAllButtonProps {
   execution: IExecution
+  type?: 'execution' | 'iteration'
 }
 
-export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
+export const RetryAllButton = ({ execution, type }: RetryAllButtonProps) => {
   const flowId = execution.flow?.id
+  const executionId = execution.id
   const { flags } = useContext(LaunchDarklyContext)
   const toast = useToast()
   const [isBulkRetrying, setIsBulkRetrying] = useState(false)
   const [hasBulkRetried, setHasBulkRetried] = useState(false)
   const [bulkRetryExecutions] = useMutation(BULK_RETRY_EXECUTIONS)
-  const onBulkRetryExecutions = useCallback(async () => {
-    setIsBulkRetrying(true)
+  const [bulkRetryIterations] = useMutation(BULK_RETRY_ITERATIONS)
+  const onBulkRetry = useCallback(async () => {
     try {
-      const result = await bulkRetryExecutions({
-        variables: {
-          input: {
-            flowId: flowId ?? '',
+      let message = `Plumber has started retrying all ${
+        type === 'execution'
+          ? 'failures for this pipe'
+          : 'failed items for this execution'
+      } . Please check this page after a while to see updated status.`
+
+      if (type === 'execution') {
+        const result = await bulkRetryExecutions({
+          variables: {
+            input: {
+              flowId: flowId ?? '',
+            },
           },
-        },
-      })
-      let message =
-        'Plumber has started retrying all failures for this pipe. Please check the executions page after a while to see updated status.'
-      if (result.data?.bulkRetryExecutions?.numFailedExecutions === 0) {
-        message = 'Plumber did not find any failed executions to retry.'
-      } else if (!result.data?.bulkRetryExecutions?.allSuccessfullyRetried) {
-        message =
-          'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
+        })
+        if (result.data?.bulkRetryExecutions?.numFailedExecutions === 0) {
+          message = 'Plumber did not find any failed executions to retry.'
+        } else if (!result.data?.bulkRetryExecutions?.allSuccessfullyRetried) {
+          message =
+            'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
+        }
+      } else {
+        if (!flowId || !executionId) {
+          throw new Error('Flow ID or execution ID is required')
+        }
+
+        const result = await bulkRetryIterations({
+          variables: {
+            input: {
+              flowId: flowId,
+              executionId: executionId,
+            },
+          },
+        })
+
+        if (result.data?.bulkRetryIterations?.numFailedIterations === 0) {
+          message = 'Plumber did not find any failed items to retry.'
+        } else if (!result.data?.bulkRetryIterations?.allSuccessfullyRetried) {
+          message =
+            'Plumber was unable to retry some failed items. Please manually retry the failed items.'
+        }
       }
 
       toast({
@@ -51,7 +80,14 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
       setIsBulkRetrying(false)
       setHasBulkRetried(true)
     }
-  }, [flowId, bulkRetryExecutions, toast])
+  }, [
+    type,
+    toast,
+    bulkRetryExecutions,
+    flowId,
+    executionId,
+    bulkRetryIterations,
+  ])
 
   if (!flags?.[BULK_RETRY_EXECUTIONS_FLAG]) {
     return null
@@ -65,9 +101,11 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
       isDisabled={hasBulkRetried}
       spinner={<Spinner fontSize={24} />}
       size="md"
-      onClick={onBulkRetryExecutions}
+      onClick={onBulkRetry}
     >
-      Retry all failures for this pipe
+      {type === 'execution'
+        ? 'Retry all failures for this pipe'
+        : 'Retry all failures'}
     </Button>
   )
 }

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -32,7 +32,7 @@ export const RetryAllButton = ({ execution, type }: RetryAllButtonProps) => {
         type === 'execution'
           ? 'failures for this pipe'
           : 'failed items for this execution'
-      } . Please check this page after a while to see updated status.`
+      }. Please check this page after a while to see updated status.`
 
       if (type === 'execution') {
         const result = await bulkRetryExecutions({

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllIterationsButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllIterationsButton.tsx
@@ -8,36 +8,44 @@ import { Button, Spinner, useToast } from '@opengovsg/design-system-react'
 
 import { BULK_RETRY_EXECUTIONS_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
-import { BULK_RETRY_EXECUTIONS } from '@/graphql/mutations/bulk-retry-executions'
+import { BULK_RETRY_ITERATIONS } from '@/graphql/mutations/bulk-retry-iterations'
 
-interface RetryAllButtonProps {
+interface RetryAllIterationsButtonProps {
   execution: IExecution
 }
 
-export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
-  const flowId = execution.flow?.id
+export const RetryAllIterationsButton = ({
+  execution,
+}: RetryAllIterationsButtonProps) => {
+  const executionId = execution.id
   const { flags } = useContext(LaunchDarklyContext)
   const toast = useToast()
   const [isBulkRetrying, setIsBulkRetrying] = useState(false)
   const [hasBulkRetried, setHasBulkRetried] = useState(false)
-  const [bulkRetryExecutions] = useMutation(BULK_RETRY_EXECUTIONS)
-  const onBulkRetryExecutions = useCallback(async () => {
-    setIsBulkRetrying(true)
+
+  const [bulkRetryIterations] = useMutation(BULK_RETRY_ITERATIONS)
+  const onBulkRetry = useCallback(async () => {
     try {
-      const result = await bulkRetryExecutions({
+      setIsBulkRetrying(true)
+      let message = `Plumber has started retrying all ${'failed items for this execution'}. Please check this page after a while to see updated status.`
+
+      if (!executionId) {
+        throw new Error('Flow ID or execution ID is required')
+      }
+
+      const result = await bulkRetryIterations({
         variables: {
           input: {
-            flowId: flowId ?? '',
+            executionId: executionId,
           },
         },
       })
-      let message =
-        'Plumber has started retrying all failures for this pipe. Please check the executions page after a while to see updated status.'
-      if (result.data?.bulkRetryExecutions?.numFailedExecutions === 0) {
-        message = 'Plumber did not find any failed executions to retry.'
-      } else if (!result.data?.bulkRetryExecutions?.allSuccessfullyRetried) {
+
+      if (result.data?.bulkRetryIterations?.numFailedIterations === 0) {
+        message = 'Plumber did not find any failed items to retry.'
+      } else if (!result.data?.bulkRetryIterations?.allSuccessfullyRetried) {
         message =
-          'Plumber was unable to retry some failed executions. Please manually retry the failed step.'
+          'Plumber was unable to retry some failed items. Please manually retry the failed items.'
       }
 
       toast({
@@ -51,7 +59,7 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
       setIsBulkRetrying(false)
       setHasBulkRetried(true)
     }
-  }, [flowId, bulkRetryExecutions, toast])
+  }, [toast, executionId, bulkRetryIterations])
 
   if (!flags?.[BULK_RETRY_EXECUTIONS_FLAG]) {
     return null
@@ -65,9 +73,9 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
       isDisabled={hasBulkRetried}
       spinner={<Spinner fontSize={24} />}
       size="md"
-      onClick={onBulkRetryExecutions}
+      onClick={onBulkRetry}
     >
-      Retry all failures for this pipe
+      Retry all failed items
     </Button>
   )
 }

--- a/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
@@ -15,7 +15,7 @@ const retryIcon = <Icon boxSize={6} as={BiRedo} />
 
 const RetryButton = ({
   executionStepId,
-  customButtonText = 'Retry',
+  customButtonText,
 }: RetryButtonProps) => {
   const [isRetrySuccessful, setIsRetrySuccessful] = useState<boolean | null>(
     null,
@@ -52,7 +52,7 @@ const RetryButton = ({
         leftIcon={retryIcon}
         onClick={() => retryExecutionStep()}
       >
-        {customButtonText}
+        {customButtonText ?? 'Retry'}
       </Button>
     )
   } else {

--- a/packages/frontend/src/graphql/mutations/bulk-retry-iterations.ts
+++ b/packages/frontend/src/graphql/mutations/bulk-retry-iterations.ts
@@ -1,0 +1,10 @@
+import { graphql } from '../__generated__/gql'
+
+export const BULK_RETRY_ITERATIONS = graphql(`
+  mutation BulkRetryIterations($input: BulkRetryIterationsInput) {
+    bulkRetryIterations(input: $input) {
+      numFailedIterations
+      allSuccessfullyRetried
+    }
+  }
+`)


### PR DESCRIPTION
### TL;DR

Added functionality to retry all failed iterations within a single execution.
This enhances user experience by making it easy to retry failed iterations, instead of opening each failed iteration and clicking the 'retry' button.

### What changed?

- Created a new GraphQL mutation `bulkRetryIterations` that allows retrying all failed iterations within a specific execution
- Added backend implementation to identify and retry failed iterations in chunks
- Enhanced the frontend UI to support retrying all failed iterations from the execution view
- Added a new retry button in the iteration selector component

### How to test?
- Create Pipe with for-each that will throw errors and cause failures
  - [ ] Should see 'Retry all failed items' button
  - [ ] Click on the button and should see toast indicating that Plumber is attempting to retry all failed items
  - [ ] Status on Executions page should reflect correct status
    - Success if all retries passed
    - Failed if any retries failed

### Screenshots

[Screen Recording 2025-06-22 at 4.17.46 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/a782a66c-d79f-42b2-9ae1-c72a132be29d.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/a782a66c-d79f-42b2-9ae1-c72a132be29d.mov)

