### PR TITLE
[FIND-MULTIPLE-ROWS-7]: Update to multirow-multicol

### DIFF
--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -2,16 +2,15 @@ import { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
-import {
-  getTableRows,
-  TableRowFilter,
-  TableRowFilterOperator,
-} from '@/models/dynamodb/table-row'
+import { getTableRows, TableRowFilter } from '@/models/dynamodb/table-row'
 import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
-import { FIND_MULTIPLE_ROWS_LIMIT } from '../../common/constants'
+import {
+  FIND_MULTIPLE_ROWS_LIMIT,
+  LOOKUP_CONDITIONS_SUBFIELDS,
+} from '../../common/constants'
 import { validateFilters } from '../../common/validate-filters'
 import { FindMultipleRowsOutput, TileColumnMetadata } from '../../types'
 
@@ -45,78 +44,13 @@ const action: IRawAction = {
       description:
         'Only the first 500 rows that meet the conditions will be returned',
       key: 'filters',
-      type: 'multirow' as const,
+      type: 'multirow-multicol' as const,
       required: true,
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',
       },
-      subFields: [
-        {
-          placeholder: 'Column',
-          key: 'columnId',
-          type: 'dropdown' as const,
-          required: true,
-          variables: false,
-          showOptionValue: false,
-          source: {
-            type: 'query' as const,
-            name: 'getDynamicData' as const,
-            arguments: [
-              {
-                name: 'key',
-                value: 'listColumns',
-              },
-              {
-                name: 'parameters.tableId',
-                value: '{parameters.tableId}',
-              },
-            ],
-          },
-        },
-        {
-          placeholder: 'Condition',
-          key: 'operator',
-          type: 'dropdown' as const,
-          required: true,
-          variables: false,
-          showOptionValue: false,
-          options: [
-            { label: 'Equals to', value: TableRowFilterOperator.Equals },
-            {
-              label: 'Greater than ',
-              value: TableRowFilterOperator.GreaterThan,
-            },
-            {
-              label: 'Greater than or equals to',
-              value: TableRowFilterOperator.GreaterThanOrEquals,
-            },
-            { label: 'Less than', value: TableRowFilterOperator.LessThan },
-            {
-              label: 'Less than or equals to',
-              value: TableRowFilterOperator.LessThanOrEquals,
-            },
-            { label: 'Begins with', value: TableRowFilterOperator.BeginsWith },
-            { label: 'Contains', value: TableRowFilterOperator.Contains },
-            {
-              label: 'Is empty',
-              value: TableRowFilterOperator.IsEmpty,
-            },
-          ],
-        },
-        {
-          placeholder: 'Value',
-          key: 'value',
-          type: 'string' as const,
-          required: true,
-          variables: true,
-          hiddenIf: {
-            fieldKey: 'operator',
-            op: 'equals',
-            fieldValue: TableRowFilterOperator.IsEmpty,
-          },
-        },
-      ],
+      subFields: LOOKUP_CONDITIONS_SUBFIELDS,
     },
     {
       label: 'Order of rows',

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -6,12 +6,12 @@ import {
   getRawRowById,
   getTableRows,
   TableRowFilter,
-  TableRowFilterOperator,
 } from '@/models/dynamodb/table-row'
 import Step from '@/models/step'
 import TableCollaborator from '@/models/table-collaborators'
 import TableColumnMetadata from '@/models/table-column-metadata'
 
+import { LOOKUP_CONDITIONS_SUBFIELDS } from '../../common/constants'
 import { validateFilters } from '../../common/validate-filters'
 import { FindSingleRowOutput } from '../../types'
 
@@ -51,75 +51,7 @@ const action: IRawAction = {
         fieldKey: 'tableId',
         op: 'is_empty',
       },
-      subFields: [
-        {
-          placeholder: 'Column',
-          key: 'columnId',
-          type: 'dropdown' as const,
-          required: true,
-          variables: false,
-          showOptionValue: false,
-          source: {
-            type: 'query' as const,
-            name: 'getDynamicData' as const,
-            arguments: [
-              {
-                name: 'key',
-                value: 'listColumns',
-              },
-              {
-                name: 'parameters.tableId',
-                value: '{parameters.tableId}',
-              },
-            ],
-          },
-          customStyle: { flex: 1 },
-        },
-        {
-          placeholder: 'Condition',
-          key: 'operator',
-          type: 'dropdown' as const,
-          required: true,
-          variables: false,
-          showOptionValue: false,
-          options: [
-            { label: 'Equals to', value: TableRowFilterOperator.Equals },
-            {
-              label: 'Greater than ',
-              value: TableRowFilterOperator.GreaterThan,
-            },
-            {
-              label: 'Greater than or equals to',
-              value: TableRowFilterOperator.GreaterThanOrEquals,
-            },
-            { label: 'Less than', value: TableRowFilterOperator.LessThan },
-            {
-              label: 'Less than or equals to',
-              value: TableRowFilterOperator.LessThanOrEquals,
-            },
-            { label: 'Begins with', value: TableRowFilterOperator.BeginsWith },
-            { label: 'Contains', value: TableRowFilterOperator.Contains },
-            {
-              label: 'Is empty',
-              value: TableRowFilterOperator.IsEmpty,
-            },
-          ],
-          customStyle: { flex: 1 },
-        },
-        {
-          placeholder: 'Value',
-          key: 'value',
-          type: 'string' as const,
-          required: true,
-          variables: true,
-          hiddenIf: {
-            fieldKey: 'operator',
-            op: 'equals',
-            fieldValue: TableRowFilterOperator.IsEmpty,
-          },
-          customStyle: { flex: 2, minWidth: 0, maxWidth: '50%' },
-        },
-      ],
+      subFields: LOOKUP_CONDITIONS_SUBFIELDS,
     },
     {
       label: 'Return most recent row instead?',

--- a/packages/backend/src/apps/tiles/common/constants.ts
+++ b/packages/backend/src/apps/tiles/common/constants.ts
@@ -1,1 +1,75 @@
+import { IFieldVisibilityCondition } from '@plumber/types'
+
+import { TableRowFilterOperator } from '@/models/dynamodb/table-row'
+
 export const FIND_MULTIPLE_ROWS_LIMIT = 500
+
+export const LOOKUP_CONDITIONS_SUBFIELDS = [
+  {
+    placeholder: 'Column',
+    key: 'columnId',
+    type: 'dropdown' as const,
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    source: {
+      type: 'query' as const,
+      name: 'getDynamicData' as const,
+      arguments: [
+        {
+          name: 'key',
+          value: 'listColumns',
+        },
+        {
+          name: 'parameters.tableId',
+          value: '{parameters.tableId}',
+        },
+      ],
+    },
+    customStyle: { flex: 1 },
+  },
+  {
+    placeholder: 'Condition',
+    key: 'operator',
+    type: 'dropdown' as const,
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: [
+      { label: 'Equals to', value: TableRowFilterOperator.Equals },
+      {
+        label: 'Greater than ',
+        value: TableRowFilterOperator.GreaterThan,
+      },
+      {
+        label: 'Greater than or equals to',
+        value: TableRowFilterOperator.GreaterThanOrEquals,
+      },
+      { label: 'Less than', value: TableRowFilterOperator.LessThan },
+      {
+        label: 'Less than or equals to',
+        value: TableRowFilterOperator.LessThanOrEquals,
+      },
+      { label: 'Begins with', value: TableRowFilterOperator.BeginsWith },
+      { label: 'Contains', value: TableRowFilterOperator.Contains },
+      {
+        label: 'Is empty',
+        value: TableRowFilterOperator.IsEmpty,
+      },
+    ],
+    customStyle: { flex: 1 },
+  },
+  {
+    placeholder: 'Value',
+    key: 'value',
+    type: 'string' as const,
+    required: true,
+    variables: true,
+    hiddenIf: {
+      fieldKey: 'operator',
+      op: 'equals',
+      fieldValue: TableRowFilterOperator.IsEmpty,
+    } as IFieldVisibilityCondition,
+    customStyle: { flex: 2, minWidth: 0, maxWidth: '50%' },
+  },
+]


### PR DESCRIPTION
### TL;DR
Refactor Tiles multiple row lookup conditions to 'multirow-multicol'.

### What changed?
- Changed `find-multiple-rows` from `multirow` to `multirow-multicol`
- Created a new constant `LOOKUP_CONDITIONS_SUBFIELDS` in `constants.ts` that contains the shared filter condition configuration
- Updated the `find-multiple-rows` action to use the new constant instead of inline subfields
- Updated the `find-single-row` action to use the same shared constant


### How to test?

1. Verify that the "Find Multiple Rows" action still displays the correct filter conditions
2. Verify that the "Find Single Row" action still displays the correct filter conditions
3. Confirm that all filter operations (equals, greater than, contains, etc.) work as expected in both actions
