### PR TITLE
[DUPLICATE-STEP-3] Add SortableList components

### DIFF
--- a/packages/frontend/src/components/SortableList/SortableList.css
+++ b/packages/frontend/src/components/SortableList/SortableList.css
@@ -1,0 +1,6 @@
+.SortableList {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  list-style: none;
+}

--- a/packages/frontend/src/components/SortableList/components/SortableItem/SortableItem.css
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/SortableItem.css
@@ -1,0 +1,42 @@
+.SortableItem {
+  display: flex;
+  justify-content: center;
+  flex-grow: 1;
+  width: 100%;
+  align-items: center;
+  box-sizing: border-box;
+  list-style: none;
+  color: #333;
+  font-weight: 400;
+  font-size: 1rem;
+  font-family: sans-serif;
+}
+
+.DragHandle {
+  display: flex;
+  width: 12px;
+  padding: 15px;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  touch-action: none;
+  cursor: var(--cursor, pointer);
+  border-radius: 5px;
+  border: none;
+  outline: none;
+  appearance: none;
+  background-color: transparent;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.DragHandle:focus-visible {
+  box-shadow: 0 0px 0px 2px #4c9ffe;
+}
+
+.DragHandle svg {
+  flex: 0 0 auto;
+  margin: auto;
+  height: 100%;
+  overflow: visible;
+  fill: #919eab;
+}

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -1,0 +1,76 @@
+import './SortableItem.css'
+
+import type { CSSProperties, PropsWithChildren } from 'react'
+import React, { createContext, useContext, useMemo } from 'react'
+import type {
+  DraggableSyntheticListeners,
+  UniqueIdentifier,
+} from '@dnd-kit/core'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+interface Props {
+  id: UniqueIdentifier
+}
+
+interface Context {
+  attributes: Record<string, any>
+  listeners: DraggableSyntheticListeners
+  ref(node: HTMLElement | null): void
+  isDragging: boolean
+}
+
+const SortableItemContext = createContext<Context>({
+  attributes: {},
+  listeners: undefined,
+  ref() {
+    // Empty implementation for default context
+  },
+  isDragging: false,
+})
+
+export function SortableItem({ children, id }: PropsWithChildren<Props>) {
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id })
+  const context = useMemo(
+    () => ({
+      attributes,
+      listeners,
+      ref: setActivatorNodeRef,
+      isDragging,
+    }),
+    [attributes, listeners, setActivatorNodeRef, isDragging],
+  )
+  const style: CSSProperties = {
+    opacity: isDragging ? 0.4 : undefined,
+    transform: CSS.Translate.toString(transform),
+    transition,
+  }
+
+  return (
+    <SortableItemContext.Provider value={context}>
+      <li className="SortableItem" ref={setNodeRef} style={style}>
+        {children}
+      </li>
+    </SortableItemContext.Provider>
+  )
+}
+
+export function DragHandle() {
+  const { attributes, listeners, ref } = useContext(SortableItemContext)
+
+  return (
+    <button className="DragHandle" {...attributes} {...listeners} ref={ref}>
+      <svg viewBox="0 0 20 20" width="12">
+        <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z"></path>
+      </svg>
+    </button>
+  )
+}

--- a/packages/frontend/src/components/SortableList/components/SortableOverlay/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableOverlay/index.tsx
@@ -1,0 +1,22 @@
+import type { DropAnimation } from '@dnd-kit/core'
+import { defaultDropAnimationSideEffects, DragOverlay } from '@dnd-kit/core'
+
+const dropAnimationConfig: DropAnimation = {
+  sideEffects: defaultDropAnimationSideEffects({
+    styles: {
+      active: {
+        opacity: '0.4',
+      },
+    },
+  }),
+}
+
+interface SortableOverlayProps {
+  children: React.ReactNode
+}
+
+export function SortableOverlay({ children }: SortableOverlayProps) {
+  return (
+    <DragOverlay dropAnimation={dropAnimationConfig}>{children}</DragOverlay>
+  )
+}

--- a/packages/frontend/src/components/SortableList/components/index.ts
+++ b/packages/frontend/src/components/SortableList/components/index.ts
@@ -1,0 +1,2 @@
+export { DragHandle, SortableItem } from './SortableItem'
+export { SortableOverlay } from './SortableOverlay'

--- a/packages/frontend/src/components/SortableList/index.tsx
+++ b/packages/frontend/src/components/SortableList/index.tsx
@@ -30,7 +30,7 @@ interface BaseItem {
 interface Props<T extends BaseItem> {
   items: T[]
   onChange(items: T[]): void
-  renderItem(item: T, isDragging: boolean): ReactNode
+  renderItem(item: T, isDragging: boolean, isOverlay?: boolean): ReactNode
 }
 
 export function SortableList<T extends BaseItem>({
@@ -78,13 +78,13 @@ export function SortableList<T extends BaseItem>({
         <ul className="SortableList" role="application">
           {items.map((item) => (
             <React.Fragment key={item.id}>
-              {renderItem(item, active?.id === item.id)}
+              {renderItem(item, active?.id === item.id, false)}
             </React.Fragment>
           ))}
         </ul>
       </SortableContext>
       <SortableOverlay>
-        {activeItem ? renderItem(activeItem, true) : null}
+        {activeItem ? renderItem(activeItem, true, true) : null}
       </SortableOverlay>
     </DndContext>
   )

--- a/packages/frontend/src/components/SortableList/index.tsx
+++ b/packages/frontend/src/components/SortableList/index.tsx
@@ -1,0 +1,94 @@
+import './SortableList.css'
+
+import type { ReactNode } from 'react'
+import React, { useMemo, useState } from 'react'
+import type { Active, UniqueIdentifier } from '@dnd-kit/core'
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  restrictToParentElement,
+  restrictToVerticalAxis,
+  restrictToWindowEdges,
+} from '@dnd-kit/modifiers'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
+
+import { DragHandle, SortableItem, SortableOverlay } from './components'
+
+interface BaseItem {
+  id: UniqueIdentifier
+}
+
+interface Props<T extends BaseItem> {
+  items: T[]
+  onChange(items: T[]): void
+  renderItem(item: T, isDragging: boolean): ReactNode
+}
+
+export function SortableList<T extends BaseItem>({
+  items,
+  onChange,
+  renderItem,
+}: Props<T>) {
+  const [active, setActive] = useState<Active | null>(null)
+  const activeItem = useMemo(
+    () => items.find((item) => item.id === active?.id),
+    [active, items],
+  )
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={({ active }) => {
+        setActive(active)
+      }}
+      onDragEnd={({ active, over }) => {
+        if (over && active.id !== over?.id) {
+          const activeIndex = items.findIndex(({ id }) => id === active.id)
+          const overIndex = items.findIndex(({ id }) => id === over.id)
+
+          onChange(arrayMove(items, activeIndex, overIndex))
+        }
+        setActive(null)
+      }}
+      onDragCancel={() => {
+        setActive(null)
+      }}
+      modifiers={[
+        restrictToVerticalAxis,
+        restrictToParentElement,
+        restrictToWindowEdges,
+      ]}
+    >
+      <SortableContext items={items}>
+        <ul className="SortableList" role="application">
+          {items.map((item) => (
+            <React.Fragment key={item.id}>
+              {renderItem(item, active?.id === item.id)}
+            </React.Fragment>
+          ))}
+        </ul>
+      </SortableContext>
+      <SortableOverlay>
+        {activeItem ? renderItem(activeItem, true) : null}
+      </SortableOverlay>
+    </DndContext>
+  )
+}
+
+SortableList.Item = SortableItem
+SortableList.DragHandle = DragHandle


### PR DESCRIPTION
## TL;DR
This PR introduces a new `SortableList` component that enables drag-and-drop reordering of list items. The implementation uses the `@dnd-kit` library to handle the drag and drop functionality.

Key features:
- Reusable `SortableList` component with customisable item rendering
- Drag handle for intuitive item reordering
- Visual feedback during dragging operations
- Keyboard accessibility support
- Vertical axis movement restriction

The component structure includes:
- Main `SortableList` container
- `SortableItem` for individual list entries
- `DragHandle` for initiating drag operations
- `SortableOverlay` for visual feedback during dragging

## How to test?
Nothing to test yet, this just creates the component to be used in subsequent PRs.