### PR TITLE
[DUPLICATE-STEP-6]: warn on unsaved changes when reordering step

### DIFF
--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -262,10 +262,10 @@ export default function FlowStep(
           </Flex>
           {shouldShowDragHandle &&
             (isNested ? (
-              <SortableList.DragHandle />
+              <SortableList.DragHandle onWarningOpen={onWarningOpen} />
             ) : (
               <Box position="absolute" left="100%" alignSelf="center">
-                <SortableList.DragHandle />
+                <SortableList.DragHandle onWarningOpen={onWarningOpen} />
               </Box>
             ))}
         </Flex>

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -1,7 +1,7 @@
 import './SortableItem.css'
 
 import type { CSSProperties, PropsWithChildren } from 'react'
-import { createContext, useContext, useMemo } from 'react'
+import React, { createContext, useContext, useMemo } from 'react'
 import type {
   DraggableSyntheticListeners,
   UniqueIdentifier,
@@ -76,13 +76,7 @@ export function DragHandle(props: { onWarningOpen?: () => void }) {
       {...attributes}
       {...listeners}
       ref={ref}
-      onPointerDown={() => {
-        if (shouldWarnOnLeave) {
-          onWarningOpen?.()
-        } else {
-          listeners?.onPointerDown?.()
-        }
-      }}
+      {...(shouldWarnOnLeave && { onPointerDown: onWarningOpen })}
     >
       <svg viewBox="0 0 20 20" width="12">
         <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z"></path>

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -1,13 +1,15 @@
 import './SortableItem.css'
 
 import type { CSSProperties, PropsWithChildren } from 'react'
-import React, { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 import type {
   DraggableSyntheticListeners,
   UniqueIdentifier,
 } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+
+import { EditorContext } from '@/contexts/Editor'
 
 interface Props {
   id: UniqueIdentifier
@@ -63,11 +65,25 @@ export function SortableItem({ children, id }: PropsWithChildren<Props>) {
   )
 }
 
-export function DragHandle() {
+export function DragHandle(props: { onWarningOpen?: () => void }) {
+  const { onWarningOpen } = props
   const { attributes, listeners, ref } = useContext(SortableItemContext)
+  const { shouldWarnOnLeave } = useContext(EditorContext)
 
   return (
-    <button className="DragHandle" {...attributes} {...listeners} ref={ref}>
+    <button
+      className="DragHandle"
+      {...attributes}
+      {...listeners}
+      ref={ref}
+      onPointerDown={() => {
+        if (shouldWarnOnLeave) {
+          onWarningOpen?.()
+        } else {
+          listeners?.onPointerDown?.()
+        }
+      }}
+    >
       <svg viewBox="0 0 20 20" width="12">
         <path d="M7 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 2zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 7 14zm6-8a2 2 0 1 0-.001-4.001A2 2 0 0 0 13 6zm0 2a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 8zm0 6a2 2 0 1 0 .001 4.001A2 2 0 0 0 13 14z"></path>
       </svg>


### PR DESCRIPTION
### TL;DR

Added warning to prevent accidental drag operations when unsaved changes exist.

### What changed?

- Modified the `DragHandle` component to accept an `onWarningOpen` prop
- Used the `onPointerDown` handler to trigger the unsaved changes warning

### How to test?

1. Make changes to a step that would trigger the "unsaved changes" state
2. Try to drag a step using the drag handle
3. Verify that a warning appears instead of immediately starting the drag operation
4. Confirm that when no unsaved changes exist, dragging works normally without warnings

### Screenshots

[Screen Recording 2025-07-15 at 12.11.46 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Wrwhm8Mmhv1Z2GwlSb7V/beca6d1b-6f4a-4ad4-86c4-0480ea239a63.mov" />](https://app.graphite.dev/media/video/Wrwhm8Mmhv1Z2GwlSb7V/beca6d1b-6f4a-4ad4-86c4-0480ea239a63.mov)

