### PR TITLE
PLU-511: update flow updated_at on step changes

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -119,6 +119,22 @@ describe('createStep mutation integration tests', async () => {
     expect(steps.map((step) => step.position)).toEqual([1, 2, 3, 4])
   })
 
+  it('should update flow updatedAt when creating a step', async () => {
+    const originalUpdatedAt = testFlow.updatedAt
+    const params = {
+      input: {
+        flow: { id: testFlow.id },
+        previousStep: { id: existingSteps[2].id },
+      },
+    }
+
+    await createStep(null, params, context)
+    const updatedFlow = await Flow.query().findById(testFlow.id)
+    expect(new Date(updatedFlow.updatedAt).getTime()).toBeGreaterThan(
+      new Date(originalUpdatedAt).getTime(),
+    )
+  })
+
   it('throws an error if the flow does not belong to the current user', async () => {
     // Create another user who does not own the existing flow.
     const otherUser = await User.query().insertAndFetch({

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import createStep from '@/graphql/mutations/create-step'
 import Flow from '@/models/flow'
@@ -10,9 +10,16 @@ describe('createStep mutation integration tests', async () => {
   let testFlow: Flow
   let existingSteps: Step[]
   let context: Context
+  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   // Clean up (and seed) database before each test.
   beforeEach(async () => {
+    vi.resetAllMocks()
+
+    vi.spyOn(Step.prototype, 'patchFlowLastUpdated').mockImplementation(
+      patchFlowLastUpdatedSpy,
+    )
+
     // Clear out all rows. Adjust deletion order if using foreign keys.
     await Step.query().delete()
     await Flow.query().delete()
@@ -119,20 +126,15 @@ describe('createStep mutation integration tests', async () => {
     expect(steps.map((step) => step.position)).toEqual([1, 2, 3, 4])
   })
 
-  it('should update flow updatedAt when creating a step', async () => {
-    const originalUpdatedAt = testFlow.updatedAt
+  it('should call patchFlowLastUpdated when creating a step', async () => {
     const params = {
       input: {
         flow: { id: testFlow.id },
         previousStep: { id: existingSteps[2].id },
       },
     }
-
     await createStep(null, params, context)
-    const updatedFlow = await Flow.query().findById(testFlow.id)
-    expect(new Date(updatedFlow.updatedAt).getTime()).toBeGreaterThan(
-      new Date(originalUpdatedAt).getTime(),
-    )
+    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('throws an error if the flow does not belong to the current user', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -167,4 +167,49 @@ describe('deleteStep mutation', () => {
     const invalidatedStep = await Step.query().findById(referencingStep.id)
     expect(invalidatedStep.status).toBe('incomplete')
   })
+
+  it('should update flow updatedAt when deleting trigger step', async () => {
+    const originalUpdatedAt = testFlow.updatedAt
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const result = await deleteStep(
+      null,
+      { input: { ids: [testSteps[0].id] } },
+      context,
+    )
+
+    // Verify the flow's updatedAt was updated
+    expect(result.updatedAt).toBeDefined()
+    expect(new Date(result.updatedAt).getTime()).toBeGreaterThan(
+      new Date(originalUpdatedAt).getTime(),
+    )
+
+    // Verify the returned flow has the updated timestamp
+    const updatedFlow = await Flow.query().findById(testFlow.id)
+    expect(updatedFlow.updatedAt).toStrictEqual(result.updatedAt)
+  })
+
+  it('should update flow updatedAt when deleting action steps', async () => {
+    const originalUpdatedAt = testFlow.updatedAt
+
+    // Wait a moment to ensure different timestamp
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const result = await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id, testSteps[2].id] } },
+      context,
+    )
+
+    // Verify the flow's updatedAt was updated
+    expect(result.updatedAt).toBeDefined()
+    expect(new Date(result.updatedAt).getTime()).toBeGreaterThan(
+      new Date(originalUpdatedAt).getTime(),
+    )
+
+    // Verify the returned flow has the updated timestamp
+    const updatedFlow = await Flow.query().findById(testFlow.id)
+    expect(updatedFlow.updatedAt).toStrictEqual(result.updatedAt)
+  })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import deleteStep from '@/graphql/mutations/delete-step'
 import Flow from '@/models/flow'
@@ -12,8 +12,16 @@ describe('deleteStep mutation', () => {
   let context: Context
   let testFlow: Flow
   let testSteps: Step[]
+  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   beforeEach(async () => {
+    vi.resetAllMocks()
+
+    // Mock the patchFlowLastUpdated method
+    vi.spyOn(Step.prototype, 'patchFlowLastUpdated').mockImplementation(
+      patchFlowLastUpdatedSpy,
+    )
+
     // Clear out all rows
     await Step.query().delete()
     await Flow.query().delete()
@@ -168,48 +176,17 @@ describe('deleteStep mutation', () => {
     expect(invalidatedStep.status).toBe('incomplete')
   })
 
-  it('should update flow updatedAt when deleting trigger step', async () => {
-    const originalUpdatedAt = testFlow.updatedAt
-
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    const result = await deleteStep(
-      null,
-      { input: { ids: [testSteps[0].id] } },
-      context,
-    )
-
-    // Verify the flow's updatedAt was updated
-    expect(result.updatedAt).toBeDefined()
-    expect(new Date(result.updatedAt).getTime()).toBeGreaterThan(
-      new Date(originalUpdatedAt).getTime(),
-    )
-
-    // Verify the returned flow has the updated timestamp
-    const updatedFlow = await Flow.query().findById(testFlow.id)
-    expect(updatedFlow.updatedAt).toStrictEqual(result.updatedAt)
+  it('should call patchFlowLastUpdated when deleting trigger step', async () => {
+    await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
+    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('should update flow updatedAt when deleting action steps', async () => {
-    const originalUpdatedAt = testFlow.updatedAt
-
-    // Wait a moment to ensure different timestamp
-    await new Promise((resolve) => setTimeout(resolve, 10))
-
-    const result = await deleteStep(
+  it('should call patchFlowLastUpdated when deleting action steps', async () => {
+    await deleteStep(
       null,
       { input: { ids: [testSteps[1].id, testSteps[2].id] } },
       context,
     )
-
-    // Verify the flow's updatedAt was updated
-    expect(result.updatedAt).toBeDefined()
-    expect(new Date(result.updatedAt).getTime()).toBeGreaterThan(
-      new Date(originalUpdatedAt).getTime(),
-    )
-
-    // Verify the returned flow has the updated timestamp
-    const updatedFlow = await Flow.query().findById(testFlow.id)
-    expect(updatedFlow.updatedAt).toStrictEqual(result.updatedAt)
+    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -107,7 +107,9 @@ describe('updateStep mutation', () => {
 
     // Mock Step.transaction
     vi.spyOn(Step, 'transaction').mockImplementation(async (callback) => {
-      const trx = {}
+      const trx = {
+        raw: vi.fn().mockResolvedValue({}),
+      } as any
       return callback(trx)
     })
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -16,7 +16,7 @@ const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 describe('updateStep mutation', () => {
   let context: Context
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
-  const flowPatchSpy = vi.fn().mockResolvedValue({})
+  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   // Helper to create step mock with flow
   const createStepMock = (stepData: any = {}) => ({
@@ -31,10 +31,8 @@ describe('updateStep mutation', () => {
               status: 'completed',
               flow: {
                 id: mockFlowId,
-                $query: vi.fn().mockReturnValue({
-                  patch: flowPatchSpy,
-                }),
               },
+              patchFlowLastUpdated: patchFlowLastUpdatedSpy,
               ...stepData,
             },
       ),
@@ -304,12 +302,6 @@ describe('updateStep mutation', () => {
   it('updating empty step name should not update template config', async () => {
     // Override the steps query to return template config
     setupRelatedQueryMock({
-      flow: {
-        id: mockFlowId,
-        $query: vi.fn().mockReturnValue({
-          patch: vi.fn().mockResolvedValue({}),
-        }),
-      },
       config: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
@@ -346,18 +338,8 @@ describe('updateStep mutation', () => {
     )
   })
 
-  it('should call flow patch method when updating a step', async () => {
+  it('should call patchFlowLastUpdated when updating a step', async () => {
     await updateStep(null, { input: { ...genericInputParams } }, context)
-
-    // Verify flow's patch method was called
-    expect(flowPatchSpy).toHaveBeenCalledTimes(1)
-    expect(flowPatchSpy).toHaveBeenCalledWith({
-      updatedAt: expect.any(String),
-    })
-
-    const updatedAtCall = flowPatchSpy.mock.calls[0][0]
-    expect(new Date(updatedAtCall.updatedAt).toISOString()).toBe(
-      updatedAtCall.updatedAt,
-    )
+    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -16,6 +16,55 @@ const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 describe('updateStep mutation', () => {
   let context: Context
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
+  const flowPatchSpy = vi.fn().mockResolvedValue({})
+
+  // Helper to create step mock with flow
+  const createStepMock = (stepData: any = {}) => ({
+    findOne: vi.fn().mockReturnValue({
+      withGraphFetched: vi.fn().mockResolvedValue(
+        stepData === null
+          ? null
+          : {
+              id: mockStepId,
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              status: 'completed',
+              flow: {
+                id: mockFlowId,
+                $query: vi.fn().mockReturnValue({
+                  patch: flowPatchSpy,
+                }),
+              },
+              ...stepData,
+            },
+      ),
+    }),
+  })
+
+  // Helper to create connection mock
+  const createConnectionMock = (connectionData: any = null) => ({
+    findOne: vi.fn().mockResolvedValue(connectionData),
+  })
+
+  // Helper to setup $relatedQuery mock
+  const setupRelatedQueryMock = (
+    stepData?: any,
+    connectionData: any = { id: mockConnectionId, key: 'postman' },
+  ) => {
+    context.currentUser.$relatedQuery = vi
+      .fn()
+      .mockImplementation((relation) => {
+        if (relation === 'steps') {
+          return createStepMock(stepData)
+        }
+        if (relation === 'connections') {
+          return createConnectionMock(connectionData)
+        }
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      })
+  }
 
   const genericInputParams = {
     id: mockStepId,
@@ -67,31 +116,8 @@ describe('updateStep mutation', () => {
       patchAndFetchById: patchAndFetchByIdSpy,
     } as any)
 
-    // Mock context.currentUser.$relatedQuery for steps
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation) => {
-        if (relation === 'steps') {
-          return {
-            findOne: vi.fn().mockResolvedValue({
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return {
-            findOne: vi
-              .fn()
-              .mockResolvedValue({ id: mockConnectionId, key: 'postman' }),
-          }
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
+    // Setup default mock
+    setupRelatedQueryMock()
   })
 
   it('should successfully update a step', async () => {
@@ -139,28 +165,7 @@ describe('updateStep mutation', () => {
     }
 
     // Override only the connections query
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation) => {
-        if (relation === 'steps') {
-          return {
-            findOne: vi.fn().mockResolvedValue({
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return {
-            findOne: vi.fn().mockResolvedValue(null),
-          }
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
+    setupRelatedQueryMock(undefined, null)
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
@@ -175,23 +180,7 @@ describe('updateStep mutation', () => {
     }
 
     // Override the steps query to return null
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation) => {
-        if (relation === 'steps') {
-          return {
-            findOne: vi.fn().mockResolvedValue(null),
-          }
-        }
-        if (relation === 'connections') {
-          return {
-            findOne: vi.fn().mockResolvedValue({ id: mockConnectionId }),
-          }
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
+    setupRelatedQueryMock(null, { id: mockConnectionId })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
@@ -273,35 +262,12 @@ describe('updateStep mutation', () => {
 
   it('updating step name should not update template config', async () => {
     // Override the steps query to return template config
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation) => {
-        if (relation === 'steps') {
-          return {
-            findOne: vi.fn().mockResolvedValue({
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-              connection: { id: mockConnectionId },
-              config: {
-                stepName: 'some-step-name',
-                templateConfig: { appEventKey: 'existingAppEventKey' },
-              },
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return {
-            findOne: vi
-              .fn()
-              .mockResolvedValue({ id: mockConnectionId, key: 'postman' }),
-          }
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
+    setupRelatedQueryMock({
+      config: {
+        stepName: 'some-step-name',
+        templateConfig: { appEventKey: 'existingAppEventKey' },
+      },
+    })
 
     const input = {
       ...genericInputParams,
@@ -335,35 +301,18 @@ describe('updateStep mutation', () => {
 
   it('updating empty step name should not update template config', async () => {
     // Override the steps query to return template config
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation) => {
-        if (relation === 'steps') {
-          return {
-            findOne: vi.fn().mockResolvedValue({
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-              connection: { id: mockConnectionId },
-              config: {
-                stepName: 'some-step-name',
-                templateConfig: { appEventKey: 'existingAppEventKey' },
-              },
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return {
-            findOne: vi
-              .fn()
-              .mockResolvedValue({ id: mockConnectionId, key: 'postman' }),
-          }
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
+    setupRelatedQueryMock({
+      flow: {
+        id: mockFlowId,
+        $query: vi.fn().mockReturnValue({
+          patch: vi.fn().mockResolvedValue({}),
+        }),
+      },
+      config: {
+        stepName: 'some-step-name',
+        templateConfig: { appEventKey: 'existingAppEventKey' },
+      },
+    })
 
     const input = {
       ...genericInputParams,
@@ -392,6 +341,21 @@ describe('updateStep mutation', () => {
     })
     expect(patchAndFetchByIdSpy.mock.results[0].value.config.stepName).toEqual(
       '',
+    )
+  })
+
+  it('should call flow patch method when updating a step', async () => {
+    await updateStep(null, { input: { ...genericInputParams } }, context)
+
+    // Verify flow's patch method was called
+    expect(flowPatchSpy).toHaveBeenCalledTimes(1)
+    expect(flowPatchSpy).toHaveBeenCalledWith({
+      updatedAt: expect.any(String),
+    })
+
+    const updatedAtCall = flowPatchSpy.mock.calls[0][0]
+    expect(new Date(updatedAtCall.updatedAt).toISOString()).toBe(
+      updatedAtCall.updatedAt,
     )
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -20,23 +20,21 @@ describe('updateStep mutation', () => {
 
   // Helper to create step mock with flow
   const createStepMock = (stepData: any = {}) => ({
-    findOne: vi.fn().mockReturnValue({
-      withGraphFetched: vi.fn().mockResolvedValue(
-        stepData === null
-          ? null
-          : {
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-              flow: {
-                id: mockFlowId,
-              },
-              patchFlowLastUpdated: patchFlowLastUpdatedSpy,
-              ...stepData,
+    findOne: vi.fn().mockResolvedValue(
+      stepData === null
+        ? null
+        : {
+            id: mockStepId,
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            status: 'completed',
+            flow: {
+              id: mockFlowId,
             },
-      ),
-    }),
+            patchFlowLastUpdated: patchFlowLastUpdatedSpy,
+            ...stepData,
+          },
+    ),
   })
 
   // Helper to create connection mock

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -56,7 +56,7 @@ const createStep: MutationResolvers['createStep'] = async (
       connectionId: input.connection?.id,
     })
 
-    await step.patchFlowLastUpdated()
+    await step.patchFlowLastUpdated(trx)
 
     return step
   })

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -56,6 +56,8 @@ const createStep: MutationResolvers['createStep'] = async (
       connectionId: input.connection?.id,
     })
 
+    await flow.$query(trx).patch({ updatedAt: new Date().toISOString() })
+
     return step
   })
 }

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -56,7 +56,7 @@ const createStep: MutationResolvers['createStep'] = async (
       connectionId: input.connection?.id,
     })
 
-    await flow.$query(trx).patch({ updatedAt: new Date().toISOString() })
+    await step.patchFlowLastUpdated()
 
     return step
   })

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -112,6 +112,9 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
 
     return await flow
       .$query(trx)
+      .patchAndFetch({
+        updatedAt: new Date().toISOString(),
+      })
       .withGraphJoined('steps')
       .orderBy('steps.position', 'asc')
   })

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -110,11 +110,10 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
+    await flow.$query(trx).patch({ updatedAt: new Date().toISOString() })
+
     return await flow
       .$query(trx)
-      .patchAndFetch({
-        updatedAt: new Date().toISOString(),
-      })
       .withGraphJoined('steps')
       .orderBy('steps.position', 'asc')
   })

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -110,7 +110,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    await steps[0].patchFlowLastUpdated()
+    await steps[0].patchFlowLastUpdated(trx)
 
     return await flow
       .$query(trx)

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -110,7 +110,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    await flow.$query(trx).patch({ updatedAt: new Date().toISOString() })
+    await steps[0].patchFlowLastUpdated()
 
     return await flow
       .$query(trx)

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -13,13 +13,10 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const step = await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
-    const step = await context.currentUser
-      .$relatedQuery('steps', trx)
-      .findOne({
-        'steps.id': input.id,
-        flow_id: input.flow.id,
-      })
-      .withGraphFetched('flow')
+    const step = await context.currentUser.$relatedQuery('steps', trx).findOne({
+      'steps.id': input.id,
+      flow_id: input.flow.id,
+    })
 
     if (!step) {
       throw new BadUserInputError('Step not found')

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -11,10 +11,16 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const { input } = params
 
   const step = await Step.transaction(async (trx) => {
-    const step = await context.currentUser.$relatedQuery('steps', trx).findOne({
-      'steps.id': input.id,
-      flow_id: input.flow.id,
-    })
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    const step = await context.currentUser
+      .$relatedQuery('steps', trx)
+      .findOne({
+        'steps.id': input.id,
+        flow_id: input.flow.id,
+      })
+      .withGraphFetched('flow')
+
     if (!step) {
       throw new BadUserInputError('Step not found')
     }
@@ -52,6 +58,12 @@ const updateStep: MutationResolvers['updateStep'] = async (
         },
       })
       .withGraphFetched('connection')
+
+    // update the flow's last updated
+    await step.flow.$query(trx).patch({
+      updatedAt: new Date().toISOString(),
+    })
+
     return updatedStep
   })
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -60,9 +60,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
       .withGraphFetched('connection')
 
     // update the flow's last updated
-    await step.flow.$query(trx).patch({
-      updatedAt: new Date().toISOString(),
-    })
+    await step.patchFlowLastUpdated()
 
     return updatedStep
   })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -57,7 +57,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
       .withGraphFetched('connection')
 
     // update the flow's last updated
-    await step.patchFlowLastUpdated()
+    await step.patchFlowLastUpdated(trx)
 
     return updatedStep
   })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -11,8 +11,6 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const { input } = params
 
   const step = await Step.transaction(async (trx) => {
-    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
-
     const step = await context.currentUser.$relatedQuery('steps', trx).findOne({
       'steps.id': input.id,
       flow_id: input.flow.id,

--- a/packages/backend/src/models/__tests__/step.itest.ts
+++ b/packages/backend/src/models/__tests__/step.itest.ts
@@ -166,4 +166,20 @@ describe('step model', () => {
       expect(lastExecutionStep).toHaveProperty('id', executionStepIds[1])
     })
   })
+
+  describe('patchFlowLastUpdated', () => {
+    it('should patch the flow last updated', async () => {
+      const flow = await step.$relatedQuery('flow')
+      const originalUpdatedAt = flow.updatedAt
+
+      await step.patchFlowLastUpdated()
+
+      const updatedFlow = await step.$relatedQuery('flow')
+
+      expect(updatedFlow.updatedAt).toBeDefined()
+      expect(new Date(updatedFlow.updatedAt).getTime()).toBeGreaterThan(
+        new Date(originalUpdatedAt).getTime(),
+      )
+    })
+  })
 })

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -192,6 +192,12 @@ class Step extends Base {
     return command
   }
 
+  async patchFlowLastUpdated() {
+    await this.$relatedQuery('flow').patch({
+      updatedAt: new Date().toISOString(),
+    })
+  }
+
   static async beforeUpdate(args: StaticHookArguments<Step>): Promise<void> {
     await super.beforeUpdate(args)
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -4,6 +4,7 @@ import {
   raw,
   RelatedQueryBuilder,
   type StaticHookArguments,
+  Transaction,
   ValidationError,
 } from 'objection'
 import { URL } from 'url'
@@ -192,8 +193,8 @@ class Step extends Base {
     return command
   }
 
-  async patchFlowLastUpdated() {
-    await this.$relatedQuery('flow').patch({
+  async patchFlowLastUpdated(trx?: Transaction) {
+    await this.$relatedQuery('flow', trx).patch({
       updatedAt: new Date().toISOString(),
     })
   }

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -151,7 +151,7 @@ export function useIfThenInitializer(): [
     async (currStep: IStep) => {
       setIsInitializing(true)
 
-      const updateFirstBranch = updateStep({
+      const updateFirstBranch = await updateStep({
         variables: {
           input: {
             id: currStep.id,
@@ -170,7 +170,7 @@ export function useIfThenInitializer(): [
           },
         },
       })
-      const createSecondBranch = createStep({
+      const createSecondBranch = await createStep({
         variables: {
           input: {
             key: TOOLBOX_ACTIONS.IfThen,


### PR DESCRIPTION
## Problem
Not all actions performed by users on a pipe updates the updated at time, which may be misleading for users.

Actions that update: checking step, publish / un-publish pipe
Actions that do not update: 
* add step
* delete step
* modify parameters in step


## Solution
Update mutations to patch the `updated_at` in `flows`

## Other changes
* Updated tests to handle the timestamp update
* Set update step's isolation level to serializable

## How to test?
Make sure that the Pipe's updated at is updated for the following:
- [x] Add a step
- [x] Add a branch
- [x] Delete a step
- [x] Delete a branch
- [x] Edit parameters of a step
