### PR TITLE
[DUPLICATE-STEP-2] Duplicate branch

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -8,30 +8,22 @@ import {
   useMemo,
   useRef,
 } from 'react'
-import { BiTrash } from 'react-icons/bi'
+import { BiDuplicate, BiTrash } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
-import {
-  AlertDialog,
-  AlertDialogBody,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogOverlay,
-  Box,
-  Button,
-  Flex,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react'
+import { Box, Flex, Text, useDisclosure } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
+import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import FlowStep from '@/components/FlowStep'
+import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import { HoverAddStepButton } from './HoverAddStepButton'
 import { branchStyles } from './styles'
+import useDuplicateBranch from './useDuplicateBranch'
 import { allowAddStep } from './utils'
 
 interface BranchProps {
@@ -48,6 +40,7 @@ export default function Branch(props: BranchProps) {
     readOnly: isEditorReadOnly,
     onDrawerClose,
     setCurrentStepId,
+    shouldWarnOnLeave,
   } = useContext(EditorContext)
 
   // Handle branch deletion
@@ -86,6 +79,42 @@ export default function Branch(props: BranchProps) {
 
   const canAddStep = useMemo(() => allowAddStep(branchSteps), [branchSteps])
 
+  // Handle duplicate branch
+  // we only warn on unsaved changes when duplicating branch to ensure that the
+  // latest changes are saved before
+  const cancelDuplicateButton = useRef<HTMLButtonElement>(null)
+  const {
+    canDuplicateBranch,
+    duplicateConfirmationIsOpen,
+    isDuplicatingBranch,
+    closeDuplicateConfirmation,
+    duplicateBranch,
+    openDuplicateConfirmation,
+  } = useDuplicateBranch(branchSteps)
+
+  const {
+    cancelRef,
+    isWarningOpen,
+    onWarningOpen,
+    onWarningClose,
+    handleProceed,
+    handleLeave: discardChanges,
+  } = useUnsavedChanges({
+    onProceed: openDuplicateConfirmation,
+  })
+
+  const onDuplicate = useCallback(() => {
+    if (shouldWarnOnLeave) {
+      onWarningOpen()
+    } else {
+      handleProceed()
+    }
+  }, [handleProceed, onWarningOpen, shouldWarnOnLeave])
+
+  const onLeave = () => {
+    discardChanges()
+  }
+
   return (
     <Flex key={branchSteps[0].id} {...branchStyles.container}>
       <Box
@@ -107,21 +136,34 @@ export default function Branch(props: BranchProps) {
             {branchSteps[0].parameters.branchName as string}
           </Text>
 
-          {/* Delete branch button */}
+          {/* Duplicate/delete branch buttons */}
           {!isEditorReadOnly && (
-            <Flex ml="auto" opacity={0} _groupHover={{ opacity: 1 }}>
+            <Flex
+              ml="auto"
+              opacity={{ base: 1, lg: 0 }}
+              _groupHover={{ opacity: 1 }}
+            >
+              {canDuplicateBranch && (
+                <IconButton
+                  boxSize={8}
+                  onClick={onDuplicate}
+                  variant="clear"
+                  aria-label="Duplicate branch"
+                  colorScheme="secondary"
+                  icon={<BiDuplicate />}
+                  isLoading={isDuplicatingBranch}
+                  isDisabled={isDuplicatingBranch || isDeletingBranch}
+                />
+              )}
               <IconButton
                 boxSize={8}
-                onClick={(event) => {
-                  openDeleteConfirmation(event)
-                  event.stopPropagation()
-                }}
+                onClick={openDeleteConfirmation}
                 variant="clear"
                 aria-label="Delete branch"
                 colorScheme="secondary"
                 icon={<BiTrash />}
                 isLoading={isDeletingBranch}
-                isDisabled={isDeletingBranch}
+                isDisabled={isDeletingBranch || isDuplicatingBranch}
               />
             </Flex>
           )}
@@ -148,36 +190,34 @@ export default function Branch(props: BranchProps) {
       })}
 
       {/* Delete Confirmation Modal */}
-      <AlertDialog
-        isOpen={deleteConfirmationIsOpen}
-        leastDestructiveRef={cancelDeleteButton}
-        onClose={closeDeleteConfirmation}
-      >
-        <AlertDialogOverlay>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              Delete {branchSteps[0].parameters.branchName as string}
-            </AlertDialogHeader>
-            <AlertDialogBody>
-              Are you sure you want to delete this branch? This action cannot be
-              undone.
-            </AlertDialogBody>
-            <AlertDialogFooter>
-              <Button
-                colorScheme="neutral"
-                variant="clear"
-                ref={cancelDeleteButton}
-                onClick={closeDeleteConfirmation}
-              >
-                Cancel
-              </Button>
-              <Button colorScheme="critical" onClick={deleteBranch} ml={3}>
-                Yes, delete branch
-              </Button>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialogOverlay>
-      </AlertDialog>
+      <MenuAlertDialog
+        isDialogOpen={deleteConfirmationIsOpen}
+        cancelRef={cancelDeleteButton}
+        onDialogClose={closeDeleteConfirmation}
+        dialogHeader="Branch"
+        dialogType="delete"
+        onClick={deleteBranch}
+        isLoading={isDeletingBranch}
+      />
+
+      {/* Duplicate Confirmation Modal */}
+      <MenuAlertDialog
+        isDialogOpen={duplicateConfirmationIsOpen}
+        cancelRef={cancelDuplicateButton}
+        onDialogClose={closeDuplicateConfirmation}
+        dialogHeader="Branch"
+        dialogType="duplicate-branch"
+        onClick={duplicateBranch}
+        isLoading={false}
+      />
+
+      {/* Unsaved Changes Alert */}
+      <UnsavedChangesAlert
+        cancelRef={cancelRef}
+        isOpen={isWarningOpen}
+        onClose={onWarningClose}
+        onLeave={onLeave}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -208,7 +208,7 @@ export default function Branch(props: BranchProps) {
         dialogHeader="Branch"
         dialogType="duplicate-branch"
         onClick={duplicateBranch}
-        isLoading={false}
+        isLoading={isDuplicatingBranch}
       />
 
       {/* Unsaved Changes Alert */}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -44,54 +44,59 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
 
     setIsDuplicatingBranch(true)
 
-    let newConditionId = null
-    let newConditionIndex = null
-    let previousStepId = branchSteps[branchSteps.length - 1]?.id
-    if (!previousStepId) {
-      return
-    }
-    // Create steps sequentially to avoid serialization conflicts
-    for (const step of branchSteps) {
-      const { appKey, key, connection, parameters } = step
-      const { branchName, ...restParameters } = parameters
+    try {
+      let newConditionId = null
+      let newConditionIndex = null
+      let previousStepId = branchSteps[branchSteps.length - 1]?.id
+      if (!previousStepId) {
+        return
+      }
+      // Create steps sequentially to avoid serialization conflicts
+      for (const step of branchSteps) {
+        const { appKey, key, connection, parameters } = step
+        const { branchName, ...restParameters } = parameters
 
-      // use a new branch name
-      const newBranchName = `[COPY] ${branchName}`
+        // use a new branch name
+        const newBranchName = `[COPY] ${branchName}`
 
-      const mutationInput = {
-        previousStep: { id: previousStepId },
-        flow: { id: flow.id },
-        appKey,
-        key,
-        ...(connection && { connection: { id: connection.id } }),
-        parameters: {
-          ...restParameters,
-          ...(branchName && { branchName: newBranchName }),
-        },
+        const mutationInput = {
+          previousStep: { id: previousStepId },
+          flow: { id: flow.id },
+          appKey,
+          key,
+          ...(connection && { connection: { id: connection.id } }),
+          parameters: {
+            ...restParameters,
+            ...(branchName && { branchName: newBranchName }),
+          },
+        }
+
+        const createdStep = await createStep({
+          fetchPolicy: 'no-cache',
+          variables: { input: mutationInput },
+        })
+
+        if (key === TOOLBOX_ACTIONS.IfThen) {
+          newConditionId = createdStep.data.createStep.id
+          newConditionIndex = createdStep.data.createStep.position - 1
+        }
+
+        // use the new step id as the previous step id for the next step
+        previousStepId = createdStep.data.createStep.id
       }
 
-      const createdStep = await createStep({
-        fetchPolicy: 'no-cache',
-        variables: { input: mutationInput },
-      })
+      // Refetch flow data only once after all steps are created
+      await client.refetchQueries({ include: [GET_FLOW] })
 
-      if (key === TOOLBOX_ACTIONS.IfThen) {
-        newConditionId = createdStep.data.createStep.id
-        newConditionIndex = createdStep.data.createStep.position - 1
+      setCurrentStepId(newConditionId)
+      setCurrentStepIndex(newConditionIndex)
+      if (!isDrawerOpen) {
+        onDrawerOpen()
       }
-
-      // use the new step id as the previous step id for the next step
-      previousStepId = createdStep.data.createStep.id
-    }
-
-    // Refetch flow data only once after all steps are created
-    await client.refetchQueries({ include: [GET_FLOW] })
-
-    setCurrentStepId(newConditionId)
-    setCurrentStepIndex(newConditionIndex)
-    setIsDuplicatingBranch(false)
-    if (!isDrawerOpen) {
-      onDrawerOpen()
+    } catch (err) {
+      console.error('Error duplicating branch', err)
+    } finally {
+      setIsDuplicatingBranch(false)
     }
   }
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -1,0 +1,110 @@
+import { IStep } from '@plumber/types'
+
+import { useCallback, useContext, useMemo, useState } from 'react'
+import { useMutation } from '@apollo/client'
+import { useDisclosure } from '@chakra-ui/react'
+
+import { EditorContext } from '@/contexts/Editor'
+import client from '@/graphql/client'
+import { CREATE_STEP } from '@/graphql/mutations/create-step'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+
+export default function useDuplicateBranch(branchSteps: IStep[]) {
+  const {
+    isOpen: duplicateConfirmationIsOpen,
+    onOpen: openDuplicateConfirmationImpl,
+    onClose: closeDuplicateConfirmation,
+  } = useDisclosure()
+
+  const [isDuplicatingBranch, setIsDuplicatingBranch] = useState(false)
+  const {
+    flow,
+    isDrawerOpen,
+    onDrawerOpen,
+    setCurrentStepId,
+    setCurrentStepIndex,
+  } = useContext(EditorContext)
+
+  const [createStep] = useMutation(CREATE_STEP, { fetchPolicy: 'no-cache' })
+
+  const canDuplicateBranch = useMemo(() => {
+    return (
+      branchSteps.length >= 2 &&
+      branchSteps.every((step) => step.appKey && step.key)
+    )
+  }, [branchSteps])
+
+  const duplicateBranch = async () => {
+    closeDuplicateConfirmation()
+
+    if (branchSteps.length < 2) {
+      return
+    }
+
+    setIsDuplicatingBranch(true)
+
+    let newConditionId = null
+    let newConditionIndex = null
+    let previousStepId = branchSteps[branchSteps.length - 1]?.id
+    if (!previousStepId) {
+      return
+    }
+    // Create steps sequentially to avoid serialization conflicts
+    for (const step of branchSteps) {
+      const { appKey, key, connection, parameters } = step
+      const { branchName, ...restParameters } = parameters
+
+      // use a new branch name
+      const newBranchName = `[COPY] ${branchName}`
+
+      const mutationInput = {
+        previousStep: { id: previousStepId },
+        flow: { id: flow.id },
+        appKey,
+        key,
+        ...(connection && { connection: { id: connection.id } }),
+        parameters: {
+          ...restParameters,
+          ...(branchName && { branchName: newBranchName }),
+        },
+      }
+
+      const createdStep = await createStep({
+        fetchPolicy: 'no-cache',
+        variables: { input: mutationInput },
+      })
+
+      if (key === TOOLBOX_ACTIONS.IfThen) {
+        newConditionId = createdStep.data.createStep.id
+        newConditionIndex = createdStep.data.createStep.position - 1
+      }
+
+      // use the new step id as the previous step id for the next step
+      previousStepId = createdStep.data.createStep.id
+    }
+
+    // Refetch flow data only once after all steps are created
+    await client.refetchQueries({ include: [GET_FLOW] })
+
+    setCurrentStepId(newConditionId)
+    setCurrentStepIndex(newConditionIndex)
+    setIsDuplicatingBranch(false)
+    if (!isDrawerOpen) {
+      onDrawerOpen()
+    }
+  }
+
+  const openDuplicateConfirmation = useCallback(() => {
+    openDuplicateConfirmationImpl()
+  }, [openDuplicateConfirmationImpl])
+
+  return {
+    canDuplicateBranch,
+    duplicateConfirmationIsOpen,
+    isDuplicatingBranch,
+    closeDuplicateConfirmation,
+    duplicateBranch,
+    openDuplicateConfirmation,
+  }
+}

--- a/packages/frontend/src/components/MenuAlertDialog/index.tsx
+++ b/packages/frontend/src/components/MenuAlertDialog/index.tsx
@@ -9,8 +9,14 @@ import {
 } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
 
-export type AlertDialogType = 'delete' | 'duplicate'
-export type AlertHeaderType = 'Connection' | 'Pipe' | 'Tile' | 'Step' | 'File'
+export type AlertDialogType = 'delete' | 'duplicate' | 'duplicate-branch'
+export type AlertHeaderType =
+  | 'Connection'
+  | 'Pipe'
+  | 'Tile'
+  | 'Step'
+  | 'File'
+  | 'Branch'
 
 interface MenuAlertDialogProps {
   isDialogOpen: boolean
@@ -43,6 +49,12 @@ function getAlertDialogContent(
       return {
         header: 'Duplicate Pipe',
         body: `You'll need to replace the data in every step and test each step in your duplicated pipe before publishing it.`,
+        buttonText: 'Duplicate',
+      }
+    case 'duplicate-branch':
+      return {
+        header: `Duplicate ${dialogHeader}`,
+        body: `Every step in this ${dialogHeader} will be duplicated. You will need to check each step again.`,
         buttonText: 'Duplicate',
       }
   }

--- a/packages/frontend/src/graphql/cache.ts
+++ b/packages/frontend/src/graphql/cache.ts
@@ -17,6 +17,11 @@ export const cacheConfig = {
             return incoming // Replace existing with incoming
           },
         },
+        steps: {
+          merge(_existing = [], incoming: any[]) {
+            return incoming // Replace existing with incoming
+          },
+        },
       },
     },
     // prevent apollo client from complaining about cache data loss


### PR DESCRIPTION
### TL;DR

Added the ability to duplicate if-then branches.

### What changed?

- Added a new duplicate branch button next to the delete button in the Branch component
- Created a new `useDuplicateBranch` hook to handle branch duplication logic
- Implemented unsaved changes warning when duplicating a branch
- Replaced the custom AlertDialog with the reusable MenuAlertDialog component
- Added a new dialog type 'duplicate-branch' to MenuAlertDialog to warn users that all steps within the branch will be duplicated

### How to test?
**Setup**: Create a Pipe with If-then branches and steps within the branch

- [ ] Duplicate a branch
  - [ ] Should show warning that all actions within the branch will be duplicated
  - [ ] All steps within the branch are duplicated
  - [ ] New branch is created with "[COPY]" prefix in the name
- [ ] Test the unsaved changes warning by making changes to a branch and then trying to duplicate it

### Why make this change?

This feature improves user workflow by allowing them to duplicate complex branches instead of recreating them from scratch. This saves time and reduces errors when users need similar logic across multiple branches.