### PR TITLE
fix: accept null values in for each row data

### DIFF
--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/schema.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod'
 
+export const tableRowDataSchema = z.record(
+  z.string(),
+  z.union([z.string(), z.number(), z.null()]).default(null),
+)
+
 const tableRowOutputSchema = z.object({
   rowId: z.string(),
   // for tiles v1, empty cells is either an empty string or wont even have their key returned
   // for tiles v2, empty cells return null
-  data: z.record(z.string(), z.union([z.string(), z.number(), z.null()])),
+  data: tableRowDataSchema,
 })
 
 export const dataOutSchema = z.object({

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { tableRowDataSchema } from '@/apps/tiles/actions/find-multiple-rows/schema'
+
 import {
   FOR_EACH_INPUT_SOURCE,
   FOR_EACH_TABLE_SOURCES,
@@ -15,7 +17,7 @@ const tableColumnsSchema = z.array(
 
 const tableRowsSchema = z.array(
   z.object({
-    data: z.record(z.string(), z.string().or(z.number())),
+    data: tableRowDataSchema,
     rowId: z.string().optional(), // only for tiles
   }),
 )

--- a/packages/frontend/src/components/VariablesList/schema.ts
+++ b/packages/frontend/src/components/VariablesList/schema.ts
@@ -7,7 +7,10 @@ const RowDataSchema = z.object({
     z.object({
       // for tiles v1, empty cells is either an empty string or wont even have their key returned
       // for tiles v2, empty cells return null
-      data: z.record(z.string(), z.union([z.string(), z.number(), z.null()])),
+      data: z.record(
+        z.string(),
+        z.union([z.string(), z.number(), z.null()]).default(null),
+      ),
       rowId: z.string().optional(), // only Tiles will have this
     }),
   ),


### PR DESCRIPTION
## Problem
For each 'Check step' fails when row data contains `null` values.
This was caused by zod validator only accepting `string` or `number`.

## Solution
Update schema to accept `string`, `number`, `null` and defaults to `null` to be safe.

## How to test?
- Existing functionalities work in for each
  - [ ] FormSG table field is still processed as intended
  - [ ] FormSG checkboxes are still processed as intended
  - [ ] Excel row data is processed as intended
- Row data with `null` values work
  -  Modify the _data_out_ of the find multiple rows: change one or more values to `null`
  - Use that as the input of the for each
  - [ ] Items are processed correctly when running 'Check step' at for each
  - [ ] Columns are displayed correctly
