### PR TITLE
[DUPLICATE-STEP-4] Drag and reorder steps frontend

### DIFF
--- a/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
@@ -1,0 +1,73 @@
+import { IStep } from '@plumber/types'
+
+import { useContext, useMemo } from 'react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { FlowStep } from '@/exports/components'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+
+import { AddStepButton } from './AddStepButton'
+
+export default function FlowStepWithAddButton({
+  step,
+  isLastStep,
+  isNested,
+  stepsBeforeGroup,
+  groupedSteps,
+  showAddButton = true,
+}: {
+  step: IStep
+  isLastStep: boolean
+  isNested?: boolean
+  stepsBeforeGroup: IStep[]
+  groupedSteps: IStep[][]
+  showAddButton?: boolean
+}) {
+  const { readOnly } = useContext(EditorContext)
+
+  const nonIfThenActionSteps = stepsBeforeGroup.filter(
+    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.IfThen,
+  )
+
+  // Disables last add step and hide in-between add step buttons
+  const hasExactlyOneEmptyActionStep =
+    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
+
+  // Disables last add step button but show empty action instead
+  const hasNoActionSteps = nonIfThenActionSteps.length === 0
+
+  const getAddStepButtonProps = useMemo(() => {
+    const shouldShowEmptyAction = hasNoActionSteps && !groupedSteps.length
+    const shouldDisableButton =
+      (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !groupedSteps.length
+
+    return (isLastStep: boolean, stepId: string) => ({
+      isHidden: readOnly,
+      showEmptyAction: shouldShowEmptyAction,
+      isDisabled: shouldDisableButton,
+      isLastStep,
+      stepId,
+    })
+  }, [
+    readOnly,
+    hasNoActionSteps,
+    groupedSteps.length,
+    hasExactlyOneEmptyActionStep,
+  ])
+
+  return (
+    <>
+      <FlowStep
+        step={step}
+        isDeletable={true}
+        isLastStep={isLastStep}
+        isNested={isNested}
+        // only allow reordering if there are more than 1 action steps
+        allowReorder={nonIfThenActionSteps.length > 1}
+      />
+      {showAddButton && (
+        <AddStepButton {...getAddStepButtonProps(isLastStep, step.id)} />
+      )}
+    </>
+  )
+}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -1,19 +1,19 @@
 import type { IApp, IStep } from '@plumber/types'
 
-import { Fragment, useContext, useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { Center, Flex } from '@chakra-ui/react'
 
 import EditorRightDrawer from '@/components/EditorRightDrawer'
-import FlowStep from '@/components/FlowStep'
 import FlowStepGroup from '@/components/FlowStepGroup'
+import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
-import { extractBranchesWithSteps, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
 import PrimarySpinner from '../PrimarySpinner'
 
-import { AddStepButton } from './AddStepButton'
 import { EDITOR_RIGHT_DRAWER_WIDTH } from './constants'
+import FlowStepWithAddButton from './FlowStepWithAddButton'
 import { editorStyles } from './styles'
 
 type EditorProps = {
@@ -23,14 +23,8 @@ type EditorProps = {
 export default function Editor(props: EditorProps): React.ReactElement {
   const { isNested } = props
 
-  const {
-    allApps,
-    readOnly: isReadOnlyEditor,
-    isDrawerOpen,
-    isMobile,
-    currentStepId,
-    flow,
-  } = useContext(EditorContext)
+  const { allApps, isDrawerOpen, isMobile, currentStepId, flow } =
+    useContext(EditorContext)
 
   const rawSteps = flow.steps
   const steps = useMemo(
@@ -64,9 +58,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
     )
   }, [appsWithActions])
 
-  const [stepsBeforeGroup, groupedSteps] = useMemo(() => {
+  const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(() => {
     if (!groupingActions) {
-      return [[], []]
+      return [null, [], []]
     }
 
     const groupStepIdx = steps.findIndex((step, index) => {
@@ -88,9 +82,11 @@ export default function Editor(props: EditorProps): React.ReactElement {
       branchesWithSteps = extractBranchesWithSteps(steps.slice(groupStepIdx), 0)
     }
 
+    const triggerStep = steps[0]
+
     return groupStepIdx === -1
-      ? [steps, []]
-      : [steps.slice(0, groupStepIdx), branchesWithSteps]
+      ? [triggerStep, steps.slice(1), []]
+      : [triggerStep, steps.slice(1, groupStepIdx), branchesWithSteps]
   }, [groupingActions, steps])
 
   const flowStepGroupIconUrl = useMemo(() => {
@@ -125,15 +121,26 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [stepsBeforeGroup, groupStepsToInclude],
   )
 
-  const nonIfThenActionSteps = stepsBeforeGroup.filter(
-    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.IfThen,
-  )
-  // Disables last add step and hide in-between add step buttons
-  const hasExactlyOneEmptyActionStep =
-    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
+  const handleReorderSteps = async (items: any[]) => {
+    const stepPositions = items.map((item, index) => ({
+      id: item.id, // step id
+      position: index + 2, // trigger position is 1
+      step: {
+        id: item.step.id,
+        type: item.step.type,
+      },
+    }))
 
-  // Disables last add step button but show empty action instead
-  const hasNoActionSteps = nonIfThenActionSteps.length === 0
+    try {
+      // TODO: make api call to update step positions
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
 
   if (!appsWithActions || !groupingActions) {
     return (
@@ -170,29 +177,52 @@ export default function Editor(props: EditorProps): React.ReactElement {
             isDrawerOpen ? EDITOR_RIGHT_DRAWER_WIDTH : '0px'
           })`}
         >
-          {stepsBeforeGroup.map((step, index) => (
-            <Fragment key={`${step.id}-${index}`}>
-              <FlowStep
-                step={step}
-                isDeletable={true}
-                isLastStep={index === steps.length - 1}
+          {triggerStep && (
+            <>
+              <FlowStepWithAddButton
+                step={triggerStep}
+                isLastStep={false}
                 isNested={isNested}
+                stepsBeforeGroup={stepsBeforeGroup}
+                groupedSteps={groupedSteps}
               />
-              <AddStepButton
-                // hide all add button steps if is readonly
-                isHidden={isReadOnlyEditor}
-                // show empty action if no action step exists
-                showEmptyAction={hasNoActionSteps && !groupedSteps.length}
-                // Disable add button steps if first action is not set up
-                isDisabled={
-                  (hasExactlyOneEmptyActionStep || hasNoActionSteps) &&
-                  !groupedSteps.length
-                }
-                isLastStep={index === steps.length - 1}
-                stepId={step.id}
-              />
-            </Fragment>
-          ))}
+            </>
+          )}
+
+          <SortableList
+            items={stepsBeforeGroup.map((step) => ({
+              id: step.id,
+              step,
+              position: step.position,
+            }))}
+            onChange={handleReorderSteps}
+            renderItem={(item, _isDragging, isOverlay) => {
+              const { step, position } = item
+              const index = position - 1
+
+              return (
+                <>
+                  <SortableList.Item id={item.id}>
+                    <Flex
+                      key={`${step.id}-${position}`}
+                      width={isDrawerOpen || isMobile ? '100%' : 'auto'}
+                      flexDir="column"
+                      position="relative"
+                    >
+                      <FlowStepWithAddButton
+                        step={step}
+                        isLastStep={index === steps.length - 1}
+                        isNested={isNested}
+                        stepsBeforeGroup={stepsBeforeGroup}
+                        groupedSteps={groupedSteps}
+                        showAddButton={!isOverlay}
+                      />
+                    </Flex>
+                  </SortableList.Item>
+                </>
+              )
+            }}
+          />
           {groupedSteps.length > 0 && (
             <FlowStepGroup
               stepsBeforeGroup={stepsBeforeGroup}

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -8,7 +8,6 @@ import FlowStepGroup from '@/components/FlowStepGroup'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
-import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
 import PrimarySpinner from '../PrimarySpinner'

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -8,6 +8,7 @@ import FlowStepGroup from '@/components/FlowStepGroup'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
 import PrimarySpinner from '../PrimarySpinner'
@@ -121,14 +122,11 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [stepsBeforeGroup, groupStepsToInclude],
   )
 
-  const handleReorderSteps = async (items: any[]) => {
-    const stepPositions = items.map((item, index) => ({
-      id: item.id, // step id
+  const handleReorderSteps = async (steps: IStep[]) => {
+    const stepPositions = steps.map((step, index) => ({
+      id: step.id,
       position: index + 2, // trigger position is 1
-      step: {
-        id: item.step.id,
-        type: item.step.type,
-      },
+      type: step.type,
     }))
 
     try {
@@ -178,48 +176,41 @@ export default function Editor(props: EditorProps): React.ReactElement {
           })`}
         >
           {triggerStep && (
-            <>
-              <FlowStepWithAddButton
-                step={triggerStep}
-                isLastStep={false}
-                isNested={isNested}
-                stepsBeforeGroup={stepsBeforeGroup}
-                groupedSteps={groupedSteps}
-              />
-            </>
+            <FlowStepWithAddButton
+              step={triggerStep}
+              isLastStep={
+                stepsBeforeGroup.length === 0 && groupedSteps.length === 0
+              }
+              isNested={isNested}
+              stepsBeforeGroup={stepsBeforeGroup}
+              groupedSteps={groupedSteps}
+              showAddButton={true}
+            />
           )}
 
           <SortableList
-            items={stepsBeforeGroup.map((step) => ({
-              id: step.id,
-              step,
-              position: step.position,
-            }))}
+            items={stepsBeforeGroup}
             onChange={handleReorderSteps}
-            renderItem={(item, _isDragging, isOverlay) => {
-              const { step, position } = item
-              const index = position - 1
-
+            renderItem={(step, _isDragging, isOverlay) => {
+              const { id, position } = step
               return (
-                <>
-                  <SortableList.Item id={item.id}>
-                    <Flex
-                      key={`${step.id}-${position}`}
-                      width={isDrawerOpen || isMobile ? '100%' : 'auto'}
-                      flexDir="column"
-                      position="relative"
-                    >
-                      <FlowStepWithAddButton
-                        step={step}
-                        isLastStep={index === steps.length - 1}
-                        isNested={isNested}
-                        stepsBeforeGroup={stepsBeforeGroup}
-                        groupedSteps={groupedSteps}
-                        showAddButton={!isOverlay}
-                      />
-                    </Flex>
-                  </SortableList.Item>
-                </>
+                <SortableList.Item id={id}>
+                  <Flex
+                    key={`${id}-${position}`}
+                    width={isDrawerOpen || isMobile ? '100%' : 'auto'}
+                    flexDir="column"
+                    position="relative"
+                  >
+                    <FlowStepWithAddButton
+                      step={step}
+                      isLastStep={position === steps.length}
+                      isNested={isNested}
+                      stepsBeforeGroup={stepsBeforeGroup}
+                      groupedSteps={groupedSteps}
+                      showAddButton={!isOverlay}
+                    />
+                  </Flex>
+                </SortableList.Item>
               )
             }}
           />

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -115,10 +115,11 @@ export default function Editor(props: EditorProps): React.ReactElement {
   const stepExecutionsToInclude = useMemo(
     () =>
       new Set([
+        ...(triggerStep?.id ? [triggerStep.id] : []),
         ...stepsBeforeGroup.map((step) => step.id),
         ...groupStepsToInclude.flatMap((step) => step.map((s) => s.id)),
       ]),
-    [stepsBeforeGroup, groupStepsToInclude],
+    [triggerStep, stepsBeforeGroup, groupStepsToInclude],
   )
 
   const handleReorderSteps = async (steps: IStep[]) => {
@@ -190,7 +191,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
           <SortableList
             items={stepsBeforeGroup}
             onChange={handleReorderSteps}
-            renderItem={(step, _isDragging, isOverlay) => {
+            renderItem={(step, isOverlay) => {
               const { id, position } = step
               return (
                 <SortableList.Item id={id}>

--- a/packages/frontend/src/components/Editor/styles.ts
+++ b/packages/frontend/src/components/Editor/styles.ts
@@ -1,6 +1,6 @@
 import { FlexProps } from '@chakra-ui/react'
 
-import { EDITOR_MAX_HEIGHT, EDITOR_RIGHT_DRAWER_WIDTH } from './constants'
+import { EDITOR_MAX_HEIGHT } from './constants'
 
 export const editorStyles = {
   editorWrapper: {
@@ -39,7 +39,7 @@ export const editorStyles = {
     borderLeftColor: 'base.divider.medium',
     opacity: 0,
     right: 0,
-    minWidth: EDITOR_RIGHT_DRAWER_WIDTH,
+    minWidth: 0,
     maxHeight: EDITOR_MAX_HEIGHT,
     h: EDITOR_MAX_HEIGHT,
     overflowY: 'auto' as FlexProps['overflowY'],

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -18,6 +18,7 @@ import UnsavedChangesAlert from '../Editor/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '../EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '../FlowStepConfigurationModal'
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
+import { SortableList } from '../SortableList'
 
 import DeleteStepButton from './components/DeleteStepButton'
 import DuplicateStepButton from './components/DuplicateStepButton'
@@ -32,12 +33,13 @@ type FlowStepProps = {
   isDeletable?: boolean
   isLastStep: boolean
   isNested?: boolean
+  allowReorder?: boolean
 }
 
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, isLastStep, isNested } = props
+  const { step, isLastStep, isNested, allowReorder = true } = props
 
   const {
     isOpen: isModalOpen,
@@ -64,6 +66,7 @@ export default function FlowStep(
     app,
     caption,
     isCompleted,
+    isIfThenStep,
     isTrigger,
     selectedActionOrTrigger,
     substeps,
@@ -137,6 +140,18 @@ export default function FlowStep(
   }
 
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
+  /**
+   * NOTE: there are various conditions that determine whether the drag handle
+   * should be shown.
+   *
+   * - not read only
+   * - not in mobile view
+   * - step is not a trigger
+   * - step is not an if-then condition step
+   * - allowReorder is true
+   */
+  const shouldShowDragHandle =
+    !readOnly && !isTrigger && !isMobile && !isIfThenStep && allowReorder
 
   // generate help message only if template config exists
   const stepAppEventKey = `${step?.appKey}_${step?.key}`
@@ -169,75 +184,91 @@ export default function FlowStep(
           onModalOpen={handleProceed}
         />
       ) : (
-        <>
-          {shouldTestStepAgain && (
-            <TestAgainInfobox
-              isNested={isNested}
-              shouldHighlight={shouldHighlight}
-            />
-          )}
-          {shouldShowTemplateMsg && (
-            <Box
+        <Flex flexDir="row" w="100%">
+          <Flex
+            alignItems="center"
+            justifyContent="center"
+            flexDir="column"
+            flex="1"
+            minW="0"
+          >
+            {shouldTestStepAgain && (
+              <TestAgainInfobox
+                isNested={isNested}
+                shouldHighlight={shouldHighlight}
+              />
+            )}
+            {shouldShowTemplateMsg && (
+              <Box
+                borderColor={
+                  shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
+                }
+                borderRadius="lg"
+                borderWidth="1px"
+                borderBottomRadius="none"
+                borderBottomWidth={0}
+                w={headerWidth}
+              >
+                <Infobox
+                  icon={<BiInfoCircle />}
+                  variant="secondary"
+                  style={{
+                    borderBottomLeftRadius: '0',
+                    borderBottomRightRadius: '0',
+                  }}
+                >
+                  <MarkdownRenderer
+                    source={templateStepHelpMessage}
+                    components={infoboxMdComponents}
+                  />
+                </Infobox>
+              </Box>
+            )}
+            <Flex
+              data-test="flow-step"
+              {...flowStepStyles.container}
+              borderTopWidth={hasInfoBox ? 0 : '1px'}
               borderColor={
                 shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
               }
-              borderRadius="lg"
-              borderWidth="1px"
-              borderBottomRadius="none"
-              borderBottomWidth={0}
+              borderTopRadius={hasInfoBox ? 'none' : 'lg'}
+              h={isNested ? '48px' : '64px'}
               w={headerWidth}
             >
-              <Infobox
-                icon={<BiInfoCircle />}
-                variant="secondary"
-                style={{
-                  borderBottomLeftRadius: '0',
-                  borderBottomRightRadius: '0',
-                }}
+              <Flex
+                {...flowStepStyles.topHeader}
+                py={isNested ? 2 : 4}
+                onClick={handleClick}
               >
-                <MarkdownRenderer
-                  source={templateStepHelpMessage}
-                  components={infoboxMdComponents}
+                <StepAppIcon
+                  isCompleted={isCompleted}
+                  isNested={isNested}
+                  isTestSuccessful={isTestSuccessful}
+                  shouldTestStepAgain={shouldTestStepAgain}
+                  app={app}
+                  step={step}
                 />
-              </Infobox>
-            </Box>
-          )}
-          <Flex
-            data-test="flow-step"
-            {...flowStepStyles.container}
-            borderTopWidth={hasInfoBox ? 0 : '1px'}
-            borderColor={
-              shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
-            }
-            borderTopRadius={hasInfoBox ? 'none' : 'lg'}
-            h={isNested ? '48px' : '64px'}
-            w={headerWidth}
-          >
-            <Flex
-              {...flowStepStyles.topHeader}
-              py={isNested ? 2 : 4}
-              onClick={handleClick}
-            >
-              <StepAppIcon
-                isCompleted={isCompleted}
-                isNested={isNested}
-                isTestSuccessful={isTestSuccessful}
-                shouldTestStepAgain={shouldTestStepAgain}
-                app={app}
-                step={step}
-              />
-              <StepCaptionAndDemo app={app} caption={caption} />
-              {isDeletable && (
-                <Flex gap={1} ml="auto">
-                  {!isTrigger && (
-                    <DuplicateStepButton isNested={isNested} step={step} />
-                  )}
-                  <DeleteStepButton isNested={isNested} step={step} />
-                </Flex>
-              )}
+                <StepCaptionAndDemo app={app} caption={caption} />
+                {isDeletable && (
+                  <Flex gap={1} ml="auto">
+                    {!isTrigger && (
+                      <DuplicateStepButton isNested={isNested} step={step} />
+                    )}
+                    <DeleteStepButton isNested={isNested} step={step} />
+                  </Flex>
+                )}
+              </Flex>
             </Flex>
           </Flex>
-        </>
+          {shouldShowDragHandle &&
+            (isNested ? (
+              <SortableList.DragHandle />
+            ) : (
+              <Box position="absolute" left="100%" alignSelf="center">
+                <SortableList.DragHandle />
+              </Box>
+            ))}
+        </Flex>
       )}
       {isModalOpen && (
         <FlowStepConfigurationModal

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -1,7 +1,6 @@
 import { IStep } from '@plumber/types'
 
 import {
-  Fragment,
   MouseEventHandler,
   useCallback,
   useContext,
@@ -16,11 +15,13 @@ import { IconButton } from '@opengovsg/design-system-react'
 import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import FlowStep from '@/components/FlowStep'
 import MenuAlertDialog from '@/components/MenuAlertDialog'
+import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
+import BranchStepWithAddButton from './BranchStepWithAddButton'
 import { HoverAddStepButton } from './HoverAddStepButton'
 import { branchStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
@@ -32,7 +33,7 @@ interface BranchProps {
 }
 
 export default function Branch(props: BranchProps) {
-  const { branchSteps, stepsBeforeGroup } = props
+  const { branchSteps } = props
 
   const {
     isDrawerOpen,
@@ -115,6 +116,35 @@ export default function Branch(props: BranchProps) {
     discardChanges()
   }
 
+  const handleReorderSteps = async (items: any[]) => {
+    const branchPosition = branchSteps[0].position
+    const stepPositions = items.map((item, index) => ({
+      id: item.id,
+      position: branchPosition + index + 1, // index starts at 0
+      step: {
+        id: item.step.id,
+        type: item.step.type,
+      },
+    }))
+
+    try {
+      // TODO: make api call to update step positions
+    } catch (error) {
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
+  const { conditionStep, actionSteps } = useMemo(() => {
+    const conditionStep = branchSteps[0]
+    const actionSteps = branchSteps.slice(1)
+
+    return { conditionStep, actionSteps }
+  }, [branchSteps])
+
   return (
     <Flex key={branchSteps[0].id} {...branchStyles.container}>
       <Box
@@ -169,24 +199,46 @@ export default function Branch(props: BranchProps) {
           )}
         </Flex>
       </Box>
-      {branchSteps.map((step, index) => {
-        return (
-          <Fragment key={`${step.id}-${stepsBeforeGroup.length + index}`}>
-            <FlowStep
-              step={step}
-              isDeletable={index !== 0}
-              isNested={true}
-              isLastStep={index === branchSteps.length - 1}
-            />
-            <HoverAddStepButton
-              isDisabled={isEditorReadOnly || !canAddStep}
-              isDrawerOpen={isDrawerOpen}
-              isLastStep={index === branchSteps.length - 1}
-              prevStepId={step.id}
-            />
-          </Fragment>
-        )
-      })}
+      <Flex w="100%" flexDir="column">
+        <BranchStepWithAddButton
+          step={conditionStep}
+          canAddStep={canAddStep}
+          isLastStep={false}
+        />
+        <SortableList
+          items={actionSteps.map((step, index) => ({
+            id: step.id,
+            step,
+            index,
+          }))}
+          onChange={handleReorderSteps}
+          renderItem={(item, isDragging, isOverlay) => {
+            const { step, index } = item
+
+            return (
+              <SortableList.Item id={item.id}>
+                <Flex w="100%" flexDir="column">
+                  <FlowStep
+                    step={item.step}
+                    isDeletable={true}
+                    isLastStep={index === branchSteps.length - 2}
+                    isNested={true}
+                    allowReorder={branchSteps.length > 2}
+                  />
+                  {!isOverlay && (
+                    <HoverAddStepButton
+                      isDisabled={isEditorReadOnly || !canAddStep}
+                      isDrawerOpen={isDrawerOpen}
+                      isLastStep={index === branchSteps.length - 2}
+                      prevStepId={step.id}
+                    />
+                  )}
+                </Flex>
+              </SortableList.Item>
+            )
+          }}
+        />
+      </Flex>
 
       {/* Delete Confirmation Modal */}
       <MenuAlertDialog

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -209,7 +209,7 @@ export default function Branch(props: BranchProps) {
             index,
           }))}
           onChange={handleReorderSteps}
-          renderItem={(item, isDragging, isOverlay) => {
+          renderItem={(item, isOverlay) => {
             const { step, index } = item
             const isLastStep = index === actionSteps.length - 1 // index is 0-based
 

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -13,7 +13,6 @@ import { Box, Flex, Text, useDisclosure } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
-import FlowStep from '@/components/FlowStep'
 import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
@@ -22,7 +21,6 @@ import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import BranchStepWithAddButton from './BranchStepWithAddButton'
-import { HoverAddStepButton } from './HoverAddStepButton'
 import { branchStyles } from './styles'
 import useDuplicateBranch from './useDuplicateBranch'
 import { allowAddStep } from './utils'
@@ -116,15 +114,19 @@ export default function Branch(props: BranchProps) {
     discardChanges()
   }
 
+  const { conditionStep, actionSteps } = useMemo(() => {
+    const conditionStep = branchSteps[0]
+    const actionSteps = branchSteps.slice(1)
+
+    return { conditionStep, actionSteps }
+  }, [branchSteps])
+
   const handleReorderSteps = async (items: any[]) => {
-    const branchPosition = branchSteps[0].position
+    const branchPosition = conditionStep.position
     const stepPositions = items.map((item, index) => ({
       id: item.id,
-      position: branchPosition + index + 1, // index starts at 0
-      step: {
-        id: item.step.id,
-        type: item.step.type,
-      },
+      position: branchPosition + index + 1, // index is 0-based
+      type: item.step.type,
     }))
 
     try {
@@ -137,13 +139,6 @@ export default function Branch(props: BranchProps) {
       )
     }
   }
-
-  const { conditionStep, actionSteps } = useMemo(() => {
-    const conditionStep = branchSteps[0]
-    const actionSteps = branchSteps.slice(1)
-
-    return { conditionStep, actionSteps }
-  }, [branchSteps])
 
   return (
     <Flex key={branchSteps[0].id} {...branchStyles.container}>
@@ -209,30 +204,25 @@ export default function Branch(props: BranchProps) {
           items={actionSteps.map((step, index) => ({
             id: step.id,
             step,
+            // need to use index because the step position will
+            // not be enough to identify if its the last step
             index,
           }))}
           onChange={handleReorderSteps}
           renderItem={(item, isDragging, isOverlay) => {
             const { step, index } = item
+            const isLastStep = index === actionSteps.length - 1 // index is 0-based
 
             return (
               <SortableList.Item id={item.id}>
                 <Flex w="100%" flexDir="column">
-                  <FlowStep
-                    step={item.step}
-                    isDeletable={true}
-                    isLastStep={index === branchSteps.length - 2}
-                    isNested={true}
-                    allowReorder={branchSteps.length > 2}
+                  <BranchStepWithAddButton
+                    step={step}
+                    canAddStep={canAddStep}
+                    isLastStep={isLastStep}
+                    isOverlay={isOverlay}
+                    allowReorder={actionSteps.length > 1}
                   />
-                  {!isOverlay && (
-                    <HoverAddStepButton
-                      isDisabled={isEditorReadOnly || !canAddStep}
-                      isDrawerOpen={isDrawerOpen}
-                      isLastStep={index === branchSteps.length - 2}
-                      prevStepId={step.id}
-                    />
-                  )}
                 </Flex>
               </SortableList.Item>
             )

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchStepWithAddButton.tsx
@@ -13,12 +13,13 @@ interface BranchStepWithAddButtonProps {
   canAddStep: boolean
   isLastStep: boolean
   isOverlay?: boolean
+  allowReorder?: boolean
 }
 
 export default function BranchStepWithAddButton(
   props: BranchStepWithAddButtonProps,
 ) {
-  const { step, canAddStep, isLastStep, isOverlay } = props
+  const { step, canAddStep, isLastStep, isOverlay, allowReorder } = props
   const { isDrawerOpen, readOnly } = useContext(EditorContext)
 
   // cannot delete the condition step
@@ -33,6 +34,7 @@ export default function BranchStepWithAddButton(
         // branch steps are always nested
         isNested={true}
         isLastStep={isLastStep}
+        allowReorder={allowReorder}
       />
       {!isOverlay && (
         <HoverAddStepButton

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/BranchStepWithAddButton.tsx
@@ -1,0 +1,47 @@
+import { IStep } from '@plumber/types'
+
+import { useContext } from 'react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { FlowStep } from '@/exports/components'
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+
+import { HoverAddStepButton } from './HoverAddStepButton'
+
+interface BranchStepWithAddButtonProps {
+  step: IStep
+  canAddStep: boolean
+  isLastStep: boolean
+  isOverlay?: boolean
+}
+
+export default function BranchStepWithAddButton(
+  props: BranchStepWithAddButtonProps,
+) {
+  const { step, canAddStep, isLastStep, isOverlay } = props
+  const { isDrawerOpen, readOnly } = useContext(EditorContext)
+
+  // cannot delete the condition step
+  const isDeletable =
+    step.appKey !== TOOLBOX_APP_KEY && step.key !== TOOLBOX_ACTIONS.IfThen
+
+  return (
+    <>
+      <FlowStep
+        step={step}
+        isDeletable={isDeletable}
+        // branch steps are always nested
+        isNested={true}
+        isLastStep={isLastStep}
+      />
+      {!isOverlay && (
+        <HoverAddStepButton
+          isDisabled={readOnly || !canAddStep}
+          isDrawerOpen={isDrawerOpen}
+          isLastStep={isLastStep}
+          prevStepId={step.id}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/frontend/src/components/SortableList/index.tsx
+++ b/packages/frontend/src/components/SortableList/index.tsx
@@ -30,7 +30,7 @@ interface BaseItem {
 interface Props<T extends BaseItem> {
   items: T[]
   onChange(items: T[]): void
-  renderItem(item: T, isDragging: boolean, isOverlay?: boolean): ReactNode
+  renderItem(item: T, isOverlay?: boolean): ReactNode
 }
 
 export function SortableList<T extends BaseItem>({
@@ -78,13 +78,13 @@ export function SortableList<T extends BaseItem>({
         <ul className="SortableList" role="application">
           {items.map((item) => (
             <React.Fragment key={item.id}>
-              {renderItem(item, active?.id === item.id, false)}
+              {renderItem(item, false)}
             </React.Fragment>
           ))}
         </ul>
       </SortableContext>
       <SortableOverlay>
-        {activeItem ? renderItem(activeItem, true, true) : null}
+        {activeItem ? renderItem(activeItem, true) : null}
       </SortableOverlay>
     </DndContext>
   )


### PR DESCRIPTION
## TL;DR
This PR adds drag and drop functionality to reorder steps in the flow editor.
Note that this is a pure frontend change.

## What changed?
- Added a new `FlowStepWithAddButton` component to encapsulate flow step rendering with add button logic
- Integrated `SortableList` component for drag and drop functionality in the main editor and if-then branches
- Added drag handles that appear when steps can be reordered
- Implemented conditional logic to hide drag handles when there's only one action step
- Created handlers for updating step positions when reordering occurs
- Improved UI for nested steps in if-then branches

## How to test?
- [ ] Cannot drag the Trigger step
- [ ] Can drag action steps (except the trigger)
  - [ ] Only have drag handle if more than 1 action step
  - [ ] Cannot drag action steps into the If-then
  - [ ] Add step button should not be visible for actions step that is being dragged
- [ ] Steps within if-then branches
  - [ ] Only see drag handle if more than 1 action step within the branch
  - [ ] Can only drag step within the branch
- [ ] Can only drag steps vertically
  - [ ] Dragging horizontally does nothing

## Screenshots

[Screen Recording 2025-07-03 at 10.44.22 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/7d0ac436-89cf-4638-9957-646d2aaf3ede.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/7d0ac436-89cf-4638-9957-646d2aaf3ede.mov)

