### PR TITLE
feat: new badge for actions

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -21,6 +21,7 @@ const action: IRawAction = {
   name: 'Find table rows',
   key: 'getTableRows',
   description: 'Gets multiple rows of data from your Excel table',
+  isNew: true,
   arguments: [
     {
       key: 'fileId',

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -21,6 +21,7 @@ const action: IRawAction = {
   name: 'Find multiple rows',
   key: 'findMultipleRows',
   description: 'Gets data of multiple rows from your tile',
+  isNew: true,
   arguments: [
     {
       label: 'Select Tile',

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -20,6 +20,7 @@ const action: IRawAction = {
   key: 'forEach',
   description: 'Repeat actions for each item',
   groupsLaterSteps: true,
+  isNew: true,
   arguments: [
     {
       label: 'Choose items',

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -58,26 +58,43 @@ export const ACTION_APPS_RANKING = [
 
 function sortApps(apps: IApp[]): IApp[] {
   // trade off for increased time complexity but easier to add a new app to the ranking
-  return apps.sort((a, b) => {
-    const firstPriority = a.triggers
-      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
-      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
-    const secondPriority = b.triggers
-      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
-      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
+  return apps
+    .sort((a, b) => {
+      const firstPriority = a.triggers
+        ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+        : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
+      const secondPriority = b.triggers
+        ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+        : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
 
-    // sort by newApp flag, followed by priority
-    if (a.isNewApp && b.isNewApp) {
+      // sort by newApp flag, followed by priority
+      if (a.isNewApp && b.isNewApp) {
+        return firstPriority - secondPriority
+      }
+      if (a.isNewApp) {
+        return -1
+      }
+      if (b.isNewApp) {
+        return 1
+      }
       return firstPriority - secondPriority
-    }
-    if (a.isNewApp) {
-      return -1
-    }
-    if (b.isNewApp) {
-      return 1
-    }
-    return firstPriority - secondPriority
-  })
+    })
+    .map((app) => ({
+      ...app,
+      // Sort actions within each app so that actions with isNew appear first
+      actions: app.actions?.sort((a, b) => {
+        if (a.isNew && b.isNew) {
+          return 0
+        }
+        if (a.isNew) {
+          return -1
+        }
+        if (b.isNew) {
+          return 1
+        }
+        return 0
+      }),
+    }))
 }
 
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -57,48 +57,27 @@ export const ACTION_APPS_RANKING = [
 ]
 
 function sortApps(apps: IApp[]): IApp[] {
-  // Helper function to sort items with isNew flag first
-  const sortByIsNew = (a: { isNew?: boolean }, b: { isNew?: boolean }) => {
-    if (a.isNew && b.isNew) {
-      return 0
+  // trade off for increased time complexity but easier to add a new app to the ranking
+  return apps.sort((a, b) => {
+    const firstPriority = a.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
+    const secondPriority = b.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
+
+    // sort by newApp flag, followed by priority
+    if (a.isNewApp && b.isNewApp) {
+      return firstPriority - secondPriority
     }
-    if (a.isNew) {
+    if (a.isNewApp) {
       return -1
     }
-    if (b.isNew) {
+    if (b.isNewApp) {
       return 1
     }
-    return 0
-  }
-
-  // trade off for increased time complexity but easier to add a new app to the ranking
-  return apps
-    .sort((a, b) => {
-      const firstPriority = a.triggers
-        ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
-        : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
-      const secondPriority = b.triggers
-        ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
-        : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
-
-      // sort by newApp flag, followed by priority
-      if (a.isNewApp && b.isNewApp) {
-        return firstPriority - secondPriority
-      }
-      if (a.isNewApp) {
-        return -1
-      }
-      if (b.isNewApp) {
-        return 1
-      }
-      return firstPriority - secondPriority
-    })
-    .map((app) => ({
-      ...app,
-      // Sort actions within each app so that actions with isNew appear first
-      actions: app.actions?.sort(sortByIsNew),
-      triggers: app.triggers?.sort(sortByIsNew),
-    }))
+    return firstPriority - secondPriority
+  })
 }
 
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -57,6 +57,20 @@ export const ACTION_APPS_RANKING = [
 ]
 
 function sortApps(apps: IApp[]): IApp[] {
+  // Helper function to sort items with isNew flag first
+  const sortByIsNew = (a: { isNew?: boolean }, b: { isNew?: boolean }) => {
+    if (a.isNew && b.isNew) {
+      return 0
+    }
+    if (a.isNew) {
+      return -1
+    }
+    if (b.isNew) {
+      return 1
+    }
+    return 0
+  }
+
   // trade off for increased time complexity but easier to add a new app to the ranking
   return apps
     .sort((a, b) => {
@@ -82,18 +96,8 @@ function sortApps(apps: IApp[]): IApp[] {
     .map((app) => ({
       ...app,
       // Sort actions within each app so that actions with isNew appear first
-      actions: app.actions?.sort((a, b) => {
-        if (a.isNew && b.isNew) {
-          return 0
-        }
-        if (a.isNew) {
-          return -1
-        }
-        if (b.isNew) {
-          return 1
-        }
-        return 0
-      }),
+      actions: app.actions?.sort(sortByIsNew),
+      triggers: app.triggers?.sort(sortByIsNew),
     }))
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -160,6 +160,7 @@ type Action {
   description: String
   groupsLaterSteps: Boolean
   setupMessage: SetupMessage
+  isNew: Boolean
   substeps: [ActionSubstep]
 }
 
@@ -671,6 +672,7 @@ type Trigger {
   setupMessage: SetupMessage
   webhookTriggerInstructions: TriggerInstructions
   substeps: [TriggerSubstep]
+  isNew: Boolean
 }
 
 type TriggerInstructions {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -19,7 +19,7 @@ import {
   ModalHeader,
   Text,
 } from '@chakra-ui/react'
-import { Badge, Input, ModalCloseButton } from '@opengovsg/design-system-react'
+import { Input, ModalCloseButton } from '@opengovsg/design-system-react'
 import fuzzysort from 'fuzzysort'
 import { groupBy } from 'lodash'
 
@@ -32,6 +32,7 @@ import { useIsAppSelectable } from '../hooks/useIsAppSelectable'
 
 import FeedbackFooter from './FeedbackFooter'
 import { HighlightedText } from './HighlightedText'
+import NewBadge from './NewBadge'
 import ToolboxEvent from './ToolboxEvent'
 
 const OTHERS_CATEGORY = 'Other'
@@ -352,14 +353,7 @@ export default function ChooseApp(props: ChooseAppProps) {
                                 searchQuery={searchQuery}
                                 textToHighlight={app.name}
                               />
-                              {app.isNewApp && (
-                                <Badge
-                                  bgColor="interaction.muted.main.active"
-                                  color="primary.500"
-                                >
-                                  New
-                                </Badge>
-                              )}
+                              {app.isNewApp && <NewBadge />}
                             </Flex>
                             <Text textStyle="body-2">
                               <HighlightedText

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -12,6 +12,7 @@ import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import InvalidModalScreen from '../InvalidModalScreen'
 
 import FeedbackFooter from './FeedbackFooter'
+import NewBadge from './NewBadge'
 
 interface ChooseEventProps {
   onSelectAppEvent: (app: IApp, event: ITrigger | IAction) => void
@@ -105,7 +106,10 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
                     }
                   }}
                 >
-                  <Text textStyle="subhead-1">{triggerOrAction.name}</Text>
+                  <Flex gap={2}>
+                    <Text textStyle="subhead-1">{triggerOrAction.name}</Text>
+                    {triggerOrAction?.isNew && <NewBadge />}
+                  </Flex>
                   <Text textStyle="body-2">{triggerOrAction.description}</Text>
                 </Box>
               )

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/NewBadge.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/NewBadge.tsx
@@ -1,0 +1,9 @@
+import { Badge } from '@opengovsg/design-system-react'
+
+export default function NewBadge() {
+  return (
+    <Badge bgColor="interaction.muted.main.active" color="primary.500">
+      New
+    </Badge>
+  )
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ToolboxEvent.tsx
@@ -6,6 +6,7 @@ import { Flex, Icon, Text } from '@chakra-ui/react'
 import { TouchableTooltip } from '@opengovsg/design-system-react'
 
 import { HighlightedText } from './HighlightedText'
+import NewBadge from './NewBadge'
 
 export const TOOLBOX_ACTION_TO_ICON_MAP = {
   onlyContinueIf: BiFilterAlt,
@@ -68,10 +69,13 @@ export default function ToolboxEvent(props: ToolboxEventProps): JSX.Element {
           />
 
           <Flex flexDir="column" gap={1}>
-            <HighlightedText
-              searchQuery={searchQuery}
-              textToHighlight={action.name}
-            />
+            <Flex gap={2}>
+              <HighlightedText
+                searchQuery={searchQuery}
+                textToHighlight={action.name}
+              />
+              {action?.isNew && <NewBadge />}
+            </Flex>
             <Text textStyle="body-2">
               <HighlightedText
                 searchQuery={searchQuery}

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -86,6 +86,7 @@ export const GET_APPS = gql`
         type
         pollInterval
         description
+        isNew
         setupMessage {
           variant
           messageBody
@@ -173,6 +174,7 @@ export const GET_APPS = gql`
           messageBody
         }
         groupsLaterSteps
+        isNew
         substeps {
           key
           name

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -669,6 +669,7 @@ export interface IBaseTrigger {
   type?: 'webhook' | 'polling'
   pollInterval?: number
   description: string
+  isNew?: boolean
   webhookTriggerInstructions?: ITriggerInstructions
   getInterval?(parameters: IStep['parameters']): string
   run?($: IGlobalVariable): Promise<void>
@@ -737,6 +738,7 @@ export interface IBaseAction {
   name: string
   key: string
   description: string
+  isNew?: boolean
   run?(
     $: IGlobalVariable,
     metadata?: NextStepMetadata,


### PR DESCRIPTION
### TL;DR
This PR adds a "New" badge to actions marked with `isNew: true` and ensures they appear at the top of their respective app sections in the UI. 

### What changed?
- Added `isNew` property to the GraphQL schema for both Action and Trigger types
- Created a reusable `NewBadge` component to display the "New" badge consistently
- Modified the app sorting logic to prioritise actions with `isNew: true` within each app
- Added the `isNew: true` flag to several actions:
  - "Find table rows" in Excel
  - "Find multiple rows" in Tiles
  - "For each" in Toolbox
- Updated the UI components to display the "New" badge next to actions and triggers when applicable

### Screenshots
- For each action
![Screenshot 2025-07-09 at 7.30.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/57b7c962-cd09-4f4a-900a-139c3381ed4e.png)

- Find multiple rows action

![Screenshot 2025-07-09 at 7.32.03 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/3b2c4843-209a-4b16-a3f4-d1519450339a.png)

![Screenshot 2025-07-09 at 7.32.42 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/cdf051b1-e9b6-4054-9feb-d2da8483f6c2.png)

