### PR TITLE
[POSTMAN-UNSUPPORTED-ATTACHMENT-2] PLU-491: Retry without attachments

### DIFF
--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -74,9 +74,6 @@ const action: IRawAction = {
       )
     }
 
-    const { attachmentFiles, invalidAttachments, submissionId } =
-      await filterAttachments(result.data.attachments, $)
-
     let recipientsToSend = result.data.destinationEmail
     /**
      * Logic to handle retries here:
@@ -98,6 +95,18 @@ const action: IRawAction = {
       lastExecutionStep.errorDetails &&
       // Don't do partial retry in test runs! always send to all recipients
       !$.execution.testRun
+
+    const {
+      attachmentFiles,
+      invalidAttachments,
+      submissionId,
+      isRetryWithoutAttachments,
+    } = await filterAttachments({
+      $,
+      attachmentsList: result.data.attachments,
+      isPartialRetry,
+      lastExecutionStep,
+    })
 
     if (isPartialRetry) {
       const { status, recipient } = prevDataOutParseResult.data
@@ -196,8 +205,14 @@ const action: IRawAction = {
     /**
      * Send invalid attachments notification email
      * Do not send on partial retry as we would have already sent this once with the blacklist email
+     * Do not send on retry when removing all attachments
      */
-    if (hasInvalidAttachments && !isPartialRetry && !$.execution.testRun) {
+    if (
+      hasInvalidAttachments &&
+      !isPartialRetry &&
+      !$.execution.testRun &&
+      !isRetryWithoutAttachments
+    ) {
       await sendInvalidAttachmentsEmail({
         ...defaultSendEmailParams,
         ...invalidAttachmentParams,
@@ -222,6 +237,7 @@ const action: IRawAction = {
         isPartialSuccess: hasAtLeastOneSuccess || invalidAttachments.length > 0,
         blacklistedRecipients,
         invalidAttachments,
+        isRetryWithoutAttachments,
       })
     }
   },

--- a/packages/backend/src/apps/postman/common/parameters-helper.ts
+++ b/packages/backend/src/apps/postman/common/parameters-helper.ts
@@ -1,4 +1,4 @@
-import { IGlobalVariable } from '@plumber/types'
+import { IExecutionStep, IGlobalVariable, IJSONObject } from '@plumber/types'
 
 import { COMMON_S3_BUCKET, getObjectFromS3Id } from '@/helpers/s3'
 import Flow from '@/models/flow'
@@ -13,13 +13,49 @@ export async function getDefaultReplyTo(flowId: string): Promise<string> {
   return flow.user.email
 }
 
-export async function filterAttachments(
-  attachmentsList: string[],
-  $: IGlobalVariable,
-) {
+export async function filterAttachments({
+  $,
+  attachmentsList,
+  isPartialRetry,
+  lastExecutionStep,
+}: {
+  $: IGlobalVariable
+  attachmentsList: string[]
+  isPartialRetry: boolean
+  lastExecutionStep: IExecutionStep | null
+}) {
   let submissionId: string | null = null
   const invalidAttachments: string[] = []
   const attachmentFiles: { fileName: string; data: Uint8Array }[] = []
+
+  const errorName = lastExecutionStep?.errorDetails?.name
+  const partialRetryButtonMessage = (
+    lastExecutionStep?.errorDetails?.partialRetry as IJSONObject
+  )?.buttonMessage
+
+  /**
+   * NOTE: there are different scenarios where we should retry without attachments:
+   * 1. Password-protected attachment(s)
+   *    Postman does not tell us reliably which attachment(s) are password-protected
+   *    so we remove all attachments instead.
+   *
+   * 2. Unsupported attachment file type
+   *    This is the old error code that is thrown when there are unsupported or password-protected attachments.
+   *    We remove all attachments when retrying old executions to avoid having to retry twice in the event
+   *    that there are password-protected attachments, which will cause another failure.
+   *
+   * 3. isPartialRetry and Resend to blacklisted recipients without attachments
+   *    This is to handle executions that failed due to invalid attachments and had blacklisted recipients.
+   *    Upon retry, the execution runs without attachments, but the blacklisted recipient still exists.
+   *    In such scenarios, we show the partial retry button with 'Resend to blacklisted recipients without attachments',
+   *    and use this to tell the worker to remove all attachments.
+   */
+  const isRetryWithoutAttachments =
+    errorName === 'Password-protected attachment(s)' ||
+    errorName === 'Unsupported attachment file type' ||
+    (isPartialRetry &&
+      partialRetryButtonMessage ===
+        'Resend to blacklisted recipients without attachments')
 
   await Promise.all(
     attachmentsList?.map(async (attachment) => {
@@ -28,6 +64,12 @@ export async function filterAttachments(
       const obj = await getObjectFromS3Id(attachment, { flowId: $.flow.id }, $)
       const fileName = obj.name
       const fileType = obj.name.split('.').pop()?.toLowerCase()
+
+      if (isRetryWithoutAttachments) {
+        invalidAttachments.push(fileName)
+        return
+      }
+
       if (!fileType || !POSTMAN_ACCEPTED_EXTENSIONS.includes(fileType)) {
         invalidAttachments.push(fileName)
 
@@ -43,5 +85,20 @@ export async function filterAttachments(
       return
     }),
   )
-  return { attachmentFiles, invalidAttachments, submissionId }
+
+  if (isRetryWithoutAttachments) {
+    return {
+      attachmentFiles: [],
+      invalidAttachments,
+      submissionId,
+      isRetryWithoutAttachments,
+    }
+  }
+
+  return {
+    attachmentFiles,
+    invalidAttachments,
+    submissionId,
+    isRetryWithoutAttachments,
+  }
 }

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -47,10 +47,23 @@ export function getPostmanErrorStatus(
   }
 }
 
-function getInvalidAttachmentSolution(invalidAttachments: string[]) {
-  return `The following attachment(s) are not supported by Postman and have been removed from the email:
-  \n${invalidAttachments.map((attachment) => `**${attachment}**`).join('\n\n')}
-  \nIf you require the attachment(s), log in to your form to download them for this submission.
+function getInvalidAttachmentSolution({
+  invalidAttachments,
+  showAttachmentsList = true,
+}: {
+  invalidAttachments: string[]
+  showAttachmentsList?: boolean
+}) {
+  if (showAttachmentsList) {
+    return `The following attachment(s) are not supported by Postman and have been removed from the email:
+    \n${invalidAttachments
+      .map((attachment) => `**${attachment}**`)
+      .join('\n\n')}
+    \nIf you require the attachment(s), log in to your form to download them for this submission.
+    `
+  }
+  return `There were attachment(s) that could not be sent by Postman and have been removed from the email.
+    \nIf you require the attachment(s), log in to your form to download them for this submission.
   `
 }
 
@@ -61,6 +74,7 @@ export function throwPostmanStepError({
   isPartialSuccess,
   blacklistedRecipients,
   invalidAttachments,
+  isRetryWithoutAttachments,
 }: {
   $: IGlobalVariable
   status: PostmanEmailSendStatus
@@ -68,13 +82,17 @@ export function throwPostmanStepError({
   isPartialSuccess: boolean
   blacklistedRecipients: string[]
   invalidAttachments: string[]
+  isRetryWithoutAttachments: boolean
 }) {
   const position = $.step.position
   const appName = $.app.name
 
   const hasInvalidAttachments = invalidAttachments.length > 0
-  const invalidAttachmentsSolution =
-    getInvalidAttachmentSolution(invalidAttachments)
+  const invalidAttachmentsSolution = getInvalidAttachmentSolution({
+    invalidAttachments,
+    // should not show attachments list if we are retrying without attachments
+    showAttachmentsList: !isRetryWithoutAttachments,
+  })
 
   switch (status) {
     case 'BLACKLISTED': {
@@ -96,6 +114,11 @@ export function throwPostmanStepError({
         solution += `\n\n&nbsp;\n\n${invalidAttachmentsSolution}`
       }
 
+      let buttonMessage = 'Resend to blacklisted recipients'
+      if (isRetryWithoutAttachments) {
+        buttonMessage += ' without attachments'
+      }
+
       if (isPartialSuccess) {
         throw new PartialStepError({
           name,
@@ -103,7 +126,7 @@ export function throwPostmanStepError({
           position,
           appName,
           partialRetry: {
-            buttonMessage: 'Resend to blacklisted recipients',
+            buttonMessage,
           },
         })
       }
@@ -152,7 +175,10 @@ export function throwPostmanStepError({
       // attachments that are password-protected
       if (hasInvalidAttachments) {
         const name = 'Invalid attachment(s)'
-        const solution = getInvalidAttachmentSolution(invalidAttachments)
+        const solution = getInvalidAttachmentSolution({
+          invalidAttachments,
+          showAttachmentsList: true,
+        })
 
         // throw StepError for test runs so that user cannot publish the pipe
         // until the error is fixed
@@ -162,7 +188,7 @@ export function throwPostmanStepError({
 
         throw new PartialStepError({
           name,
-          solution,
+          solution: invalidAttachmentsSolution,
           position,
           appName,
           partialRetry: { buttonMessage: '' }, // nothing to retry

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -70,7 +70,7 @@ export function useExecutionStepStatus({
     // - attachment is password-protected; AND/OR
     // - attachment is unsupported
     if (
-      errorDetails?.details?.code === 'invalid_template' ||
+      errorDetails?.name === 'Unsupported attachment file type' ||
       errorDetails?.name === 'Password-protected attachment(s)'
     ) {
       return 'Retry without attachments'

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -30,6 +30,7 @@ export interface UseExecutionStepStatusReturn {
   isPartialSuccess: boolean
   canRetry: boolean
   loading: boolean
+  customRetryButtonText?: string
 }
 
 export function useExecutionStepStatus({
@@ -63,6 +64,20 @@ export function useExecutionStepStatus({
     return failureIcon
   }, [isPartialSuccess, isStepSuccessful, status])
 
+  const customRetryButtonText = useMemo(() => {
+    // specific to email by postman where we want to allow users to retry without attachments
+    // postman returns this error code when:
+    // - attachment is password-protected; AND/OR
+    // - attachment is unsupported
+    if (
+      errorDetails?.details?.code === 'invalid_template' ||
+      errorDetails?.name === 'Password-protected attachment(s)'
+    ) {
+      return 'Retry without attachments'
+    }
+    return undefined
+  }, [errorDetails])
+
   return {
     app,
     appName,
@@ -72,5 +87,6 @@ export function useExecutionStepStatus({
     isPartialSuccess,
     canRetry,
     loading,
+    customRetryButtonText,
   }
 }

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -42,14 +42,21 @@ export default function ExecutionStep({
 }: ExecutionStepProps): React.ReactElement | null {
   const { appKey, jobId, errorDetails, status } = executionStep
 
-  const { app, appName, statusIcon, hasError, isPartialSuccess, canRetry } =
-    useExecutionStepStatus({
-      appKey,
-      status,
-      errorDetails,
-      execution,
-      jobId,
-    })
+  const {
+    app,
+    appName,
+    statusIcon,
+    hasError,
+    isPartialSuccess,
+    canRetry,
+    customRetryButtonText,
+  } = useExecutionStepStatus({
+    appKey,
+    status,
+    errorDetails,
+    execution,
+    jobId,
+  })
 
   if (!app) {
     return null
@@ -77,7 +84,10 @@ export default function ExecutionStep({
             {!isInForEach && canRetry && (
               <>
                 <RetryAllButton execution={execution} />
-                <RetryButton executionStepId={executionStep.id} />
+                <RetryButton
+                  executionStepId={executionStep.id}
+                  customButtonText={customRetryButtonText}
+                />
               </>
             )}
           </HStack>


### PR DESCRIPTION
## TL;DR
This update enhances the retry functionality for Email by Postman actions by allowing users to retry sending emails without attachments, in the following cases:
	•	Old executions that failed due to unsupported and/or password-protected attachments
	•	New executions that fail due to password-protected attachments

## Why make this change?
Currently, if an email fails due to unsupported or password-protected attachments, users are unable to successfully retry sending it—even if the content is otherwise valid.
This change introduces an option for users to resend the email **without any attachments**, enabling successful delivery.

**Why remove all attachments if there are password-protected attachments?**
Postman returns the same error for both unsupported and password-protected attachments, and we cannot reliably identify which specific file is password-protected. As a result, all attachments must be removed to ensure the retry succeeds.


## How to test?
_bear with me, there are many scenarios to test_ 😅

### Existing failed executions
Need to trigger these failed executions while on `develop-v2` first
- [x] **Blacklisted**: retry sends as intended (current behaviour)
- [x] **Blacklisted + password-protected**: 
  - [x] if email is still blacklisted, sends email without any attachments
  - [x] once email is whitelisted, retry sends without any attachment
- [x] **Blacklisted + unsupported**: retry sends without any attachment
  - [x] if email is still blacklisted, sends email without any attachments
  - [x] once email is whitelisted, retry sends without any attachment
- [x] **Blacklisted + password-protected + unsupported**: retry sends without any attachment
  - [x] if email is still blacklisted, sends email without any attachments
  - [x] once email is whitelisted, retry sends without any attachment
- [x] **Password-protected**: retry sends without any attachment
- [x] **Password-protected + unsupported**: retry sends without any attachment
- [x] **Unsupported**: retry sends without any attachment

### New executions using the pre-emptive filter
These failed executions can be triggered while on this branch
- [x] **Blacklisted**: retry sends as intended (current behaviour)
  - [x] Includes all supported attachments
- [x] **Blacklisted + password-protected**: 
  - [x] if still blacklisted, retry sends without any attachment
  - [x] once email is whitelisted, retry sends without any attachment
- [x] **Blacklisted + unsupported**: retry sends without the _unsupported_ attachment
  - [x] Non-blacklisted recipients would have received all other attachments less the _unsupported_ one
   - [x] Retry button should say `Resend to blacklisted recipients`
   - [x] Retry sends email without the _unsupported_ attachment to the whitelisted email
- [x] **Blacklisted + password-protected + unsupported**
  - [x] if still blacklisted, retry sends without any attachment
  - [x] once email is whitelisted, retry sends without any attachment
- [x] **Password-protected**: retry sends without any attachment
- [x] **Password-protected + unsupported**: retry sends without any attachment
