### PR TITLE
chore: bump vulnerable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10992,12 +10992,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
-      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -23398,7 +23398,7 @@
         "@taskforcesh/bullmq-pro": "7.7.1",
         "ajv-formats": "^2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.8.3",
+        "axios": "1.11.0",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.6",
         "copyfiles": "^2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18289,33 +18289,6 @@
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true
     },
-    "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.6.0",
-        "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">= 10.16.0"
-      }
-    },
-    "node_modules/multer/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "dev": true,
@@ -23453,7 +23426,7 @@
         "lottie-web": "5.12.2",
         "luxon": "2.5.2",
         "morgan": "^1.10.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "nanoid": "3.3.8",
         "objection": "^3.0.0",
         "p-limit": "3.1.0",
@@ -23498,6 +23471,34 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "packages/backend/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "packages/backend/node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
       }
     },
     "packages/frontend": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
       "packages/*"
     ]
   },
+  "overrides": {
+    "form-data": "4.0.4"
+  },
   "devDependencies": {
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",
     "@graphql-codegen/cli": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "overrides": {
-    "form-data": "4.0.4"
+    "axios": "1.11.0"
   },
   "devDependencies": {
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -41,7 +41,7 @@
     "@taskforcesh/bullmq-pro": "7.7.1",
     "ajv-formats": "^2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.8.3",
+    "axios": "1.11.0",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.6",
     "copyfiles": "^2.4.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -69,7 +69,7 @@
     "lottie-web": "5.12.2",
     "luxon": "2.5.2",
     "morgan": "^1.10.0",
-    "multer": "2.0.1",
+    "multer": "2.0.2",
     "nanoid": "3.3.8",
     "objection": "^3.0.0",
     "p-limit": "3.1.0",


### PR DESCRIPTION
## Problem
Bumping versions of `form-data` and `multer`
1. Critical vulnerability in `form-data@4.0.0`. 
  See [CVE‑2025‑7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783).
  Bug report on axios: https://github.com/axios/axios/issues/6969

1. Vulnerability in `multer@2.0.1`
  See https://github.com/advisories/GHSA-fjgf-rc76-4x9p

## Solution
* Bump `form-data@` version to `4.0.4`
* Set overrides so that axios is forced to use `form-data@4.0.4`

## Tests
Verify that actions using `form-data` still work as intended
- [ ] M365-Excel actions work as intended
- [ ] Email by Postman with and without attachments works as intended

Verify that actions using `multer` still work as intended
- [ ] Webhook receives requests correctly
- [ ] Webhook rejects file uploads
- [ ] Form submissions are received including attachments

