### PR TITLE
[PLU-508]: UI: Add step modal icon shift sometimes

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -328,7 +328,7 @@ export default function ChooseApp(props: ChooseAppProps) {
                             fit="contain"
                             fallback={
                               <Icon
-                                boxSize={6}
+                                boxSize={8}
                                 as={BiArrowFromRight}
                                 color="base.content.default"
                               />


### PR DESCRIPTION
## Problem
Add step modal icon shift sometimes

## Solution
* Make fallback icon `boxSize` the same as the actual icon


## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/74a937e3-e45b-4b2d-9d10-4270abed0b48


**AFTER**:

https://github.com/user-attachments/assets/915c792a-2d22-491c-ac1b-09042dab610c



## Tests
- [ ] Open the "Add step" modal, verify that the icons and labels do not have any left-right shift

