### PR TITLE
fix: show all variables in test result

### DIFF
--- a/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
+++ b/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
@@ -1,11 +1,6 @@
 import { IExecutionStep, IJSONObject, IStep } from '@plumber/types'
 
-import {
-  extractVariables,
-  filterVariables,
-  Variable,
-  VISIBLE_VARIABLE_TYPES,
-} from '@/helpers/variables'
+import { extractVariables, Variable } from '@/helpers/variables'
 
 interface UseTestDetailsResult {
   isTestSuccessful: boolean
@@ -28,13 +23,7 @@ export function useTestDetails(
   const lastErrorDetails = currentTestExecutionStep?.errorDetails
 
   const testVariables = currentTestExecutionStep
-    ? filterVariables(
-        extractVariables([currentTestExecutionStep]),
-        (variable) => {
-          const variableType = variable.type ?? 'text'
-          return VISIBLE_VARIABLE_TYPES.includes(variableType)
-        },
-      )[0]?.output ?? []
+    ? extractVariables([currentTestExecutionStep])[0]?.output ?? []
     : null
 
   return {


### PR DESCRIPTION
## Problem
* FormSG attachments are missing from test result
* Caused by mistake during rebase

## Before & After Screenshots

**BEFORE**:
Attachment not visible in form test result
<img width="943" alt="Screenshot 2025-06-13 at 3 47 22 PM" src="https://github.com/user-attachments/assets/87310bef-14d0-47d0-b780-bd1e65c1e0d3" />
<img width="1629" alt="Screenshot 2025-06-13 at 3 47 37 PM" src="https://github.com/user-attachments/assets/940d89ea-b98b-42f9-9bd2-251f99b7bfe7" />


**AFTER**:
Attachment(s) visible in form test result
<img width="1624" alt="Screenshot 2025-06-13 at 3 46 17 PM" src="https://github.com/user-attachments/assets/01a583e1-cc81-42bd-9e50-08deed654f48" />

## How to test?
- [ ] Connect your form with attachments and check step, verify that attachments appear in test result
- [ ] Test results are displayed correctly for all other action types
