### PR TITLE
fix: for each template variable check step

### DIFF
--- a/packages/backend/src/db/storage/for-each-reminder.ts
+++ b/packages/backend/src/db/storage/for-each-reminder.ts
@@ -50,7 +50,6 @@ export const FOR_EACH_REMINDER_TEMPLATE: ITemplate = {
       parameters: {
         items: CREATE_TEMPLATE_STEP_VARIABLE(
           'Replace with rows data from step 2',
-          2,
         ),
       },
     },
@@ -71,10 +70,7 @@ export const FOR_EACH_REMINDER_TEMPLATE: ITemplate = {
       eventKey: 'updateSingleRow',
       parameters: {
         tableId: TILE_ID_PLACEHOLDER,
-        rowId: CREATE_TEMPLATE_STEP_VARIABLE(
-          'Replace with Row ID from Step 3',
-          3,
-        ),
+        rowId: CREATE_TEMPLATE_STEP_VARIABLE('Replace with Row ID from Step 3'),
         rowData: [
           {
             columnId: TILE_COL_DATA_PLACEHOLDER('Reminder sent'),

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -200,7 +200,7 @@ export const matchParamsToDataIn = (
       }
 
       const tableData = getTableData(lastTest, inputSource)
-      const lastTestColumns = tableData.columns?.map((c) => c.name) ?? []
+      const lastTestColumns = tableData?.columns?.map((c) => c.name) ?? []
       const mapKey = isFormSgTable ? searchKey : `${searchKey}.data`
       const varInfo = Array.from(varInfoMap.entries())
         .filter(([key]) => key.includes(mapKey))
@@ -219,7 +219,7 @@ export const matchParamsToDataIn = (
          * since there is no safe way to parse the FormSG table columns properly,
          * we do a best-effort comparison to just check that the columns are present.
          */
-        if (tableData.rows?.length === 0) {
+        if (tableData?.rows?.length === 0) {
           return true
         }
 
@@ -231,7 +231,7 @@ export const matchParamsToDataIn = (
           `{{${searchKey}.rowsFound}}`,
         )?.testRunValue
 
-        if (Number(varRowsFound) !== Number(tableData.rows?.length)) {
+        if (Number(varRowsFound) !== Number(tableData?.rows?.length)) {
           return false
         }
 


### PR DESCRIPTION
## Problem
Check step with template variable at for each throws error and causes page to crash.
Caused by failure to use optional chaining operator.

## Solution
Added optional chaining operator to `tableData` so that `tableData?.rows` and `tableData?.columns` does not fail.

## Before & After Screenshots

**BEFORE**:
<img width="5088" height="3372" alt="image" src="https://github.com/user-attachments/assets/a4804123-1dc7-4883-827b-c472db5d3123" />


**AFTER**:
<img width="5088" height="3372" alt="image" src="https://github.com/user-attachments/assets/ac58a604-2498-44b7-9045-8ba8a9b67b18" />


## How to test?
Create a Pipe using the for each template
- [ ] Check step with the template variable at the For each step
  - [ ] Should not throw error
  - [ ] Should show invalid input list
