### PR TITLE
PLU-505: Clickable area in nested step smaller than step

### DIFF
--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -220,11 +220,7 @@ export default function FlowStep(
             h={isNested ? '48px' : '64px'}
             w={headerWidth}
           >
-            <Flex
-              {...flowStepStyles.topHeader}
-              py={isNested ? 2 : 4}
-              onClick={handleClick}
-            >
+            <Flex {...flowStepStyles.topHeader} onClick={handleClick}>
               <StepAppIcon
                 isCompleted={isCompleted}
                 isNested={isNested}

--- a/packages/frontend/src/components/FlowStep/styles.ts
+++ b/packages/frontend/src/components/FlowStep/styles.ts
@@ -31,6 +31,7 @@ export const flowStepStyles = {
     alignItems: 'center',
     borderRadius: 'inherit',
     px: 4,
+    py: 4,
     w: 'full',
     _hover: {
       bg: 'interaction.muted.neutral.hover',


### PR DESCRIPTION
## Problem
Clickable area in nested step smaller than step due to unnecessary difference in padding in nested and non-nested step.

## Solution
Make padding the same for both nested and non-nested steps

## Before & After Screenshots

**BEFORE**:
<img width="1424" height="648" alt="image" src="https://github.com/user-attachments/assets/f5eacf62-879b-4f82-af08-c50542989873" />

**AFTER**:
<img width="471" height="310" alt="Screenshot 2025-07-14 at 6 50 32 PM" src="https://github.com/user-attachments/assets/7f102870-57e7-4d3d-9d8b-dc98d907b2e5" />


## Tests
- [ ] Side drawer opens/closes when clicking on both nested and non-nested step
- [ ] Step can be renamed
- [ ] Step can be deleted
