### PR TITLE
fix: handle zero values properly

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -267,7 +267,7 @@ describe('getDataOutMetadata', () => {
               name: { isHidden: true },
               value: {
                 label: 'Column 1',
-                displayedValue: ' ',
+                displayedValue: '',
                 order: 1,
                 type: 'text',
               },
@@ -450,7 +450,7 @@ describe('getDataOutMetadata', () => {
               name: { isHidden: true },
               value: {
                 label: 'Name',
-                displayedValue: ' ',
+                displayedValue: '',
                 order: 1,
                 type: 'text',
               },
@@ -460,7 +460,7 @@ describe('getDataOutMetadata', () => {
               name: { isHidden: true },
               value: {
                 label: 'Row ID',
-                displayedValue: ' ',
+                displayedValue: '',
                 order: 2,
                 type: 'tile_row_id',
               },
@@ -767,7 +767,7 @@ describe('getDataOutMetadata', () => {
               name: { isHidden: true },
               value: {
                 label: 'Number',
-                displayedValue: 42,
+                displayedValue: '42',
                 order: 1,
                 type: 'text',
               },

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -39,7 +39,7 @@ async function getDataOutMetadata(
       item: {
         label: 'Item',
         type: 'text',
-        displayedValue: items[0] ?? '',
+        displayedValue: items[0] ? String(items[0]) : '',
       },
     }
   }
@@ -55,8 +55,8 @@ async function getDataOutMetadata(
         label: column.name,
         displayedValue:
           column.id === 'rowId'
-            ? items?.rows?.[0]?.rowId ?? ' '
-            : items?.rows?.[0]?.data?.[column.id] ?? ' ',
+            ? items?.rows?.[0]?.rowId ?? ''
+            : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
         order: index + 1,
         type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
       },

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -130,14 +130,14 @@ export function computeForEachParameters({
     executionStep?.appKey === TOOLBOX_APP_KEY &&
     executionStep?.key === TOOLBOX_ACTIONS.FOR_EACH
   ) {
-    dataValue = get(data, forEachKeyPath as string) || ''
+    dataValue = get(data, forEachKeyPath as string) ?? ''
   } else if (currentStepPosition > forEachStepPosition) {
     // find the specific execution step for the same iteration
     const iterationExecutionStep = executionSteps.find(
       (es) =>
         es.stepId === stepId && es.metadata.iteration === metadata?.iteration,
     )
-    dataValue = get(iterationExecutionStep?.dataOut, keyPath) || ''
+    dataValue = get(iterationExecutionStep?.dataOut, keyPath) ?? ''
   }
 
   return dataValue

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -227,9 +227,7 @@ const Editor = ({
         attrs: {
           id: variable.name,
           label: variable.label,
-          value: variable.displayedValue
-            ? variable.displayedValue
-            : variable.value,
+          value: variable.displayedValue ?? variable.value,
         },
       })
       editor?.commands.focus()


### PR DESCRIPTION
### TL;DR
Fixed inconsistent handling of empty values in For Each action, which caused issues when cell values were `0` by standardising how empty values and string conversions are managed.

### What changed?

- Modified `getDataOutMetadata.ts` to consistently convert displayed values to strings using `String()` instead of relying on implicit conversion
- Changed empty value representation from space character (`' '`) to empty string (`''`) in tests and implementation so that checking against step parameters against test executions yielded accurate results of whether that was the latest test
- Fixed the fallback logic in `computeForEachParameters.ts` to use nullish coalescing (`??`) instead of logical OR (`||`) to properly handle falsy values like `0` or `false`
- Simplified the variable value selection in `RichTextEditor` component using nullish coalescing

### How to test?

1. Create a Pipe with a For Each action
2. Test with various data types including empty values, zeros, and boolean values

- [ ] Variable pills should show `0`
- [ ] Variable should show `false`
- [ ] Variable with empty displayedValue should be an empty variable pill with dotted outline


### Screenshots
#### Before

![Screenshot 2025-07-10 at 9.47.09 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/8404508c-85ee-43ec-a6f1-ca8357ea45a5.png)

#### After

![Screenshot 2025-07-10 at 9.54.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Wrwhm8Mmhv1Z2GwlSb7V/d57d32a2-4cd8-4140-bb64-424b1f5a810e.png)

### Why make this change?

This change ensures consistent handling of empty and falsy values throughout the For Each action. The previous implementation had inconsistencies where empty values were sometimes represented as spaces and numeric values weren't properly converted to strings. Using nullish coalescing instead of logical OR prevents valid falsy values (like 0 or false) from being incorrectly replaced with empty strings.