### PR TITLE
chore: mark iteration as partial success

### DIFF
--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -6,6 +6,7 @@ import { fromZodError } from 'zod-validation-error'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import { getObjectFromS3Id } from '@/helpers/s3'
+import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
 
 import { dataOutSchema } from '../../common/data-out-validator'
@@ -91,6 +92,7 @@ const action: IRawAction = {
      */
     const lastExecutionStep = await $.getLastExecutionStep({
       sameExecution: true,
+      iteration: Number($.metadata?.iteration) || undefined,
     })
 
     /**
@@ -144,6 +146,35 @@ const action: IRawAction = {
       })
       dataOut.status = updatedStatus
       dataOut.recipient = prevDataOut.recipient
+
+      /**
+       * Partial retry means that subsequent steps were allowed to proceed in the initial execution.
+       * We need to manually handle the status of the iteration here as the nextStep would not continue to run
+       * if the subsequent steps have already run and succeeded.
+       */
+      if (
+        $.metadata?.iteration &&
+        dataOut.status.every((status) => status === 'ACCEPTED')
+      ) {
+        const iterationSteps = await ExecutionStep.getIterationSteps(
+          $.execution.id,
+          Number($.metadata.iteration),
+        )
+
+        const isIterationSuccessful = iterationSteps
+          .filter((es) => es.stepId !== $.step.id) // exclude this current step as it has not been updated yet
+          .every(
+            (step) => step.status === 'success' && step.errorDetails === null,
+          )
+
+        if (isIterationSuccessful) {
+          await ExecutionStep.patchIterationStatus(
+            $.execution.id,
+            Number($.metadata.iteration),
+            'success',
+          )
+        }
+      }
     }
 
     /**

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -6,7 +6,6 @@ import { fromZodError } from 'zod-validation-error'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import { getObjectFromS3Id } from '@/helpers/s3'
-import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
 
 import { dataOutSchema } from '../../common/data-out-validator'
@@ -146,35 +145,6 @@ const action: IRawAction = {
       })
       dataOut.status = updatedStatus
       dataOut.recipient = prevDataOut.recipient
-
-      /**
-       * Partial retry means that subsequent steps were allowed to proceed in the initial execution.
-       * We need to manually handle the status of the iteration here as the nextStep would not continue to run
-       * if the subsequent steps have already run and succeeded.
-       */
-      if (
-        $.metadata?.iteration &&
-        dataOut.status.every((status) => status === 'ACCEPTED')
-      ) {
-        const iterationSteps = await ExecutionStep.getIterationSteps(
-          $.execution.id,
-          Number($.metadata.iteration),
-        )
-
-        const isIterationSuccessful = iterationSteps
-          .filter((es) => es.stepId !== $.step.id) // exclude this current step as it has not been updated yet
-          .every(
-            (step) => step.status === 'success' && step.errorDetails === null,
-          )
-
-        if (isIterationSuccessful) {
-          await ExecutionStep.patchIterationStatus(
-            $.execution.id,
-            Number($.metadata.iteration),
-            'success',
-          )
-        }
-      }
     }
 
     /**

--- a/packages/backend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-partial-step.ts
@@ -34,6 +34,7 @@ const retryPartialStep: MutationResolvers['retryPartialStep'] = async (
       executionId: executionStep.executionId,
       flowId: executionStep.execution.flowId,
       stepId: executionStep.stepId,
+      metadata: executionStep.metadata,
     })
   } catch (e) {
     throw new Error('Failed to retry partial step')

--- a/packages/backend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-partial-step.ts
@@ -36,6 +36,31 @@ const retryPartialStep: MutationResolvers['retryPartialStep'] = async (
       stepId: executionStep.stepId,
       metadata: executionStep.metadata,
     })
+
+    /**
+     * FOR-EACH SPECIAL CASE:
+     * Partial retry means that subsequent steps were allowed to proceed in the initial execution.
+     * We need to manually handle the iteration status here as the nextStep would not continue to run
+     * if the subsequent steps have already run and succeeded.
+     */
+    if (executionStep.metadata?.iteration) {
+      const iterationSteps = await ExecutionStep.getIterationSteps(
+        executionStep.executionId,
+        executionStep.metadata.iteration,
+      )
+
+      const isIterationSuccessful = iterationSteps.every(
+        (step) => step.status === 'success' && step.errorDetails === null,
+      )
+
+      if (isIterationSuccessful) {
+        await ExecutionStep.patchIterationStatus(
+          executionStep.executionId,
+          executionStep.metadata.iteration,
+          'success',
+        )
+      }
+    }
   } catch (e) {
     throw new Error('Failed to retry partial step')
   }

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -58,26 +58,43 @@ export const ACTION_APPS_RANKING = [
 
 function sortApps(apps: IApp[]): IApp[] {
   // trade off for increased time complexity but easier to add a new app to the ranking
-  return apps.sort((a, b) => {
-    const firstPriority = a.triggers
-      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
-      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
-    const secondPriority = b.triggers
-      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
-      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
+  return apps
+    .sort((a, b) => {
+      const firstPriority = a.triggers
+        ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+        : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
+      const secondPriority = b.triggers
+        ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+        : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
 
-    // sort by newApp flag, followed by priority
-    if (a.isNewApp && b.isNewApp) {
+      // sort by newApp flag, followed by priority
+      if (a.isNewApp && b.isNewApp) {
+        return firstPriority - secondPriority
+      }
+      if (a.isNewApp) {
+        return -1
+      }
+      if (b.isNewApp) {
+        return 1
+      }
       return firstPriority - secondPriority
-    }
-    if (a.isNewApp) {
-      return -1
-    }
-    if (b.isNewApp) {
-      return 1
-    }
-    return firstPriority - secondPriority
-  })
+    })
+    .map((app) => ({
+      ...app,
+      // Sort actions within each app so that actions with isNew appear first
+      actions: app.actions?.sort((a, b) => {
+        if (a.isNew && b.isNew) {
+          return 0
+        }
+        if (a.isNew) {
+          return -1
+        }
+        if (b.isNew) {
+          return 1
+        }
+        return 0
+      }),
+    }))
 }
 
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -57,48 +57,27 @@ export const ACTION_APPS_RANKING = [
 ]
 
 function sortApps(apps: IApp[]): IApp[] {
-  // Helper function to sort items with isNew flag first
-  const sortByIsNew = (a: { isNew?: boolean }, b: { isNew?: boolean }) => {
-    if (a.isNew && b.isNew) {
-      return 0
+  // trade off for increased time complexity but easier to add a new app to the ranking
+  return apps.sort((a, b) => {
+    const firstPriority = a.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
+    const secondPriority = b.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
+
+    // sort by newApp flag, followed by priority
+    if (a.isNewApp && b.isNewApp) {
+      return firstPriority - secondPriority
     }
-    if (a.isNew) {
+    if (a.isNewApp) {
       return -1
     }
-    if (b.isNew) {
+    if (b.isNewApp) {
       return 1
     }
-    return 0
-  }
-
-  // trade off for increased time complexity but easier to add a new app to the ranking
-  return apps
-    .sort((a, b) => {
-      const firstPriority = a.triggers
-        ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
-        : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
-      const secondPriority = b.triggers
-        ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
-        : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
-
-      // sort by newApp flag, followed by priority
-      if (a.isNewApp && b.isNewApp) {
-        return firstPriority - secondPriority
-      }
-      if (a.isNewApp) {
-        return -1
-      }
-      if (b.isNewApp) {
-        return 1
-      }
-      return firstPriority - secondPriority
-    })
-    .map((app) => ({
-      ...app,
-      // Sort actions within each app so that actions with isNew appear first
-      actions: app.actions?.sort(sortByIsNew),
-      triggers: app.triggers?.sort(sortByIsNew),
-    }))
+    return firstPriority - secondPriority
+  })
 }
 
 const getApps: QueryResolvers['getApps'] = async (_parent, params) => {

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -57,6 +57,20 @@ export const ACTION_APPS_RANKING = [
 ]
 
 function sortApps(apps: IApp[]): IApp[] {
+  // Helper function to sort items with isNew flag first
+  const sortByIsNew = (a: { isNew?: boolean }, b: { isNew?: boolean }) => {
+    if (a.isNew && b.isNew) {
+      return 0
+    }
+    if (a.isNew) {
+      return -1
+    }
+    if (b.isNew) {
+      return 1
+    }
+    return 0
+  }
+
   // trade off for increased time complexity but easier to add a new app to the ranking
   return apps
     .sort((a, b) => {
@@ -82,18 +96,8 @@ function sortApps(apps: IApp[]): IApp[] {
     .map((app) => ({
       ...app,
       // Sort actions within each app so that actions with isNew appear first
-      actions: app.actions?.sort((a, b) => {
-        if (a.isNew && b.isNew) {
-          return 0
-        }
-        if (a.isNew) {
-          return -1
-        }
-        if (b.isNew) {
-          return 1
-        }
-        return 0
-      }),
+      actions: app.actions?.sort(sortByIsNew),
+      triggers: app.triggers?.sort(sortByIsNew),
     }))
 }
 

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -26,6 +26,7 @@ type GlobalVariableOptions = {
   testRun?: boolean
   request?: IRequest
   user?: User // only required in GraphQL context
+  metadata?: IJSONObject
 }
 
 const globalVariable = async (
@@ -40,6 +41,7 @@ const globalVariable = async (
     request,
     testRun = false,
     user,
+    metadata,
   } = options
 
   const isTrigger = step?.isTrigger
@@ -90,6 +92,8 @@ const globalVariable = async (
      * This function is mainly used in testRuns for triggers
      * specify sameExection as true, if you want to get the last execution step of the SAME execution
      * (e.g. for retries that require the context from the last execution step)
+     *
+     * For-each case: add the iteration number to get the correct execution step for steps in the for-each
      */
     getLastExecutionStep: async (options) => {
       if (options?.sameExecution && !execution?.id) {
@@ -99,6 +103,7 @@ const globalVariable = async (
         await step?.getLastExecutionStep({
           executionId: options?.sameExecution ? execution.id : undefined,
           testRunOnly: options?.testRunOnly,
+          iteration: options?.iteration,
         })
       )?.toJSON()
     },
@@ -127,6 +132,7 @@ const globalVariable = async (
       $.actionOutput.data = actionItem
     },
     user: flow?.user ?? user,
+    metadata,
   }
 
   if (request) {

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -100,7 +100,7 @@ class ExecutionStep extends Base {
   static async patchIterationStatus(
     executionId: string,
     iteration: number,
-    status: 'success' | 'failure' | null,
+    status: 'success' | 'failure' | 'partial-success' | null,
   ) {
     const updateData =
       status !== null

--- a/packages/backend/src/models/execution-step.ts
+++ b/packages/backend/src/models/execution-step.ts
@@ -184,7 +184,9 @@ class ExecutionStep extends Base {
         Object.values(iterationStatus).every((value) => value !== null),
       areAllStepsSuccessful:
         iterationStatus &&
-        Object.values(iterationStatus).every((value) => value === 'success'),
+        Object.values(iterationStatus).every(
+          (value) => value === 'success' || value === 'partial-success',
+        ),
     }
   }
 }

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,6 +1,6 @@
 import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
 
-import { type StaticHookArguments, ValidationError } from 'objection'
+import { raw, type StaticHookArguments, ValidationError } from 'objection'
 import { URL } from 'url'
 
 import apps from '@/apps'
@@ -123,9 +123,11 @@ class Step extends Base {
   async getLastExecutionStep({
     executionId,
     testRunOnly,
+    iteration,
   }: {
     executionId?: string
     testRunOnly?: boolean
+    iteration?: number
   }) {
     const query = this.$relatedQuery('executionSteps')
       .orderBy('created_at', 'desc')
@@ -137,6 +139,11 @@ class Step extends Base {
     }
     if (executionId) {
       query.andWhere('execution_id', executionId)
+    }
+    if (iteration) {
+      query.andWhere(
+        raw(`(execution_steps.metadata ->> 'iteration')::int = ?`, [iteration]),
+      )
     }
     const lastExecutionStep = await query
     if (lastExecutionStep?.appKey !== this.appKey) {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -116,6 +116,7 @@ export const processAction = async (options: ProcessActionOptions) => {
     connection: await step.$relatedQuery('connection'),
     execution: execution,
     testRun,
+    metadata,
   })
 
   const priorExecutionSteps = await ExecutionStep.query().where({

--- a/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
+++ b/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
@@ -64,13 +64,13 @@ describe('processForEachStatus', () => {
   describe('when step is a for-each step', () => {
     it('should return false if isLastStep is undefined', async () => {
       const metadata: IExecutionStepMetadata = {}
+      mocks.getIterationSteps.mockResolvedValueOnce([])
 
       const result = await processForEachStatus({
         executionId: mockExecutionId,
         currStep: mockForEachStep,
         nextStepMetadata: metadata,
       })
-      mocks.getIterationSteps.mockResolvedValue([])
 
       expect(result).toBe(false)
       expect(mocks.patchIterationStatus).not.toHaveBeenCalled()

--- a/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
+++ b/packages/backend/src/workers/__tests__/helpers.for-each-status-manager.test.ts
@@ -14,6 +14,12 @@ import processForEachStatus from '../helpers/for-each-status-manager'
 const mocks = vi.hoisted(() => ({
   patchIterationStatus: vi.fn(),
   getForEachExecutionState: vi.fn(),
+  getIterationSteps: vi.fn(() => [
+    {
+      status: 'success',
+      errorDetails: null,
+    },
+  ]),
   setStatus: vi.fn(),
 }))
 
@@ -21,6 +27,7 @@ vi.mock('@/models/execution-step', () => ({
   default: {
     patchIterationStatus: mocks.patchIterationStatus,
     getForEachExecutionState: mocks.getForEachExecutionState,
+    getIterationSteps: mocks.getIterationSteps,
   },
 }))
 
@@ -63,6 +70,7 @@ describe('processForEachStatus', () => {
         currStep: mockForEachStep,
         nextStepMetadata: metadata,
       })
+      mocks.getIterationSteps.mockResolvedValue([])
 
       expect(result).toBe(false)
       expect(mocks.patchIterationStatus).not.toHaveBeenCalled()
@@ -193,6 +201,35 @@ describe('processForEachStatus', () => {
         mockExecutionId,
         1,
         'success',
+      )
+    })
+
+    it('should return partial-success if iteration steps are not successful', async () => {
+      const metadata: IExecutionStepMetadata = {
+        iteration: 1,
+        isLastStep: true,
+      }
+
+      mocks.getIterationSteps.mockResolvedValueOnce([
+        {
+          status: 'success',
+          errorDetails: {
+            message: 'Error',
+          },
+        },
+      ])
+
+      const result = await processForEachStatus({
+        executionId: mockExecutionId,
+        currStep: mockForEachStep,
+        nextStepMetadata: metadata,
+      })
+
+      expect(result).toBe(true)
+      expect(mocks.patchIterationStatus).toHaveBeenCalledWith(
+        mockExecutionId,
+        1,
+        'partial-success',
       )
     })
 

--- a/packages/backend/src/workers/helpers/for-each-status-manager.ts
+++ b/packages/backend/src/workers/helpers/for-each-status-manager.ts
@@ -49,11 +49,22 @@ export default async function processForEachStatus({
     // only need to check at the last step to set the execution status
     if (isLastStep) {
       try {
-        await ExecutionStep.patchIterationStatus(
+        const iterationSteps = await ExecutionStep.getIterationSteps(
           executionId,
           iteration,
-          'success',
         )
+
+        /**
+         * check for partial success as failures would have been caught earlier
+         * most partial success will be due to email by postman where there
+         * are blacklisted recipients.
+         * partial success is indicated by status = 'success' and errorDetails !== null
+         */
+        const isIterationSuccessful = iterationSteps.every(
+          (step) => step.status === 'success' && step.errorDetails === null,
+        )
+        const status = isIterationSuccessful ? 'success' : 'partial-success'
+        await ExecutionStep.patchIterationStatus(executionId, iteration, status)
       } catch (err) {
         logger.error('Failed to patch iteration status', {
           err,

--- a/packages/frontend/src/components/ExecutionGroup/GroupStatusFilter.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/GroupStatusFilter.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 import { Flex, Tag } from '@chakra-ui/react'
 import startCase from 'lodash/startCase'
 
+import { GroupStats } from '@/helpers/processExecutionSteps'
+
 import { SingleSelect } from '../SingleSelect/SingleSelect'
 
 export enum GroupStatusType {
@@ -9,11 +11,12 @@ export enum GroupStatusType {
   Success = 'success',
   Failure = 'failure',
   Waiting = 'waiting',
+  PartialSuccess = 'partial-success',
 }
 
 interface GroupStatusFilterProps {
   statusFilter: GroupStatusType
-  groupStats: { success: number; failure: number; waiting: number }
+  groupStats: GroupStats
   setStatusFilter: (status: GroupStatusType) => void
 }
 
@@ -23,7 +26,10 @@ const getLabel = (status: GroupStatusType, count: number) => {
     colorScheme = 'success'
   } else if (status === GroupStatusType.Failure) {
     colorScheme = 'critical'
-  } else if (status === GroupStatusType.Waiting) {
+  } else if (
+    status === GroupStatusType.Waiting ||
+    status === GroupStatusType.PartialSuccess
+  ) {
     colorScheme = 'warning'
   }
   return (
@@ -47,8 +53,13 @@ export default function GroupStatusFilter({
   setStatusFilter,
 }: GroupStatusFilterProps) {
   const items = useMemo(() => {
-    const { failure, success, waiting } = groupStats
-    const allCount = success + failure + waiting
+    const {
+      failure,
+      success,
+      waiting,
+      'partial-success': partialSuccess,
+    } = groupStats
+    const allCount = success + failure + waiting + partialSuccess
 
     return [
       {
@@ -59,6 +70,11 @@ export default function GroupStatusFilter({
         label: getLabel(GroupStatusType.Success, success),
         value: GroupStatusType.Success,
         disabled: success === 0,
+      },
+      {
+        label: getLabel(GroupStatusType.PartialSuccess, partialSuccess),
+        value: GroupStatusType.PartialSuccess,
+        disabled: partialSuccess === 0,
       },
       {
         label: getLabel(GroupStatusType.Failure, failure),

--- a/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/IterationSelector.tsx
@@ -34,7 +34,8 @@ export default function IterationSelector({
           Item {iteration}
           <Tag
             colorScheme={
-              status === GroupStatusType.Waiting
+              status === GroupStatusType.Waiting ||
+              status === GroupStatusType.PartialSuccess
                 ? 'warning'
                 : status === GroupStatusType.Success
                 ? 'success'
@@ -47,6 +48,8 @@ export default function IterationSelector({
               ? 'Waiting'
               : status === GroupStatusType.Success
               ? 'Success'
+              : status === GroupStatusType.PartialSuccess
+              ? 'Partial Success'
               : 'Failure'}
           </Tag>
         </Flex>

--- a/packages/frontend/src/components/ExecutionGroup/index.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/index.tsx
@@ -1,14 +1,21 @@
 import type { IExecution, IExecutionStep } from '@plumber/types'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { Card, CardBody, Flex, Grid, HStack, Text } from '@chakra-ui/react'
 import { Pagination } from '@opengovsg/design-system-react'
 
 import ExecutionStep from '@/components/ExecutionStep'
 import AppIconWithStatus from '@/components/ExecutionStep/components/AppIconWithStatus'
+import {
+  failureIcon,
+  partialIcon,
+  successIcon,
+  waitingIcon,
+} from '@/components/ExecutionStep/components/StatusIcons'
 import { useExecutionStepStatus } from '@/components/ExecutionStep/hooks/useExecutionStepStatus'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
+import { GroupStats } from '@/helpers/processExecutionSteps'
 import { EXECUTION_STEP_PER_PAGE, getLimitAndOffset } from '@/pages/Execution'
 
 import GroupStatusFilter, { GroupStatusType } from './GroupStatusFilter'
@@ -17,7 +24,7 @@ import IterationSelector from './IterationSelector'
 interface ExecutionGroupProps {
   execution: IExecution
   groupingStep: IExecutionStep
-  groupStats: { success: number; failure: number; waiting: number }
+  groupStats: GroupStats
   iterationMap: Map<number, string>
   numStepsBeforeGroup: number
 }
@@ -76,7 +83,7 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
     }
   }, [iterationMap, statusFilter])
 
-  const { app, appName, statusIcon } = useExecutionStepStatus({
+  const { app, appName } = useExecutionStepStatus({
     appKey: groupingStep?.appKey ?? '',
     status: !execution?.status
       ? GroupStatusType.Waiting
@@ -87,6 +94,20 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
     execution,
     jobId: groupingStep?.jobId,
   })
+
+  const groupStatusIcon = useMemo(() => {
+    // show failure immediately
+    if (groupStats.failure > 0) {
+      return failureIcon
+    }
+    if (groupStats.waiting > 0) {
+      return waitingIcon
+    }
+    if (groupStats['partial-success'] > 0) {
+      return partialIcon
+    }
+    return successIcon
+  }, [groupStats])
 
   if (!execution || !groupingStep || !app) {
     return null
@@ -106,7 +127,7 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
             <AppIconWithStatus
               iconUrl={app.iconUrl}
               appName={appName}
-              statusIcon={statusIcon}
+              statusIcon={groupStatusIcon}
             />
             <Flex
               justifyContent="space-between"

--- a/packages/frontend/src/helpers/__tests__/processExecutionSteps.test.ts
+++ b/packages/frontend/src/helpers/__tests__/processExecutionSteps.test.ts
@@ -12,6 +12,7 @@ describe('processExecutionSteps', () => {
     key: string,
     status: 'success' | 'failure' = 'success',
     metadata: Record<string, any> = {},
+    errorDetails: Record<string, any> = {},
   ): IExecutionStep => ({
     id: 'executionStepId',
     executionId: 'executionId',
@@ -19,7 +20,7 @@ describe('processExecutionSteps', () => {
     step: {} as any,
     dataIn: {},
     dataOut: {},
-    errorDetails: {},
+    errorDetails,
     status,
     appKey,
     createdAt: new Date().toISOString(),
@@ -32,7 +33,7 @@ describe('processExecutionSteps', () => {
     const result = processExecutionSteps(undefined as any)
     expect(result).toEqual({
       groupingStep: {},
-      groupStats: { success: 0, failure: 0, waiting: 0 },
+      groupStats: { success: 0, failure: 0, waiting: 0, 'partial-success': 0 },
       iterationMap: new Map<number, string>(),
       hasGrouping: false,
       stepsBeforeGroup: [],
@@ -43,7 +44,7 @@ describe('processExecutionSteps', () => {
     const result = processExecutionSteps([])
     expect(result).toEqual({
       groupingStep: {},
-      groupStats: { success: 0, failure: 0, waiting: 0 },
+      groupStats: { success: 0, failure: 0, waiting: 0, 'partial-success': 0 },
       hasGrouping: false,
       iterationMap: new Map<number, string>(),
       stepsBeforeGroup: [],
@@ -58,7 +59,7 @@ describe('processExecutionSteps', () => {
     const result = processExecutionSteps(steps)
     expect(result).toEqual({
       groupingStep: {},
-      groupStats: { success: 0, failure: 0, waiting: 0 },
+      groupStats: { success: 0, failure: 0, waiting: 0, 'partial-success': 0 },
       hasGrouping: false,
       iterationMap: new Map<number, string>(),
       stepsBeforeGroup: steps,
@@ -84,7 +85,12 @@ describe('processExecutionSteps', () => {
     expect(result.hasGrouping).toBe(true)
     expect(result.stepsBeforeGroup).toHaveLength(1)
     expect(result.iterationMap.size).toBe(1)
-    expect(result.groupStats).toEqual({ success: 1, failure: 0, waiting: 0 })
+    expect(result.groupStats).toEqual({
+      success: 1,
+      failure: 0,
+      waiting: 0,
+      'partial-success': 0,
+    })
   })
 
   it('should handle multiple iterations with mixed statuses', () => {
@@ -93,7 +99,7 @@ describe('processExecutionSteps', () => {
       createMockStep(TOOLBOX_APP_KEY, TOOLBOX_ACTIONS.ForEach, 'failure', {
         iterations: 2,
         iterationStatus: {
-          iteration_1: 'success',
+          iteration_1: 'partial-success',
           iteration_2: 'failure',
         },
       }),
@@ -101,6 +107,9 @@ describe('processExecutionSteps', () => {
       createMockStep('app3', 'action3', 'success', {
         iteration: 1,
         isLastStep: true,
+        errorDetails: {
+          message: 'Error',
+        },
       }),
       createMockStep('app2', 'action2', 'failure', { iteration: 2 }),
       createMockStep('app3', 'action3', 'failure', {
@@ -111,7 +120,12 @@ describe('processExecutionSteps', () => {
     const result = processExecutionSteps(steps)
     expect(result.hasGrouping).toBe(true)
     expect(result.iterationMap.size).toBe(2)
-    expect(result.groupStats).toEqual({ success: 1, failure: 1, waiting: 0 })
+    expect(result.groupStats).toEqual({
+      success: 0,
+      failure: 1,
+      waiting: 0,
+      'partial-success': 1,
+    })
   })
 
   it('should handle incomplete iterations', () => {
@@ -129,6 +143,11 @@ describe('processExecutionSteps', () => {
     const result = processExecutionSteps(steps)
     expect(result.hasGrouping).toBe(true)
     expect(result.iterationMap.size).toBe(1)
-    expect(result.groupStats).toEqual({ success: 0, failure: 0, waiting: 1 })
+    expect(result.groupStats).toEqual({
+      success: 0,
+      failure: 0,
+      waiting: 1,
+      'partial-success': 0,
+    })
   })
 })

--- a/packages/frontend/src/helpers/processExecutionSteps.ts
+++ b/packages/frontend/src/helpers/processExecutionSteps.ts
@@ -8,9 +8,16 @@ export type GroupedSteps = Array<{
   status: string
 }>
 
+export type GroupStats = {
+  success: number
+  failure: number
+  waiting: number
+  'partial-success': number
+}
+
 const DEFAULT_EMPTY_RESULT = {
   groupingStep: {} as IExecutionStep,
-  groupStats: { success: 0, failure: 0, waiting: 0 },
+  groupStats: { success: 0, failure: 0, waiting: 0, 'partial-success': 0 },
   hasGrouping: false,
   iterationMap: new Map<number, string>(),
   stepsBeforeGroup: [],
@@ -47,10 +54,11 @@ export default function processExecutionSteps(
     iterationMap.set(iteration, status ? status : 'waiting')
   })
 
-  const groupStats: { success: number; failure: number; waiting: number } = {
+  const groupStats: GroupStats = {
     success: 0,
     failure: 0,
     waiting: 0,
+    'partial-success': 0,
   }
 
   for (const [, status] of iterationMap) {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -848,12 +848,14 @@ export type IGlobalVariable = {
     options?: Partial<{
       sameExecution: boolean
       testRunOnly: boolean
+      iteration?: number
     }>,
   ) => Promise<IExecutionStep | undefined>
   execution?: {
     id: string
     testRun: boolean
   }
+  metadata?: IJSONObject
   webhookUrl?: string
   triggerOutput?: ITriggerOutput
   actionOutput?: IActionOutput

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -128,7 +128,10 @@ export interface IExecutionStepMetadata {
   isMock?: boolean
   iteration?: number
   iterations?: number
-  iterationStatus?: Record<string, 'success' | 'failure' | null>
+  iterationStatus?: Record<
+    string,
+    'success' | 'failure' | 'partial-success' | null
+  >
   isLastIteration?: boolean
   isLastStep?: boolean
 }


### PR DESCRIPTION
### TL;DR
Added a new 'partial-success' status for For Each iterations to better represent scenarios where steps complete with non-critical errors. This also makes it easier for users to filter iterations for retry on the Executions page.
_Partial successes are most likely to occur in Email by Postman actions where recipient emails are blacklisted._

### What changed?

- Added a new 'partial-success' status type to the execution step model
- Updated the frontend to display and filter partial success states
- Added a partial success icon and updated the GroupStatusFilter component to include the new status
- Modified the iteration status detection logic to identify partial success when a step has errorDetails but still completes

### How to test?
1. Create a Pipe with a ForEach step that includes an action that might result in partial success (e.g., email sending with some blacklisted recipients - `malcolm+blacklist@open.gov.sg`)
2. Execute the workflow and observe the partial success status in the execution page

- [ ] Execution should still be a success
- [ ] For each step should show as partial success
- [ ] Iteration selector should show the correct iteration with the partial success state
- [ ] Status filters should filter the different status correctly


### Screenshots

[Screen Recording 2025-07-09 at 11.14.01 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/35adf176-1bb6-45eb-892b-a798b93f4780.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/35adf176-1bb6-45eb-892b-a798b93f4780.mov)

