### PR TITLE
PLU-527: fix: warn for unsaved changes on publish

### DIFF
--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -45,6 +45,7 @@ import { LensSurvey } from './LensSurvey'
 
 export default function EditorLayout() {
   const cancelRef = useRef(null)
+  const resetFormRef = useRef<(() => void) | null>(null)
   const { flowId } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -53,6 +54,7 @@ export default function EditorLayout() {
   const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS, {
     refetchQueries: [GET_FLOW],
   })
+  const [warnTriggeredBy, setWarnTriggeredBy] = useState<string | null>(null)
   const [shouldWarnOnLeave, setShouldWarnOnLeave] = useState(false)
   const [leaveToUrl, setLeaveToUrl] = useState(URLS.FLOWS)
   const {
@@ -142,6 +144,15 @@ export default function EditorLayout() {
     },
     [shouldWarnOnLeave, onWarningOpen],
   )
+
+  const onDiscardChanges = useCallback(() => {
+    if (warnTriggeredBy === 'publish') {
+      onFlowStatusUpdate(!flow?.active)
+      resetFormRef.current?.()
+    } else {
+      navigate(leaveToUrl)
+    }
+  }, [onFlowStatusUpdate, flow?.active, leaveToUrl, navigate, warnTriggeredBy])
 
   // disallow user from publishing pipe if any step is incomplete
   const isFlowIncomplete = useMemo(
@@ -282,7 +293,14 @@ export default function EditorLayout() {
               isLoading={loading}
               spinner={<Spinner fontSize={24} />}
               size="sm"
-              onClick={() => onFlowStatusUpdate(!flow.active)}
+              onClick={(e) => {
+                if (shouldWarnOnLeave) {
+                  setWarnTriggeredBy('publish')
+                  handleWarnOnLeave(e)
+                } else {
+                  onFlowStatusUpdate(!flow.active)
+                }
+              }}
             >
               <Skeleton isLoaded={!loading}>
                 <Text textStyle="subhead-1">
@@ -305,6 +323,7 @@ export default function EditorLayout() {
             flow={flow}
             shouldWarnOnLeave={shouldWarnOnLeave}
             setShouldWarnOnLeave={setShouldWarnOnLeave}
+            resetFormRef={resetFormRef}
           >
             <Editor />
             {flow.active && flow.config?.showSurvey && <LensSurvey />}
@@ -315,7 +334,7 @@ export default function EditorLayout() {
       <EditorSnackbar
         isOpen={!!flow?.active}
         handleUnpublish={() => onFlowStatusUpdate(!flow.active)}
-      ></EditorSnackbar>
+      />
 
       {shouldOpenAnnouncementModal && (
         <AnnouncementModal
@@ -335,7 +354,7 @@ export default function EditorLayout() {
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
         onClose={onWarningClose}
-        onLeave={() => navigate(leaveToUrl)}
+        onLeave={onDiscardChanges}
       />
     </>
   )

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -54,7 +54,7 @@ export default function EditorLayout() {
   const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS, {
     refetchQueries: [GET_FLOW],
   })
-  const [warnTriggeredBy, setWarnTriggeredBy] = useState<string | null>(null)
+  const [shouldWarnOnPublish, setShouldWarnOnPublish] = useState(false)
   const [shouldWarnOnLeave, setShouldWarnOnLeave] = useState(false)
   const [leaveToUrl, setLeaveToUrl] = useState(URLS.FLOWS)
   const {
@@ -135,6 +135,11 @@ export default function EditorLayout() {
     [flow?.id, flowId, updateFlowStatus],
   )
 
+  const handleWarningClose = useCallback(() => {
+    setShouldWarnOnPublish(false)
+    onWarningClose()
+  }, [onWarningClose])
+
   const handleWarnOnLeave = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
       if (shouldWarnOnLeave) {
@@ -146,13 +151,19 @@ export default function EditorLayout() {
   )
 
   const onDiscardChanges = useCallback(() => {
-    if (warnTriggeredBy === 'publish') {
+    if (shouldWarnOnPublish) {
       onFlowStatusUpdate(!flow?.active)
       resetFormRef.current?.()
     } else {
       navigate(leaveToUrl)
     }
-  }, [onFlowStatusUpdate, flow?.active, leaveToUrl, navigate, warnTriggeredBy])
+  }, [
+    onFlowStatusUpdate,
+    flow?.active,
+    leaveToUrl,
+    navigate,
+    shouldWarnOnPublish,
+  ])
 
   // disallow user from publishing pipe if any step is incomplete
   const isFlowIncomplete = useMemo(
@@ -295,7 +306,7 @@ export default function EditorLayout() {
               size="sm"
               onClick={(e) => {
                 if (shouldWarnOnLeave) {
-                  setWarnTriggeredBy('publish')
+                  setShouldWarnOnPublish(true)
                   handleWarnOnLeave(e)
                 } else {
                   onFlowStatusUpdate(!flow.active)
@@ -353,7 +364,7 @@ export default function EditorLayout() {
       <UnsavedChangesAlert
         cancelRef={cancelRef}
         isOpen={isWarningOpen}
-        onClose={onWarningClose}
+        onClose={handleWarningClose}
         onLeave={onDiscardChanges}
       />
     </>

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -1,6 +1,13 @@
 import type { IApp, IExecutionStep, IFlow, IStep } from '@plumber/types'
 
-import { createContext, ReactNode, useCallback, useMemo, useState } from 'react'
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useMutation, useQuery } from '@apollo/client'
 import { Center, useDisclosure } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
@@ -98,6 +105,7 @@ type EditorProviderProps = {
   flow: IFlow
   shouldWarnOnLeave: boolean
   setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
+  resetFormRef?: React.MutableRefObject<(() => void) | null>
 }
 
 /**
@@ -147,6 +155,7 @@ export const EditorProvider = ({
   flow,
   shouldWarnOnLeave,
   setShouldWarnOnLeave,
+  resetFormRef,
   children,
 }: EditorProviderProps) => {
   const isMobile = useIsMobile()
@@ -362,6 +371,13 @@ export const EditorProvider = ({
   const resetForm = useCallback(() => {
     setResetTimestamp(Date.now())
   }, [])
+
+  // Set the resetForm function in the ref so EditorLayout can access it
+  useEffect(() => {
+    if (resetFormRef) {
+      resetFormRef.current = resetForm
+    }
+  }, [resetForm, resetFormRef])
 
   if (isLoadingAllApps) {
     return (


### PR DESCRIPTION
## Problem
No warning when user publishes a Pipe with unsaved changes

## Solution
* Add warning for unsaved changes
* Resets form and publishes Pipe if user discards changes

## How to test?
Open a Pipe that can be published.
- [ ] Make changes to a step, attempt to publish, should show warning
- [ ] Continue editing closes warning with changes preserved
- [ ] Discard changes removes the changes and publishes the Pipe
- [ ] Manually undo the changes, should publish without warning
- [ ] Existing behaviour of warning on the following still works:
  - [ ] Adding step
  - [ ] Changing step
  - [ ] Closing side drawer
  - [ ] Going back to Pipes page

## Screenshots

https://github.com/user-attachments/assets/92b10e07-e723-450f-ad09-c33e32d6f09a

