### PR TITLE
chore: allow lookup for blank cells in Excel actions

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -83,6 +83,9 @@ describe('getTableRowsAction', () => {
         ['non-matching', 'data1'],
         ['test-value', 'data2'],
         ['test-value', 'data3'],
+        ['', 'data4'],
+        ['row5', ''],
+        ['', 'data6'],
       ],
       headerSheetRowIndex: 0,
     })
@@ -200,6 +203,56 @@ describe('getTableRowsAction', () => {
       'test-value',
     )
     expect(rowData[1].data[getHexEncodedColumnName('Column2')]).toBe('data3')
+  })
+
+  it('should return matching rows when lookup value is empty', async () => {
+    $.step.parameters.lookupValue = ''
+    await getTableRowsAction.run($)
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: expect.objectContaining({
+        rowsFound: 2,
+        data: {
+          columns: expect.arrayContaining([
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column1'),
+              name: 'Column1',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
+            }),
+            expect.objectContaining({
+              id: getHexEncodedColumnName('Column2'),
+              name: 'Column2',
+              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
+            }),
+          ]),
+          rows: expect.arrayContaining([
+            expect.objectContaining({
+              data: {
+                [getHexEncodedColumnName('Column1')]: '',
+                [getHexEncodedColumnName('Column2')]: 'data4',
+              },
+            }),
+            expect.objectContaining({
+              data: {
+                [getHexEncodedColumnName('Column1')]: '',
+                [getHexEncodedColumnName('Column2')]: 'data6',
+              },
+            }),
+          ]),
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+        },
+      }),
+    })
+
+    // Verify the rowData contains the expected rows
+    const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const rowData = call.raw.data.rows
+
+    expect(rowData).toHaveLength(2)
+    expect(rowData[0].data[getHexEncodedColumnName('Column1')]).toBe('')
+    expect(rowData[0].data[getHexEncodedColumnName('Column2')]).toBe('data4')
+    expect(rowData[1].data[getHexEncodedColumnName('Column1')]).toBe('')
+    expect(rowData[1].data[getHexEncodedColumnName('Column2')]).toBe('data6')
   })
 
   it('should handle invalid parameters', async () => {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -104,7 +104,7 @@ const action: IRawAction = {
       // weird (e.g. currency cells have a trailing space), and will lead to too
       // much user confusion.
       description:
-        'Case sensitive and should not include units. E.g. $5.20 → 5.2',
+        'Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.',
       type: 'string' as const,
       required: false,
       variables: true,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -106,7 +106,7 @@ const action: IRawAction = {
       description:
         'Case sensitive and should not include units. E.g. $5.20 → 5.2',
       type: 'string' as const,
-      required: true,
+      required: false,
       variables: true,
       hiddenIf: {
         fieldKey: 'tableId',

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
@@ -17,7 +17,7 @@ export const parametersSchema = z.object({
   }),
   // * We don't trim as we want to match _exactly_ on the user's input.
   // * We allow empty strings to support optional form fields.
-  lookupValue: z.string(),
+  lookupValue: z.string().default(''),
 })
 
 export const dataOutSchema = z.discriminatedUnion('foundRow', [

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -103,7 +103,7 @@ const action: IRawAction = {
       // weird (e.g. currency cells have a trailing space), and will lead to too
       // much user confusion.
       description:
-        'Case sensitive and should not include units. E.g. $5.20 → 5.2',
+        'Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.',
       type: 'string' as const,
       required: false,
       variables: true,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -105,7 +105,7 @@ const action: IRawAction = {
       description:
         'Case sensitive and should not include units. E.g. $5.20 → 5.2',
       type: 'string' as const,
-      required: true,
+      required: false,
       variables: true,
     },
   ],

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -17,7 +17,7 @@ export const parametersSchema = z.object({
   }),
   // * We don't trim as we want to match _exactly_ on the user's input.
   // * We allow empty strings to support optional form fields.
-  lookupValue: z.string(),
+  lookupValue: z.string().default(''),
 })
 
 export const dataOutSchema = z.object({


### PR DESCRIPTION
## Problem
Users are unable to search for blank values in their Excel columns using the “Find table row” or “Find table rows” actions.
This is a key difference between Tiles and M365 Excel, which often requires a workaround: creating a column specifically for lookup purposes and then updating that column’s value once the workflow is completed.


## Solution
Change the `required` property of the lookup value field from `true` to `false`

## Tests
- [ ] Existing Excel steps that were previously set up still work
- [ ] 'Check step' is allowed when lookup value is empty
  - [ ] Find table row
  - [ ] Find table rows
- [ ] Update existing Excel step's lookup value to empty, should still be able to fetch row(s)
  - [ ] Find table row
  - [ ] Find table rows
- [ ] New Excel steps can set lookup value to empty, and can still fetch row(s)
  - [ ] Find table row
  - [ ] Find table rows

## Before & After Screenshots
https://github.com/user-attachments/assets/00a42934-4a12-4978-bb40-a48fb04108a1

