### PR TITLE
fix: reduce add row flicker, improve mobile view

### DIFF
--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,6 +1,6 @@
 import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
-import { useContext } from 'react'
+import React, { useContext } from 'react'
 import { BiTrash } from 'react-icons/bi'
 import { Divider, Flex } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
@@ -64,7 +64,7 @@ export default function MultiCol(props: MultiColProps) {
       {subFields.map((subF, subFIndex) => {
         const showDeleteButton = subFIndex === 0 && canRemoveRow
         return isMobile ? (
-          <>
+          <React.Fragment key={`${name}.${subF.key}`}>
             {index !== 0 && subFIndex === 0 && <Divider />}
             <Flex
               key={`${name}.${subF.key}`}
@@ -73,7 +73,7 @@ export default function MultiCol(props: MultiColProps) {
               {renderSubFieldInput(subF, subFIndex)}
               {showDeleteButton && <DeleteButton />}
             </Flex>
-          </>
+          </React.Fragment>
         ) : (
           <div key={`${name}.${subF.key}`} style={subF.customStyle}>
             {renderSubFieldInput(subF, subFIndex)}

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,10 +1,12 @@
 import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
+import { useContext } from 'react'
 import { BiTrash } from 'react-icons/bi'
-import { Flex, useBreakpointValue } from '@chakra-ui/react'
+import { Divider, Flex } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
+import { EditorContext } from '@/contexts/Editor'
 
 type MultiColProps = {
   name: string
@@ -26,36 +28,59 @@ export default function MultiCol(props: MultiColProps) {
     ...forwardedInputCreatorProps
   } = props
 
-  const isMobile = useBreakpointValue({ base: true, sm: false })
+  const { isMobile } = useContext(EditorContext)
+
+  const DeleteButton = () => {
+    return (
+      <IconButton
+        variant="clear"
+        aria-label="Remove"
+        icon={<BiTrash />}
+        isDisabled={isEditorReadOnly}
+        onClick={() => remove?.(index)}
+        colorScheme="secondary"
+      />
+    )
+  }
+
+  const renderSubFieldInput = (
+    subF: IFieldMultiRowMultiColSubField,
+    subFIndex: number,
+  ) => {
+    const { type, variables } = subF
+    return (
+      <InputCreator
+        schema={subF}
+        namePrefix={name}
+        parentType="multicol"
+        autoFocus={subFIndex === 0 && type === 'string' && variables}
+        {...forwardedInputCreatorProps}
+      />
+    )
+  }
+
   return (
     <Flex flexDir={isMobile ? 'column' : 'row'} gap={2} alignItems="center">
       {subFields.map((subF, subFIndex) => {
-        const { type, variables } = subF
-        return (
-          <div
-            key={`${name}.${subF.key}`}
-            style={isMobile ? { flex: 1, width: '100%' } : subF.customStyle}
-          >
-            <InputCreator
-              schema={subF}
-              namePrefix={name}
-              parentType="multicol"
-              autoFocus={subFIndex === 0 && type === 'string' && variables}
-              {...forwardedInputCreatorProps}
-            />
+        const showDeleteButton = subFIndex === 0 && canRemoveRow
+        return isMobile ? (
+          <>
+            {index !== 0 && subFIndex === 0 && <Divider />}
+            <Flex
+              key={`${name}.${subF.key}`}
+              style={{ flex: 1, width: '100%', marginTop: 8 }}
+            >
+              {renderSubFieldInput(subF, subFIndex)}
+              {showDeleteButton && <DeleteButton />}
+            </Flex>
+          </>
+        ) : (
+          <div key={`${name}.${subF.key}`} style={subF.customStyle}>
+            {renderSubFieldInput(subF, subFIndex)}
           </div>
         )
       })}
-      {canRemoveRow && (
-        <IconButton
-          variant="clear"
-          aria-label="Remove"
-          icon={<BiTrash />}
-          isDisabled={isEditorReadOnly}
-          onClick={() => remove?.(index)}
-          colorScheme="secondary"
-        />
-      )}
+      {!isMobile && canRemoveRow && <DeleteButton />}
     </Flex>
   )
 }

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -296,6 +296,7 @@
   border-radius: inherit;
   mask-image: linear-gradient(to right, black 100%, black 100%);
   -webkit-mask-image: linear-gradient(to right, black 100%, black 100%);
+  min-height: 2.625rem;
 
   // NOTE: forcefully hide the scrollbar so that it does not
   // cause misalignment with the height of the multirow


### PR DESCRIPTION
## Problem
Adding a new row in multicol-multirow has visible UI flicker.
This was due to the usage of Chakra's `useBreakpointValue` which causes re-render when new row is added.

## Solution
Use `isMobile` from the editor context to determine if its in mobile mode.

**Improvements**:
Minor improvement to the mobile view:
- shift the delete button next to the first input
- add a divider between inputs

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/2b544b0c-c14b-4f8f-bf63-8fd0d13c39f0

<img width="415" height="486" alt="Screenshot 2025-07-11 at 4 41 09 PM" src="https://github.com/user-attachments/assets/8aa6dee6-b3b3-4ec2-b322-90531db727a3" />


**AFTER**:

https://github.com/user-attachments/assets/71716c83-40db-464b-8e58-392a35eca1b0


<img width="403" height="660" alt="Screenshot 2025-07-11 at 4 01 54 PM" src="https://github.com/user-attachments/assets/b2bacf38-f31c-4cb4-98e4-bf7c2da6580b" />

## Tests
- [ ] Multirow-multicol inputs can be edited and saved properly
- [ ] Input rows can be added
- [ ] Input rows can be deleted

