### PR TITLE
fix: postman attachments selector

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/components/TagList.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/TagList.tsx
@@ -28,11 +28,11 @@ function TagList(props: TagsProps) {
 
   return (
     <>
-      {tags?.map((tag) => {
+      {tags?.map((tag, index) => {
         const { label, value } = tag
         return (
           <Tag
-            key={`${label}-${value}`}
+            key={`${index}-${label}-${value}`}
             size="md"
             colorScheme="primary"
             borderRadius="md"

--- a/packages/frontend/src/components/AttachmentSuggestions/style.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/style.ts
@@ -13,7 +13,7 @@ export const boxStyles = {
   '&:focus-within': {
     borderColor: 'primary.500',
   },
-  minHeight: '40px',
+  minHeight: '46px',
 }
 
 export const divWrapperStyles = { height: 40, width: '100%' }


### PR DESCRIPTION
## Problem
* Postman attachment input height shifts when changing from empty state to selecting an attachment.
* Attachment tag keys are not unique when using default field name and default attachment from mock data.

## Solution
* Increased the minHeight for the input so that it remains the same height regardless of whether an attachment was selected.
* Added the index to the key to de-duplicate attachments particularly when using mock data and default field name. 

## Tests
- [ ] Attachments from FormSG can be selected and added to the email
- [ ] Attachments can have the same field name and filename from FormSG (especially from mock data) and does not create duplicate Tags in the input field
- [ ] Attachments can be uploaded at the Postman step and added to the email
- [ ] Height of selector does not change when selecting / de-selecting attachment


## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/7192662f-1b65-4451-81dd-8f8a21778a58



**AFTER**:

https://github.com/user-attachments/assets/3614b9d0-01d7-45b1-acd5-a8c86d3b6d91



