### PR TITLE
chore: add docker command for minio

### DIFF
--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -37,6 +37,7 @@ services:
       - MINIO_SITE_REGION=ap-southeast-1
     volumes:
       - plumber-minio:/data
+    command: server /data --console-address ":9001"
     healthcheck:
       test: ['CMD', 'curl', '-I', 'http://minio:9000/minio/health/live']
       interval: 1s


### PR DESCRIPTION
## Problem

Minio is not working when using the latest docker image after migrating to orbstack
New: DEVELOPMENT.2025-05-24T17-08-30Z → Console not enabled by default
Old: DEVELOPMENT.2024-04-18T19-09-19Z → Console likely still enabled on port 9000 by default

To check differences: run `docker exec -it backend-minio-1  minio --version`
## Solution

Add entrypoint command for the MinIO container — it tells the MinIO server what to run when the container starts.
`command: server /data --console-address ":9001"`
Starts the MinIO object storage server, store files in /data, and make the admin web console available on port 9001.

## Tests
- Ensure that your minio web UI is still working
