### PR TITLE
[TILES-V2-13] fix: support tiles v2 nullable cells

### DIFF
--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/get-data-out-metadata.ts
@@ -1,5 +1,7 @@
 import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
+import logger from '@/helpers/logger'
+
 import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
@@ -10,12 +12,20 @@ async function getDataOutMetadata(
   if (!rawDataOut) {
     return null
   }
-  const dataOut = dataOutSchema.parse(rawDataOut)
+  const dataOut = dataOutSchema.safeParse(rawDataOut)
+  if (!dataOut.success) {
+    logger.error({
+      message: 'Invalid data out schema for tiles find multiple rows action',
+      executionId: executionStep.executionId,
+      action: 'find-multiple-rows',
+    })
+    return null
+  }
 
   const metadata: IDataOutMetadata = {
     data: {
       label: 'Row(s) found',
-      displayedValue: `Preview ${dataOut.rowsFound} row(s)`,
+      displayedValue: `Preview ${dataOut.data.rowsFound} row(s)`,
       type: 'table',
       order: 1,
     },

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
@@ -2,7 +2,9 @@ import { z } from 'zod'
 
 const tableRowOutputSchema = z.object({
   rowId: z.string(),
-  data: z.record(z.string(), z.string().or(z.number())),
+  // for tiles v1, empty cells is either an empty string or wont even have their key returned
+  // for tiles v2, empty cells return null
+  data: z.record(z.string(), z.union([z.string(), z.number(), z.null()])),
 })
 
 export const dataOutSchema = z.object({

--- a/packages/frontend/src/components/VariablesList/schema.ts
+++ b/packages/frontend/src/components/VariablesList/schema.ts
@@ -3,7 +3,9 @@ import { z } from 'zod'
 const RowDataSchema = z.object({
   rows: z.array(
     z.object({
-      data: z.record(z.string(), z.union([z.string(), z.number()])),
+      // for tiles v1, empty cells is either an empty string or wont even have their key returned
+      // for tiles v2, empty cells return null
+      data: z.record(z.string(), z.union([z.string(), z.number(), z.null()])),
       rowId: z.string().optional(), // only Tiles will have this
     }),
   ),

--- a/packages/frontend/src/components/VariablesList/utils.tsx
+++ b/packages/frontend/src/components/VariablesList/utils.tsx
@@ -9,7 +9,7 @@ export interface RawColumn {
 }
 
 export interface RawRow {
-  data: Record<string, string | number>
+  data: Record<string, string | number | null>
   rowId?: string // only Tiles will have this
 }
 

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -163,7 +163,7 @@ const process = (
      */
     const { columns, rows } = data
     const columnVariables = columns.map((column: RawColumn) => {
-      const rowValues: (string | number)[] = []
+      const rowValues: (string | number | null)[] = []
       rows.forEach((row: RawRow) => {
         /**
          * NOTE: do not push empty values as we do not want to cause any errors


### PR DESCRIPTION
### TL;DR

This change addresses a compatibility issue between Tiles v1 and v2. In v1, empty cells were represented as empty strings or by omitting the key entirely, while in v2, empty cells return null values. This update ensures the application can properly handle data from both versions.