### PR TITLE
fix: mock data statement field

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -121,6 +121,7 @@ async function getMockData($: IGlobalVariable) {
         // formsg payload doesnt contain this anyways, so we dont return in mock data
         if (data.responses[formFields[i]._id].fieldType === 'statement') {
           delete data.responses[formFields[i]._id]
+          continue
         }
 
         if (data.responses[formFields[i]._id].fieldType === 'address') {


### PR DESCRIPTION
## Problem

Error with mock data statement field: `error TypeError: Cannot read properties of undefined (reading 'fieldType')`

## Solution
Skip the remaining checks for mock data

## Screenshots
![image](https://github.com/user-attachments/assets/52ff9a72-bcf4-4689-bb44-41d7afc551c3)

