### PR TITLE
chore: extract time of day options to constant

### DIFF
--- a/packages/backend/src/apps/scheduler/common/constants.ts
+++ b/packages/backend/src/apps/scheduler/common/constants.ts
@@ -1,6 +1,3 @@
-export const SCHEDULER_MAX_DELAY_IN_MS = 30 * 60 * 1000
-export const SCHEDULER_DEFAULT_INTERVAL_IN_MS = 10 * 60 * 1000
-
 export const TIME_OF_DAY_DESCRIPTION =
   'What time of day should this workflow start?'
 

--- a/packages/backend/src/apps/scheduler/common/constants.ts
+++ b/packages/backend/src/apps/scheduler/common/constants.ts
@@ -1,0 +1,104 @@
+export const SCHEDULER_MAX_DELAY_IN_MS = 30 * 60 * 1000
+export const SCHEDULER_DEFAULT_INTERVAL_IN_MS = 10 * 60 * 1000
+
+export const TIME_OF_DAY_DESCRIPTION =
+  'What time of day should this workflow start?'
+
+export const TIME_OF_DAY_OPTIONS = [
+  {
+    label: '00:00',
+    value: 0,
+  },
+  {
+    label: '01:00',
+    value: 1,
+  },
+  {
+    label: '02:00',
+    value: 2,
+  },
+  {
+    label: '03:00',
+    value: 3,
+  },
+  {
+    label: '04:00',
+    value: 4,
+  },
+  {
+    label: '05:00',
+    value: 5,
+  },
+  {
+    label: '06:00',
+    value: 6,
+  },
+  {
+    label: '07:00',
+    value: 7,
+  },
+  {
+    label: '08:00',
+    value: 8,
+  },
+  {
+    label: '09:00',
+    value: 9,
+  },
+  {
+    label: '10:00',
+    value: 10,
+  },
+  {
+    label: '11:00',
+    value: 11,
+  },
+  {
+    label: '12:00',
+    value: 12,
+  },
+  {
+    label: '13:00',
+    value: 13,
+  },
+  {
+    label: '14:00',
+    value: 14,
+  },
+  {
+    label: '15:00',
+    value: 15,
+  },
+  {
+    label: '16:00',
+    value: 16,
+  },
+  {
+    label: '17:00',
+    value: 17,
+  },
+  {
+    label: '18:00',
+    value: 18,
+  },
+  {
+    label: '19:00',
+    value: 19,
+  },
+  {
+    label: '20:00',
+    value: 20,
+  },
+  {
+    label: '21:00',
+    value: 21,
+  },
+  {
+    label: '22:00',
+    value: 22,
+  },
+  {
+    label: '23:00',
+    value: 23,
+  },
+]

--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -2,6 +2,10 @@ import { IGlobalVariable, IRawTrigger } from '@plumber/types'
 
 import { DateTime } from 'luxon'
 
+import {
+  TIME_OF_DAY_DESCRIPTION,
+  TIME_OF_DAY_OPTIONS,
+} from '../../common/constants'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
@@ -34,109 +38,12 @@ const trigger: IRawTrigger = {
       label: 'Time of day',
       key: 'hour',
       type: 'dropdown' as const,
-      description: 'What time of day should this flow trigger at?',
+      description: TIME_OF_DAY_DESCRIPTION,
       required: true,
       value: null,
       variables: false,
       showOptionValue: false,
-      options: [
-        {
-          label: '00:00',
-          value: 0,
-        },
-        {
-          label: '01:00',
-          value: 1,
-        },
-        {
-          label: '02:00',
-          value: 2,
-        },
-        {
-          label: '03:00',
-          value: 3,
-        },
-        {
-          label: '04:00',
-          value: 4,
-        },
-        {
-          label: '05:00',
-          value: 5,
-        },
-        {
-          label: '06:00',
-          value: 6,
-        },
-        {
-          label: '07:00',
-          value: 7,
-        },
-        {
-          label: '08:00',
-          value: 8,
-        },
-        {
-          label: '09:00',
-          value: 9,
-        },
-        {
-          label: '10:00',
-          value: 10,
-        },
-        {
-          label: '11:00',
-          value: 11,
-        },
-        {
-          label: '12:00',
-          value: 12,
-        },
-        {
-          label: '13:00',
-          value: 13,
-        },
-        {
-          label: '14:00',
-          value: 14,
-        },
-        {
-          label: '15:00',
-          value: 15,
-        },
-        {
-          label: '16:00',
-          value: 16,
-        },
-        {
-          label: '17:00',
-          value: 17,
-        },
-        {
-          label: '18:00',
-          value: 18,
-        },
-        {
-          label: '19:00',
-          value: 19,
-        },
-        {
-          label: '20:00',
-          value: 20,
-        },
-        {
-          label: '21:00',
-          value: 21,
-        },
-        {
-          label: '22:00',
-          value: 22,
-        },
-        {
-          label: '23:00',
-          value: 23,
-        },
-      ],
+      options: TIME_OF_DAY_OPTIONS,
     },
   ],
   getDataOutMetadata,

--- a/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-day/index.ts
@@ -20,7 +20,7 @@ const trigger: IRawTrigger = {
       label: 'Trigger on weekends?',
       key: 'triggersOnWeekend',
       type: 'boolean-radio' as const,
-      description: 'Should this flow trigger on Saturday and Sunday?',
+      description: 'Should this workflow start on Saturday and Sunday?',
       required: true,
       // flip the order of the default options
       options: [

--- a/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-hour/index.ts
@@ -16,7 +16,7 @@ const trigger: IRawTrigger = {
       label: 'Trigger on weekends?',
       key: 'triggersOnWeekend',
       type: 'boolean-radio' as const,
-      description: 'Should this flow trigger on Saturday and Sunday?',
+      description: 'Should this workflow start on Saturday and Sunday?',
       required: true,
       // flip the order of the default options
       options: [

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -2,6 +2,10 @@ import { IGlobalVariable, IRawTrigger } from '@plumber/types'
 
 import { DateTime } from 'luxon'
 
+import {
+  TIME_OF_DAY_DESCRIPTION,
+  TIME_OF_DAY_OPTIONS,
+} from '../../common/constants'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
@@ -153,109 +157,12 @@ const trigger: IRawTrigger = {
       label: 'Time of day',
       key: 'hour',
       type: 'dropdown' as const,
-      description: 'What time of day should this flow trigger at?',
+      description: TIME_OF_DAY_DESCRIPTION,
       required: true,
       value: null,
       variables: false,
       showOptionValue: false,
-      options: [
-        {
-          label: '00:00',
-          value: 0,
-        },
-        {
-          label: '01:00',
-          value: 1,
-        },
-        {
-          label: '02:00',
-          value: 2,
-        },
-        {
-          label: '03:00',
-          value: 3,
-        },
-        {
-          label: '04:00',
-          value: 4,
-        },
-        {
-          label: '05:00',
-          value: 5,
-        },
-        {
-          label: '06:00',
-          value: 6,
-        },
-        {
-          label: '07:00',
-          value: 7,
-        },
-        {
-          label: '08:00',
-          value: 8,
-        },
-        {
-          label: '09:00',
-          value: 9,
-        },
-        {
-          label: '10:00',
-          value: 10,
-        },
-        {
-          label: '11:00',
-          value: 11,
-        },
-        {
-          label: '12:00',
-          value: 12,
-        },
-        {
-          label: '13:00',
-          value: 13,
-        },
-        {
-          label: '14:00',
-          value: 14,
-        },
-        {
-          label: '15:00',
-          value: 15,
-        },
-        {
-          label: '16:00',
-          value: 16,
-        },
-        {
-          label: '17:00',
-          value: 17,
-        },
-        {
-          label: '18:00',
-          value: 18,
-        },
-        {
-          label: '19:00',
-          value: 19,
-        },
-        {
-          label: '20:00',
-          value: 20,
-        },
-        {
-          label: '21:00',
-          value: 21,
-        },
-        {
-          label: '22:00',
-          value: 22,
-        },
-        {
-          label: '23:00',
-          value: 23,
-        },
-      ],
+      options: TIME_OF_DAY_OPTIONS,
     },
   ],
   getDataOutMetadata,

--- a/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-month/index.ts
@@ -21,7 +21,7 @@ const trigger: IRawTrigger = {
       label: 'Day of the month',
       key: 'day',
       type: 'dropdown' as const,
-      description: 'What day of the month should this flow trigger at?',
+      description: 'What day of the month should this workflow start?',
       required: true,
       value: null,
       variables: false,

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -21,7 +21,7 @@ const trigger: IRawTrigger = {
       label: 'Day of the week',
       key: 'weekday',
       type: 'dropdown' as const,
-      description: 'What day of the week should this flow trigger at?',
+      description: 'What day of the week should this workflow start?',
       required: true,
       value: null,
       variables: false,

--- a/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
+++ b/packages/backend/src/apps/scheduler/triggers/every-week/index.ts
@@ -2,6 +2,10 @@ import { IGlobalVariable, IRawTrigger } from '@plumber/types'
 
 import { DateTime } from 'luxon'
 
+import {
+  TIME_OF_DAY_DESCRIPTION,
+  TIME_OF_DAY_OPTIONS,
+} from '../../common/constants'
 import cronTimes from '../../common/cron-times'
 import getDateTimeObjectRepresentation from '../../common/get-date-time-object'
 import getNextCronDateTime from '../../common/get-next-cron-date-time'
@@ -57,109 +61,12 @@ const trigger: IRawTrigger = {
       label: 'Time of day',
       key: 'hour',
       type: 'dropdown' as const,
-      description: 'What time of day should this flow trigger at?',
+      description: TIME_OF_DAY_DESCRIPTION,
       required: true,
       value: null,
       variables: false,
       showOptionValue: false,
-      options: [
-        {
-          label: '00:00',
-          value: 0,
-        },
-        {
-          label: '01:00',
-          value: 1,
-        },
-        {
-          label: '02:00',
-          value: 2,
-        },
-        {
-          label: '03:00',
-          value: 3,
-        },
-        {
-          label: '04:00',
-          value: 4,
-        },
-        {
-          label: '05:00',
-          value: 5,
-        },
-        {
-          label: '06:00',
-          value: 6,
-        },
-        {
-          label: '07:00',
-          value: 7,
-        },
-        {
-          label: '08:00',
-          value: 8,
-        },
-        {
-          label: '09:00',
-          value: 9,
-        },
-        {
-          label: '10:00',
-          value: 10,
-        },
-        {
-          label: '11:00',
-          value: 11,
-        },
-        {
-          label: '12:00',
-          value: 12,
-        },
-        {
-          label: '13:00',
-          value: 13,
-        },
-        {
-          label: '14:00',
-          value: 14,
-        },
-        {
-          label: '15:00',
-          value: 15,
-        },
-        {
-          label: '16:00',
-          value: 16,
-        },
-        {
-          label: '17:00',
-          value: 17,
-        },
-        {
-          label: '18:00',
-          value: 18,
-        },
-        {
-          label: '19:00',
-          value: 19,
-        },
-        {
-          label: '20:00',
-          value: 20,
-        },
-        {
-          label: '21:00',
-          value: 21,
-        },
-        {
-          label: '22:00',
-          value: 22,
-        },
-        {
-          label: '23:00',
-          value: 23,
-        },
-      ],
+      options: TIME_OF_DAY_OPTIONS,
     },
   ],
   getDataOutMetadata,


### PR DESCRIPTION
### What changed?
- Updated scheduler description to: `What time of day should this workflow start?`
- Extracted time of day options to a reusable constant

### How to test?
- [ ] Existing scheduler actions work as intended and are populated with the correct timings
- [ ] New scheduler actions execute at the desired time