### PR TITLE
chore: convert import to js for plumber admin

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -113,12 +113,12 @@
   "exports": {
     ".": {
       "types": "./dist/lib/exports/index.d.ts",
-      "import": "./dist/lib/exports/index.mjs"
+      "import": "./dist/lib/exports/index.js"
     },
     "./style.css": "./dist/lib/style.css",
     "./*": {
       "types": "./dist/lib/exports/*.d.ts",
-      "import": "./dist/lib/exports/*.mjs"
+      "import": "./dist/lib/exports/*.js"
     }
   }
 }


### PR DESCRIPTION
## Problem
Cannot sync `plumber-admin` to the current production build.

## Solution
Got it to work by converting the imports from `.mjs` to `.js`
Seems be safe to do that since we already specify "type": "module", and the .js files are still treated as ES modules.

## How to test?
- [ ] Pull this and run on your local plumber-admin
- [ ] Deploy to staging and verify
