### PR TITLE
[REMOCK-2] PLU-471: allow metadata in testRun, formsg testRun support preferMock metadata

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -2,13 +2,30 @@ import {
   IDataOutMetadata,
   IDataOutMetadatum,
   IExecutionStep,
+  IGlobalVariable,
   IJSONObject,
 } from '@plumber/types'
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ADDRESS_LABELS } from '../../common/constants'
 import trigger from '../../triggers/new-submission'
+
+const pushTriggerItemMock = vi.fn()
+const getLastExecutionStepMock = vi.fn()
+
+const mocks = vi.hoisted(() => ({
+  getMockData: vi.fn(),
+  getFormDetailsFromGlobalVariable: vi.fn(),
+}))
+
+vi.mock('../../triggers/new-submission/get-mock-data', () => ({
+  default: mocks.getMockData,
+}))
+
+vi.mock('../../common/webhook-settings', () => ({
+  getFormDetailsFromGlobalVariable: mocks.getFormDetailsFromGlobalVariable,
+}))
 
 describe('new submission trigger', () => {
   let executionStep: IExecutionStep
@@ -42,6 +59,117 @@ describe('new submission trigger', () => {
     } as unknown as IExecutionStep
   })
 
+  describe('testRun', () => {
+    const $ = {
+      auth: { data: { formId: '123' } },
+      user: { email: 'test@test.com' },
+      pushTriggerItem: pushTriggerItemMock,
+      getLastExecutionStep: getLastExecutionStepMock,
+    } as unknown as IGlobalVariable
+
+    const mockData = {
+      formId: '123',
+      responses: {
+        mockTextFieldId: {
+          question: 'What is your name?',
+          answer: 'herp derp',
+        },
+      },
+    }
+
+    const actualData = {
+      formId: '123',
+      responses: {
+        textFieldId: {
+          question: 'What is your age?',
+          answer: 10,
+        },
+      },
+    }
+
+    beforeEach(() => {
+      mocks.getMockData.mockResolvedValue(mockData)
+      mocks.getFormDetailsFromGlobalVariable.mockReturnValue({
+        formId: '123',
+      })
+    })
+
+    afterEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should use mock data if preferMock is true and there is no past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue(null)
+      await trigger.testRun($, { preferMock: true })
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: mockData,
+        meta: {
+          internalId: '',
+        },
+        isMock: true,
+      })
+    })
+
+    it('should use mock data if preferMock is true even though there is past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      await trigger.testRun($, { preferMock: true })
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: mockData,
+        meta: {
+          internalId: '',
+        },
+        isMock: true,
+      })
+    })
+
+    it('should use mock data if testRunMetadata is undefined and there is no past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue(null)
+      await trigger.testRun($, undefined)
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: mockData,
+        meta: {
+          internalId: '',
+        },
+        isMock: true,
+      })
+    })
+
+    it('should use last test submission if testRunMetadata is undefined and there is past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      await trigger.testRun($, undefined)
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: actualData,
+        meta: {
+          internalId: '',
+        },
+        isMock: false,
+      })
+    })
+
+    it('should use last test submission if preferMock is false and there is past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      await trigger.testRun($, { preferMock: false })
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: actualData,
+        meta: {
+          internalId: '',
+        },
+        isMock: false,
+      })
+    })
+
+    it('should use mock data if preferMock is false and there is no past submission', async () => {
+      getLastExecutionStepMock.mockResolvedValue(null)
+      await trigger.testRun($, { preferMock: false })
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: mockData,
+        meta: {
+          internalId: '',
+        },
+        isMock: true,
+      })
+    })
+  })
   describe('dataOut metadata', () => {
     it('ensures that only question, answer and answerArray props are visible', async () => {
       const metadata = await trigger.getDataOutMetadata(executionStep)

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -1,11 +1,21 @@
 import { IGlobalVariable, IRawTrigger } from '@plumber/types'
 
+import { RelatedQueryBuilder } from 'objection'
+import { z } from 'zod'
+
 import StepError from '@/errors/step'
+import ExecutionStep from '@/models/execution-step'
 
 import { getFormDetailsFromGlobalVariable } from '../../common/webhook-settings'
 
 import getDataOutMetadata from './get-data-out-metadata'
 import getMockData from './get-mock-data'
+
+const formsgTestRunMetadataSchema = z
+  .object({
+    preferMock: z.boolean().optional(),
+  })
+  .default({ preferMock: false })
 
 export const NricFilter = {
   None: 'none',
@@ -59,7 +69,7 @@ const trigger: IRawTrigger = {
 
   getDataOutMetadata,
 
-  async testRun($: IGlobalVariable) {
+  async testRun($: IGlobalVariable, testRunMetadata?: { preferMock: boolean }) {
     if (!$.auth.data) {
       throw new StepError(
         'Missing FormSG connection',
@@ -69,28 +79,46 @@ const trigger: IRawTrigger = {
       )
     }
 
+    const testRunMetadataRes =
+      formsgTestRunMetadataSchema.safeParse(testRunMetadata)
+    if (!testRunMetadataRes.success) {
+      throw new StepError(
+        'Something went wrong',
+        'Invalid test run metadata. Please refresh and try again.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
     // data out should never be empty after test step is pressed once: either mock or actual data
     const { formId } = getFormDetailsFromGlobalVariable($)
-    // We use last test execution step
-    const lastTestExecutionStep = await $.getLastExecutionStep({
+    // We use last actual submission test execution step execution step
+    const lastSubmittedTestExecutionStep = await $.getLastExecutionStep({
       testRunOnly: true,
+      additionalFilter: (qb: RelatedQueryBuilder<ExecutionStep>) =>
+        qb.andWhereRaw("(metadata->>'isMock')::boolean IS DISTINCT FROM true"),
     })
-    // If no past submission (no form) or the form is changed, it is a mock run (re-pull mock data)
+
     const hasNoPastSubmission =
-      lastTestExecutionStep?.dataOut?.formId !== formId ||
-      lastTestExecutionStep.metadata.isMock
+      !lastSubmittedTestExecutionStep ||
+      lastSubmittedTestExecutionStep?.dataOut?.formId !== formId
+
+    const shouldUseMockData =
+      hasNoPastSubmission || testRunMetadataRes.data.preferMock
+
+    // if test with mock data is selected OR no past submission exists
+    // we use mock data
+    const testData = shouldUseMockData
+      ? await getMockData($)
+      : lastSubmittedTestExecutionStep?.dataOut
 
     // if different or no form is detected, use mock data
     await $.pushTriggerItem({
-      raw: hasNoPastSubmission
-        ? await getMockData($)
-        : lastTestExecutionStep?.dataOut,
+      raw: testData,
       meta: {
         internalId: '',
       },
-      isMock:
-        hasNoPastSubmission ||
-        (lastTestExecutionStep.metadata?.isMock ?? false), // use previous mock run status from metadata by default
+      isMock: shouldUseMockData,
     })
   },
 }

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -9,7 +9,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
   params,
   context,
 ) => {
-  const { stepId } = params.input
+  const { stepId, testRunMetadata } = params.input
 
   // Just checking for permissions here
   const stepToTest = await context.currentUser
@@ -20,6 +20,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
 
   const { executionStep, executionId } = await testStep({
     stepId: stepToTest.id,
+    testRunMetadata,
   })
 
   // Update flow to use the new test execution

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -475,6 +475,7 @@ input UpdateFlowConfigInput {
 
 input ExecuteStepInput {
   stepId: String!
+  testRunMetadata: JSONObject
 }
 
 input DeleteFlowInput {

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -99,6 +99,7 @@ const globalVariable = async (
         await step?.getLastExecutionStep({
           executionId: options?.sameExecution ? execution.id : undefined,
           testRunOnly: options?.testRunOnly,
+          additionalFilter: options?.additionalFilter,
         })
       )?.toJSON()
     },

--- a/packages/backend/src/models/__tests__/step.itest.ts
+++ b/packages/backend/src/models/__tests__/step.itest.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import Step from '@/models/step'
+
+import Execution from '../execution'
+import Flow from '../flow'
+
+const flowId = randomUUID()
+const stepId = randomUUID()
+const executionIds = [randomUUID(), randomUUID(), randomUUID()]
+const executionStepIds = [randomUUID(), randomUUID(), randomUUID()]
+
+describe('step model', () => {
+  let step: Step
+
+  beforeEach(async () => {
+    await Flow.query().insert({
+      id: flowId,
+      name: 'test flow',
+    })
+    step = await Step.query()
+      .insert({
+        flowId,
+        id: stepId,
+        key: 'new-submission',
+        appKey: 'formsg',
+        type: 'trigger',
+        status: 'incomplete',
+        position: 1,
+        parameters: {},
+      })
+      .returning('*')
+
+    // executionSteps inserted as [real, mock , real]
+    for (let i = 0; i < executionIds.length; i++) {
+      await Execution.query().insertGraph({
+        id: executionIds[i],
+        flowId,
+        status: 'success',
+        testRun: true,
+        executionSteps: [
+          {
+            id: executionStepIds[i],
+            appKey: 'formsg',
+            stepId,
+            status: 'success',
+            dataOut: {
+              a: 1,
+            },
+            metadata: i === 1 ? { isMock: true } : {},
+          },
+        ],
+      })
+    }
+  })
+
+  describe('getLastExecutionStep', () => {
+    it('should return the last test execution step', async () => {
+      const lastExecutionStep = await step.getLastExecutionStep({
+        testRunOnly: true,
+      })
+      expect(lastExecutionStep).toHaveProperty('id', executionStepIds[2])
+    })
+
+    it('should filter out non-test execution steps', async () => {
+      // inserting a non-testrun execution
+      await Execution.query().insertGraph({
+        id: randomUUID(),
+        flowId,
+        status: 'success',
+        testRun: false,
+        executionSteps: [
+          {
+            id: randomUUID(),
+            appKey: 'formsg',
+            stepId,
+            status: 'success',
+            dataOut: {
+              a: 1,
+            },
+            metadata: {},
+          },
+        ],
+      })
+      const lastExecutionStep = await step.getLastExecutionStep({
+        testRunOnly: true,
+      })
+      expect(lastExecutionStep).toHaveProperty('id', executionStepIds[2])
+    })
+
+    it('should return only the corresponding execution step if executionId is provided', async () => {
+      const lastExecutionStep = await step.getLastExecutionStep({
+        executionId: executionIds[1],
+      })
+      expect(lastExecutionStep).toHaveProperty('id', executionStepIds[1])
+    })
+
+    /**
+     * This test is actually to check formsg trigger test run
+     */
+    it('should support additional filter: filter non-mock execution steps i.e. isMock is not set or is false', async () => {
+      // add another mock execution step so that the expected result is not the latest one
+      await Execution.query().insertGraph({
+        id: randomUUID(),
+        flowId,
+        status: 'success',
+        testRun: false,
+        executionSteps: [
+          {
+            id: randomUUID(),
+            appKey: 'formsg',
+            stepId,
+            status: 'success',
+            dataOut: {
+              a: 1,
+            },
+            metadata: {
+              isMock: true,
+            },
+          },
+        ],
+      })
+      const lastExecutionStep = await step.getLastExecutionStep({
+        additionalFilter: (qb) =>
+          qb.andWhereRaw(
+            "(metadata->>'isMock')::boolean IS DISTINCT FROM true",
+          ),
+      })
+      expect(lastExecutionStep).toHaveProperty('id', executionStepIds[2])
+      const newExecutionId = randomUUID()
+      await Execution.query().insertGraph({
+        id: randomUUID(),
+        flowId,
+        status: 'success',
+        testRun: false,
+        executionSteps: [
+          {
+            id: newExecutionId,
+            appKey: 'formsg',
+            stepId,
+            status: 'success',
+            dataOut: {
+              a: 1,
+            },
+            metadata: {
+              isMock: false,
+            },
+          },
+        ],
+      })
+      const lastExecutionStep2 = await step.getLastExecutionStep({
+        additionalFilter: (qb) =>
+          qb.andWhereRaw(
+            "(metadata->>'isMock')::boolean IS DISTINCT FROM true",
+          ),
+      })
+      expect(lastExecutionStep2).toHaveProperty('id', newExecutionId)
+    })
+
+    it('should support additional filter: filter mock execution steps', async () => {
+      const lastExecutionStep = await step.getLastExecutionStep({
+        additionalFilter: (qb) =>
+          qb.andWhereRaw("(metadata->>'isMock')::boolean = true"),
+      })
+      expect(lastExecutionStep).toHaveProperty('id', executionStepIds[1])
+    })
+  })
+})

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,6 +1,10 @@
 import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
 
-import { type StaticHookArguments, ValidationError } from 'objection'
+import {
+  RelatedQueryBuilder,
+  type StaticHookArguments,
+  ValidationError,
+} from 'objection'
 import { URL } from 'url'
 
 import apps from '@/apps'
@@ -123,9 +127,11 @@ class Step extends Base {
   async getLastExecutionStep({
     executionId,
     testRunOnly,
+    additionalFilter,
   }: {
     executionId?: string
     testRunOnly?: boolean
+    additionalFilter?: (qb: RelatedQueryBuilder<ExecutionStep>) => void
   }) {
     const query = this.$relatedQuery('executionSteps')
       .orderBy('created_at', 'desc')
@@ -137,6 +143,9 @@ class Step extends Base {
     }
     if (executionId) {
       query.andWhere('execution_id', executionId)
+    }
+    if (additionalFilter) {
+      additionalFilter(query)
     }
     const lastExecutionStep = await query
     if (lastExecutionStep?.appKey !== this.appKey) {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,4 +1,4 @@
-import { type IActionRunResult, NextStepMetadata } from '@plumber/types'
+import { type IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import HttpError from '@/errors/http'
 import PartialStepError from '@/errors/partial-error'
@@ -17,7 +17,7 @@ type ProcessActionOptions = {
   stepId: string
   jobId?: string
   testRun?: boolean
-  metadata?: NextStepMetadata
+  metadata?: TestRunStepMetadata
 }
 
 export const processAction = async (options: ProcessActionOptions) => {
@@ -27,7 +27,7 @@ export const processAction = async (options: ProcessActionOptions) => {
     executionId,
     jobId,
     testRun = false,
-    metadata,
+    metadata: testRunMetadata,
   } = options
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
@@ -70,8 +70,8 @@ export const processAction = async (options: ProcessActionOptions) => {
     // Cannot assign directly to runResult due to void return type.
     const result =
       testRun && actionCommand.testRun
-        ? await actionCommand.testRun($, metadata)
-        : await actionCommand.run($, metadata)
+        ? await actionCommand.testRun($, testRunMetadata)
+        : await actionCommand.run($)
     if (result) {
       runResult = result
     }
@@ -141,7 +141,6 @@ export const processAction = async (options: ProcessActionOptions) => {
     executionStep,
     computedParameters,
     nextStep,
-    nextStepMetadata: runResult.nextStepMetadata,
     executionError,
   }
 }

--- a/packages/backend/src/services/flow.ts
+++ b/packages/backend/src/services/flow.ts
@@ -1,3 +1,5 @@
+import type { TestRunStepMetadata } from '@plumber/types'
+
 import EarlyExitError from '@/errors/early-exit'
 import HttpError from '@/errors/http'
 import globalVariable from '@/helpers/global-variable'
@@ -6,6 +8,7 @@ import Flow from '@/models/flow'
 type ProcessFlowOptions = {
   flowId: string
   testRun?: boolean
+  testRunMetadata?: TestRunStepMetadata
 }
 
 // TODO(ian): change this function name, it's actually processing trigger
@@ -29,7 +32,7 @@ export const processFlow = async (options: ProcessFlowOptions) => {
   try {
     // why not check if test run here?
     if (triggerCommand.type === 'webhook' && !flow.active) {
-      await triggerCommand.testRun($)
+      await triggerCommand.testRun($, options.testRunMetadata)
     } else {
       await triggerCommand.run($)
     }

--- a/packages/backend/src/services/test-step.ts
+++ b/packages/backend/src/services/test-step.ts
@@ -1,3 +1,5 @@
+import type { TestRunStepMetadata } from '@plumber/types'
+
 import { getTestExecutionSteps } from '@/helpers/get-test-execution-steps'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
@@ -9,6 +11,7 @@ import { processTrigger } from '@/services/trigger'
 
 interface TestStepOptions {
   stepId: string
+  testRunMetadata?: TestRunStepMetadata
 }
 
 interface TestStepResult {
@@ -112,6 +115,7 @@ const testStep = async (options: TestStepOptions): Promise<TestStepResult> => {
     const { data, error: triggerError } = await processFlow({
       flowId: flow.id,
       testRun: true,
+      testRunMetadata: options.testRunMetadata,
     })
 
     const hasTriggerStepFailed = !!triggerError

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,4 +1,4 @@
-import { IJSONObject, ITriggerItem } from '@plumber/types'
+import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
 import logger from '@/helpers/logger'
 import Execution from '@/models/execution'

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -128,21 +128,15 @@ export function makeActionWorker(
           workerVersion: appConfig.version,
         })
 
-        const {
-          flowId,
-          executionId,
-          nextStep,
-          executionStep,
-          nextStepMetadata,
-          executionError,
-        } = await processAction({ ...jobData, jobId }).catch(async (err) => {
-          // This happens when the prerequisite steps for the action fails (e.g.
-          // db error, missing execution, flow, step, etc...) in such cases, we
-          // do not want to retry
-          throw new UnrecoverableError(
-            err.message || 'Action failed to execute',
-          )
-        })
+        const { flowId, executionId, nextStep, executionStep, executionError } =
+          await processAction({ ...jobData, jobId }).catch(async (err) => {
+            // This happens when the prerequisite steps for the action fails (e.g.
+            // db error, missing execution, flow, step, etc...) in such cases, we
+            // do not want to retry
+            throw new UnrecoverableError(
+              err.message || 'Action failed to execute',
+            )
+          })
 
         if (executionStep.isFailed) {
           return handleFailedStepAndThrow({
@@ -168,7 +162,6 @@ export function makeActionWorker(
           flowId,
           executionId,
           stepId: nextStep.id,
-          metadata: nextStepMetadata,
         }
 
         let jobOptions = DEFAULT_JOB_OPTIONS

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -9,6 +9,7 @@ import type {
 import type { JsonArray, JsonObject, JsonPrimitive, JsonValue } from 'type-fest'
 
 import type { JobsProOptions, WorkerProOptions } from '@taskforcesh/bullmq-pro'
+import type { RelatedQueryBuilder } from 'objection'
 
 import HttpError from '@/errors/http'
 
@@ -661,7 +662,10 @@ export interface IBaseTrigger {
   webhookTriggerInstructions?: ITriggerInstructions
   getInterval?(parameters: IStep['parameters']): string
   run?($: IGlobalVariable): Promise<void>
-  testRun?($: IGlobalVariable): Promise<void>
+  testRun?(
+    $: IGlobalVariable,
+    testRunMetadata?: TestRunStepMetadata,
+  ): Promise<void>
   sort?(item: ITriggerItem, nextItem: ITriggerItem): number
 
   /**
@@ -690,14 +694,14 @@ export interface ITrigger extends IBaseTrigger {
 }
 
 // Can add more type in this union later for different action types
-export type NextStepMetadata = Record<string, any>
+export type TestRunStepMetadata = Record<string, any>
 
 export interface IActionJobData {
   flowId: string
   executionId: string
   stepId: string
-  metadata?: NextStepMetadata
 }
+
 export interface IActionRunResult {
   /**
    * This enables actions to control pipe execution flow. This is for actions
@@ -709,7 +713,6 @@ export interface IActionRunResult {
   nextStep?:
     | { command: 'jump-to-step'; stepId: IStep['id'] }
     | { command: 'stop-execution' }
-  nextStepMetadata?: NextStepMetadata
 }
 
 export interface IActionOutput {
@@ -725,13 +728,10 @@ export interface IBaseAction {
   name: string
   key: string
   description: string
-  run?(
-    $: IGlobalVariable,
-    metadata?: NextStepMetadata,
-  ): Promise<IActionRunResult | void>
+  run?($: IGlobalVariable): Promise<IActionRunResult | void>
   testRun?(
     $: IGlobalVariable,
-    metadata?: NextStepMetadata,
+    testRunMetadata?: TestRunStepMetadata,
   ): Promise<IActionRunResult | void>
 
   /**
@@ -831,6 +831,9 @@ export type IGlobalVariable = {
     options?: Partial<{
       sameExecution: boolean
       testRunOnly: boolean
+      additionalFilter?: (
+        qb: RelatedQueryBuilder<ExecutionStep, ExecutionStep>,
+      ) => void
     }>,
   ) => Promise<IExecutionStep | undefined>
   execution?: {


### PR DESCRIPTION
### Summary

`testRun` functions in apps now support an additional param `testRunMetadata`.

FormSG's `testRun` now accepts `preferMock` as part of `testRunMetadata`

### Changes

- FormSG test run pulls last executionStep filtered by 'isMock'
- `getLastExecutionStep` now supports an additional filter to the query builder
- Added integration tests for the Step model's `getLastExecutionStep` method
- Updated GraphQL schema to include `testRunMetadata` in the `ExecuteStepInput`
- Modified the execute-step mutation to pass test run metadata to the test step service

### How to test?

1. Call the `executeStep` mutation directly with
```
{ 
  "stepId": "...",
  "testRunMetadata":  {
     "preferMock": true/false
  }
}

