### PR TITLE
[FOR-EACH-9]: Template for for-each

### DIFF
--- a/packages/backend/src/db/storage/for-each-reminder.ts
+++ b/packages/backend/src/db/storage/for-each-reminder.ts
@@ -1,0 +1,117 @@
+import type { ITemplate } from '@plumber/types'
+
+import {
+  CREATE_TEMPLATE_STEP_VARIABLE,
+  TILE_COL_DATA_PLACEHOLDER,
+  TILE_ID_PLACEHOLDER,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
+
+const FOR_EACH_REMINDER_ID = 'b8dd6c22-3578-460d-89e2-e2062b3601f2'
+
+export const FOR_EACH_REMINDER_TEMPLATE: ITemplate = {
+  id: FOR_EACH_REMINDER_ID,
+  name: 'Schedule reminders to a list of emails',
+  description: 'Schedule a recurring reminder to a group of people',
+  iconName: 'BiCalendar',
+  tags: ['new'],
+  // Steps: scheduler --> tiles --> for-each --> postman --> tiles
+  steps: [
+    {
+      position: 1,
+      appKey: 'scheduler',
+      eventKey: 'everyDay',
+      parameters: { hour: '10', triggersOnWeekend: false },
+    },
+    {
+      position: 2,
+      appKey: 'tiles',
+      eventKey: 'findMultipleRows',
+      parameters: {
+        tableId: TILE_ID_PLACEHOLDER,
+        filters: [
+          {
+            columnId: TILE_COL_DATA_PLACEHOLDER('RSVPed'),
+            value: 'Yes',
+            operator: 'equals',
+          },
+          {
+            columnId: TILE_COL_DATA_PLACEHOLDER('Reminder sent'),
+            operator: 'empty',
+          },
+        ],
+        returnLastRowFirst: true,
+      },
+    },
+    {
+      position: 3,
+      appKey: 'toolbox',
+      eventKey: 'forEach',
+      parameters: {
+        items: CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace with rows data from step 2',
+          2,
+        ),
+      },
+    },
+    {
+      position: 4,
+      appKey: 'postman',
+      eventKey: 'sendTransactionalEmail',
+      parameters: {
+        body: '<p style="margin: 0">This is a gentle reminder for the upcoming event! </p>',
+        subject: 'Event reminder',
+        senderName: 'Event reminder',
+        destinationEmail: USER_EMAIL_PLACEHOLDER,
+      },
+    },
+    {
+      position: 5,
+      appKey: 'tiles',
+      eventKey: 'updateSingleRow',
+      parameters: {
+        tableId: TILE_ID_PLACEHOLDER,
+        rowId: CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace with Row ID from Step 3',
+          3,
+        ),
+        rowData: [
+          {
+            columnId: TILE_COL_DATA_PLACEHOLDER('Reminder sent'),
+            cellValue: 'Yes',
+          },
+        ],
+      },
+    },
+  ],
+  tileTemplateData: {
+    name: 'Event Sign ups',
+    columns: ['Name', 'Email', 'Mobile number', 'RSVPed', 'Reminder sent'],
+    rowData: [
+      {
+        Name: 'Anna Lee',
+        Email: 'anna_lee@email.com',
+        'Mobile number': '+6598625072',
+        RSVPed: 'Yes',
+      },
+      {
+        Name: 'Susan Tan Jia Ling',
+        Email: 'susan_tjl@email.com',
+      },
+      {
+        Name: 'Jane Lim',
+        Email: 'jane_98@email.com',
+        RSVPed: 'Yes',
+      },
+      {
+        Name: 'Amy Low',
+        Email: 'amy_low_ll@email.com',
+        RSVPed: 'Yes',
+      },
+      {
+        Name: 'Judy Ng',
+        Email: 'judy_00@email.com',
+      },
+    ],
+  },
+}

--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -1,9 +1,9 @@
 import type { ITemplate } from '@plumber/types'
 
 import { ATTENDANCE_TAKING_TEMPLATE } from './attendance-taking'
+import { FOR_EACH_REMINDER_TEMPLATE } from './for-each-reminder'
 import { GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE } from './get-live-updates-through-telegram'
 import { ROUTE_SUPPORT_ENQUIRIES_TEMPLATE } from './route-support-enquiries'
-import { SCHEDULE_REMINDERS_TEMPLATE } from './schedule-reminders'
 import { SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE } from './send-a-copy-of-form-response'
 import { SEND_FOLLOW_UPS_TEMPLATE } from './send-follow-ups'
 import { SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE } from './send-message-to-a-slack-channel'
@@ -29,7 +29,7 @@ function deepFreeze<T>(object: T): T {
 export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   SEND_FOLLOW_UPS_TEMPLATE, // contains demo video
   SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE,
-  SCHEDULE_REMINDERS_TEMPLATE,
+  FOR_EACH_REMINDER_TEMPLATE,
   TRACK_FEEDBACK_TEMPLATE,
   ATTENDANCE_TAKING_TEMPLATE,
   UPDATE_MAILING_LISTS_TEMPLATE,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -966,6 +966,7 @@ type TemplateStep {
 enum TemplateTagType {
   demo
   empty # for empty flows state
+  new
 }
 
 # End of template types

--- a/packages/frontend/src/pages/Templates/components/TemplateTile.tsx
+++ b/packages/frontend/src/pages/Templates/components/TemplateTile.tsx
@@ -16,6 +16,7 @@ export default function TemplateTile({ template }: TemplateTileProps) {
   const navigate = useNavigate()
 
   const isDemoTemplate = tags?.some((tag) => tag === 'demo')
+  const isNewTemplate = tags?.some((tag) => tag === 'new')
 
   return (
     <Tile
@@ -25,9 +26,9 @@ export default function TemplateTile({ template }: TemplateTileProps) {
         </Box>
       )}
       badge={
-        isDemoTemplate ? (
+        isDemoTemplate || isNewTemplate ? (
           <Badge bg="primary.100" color="primary.500">
-            Demo included
+            {isDemoTemplate ? 'Demo included' : 'New'}
           </Badge>
         ) : undefined
       }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -969,7 +969,7 @@ export interface ITemplate {
 }
 
 // demo template or for empty flows state
-export type TemplateTagType = 'demo' | 'empty'
+export type TemplateTagType = 'demo' | 'empty' | 'new'
 
 export interface ITemplateStep {
   position: number // primary key, no need id for now


### PR DESCRIPTION
### TL;DR

Added a new "For Each Reminder" template to replace the existing "Schedule Reminders" template, with a new tag system to highlight new templates.

### What changed?

- Created a new template file `for-each-reminder.ts` that implements a workflow for scheduling reminders to multiple email recipients
- Updated the template index to use the new template instead of the old `SCHEDULE_REMINDERS_TEMPLATE`
- Added a new template tag type `new` to the GraphQL schema and TypeScript types
- Enhanced the `TemplateTile` component to display a "New" badge for templates with the "new" tag

### How to test?

1. Navigate to the templates page
2. Verify that the "Schedule reminders to a list of emails" template appears with a "New" badge
3. Create a flow using this template and confirm that it correctly:
   - Finds rows in a Tiles table where "RSVPed" is "Yes" and "Reminder sent" is empty
   - Iterates through each row using the forEach toolbox function
   - Sends an email reminder to each person
   - Updates the "Reminder sent" column to "Yes" after sending

### Why make this change?
This change aims to introduce and guide users to set up their for-each actions.

### Screenshots

[Screen Recording 2025-06-17 at 1.22.43 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/bca30412-2437-4ad5-ba93-1dde672049e0.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/bca30412-2437-4ad5-ba93-1dde672049e0.mov)

