### PR TITLE
feat: allow overriding webhook response in step config

### DIFF
--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -13,7 +13,7 @@ import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 import Flow from '@/models/flow'
 import { enqueueActionJob } from '@/queues/action'
-import { processTrigger } from '@/services/trigger'
+import { type CustomWebhookResponse, processTrigger } from '@/services/trigger'
 
 const DEFAULT_MAX_QPS = 10
 
@@ -30,6 +30,17 @@ const getRateLimiter = memoize((maxQps: number): RateLimiterRedis => {
     storeClient: redisRateLimitClient,
   })
 })
+
+async function sendWebhookResponse(
+  response: Response,
+  customWebhookResponse: CustomWebhookResponse,
+) {
+  if (customWebhookResponse) {
+    response.setHeader('Content-Type', customWebhookResponse.contentType)
+    return response.send(customWebhookResponse.body)
+  }
+  return response.sendStatus(200)
+}
 
 export default async (request: IRequest, response: Response) => {
   const span = tracer.scope().active()
@@ -139,12 +150,13 @@ export default async (request: IRequest, response: Response) => {
    * Plumber will still return a 200 status code, so that FormSG does not auto-retry,
    * but Plumber not enqueue the job.
    */
-  const { executionId, shouldExecute } = await processTrigger({
-    flowId,
-    stepId: triggerStep.id,
-    triggerItem,
-    testRun,
-  })
+  const { executionId, shouldExecute, customWebhookResponse } =
+    await processTrigger({
+      flowId,
+      stepId: triggerStep.id,
+      triggerItem,
+      testRun,
+    })
 
   span?.addTags({
     flowId,
@@ -155,7 +167,7 @@ export default async (request: IRequest, response: Response) => {
   })
 
   if (testRun || !shouldExecute) {
-    return response.sendStatus(200)
+    return sendWebhookResponse(response, customWebhookResponse)
   }
 
   const nextStep = await triggerStep.getNextStep()
@@ -174,5 +186,5 @@ export default async (request: IRequest, response: Response) => {
     jobOptions: DEFAULT_JOB_OPTIONS,
   })
 
-  return response.sendStatus(200)
+  return sendWebhookResponse(response, customWebhookResponse)
 }

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -33,11 +33,11 @@ const getRateLimiter = memoize((maxQps: number): RateLimiterRedis => {
 
 async function sendWebhookResponse(
   response: Response,
-  customWebhookResponse: CustomWebhookResponse,
+  customWebhookResponse?: CustomWebhookResponse,
 ) {
   if (customWebhookResponse) {
     response.setHeader('Content-Type', customWebhookResponse.contentType)
-    return response.send(customWebhookResponse.body)
+    return response.status(200).send(customWebhookResponse.body)
   }
   return response.sendStatus(200)
 }

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,7 +1,10 @@
 import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
+import { z } from 'zod'
+
 import logger from '@/helpers/logger'
 import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
 
 type ProcessTriggerOptions = {
@@ -12,8 +15,39 @@ type ProcessTriggerOptions = {
   testRun?: boolean
 }
 
+const customWebhookResponseSchema = z.object({
+  contentType: z.string(),
+  body: z.string(),
+})
+
+export type CustomWebhookResponse = z.infer<typeof customWebhookResponseSchema>
+
+type ProcessTriggerResult = {
+  flowId: string
+  stepId: string
+  executionId: string
+  executionStep: ExecutionStep | null
+  shouldExecute: boolean
+  customWebhookResponse?: CustomWebhookResponse
+}
+
+function getCustomWebhookResponse(step: Step) {
+  const customWebhookResponse =
+    step.config?.adminOverride?.customWebhookResponse
+  if (step.appKey !== 'webhook' || !customWebhookResponse) {
+    return undefined
+  }
+  const parsed = customWebhookResponseSchema.safeParse(customWebhookResponse)
+  if (parsed.success) {
+    return parsed.data
+  }
+  return undefined
+}
+
 // TODO(ian): change this function name, it's basically just storing trigger data
-export const processTrigger = async (options: ProcessTriggerOptions) => {
+export const processTrigger = async (
+  options: ProcessTriggerOptions,
+): Promise<ProcessTriggerResult> => {
   const { flowId, stepId, triggerItem, error, testRun } = options
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
@@ -95,11 +129,14 @@ export const processTrigger = async (options: ProcessTriggerOptions) => {
       key: step.key,
     })
 
+  const customWebhookResponse = getCustomWebhookResponse(step)
+
   return {
     flowId,
     stepId,
     executionId: execution.id,
     executionStep,
     shouldExecute: true,
+    customWebhookResponse,
   }
 }

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -31,7 +31,9 @@ type ProcessTriggerResult = {
   customWebhookResponse?: CustomWebhookResponse
 }
 
-function getCustomWebhookResponse(step: Step) {
+function getCustomWebhookResponse(
+  step: Step,
+): CustomWebhookResponse | undefined {
   const customWebhookResponse =
     step.config?.adminOverride?.customWebhookResponse
   if (step.appKey !== 'webhook' || !customWebhookResponse) {


### PR DESCRIPTION
## To test

Set this in the `config` column in `steps` table
```
{"adminOverride": {"customWebhookResponse": {"body": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><xml><message><status>1</status><text>Valid Ticket</text></message></xml>", "contentType": "application/xml"}}}
```

Call webhook