### PR TITLE
chore: refactor get apps for templates page

### DIFF
--- a/packages/frontend/src/pages/Template/components/IfThenBranchContent.tsx
+++ b/packages/frontend/src/pages/Template/components/IfThenBranchContent.tsx
@@ -33,7 +33,7 @@ export default function IfThenBranchContent(props: IfThenBranchContentProps) {
           return (
             <Fragment key={index}>
               <TemplateStepContent
-                app={apps?.find((app: IApp) => templateStep.appKey === app.key)}
+                app={apps.find((app: IApp) => templateStep.appKey === app.key)}
                 templateStep={templateStep}
                 isNested={true}
               />

--- a/packages/frontend/src/pages/Template/components/IfThenTemplateStepContent.tsx
+++ b/packages/frontend/src/pages/Template/components/IfThenTemplateStepContent.tsx
@@ -9,7 +9,7 @@ import IfThenBranchContent from './IfThenBranchContent'
 
 interface IfThenTemplateStepContentProps {
   templateSteps: ITemplateStep[]
-  apps?: IApp[]
+  apps: IApp[]
 }
 
 function extractBranchesWithSteps(templateSteps: ITemplateStep[]) {
@@ -67,7 +67,7 @@ export default function IfThenTemplateStepContent(
             <IfThenBranchContent
               key={branchSteps[0].position}
               branchSteps={branchSteps}
-              apps={apps ?? []}
+              apps={apps}
             />
           )
         })}

--- a/packages/frontend/src/pages/Template/components/TemplateBody.tsx
+++ b/packages/frontend/src/pages/Template/components/TemplateBody.tsx
@@ -1,18 +1,15 @@
 import type { IApp, ITemplateStep } from '@plumber/types'
 
 import { Fragment, useMemo } from 'react'
-import { useQuery } from '@apollo/client'
-import { AbsoluteCenter, Box, Divider, Flex, Text } from '@chakra-ui/react'
+import { Box, Divider, Flex, Text } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
-
-import PrimarySpinner from '@/components/PrimarySpinner'
-import { GET_APPS } from '@/graphql/queries/get-apps'
 
 import IfThenTemplateStepContent from './IfThenTemplateStepContent'
 import TemplateStepContent from './TemplateStepContent'
 
 interface TemplateBodyProps {
   templateSteps: ITemplateStep[]
+  apps: IApp[]
 }
 
 export function BetweenStepsGraphic() {
@@ -24,7 +21,7 @@ export function BetweenStepsGraphic() {
 }
 
 export default function TemplateBody(props: TemplateBodyProps) {
-  const { templateSteps } = props
+  const { templateSteps, apps } = props
 
   const [templateStepsBeforeIfThen, templateStepsAfterIfThen] = useMemo(() => {
     const ifThenStartIndex = templateSteps.findIndex(
@@ -40,18 +37,6 @@ export default function TemplateBody(props: TemplateBodyProps) {
       templateSteps.slice(ifThenStartIndex),
     ]
   }, [templateSteps])
-
-  // get all apps here and pass the correct app to the template step
-  const { data, loading } = useQuery(GET_APPS)
-  const apps: IApp[] = data?.getApps
-
-  if (loading) {
-    return (
-      <AbsoluteCenter>
-        <PrimarySpinner fontSize="4xl" />
-      </AbsoluteCenter>
-    )
-  }
 
   return (
     <Flex
@@ -83,7 +68,7 @@ export default function TemplateBody(props: TemplateBodyProps) {
       {/* Steps to display for if-then */}
       <IfThenTemplateStepContent
         templateSteps={templateStepsAfterIfThen}
-        apps={apps ?? []}
+        apps={apps}
       />
     </Flex>
   )

--- a/packages/frontend/src/pages/Template/index.tsx
+++ b/packages/frontend/src/pages/Template/index.tsx
@@ -1,4 +1,4 @@
-import type { ITemplate } from '@plumber/types'
+import type { IApp, ITemplate } from '@plumber/types'
 
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -24,11 +24,12 @@ import TemplateBody from './components/TemplateBody'
 
 interface TemplateProps {
   template: ITemplate
+  apps: IApp[]
 }
 
 // The template page is a modal and the route is /templates/:templateId
 export default function TemplateModal(props: TemplateProps) {
-  const { template } = props
+  const { template, apps } = props
   const navigate = useNavigate()
   const goToTemplatesPage = () => navigate(URLS.TEMPLATES)
 
@@ -90,7 +91,7 @@ export default function TemplateModal(props: TemplateProps) {
           </ModalHeader>
 
           <ModalBody mx={6} mb={8} borderWidth={1} borderRadius="lg">
-            <TemplateBody templateSteps={steps} />
+            <TemplateBody templateSteps={steps} apps={apps} />
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -1,4 +1,4 @@
-import { ITemplate } from '@plumber/types'
+import type { IApp, ITemplate } from '@plumber/types'
 
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
@@ -8,6 +8,7 @@ import { Link } from '@opengovsg/design-system-react'
 import Container from '@/components/Container'
 import PageTitle from '@/components/PageTitle'
 import * as URLS from '@/config/urls'
+import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_TEMPLATES } from '@/graphql/queries/get-templates'
 
 import TemplateModal from '../Template'
@@ -24,6 +25,10 @@ export default function Templates(): JSX.Element {
   const templates: ITemplate[] = data?.getTemplates
   const { templateId } = useParams()
   const template = templates?.find((template) => template.id === templateId)
+
+  const { data: appsData, loading: appsLoading } = useQuery(GET_APPS)
+  const apps: IApp[] = appsData?.getApps ?? []
+
   return (
     <>
       <Container py={9}>
@@ -51,7 +56,7 @@ export default function Templates(): JSX.Element {
           rowGap={6}
           mb={8}
         >
-          {loading
+          {loading || appsLoading
             ? Array.from({ length: TEMPLATES_COUNT }).map((_, index) => (
                 <TemplateTileSkeleton key={index} />
               ))
@@ -77,7 +82,7 @@ export default function Templates(): JSX.Element {
         </Flex>
       </Container>
 
-      {template && <TemplateModal template={template} />}
+      {template && <TemplateModal template={template} apps={apps} />}
     </>
   )
 }

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -20,7 +20,7 @@ const TEMPLATES_TITLE = 'Templates'
 const TEMPLATES_COUNT = 9
 
 export default function Templates(): JSX.Element {
-  const { data, loading } = useQuery(GET_TEMPLATES)
+  const { data, loading: templatesLoading } = useQuery(GET_TEMPLATES)
 
   const templates: ITemplate[] = data?.getTemplates
   const { templateId } = useParams()
@@ -56,7 +56,7 @@ export default function Templates(): JSX.Element {
           rowGap={6}
           mb={8}
         >
-          {loading || appsLoading
+          {templatesLoading || appsLoading
             ? Array.from({ length: TEMPLATES_COUNT }).map((_, index) => (
                 <TemplateTileSkeleton key={index} />
               ))


### PR DESCRIPTION
## Problem

Unnecessary graphql call to each template when it loads.

## Solution

Move the get_apps call to the templates page instead.

## Tests
- Check that get_apps is only called on the templates page
- Each template page still loads correctly, no loading spinner.
