### PR TITLE
chore: remove unnecessary step index

### DIFF
--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -29,7 +29,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
     isDrawerOpen,
     isMobile,
     currentStepId,
-    currentStepIndex,
     flow,
   } = useContext(EditorContext)
 
@@ -176,7 +175,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
               <FlowStep
                 step={step}
                 isDeletable={true}
-                index={index}
                 isLastStep={index === steps.length - 1}
                 isNested={isNested}
               />
@@ -217,7 +215,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
         >
           <EditorRightDrawer
             flowStepGroupIconUrl={flowStepGroupIconUrl}
-            index={currentStepIndex}
             steps={steps}
           />
         </Flex>

--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -12,12 +12,11 @@ import { editorRightDrawerStyles as styles } from './styles'
 
 interface EditorRightDrawerProps {
   flowStepGroupIconUrl?: string
-  index: number | null
   steps: IStep[]
 }
 
 export default function EditorRightDrawer(props: EditorRightDrawerProps) {
-  const { index, steps } = props
+  const { steps } = props
 
   const { allApps, currentStepId } = useContext(EditorContext)
 
@@ -41,7 +40,7 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
     >
       <StepHeader step={step} />
       <Flex {...styles.stepContentsWrapper} pt={hasConnection ? 0 : 4}>
-        <Step step={step} isLastStep={index === steps.length - 1} />
+        <Step step={step} isLastStep={step.position === steps.length} />
       </Flex>
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -36,7 +36,6 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
     isMobile,
     onDrawerClose,
     setCurrentStepId,
-    setCurrentStepIndex,
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
 
@@ -80,7 +79,6 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
       // NOTE: this ensures that the drawer is closed and step headers
       // return to the original width when the drawer is closed
       setCurrentStepId(null)
-      setCurrentStepIndex(null)
       setShouldWarnOnLeave(false)
       onDrawerClose()
     },
@@ -89,7 +87,6 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
       step,
       deleteStep,
       setCurrentStepId,
-      setCurrentStepIndex,
       setShouldWarnOnLeave,
       onDrawerClose,
       createStep,

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -62,13 +62,8 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
 export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
   const { isNested, step } = props
 
-  const {
-    flow,
-    isMobile,
-    onDrawerOpen,
-    setCurrentStepId,
-    setCurrentStepIndex,
-  } = useContext(EditorContext)
+  const { flow, isMobile, onDrawerOpen, setCurrentStepId } =
+    useContext(EditorContext)
 
   const [createStep] = useMutation(CREATE_STEP, { refetchQueries: [GET_FLOW] })
 
@@ -97,18 +92,9 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     })
 
     const newStep = createdStep.data.createStep
-    const newStepIndex = newStep.position - 1
     setCurrentStepId(newStep.id)
-    setCurrentStepIndex(newStepIndex)
     onDrawerOpen()
-  }, [
-    flow.id,
-    step,
-    createStep,
-    setCurrentStepId,
-    setCurrentStepIndex,
-    onDrawerOpen,
-  ])
+  }, [flow.id, step, createStep, setCurrentStepId, onDrawerOpen])
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -29,7 +29,6 @@ import { flowStepStyles } from './styles'
 
 type FlowStepProps = {
   step: IStep
-  index: number
   isDeletable?: boolean
   isLastStep: boolean
   isNested?: boolean
@@ -38,7 +37,7 @@ type FlowStepProps = {
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, index, isLastStep, isNested } = props
+  const { step, isLastStep, isNested } = props
 
   const {
     isOpen: isModalOpen,
@@ -58,7 +57,6 @@ export default function FlowStep(
     onDrawerClose,
     onDrawerOpen,
     setCurrentStepId,
-    setCurrentStepIndex,
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
   const displayOverrides = useContext(StepDisplayOverridesContext)?.[step.id]
@@ -107,17 +105,14 @@ export default function FlowStep(
 
     if (isDrawerOpen && currentStepId === step.id) {
       setCurrentStepId(null)
-      setCurrentStepIndex(null)
       onDrawerClose()
     } else {
       setCurrentStepId(step.id)
-      setCurrentStepIndex(index)
       onDrawerOpen()
     }
   }, [
     app,
     currentStepId,
-    index,
     isDrawerOpen,
     shouldWarnOnLeave,
     step.id,
@@ -126,13 +121,11 @@ export default function FlowStep(
     onModalOpen,
     onWarningOpen,
     setCurrentStepId,
-    setCurrentStepIndex,
   ])
 
   const onLeave = () => {
     if (currentStepId === step.id) {
       setCurrentStepId(null)
-      setCurrentStepIndex(null)
       setShouldWarnOnLeave(false)
       onDrawerClose()
     } else if (!app || !selectedActionOrTrigger) {
@@ -140,7 +133,6 @@ export default function FlowStep(
       discardChanges()
     } else {
       setCurrentStepId(step.id)
-      setCurrentStepIndex(index)
     }
   }
 

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -64,14 +64,8 @@ export default function ChooseAndAddConnection(
   props: ChooseAndAddConnectionProps,
 ) {
   const { onClose } = props
-  const {
-    flowId,
-    onCreateStep,
-    onDrawerOpen,
-    onUpdateStep,
-    setCurrentStepId,
-    setCurrentStepIndex,
-  } = useContext(EditorContext)
+  const { flowId, onCreateStep, onDrawerOpen, onUpdateStep, setCurrentStepId } =
+    useContext(EditorContext)
   const { modalState, patchModalState, step, prevStepId } = useContext(
     FlowStepConfigurationContext,
   )
@@ -119,7 +113,6 @@ export default function ChooseAndAddConnection(
 
       patchModalState({ isLoading: true })
       let newStepId = null
-      let newStepIndex = null
       try {
         if (prevStepId) {
           const createdStep = await onCreateStep(
@@ -129,7 +122,6 @@ export default function ChooseAndAddConnection(
             connectionId,
           )
           newStepId = createdStep.id
-          newStepIndex = createdStep.position - 1
         } else if (step) {
           const updatedStep = await onUpdateStep({
             ...step,
@@ -140,14 +132,12 @@ export default function ChooseAndAddConnection(
             },
           })
           newStepId = updatedStep.id
-          newStepIndex = updatedStep.position - 1
         }
         onClose()
       } finally {
         patchModalState({ isLoading: false })
         onDrawerOpen()
         setCurrentStepId(newStepId)
-        setCurrentStepIndex(newStepIndex)
       }
     },
     [
@@ -161,7 +151,6 @@ export default function ChooseAndAddConnection(
       onUpdateStep,
       onDrawerOpen,
       setCurrentStepId,
-      setCurrentStepIndex,
     ],
   )
 

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -31,7 +31,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
     allApps,
     onDrawerOpen,
     setCurrentStepId,
-    setCurrentStepIndex,
   } = useContext(EditorContext)
 
   const { modalState, patchModalState, prevStepId, isTrigger, step } =
@@ -104,7 +103,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       // Exception: M365 will auto connect if verified once...
       patchModalState({ isLoading: true })
       let newStepId = null
-      let newStepIndex = null
       if (prevStepId) {
         const createdStep = await onCreateStep(
           prevStepId,
@@ -113,7 +111,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
           excelConnection?.id || undefined,
         )
         newStepId = createdStep.id
-        newStepIndex = createdStep.position - 1
       } else if (step) {
         // account for the if-then edge case
         if (
@@ -122,7 +119,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
         ) {
           const ifThen = await initializeIfThen(step)
           newStepId = ifThen.id
-          newStepIndex = ifThen.position - 1
         } else {
           const updatedStep = await onUpdateStep({
             ...step,
@@ -133,14 +129,12 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             },
           })
           newStepId = updatedStep.id
-          newStepIndex = updatedStep.position - 1
         }
       }
       patchModalState({ isLoading: false })
       onClose()
       onDrawerOpen()
       setCurrentStepId(newStepId)
-      setCurrentStepIndex(newStepIndex)
     },
     [
       excelConnection?.verified,
@@ -151,7 +145,6 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       onClose,
       onDrawerOpen,
       setCurrentStepId,
-      setCurrentStepIndex,
       onCreateStep,
       initializeIfThen,
       onUpdateStep,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -174,7 +174,6 @@ export default function Branch(props: BranchProps) {
           <Fragment key={`${step.id}-${stepsBeforeGroup.length + index}`}>
             <FlowStep
               step={step}
-              index={stepsBeforeGroup.length + index}
               isDeletable={index !== 0}
               isNested={true}
               isLastStep={index === branchSteps.length - 1}

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -18,13 +18,8 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
   } = useDisclosure()
 
   const [isDuplicatingBranch, setIsDuplicatingBranch] = useState(false)
-  const {
-    flow,
-    isDrawerOpen,
-    onDrawerOpen,
-    setCurrentStepId,
-    setCurrentStepIndex,
-  } = useContext(EditorContext)
+  const { flow, isDrawerOpen, onDrawerOpen, setCurrentStepId } =
+    useContext(EditorContext)
 
   const [createStep] = useMutation(CREATE_STEP, { fetchPolicy: 'no-cache' })
 
@@ -46,7 +41,6 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
 
     try {
       let newConditionId = null
-      let newConditionIndex = null
       let previousStepId = branchSteps[branchSteps.length - 1]?.id
       if (!previousStepId) {
         return
@@ -78,7 +72,6 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
 
         if (key === TOOLBOX_ACTIONS.IfThen) {
           newConditionId = createdStep.data.createStep.id
-          newConditionIndex = createdStep.data.createStep.position - 1
         }
 
         // use the new step id as the previous step id for the next step
@@ -89,7 +82,6 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
       await client.refetchQueries({ include: [GET_FLOW] })
 
       setCurrentStepId(newConditionId)
-      setCurrentStepIndex(newConditionIndex)
       if (!isDrawerOpen) {
         onDrawerOpen()
       }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -31,7 +31,6 @@ interface IEditorContextValue {
   readOnly: boolean
   testExecutionSteps: IExecutionStep[]
   currentStepId: string | null
-  currentStepIndex: number | null
   hasIfThen: boolean
   currentTestExecutionStep: IExecutionStep | null
   isDrawerOpen: boolean
@@ -45,7 +44,6 @@ interface IEditorContextValue {
   onDrawerOpen: () => void
   onDrawerClose: () => void
   setCurrentStepId: (stepId: string | null) => void
-  setCurrentStepIndex: (stepIndex: number | null) => void
   setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
   onCreateStep: (
     previousStepId: string,
@@ -63,7 +61,6 @@ export const EditorContext = createContext<IEditorContextValue>({
   flow: {} as IFlow,
   flowId: '',
   currentStepId: null,
-  currentStepIndex: null,
   hasIfThen: false,
   currentTestExecutionStep: null,
   isDrawerOpen: false,
@@ -81,7 +78,6 @@ export const EditorContext = createContext<IEditorContextValue>({
   onUpdateStep: () => Promise.resolve({} as IStep),
   executeTestStep: () => Promise.resolve(),
   setCurrentStepId: () => null,
-  setCurrentStepIndex: () => null,
   setShouldWarnOnLeave: () => null,
   allApps: [],
   resetForm: () => null,
@@ -149,7 +145,6 @@ export const EditorProvider = ({
 
   const flowId = flow.id
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
-  const [currentStepIndex, setCurrentStepIndex] = useState<number | null>(0)
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
@@ -368,7 +363,6 @@ export const EditorProvider = ({
       value={{
         allApps,
         currentStepId,
-        currentStepIndex,
         hasIfThen,
         isDrawerOpen,
         isMobile,
@@ -388,7 +382,6 @@ export const EditorProvider = ({
         onDrawerClose,
         onUpdateStep,
         setCurrentStepId,
-        setCurrentStepIndex,
         setShouldWarnOnLeave,
         resetForm,
         resetTimestamp,


### PR DESCRIPTION
## TL;DR
This PR does clean up to remove unnecessary `currentStepIndex`

## What changed?
Removes the `currentStepIndex` state and related props from the editor components. Instead, it uses the step's `position` property when needed.

## How to test?
- [ ] Add step button is shown correctly at the last step
- [ ] If-then can only be selected at the last step
- [ ] Delete all steps in a Pipe, should show trigger step and empty flow step header