### PR TITLE
PLU-535: chore: set ioredis config to resend failed command

### DIFF
--- a/packages/backend/src/config/redis.ts
+++ b/packages/backend/src/config/redis.ts
@@ -19,7 +19,9 @@ function reconnectOnError(err: Error) {
   if (err.message.includes(targetError)) {
     // Only reconnect when the error contains "READONLY"
     // during node failover, this is thrown: 149: -READONLY You can't write against a read only replica.
-    return true
+    // Using reconnectOnError, we can force the connection to reconnect on this error in order to connect to the new master.
+    // We return 2 so that ioredis will resend the failed command after reconnecting.
+    return 2
   }
   return false
 }


### PR DESCRIPTION
## Problem
MemoryDB service updates are not being applied automatically. This requires Plumbers to manually trigger the service updates, which could potentially cause downtime if requests get dropped and are not retried by the source.

## Solution
Set ioRedis config to return `2`, which will resend the failed command after redis reconnects.

## Tests
See https://www.notion.so/opengov/Test-ioRedis-config-to-avoid-downtime-24077dbba78880dba119cb3c92f5978f?source=copy_link for the test results in UAT and Staging.
✅ No requests dropped during service updates or failover
✅ Service updates applied to both nodes
✅ All service updates applied

