### PR TITLE
[COLLAB-1]: Create flow_collaborators table, model, resolvers

### DIFF
--- a/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
+++ b/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
@@ -1,0 +1,17 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('flow_collaborators', (table) => {
+    table.uuid('flow_id').references('id').inTable('flows').notNullable()
+    table.uuid('user_id').references('id').inTable('users').notNullable()
+    table.string('role').notNullable()
+    table.timestamps(true, true)
+    table.timestamp('deleted_at').nullable()
+    table.timestamp('last_accessed_at').notNullable().defaultTo(knex.fn.now())
+    table.uuid('updated_by').references('id').inTable('users').notNullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('flow_collaborators')
+}

--- a/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
+++ b/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
@@ -9,6 +9,8 @@ export async function up(knex: Knex): Promise<void> {
     table.timestamp('deleted_at').nullable()
     table.timestamp('last_accessed_at').notNullable().defaultTo(knex.fn.now())
     table.uuid('updated_by').references('id').inTable('users').notNullable()
+
+    table.primary(['flow_id', 'user_id'])
   })
 }
 

--- a/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
@@ -1,0 +1,21 @@
+import type { Resolvers } from '../__generated__/types.generated'
+
+type FlowCollaboratorResolver = Resolvers['FlowCollaborator']
+
+const email: FlowCollaboratorResolver['email'] = async (parent) => {
+  // user is eagerly loaded in queries, we should use the loaded relation first
+  if (parent?.user?.email) {
+    return parent?.user?.email
+  }
+
+  // edge case: fallback to query if user relation is not loaded
+  const user = await parent
+    .$relatedQuery('user')
+    .select('email')
+    .throwIfNotFound()
+  return user.email
+}
+
+export default {
+  email,
+} satisfies FlowCollaboratorResolver

--- a/packages/backend/src/graphql/schema.gql-to-typescript.ts
+++ b/packages/backend/src/graphql/schema.gql-to-typescript.ts
@@ -3,11 +3,13 @@ import App from '@/models/app'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
 import FlowTransfer from '@/models/flow-transfers'
 import TableMetadata from '@/models/table-metadata'
 
 export type AppGraphQLType = App
 export type ExecutionStepGraphQLType = ExecutionStep
+export type FlowCollaboratorGraphQLType = FlowCollaborator
 export type TableMetadataGraphQLType = TableMetadata
 export type FlowTransferGraphQLType = FlowTransfer
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -391,6 +391,11 @@ type Flow {
   template: Template
 }
 
+type FlowCollaborator {
+  role: String!
+  email: String!
+}
+
 # Rate limiting config is omitted here e.g. maxQps
 type FlowConfig {
   errorConfig: FlowErrorConfig

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -1,0 +1,16 @@
+import type { IFlowCollabRole } from '@plumber/types'
+
+const PERMISSION_LEVELS = ['viewer', 'editor', 'owner']
+
+export const checkUserPermission = (
+  collaboratorRole: IFlowCollabRole,
+  requiredRole: IFlowCollabRole,
+) => {
+  if (
+    PERMISSION_LEVELS.indexOf(collaboratorRole) >=
+    PERMISSION_LEVELS.indexOf(requiredRole)
+  ) {
+    return true
+  }
+  throw new Error('You do not have the required permissions.')
+}

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -99,4 +99,14 @@ describe('flow collaborators model', () => {
       }),
     ).rejects.toThrow(ForbiddenError)
   })
+
+  it('should throw an error if the flow does not exist', async () => {
+    await expect(
+      FlowCollaborator.hasAccess({
+        userId: ownerUserId,
+        flowId: randomUUID(),
+        requiredRole: 'editor',
+      }),
+    ).rejects.toThrow('Flow not found')
+  })
 })

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -1,0 +1,102 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+
+import Flow from '../flow'
+import FlowCollaborator from '../flow-collaborators'
+import User from '../user'
+
+describe('flow collaborators model', () => {
+  let flowId: string
+  const ownerUserId = randomUUID()
+  const editorUserId = randomUUID()
+  const viewerUserId = randomUUID()
+
+  beforeEach(async () => {
+    flowId = randomUUID()
+
+    await User.query().insert([
+      {
+        id: ownerUserId,
+        email: 'owner@example.com',
+      },
+      {
+        id: editorUserId,
+        email: 'editor@example.com',
+      },
+      {
+        id: viewerUserId,
+        email: 'viewer@example.com',
+      },
+    ])
+
+    await Flow.query().insert({
+      id: flowId,
+      name: 'test flow',
+      userId: ownerUserId,
+    })
+    await FlowCollaborator.query().insert([
+      {
+        flowId,
+        userId: editorUserId,
+        role: 'editor',
+        updatedBy: ownerUserId,
+      },
+      {
+        flowId,
+        userId: viewerUserId,
+        role: 'viewer',
+        updatedBy: ownerUserId,
+      },
+    ])
+  })
+
+  it.each([
+    { userId: ownerUserId, requiredRole: 'owner', expectedRole: 'owner' },
+    { userId: ownerUserId, requiredRole: 'editor', expectedRole: 'owner' },
+    { userId: ownerUserId, requiredRole: 'viewer', expectedRole: 'owner' },
+    { userId: editorUserId, requiredRole: 'editor', expectedRole: 'editor' },
+    { userId: editorUserId, requiredRole: 'viewer', expectedRole: 'editor' },
+    { userId: viewerUserId, requiredRole: 'viewer', expectedRole: 'viewer' },
+  ])(
+    'should return the correct access for the user',
+    async ({ userId, requiredRole, expectedRole }) => {
+      const role = await FlowCollaborator.hasAccess({
+        userId,
+        flowId,
+        requiredRole: requiredRole as IFlowCollabRole,
+      })
+      expect(role).toBe(expectedRole)
+    },
+  )
+
+  it.each([
+    { userId: viewerUserId, requiredRole: 'owner' },
+    { userId: viewerUserId, requiredRole: 'editor' },
+    { userId: editorUserId, requiredRole: 'owner' },
+  ])(
+    'should throw error if user does not have enough permissions',
+    async ({ userId, requiredRole }) => {
+      await expect(
+        FlowCollaborator.hasAccess({
+          userId,
+          flowId,
+          requiredRole: requiredRole as IFlowCollabRole,
+        }),
+      ).rejects.toThrow()
+    },
+  )
+
+  it('should throw an error if the user does not have access', async () => {
+    await expect(
+      FlowCollaborator.hasAccess({
+        userId: randomUUID(),
+        flowId,
+        requiredRole: 'editor',
+      }),
+    ).rejects.toThrow(ForbiddenError)
+  })
+})

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -81,9 +81,12 @@ class FlowCollaborator extends Base {
   }): Promise<IFlowCollabRole | never> => {
     // flow owner is identified by the flow.userId
 
-    const flowOwner = await Flow.query(trx).findOne({
-      id: flowId,
-    })
+    const flowOwner = await Flow.query(trx)
+      .findOne({
+        id: flowId,
+      })
+      .throwIfNotFound({ message: 'Flow not found' })
+
     if (flowOwner?.userId === userId) {
       return 'owner'
     }

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -1,4 +1,10 @@
-import { IFlowCollabRole } from '@plumber/types'
+import { IFlowCollabRole, IGlobalVariable } from '@plumber/types'
+
+import { Transaction } from 'objection'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import StepError from '@/errors/step'
+import { checkUserPermission } from '@/helpers/check-user-permission'
 
 import Base from './base'
 import Flow from './flow'
@@ -55,6 +61,60 @@ class FlowCollaborator extends Base {
       },
     },
   })
+
+  /**
+   * Checks whether user has the necessary role to access the flow
+   * permission levels: viewer, editor, owner
+   */
+  static hasAccess = async ({
+    userId,
+    flowId,
+    requiredRole,
+    $ = undefined,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    requiredRole: IFlowCollabRole
+    $?: IGlobalVariable
+    trx?: Transaction
+  }): Promise<IFlowCollabRole | never> => {
+    // flow owner is identified by the flow.userId
+
+    const flowOwner = await Flow.query(trx).findOne({
+      id: flowId,
+    })
+    if (flowOwner?.userId === userId) {
+      return 'owner'
+    }
+
+    // only collaborators need to be checked against flow_collaborators table
+    const collaborator = await this.query(trx).findOne({
+      user_id: userId,
+      flow_id: flowId,
+    })
+
+    if (
+      !collaborator ||
+      !checkUserPermission(collaborator.role, requiredRole)
+    ) {
+      if ($) {
+        throw new StepError(
+          'You do not have sufficient permissions for this pipe',
+          `Please ensure that you are ${
+            requiredRole === 'viewer' ? 'a' : 'an'
+          } ${requiredRole} of this pipe.`,
+          $.step.position,
+          $.app.name,
+        )
+      }
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this pipe',
+      )
+    } else {
+      return collaborator.role
+    }
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -1,0 +1,60 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import Base from './base'
+import Flow from './flow'
+import User from './user'
+
+// Reuse the same role type as tables for consistency
+
+class FlowCollaborator extends Base {
+  userId!: string
+  flowId!: string
+  role!: IFlowCollabRole
+  user!: User
+  flow!: Flow
+  lastAccessedAt?: string
+  updatedBy?: string
+
+  // Virtual field for GraphQL compatibility - populated by custom resolver
+  // Email is guaranteed to be available when user relation is loaded
+  email: string
+
+  static tableName = 'flow_collaborators'
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      userId: { type: 'string', format: 'uuid' },
+      flowId: { type: 'string', format: 'uuid' },
+      role: { type: 'string', enum: ['owner', 'editor', 'viewer'] },
+      lastAccessedAt: { type: 'string', format: 'date-time' },
+      updatedBy: { type: 'string', format: 'uuid' },
+    },
+  }
+
+  // Acts as a composite primary key
+  static get idColumn() {
+    return ['user_id', 'flow_id']
+  }
+
+  static relationMappings = () => ({
+    user: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: User,
+      join: {
+        from: `${this.tableName}.user_id`,
+        to: `${User.tableName}.id`,
+      },
+    },
+    flow: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Flow,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${Flow.tableName}.id`,
+      },
+    },
+  })
+}
+
+export default FlowCollaborator

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -26,7 +26,7 @@ class FlowCollaborator extends Base {
     properties: {
       userId: { type: 'string', format: 'uuid' },
       flowId: { type: 'string', format: 'uuid' },
-      role: { type: 'string', enum: ['owner', 'editor', 'viewer'] },
+      role: { type: 'string', enum: ['editor', 'viewer'] },
       lastAccessedAt: { type: 'string', format: 'date-time' },
       updatedBy: { type: 'string', format: 'uuid' },
     },

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -228,6 +228,13 @@ export interface IFlowAttachmentsConfig {
   updatedAt: string
 }
 
+export type IFlowCollabRole = 'owner' | 'editor' | 'viewer'
+
+export interface IFlowCollaborator {
+  email?: string // Populated by GraphQL resolver
+  role: IFlowCollabRole
+}
+
 export interface IFlow {
   id: string
   name: string


### PR DESCRIPTION
## TL;DR
This PR creates the `flow_collaborators` table and adds the necessary support to work with the collaborators.

## What changed?
- Creates a new `flow_collaborators` table
- Implements the `FlowCollaborator` model with role-based access control
- Adds a custom GraphQL resolver for collaborator email
- Implements permission checking helper for role-based authorisation

## Tests
Verify that the `hasAccess` function in the flow-collaborators model is correct
- [ ] If required role is `owner`:
  - [ ] `owner` should have access
  - [ ] `editor` should NOT have access
  - [ ] `viewer` should NOT have access
- [ ] If required role is `editor`:
  - [ ] `owner` should have access
  - [ ] `editor` should have access
  - [ ] `viewer` should NOT have access
- [ ] If required role is `viewer`:
  - [ ] all should have access