### PR TITLE
[DUPLICATE-STEP-1] Duplicate step

### DIFF
--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -54,6 +54,7 @@ const createStep: MutationResolvers['createStep'] = async (
       position: previousStep.position + 1,
       parameters: input.parameters,
       connectionId: input.connection?.id,
+      config: input.config,
     })
 
     return step

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -505,6 +505,7 @@ input CreateStepInput {
   flow: StepFlowInput
   parameters: JSONObject
   previousStep: PreviousStepInput
+  config: StepConfigInput
 }
 
 input StepConfigInput {

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -16,13 +16,13 @@ import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-s
 
 import { findAdjacentSteps, shouldCreateEmptyStep } from '../utils'
 
-interface StepDeleteButtonProps {
+interface DeleteStepButtonProps {
   isNested?: boolean
   isDeletingStep?: boolean
   step: IStep
 }
 
-export default function StepDeleteButton(props: StepDeleteButtonProps) {
+export default function DeleteStepButton(props: DeleteStepButtonProps) {
   const { isNested, step } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
   const {

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -35,7 +35,7 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
       iconUrl: null,
       webhookUrl: null,
       config: {
-        stepName: null,
+        stepName: createdStep?.config?.stepName || null,
         templateConfig: {
           appEventKey: null,
         },
@@ -62,8 +62,13 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
 export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
   const { isNested, step } = props
 
-  const { flow, isMobile, setCurrentStepId, setCurrentStepIndex } =
-    useContext(EditorContext)
+  const {
+    flow,
+    isMobile,
+    onDrawerOpen,
+    setCurrentStepId,
+    setCurrentStepIndex,
+  } = useContext(EditorContext)
 
   const [createStep] = useMutation(CREATE_STEP, { refetchQueries: [GET_FLOW] })
 
@@ -79,6 +84,11 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
       key: step.key,
       connection: { id: step.connection?.id },
       parameters: { ...step.parameters },
+      ...(step.config?.stepName && {
+        config: {
+          stepName: `[COPY] ${step.config.stepName}`,
+        },
+      }),
     }
 
     const createdStep = await createStep({
@@ -90,7 +100,15 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     const newStepIndex = newStep.position - 1
     setCurrentStepId(newStep.id)
     setCurrentStepIndex(newStepIndex)
-  }, [flow.id, step, createStep, setCurrentStepId, setCurrentStepIndex])
+    onDrawerOpen()
+  }, [
+    flow.id,
+    step,
+    createStep,
+    setCurrentStepId,
+    setCurrentStepIndex,
+    onDrawerOpen,
+  ])
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -3,7 +3,7 @@ import { IStep } from '@plumber/types'
 import { useCallback, useContext } from 'react'
 import { BiDuplicate } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
-import { IconButton } from '@opengovsg/design-system-react'
+import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
@@ -94,20 +94,22 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
    * - handle warn on unsaved changes
    */
   return (
-    <IconButton
-      boxSize={isNested ? 6 : 8}
-      onClick={(event) => {
-        event.stopPropagation()
-        onDuplicateStep()
-      }}
-      variant="clear"
-      aria-label="Delete Step"
-      colorScheme="secondary"
-      icon={<BiDuplicate />}
-      minHeight={isNested ? 6 : 8}
-      minWidth={isNested ? 6 : 8}
-      className={isMobile ? undefined : 'hover-remove-button'}
-      visibility={isMobile ? 'visible' : 'hidden'}
-    />
+    <TouchableTooltip label="Duplicate step">
+      <IconButton
+        boxSize={isNested ? 6 : 8}
+        onClick={(event) => {
+          event.stopPropagation()
+          onDuplicateStep()
+        }}
+        variant="clear"
+        aria-label="Duplicate Step"
+        colorScheme="secondary"
+        icon={<BiDuplicate />}
+        minHeight={isNested ? 6 : 8}
+        minWidth={isNested ? 6 : 8}
+        className={isMobile ? undefined : 'hover-remove-button'}
+        visibility={isMobile ? 'visible' : 'hidden'}
+      />
+    </TouchableTooltip>
   )
 }

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -6,9 +6,11 @@ import { useMutation } from '@apollo/client'
 import { Tooltip } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
+import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import { EditorContext } from '@/contexts/Editor'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 interface DuplicateStepButtonProps {
   isNested?: boolean
@@ -90,27 +92,41 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     setCurrentStepIndex(newStepIndex)
   }, [flow.id, step, createStep, setCurrentStepId, setCurrentStepIndex])
 
-  /**
-   * TODOs:
-   * - handle warn on unsaved changes
-   */
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave,
+  } = useUnsavedChanges({
+    onProceed: onDuplicateStep,
+  })
+
   return (
-    <Tooltip label="Duplicate step" hasArrow>
-      <IconButton
-        boxSize={isNested ? 6 : 8}
-        onClick={(event) => {
-          event.stopPropagation()
-          onDuplicateStep()
-        }}
-        variant="clear"
-        aria-label="Duplicate Step"
-        colorScheme="secondary"
-        icon={<BiDuplicate />}
-        minHeight={isNested ? 6 : 8}
-        minWidth={isNested ? 6 : 8}
-        className={isMobile ? undefined : 'hover-remove-button'}
-        visibility={isMobile ? 'visible' : 'hidden'}
+    <>
+      <Tooltip label="Duplicate step" hasArrow>
+        <IconButton
+          boxSize={isNested ? 6 : 8}
+          onClick={(event) => {
+            event.stopPropagation()
+            handleProceed()
+          }}
+          variant="clear"
+          aria-label="Duplicate Step"
+          colorScheme="secondary"
+          icon={<BiDuplicate />}
+          minHeight={isNested ? 6 : 8}
+          minWidth={isNested ? 6 : 8}
+          className={isMobile ? undefined : 'hover-remove-button'}
+          visibility={isMobile ? 'visible' : 'hidden'}
+        />
+      </Tooltip>
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={handleLeave}
       />
-    </Tooltip>
+    </>
   )
 }

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -3,7 +3,8 @@ import { IStep } from '@plumber/types'
 import { useCallback, useContext } from 'react'
 import { BiDuplicate } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
-import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
+import { Tooltip } from '@chakra-ui/react'
+import { IconButton } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
@@ -94,7 +95,7 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
    * - handle warn on unsaved changes
    */
   return (
-    <TouchableTooltip label="Duplicate step">
+    <Tooltip label="Duplicate step" hasArrow>
       <IconButton
         boxSize={isNested ? 6 : 8}
         onClick={(event) => {
@@ -110,6 +111,6 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
         className={isMobile ? undefined : 'hover-remove-button'}
         visibility={isMobile ? 'visible' : 'hidden'}
       />
-    </TouchableTooltip>
+    </Tooltip>
   )
 }

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -1,0 +1,113 @@
+import { IStep } from '@plumber/types'
+
+import { useCallback, useContext } from 'react'
+import { BiDuplicate } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import { IconButton } from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { CREATE_STEP } from '@/graphql/mutations/create-step'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
+
+interface DuplicateStepButtonProps {
+  isNested?: boolean
+  step: IStep
+}
+
+/**
+ * Helper function to update the flow in the cache
+ */
+function updateHandlerFactory(flowId: string, previousStepId: string) {
+  return function createStepUpdateHandler(cache: any, mutationResult: any) {
+    const { data } = mutationResult
+    const { createStep: createdStep } = data
+    const { getFlow: flow } = cache.readQuery({
+      query: GET_FLOW,
+      variables: { id: flowId },
+    })
+
+    // getFlow requires certain attributes to be returned
+    const completeCreatedStep = {
+      ...createdStep,
+      iconUrl: null,
+      webhookUrl: null,
+      config: {
+        stepName: null,
+        templateConfig: {
+          appEventKey: null,
+        },
+      },
+      createdAt: new Date().toISOString(),
+    }
+
+    const steps = flow.steps.reduce((steps: any[], currentStep: any) => {
+      if (currentStep.id === previousStepId) {
+        return [...steps, currentStep, completeCreatedStep]
+      }
+
+      return [...steps, currentStep]
+    }, [])
+
+    cache.writeQuery({
+      query: GET_FLOW,
+      variables: { id: flowId },
+      data: { getFlow: { ...flow, steps } },
+    })
+  }
+}
+
+export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
+  const { isNested, step } = props
+
+  const { flow, isMobile, setCurrentStepId, setCurrentStepIndex } =
+    useContext(EditorContext)
+
+  const [createStep] = useMutation(CREATE_STEP, { refetchQueries: [GET_FLOW] })
+
+  const onDuplicateStep = useCallback(async () => {
+    const mutationInput = {
+      previousStep: {
+        id: step.id,
+      },
+      flow: {
+        id: flow.id,
+      },
+      appKey: step.appKey,
+      key: step.key,
+      connection: { id: step.connection?.id },
+      parameters: { ...step.parameters },
+    }
+
+    const createdStep = await createStep({
+      variables: { input: mutationInput },
+      update: updateHandlerFactory(flow.id, step.id),
+    })
+
+    const newStep = createdStep.data.createStep
+    const newStepIndex = newStep.position - 1
+    setCurrentStepId(newStep.id)
+    setCurrentStepIndex(newStepIndex)
+  }, [flow.id, step, createStep, setCurrentStepId, setCurrentStepIndex])
+
+  /**
+   * TODOs:
+   * - handle warn on unsaved changes
+   */
+  return (
+    <IconButton
+      boxSize={isNested ? 6 : 8}
+      onClick={(event) => {
+        event.stopPropagation()
+        onDuplicateStep()
+      }}
+      variant="clear"
+      aria-label="Delete Step"
+      colorScheme="secondary"
+      icon={<BiDuplicate />}
+      minHeight={isNested ? 6 : 8}
+      minWidth={isNested ? 6 : 8}
+      className={isMobile ? undefined : 'hover-remove-button'}
+      visibility={isMobile ? 'visible' : 'hidden'}
+    />
+  )
+}

--- a/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepCaptionAndDemo.tsx
@@ -11,7 +11,7 @@ export default function StepCaptionAndDemo(props: StepCaptionProps) {
   const { caption } = props
   return (
     <>
-      <Flex direction="column" align="start" maxW="80%" flexShrink={1}>
+      <Flex direction="column" align="start" maxW="70%" flexShrink={1}>
         <Flex alignItems="center" gap={2} maxW="100%">
           <Text
             textStyle="subhead-1"

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -19,9 +19,10 @@ import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
 
+import DeleteStepButton from './components/DeleteStepButton'
+import DuplicateStepButton from './components/DuplicateStepButton'
 import StepAppIcon from './components/StepAppIcon'
 import StepCaptionAndDemo from './components/StepCaptionAndDemo'
-import StepDeleteButton from './components/StepDeleteButton'
 import TestAgainInfobox from './components/TestAgainInfobox'
 import FlowStepWrapper from './FlowStepWrapper'
 import { flowStepStyles } from './styles'
@@ -235,7 +236,12 @@ export default function FlowStep(
               />
               <StepCaptionAndDemo app={app} caption={caption} />
               {isDeletable && (
-                <StepDeleteButton isNested={isNested} step={step} />
+                <Flex gap={1} ml="auto">
+                  {!isTrigger && (
+                    <DuplicateStepButton isNested={isNested} step={step} />
+                  )}
+                  <DeleteStepButton isNested={isNested} step={step} />
+                </Flex>
               )}
             </Flex>
           </Flex>

--- a/packages/frontend/src/graphql/cache.ts
+++ b/packages/frontend/src/graphql/cache.ts
@@ -67,6 +67,15 @@ export const cacheConfig = {
         },
       },
     },
+    Step: {
+      fields: {
+        config: {
+          merge(_existing = [], incoming: any[]) {
+            return incoming // Replace existing with incoming
+          },
+        },
+      },
+    },
   },
 } satisfies InMemoryCacheConfig
 

--- a/packages/frontend/src/graphql/mutations/create-step.ts
+++ b/packages/frontend/src/graphql/mutations/create-step.ts
@@ -13,6 +13,9 @@ export const CREATE_STEP = gql`
       connection {
         id
       }
+      config {
+        stepName
+      }
     }
   }
 `


### PR DESCRIPTION
## TL;DR
This PR adds a new feature to duplicate steps within a Pipe.

## What changed?
- Added a `DuplicateStepButton` button that appears on hover to duplicate the step including all parameters that have been set
- Renamed `StepDeleteButton` to `DeleteStepButton` for consistency
- Added a tooltip to the duplicate button for better UX

## How to test?
- [ ] Duplicate a step
  - [ ] All parameters are duplicated in the new step
- [ ] Duplicate a step within the if-then branch
  - [ ] Step is within the same branch
  - [ ] All parameters are duplicated in the new step

## Why make this change?
This makes it easier for users to replicate steps without having to reconfigure all fields manually.