### PR TITLE
chore: allow variable replacement in single select mode

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -213,11 +213,11 @@ const Editor = ({
   const handleVariableClick = useCallback(
     (variable: Variable) => {
       // if the selection is a node, means the user clicked on a variable
-      const selection = editor?.state.selection.toJSON()
+      const selectionType = editor?.state?.selection?.toJSON()?.type
       if (
         singleVariableSelection &&
         editor?.getText().match(GLOBAL_VARIABLE_REGEX) &&
-        selection.type !== 'node'
+        selectionType !== 'node'
       ) {
         return
       }

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -212,12 +212,16 @@ const Editor = ({
 
   const handleVariableClick = useCallback(
     (variable: Variable) => {
+      // if the selection is a node, means the user clicked on a variable
+      const selection = editor?.state.selection.toJSON()
       if (
         singleVariableSelection &&
-        editor?.getText().match(GLOBAL_VARIABLE_REGEX)
+        editor?.getText().match(GLOBAL_VARIABLE_REGEX) &&
+        selection.type !== 'node'
       ) {
         return
       }
+
       editor?.commands.insertContent({
         type: StepVariable.name,
         attrs: {


### PR DESCRIPTION
### TL;DR
Allows users to replace variables in single-select mode by clicking on a variable in the input and selecting a new one from the suggestions popover.


### How to test?
- [ ] Single select inputs (For-each item)
  - [ ] Can select variable in empty input
  - [ ] Can delete variable and select a new variable
  - [ ] Can select variable and replace with another variable from the suggestions popover

- [ ] All other inputs
  - [ ] Can still select multiple variables and type freely in them
  - [ ] Can select variable and replace with another variable from the suggestions popover

### Screenshots

[Screen Recording 2025-07-09 at 10.59.31 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/14695cf9-0766-49d4-b236-c275dc4856a3.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/14695cf9-0766-49d4-b236-c275dc4856a3.mov)

### Why make this change?
Previously, users could replace variables by clicking on them and selecting a new one from the suggestions popover. This change prevents a regression and restores that expected behaviour.
