### PR TITLE
chore: use flag to show/hide reminder templates

### DIFF
--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -4,6 +4,7 @@ import { ATTENDANCE_TAKING_TEMPLATE } from './attendance-taking-v2'
 import { FOR_EACH_REMINDER_TEMPLATE } from './for-each-reminder'
 import { GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE } from './get-live-updates-through-telegram'
 import { ROUTE_SUPPORT_ENQUIRIES_TEMPLATE } from './route-support-enquiries'
+import { SCHEDULE_REMINDERS_TEMPLATE } from './schedule-reminders'
 import { SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE } from './send-a-copy-of-form-response'
 import { SEND_FOLLOW_UPS_TEMPLATE } from './send-follow-ups'
 import { SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE } from './send-message-to-a-slack-channel'
@@ -36,6 +37,8 @@ export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   SEND_FOLLOW_UPS_TEMPLATE, // contains demo video
   SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE,
   FOR_EACH_REMINDER_TEMPLATE,
+  // TODO (kevinkim-ogp): remove this when for-each is released to all users
+  SCHEDULE_REMINDERS_TEMPLATE,
   TRACK_FEEDBACK_TEMPLATE,
   ATTENDANCE_TAKING_TEMPLATE,
   UPDATE_MAILING_LISTS_TEMPLATE,

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -1,5 +1,6 @@
 import type { IApp, ITemplate } from '@plumber/types'
 
+import { useContext } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Flex, Grid, Text } from '@chakra-ui/react'
@@ -8,6 +9,7 @@ import { Link } from '@opengovsg/design-system-react'
 import Container from '@/components/Container'
 import PageTitle from '@/components/PageTitle'
 import * as URLS from '@/config/urls'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { GET_TEMPLATES } from '@/graphql/queries/get-templates'
 
@@ -20,9 +22,21 @@ const TEMPLATES_TITLE = 'Templates'
 const TEMPLATES_COUNT = 9
 
 export default function Templates(): JSX.Element {
+  const { flags: ldFlags } = useContext(LaunchDarklyContext)
   const { data, loading: templatesLoading } = useQuery(GET_TEMPLATES)
 
-  const templates: ITemplate[] = data?.getTemplates
+  // TODO (kevinkim-ogp): remove this when for-each is released to all users
+  // we do this to avoid adding extra flags or parameters into the query
+  const templates: ITemplate[] =
+    data?.getTemplates?.filter((template: ITemplate) => {
+      if (ldFlags?.app_toolbox_action_forEach) {
+        return template.id !== '65e90f41-b605-4e83-bcd7-e4d2e349299d' // SCHEDULE_REMINDERS_TEMPLAT
+      } else if (!ldFlags?.app_toolbox_action_forEach) {
+        return template.id !== 'b8dd6c22-3578-460d-89e2-e2062b3601f2' // FOR_EACH_REMINDER_TEMPLATE
+      }
+      return true
+    }) ?? []
+
   const { templateId } = useParams()
   const template = templates?.find((template) => template.id === templateId)
 


### PR DESCRIPTION
### TL;DR
Use the `app_toolbox_action_forEach` LD flag to decide on the frontend whether to show the "Schedule reminders" template with or without the for-each step.

### Why make this change?
As for-each is a beta release, we only want whitelisted users to be able to view, use, and test the template. All remaining users should be able to use the existing "Schedule reminders" template.

_Using the frontend check and remove when going to GA as it is unlikely that we will have to flag templates often and we do not want to add additional parameters to the getTemplates query_


### How to test?
- [ ] Login as a non-whitelisted user, should see the original Schedule reminders template
  - [ ] Verify that template can be used
- [ ] Login as whitelisted user, should see the NEW Schedule reminders template with for-each and find multiple rows
  - [ ] Verify that template can be used
