### PR TITLE
[FOR-EACH-2.5]: RTE select one variable only

### DIFF
--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -48,6 +48,7 @@ const action: IRawAction = {
         op: 'is_empty',
       },
       variableTypes: ['tile_row_id'],
+      singleVariableSelection: true,
     },
     {
       label: 'Row data',

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -48,7 +48,6 @@ const action: IRawAction = {
         op: 'is_empty',
       },
       variableTypes: ['tile_row_id'],
-      singleVariableSelection: true,
     },
     {
       label: 'Row data',

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -20,6 +20,7 @@ const action: IRawAction = {
       required: true,
       variables: true,
       variableTypes: ['array', 'table'],
+      singleVariableSelection: true,
     },
   ],
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -196,6 +196,9 @@ type ActionSubstepArgument {
   addRowButtonText: String
   tooltipText: String
 
+  # Only for string and multiline
+  singleVariableSelection: Boolean
+
   # Only for dropdown
   addNewOption: DropdownAddNewOption
 

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -137,6 +137,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
           variableTypes={schema.variableTypes}
           parentType={parentType}
           autoFocus={autoFocus}
+          singleVariableSelection={schema.singleVariableSelection}
         />
       )
     }

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -47,6 +47,7 @@ import {
   checkAutoFocus,
   genVariableInfoMap,
   getPopoverPlacement,
+  GLOBAL_VARIABLE_REGEX,
   singleLineEditorScroll,
   substituteOldTemplates,
 } from './utils'
@@ -96,6 +97,7 @@ interface EditorProps {
   variableTypes?: TDataOutMetadatumType[]
   parentType?: string
   autoFocus?: boolean
+  singleVariableSelection?: boolean
 }
 const Editor = ({
   onChange,
@@ -107,6 +109,7 @@ const Editor = ({
   isSingleLine,
   variableTypes,
   parentType,
+  singleVariableSelection,
   autoFocus = false,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
@@ -208,6 +211,12 @@ const Editor = ({
 
   const handleVariableClick = useCallback(
     (variable: Variable) => {
+      if (
+        singleVariableSelection &&
+        editor?.getText().match(GLOBAL_VARIABLE_REGEX)
+      ) {
+        return
+      }
       editor?.commands.insertContent({
         type: StepVariable.name,
         attrs: {
@@ -226,7 +235,7 @@ const Editor = ({
         })
       }
     },
-    [editor, isMulticol],
+    [editor, isMulticol, singleVariableSelection],
   )
 
   const {
@@ -275,7 +284,15 @@ const Editor = ({
                 editable={editable ?? false}
               />
             )}
-            <EditorContent className="editor__content" editor={editor} />
+            <EditorContent
+              className="editor__content"
+              editor={editor}
+              onKeyDown={(e) => {
+                if (singleVariableSelection) {
+                  e.preventDefault()
+                }
+              }}
+            />
             <Portal>
               <PopoverContent
                 w={isMobile ? '100%' : isMulticol ? '55vw' : '100%'}
@@ -318,6 +335,7 @@ interface RichTextEditorProps {
   variableTypes?: TDataOutMetadatumType[]
   parentType?: string
   autoFocus?: boolean
+  singleVariableSelection?: boolean
 }
 const RichTextEditor = ({
   required,
@@ -333,6 +351,7 @@ const RichTextEditor = ({
   variableTypes,
   parentType,
   autoFocus,
+  singleVariableSelection,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -379,6 +398,7 @@ const RichTextEditor = ({
             variableTypes={variableTypes}
             parentType={parentType}
             autoFocus={shouldAutoFocus}
+            singleVariableSelection={singleVariableSelection}
           />
         )}
       />

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -215,6 +215,7 @@ export const GET_APPS = gql`
               label
               type
             }
+            singleVariableSelection
             # Only for multi-row
             subFields {
               label
@@ -253,6 +254,7 @@ export const GET_APPS = gql`
                   value
                 }
               }
+              singleVariableSelection
             }
           }
         }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -349,6 +349,9 @@ export interface IFieldText extends IBaseField {
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
+
+  // To only allow selection of one variable
+  singleVariableSelection?: boolean
 }
 
 export interface IFieldAttachment extends IBaseField {
@@ -364,6 +367,9 @@ export interface IFieldMultiline extends IBaseField {
 
   // Not applicable if field has variables.
   autoComplete?: AutoCompleteValue
+
+  // To only allow selection of one variable
+  singleVariableSelection?: boolean
 }
 
 export interface IFieldMultiSelect extends IBaseField {


### PR DESCRIPTION
### TL;DR

Added `singleVariableSelection` property to restrict variable selection to a single variable in `string` and `multiline` RTE.

### What changed?

- Added a new `singleVariableSelection` property to the schema for string and multiline field types
- Implemented the property in the RichTextEditor component to prevent adding more than one variable when enabled
- Added keyboard event prevention to block typing when a variable is already selected
- Applied this property to specific actions:
  - "Update Row" action in the Tiles app
  - "For Each" action in the Toolbox app

### How to test?

- [ ] Open the "Update Row" action in the Tiles app and verify that the "Row ID" field only allows selecting a single variable
  - [ ] Verify that variable can be deleted using backspace
  - [ ] Verify that Row ID can be pasted in the input when copied from the Tiles page
- [ ] Open the "For Each" action in the Toolbox app and verify that the input field only allows selecting a single variable
  - [ ] Verify that variable can be deleted using backspace
- [ ] Verify that other fields without this property continue to allow multiple variables as before

### Why make this change?
Some action fields are designed to accept a single variable as input rather than a combination of text and variables. This change enforces that constraint in the UI, preventing users from creating invalid configurations that could lead to runtime errors or unexpected behaviour.

### Screenshots
**Tiles row ID**

[Screen Recording 2025-06-16 at 8.49.47 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/cd6b88f6-6aa9-4802-92d9-53272d448154.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/cd6b88f6-6aa9-4802-92d9-53272d448154.mov)

**For-each**

[Screen Recording 2025-06-16 at 8.50.23 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/098e4251-fd65-474f-8701-68ae461882ab.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/098e4251-fd65-474f-8701-68ae461882ab.mov)

