### PR TITLE
chore: add index on app_key and key

### DIFF
--- a/packages/backend/src/db/migrations/20250804015323_add_composite_index_on_execution_steps.ts
+++ b/packages/backend/src/db/migrations/20250804015323_add_composite_index_on_execution_steps.ts
@@ -1,13 +1,15 @@
 import { Knex } from 'knex'
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table('execution_steps', (table) => {
-    table.index(['app_key', 'key'])
-  })
+  await knex.raw(
+    'CREATE INDEX CONCURRENTLY IF NOT EXISTS execution_steps_app_key_key_index ON execution_steps (app_key, key)',
+  )
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table('execution_steps', (table) => {
-    table.dropIndex(['app_key', 'key'])
-  })
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS execution_steps_app_key_key_index',
+  )
 }
+
+export const config = { transaction: false }

--- a/packages/backend/src/db/migrations/20250804015323_add_composite_index_on_execution_steps.ts
+++ b/packages/backend/src/db/migrations/20250804015323_add_composite_index_on_execution_steps.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('execution_steps', (table) => {
+    table.index(['app_key', 'key'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('execution_steps', (table) => {
+    table.dropIndex(['app_key', 'key'])
+  })
+}


### PR DESCRIPTION
## Problem
Unable to query `execution_steps` table to find steps using `app_key` and `key`.

**Why need to query using `app_key` and `key`?**
To accurately count executions that use a specific `app_key` and `key`, we need to query the `execution_steps` table instead of steps. This is because users can modify the steps in their Pipe, and queries based solely on steps will reflect only the latest configuration—potentially including past executions where that particular `app_key` and `key` were not yet in use.

## Solution
Create a composite index with both `app_key` and `key`

## Tests
- [ ] Executions are still displayed correctly

## Deploy Notes
Create the index manually, **DO NOT** run the migration script as it will lock the table and may cause problems.

```
CREATE INDEX CONCURRENTLY IF NOT EXISTS execution_steps_app_key_key_index
ON execution_steps (app_key, key)
```

- [ ] UAT
- [ ] Staging
- [ ] Prod

