### PR TITLE
feat: show iteration number in for each variables

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -50,9 +50,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -79,9 +82,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -108,9 +114,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -138,9 +147,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -187,9 +199,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -253,9 +268,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -300,9 +318,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -365,9 +386,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -436,9 +460,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -498,9 +525,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -575,9 +605,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,
@@ -753,9 +786,12 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        iteration: {
+          label: 'Item number',
+          displayedValue: '1',
+        },
         iterations: {
-          label: 'Items',
-          isHidden: true,
+          label: 'Items found',
         },
         inputSource: {
           isHidden: true,

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -96,6 +96,7 @@ describe('For each action', () => {
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 3,
           items: checkboxItems,
           inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
@@ -121,6 +122,7 @@ describe('For each action', () => {
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 3,
           items: checkboxItems,
           inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
@@ -139,6 +141,7 @@ describe('For each action', () => {
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 1,
           items: checkboxItems,
           inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
@@ -211,6 +214,7 @@ describe('For each action', () => {
       expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 2,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.TILES,
@@ -246,6 +250,7 @@ describe('For each action', () => {
       expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 2,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
@@ -276,6 +281,7 @@ describe('For each action', () => {
       expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 2,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
@@ -308,6 +314,7 @@ describe('For each action', () => {
       expect(mockedProcessItems).toHaveBeenCalledWith(mockTableFieldData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 0,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
@@ -343,6 +350,7 @@ describe('For each action', () => {
 
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
           iterations: 0,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.TILES,

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -20,12 +20,18 @@ async function getDataOutMetadata(
     console.error(dataOut.error)
     return null
   }
-  const { inputSource, items } = dataOut.data
+  const { inputSource, items, iterations } = dataOut.data
 
   const baseMetadata = {
+    // NOTE: we expose these two fields to allow users
+    // to track the iteration number and create actions
+    // when the loop ends using "Only continue if"
+    iteration: {
+      label: 'Item number',
+      displayedValue: iterations > 0 ? '1' : '',
+    },
     iterations: {
-      label: 'Items',
-      isHidden: true,
+      label: 'Items found',
     },
 
     // hidden fields

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -54,12 +54,14 @@ const action: IRawAction = {
 
     try {
       const { items, inputSource, iterations } = parsedResult.data
-      let output: {
+      const output: {
+        iteration: string
         iterations: number
         items: any[]
         inputSource: string
         item?: string
       } = {
+        iteration: FOR_EACH_ITERATION_KEY,
         iterations: 0,
         items: [],
         inputSource: '',
@@ -69,22 +71,17 @@ const action: IRawAction = {
         Array.isArray(items) &&
         isCheckboxItems(items)
       ) {
-        output = {
-          iterations: items.length,
-          items: items,
-          inputSource: FOR_EACH_INPUT_SOURCE.STRING_ARRAY,
-          // NOTE: this is specifically for checkboxes
-          // table data is handled differently in processItems
-          item: `items.${FOR_EACH_ITERATION_KEY}`,
-        }
+        output.iterations = items.length
+        output.items = items
+        output.inputSource = FOR_EACH_INPUT_SOURCE.STRING_ARRAY
+        // NOTE: this is specifically for checkboxes
+        // table data is handled differently in processItems
+        output['item'] = `items.${FOR_EACH_ITERATION_KEY}`
       } else if (FOR_EACH_TABLE_SOURCES.includes(inputSource)) {
         const processedItems = processItems(items as MultipleRowObject)
-
-        output = {
-          iterations: iterations,
-          items: processedItems,
-          inputSource,
-        }
+        output.iterations = iterations
+        output.items = processedItems
+        output.inputSource = inputSource
       }
 
       $.setActionItem({ raw: output })

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -54,6 +54,7 @@ const mockForEachCheckboxExecutionStep = {
   dataOut: {
     item: 'items.__ITERATION__',
     items: ['Option 4', 'Option 3', 'Option 2', 'Option 1'],
+    iteration: '__ITERATION__',
     iterations: 4,
     inputSource: 'checkbox',
   },
@@ -179,6 +180,7 @@ const mockForEachTableExecutionStep = {
         },
       ],
     },
+    iteration: `__ITERATION__`,
     iterations: 4,
     inputSource: 'tiles',
   },
@@ -391,16 +393,22 @@ describe('computeForEachParameters', () => {
   }
 
   it.each([
-    { iteration: 1, expected: 'Option 4' },
-    { iteration: 2, expected: 'Option 3' },
-    { iteration: 3, expected: 'Option 2' },
-    { iteration: 4, expected: 'Option 1' },
-    { iteration: 5, expected: '' },
+    { keyPath: 'item', iteration: 1, expected: 'Option 4' },
+    { keyPath: 'item', iteration: 2, expected: 'Option 3' },
+    { keyPath: 'item', iteration: 3, expected: 'Option 2' },
+    { keyPath: 'item', iteration: 4, expected: 'Option 1' },
+    { keyPath: 'item', iteration: 5, expected: '' },
+    { keyPath: 'iteration', iteration: 1, expected: 1 },
+    { keyPath: 'iteration', iteration: 2, expected: 2 },
+    { keyPath: 'iteration', iteration: 3, expected: 3 },
+    { keyPath: 'iteration', iteration: 4, expected: 4 },
+    { keyPath: 'iterations', iteration: 1, expected: 4 },
+    { keyPath: 'iterations', iteration: 2, expected: 4 },
+    { keyPath: 'iterations', iteration: 3, expected: 4 },
+    { keyPath: 'iterations', iteration: 4, expected: 4 },
   ])(
     'should handle checkbox data retrieval from for-each step %s',
-    ({ iteration, expected }) => {
-      const keyPath = `item`
-
+    ({ keyPath, iteration, expected }) => {
       const executionStep = mockExecutionStepsCheckbox[1] // for-each step
 
       const result = computeForEachParameters({
@@ -435,6 +443,46 @@ describe('computeForEachParameters', () => {
     { keyPath: `items.columns.7.value`, iteration: 2, expected: '' },
     { keyPath: `items.columns.7.value`, iteration: 3, expected: '' },
     { keyPath: `items.columns.7.value`, iteration: 4, expected: 'bye' },
+    {
+      keyPath: 'iteration',
+      iteration: 1,
+      expected: 1,
+    },
+    {
+      keyPath: 'iteration',
+      iteration: 2,
+      expected: 2,
+    },
+    {
+      keyPath: 'iteration',
+      iteration: 3,
+      expected: 3,
+    },
+    {
+      keyPath: 'iteration',
+      iteration: 4,
+      expected: 4,
+    },
+    {
+      keyPath: 'iterations',
+      iteration: 1,
+      expected: 4,
+    },
+    {
+      keyPath: 'iterations',
+      iteration: 2,
+      expected: 4,
+    },
+    {
+      keyPath: 'iterations',
+      iteration: 3,
+      expected: 4,
+    },
+    {
+      keyPath: 'iterations',
+      iteration: 4,
+      expected: 4,
+    },
   ])(
     'should handle table data retrieval from for-each step',
     ({ keyPath, iteration, expected }) => {
@@ -450,7 +498,6 @@ describe('computeForEachParameters', () => {
           executionStepMetadata: { iteration },
         },
       })
-      // console.log('result', result)
       expect(result).toEqual(expected)
     },
   )

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -126,6 +126,7 @@ export function computeForEachParameters({
   let forEachKeyPath = get(data, keyPath)
 
   // SPECIAL CASE: this returns the iteration number of the specific iteration.
+  // metadata.iteration is not available for test runs
   if (forEachKeyPath === FOR_EACH_ITERATION_KEY) {
     return metadata?.iteration ? metadata.iteration : 1
   }

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -116,8 +116,20 @@ export function computeForEachParameters({
     stepPositions,
   } = forEachContext || {}
 
+  // SPECIAL CASE: this returns the total number of items that the for each step is processing.
+  // return early as it is part of the for each data field and does not need additional computation
+  if (keyPath === 'iterations') {
+    return get(data, keyPath) ?? 0
+  }
+
   let dataValue: IJSONValue = keyPath
   let forEachKeyPath = get(data, keyPath)
+
+  // SPECIAL CASE: this returns the iteration number of the specific iteration.
+  if (forEachKeyPath === FOR_EACH_ITERATION_KEY) {
+    return metadata?.iteration ? metadata.iteration : 1
+  }
+
   const currentStepPosition = stepPositions?.[executionStep?.stepId] || -1
 
   forEachKeyPath = String(forEachKeyPath).replace(


### PR DESCRIPTION
## Problem
Unable to add actions at the end of the for each action.

## Solution
Exposed `Item number` and `Items found` variables so that users can use "Only continue if" action to perform some actions at the end of the for each.

## Screenshots
<img width="995" height="604" alt="Screenshot 2025-08-04 at 9 21 52 AM" src="https://github.com/user-attachments/assets/be228c59-beab-4f99-b373-5510cb2734a7" />

<img width="1672" height="987" alt="Screenshot 2025-08-04 at 9 22 10 AM" src="https://github.com/user-attachments/assets/463f528c-9ea2-4a25-a525-b6efe4e5609c" />


## Tests
- [ ] Existing Pipes with For each actions execute correctly
- [ ] New and Existing Pipes are updated and expose the `Item number` and `Items found` variables upon checking step
  - [ ] `Items found` corresponds to the number of items in the input
  - [ ] `Item number` === `Items found` is evaluated correctly in the "Only continue if" action
  - [ ] Actions that are created after the "Only continue if" are executed correctly and at the right time

