### PR TITLE
chore: use step name in suggestions popover

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
@@ -1,7 +1,8 @@
 import { IExecutionStep, TDataOutMetadatumType } from '@plumber/types'
 
-import { useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { GetFlowQuery } from '@/graphql/__generated__/graphql'
 import {
   extractVariables,
@@ -19,6 +20,7 @@ export function useAttachmentOptions(
   priorExecutionSteps: IExecutionStep[],
   variableTypes: TDataOutMetadatumType[] | null,
 ) {
+  const { allApps } = useContext(EditorContext)
   const [options, setOptions] = useState<CheckboxVariable[]>([])
 
   const uploadedItems = useMemo(() => {
@@ -29,7 +31,7 @@ export function useAttachmentOptions(
 
   const suggestions = useMemo(() => {
     const filteredVars = filterVariables(
-      extractVariables(priorExecutionSteps),
+      extractVariables(priorExecutionSteps, allApps),
       (v: Variable) => {
         const variableType = v.type ?? 'text'
         return variableTypes?.includes(variableType) ?? false
@@ -59,10 +61,10 @@ export function useAttachmentOptions(
       },
     ].filter(Boolean) as StepWithVariables[]
   }, [
-    setOptions,
-    hideUploadAttachments,
     priorExecutionSteps,
+    allApps,
     uploadedItems,
+    hideUploadAttachments,
     variableTypes,
   ])
 

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -75,7 +75,7 @@ function ControlledAutocomplete(
     isSearchable,
     variableTypes = null,
   } = props
-  const { readOnly } = useContext(EditorContext)
+  const { allApps, readOnly } = useContext(EditorContext)
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
   /**
@@ -83,10 +83,14 @@ function ControlledAutocomplete(
    */
   const items = useMemo(() => {
     if (variableTypes) {
-      return extractVariablesAsItems(priorExecutionSteps, variableTypes)
+      return extractVariablesAsItems(
+        priorExecutionSteps,
+        variableTypes,
+        allApps,
+      )
     }
     return formComboboxOptions(options, showOptionValue)
-  }, [variableTypes, options, showOptionValue, priorExecutionSteps])
+  }, [variableTypes, options, showOptionValue, priorExecutionSteps, allApps])
 
   // Do not support freeSolo if there are numerical options. Since no use case
   // for it yet and it makes things more complex.

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -110,7 +110,7 @@ export default function FlowStepTestController(
     lastErrorDetails,
     isWebhookSubstep,
     testVariables,
-  } = useTestDetails(step, currentTestExecutionStep)
+  } = useTestDetails(step, currentTestExecutionStep, allApps)
   const containerRef = useRef<HTMLDivElement>(null)
   const webhookUrlInfoRef = useRef<HTMLDivElement>(null)
   const [collapseDirection, setCollapseDirection] = useState<'up' | 'down'>(

--- a/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
+++ b/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
@@ -1,4 +1,4 @@
-import { IExecutionStep, IJSONObject, IStep } from '@plumber/types'
+import { IApp, IExecutionStep, IJSONObject, IStep } from '@plumber/types'
 
 import { extractVariables, Variable } from '@/helpers/variables'
 
@@ -14,6 +14,7 @@ interface UseTestDetailsResult {
 export function useTestDetails(
   step: IStep,
   currentTestExecutionStep: IExecutionStep | null,
+  allApps: IApp[],
 ): UseTestDetailsResult {
   const isWebhookSubstep =
     step.appKey === 'webhook' && Boolean(step?.webhookUrl)
@@ -34,7 +35,7 @@ export function useTestDetails(
   const lastErrorDetails = currentTestExecutionStep?.errorDetails
 
   const testVariables = currentTestExecutionStep
-    ? extractVariables([currentTestExecutionStep])[0]?.output ?? []
+    ? extractVariables([currentTestExecutionStep], allApps)[0]?.output ?? []
     : null
 
   return {

--- a/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
+++ b/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
@@ -1,4 +1,8 @@
-import type { IExecutionStep, TDataOutMetadatumType } from '@plumber/types'
+import type {
+  IApp,
+  IExecutionStep,
+  TDataOutMetadatumType,
+} from '@plumber/types'
 
 import { ComboboxItem } from '@opengovsg/design-system-react'
 
@@ -7,8 +11,9 @@ import { extractVariables } from '@/helpers/variables'
 function extractVariablesAsItems(
   executionSteps: IExecutionStep[],
   allowedTypes: TDataOutMetadatumType[] | null,
+  allApps: IApp[],
 ): ComboboxItem[] {
-  const stepsWithVariables = extractVariables(executionSteps)
+  const stepsWithVariables = extractVariables(executionSteps, allApps)
 
   const result: ComboboxItem[] = []
   for (const step of stepsWithVariables) {

--- a/packages/frontend/src/components/MultiSelect/index.tsx
+++ b/packages/frontend/src/components/MultiSelect/index.tsx
@@ -39,11 +39,11 @@ function MultiSelect(props: MultiSelectProps): React.ReactElement {
   } = props
   const { control } = useFormContext()
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
-  const { readOnly } = useContext(EditorContext)
+  const { allApps, readOnly } = useContext(EditorContext)
 
   const items = useMemo(
-    () => extractVariablesAsItems(priorExecutionSteps, variableTypes),
-    [priorExecutionSteps, variableTypes],
+    () => extractVariablesAsItems(priorExecutionSteps, variableTypes, allApps),
+    [priorExecutionSteps, variableTypes, allApps],
   )
 
   return (

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -113,12 +113,13 @@ const Editor = ({
   autoFocus = false,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
+  const { allApps } = useContext(EditorContext)
   const isMobile = useIsMobile()
   const isMulticol = parentType === 'multicol'
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
-      extractVariables(priorExecutionSteps),
+      extractVariables(priorExecutionSteps, allApps),
       (variable) => {
         const variableType = variable.type ?? 'text'
         if (variableTypes) {
@@ -130,7 +131,7 @@ const Editor = ({
     )
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]
-  }, [priorExecutionSteps, variableTypes])
+  }, [allApps, priorExecutionSteps, variableTypes])
 
   const extensions: Array<any> = [
     Placeholder.configure({

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -180,7 +180,10 @@ export const EditorProvider = ({
   const hasForEach = flow?.steps.some((step) => isForEachStep(step))
   const hasIfThen = flow?.steps.some((step: IStep) => isIfThenStep(step))
 
-  const allApps = getAppsData?.getApps ?? []
+  const allApps = useMemo(
+    () => getAppsData?.getApps ?? [],
+    [getAppsData?.getApps],
+  )
 
   const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
     GET_TEST_EXECUTION_STEPS,
@@ -199,10 +202,10 @@ export const EditorProvider = ({
   )
 
   const [stepsWithVars, varInfoMap] = useMemo(() => {
-    const stepsWithVars = extractVariables(testExecutionSteps)
+    const stepsWithVars = extractVariables(testExecutionSteps, allApps)
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]
-  }, [testExecutionSteps])
+  }, [testExecutionSteps, allApps])
 
   const currentTestExecutionStep = useMemo(
     () =>

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -21,6 +21,9 @@ export const GET_TEST_EXECUTION_STEPS = gql`
           }
           stepName
         }
+        key
+        appKey
+        type
       }
       status
       appKey

--- a/packages/frontend/src/helpers/__tests__/variables.test.ts
+++ b/packages/frontend/src/helpers/__tests__/variables.test.ts
@@ -22,6 +22,8 @@ describe('variables', () => {
           stepId: 'step1-id',
           step: {
             position: 1,
+            appKey: 'App1',
+            key: 'Action 1',
           },
           appKey: 'App1',
         },
@@ -37,6 +39,8 @@ describe('variables', () => {
         stepId: 'step2-id',
         step: {
           position: 2,
+          appKey: 'App2',
+          key: 'Action2',
         },
         appKey: 'App2',
       } as unknown as IExecutionStep)

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -22,8 +22,8 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
   } = step
 
   const isTrigger = type === 'trigger'
-  const isIfThen = step ? checkIfThenStep(step) : false
-  const isForEach = step ? checkForEachStep(step) : false
+  const isIfThen = checkIfThenStep(step)
+  const isForEach = checkForEachStep(step)
 
   const apps: IApp[] = allApps?.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -1,0 +1,71 @@
+import { IAction, IApp, IStep, ITrigger } from '@plumber/types'
+
+import {
+  isForEachStep as checkForEachStep,
+  isIfThenStep as checkIfThenStep,
+} from '@/helpers/toolbox'
+
+export default function getStepName(allApps: IApp[], step: IStep | undefined) {
+  if (!step) {
+    return {
+      caption: '',
+      defaultCaption: '',
+    }
+  }
+
+  const {
+    appKey,
+    key,
+    config: { stepName = undefined } = {},
+    position,
+    type,
+  } = step
+
+  const isTrigger = type === 'trigger'
+  const isIfThen = step ? checkIfThenStep(step) : false
+  const isForEach = step ? checkForEachStep(step) : false
+
+  const apps: IApp[] = allApps?.filter((app: IApp) =>
+    isTrigger ? !!app.triggers?.length : !!app.actions?.length,
+  )
+  const app = apps?.find((currentApp: IApp) => currentApp.key === appKey)
+
+  const actionsOrTriggers: Array<ITrigger | IAction> =
+    (isTrigger ? app?.triggers : app?.actions) || []
+
+  const selectedActionOrTrigger = actionsOrTriggers.find(
+    (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === key,
+  )
+
+  let caption = ''
+  let defaultCaption = selectedActionOrTrigger?.name
+  if (stepName) {
+    caption = `${position}. ${stepName}`
+  } else if (defaultCaption) {
+    caption = `${position ? `${position}. ` : ''}${defaultCaption}`
+
+    if (isIfThen) {
+      caption = `${position}. Condition`
+    }
+    if (isForEach) {
+      caption = `${position}. For each item`
+    }
+  } else if (app?.name) {
+    caption = `${position ? `${position}. ` : ''}${app.name}`
+  } else if (isTrigger) {
+    caption = 'This step starts your pipe'
+  }
+
+  if (isIfThen) {
+    defaultCaption = 'Condition'
+  }
+
+  return {
+    caption:
+      caption ||
+      (appKey
+        ? `${position}. ${appKey.charAt(0).toUpperCase() + appKey.slice(1)}`
+        : ''),
+    defaultCaption,
+  }
+}

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -39,25 +39,34 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
 
   let caption = ''
   let defaultCaption = selectedActionOrTrigger?.name
+
+  if (isIfThen) {
+    defaultCaption = 'Condition'
+    caption = stepName ? `${position}. ${stepName}` : `${position}. Condition`
+    return {
+      caption,
+      defaultCaption,
+    }
+  }
+
+  if (isForEach) {
+    caption = stepName
+      ? `${position}. ${stepName}`
+      : `${position}. For each item`
+    return {
+      caption,
+      defaultCaption,
+    }
+  }
+
   if (stepName) {
     caption = `${position}. ${stepName}`
   } else if (defaultCaption) {
     caption = `${position ? `${position}. ` : ''}${defaultCaption}`
-
-    if (isIfThen) {
-      caption = `${position}. Condition`
-    }
-    if (isForEach) {
-      caption = `${position}. For each item`
-    }
   } else if (app?.name) {
     caption = `${position ? `${position}. ` : ''}${app.name}`
   } else if (isTrigger) {
     caption = 'This step starts your pipe'
-  }
-
-  if (isIfThen) {
-    defaultCaption = 'Condition'
   }
 
   return {

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -1,13 +1,17 @@
 import type {
+  IAction,
+  IApp,
   IDataOutMetadata,
   IDataOutMetadatum,
   IExecutionStep,
+  ITrigger,
   TDataOutMetadatumType,
 } from '@plumber/types'
 
 import get from 'lodash.get'
 
 import { RawColumn, RawRow } from '@/components/VariablesList/utils'
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 
 // these are the variable types to display on the frontend (make visible)
 export const VISIBLE_VARIABLE_TYPES: TDataOutMetadatumType[] = [
@@ -41,6 +45,40 @@ export interface Variable {
    * at the for-each step
    */
   isHidden?: boolean
+}
+
+function getStepName(executionStep: IExecutionStep, allApps: IApp[]) {
+  const { appKey, key, step } = executionStep
+
+  const isTrigger = ['formsg', 'webhook', 'scheduler'].includes(appKey)
+  const isIfThen = appKey === TOOLBOX_APP_KEY && key === TOOLBOX_ACTIONS.IfThen
+  const app = allApps?.find((a: IApp) => a.key === appKey)
+  const actionsOrTriggers: Array<ITrigger | IAction> =
+    (isTrigger ? app?.triggers : app?.actions) || []
+
+  const selectedActionOrTrigger = actionsOrTriggers.find(
+    (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === key,
+  )
+
+  let caption = ''
+  const defaultCaption = selectedActionOrTrigger?.name
+  if (step?.config?.stepName) {
+    caption = `${step.config.stepName}`
+  } else if (defaultCaption) {
+    caption = defaultCaption
+
+    if (isIfThen) {
+      caption = 'Condition'
+    }
+  } else if (app?.name) {
+    caption = app.name
+  }
+
+  return (
+    step?.config?.stepName ||
+    caption ||
+    (appKey || '').charAt(0)?.toUpperCase() + appKey?.slice(1)
+  )
 }
 
 function sortVariables(variables: Variable[]): void {
@@ -197,6 +235,7 @@ const process = (
 
 export function extractVariables(
   executionSteps: IExecutionStep[],
+  allApps?: IApp[],
 ): StepWithVariables[] {
   if (!executionSteps) {
     return []
@@ -217,15 +256,12 @@ export function extractVariables(
           metadata,
           '',
         )
+        const stepName = getStepName(executionStep, allApps || [])
         // sort variable by order key in-place
         sortVariables(variables)
         return {
           id: executionStep.stepId,
-          name: `${executionStep.step.position}. ${
-            executionStep.step?.config?.stepName ||
-            (executionStep.appKey || '').charAt(0)?.toUpperCase() +
-              executionStep.appKey?.slice(1)
-          }`,
+          name: `${executionStep.step.position}. ${stepName}`,
           output: variables,
         }
       })

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -1,17 +1,15 @@
 import type {
-  IAction,
   IApp,
   IDataOutMetadata,
   IDataOutMetadatum,
   IExecutionStep,
-  ITrigger,
   TDataOutMetadatumType,
 } from '@plumber/types'
 
 import get from 'lodash.get'
 
 import { RawColumn, RawRow } from '@/components/VariablesList/utils'
-import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+import getStepName from '@/helpers/getStepName'
 
 // these are the variable types to display on the frontend (make visible)
 export const VISIBLE_VARIABLE_TYPES: TDataOutMetadatumType[] = [
@@ -45,36 +43,6 @@ export interface Variable {
    * at the for-each step
    */
   isHidden?: boolean
-}
-
-function getStepName(executionStep: IExecutionStep, allApps: IApp[]) {
-  const { appKey, key, step } = executionStep
-
-  const isTrigger = ['formsg', 'webhook', 'scheduler'].includes(appKey)
-  const isIfThen = appKey === TOOLBOX_APP_KEY && key === TOOLBOX_ACTIONS.IfThen
-  const app = allApps?.find((a: IApp) => a.key === appKey)
-  const actionsOrTriggers: Array<ITrigger | IAction> =
-    (isTrigger ? app?.triggers : app?.actions) || []
-
-  const selectedActionOrTrigger = actionsOrTriggers.find(
-    (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === key,
-  )
-
-  let caption = ''
-  const defaultCaption = selectedActionOrTrigger?.name
-  if (step?.config?.stepName) {
-    caption = `${step.config.stepName}`
-  } else if (defaultCaption) {
-    caption = defaultCaption
-
-    if (isIfThen) {
-      caption = 'Condition'
-    }
-  } else if (app?.name) {
-    caption = app.name
-  }
-
-  return caption || (appKey || '').charAt(0)?.toUpperCase() + appKey?.slice(1)
 }
 
 function sortVariables(variables: Variable[]): void {
@@ -252,12 +220,16 @@ export function extractVariables(
           metadata,
           '',
         )
-        const stepName = getStepName(executionStep, allApps || [])
+
+        const { caption: name } = getStepName(
+          allApps || [],
+          executionStep?.step,
+        )
         // sort variable by order key in-place
         sortVariables(variables)
         return {
           id: executionStep.stepId,
-          name: `${executionStep.step.position}. ${stepName}`,
+          name,
           output: variables,
         }
       })

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -74,11 +74,7 @@ function getStepName(executionStep: IExecutionStep, allApps: IApp[]) {
     caption = app.name
   }
 
-  return (
-    step?.config?.stepName ||
-    caption ||
-    (appKey || '').charAt(0)?.toUpperCase() + appKey?.slice(1)
-  )
+  return caption || (appKey || '').charAt(0)?.toUpperCase() + appKey?.slice(1)
 }
 
 function sortVariables(variables: Variable[]): void {

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -2,10 +2,8 @@ import { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
 import { useMemo } from 'react'
 
-import {
-  isForEachStep as checkForEachStep,
-  isIfThenStep as checkIfThenStep,
-} from '@/helpers/toolbox'
+import getStepName from '@/helpers/getStepName'
+import { isIfThenStep as checkIfThenStep } from '@/helpers/toolbox'
 
 interface UseStepMetadataResult {
   app: IApp | undefined
@@ -28,7 +26,6 @@ export function useStepMetadata(
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'
   const isIfThenStep = step ? checkIfThenStep(step) : false
-  const isForEachStep = step ? checkForEachStep(step) : false
 
   const apps: IApp[] = allApps?.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
@@ -49,33 +46,7 @@ export function useStepMetadata(
     [actionsOrTriggers, step?.key],
   )
 
-  // define caption description based on app and step
-  let caption = ''
-  let defaultCaption = selectedActionOrTrigger?.name
-  if (step?.config?.stepName) {
-    caption = `${step.position}. ${step.config.stepName}`
-  } else if (defaultCaption) {
-    caption = `${step?.position ? `${step.position}. ` : ''}${defaultCaption}`
-
-    if (isIfThenStep) {
-      caption = `${step?.position}. Condition`
-    }
-    if (isForEachStep) {
-      caption = `${step?.position}. For each item`
-    }
-  } else if (app?.name) {
-    caption = `${step?.position ? `${step.position}. ` : ''}${app.name}`
-  } else if (isTrigger) {
-    caption = 'This step starts your pipe'
-  } else if (step?.position === 2) {
-    caption = 'This step happens after your pipe starts'
-  } else {
-    caption = 'This step happens after the previous step'
-  }
-
-  if (isIfThenStep) {
-    defaultCaption = 'Condition'
-  }
+  const { caption, defaultCaption } = getStepName(allApps, step)
 
   const substeps = selectedActionOrTrigger?.substeps || []
   const hasConnection = substeps?.some(


### PR DESCRIPTION
## TL;DR
Use the custom step name or app display name in the suggestions popover.
This only works with steps that have been tested after for-each was introduced and have `appKey` and `key` in the ExecutionStep.

**Note**: this PR exists within the for-each stack as it uses both `appKey` and `key` from the ExecutionStep, and `key` is only added to ExecutionStep as part of for-each.

## What changed?
Added a `getStepName` function that retrieves more descriptive names for steps based on app information:
  - Custom step name if exists
  - App display name if exists
  - Defaults to app key by default

## How to test?
- [ ] Pipe whose steps were tested after the for-each
  - If custom step name is set, should show custom step name
  - Otherwise, should show the default step name (e.g., New form submission, Find single row, etc.)

- [ ] Old pipes
  - If custom step name is set, should show custom step name
  - Otherwise, should show the app key (e.g., Toolbox, Tiles, Slack)
  - Click on 'Check step again'
  - Should now change to the descriptive step name (e.g., New form submission, Find single row, etc.)


## Screenshots
**New pipe after for-each introduced `key`**

![Screenshot 2025-06-19 at 11.26.17 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/8f1bd88a-165f-4ff4-b2cd-832035b9e25d.png)

**Old pipe**

![Screenshot 2025-06-19 at 11.24.04 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/f7c57877-6926-4b20-bdd1-5f3904b1011e.png)

**Old pipe with re-tested step**

![Screenshot 2025-06-19 at 11.25.12 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/21a846dd-6652-4e36-83e8-fc51f72444f0.png)

