### PR TITLE
fix: configs for Plumber admin

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -93,7 +93,8 @@
     "launchdarkly-react-client-sdk": "3.0.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "6.11.2"
+    "react-router-dom": "6.11.2",
+    "zod": "3.22.4"
   },
   "browserslist": {
     "production": [

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -116,7 +116,7 @@
       "types": "./dist/lib/exports/index.d.ts",
       "import": "./dist/lib/exports/index.js"
     },
-    "./style.css": "./dist/lib/style.css",
+    "./style.css": "./dist/lib/frontend.css",
     "./*": {
       "types": "./dist/lib/exports/*.d.ts",
       "import": "./dist/lib/exports/*.js"

--- a/packages/frontend/vite.config.lib.ts
+++ b/packages/frontend/vite.config.lib.ts
@@ -42,6 +42,7 @@ export default defineConfig({
         'react-dom',
         'react-dom/client',
         'react-router-dom',
+        'zod',
       ],
     },
   },


### PR DESCRIPTION
## Problem
Build errors in Plumber Admin due to:
* `zod` not added as peer dependency
* default CSS name change when upgrading from Vite 4+ to 6+
  * 4+: standardised to `style.css`
  * 6+: adopts the "name" in `package.json`, which creates `frontend.css` instead

## What did it affect?
* Inputs were unstyled: RTEs, dropdowns etc
* Tiles header and columns were not fixed

## How to test?
- [ ] Pull and run locally: all inputs and pages should have the same styling as Plumber

