### PR TITLE
PLU-532: Remove deleted FormSG attachments from email step parameters

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -95,7 +95,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
       if (!checked) {
         onChange?.(currentValues.filter((v: string) => v !== nameToCheck))
       } else {
-        const { isValid, error } = validateFiles(variable, getValues(name))
+        const { isValid, error } = validateFiles(variable, currentValues)
         if (!isValid) {
           setError(name, { type: 'invalidFile', message: error })
         } else {

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -66,6 +66,12 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     variables: { id: flowId },
   })
 
+  const { options, suggestions, uploadedItems } = useAttachmentOptions(
+    flowData,
+    priorExecutionSteps,
+    variableTypes,
+  )
+
   const onSuggestionClick = useCallback(
     (
       variable: CheckboxVariable,
@@ -76,7 +82,15 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
       // We also add curly braces to check for attachments that are variables
       const { name: filename, uploaded } = variable
       const nameToCheck = uploaded ? filename : `{{${filename}}}`
-      const currentValues = getValues(name) ?? []
+
+      // NOTE: if the attachment has been deleted from the form
+      // it also needs to be removed from the step parameters
+      const optionsWithVariables = options.map((o) =>
+        o.name.startsWith('s3:') ? o.name : `{{${o.name}}}`,
+      )
+      const currentValues = (getValues(name) ?? []).filter((v: string) =>
+        optionsWithVariables.includes(v),
+      )
 
       if (!checked) {
         onChange?.(currentValues.filter((v: string) => v !== nameToCheck))
@@ -89,13 +103,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
         }
       }
     },
-    [getValues, name, setError],
-  )
-
-  const { options, suggestions, uploadedItems } = useAttachmentOptions(
-    flowData,
-    priorExecutionSteps,
-    variableTypes,
+    [getValues, name, setError, options],
   )
 
   useOutsideClick({

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -174,10 +174,10 @@ export function validateFiles(
   const totalSize = currentTotalSize + fileSize
   const currentFileCount = selectedOptions.length + 1
 
-  if (currentFileCount >= MAX_NUM_FILES) {
+  if (currentFileCount > MAX_NUM_FILES) {
     return {
       isValid: false,
-      error: 'Total number of files exceeds 10',
+      error: 'Total number of files cannot exceed 10',
     }
   }
   if (fileSize > MAX_FILE_SIZE) {


### PR DESCRIPTION
## Problem
A bug in the email attachments field caused attachments that were deleted from FormSG to remain in the parameters. As a result, users hit the maximum limit of 10 attachments, even though fewer than 10 were visible in the UI.

## Solution
When user is making changes to the selected attachments, add a filter on the existing parameters to remove attachments that no longer exist within the FormSG that is connected.


## How to test?
1. Create a FormSG with a few attachment fields and use them in email by postman step
  - [ ] Selected attachments are saved in the step parameters
1. Modify the FormSG, remove the OLD attachment fields, and add NEW attachments
2. Return to Plumber and click on 'Check step again'
  - [ ] Previous attachments should no longer appear in the input nor as suggestions
  - [ ] Select the NEW attachments in the popover
  - [ ] Verify in DB that the step parameters only include the NEW attachments
  - [ ] Verify that can select up to 10 attachments
1. Sanity check that manually uploaded attachments still work as intended
  - [ ] Can upload new
  - [ ] Can select / remove
  - [ ] Can delete
