### PR TITLE
PLU-326: fix: add clearer error message for unsupported group emails for excel

### DIFF
--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -71,22 +71,38 @@ export async function createPlumberFolder(
 
   // Make user the folder owner.
   // NOTE: If they already have an existing folder, then this becomes a no-op.
-  await $.http.post(
-    '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
-    {
-      recipients: [{ email: $.user.email }],
-      requireSignIn: true,
-      sendInvitation: false,
-      roles: ['sp.full control'],
-      retainInheritedPermissions: false,
-    },
-    {
-      urlPathParams: {
-        sharePointSiteId: tenant.sharePointSiteId,
-        folderId,
+  try {
+    await $.http.post(
+      '/v1.0/sites/:sharePointSiteId/drive/items/:folderId/invite',
+      {
+        recipients: [{ email: $.user.email }],
+        requireSignIn: true,
+        sendInvitation: false,
+        roles: ['sp.full control'],
+        retainInheritedPermissions: false,
       },
-    },
-  )
+      {
+        urlPathParams: {
+          sharePointSiteId: tenant.sharePointSiteId,
+          folderId,
+        },
+      },
+    )
+  } catch (error) {
+    if (error instanceof HttpError) {
+      const errorCode = tryParseGraphApiError(error)?.code
+      /**
+       * Local sharepoint gives this error: Your organization's policies don't allow you to share with these users. Please contact your IT department for help.
+       * Prod sharepoint gives this error: One or more users could not be resolved.
+       */
+      if (errorCode === 'noResolvedUsers') {
+        throw new Error(
+          'Group emails or shared mailboxes are not supported. Please use your personal sharepoint email instead.',
+        )
+      }
+    }
+    throw error
+  }
 
   return folderId
 }

--- a/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
+++ b/packages/backend/src/apps/m365-excel/common/create-plumber-folder.ts
@@ -97,7 +97,7 @@ export async function createPlumberFolder(
        */
       if (errorCode === 'noResolvedUsers') {
         throw new Error(
-          'Group emails or shared mailboxes are not supported. Please use your personal sharepoint email instead.',
+          'Group emails or shared mailboxes are not supported. Please use your personal SharePoint email instead.',
         )
       }
     }


### PR DESCRIPTION
## Problem

Currently, users keep seeing this error when using group emails or shared mailboxes when connecting to excel. The error message is unclear to the user.
![image](https://github.com/user-attachments/assets/711791ee-ccf9-45d3-ae4b-2c1bb1a02b5d)

## Solution
Check for the error code: `noResolvedUsers` and return a clearer error message. After researching and debugging on our local sharepoint, it could be because of a group email or shared mailbox.


https://github.com/user-attachments/assets/04db62a0-afec-4aed-b3b3-4da4a70c6589



## Tests
- Can use this shared mailbox to test the error: `sharedaccount@ogpplumbertest.onmicrosoft.com`