### PR TITLE
[COLLAB-3]: Add mutations to upsert and delete collaborators

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import deleteFlowCollaborator from '@/graphql/mutations/delete-flow-collaborator'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+
+describe('delete flow collaborators', () => {
+  let context: Context
+  let dummyFlow: Flow
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  const editorUserId = randomUUID()
+  const viewerUserId = randomUUID()
+  const nonCollaboratorUserId = randomUUID()
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    owner = context.currentUser
+
+    editor = await User.query().insert({
+      id: editorUserId,
+      email: 'editor@plumber.gov.sg',
+    })
+
+    viewer = await User.query().insert({
+      id: viewerUserId,
+      email: 'viewer@plumber.gov.sg',
+    })
+
+    nonCollaborator = await User.query().insert({
+      id: nonCollaboratorUserId,
+      email: 'non-collaborator@plumber.gov.sg',
+    })
+
+    const mockFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'test flow',
+      userId: owner.id,
+    })
+
+    await FlowCollaborator.query().insert([
+      {
+        flowId: mockFlow.id,
+        userId: editorUserId,
+        role: 'editor',
+        updatedBy: context.currentUser.id,
+      },
+      {
+        flowId: mockFlow.id,
+        userId: viewerUserId,
+        role: 'viewer',
+        updatedBy: context.currentUser.id,
+      },
+    ])
+
+    dummyFlow = mockFlow
+  })
+
+  it('should be able to delete collaborators', async () => {
+    await deleteFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: viewer.email } },
+      context,
+    )
+    const flowCollaborators = await FlowCollaborator.query()
+      .where('flow_id', dummyFlow.id)
+      .where('deleted_at', null)
+
+    expect(flowCollaborators).toHaveLength(1)
+    const removedViewer = flowCollaborators.find(
+      (col) => col.email === viewer.email,
+    )
+    expect(removedViewer).toBeUndefined()
+  })
+
+  it('should throw an error if collaborator is not found', async () => {
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: 'viewer332@plumber.gov.sg' } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('should throw an error when deleting oneself', async () => {
+    context.currentUser = editor
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: editor.email } },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('should throw an error if trying to delete owner', async () => {
+    context.currentUser = editor
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: owner.email } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError) // owner does not exist in flow_collaborators table
+  })
+
+  it('should throw an error if user is not a collaborator', async () => {
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: nonCollaborator.email,
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('should throw an error if user does not have permission to delete collaborator', async () => {
+    context.currentUser = viewer
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: editor.email } },
+        context,
+      ),
+    ).rejects.toThrowError('You do not have sufficient permissions')
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -112,7 +112,7 @@ describe('delete flow collaborators', () => {
         { input: { flowId: dummyFlow.id, email: owner.email } },
         context,
       ),
-    ).rejects.toThrow(NotFoundError) // owner does not exist in flow_collaborators table
+    ).rejects.toThrowError('No such collaborator found') // owner does not exist in flow_collaborators table
   })
 
   it('should throw an error if user is not a collaborator', async () => {
@@ -127,7 +127,7 @@ describe('delete flow collaborators', () => {
         },
         context,
       ),
-    ).rejects.toThrow(NotFoundError)
+    ).rejects.toThrowError('No such collaborator found')
   })
 
   it('should throw an error if user does not have permission to delete collaborator', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import upsertFlowCollaborator from '@/graphql/mutations/upsert-flow-collaborator'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+
+describe('upsert flow collaborator', () => {
+  let context: Context
+  let dummyFlow: Flow
+  let editor: User
+  let viewer: User
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    dummyFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'test flow',
+      userId: context.currentUser.id,
+    })
+
+    editor = await User.query().insert({
+      id: randomUUID(),
+      email: 'editor@plumber.gov.sg',
+    })
+
+    viewer = await User.query().insert({
+      id: randomUUID(),
+      email: 'viewer@plumber.gov.sg',
+    })
+  })
+
+  it('owner should be able to add new editor', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' } },
+      context,
+    )
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(editor.id)
+    expect(collaborators[0].role).toBe('editor')
+  })
+
+  it('owner should be able to add new viewer', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' } },
+      context,
+    )
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(viewer.id)
+    expect(collaborators[0].role).toBe('viewer')
+  })
+
+  it('should be able to update roles', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: editor.email, role: 'viewer' } },
+      context,
+    )
+
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(editor.id)
+    expect(collaborators[0].role).toBe('viewer')
+  })
+
+  it('should not allow editing role of owner', async () => {
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: context.currentUser.email,
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('should not allow editing of own role', async () => {
+    context.currentUser = editor
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: context.currentUser.email,
+            role: 'viewer',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('viewer should not be able to modify collaborator', async () => {
+    context.currentUser = viewer
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: 'new-user@plumber.gov.sg',
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrowError(
+      'You do not have sufficient permissions for this pipe',
+    )
+  })
+})

--- a/packages/backend/src/graphql/custom-resolvers/index.ts
+++ b/packages/backend/src/graphql/custom-resolvers/index.ts
@@ -1,5 +1,6 @@
 import ExecutionStep from './execution-step'
 import Flow from './flow'
+import FlowCollaborator from './flow-collaborator'
 import TableMetadata from './table-metadata'
 
 /**
@@ -13,4 +14,4 @@ import TableMetadata from './table-metadata'
  * schema.gql-to-typescript.ts.
  */
 
-export default { ExecutionStep, TableMetadata, Flow }
+export default { ExecutionStep, TableMetadata, Flow, FlowCollaborator }

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -8,6 +8,7 @@ import createStep from './mutations/create-step'
 import createTemplatedFlow from './mutations/create-templated-flow'
 import deleteConnection from './mutations/delete-connection'
 import deleteFlow from './mutations/delete-flow'
+import deleteFlowCollaborator from './mutations/delete-flow-collaborator'
 import deleteStep from './mutations/delete-step'
 import deleteUploadedFile from './mutations/delete-uploaded-file'
 import duplicateFlow from './mutations/duplicate-flow'
@@ -30,6 +31,7 @@ import updateFlowConfig from './mutations/update-flow-config'
 import updateFlowStatus from './mutations/update-flow-status'
 import updateFlowTransferStatus from './mutations/update-flow-transfer-status'
 import updateStep from './mutations/update-step'
+import upsertFlowCollaborator from './mutations/upsert-flow-collaborator'
 import verifyConnection from './mutations/verify-connection'
 import verifyOtp from './mutations/verify-otp'
 
@@ -65,6 +67,8 @@ export default {
   updateFlow,
   updateFlowStatus,
   updateFlowConfig,
+  upsertFlowCollaborator,
+  deleteFlowCollaborator,
   executeStep,
   deleteFlow,
   createStep,

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -23,10 +23,6 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
     }
 
     // only editor or owner can delete collaborators
-    const isOwner = await context.currentUser.$relatedQuery('flows').findOne({
-      id: flowId,
-    })
-
     await FlowCollaborator.hasAccess({
       userId: context.currentUser.id,
       flowId,
@@ -39,19 +35,15 @@ const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
       })
       .throwIfNotFound('No such user found')
 
-    if (isOwner?.userId === user.id) {
-      throw new BadUserInputError('Cannot remove owner')
-    }
-
-    const collaboratorUser = await FlowCollaborator.query()
-      .findOne({
-        flow_id: flowId,
-        user_id: user.id,
-      })
-      .throwIfNotFound('No such collaborator found')
-
     try {
-      await collaboratorUser.$query().delete()
+      await FlowCollaborator.query()
+        .delete()
+        .where({
+          flow_id: flowId,
+          user_id: user.id,
+        })
+        .returning('*')
+        .throwIfNotFound({ message: 'No such collaborator found' })
     } catch (e) {
       logger.error({
         message: 'Failed to delete collaborator',

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,0 +1,71 @@
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { validateAndParseEmail } from '@/helpers/email-validator'
+import logger from '@/helpers/logger'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+
+import { MutationResolvers } from '../__generated__/types.generated'
+
+const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
+  async (_parent, params, context) => {
+    const { flowId, email } = params.input as {
+      flowId: string
+      email: string
+    }
+
+    const validatedEmail = await validateAndParseEmail(email)
+    if (!validatedEmail) {
+      throw new BadUserInputError('Invalid collaborator email')
+    }
+
+    if (validatedEmail === context.currentUser.email) {
+      throw new BadUserInputError('Cannot remove yourself')
+    }
+
+    // only editor or owner can delete collaborators
+    const isOwner = await context.currentUser.$relatedQuery('flows').findOne({
+      id: flowId,
+    })
+
+    await FlowCollaborator.hasAccess({
+      userId: context.currentUser.id,
+      flowId,
+      requiredRole: 'editor',
+    })
+
+    const user = await User.query()
+      .findOne({
+        email: validatedEmail,
+      })
+      .throwIfNotFound('No such user found')
+
+    if (isOwner?.userId === user.id) {
+      throw new BadUserInputError('Cannot remove owner')
+    }
+
+    const collaboratorUser = await FlowCollaborator.query()
+      .findOne({
+        flow_id: flowId,
+        user_id: user.id,
+      })
+      .throwIfNotFound('No such collaborator found')
+
+    try {
+      await collaboratorUser.$query().delete()
+    } catch (e) {
+      logger.error({
+        message: 'Failed to delete collaborator',
+        data: {
+          flowId,
+          email,
+        },
+        userId: context.currentUser.id,
+        error: e,
+      })
+      throw new Error(e.message ?? 'Failed to delete collaborator')
+    }
+
+    return true
+  }
+
+export default deleteFlowCollaborator

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,0 +1,93 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { getOrCreateUser } from '@/helpers/auth'
+import { validateAndParseEmail } from '@/helpers/email-validator'
+import logger from '@/helpers/logger'
+import FlowCollaborator from '@/models/flow-collaborators'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
+  async (_parent, params, context) => {
+    const { flowId, email, role } = params.input as {
+      flowId: string
+      email: string
+      role: IFlowCollabRole
+    }
+
+    const validatedEmail = await validateAndParseEmail(email)
+    if (!validatedEmail) {
+      throw new BadUserInputError('Invalid collaborator email')
+    }
+
+    if (context.currentUser.email === validatedEmail) {
+      throw new BadUserInputError('Cannot change own role')
+    }
+
+    try {
+      /**
+       * We check if a flow collaborator has been added before (could have been soft deleted)
+       * and if so, we update the role
+       */
+      await FlowCollaborator.transaction(async (trx) => {
+        /**
+         * this mutation only allows for adding / updating collaborators.
+         * flow transfer is still handled by the updateFlowTransferStatus mutation.
+         * new user will be created if not exists
+         */
+        await FlowCollaborator.hasAccess({
+          userId: context.currentUser.id,
+          flowId,
+          requiredRole: 'editor',
+          trx,
+        })
+
+        const collaboratorUser = await getOrCreateUser(validatedEmail)
+        if (!collaboratorUser) {
+          throw new BadUserInputError('Error creating user')
+        }
+
+        const existingCollaborator = await FlowCollaborator.query(trx)
+          .findOne({
+            flow_id: flowId,
+            user_id: collaboratorUser.id,
+          })
+          .withSoftDeleted()
+
+        if (existingCollaborator) {
+          await existingCollaborator
+            .$query(trx)
+            .patchAndFetch({
+              role,
+              deletedAt: null,
+              updatedBy: context.currentUser.id,
+            })
+            .withSoftDeleted()
+        } else {
+          await FlowCollaborator.query(trx).insert({
+            flowId,
+            userId: collaboratorUser.id,
+            role,
+            updatedBy: context.currentUser.id,
+          })
+        }
+      })
+    } catch (error) {
+      logger.error({
+        message: 'Error upserting flow collaborator',
+        data: {
+          flowId,
+          email,
+          role,
+        },
+        userId: context.currentUser.id,
+        error,
+      })
+      throw new Error(error.message ?? 'Error upserting flow collaborator')
+    }
+
+    return true
+  }
+
+export default upsertFlowCollaborator

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -99,6 +99,9 @@ type Mutation {
     input: LoginWithSelectedSgidInput!
   ): LoginWithSelectedSgidResult!
   duplicateFlow(input: DuplicateFlowInput): Flow
+  # Flow collaborators
+  upsertFlowCollaborator(input: FlowCollaboratorInput!): Boolean!
+  deleteFlowCollaborator(input: DeleteFlowCollaboratorInput!): Boolean!
   # S3 operations
   generatePresignedPost(input: GeneratePresignedPostInput): PresignedPostObject
   deleteUploadedFile(id: String!): Boolean
@@ -393,6 +396,17 @@ type Flow {
 
 type FlowCollaborator {
   role: String!
+  email: String!
+}
+
+input FlowCollaboratorInput {
+  flowId: String!
+  email: String!
+  role: String!
+}
+
+input DeleteFlowCollaboratorInput {
+  flowId: String!
   email: String!
 }
 

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -12,5 +12,5 @@ export const checkUserPermission = (
   ) {
     return true
   }
-  throw new Error('You do not have the required permissions.')
+  throw new Error('You do not have sufficient permissions')
 }

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -1,5 +1,7 @@
 import type { IFlowCollabRole } from '@plumber/types'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
+
 const PERMISSION_LEVELS = ['viewer', 'editor', 'owner']
 
 export const checkUserPermission = (
@@ -12,5 +14,5 @@ export const checkUserPermission = (
   ) {
     return true
   }
-  throw new Error('You do not have sufficient permissions')
+  throw new ForbiddenError('You do not have sufficient permissions')
 }

--- a/packages/frontend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const DELETE_FLOW_COLLABORATOR = graphql(`
+  mutation DeleteFlowCollaborator($input: DeleteFlowCollaboratorInput!) {
+    deleteFlowCollaborator(input: $input)
+  }
+`)

--- a/packages/frontend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const UPSERT_FLOW_COLLABORATOR = graphql(`
+  mutation UpsertFlowCollaborator($input: FlowCollaboratorInput!) {
+    upsertFlowCollaborator(input: $input)
+  }
+`)


### PR DESCRIPTION
## TL;DR
This PR adds the GraphQL mutations required to manage flow collaborators.
The mutations do the following:
* Add new collaborator
* Update collaborator's role
* Delete collaborator

## What changed?
- Added `upsertFlowCollaborator` mutation to add or update collaborator roles
- Added `deleteFlowCollaborator` mutation to remove collaborators
- Updated `schema.graphql` with new types and mutations
- Adds corresponding frontend GraphQL mutation definitions

## How to test?
If you wish to test the mutation, you can call the mutation directly.
Otherwise, do a sanity check on the tests to make sure they are correct.
- [ ] Owner
  - [ ] Can add collaborator, both editor and viewer
  - [ ] Can update collaborator role
  - [ ] Can delete collaborator
- [ ] Editor
  - [ ] Can add editor or viewer
  - [ ] Can update roles of other collaborators
  - [ ] Can delete other collaborators
- [ ] Viewer
  - [ ] Cannot do anything
