### PR TITLE
fix(paysg): add payer identifier and address fields to one-time payment forms action

### DIFF
--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/schema.ts
@@ -25,14 +25,4 @@ export const requestSchema = createPaymentFormSubmissionRequestSchema.extend({
 
       return value
     }),
-  payer_address: z
-    .string()
-    .trim()
-    .transform((value) => value || undefined)
-    .optional(),
-  payer_identifier: z
-    .string()
-    .trim()
-    .transform((value) => value || undefined)
-    .optional(),
 })

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -58,6 +58,20 @@ const action: IRawAction = {
       variables: true,
     },
     {
+      label: 'Payer Address',
+      key: 'payer_address',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
+      label: 'Payer Identifier',
+      key: 'payer_identifier',
+      type: 'string' as const,
+      required: false,
+      variables: true,
+    },
+    {
       label: 'Amount (in cents)',
       key: 'amount_in_cents',
       type: 'string' as const,

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/schema.ts
@@ -62,6 +62,16 @@ export const requestSchema = z.object({
       return value
     })
     .optional(),
+  payer_address: z
+    .string()
+    .trim()
+    .transform((value) => value || undefined)
+    .optional(),
+  payer_identifier: z
+    .string()
+    .trim()
+    .transform((value) => value || undefined)
+    .optional(),
   amount_in_cents: z
     .string()
     .trim()


### PR DESCRIPTION
## Problem

Currently, there is a slight difference in the PaySG actions for payment forms creation, between one-time and subscriptions.

**One time**:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/62363fa1-5d6b-4924-a22e-5da47ff1c61d" />

**Subscriptions**:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/36937b03-4785-4aba-9724-9cda12b7bcef" />

As can be seen, subscriptions contains the "Payer Address" and "Payer Identifier" fields while one-time does not. 

## Solution

This PR adds the Payer Address and Payer Identifier fields to one-time payments. Both fields are **optional**, thus they should not break existing pipes. Additionally, the subscriptions schema extends from the one-time schema, so it's just a matter of moving the schema validations upstream from the subscriptions (extended) schema to the one-time (base) schema.
