### PR TITLE
PLU-503: fix error when re-selecting excel file

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -89,6 +89,10 @@ const action: IRawAction = {
       key: 'columnValues',
       type: 'multirow-multicol' as const,
       required: true,
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
       subFields: [
         {
           key: 'columnName' as const,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -92,6 +92,10 @@ const action: IRawAction = {
           },
         ],
       },
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
     },
     {
       key: 'lookupValue' as const,
@@ -104,6 +108,10 @@ const action: IRawAction = {
       type: 'string' as const,
       required: true,
       variables: true,
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
     },
   ],
 

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -39,6 +39,10 @@ const action: IRawAction = {
         'Enter the data to update the row with. Columns not specified will not be updated',
       type: 'multirow-multicol' as const,
       required: true,
+      hiddenIf: {
+        fieldKey: 'tableId',
+        op: 'is_empty',
+      },
       subFields: [
         {
           key: 'columnName' as const,

--- a/packages/frontend/src/hooks/useDynamicData.ts
+++ b/packages/frontend/src/hooks/useDynamicData.ts
@@ -120,9 +120,20 @@ function useDynamicData(
         // resetField function resets it to the last saved value which is wrong
         setValue(fieldName, null)
 
-        refetch({
-          ...getWatchedFormFieldValues(watchedFormFields, newFieldValues),
-        })
+        const parametersToRefetch = getWatchedFormFieldValues(
+          watchedFormFields,
+          newFieldValues,
+        )
+        // We check that there are no null/undefined values in the parameters,
+        for (const [_, fieldPath] of watchedFormFields.entries()) {
+          const value = get(parametersToRefetch, fieldPath)
+          if (value == null) {
+            // not all values are present, so we don't refetch
+            return
+          }
+        }
+
+        refetch(parametersToRefetch)
       },
     )
 


### PR DESCRIPTION
## Problem

Frontend attempts to fetch dynamic data specifically (listTableColumns) when excel file changed.

## Solution

Check that all parameters are populated (specifically fileId and tableId) in this case before fetching dynamic data.

Also conditionally hide the subsequent fields (table, column) so that it doesnt show the old dropdown.

## Test
1. Select Excel file, table and column in Find Single Row step in Excel
2. Click save
3. Change excel file
4. Verify that no error is thrown. 
5. Verify that the `Lookup Column` and `Lookup Value` fields are hidden
7. After selecting table, verify that columns are properly refetched.

- [ ]  Also check that All excel actions, conditionally hide fields
