### PR TITLE
[REMOCK-4] PLU-471: check step again button for formsg

### DIFF
--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -220,7 +220,7 @@ export default function EditorLayout() {
                 value={flow?.name}
                 onSave={onFlowNameUpdate}
                 readOnly={loading}
-                width={isMobile ? '40%' : undefined}
+                width="auto"
               />
             </Flex>
           </Flex>

--- a/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
@@ -1,0 +1,175 @@
+import { IExecutionStepMetadata, IStep } from '@plumber/types'
+
+import { useCallback, useMemo } from 'react'
+import { IconType } from 'react-icons'
+import { BiChevronDown } from 'react-icons/bi'
+import { PiRobot, PiUser } from 'react-icons/pi'
+import {
+  ButtonGroup,
+  Flex,
+  Icon,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+} from '@chakra-ui/react'
+import { Button, IconButton, Menu } from '@opengovsg/design-system-react'
+
+interface CheckAgainButtonProps {
+  isUnstyledInfobox: boolean
+  onClick: (testRunMetadata?: Record<string, unknown>) => void
+  isLoading: boolean
+  isDisabled: boolean
+  step: IStep
+  executionStepMetadata?: IExecutionStepMetadata
+}
+
+export function CheckAgainButton(props: CheckAgainButtonProps) {
+  const { isUnstyledInfobox, onClick, isLoading, isDisabled, step } = props
+  const isFormSgTrigger =
+    step.appKey === 'formsg' && step.key === 'newSubmission'
+  if (isFormSgTrigger) {
+    return <FormSGCheckAgainButton {...props} />
+  }
+  return (
+    <Button
+      variant={isUnstyledInfobox ? 'solid' : 'outline'}
+      onClick={() => onClick()}
+      isLoading={isLoading}
+      colorScheme={isUnstyledInfobox ? 'primary' : 'black'}
+      size="sm"
+      isDisabled={isDisabled}
+    >
+      Check step again
+    </Button>
+  )
+}
+
+/**
+ * For UX reasons, we need to have a different button for FormSG.
+ * The user flow goes like this:
+ * - If user first connects the form, the button should be "Check step again"
+ *   and display only mock data (no dropdown button)
+ * - After the real submission is made, the button should be "Check again with submission"
+ *   and display the dropdown button and real submission data
+ * - If the user clicks on the dropdown button and select "Use mock data",
+ *   the button should still show the dropdown and allow user to toggle between mock and real data
+ */
+
+interface FormSGMenuItemProps {
+  icon: IconType
+  title: string
+  description: string
+  isSelected: boolean
+  onClick: () => void
+}
+
+function FormSGMenuItem({
+  icon,
+  title,
+  description,
+  isSelected,
+  onClick,
+}: FormSGMenuItemProps) {
+  return (
+    <MenuItem
+      display="block"
+      bg={isSelected ? 'primary.50' : undefined}
+      _hover={{
+        bg: 'grey.100',
+      }}
+      onClick={onClick}
+    >
+      <Flex alignItems="center" gap={2}>
+        <Icon as={icon} fontSize={20} mb={0.5} />
+        <Text textStyle="body-1">{title}</Text>
+      </Flex>
+      <Text textStyle="body-2" mt={1} color="secondary.500">
+        {description}
+      </Text>
+    </MenuItem>
+  )
+}
+
+function FormSGCheckAgainButton(props: CheckAgainButtonProps) {
+  const {
+    isUnstyledInfobox: isTransparentInfobox,
+    onClick,
+    isLoading,
+    isDisabled,
+    executionStepMetadata,
+  } = props
+
+  const { isMock = false, lastTestSubmissionDate } = executionStepMetadata ?? {}
+
+  const buttonText = useMemo(() => {
+    if (!lastTestSubmissionDate) {
+      return <Text>Check step again</Text>
+    }
+    if (isMock) {
+      return (
+        <>
+          <Icon as={PiRobot} fontSize={20} mb={0.5} />
+          <Text>Check with mock data</Text>
+        </>
+      )
+    } else {
+      return (
+        <>
+          <Icon as={PiUser} fontSize={20} mb={0.5} />
+          <Text>Check with last submission</Text>
+        </>
+      )
+    }
+  }, [lastTestSubmissionDate, isMock])
+
+  const onTestClick = useCallback(() => {
+    if (!lastTestSubmissionDate) {
+      return onClick
+    }
+    if (isMock) {
+      onClick({ preferMock: true })
+    } else {
+      onClick({ preferMock: false })
+    }
+  }, [lastTestSubmissionDate, isMock, onClick])
+
+  return (
+    <ButtonGroup
+      isAttached
+      isDisabled={isDisabled}
+      size="sm"
+      variant={isTransparentInfobox ? 'solid' : 'outline'}
+      colorScheme={isTransparentInfobox ? 'primary' : 'black'}
+    >
+      <Button onClick={onTestClick} isLoading={isLoading} gap={2}>
+        {buttonText}
+      </Button>
+      {lastTestSubmissionDate && (
+        <Menu gutter={0} colorScheme="grey">
+          <MenuButton
+            as={IconButton}
+            icon={<BiChevronDown />}
+            isLoading={isLoading}
+          />
+          <MenuList maxW="350px">
+            <FormSGMenuItem
+              onClick={() => onClick({ preferMock: true })}
+              icon={PiRobot}
+              title="Use mock data"
+              description="Mock responses will be generated based on your form fields"
+              isSelected={isMock}
+            />
+            <FormSGMenuItem
+              onClick={() => onClick({ preferMock: false })}
+              icon={PiUser}
+              title="Use last submission"
+              description="The last form submission when this pipe is unpublished will be used"
+              isSelected={!isMock}
+            />
+          </MenuList>
+        </Menu>
+      )}
+    </ButtonGroup>
+  )
+}

--- a/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
@@ -39,6 +39,7 @@ export function CheckAgainButton(props: CheckAgainButtonProps) {
       colorScheme={isUnstyledInfobox ? 'primary' : 'black'}
       size="sm"
       isDisabled={isDisabled}
+      data-test="check-again-button"
     >
       Check step again
     </Button>
@@ -125,13 +126,12 @@ function FormSGCheckAgainButton(props: CheckAgainButtonProps) {
 
   const onTestClick = useCallback(() => {
     if (!lastTestSubmissionDate) {
-      return onClick
+      return onClick()
     }
     if (isMock) {
-      onClick({ preferMock: true })
-    } else {
-      onClick({ preferMock: false })
+      return onClick({ preferMock: true })
     }
+    return onClick({ preferMock: false })
   }, [lastTestSubmissionDate, isMock, onClick])
 
   return (
@@ -142,7 +142,12 @@ function FormSGCheckAgainButton(props: CheckAgainButtonProps) {
       variant={isTransparentInfobox ? 'solid' : 'outline'}
       colorScheme={isTransparentInfobox ? 'primary' : 'black'}
     >
-      <Button onClick={onTestClick} isLoading={isLoading} gap={2}>
+      <Button
+        onClick={onTestClick}
+        isLoading={isLoading}
+        gap={2}
+        data-test="formsg-check-again-button"
+      >
         {buttonText}
       </Button>
       {lastTestSubmissionDate && (
@@ -151,6 +156,7 @@ function FormSGCheckAgainButton(props: CheckAgainButtonProps) {
             as={IconButton}
             icon={<BiChevronDown />}
             isLoading={isLoading}
+            data-test="formsg-check-again-button-dropdown"
           />
           <MenuList maxW="350px">
             <FormSGMenuItem

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -84,7 +84,7 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
     return (
       <Box w="100%">
         {isMock && (
-          <Infobox variant="info">
+          <Infobox variant="info" style={{ paddingLeft: '24px' }}>
             <Text>{getMockDataMessage(selectedActionOrTrigger)}</Text>
           </Infobox>
         )}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -5,14 +5,20 @@ import { useFormContext } from 'react-hook-form'
 import { BiChevronDown, BiChevronUp } from 'react-icons/bi'
 import {
   Box,
-  Grid,
-  GridItem,
+  Flex,
   HStack,
+  Icon,
   Text,
   Tooltip,
   VStack,
 } from '@chakra-ui/react'
-import { Button, Infobox } from '@opengovsg/design-system-react'
+import {
+  Button,
+  BxsCheckCircle,
+  BxsErrorCircle,
+  BxsInfoCircle,
+  Infobox,
+} from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { validateStepParams } from '@/helpers/validateStepParams'
@@ -22,6 +28,7 @@ import { EDITOR_MARGIN_TOP_NUM } from '../Editor/constants'
 import ErrorResult from '../ErrorResult'
 import WebhookUrlInfo from '../WebhookUrlInfo'
 
+import { CheckAgainButton } from './CheckAgainButton'
 import { flowStepTestControllerStyles } from './styles'
 import TestResult from './TestResult'
 import { useTestDetails } from './useTestDetails'
@@ -40,7 +47,7 @@ interface FlowStepTestControllerProps {
   step: IStep
   hasDeletedVars: boolean
   handleSave: () => void
-  handleSaveAndTest: () => void
+  handleSaveAndTest: (testRunMetadata?: Record<string, unknown>) => void
   onTestResultOpen: () => void
   onTestResultClose: () => void
 }
@@ -91,7 +98,6 @@ export default function FlowStepTestController(
     allApps,
     currentTestExecutionStep,
     readOnly,
-    isMobile,
     isTestExecuting,
     testExecutionSteps,
     varInfoMap,
@@ -133,6 +139,26 @@ export default function FlowStepTestController(
     stepId: step.id,
     testVariables,
   })
+
+  const infoBoxIcon = useMemo(() => {
+    const props = {
+      fontSize: '2xl',
+      marginRight: 1,
+      display: 'flex',
+    }
+    if (infoBoxVariant === 'unstyled') {
+      return <></>
+    }
+    if (infoBoxVariant === 'error') {
+      return <Icon as={BxsErrorCircle} color="red.500" {...props} />
+    }
+    if (infoBoxVariant === 'success') {
+      return <Icon as={BxsCheckCircle} color="green.500" {...props} />
+    }
+    return <Icon as={BxsInfoCircle} color="blue.500" {...props} />
+  }, [infoBoxVariant])
+
+  const isStepUnchecked = infoBoxVariant === 'unstyled'
 
   const { shouldTestStepAgain } = useMemo(() => {
     return validateStepParams(step, testExecutionSteps, substeps)
@@ -201,42 +227,6 @@ export default function FlowStepTestController(
     return collapseDirection === 'up' ? <BiChevronUp /> : <BiChevronDown />
   }
 
-  const CheckAgainButton = useMemo(
-    () => (
-      <CheckStepTooltip
-        hasDeletedVars={hasDeletedVars}
-        isDisabled={isValid && !readOnly}
-        isReadOnly={readOnly}
-      >
-        <Button
-          variant={
-            infoBoxVariant === 'unstyled'
-              ? undefined
-              : isMobile
-              ? 'outline'
-              : 'clear'
-          }
-          onClick={handleSaveAndTest}
-          isLoading={isTestExecuting}
-          colorScheme={infoBoxVariant === 'unstyled' ? 'primary' : 'black'}
-          size="sm"
-          isDisabled={!isValid || readOnly}
-        >
-          <Text noOfLines={1}>Check step again</Text>
-        </Button>
-      </CheckStepTooltip>
-    ),
-    [
-      handleSaveAndTest,
-      hasDeletedVars,
-      infoBoxVariant,
-      isTestExecuting,
-      isValid,
-      readOnly,
-      isMobile,
-    ],
-  )
-
   return (
     <>
       {isWebhookSubstep && (
@@ -258,93 +248,93 @@ export default function FlowStepTestController(
       >
         {shouldShowTestResults ? (
           <VStack w="100%">
-            <HStack w="100%">
-              <Infobox
-                {...flowStepTestControllerStyles.testedInfobox}
-                variant={infoBoxVariant}
-                borderBottomRadius={isTestResultOpen ? 0 : undefined}
-                icon={infoBoxVariant === 'unstyled' ? <></> : null}
+            <Infobox
+              position="relative"
+              {...flowStepTestControllerStyles.testedInfobox}
+              variant={infoBoxVariant}
+              borderBottomRadius={isTestResultOpen ? 0 : undefined}
+              icon={<></>}
+            >
+              <Flex
+                justifyContent="space-between"
+                alignItems={{ base: 'flex-start', lg: 'center' }}
+                flexDirection={{ base: 'column', lg: 'row' }}
+                gap={{ base: 2, lg: 1 }}
+                flex={1}
+                maxW="100%"
               >
-                <Grid
-                  justifyContent="space-between"
-                  alignItems="center"
-                  w="100%"
-                  templateAreas={{
-                    base: `
-                      "test-result"
-                      "save-button"
-                      "check-button"
-                    `,
-                    md: `"test-result save-button check-button"`,
-                  }}
-                  gridTemplateColumns={{
-                    base: '1fr',
-                    md: '1fr auto auto',
-                  }}
-                  rowGap={2}
-                >
-                  <GridItem area="test-result">
-                    {isIfThenStep && isLastTestExecutionCurrent ? (
-                      // NOTE: special handling for If-then
-                      // do not need button as there are no variables to display
-                      <Text>{infoBoxText}</Text>
-                    ) : (
-                      <Button
-                        variant="clear"
-                        colorScheme={
-                          infoBoxVariant === 'unstyled' ? 'black' : 'green'
-                        }
-                        px={2}
-                        ml={infoBoxVariant === 'unstyled' ? -1 : -0.5}
-                        size="sm"
-                        onClick={() =>
-                          isTestResultOpen
-                            ? onTestResultClose()
-                            : onTestResultOpen()
-                        }
-                        isDisabled={isTestExecuting}
-                      >
-                        <Text
-                          color="base.content.default"
-                          noOfLines={1}
-                          textAlign="left"
-                        >
-                          {infoBoxText}
-                        </Text>
-                        {!isTestExecuting && (
-                          <Box ml={2} color="base.content.default">
-                            {getChevronIcon()}
-                          </Box>
-                        )}
-                      </Button>
-                    )}
-                  </GridItem>
-                  {shouldShowSaveButton ? (
-                    <>
-                      <GridItem area="save-button">
-                        <Button
-                          variant={isMobile ? 'outline' : 'clear'}
-                          size="sm"
-                          colorScheme="black"
-                          onClick={handleSave}
-                          isDisabled={!isDirty}
-                          mr={2}
-                        >
-                          <Text noOfLines={1}>
-                            {!isDirty ? 'Saved' : 'Save without checking'}
-                          </Text>
-                        </Button>
-                      </GridItem>
-                      <GridItem area="check-button">
-                        {CheckAgainButton}
-                      </GridItem>
-                    </>
+                <Flex alignItems="center" flex={1}>
+                  {infoBoxIcon}
+                  {isIfThenStep && isLastTestExecutionCurrent ? (
+                    // NOTE: special handling for If-then
+                    // do not need button as there are no variables to display
+                    <Text>{infoBoxText}</Text>
                   ) : (
-                    <GridItem area="check-button">{CheckAgainButton}</GridItem>
+                    <Button
+                      variant="clear"
+                      colorScheme={isStepUnchecked ? 'black' : 'green'}
+                      px={2}
+                      size="sm"
+                      flexShrink={1}
+                      onClick={() =>
+                        isTestResultOpen
+                          ? onTestResultClose()
+                          : onTestResultOpen()
+                      }
+                      isDisabled={isTestExecuting}
+                    >
+                      <Text
+                        color="base.content.default"
+                        noOfLines={1}
+                        textAlign="left"
+                      >
+                        {infoBoxText}
+                      </Text>
+                      {!isTestExecuting && (
+                        <Box ml={2} color="base.content.default">
+                          {getChevronIcon()}
+                        </Box>
+                      )}
+                    </Button>
                   )}
-                </Grid>
-              </Infobox>
-            </HStack>
+                </Flex>
+                {shouldShowSaveButton ? (
+                  <Flex>
+                    <Button
+                      variant="outline"
+                      // cant use responsive value for variant for some reason
+                      // so we have to use borderWidth instead
+                      borderWidth={{ base: '1px', lg: 0 }}
+                      size="sm"
+                      colorScheme="black"
+                      onClick={handleSave}
+                      isDisabled={!isDirty}
+                      mr={2}
+                      w="auto"
+                    >
+                      {!isDirty ? 'Saved' : 'Save without checking'}
+                    </Button>
+                    <CheckAgainButton
+                      isUnstyledInfobox={isStepUnchecked}
+                      onClick={handleSaveAndTest}
+                      isLoading={isTestExecuting}
+                      isDisabled={!isValid || readOnly}
+                      step={step}
+                      executionStepMetadata={currentTestExecutionStep?.metadata}
+                    />
+                  </Flex>
+                ) : (
+                  <CheckAgainButton
+                    isUnstyledInfobox={isStepUnchecked}
+                    onClick={handleSaveAndTest}
+                    isLoading={isTestExecuting}
+                    isDisabled={!isValid || readOnly}
+                    step={step}
+                    executionStepMetadata={currentTestExecutionStep?.metadata}
+                  />
+                )}
+              </Flex>
+            </Infobox>
             <TestResult
               step={step}
               selectedActionOrTrigger={selectedActionOrTrigger}
@@ -378,7 +368,7 @@ export default function FlowStepTestController(
                 isReadOnly={readOnly}
               >
                 <Button
-                  onClick={handleSaveAndTest}
+                  onClick={() => handleSaveAndTest()}
                   data-test="flow-substep-continue-button"
                   isDisabled={!shouldAllowCheckStep}
                   isLoading={isTestExecuting}

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -130,13 +130,16 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     })
   }, [saveStep, toast])
 
-  const handleSaveAndTest = useCallback(async () => {
-    await saveStep()
-    await executeTestStep()
-    if (!isIfThenStep(step)) {
-      onTestResultOpen()
-    }
-  }, [saveStep, executeTestStep, step, onTestResultOpen])
+  const handleSaveAndTest = useCallback(
+    async (testRunMetadata?: Record<string, unknown>) => {
+      await saveStep()
+      await executeTestStep(testRunMetadata)
+      if (!isIfThenStep(step)) {
+        onTestResultOpen()
+      }
+    },
+    [saveStep, executeTestStep, step, onTestResultOpen],
+  )
 
   return (
     <Box position="relative" display="flex" flexDirection="column">

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -41,7 +41,7 @@ interface IEditorContextValue {
   shouldWarnOnLeave: boolean
   stepsWithVars: StepWithVariables[]
   varInfoMap: VariableInfoMap
-  executeTestStep: () => Promise<void>
+  executeTestStep: (testRunMetadata?: Record<string, unknown>) => Promise<void>
   onDrawerOpen: () => void
   onDrawerClose: () => void
   setCurrentStepId: (stepId: string | null) => void
@@ -332,19 +332,23 @@ export const EditorProvider = ({
     },
   )
 
-  const executeTestStep = useCallback(async () => {
-    try {
-      await executeStep({
-        variables: {
-          input: {
-            stepId: currentStepId,
+  const executeTestStep = useCallback(
+    async (testRunMetadata?: Record<string, unknown>) => {
+      try {
+        await executeStep({
+          variables: {
+            input: {
+              stepId: currentStepId,
+              testRunMetadata,
+            },
           },
-        },
-      })
-    } catch (e) {
-      console.error(e)
-    }
-  }, [executeStep, currentStepId])
+        })
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [executeStep, currentStepId],
+  )
 
   // Force the Form to remount by changing its key when discarding changes
   const resetForm = useCallback(() => {

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -30,6 +30,7 @@ export const GET_TEST_EXECUTION_STEPS = gql`
       errorDetails
       metadata {
         isMock
+        lastTestSubmissionDate
       }
     }
   }


### PR DESCRIPTION
## Summary

Frontend implementation for FormSG check step
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/ycT2Xb5nBEjN2kf2gy95/762dd4b7-86be-4351-9858-38b0f3b37dab.png)

### What changed?

- Created a new `CheckAgainButton` component that provides specialized functionality for FormSG triggers (hardcoded for formsg for now)


### How to test?

1. Connect a fresh form
2. Click "Check step"
3. Verify that the "Check step again" button appears initially
4. After making a test submission, click on "Check step again"
5. Verify that the button text changes to "Check with last submission"
6. Test toggling between mock and real data using the dropdown menu
7. Verify that the UI is responsive on both desktop and mobile views
8. Verify that actual submission when the pipe is published is not shown here.
