### PR TITLE
fix: do not allow retries in test runs

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -38,6 +38,9 @@ describe('Delay until action', () => {
       app: {
         name: delayApp.name,
       },
+      execution: {
+        testRun: false,
+      },
       setActionItem: mocks.setActionItem,
       getLastExecutionStep: mocks.getLastExecutionStep,
     } as unknown as IGlobalVariable
@@ -111,6 +114,26 @@ describe('Delay until action', () => {
   })
 
   describe('retry logic', () => {
+    it('prevents retries during test runs', async () => {
+      $.step.parameters = {
+        delayUntil: PAST_DATE,
+        delayUntilTime: DEFAULT_TIME,
+      }
+
+      // Set testRun to true to simulate test environment
+      $.execution.testRun = true
+
+      // Mock last execution step to indicate a retry for past timestamp
+      mocks.getLastExecutionStep.mockResolvedValue({
+        errorDetails: {
+          name: 'Delay until timestamp entered is in the past',
+        },
+      })
+
+      // Should throw error even with valid retry conditions due to testRun
+      await expect(delayUntilAction.run($)).rejects.toThrowError(StepError)
+    })
+
     it('allows past timestamp when retrying after past timestamp error', async () => {
       $.step.parameters = {
         delayUntil: PAST_DATE,

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -1,4 +1,4 @@
-import { IRawAction } from '@plumber/types'
+import { IGlobalVariable, IRawAction } from '@plumber/types'
 
 import { DateTime } from 'luxon'
 
@@ -6,7 +6,12 @@ import StepError from '@/errors/step'
 
 import generateTimestamp from '../../helpers/generate-timestamp'
 
-async function isValidRetry($: any): Promise<boolean> {
+async function isValidRetry($: IGlobalVariable): Promise<boolean> {
+  // do not allow retries in test runs
+  if ($.execution.testRun) {
+    return false
+  }
+
   const lastExecutionStep = await $.getLastExecutionStep({
     sameExecution: true,
   })


### PR DESCRIPTION
## Problem
Retries are not blocked in test runs, resulting in inconsistent results despite timestamps being in the past.


## Solution
Block retries during test runs.

## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/3382039e-12fd-4068-9f1e-c80d88e61bb2



**AFTER**:

https://github.com/user-attachments/assets/464c7eea-e47b-4201-8d0c-48e9febfb456



## Tests
- [ ] Timestamps in the past are not retried and pass during check step
- [ ] Timestamps in the past are allowed to pass only during retries from real executions
