### PR TITLE
chore: order excel single row output

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
@@ -21,12 +21,21 @@ async function getDataOutMetadata(
     return metadata
   }
 
+  // hide column array from the output, its only used to order the row data
+  metadata.columns =
+    dataOut?.columns?.map((column) => ({
+      type: 'text',
+      label: column,
+      isHidden: true,
+    })) || []
+
   metadata.rowData = Object.create(null)
   for (const [key, datum] of Object.entries(dataOut.rowData)) {
     metadata.rowData[key] = {
       value: {
         type: 'text',
         label: datum.columnName,
+        order: dataOut?.columns?.indexOf(datum.columnName) + 1,
       },
       columnName: {
         isHidden: true,
@@ -57,5 +66,6 @@ export default getDataOutMetadata
 //       value: '5',
 //     },
 //   },
-//   sheetRowNumber: 3
+//   sheetRowNumber: 3,
+//   columns: ['Item', 'Unit Price'],
 // }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/get-data-out-metadata.ts
@@ -35,7 +35,7 @@ async function getDataOutMetadata(
       value: {
         type: 'text',
         label: datum.columnName,
-        order: dataOut?.columns?.indexOf(datum.columnName) + 1,
+        order: (dataOut?.columns?.indexOf(datum.columnName) ?? 0) + 1,
       },
       columnName: {
         isHidden: true,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -174,6 +174,7 @@ const action: IRawAction = {
           columns,
         }),
         sheetRowNumber,
+        columns,
       } satisfies DataOut,
     })
   },

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
@@ -26,5 +26,7 @@ export const dataOutSchema = z.discriminatedUnion('foundRow', [
     foundRow: z.literal(true),
     rowData: hexEncodedRowRecordSchema,
     sheetRowNumber: z.number(),
+    // optional for backward compatibility
+    columns: z.array(z.string()).optional(),
   }),
 ])


### PR DESCRIPTION
## Problem
The output of Excel “Find single row” is not ordered in the same sequence as the columns in the Excel workbook.

## Solution
Add the columns to `dataOut` and use them to specify the order in `getDataOutMetadata`


## Before & After Screenshots
**Excel table**
<img width="431" height="141" alt="Screenshot 2025-07-31 at 2 42 16 PM" src="https://github.com/user-attachments/assets/e8eebac5-c854-419f-819d-26f90dacaa1e" />

**BEFORE**:


https://github.com/user-attachments/assets/34757e51-be0f-4106-b802-a856a2ce22d6





**AFTER**:

https://github.com/user-attachments/assets/a2daf869-2447-4e71-ab82-b5b7861798b8



## Tests
- [ ] Existing Excel steps that do not have `columns` in their `dataOut` do not throw error, and output is still rendered correctly
- [ ] Find table row still fetches the correct rows
- [ ] Columns are now in the same order as the Excel workbook when executing 'Check step' from this PR.


