### PR TITLE
[DUPLICATE-STEP-5] Saving reordered steps

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import updateStepPositions from '@/graphql/mutations/update-step-positions'
+import Step from '@/models/step'
+
+const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+
+const MOCK_STEPS = [
+  {
+    id: 'step-0',
+    appKey: 'formsg' as const,
+    key: 'newSubmission' as const,
+    type: 'trigger',
+    flowId: mockFlowId,
+    position: 1,
+    parameters: { testParam: 'value' },
+  },
+  {
+    id: 'step-1',
+    appKey: 'postman',
+    key: 'sendTransactionalEmail' as const,
+    type: 'action',
+    flowId: mockFlowId,
+    position: 2,
+    parameters: { testParam: 'value' },
+  },
+  {
+    id: 'step-2',
+    appKey: 'tiles' as const,
+    key: 'findSingleRow' as const,
+    type: 'action',
+    flowId: mockFlowId,
+    position: 3,
+    parameters: {},
+  },
+  {
+    id: 'step-3',
+    appKey: 'tiles' as const,
+    key: 'findSingleRow' as const,
+    type: 'action',
+    flowId: mockFlowId,
+    position: 4,
+    parameters: {},
+  },
+  {
+    id: 'step-4',
+    appKey: 'slack' as const,
+    key: 'findMessage' as const,
+    type: 'action',
+    flowId: mockFlowId,
+    position: 5,
+    parameters: {},
+  },
+] as const
+
+describe('updateStepPositions mutation', () => {
+  let context: any
+  let fakeSteps: any[]
+  let fakeFlow: any
+  let fakeQuery: any
+  let stepFindByIdSpy: ReturnType<typeof vi.fn>
+  let stepPatchSpy: ReturnType<typeof vi.fn>
+  let flowPatchAndFetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    // Set up flow patch and fetch spy first
+    flowPatchAndFetchSpy = vi.fn().mockReturnValue({
+      withGraphFetched: vi.fn().mockReturnValue({
+        orderBy: vi.fn().mockResolvedValue([]),
+      }),
+    })
+    stepPatchSpy = vi.fn().mockResolvedValue({})
+
+    // Create fake flow object
+    fakeFlow = {
+      id: mockFlowId,
+      active: false,
+      $query: vi.fn().mockReturnValue({
+        patchAndFetch: flowPatchAndFetchSpy,
+      }),
+    }
+
+    // Create fake steps with flow reference
+    fakeSteps = MOCK_STEPS.map((step) => ({
+      ...step,
+      flow: fakeFlow,
+    }))
+
+    // Mock Step.transaction
+    vi.spyOn(Step, 'transaction').mockImplementation(async (callback) => {
+      const trx = {
+        raw: vi.fn().mockResolvedValue({}),
+      } as any
+      return callback(trx)
+    })
+
+    // Mock Step.query
+    stepFindByIdSpy = vi.fn().mockReturnValue({
+      patch: stepPatchSpy,
+    })
+    vi.spyOn(Step, 'query').mockReturnValue({
+      findById: stepFindByIdSpy,
+    } as any)
+
+    // Fake the chained query methods on context.currentUser.$relatedQuery('steps')
+    fakeQuery = {
+      withGraphFetched: vi.fn().mockReturnThis(),
+      whereIn: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      throwIfNotFound: vi.fn().mockResolvedValue(fakeSteps),
+    }
+
+    context = {
+      currentUser: {
+        $relatedQuery: vi.fn().mockReturnValue(fakeQuery),
+      },
+    }
+  })
+
+  it('should successfully update step positions', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-4',
+          position: 2,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-1',
+          position: 3,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-2',
+          position: 4,
+          type: 'action' as const,
+        },
+      ],
+    }
+
+    await updateStepPositions(null, { input }, context)
+
+    // should call and update the step positions
+    expect(stepFindByIdSpy).toHaveBeenCalledTimes(3)
+    expect(stepPatchSpy).toHaveBeenCalledTimes(3)
+    expect(stepFindByIdSpy).toHaveBeenNthCalledWith(1, 'step-4')
+    expect(stepPatchSpy).toHaveBeenNthCalledWith(1, { position: 2 })
+    expect(stepFindByIdSpy).toHaveBeenNthCalledWith(2, 'step-1')
+    expect(stepPatchSpy).toHaveBeenNthCalledWith(2, { position: 3 })
+    expect(stepFindByIdSpy).toHaveBeenNthCalledWith(3, 'step-2')
+    expect(stepPatchSpy).toHaveBeenNthCalledWith(3, { position: 4 })
+
+    // should update the flow updatedAt
+    expect(flowPatchAndFetchSpy).toHaveBeenCalledWith({
+      updatedAt: expect.any(String),
+    })
+  })
+
+  it('should throw an error if the step ids are not found', async () => {
+    // Mock throwIfNotFound to throw an error for missing steps
+    fakeQuery.throwIfNotFound.mockRejectedValue(new Error('Step not found'))
+
+    const input = {
+      stepPositions: [
+        {
+          id: 'non-existent-id',
+          position: 2,
+          type: 'action' as const,
+        },
+      ],
+    } as any
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Step not found',
+    )
+  })
+
+  it('should throw an error if the steps are not action steps', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-0',
+          position: 1,
+          step: { id: 'step-0', type: 'trigger' as const },
+        },
+        {
+          id: 'step-1',
+          position: 2,
+          step: { id: 'step-1', type: 'action' as const },
+        },
+      ],
+    } as any
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Failed to update: must update contiguous action steps!',
+    )
+  })
+
+  it('should throw an error if the step positions are not contiguous', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 1,
+          step: { id: 'step-1', type: 'action' as const },
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          step: { id: 'step-2', type: 'action' as const },
+        },
+      ],
+    } as any
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Failed to update: must update contiguous action steps!',
+    )
+  })
+
+  it('should throw an error if the step positions are out of bounds', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 5,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-2',
+          position: 6,
+          type: 'action' as const,
+        },
+      ],
+    } as any
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Failed to update: step positions are out of bounds.',
+    )
+  })
+
+  it('should throw an error if the pipe is active', async () => {
+    // Set the flow to active
+    fakeSteps = fakeSteps.map((step) => ({
+      ...step,
+      flow: {
+        ...step.flow,
+        active: true,
+      },
+    }))
+    fakeQuery.throwIfNotFound.mockResolvedValue(fakeSteps)
+
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          type: 'action' as const,
+        },
+      ],
+    } as any
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Pipe is active. Cannot update step in active pipe!',
+    )
+  })
+
+  it('should throw an error if steps are missing from database', async () => {
+    // Mock steps to return only some of the requested steps
+    const partialSteps = [fakeSteps[1]] // Only return step-1, missing step-2
+    fakeQuery.throwIfNotFound.mockResolvedValue(partialSteps)
+
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          type: 'action' as const,
+        },
+      ],
+    }
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Failed to update: steps were not found',
+    )
+  })
+})

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -28,6 +28,7 @@ import updateFlowConfig from './mutations/update-flow-config'
 import updateFlowStatus from './mutations/update-flow-status'
 import updateFlowTransferStatus from './mutations/update-flow-transfer-status'
 import updateStep from './mutations/update-step'
+import updateStepPositions from './mutations/update-step-positions'
 import verifyConnection from './mutations/verify-connection'
 import verifyOtp from './mutations/verify-otp'
 
@@ -66,6 +67,7 @@ export default {
   deleteFlow,
   createStep,
   updateStep,
+  updateStepPositions,
   deleteStep,
   requestOtp,
   verifyOtp,

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -1,0 +1,99 @@
+import { IStep } from '@plumber/types'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import Step from '@/models/step'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { input } = params
+  const { stepPositions } = input
+
+  if (
+    !stepPositions.every(
+      (
+        obj: { id: string; position: number; type: IStep['type'] },
+        index: number,
+      ) =>
+        (index === 0 ||
+          obj.position === stepPositions[index - 1].position + 1) &&
+        obj.type === 'action',
+    )
+  ) {
+    throw new BadUserInputError(
+      'Failed to update: must update contiguous action steps!',
+    )
+  }
+
+  const stepIds = stepPositions.map(
+    (obj: { id: string; position: number }) => obj.id,
+  )
+
+  const updatedPositions = await Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    const steps = await context.currentUser
+      .$relatedQuery('steps', trx)
+      .withGraphFetched('flow')
+      .whereIn('steps.id', stepIds)
+      .orderBy('steps.position', 'asc')
+      .throwIfNotFound()
+
+    if (steps[0].flow.active) {
+      throw new BadUserInputError(
+        'Pipe is active. Cannot update step in active pipe!',
+      )
+    }
+
+    const foundStepIds = steps.map((step) => step.id)
+    const missingStepIds = stepIds.filter(
+      (id: string) => !foundStepIds.includes(id),
+    )
+
+    if (missingStepIds.length > 0) {
+      throw new BadUserInputError('Failed to update: steps were not found')
+    }
+
+    // since we are only updating actions based on their groups
+    // e.g., non grouped steps, or actions within an if-then branch
+    // validate that the step positions are not out of bounds
+    const minPosition = steps[0].position
+    const maxPosition = steps[steps.length - 1].position
+    if (
+      stepPositions.some((obj) => obj.position > maxPosition) ||
+      stepPositions.some((obj) => obj.position < minPosition)
+    ) {
+      throw new BadUserInputError(
+        'Failed to update: step positions are out of bounds.',
+      )
+    }
+
+    const flow = steps[0].flow
+
+    // Patch each step individually with its new position
+    for (const stepPosition of stepPositions) {
+      await Step.query(trx).findById(stepPosition.id).patch({
+        position: stepPosition.position,
+      })
+    }
+
+    // Update the flow's lastUpdatedAt timestamp
+    const updatedFlow = await flow
+      .$query(trx)
+      .patchAndFetch({
+        updatedAt: new Date().toISOString(),
+      })
+      .withGraphFetched('steps')
+      .orderBy('steps.position', 'asc')
+
+    return updatedFlow.steps
+  })
+
+  return updatedPositions
+}
+
+export default updateStepPositions

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -79,6 +79,7 @@ type Mutation {
   deleteFlow(input: DeleteFlowInput): Boolean
   createStep(input: CreateStepInput): Step
   updateStep(input: UpdateStepInput): Step
+  updateStepPositions(input: UpdateStepPositionsInput): [Step]
   deleteStep(input: DeleteStepInput): Flow
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
@@ -523,6 +524,16 @@ input UpdateStepInput {
   previousStep: PreviousStepInput
   status: String
   config: StepConfigInput
+}
+
+input StepPositionInput {
+  id: String!
+  position: Int!
+  type: StepEnumType!
+}
+
+input UpdateStepPositionsInput {
+  stepPositions: [StepPositionInput!]!
 }
 
 input DeleteStepInput {

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -1,6 +1,7 @@
 import type { IApp, IStep } from '@plumber/types'
 
 import { useContext, useMemo } from 'react'
+import { useMutation } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import EditorRightDrawer from '@/components/EditorRightDrawer'
@@ -8,6 +9,9 @@ import FlowStepGroup from '@/components/FlowStepGroup'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
 import PrimarySpinner from '../PrimarySpinner'
@@ -25,7 +29,9 @@ export default function Editor(props: EditorProps): React.ReactElement {
 
   const { allApps, isDrawerOpen, isMobile, currentStepId, flow } =
     useContext(EditorContext)
-
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    refetchQueries: [GET_FLOW],
+  })
   const rawSteps = flow.steps
   const steps = useMemo(
     // Populate each step's flowId so that IStep isn't LYING about flowId being
@@ -126,11 +132,11 @@ export default function Editor(props: EditorProps): React.ReactElement {
     const stepPositions = steps.map((step, index) => ({
       id: step.id,
       position: index + 2, // trigger position is 1
-      type: step.type,
+      type: step.type as StepEnumType,
     }))
 
     try {
-      // TODO: make api call to update step positions
+      await updateStepPositions({ variables: { input: { stepPositions } } })
     } catch (error) {
       console.error(
         'Error updating step positions: ',

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -1,7 +1,6 @@
 import type { IApp, IStep } from '@plumber/types'
 
 import { useContext, useMemo } from 'react'
-import { useMutation } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import EditorRightDrawer from '@/components/EditorRightDrawer'
@@ -10,9 +9,8 @@ import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
-import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
-import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
+import useReorderSteps from '@/hooks/useReorderSteps'
 
 import PrimarySpinner from '../PrimarySpinner'
 
@@ -29,9 +27,8 @@ export default function Editor(props: EditorProps): React.ReactElement {
 
   const { allApps, isDrawerOpen, isMobile, currentStepId, flow } =
     useContext(EditorContext)
-  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
-    refetchQueries: [GET_FLOW],
-  })
+
+  const { handleReorderUpdate } = useReorderSteps(flow.id)
   const rawSteps = flow.steps
   const steps = useMemo(
     // Populate each step's flowId so that IStep isn't LYING about flowId being
@@ -128,15 +125,15 @@ export default function Editor(props: EditorProps): React.ReactElement {
     [triggerStep, stepsBeforeGroup, groupStepsToInclude],
   )
 
-  const handleReorderSteps = async (steps: IStep[]) => {
-    const stepPositions = steps.map((step, index) => ({
+  const handleReorderSteps = async (reorderedSteps: IStep[]) => {
+    const stepPositions = reorderedSteps.map((step, index) => ({
       id: step.id,
       position: index + 2, // trigger position is 1
       type: step.type as StepEnumType,
     }))
 
     try {
-      await updateStepPositions({ variables: { input: { stepPositions } } })
+      await handleReorderUpdate(stepPositions)
     } catch (error) {
       console.error(
         'Error updating step positions: ',

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -17,8 +17,8 @@ import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
-import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import BranchStepWithAddButton from './BranchStepWithAddButton'
@@ -35,6 +35,7 @@ export default function Branch(props: BranchProps) {
   const { branchSteps } = props
 
   const {
+    flow,
     isDrawerOpen,
     isMobile,
     readOnly: isEditorReadOnly,
@@ -53,9 +54,7 @@ export default function Branch(props: BranchProps) {
   const [deleteStep, { loading: isDeletingBranch }] = useMutation(DELETE_STEP, {
     refetchQueries: [GET_FLOW],
   })
-  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
-    refetchQueries: [GET_FLOW],
-  })
+  const { handleReorderUpdate } = useReorderSteps(flow.id)
   const openDeleteConfirmation = useCallback<MouseEventHandler>(
     (e) => {
       e.stopPropagation()
@@ -134,7 +133,7 @@ export default function Branch(props: BranchProps) {
     }))
 
     try {
-      await updateStepPositions({ variables: { input: { stepPositions } } })
+      handleReorderUpdate(stepPositions)
     } catch (error) {
       console.error(
         'Error updating step positions: ',

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -17,6 +17,7 @@ import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
@@ -50,6 +51,9 @@ export default function Branch(props: BranchProps) {
   } = useDisclosure()
   const cancelDeleteButton = useRef<HTMLButtonElement>(null)
   const [deleteStep, { loading: isDeletingBranch }] = useMutation(DELETE_STEP, {
+    refetchQueries: [GET_FLOW],
+  })
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
   })
   const openDeleteConfirmation = useCallback<MouseEventHandler>(
@@ -130,7 +134,7 @@ export default function Branch(props: BranchProps) {
     }))
 
     try {
-      // TODO: make api call to update step positions
+      await updateStepPositions({ variables: { input: { stepPositions } } })
     } catch (error) {
       console.error(
         'Error updating step positions: ',

--- a/packages/frontend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/frontend/src/graphql/mutations/update-step-positions.ts
@@ -1,0 +1,10 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const UPDATE_STEP_POSITIONS = graphql(`
+  mutation UpdateStepPositions($input: UpdateStepPositionsInput!) {
+    updateStepPositions(input: $input) {
+      id
+      position
+    }
+  }
+`)

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -1,0 +1,95 @@
+import { useMutation } from '@apollo/client'
+import { useToast } from '@opengovsg/design-system-react'
+
+import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
+
+interface StepPositionInput {
+  id: string
+  position: number
+  type: StepEnumType
+}
+
+const useReorderSteps = (flowId: string) => {
+  const toast = useToast()
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS)
+
+  const handleReorderUpdate = async (stepPositions: StepPositionInput[]) => {
+    try {
+      await updateStepPositions({
+        variables: { input: { stepPositions } },
+        optimisticResponse: {
+          updateStepPositions: stepPositions.map((sp) => ({
+            id: sp.id,
+            position: sp.position,
+            __typename: 'Step' as const,
+          })),
+        },
+        update: (cache) => {
+          // Update the cache with the new step positions optimistically
+          const existingData = cache.readQuery({
+            query: GET_FLOW,
+            variables: { id: flowId },
+          }) as { getFlow: any } | null
+
+          if (existingData?.getFlow) {
+            // Create a map of step positions for quick lookup
+            const positionMap = new Map(
+              stepPositions.map((sp) => [sp.id, sp.position]),
+            )
+
+            // Update steps with new positions
+            const updatedSteps = existingData.getFlow.steps.map((step: any) => {
+              const newPosition = positionMap.get(step.id)
+              return newPosition !== undefined
+                ? { ...step, position: newPosition }
+                : step
+            })
+
+            // Sort steps by position to maintain proper order
+            updatedSteps.sort((a: any, b: any) => a.position - b.position)
+
+            // Write the updated data back to the cache
+            cache.writeQuery({
+              query: GET_FLOW,
+              variables: { id: flowId },
+              data: {
+                getFlow: {
+                  ...existingData.getFlow,
+                  steps: updatedSteps,
+                },
+              },
+            })
+          }
+        },
+        onError: (error) => {
+          toast({
+            title: 'Failed to reorder steps',
+            description: 'Your changes have been reverted. Please try again.',
+            status: 'error',
+            duration: 5000,
+            isClosable: true,
+            position: 'top',
+          })
+          console.error(
+            'Error updating step positions: ',
+            error,
+            JSON.stringify(stepPositions),
+          )
+        },
+      })
+    } catch (error) {
+      // Fallback error handling (in case onError doesn't trigger)
+      console.error(
+        'Error updating step positions: ',
+        error,
+        JSON.stringify(stepPositions),
+      )
+    }
+  }
+
+  return { handleReorderUpdate }
+}
+
+export default useReorderSteps

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -26,21 +26,21 @@ const useReorderSteps = (flowId: string) => {
             __typename: 'Step' as const,
           })),
         },
-        update: (cache) => {
+        update: (cache: any) => {
           // Update the cache with the new step positions optimistically
-          const existingData = cache.readQuery({
+          const { getFlow: flow } = cache.readQuery({
             query: GET_FLOW,
             variables: { id: flowId },
-          }) as { getFlow: any } | null
+          })
 
-          if (existingData?.getFlow) {
+          if (flow) {
             // Create a map of step positions for quick lookup
             const positionMap = new Map(
               stepPositions.map((sp) => [sp.id, sp.position]),
             )
 
             // Update steps with new positions
-            const updatedSteps = existingData.getFlow.steps.map((step: any) => {
+            const updatedSteps = flow.steps.map((step: any) => {
               const newPosition = positionMap.get(step.id)
               return newPosition !== undefined
                 ? { ...step, position: newPosition }
@@ -56,7 +56,7 @@ const useReorderSteps = (flowId: string) => {
               variables: { id: flowId },
               data: {
                 getFlow: {
-                  ...existingData.getFlow,
+                  ...flow,
                   steps: updatedSteps,
                 },
               },

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -1,3 +1,5 @@
+import { IStep } from '@plumber/types'
+
 import { useMutation } from '@apollo/client'
 import { useToast } from '@opengovsg/design-system-react'
 
@@ -40,7 +42,7 @@ const useReorderSteps = (flowId: string) => {
             )
 
             // Update steps with new positions
-            const updatedSteps = flow.steps.map((step: any) => {
+            const updatedSteps = flow.steps.map((step: IStep) => {
               const newPosition = positionMap.get(step.id)
               return newPosition !== undefined
                 ? { ...step, position: newPosition }
@@ -48,7 +50,7 @@ const useReorderSteps = (flowId: string) => {
             })
 
             // Sort steps by position to maintain proper order
-            updatedSteps.sort((a: any, b: any) => a.position - b.position)
+            updatedSteps.sort((a: IStep, b: IStep) => a.position - b.position)
 
             // Write the updated data back to the cache
             cache.writeQuery({


### PR DESCRIPTION
### TL;DR
Added the ability to save ordered steps in a pipe by implementing a new `updateStepPositions` mutation.

### What changed?
- Created a new GraphQL mutation `updateStepPositions` that allows updating the positions of multiple steps in a single transaction
- Added corresponding backend resolver with validation to ensure:
  - Only action steps can be reordered
  - Steps must be contiguous
  - Positions must be within bounds (i.e., within the same positions as the original step positions)
  - Pipe must be inactive
- Implemented frontend integration in the Editor component and IfThen Branch component
- Added tests for the new mutation

### How to test?
**Setup**: Create a Pipe with action steps including if-then branches and actions
- [ ] Action steps before if-then
  - [ ] Drag and drop action steps, should save and update step positions
  - [ ] Refresh the page, step order should remain
- [ ] Action steps within if-then
  - [ ] Drag and drop action steps, should save and update step positions for that branch only, all other step positions should remain as is
- [ ] Publish the pipe, verify that drag handle no longer shows

### Screenshots

[Screen Recording 2025-07-03 at 10.45.43 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/cf9b6c05-50e9-4589-919b-469af62df285.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/cf9b6c05-50e9-4589-919b-469af62df285.mov)

