### PR TITLE
[REMOCK-3] PLU-471: store last test submission date for frontend rendering

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -105,20 +105,25 @@ describe('new submission trigger', () => {
         raw: mockData,
         meta: {
           internalId: '',
+          isMock: true,
+          lastTestSubmissionDate: undefined,
         },
-        isMock: true,
       })
     })
 
     it('should use mock data if preferMock is true even though there is past submission', async () => {
-      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      getLastExecutionStepMock.mockResolvedValue({
+        dataOut: actualData,
+        createdAt: '2025-06-16 07:06:30.155+00',
+      })
       await trigger.testRun($, { preferMock: true })
       expect(pushTriggerItemMock).toHaveBeenCalledWith({
         raw: mockData,
         meta: {
           internalId: '',
+          isMock: true,
+          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
         },
-        isMock: true,
       })
     })
 
@@ -129,32 +134,41 @@ describe('new submission trigger', () => {
         raw: mockData,
         meta: {
           internalId: '',
+          isMock: true,
+          lastTestSubmissionDate: undefined,
         },
-        isMock: true,
       })
     })
 
     it('should use last test submission if testRunMetadata is undefined and there is past submission', async () => {
-      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      getLastExecutionStepMock.mockResolvedValue({
+        dataOut: actualData,
+        createdAt: '2025-06-16 07:06:30.155+00',
+      })
       await trigger.testRun($, undefined)
       expect(pushTriggerItemMock).toHaveBeenCalledWith({
         raw: actualData,
         meta: {
           internalId: '',
+          isMock: false,
+          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
         },
-        isMock: false,
       })
     })
 
     it('should use last test submission if preferMock is false and there is past submission', async () => {
-      getLastExecutionStepMock.mockResolvedValue({ dataOut: actualData })
+      getLastExecutionStepMock.mockResolvedValue({
+        dataOut: actualData,
+        createdAt: '2025-06-16 07:06:30.155+00',
+      })
       await trigger.testRun($, { preferMock: false })
       expect(pushTriggerItemMock).toHaveBeenCalledWith({
         raw: actualData,
         meta: {
           internalId: '',
+          isMock: false,
+          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
         },
-        isMock: false,
       })
     })
 
@@ -165,8 +179,9 @@ describe('new submission trigger', () => {
         raw: mockData,
         meta: {
           internalId: '',
+          isMock: true,
+          lastTestSubmissionDate: undefined,
         },
-        isMock: true,
       })
     })
   })

--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -79,6 +79,7 @@ describe('new submission trigger', () => {
 
     const actualData = {
       formId: '123',
+      submissionTime: '2025-06-17T14:25:14.195+08:00',
       responses: {
         textFieldId: {
           question: 'What is your age?',
@@ -122,7 +123,9 @@ describe('new submission trigger', () => {
         meta: {
           internalId: '',
           isMock: true,
-          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
+          lastTestSubmissionDate: new Date(
+            '2025-06-17T14:25:14.195+08:00',
+          ).toISOString(),
         },
       })
     })
@@ -151,7 +154,9 @@ describe('new submission trigger', () => {
         meta: {
           internalId: '',
           isMock: false,
-          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
+          lastTestSubmissionDate: new Date(
+            '2025-06-17T14:25:14.195+08:00',
+          ).toISOString(),
         },
       })
     })
@@ -167,7 +172,9 @@ describe('new submission trigger', () => {
         meta: {
           internalId: '',
           isMock: false,
-          lastTestSubmissionDate: '2025-06-16 07:06:30.155+00',
+          lastTestSubmissionDate: new Date(
+            '2025-06-17T14:25:14.195+08:00',
+          ).toISOString(),
         },
       })
     })
@@ -181,6 +188,25 @@ describe('new submission trigger', () => {
           internalId: '',
           isMock: true,
           lastTestSubmissionDate: undefined,
+        },
+      })
+    })
+
+    it('should store the createdAt time if submissionTime is not available', async () => {
+      getLastExecutionStepMock.mockResolvedValue({
+        dataOut: { ...actualData, submissionTime: undefined },
+        createdAt: '2025-06-16 07:06:30.155+00',
+      })
+      await trigger.testRun($, { preferMock: false })
+
+      expect(pushTriggerItemMock).toHaveBeenCalledWith({
+        raw: { ...actualData, submissionTime: undefined },
+        meta: {
+          internalId: '',
+          isMock: false,
+          lastTestSubmissionDate: new Date(
+            '2025-06-16 07:06:30.155+00',
+          ).toISOString(),
         },
       })
     })

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -112,9 +112,15 @@ const trigger: IRawTrigger = {
       ? await getMockData($)
       : lastSubmittedTestExecutionStep?.dataOut
 
-    const lastTestSubmissionDate = lastSubmittedTestExecutionStep?.createdAt
-      ? new Date(lastSubmittedTestExecutionStep.createdAt).toISOString()
+    // If for some reason the submission time is not available, use the createdAt time
+    const lastFormSubmissionTime =
+      (lastSubmittedTestExecutionStep?.dataOut?.submissionTime as string) ??
+      lastSubmittedTestExecutionStep?.createdAt
+
+    const lastTestSubmissionDate = lastFormSubmissionTime
+      ? new Date(lastFormSubmissionTime).toISOString()
       : undefined
+
     // if different or no form is detected, use mock data
     await $.pushTriggerItem({
       raw: testData,

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -112,13 +112,17 @@ const trigger: IRawTrigger = {
       ? await getMockData($)
       : lastSubmittedTestExecutionStep?.dataOut
 
+    const lastTestSubmissionDate = lastSubmittedTestExecutionStep?.createdAt
+      ? new Date(lastSubmittedTestExecutionStep.createdAt).toISOString()
+      : undefined
     // if different or no form is detected, use mock data
     await $.pushTriggerItem({
       raw: testData,
       meta: {
         internalId: '',
+        isMock: shouldUseMockData,
+        lastTestSubmissionDate,
       },
-      isMock: shouldUseMockData,
     })
   },
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -320,6 +320,7 @@ type ExecutionStep {
 
 type ExecutionStepMetadata {
   isMock: Boolean
+  lastTestSubmissionDate: String
 }
 
 type Field {

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -41,6 +41,10 @@ class ExecutionStep extends Base {
           isMock: {
             type: 'boolean',
           },
+          // this is purely used to tell frontend that there is a past test submission
+          lastTestSubmissionDate: {
+            type: 'string',
+          },
         },
       },
     },

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -79,6 +79,9 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
     ...(error && { status: 'failure' }),
   })
 
+  // We store all metadata except internalId
+  const { internalId: _, ...metadataToStore } = triggerItem?.meta ?? {}
+
   const executionStep = await execution
     .$relatedQuery('executionSteps')
     .insertAndFetch({
@@ -88,7 +91,7 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
       dataOut: !error ? triggerItem?.raw : null,
       errorDetails: error,
       appKey: step.appKey,
-      metadata: triggerItem?.isMock ? { isMock: true } : {},
+      metadata: metadataToStore ?? {},
     })
 
   return {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -127,6 +127,7 @@ export interface IExecutionStep {
 
 export interface IExecutionStepMetadata {
   isMock?: boolean
+  lastTestSubmissionDate?: string
 }
 
 export interface IExecution {
@@ -633,8 +634,8 @@ export interface ITriggerItem {
   raw: IJSONObject
   meta: {
     internalId: string
+    [key: string]: unknown
   }
-  isMock?: boolean
 }
 
 export type ITriggerInstructions = Partial<{


### PR DESCRIPTION
## Summary

Add lastTestSubmissionTime to formsg execution step metadata. This is to allow the frontend to know if an actual submission exists.

1. Move `isMock` into the metadata object instead of being a separate property
3. Adding `lastTestSubmissionDate` to metadata to track when the last test submission occurred
4. Using the submission time when available, falling back to createdAt when not available

These changes will help the frontend determine if there's a past test submission and display appropriate information to users.

