### PR TITLE
[COLLAB-9]: Restrict UI based on role

### DIFF
--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -52,11 +52,16 @@ function ChooseConnectionSubstep(
 ): React.ReactElement {
   const { step, application, onReconnect } = props
   const { connection } = step
-  const { readOnly } = useContext(EditorContext)
+  const { readOnly, flow } = useContext(EditorContext)
   const { currentUser } = useAuthentication()
 
   const supportsConnectionRegistration =
     !!application.auth?.connectionRegistrationType
+
+  const isEditConnectionDisabled =
+    readOnly ||
+    (flow.role !== 'owner' &&
+      NON_EDITABLE_APP_CONNECTIONS.includes(application.key))
 
   const { loading: testResultLoading, data: testConnectionData } = useQuery<{
     testConnection: ITestConnectionOutput
@@ -173,9 +178,7 @@ function ChooseConnectionSubstep(
           size="xs"
           leftIcon={connection ? <BiRefresh /> : <BiLink />}
           onClick={onReconnect}
-          isDisabled={
-            readOnly || NON_EDITABLE_APP_CONNECTIONS.includes(application.key)
-          }
+          isDisabled={isEditConnectionDisabled}
         >
           {connection ? 'Reconnect' : 'Connect'}
         </Button>

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -10,6 +10,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 import useAuthentication from '@/hooks/useAuthentication'
 
+import { NON_EDITABLE_APP_CONNECTIONS } from '../Editor/constants'
 import {
   type ConnectionDropdownOption,
   optionGenerator,
@@ -51,7 +52,7 @@ function ChooseConnectionSubstep(
 ): React.ReactElement {
   const { step, application, onReconnect } = props
   const { connection } = step
-  const editorContext = useContext(EditorContext)
+  const { readOnly } = useContext(EditorContext)
   const { currentUser } = useAuthentication()
 
   const supportsConnectionRegistration =
@@ -172,7 +173,9 @@ function ChooseConnectionSubstep(
           size="xs"
           leftIcon={connection ? <BiRefresh /> : <BiLink />}
           onClick={onReconnect}
-          isDisabled={editorContext.readOnly}
+          isDisabled={
+            readOnly || NON_EDITABLE_APP_CONNECTIONS.includes(application.key)
+          }
         >
           {connection ? 'Reconnect' : 'Connect'}
         </Button>

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -38,7 +38,6 @@ export interface ControlledAutocompleteProps {
   clickableLink?: IFieldDropdown['clickableLink']
   isSearchable?: boolean
   variableTypes?: TDataOutMetadatumType[]
-  readOnly?: boolean
 }
 
 const formComboboxOptions = (
@@ -81,9 +80,8 @@ function ControlledAutocomplete(
     clickableLink,
     isSearchable,
     variableTypes = null,
-    readOnly = false,
   } = props
-  const { allApps } = useContext(EditorContext)
+  const { allApps, readOnly } = useContext(EditorContext)
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
   /**
@@ -220,7 +218,6 @@ function ControlledAutocomplete(
                   }
                 : undefined
             }
-            isDisabled={readOnly}
           />
         </Box>
       </Flex>

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -38,6 +38,7 @@ export interface ControlledAutocompleteProps {
   clickableLink?: IFieldDropdown['clickableLink']
   isSearchable?: boolean
   variableTypes?: TDataOutMetadatumType[]
+  readOnly?: boolean
 }
 
 const formComboboxOptions = (
@@ -80,8 +81,9 @@ function ControlledAutocomplete(
     clickableLink,
     isSearchable,
     variableTypes = null,
+    readOnly = false,
   } = props
-  const { allApps, readOnly } = useContext(EditorContext)
+  const { allApps } = useContext(EditorContext)
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
 
   /**
@@ -218,6 +220,7 @@ function ControlledAutocomplete(
                   }
                 : undefined
             }
+            isDisabled={readOnly}
           />
         </Box>
       </Flex>

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -7,19 +7,13 @@ export const MIN_FLOW_STEP_WIDTH = '320px'
 
 /**
  * NOTE: there are certain fields that behave like connections
- * such as slack channels, telegram chats, and excel files
+ * such as excel files
  * we do not allow collaborators to edit these fields
  * we use both the label and key as there are some
  * actions that have the same key but use different labels
  */
-const NON_EDITABLE_APPS_FIELDS = {
-  'm365-excel': [{ label: 'Excel File', key: 'fileId' }],
-  slack: [{ label: 'Channel', key: 'channel' }],
-  telegram: [{ label: 'Chat ID', key: 'chatId' }],
-  tile: [
-    { label: 'Select Tile', key: 'tableId' },
-    { label: null, key: 'columnId' },
-  ],
+const NON_EDITABLE_APPS_FIELDS: Record<string, Record<string, string>[]> = {
+  'm365-excel': [],
 }
 
 export const NON_EDITABLE_APP_CONNECTIONS = Object.keys(

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -16,7 +16,10 @@ const NON_EDITABLE_APPS_FIELDS = {
   'm365-excel': [{ label: 'Excel File', key: 'fileId' }],
   slack: [{ label: 'Channel', key: 'channel' }],
   telegram: [{ label: 'Chat ID', key: 'chatId' }],
-  tile: [{ label: 'Select Tile', key: 'tableId' }],
+  tile: [
+    { label: 'Select Tile', key: 'tableId' },
+    { label: null, key: 'columnId' },
+  ],
 }
 
 export const NON_EDITABLE_APP_CONNECTIONS = Object.keys(

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -4,3 +4,25 @@ export const EDITOR_MAX_HEIGHT = `calc(100vh - ${EDITOR_MARGIN_TOP})`
 export const EDITOR_RIGHT_DRAWER_WIDTH = '60%'
 
 export const MIN_FLOW_STEP_WIDTH = '320px'
+
+/**
+ * NOTE: there are certain fields that behave like connections
+ * such as slack channels, telegram chats, and excel files
+ * we do not allow collaborators to edit these fields
+ * we use both the label and key as there are some
+ * actions that have the same key but use different labels
+ */
+const NON_EDITABLE_APPS_FIELDS = {
+  'm365-excel': [{ label: 'Excel File', key: 'fileId' }],
+  slack: [{ label: 'Channel', key: 'channel' }],
+  telegram: [{ label: 'Chat ID', key: 'chatId' }],
+  tile: [{ label: 'Select Tile', key: 'tableId' }],
+}
+
+export const NON_EDITABLE_APP_CONNECTIONS = Object.keys(
+  NON_EDITABLE_APPS_FIELDS,
+)
+
+export const NON_EDITABLE_CONNECTION_FIELDS = Object.values(
+  NON_EDITABLE_APPS_FIELDS,
+).flat()

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -25,7 +25,9 @@ export default function PublishButton({
   return (
     <TouchableTooltip
       label={
-        hasFlowTransfer
+        flow.role === 'viewer'
+          ? 'You do not have permission to edit this pipe'
+          : hasFlowTransfer
           ? 'You cannot publish a pipe with a pending transfer'
           : isFlowIncomplete
           ? 'Set up for all steps must be completed before you can publish your pipe'
@@ -34,7 +36,9 @@ export default function PublishButton({
       wrapperStyles={{ width: '100%' }}
     >
       <Button
-        isDisabled={isFlowIncomplete || hasFlowTransfer}
+        isDisabled={
+          isFlowIncomplete || hasFlowTransfer || flow.role === 'viewer'
+        }
         isLoading={loading}
         spinner={<Spinner fontSize={24} />}
         size="sm"

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -182,13 +182,17 @@ export default function EditorLayout() {
   // navigate user to not found page if flow does not belong to the user
   if (
     error instanceof ApolloError &&
-    error?.graphQLErrors?.find((e) => e.message === 'NotFoundError')
+    error?.graphQLErrors?.find(
+      (e) =>
+        e.message === 'NotFoundError' ||
+        e.message === 'You do not have sufficient permissions for this pipe',
+    )
   ) {
     return <InvalidEditorPage />
   }
 
-  const isEditorReadOnly = hasFlowTransfer || flow?.active
-
+  const isEditorReadOnly =
+    hasFlowTransfer || flow?.active || flow?.role === 'viewer'
   if (!flowId || !flow) {
     return null
   }

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
@@ -7,6 +7,7 @@ import {
   FormErrorMessage,
   FormLabel,
   Input,
+  TouchableTooltip,
 } from '@opengovsg/design-system-react'
 import * as yup from 'yup'
 
@@ -16,6 +17,7 @@ import DisallowRequestInfobox from './FlowTransfer/DisallowRequestInfobox'
 import FlowTransferConnections from './FlowTransfer/FlowTransferConnections'
 import PublishedFlowInfobox from './FlowTransfer/PublishedFlowInfobox'
 import TransferFlowModal from './FlowTransfer/TransferFlowModal'
+import { editorSettingsStyles as styles } from './styles'
 
 const inputSchema = yup
   .object({
@@ -56,17 +58,11 @@ export default function FlowTransfer() {
 
   // boolean values to indicate whether infoboxes and button can be enabled
   const hasRequestedEmail = requestedEmail !== ''
-  const shouldDisableInput = flow.active || hasRequestedEmail
+  const shouldDisableInput =
+    flow.active || hasRequestedEmail || flow.role !== 'owner'
 
   return (
-    <Flex
-      py={{ base: '2rem', md: '3rem' }}
-      px={{ base: '1.5rem', md: '5rem' }}
-      flexDir="column"
-      gap={10}
-      maxW={{ base: '100%', xl: '60vw' }}
-      flex={1}
-    >
+    <Flex {...styles.editorSettingsWrapper}>
       <Text textStyle="h3-semibold">Transfer Pipe</Text>
 
       {flow.active && <PublishedFlowInfobox />}
@@ -80,17 +76,25 @@ export default function FlowTransfer() {
         <FormControl isInvalid={!shouldDisableInput && !isValid}>
           <Flex flexDir="column">
             <FormLabel isRequired={true}>Transfer Pipe Ownership</FormLabel>
-            <Input
-              disabled={shouldDisableInput}
-              placeholder={inputDescriptionText}
-              value={newOwnerEmail}
-              autoFocus={true}
-              {...register('email', {
-                onChange: (event) => {
-                  setNewOwnerEmail(event.target.value.toLowerCase())
-                },
-              })}
-            />
+            <TouchableTooltip
+              label={
+                flow.role !== 'owner'
+                  ? 'Only the Pipe owner can transfer ownership'
+                  : ''
+              }
+            >
+              <Input
+                disabled={shouldDisableInput}
+                placeholder={inputDescriptionText}
+                value={newOwnerEmail}
+                autoFocus={true}
+                {...register('email', {
+                  onChange: (event) => {
+                    setNewOwnerEmail(event.target.value.toLowerCase())
+                  },
+                })}
+              />
+            </TouchableTooltip>
 
             {isDirty && !isValid && (
               <FormErrorMessage>

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
@@ -55,6 +55,7 @@ export default function DisallowRequestInfobox() {
           onClick={onFlowTransferStatusUpdate}
           variant="clear"
           colorScheme="secondary"
+          isDisabled={flow.role !== 'owner'}
         >
           Cancel
         </Button>

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -17,7 +17,8 @@ export default function EmptyFlowStepHeader(
   props: EmptyFlowStepHeaderProps,
 ): JSX.Element {
   const { isTrigger, onModalOpen, isNested } = props
-  const { isDrawerOpen, isMobile, isEmptyPipe } = useContext(EditorContext)
+  const { isDrawerOpen, isMobile, isEmptyPipe, readOnly } =
+    useContext(EditorContext)
 
   return (
     <Flex
@@ -30,16 +31,16 @@ export default function EmptyFlowStepHeader(
       h={isNested ? '48px' : '64px'}
       alignItems="center"
       gap={4}
-      onClick={onModalOpen}
+      onClick={() => !readOnly && onModalOpen()}
       _hover={{
         bg: 'interaction.muted.neutral.hover',
-        cursor: 'pointer',
+        cursor: readOnly ? 'not-allowed' : 'pointer',
       }}
       _active={{
         bg: 'interaction.muted.neutral.active',
       }}
       w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)}
-      sx={isEmptyPipe && isTrigger ? pulsingBoxStyles : {}}
+      sx={isEmptyPipe && isTrigger && !readOnly ? pulsingBoxStyles : {}}
     >
       <Icon
         as={isTrigger ? BiSolidBolt : BiPlus}

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -114,10 +114,18 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
 
             <Flex alignItems="center" gap={1.5} justifyContent="flex-end">
               <Badge
-                colorScheme={flow?.active ? 'success' : 'grey'}
+                colorScheme={
+                  flow?.active && flow.role !== 'viewer' ? 'success' : 'grey'
+                }
                 variant="subtle"
               >
-                <Text>{flow?.active ? 'Published' : 'Draft'}</Text>
+                <Text>
+                  {flow.role === 'viewer'
+                    ? 'View Only'
+                    : flow?.active
+                    ? 'Published'
+                    : 'Draft'}
+                </Text>
               </Badge>
 
               {showMenu ? (

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
@@ -1,10 +1,11 @@
 import { type IApp } from '@plumber/types'
 
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 import { FormControl } from '@chakra-ui/react'
 import { FormLabel } from '@opengovsg/design-system-react'
 
 import { SingleSelect } from '@/components/SingleSelect'
+import { EditorContext } from '@/contexts/Editor'
 
 import { DEFAULT_ADD_CONNECTION_LABEL } from '../constants'
 
@@ -27,6 +28,7 @@ function ChooseConnectionDropdown({
   application,
   onAddNewConnection,
 }: ChooseConnectionDropdownProps) {
+  const { flow } = useContext(EditorContext)
   const onSelectionChange = useCallback(
     (value: string) => {
       onChange(value, false)
@@ -35,6 +37,8 @@ function ChooseConnectionDropdown({
   )
 
   const items = [...connectionOptions]
+  const canAddNew =
+    application?.auth?.connectionType === 'user-added' && flow.role === 'owner'
 
   return (
     <>
@@ -50,7 +54,7 @@ function ChooseConnectionDropdown({
           value={value || ''}
           onChange={onSelectionChange}
           addNew={
-            application?.auth?.connectionType === 'user-added'
+            canAddNew
               ? {
                   type: 'modal',
                   label:

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -96,10 +96,20 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      const result = await onUpdateStep({
-        ...currentStep,
-        status: isSubStepValid ? 'completed' : 'incomplete',
-      })
+      const result = await onUpdateStep(
+        {
+          ...currentStep,
+          status: isSubStepValid ? 'completed' : 'incomplete',
+        },
+        () => {
+          toast({
+            title: 'Step saved successfully!',
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        },
+      )
 
       if (!result) {
         throw new Error('Failed to save step')

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -114,12 +114,6 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       if (!result) {
         throw new Error('Failed to save step')
       }
-      toast({
-        title: 'Step saved successfully!',
-        status: 'success',
-        duration: 2000,
-        isClosable: true,
-      })
     } catch (error) {
       console.error('Error saving step', error)
       throw error // Re-throw the error so calling functions know saveStep failed

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -117,7 +117,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
         addNewOption={
-          schema.addNewOption && !canCollaboratorEdit
+          schema.addNewOption && (flow.role === 'owner' || canCollaboratorEdit)
             ? schema.addNewOption
             : undefined
         }

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -1,5 +1,7 @@
 import type { IField, IFieldDropdownOption } from '@plumber/types'
 
+import { useContext } from 'react'
+
 import AttachmentSuggestions from '@/components/AttachmentSuggestions'
 import ControlledAutocomplete from '@/components/ControlledAutocomplete'
 import DragDropInput from '@/components/DragDropInput'
@@ -7,8 +9,11 @@ import MultiRow from '@/components/MultiRow'
 import MultiSelect from '@/components/MultiSelect'
 import RichTextEditor from '@/components/RichTextEditor'
 import TextField from '@/components/TextField'
+import { EditorContext } from '@/contexts/Editor'
 import { useIsFieldHidden } from '@/helpers/isFieldHidden'
 import useDynamicData from '@/hooks/useDynamicData'
+
+import { NON_EDITABLE_CONNECTION_FIELDS } from '../Editor/constants'
 
 import BooleanRadio from './BooleanRadio'
 
@@ -45,6 +50,16 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     tooltipText,
     noVariablesMessage,
   } = schema
+
+  /**
+   * there are some fields that collaborators cannot edit
+   * such as slack channels, telegram chats, and excel files
+   */
+  const { flow } = useContext(EditorContext)
+  const canCollaboratorEdit = !NON_EDITABLE_CONNECTION_FIELDS.find(
+    (item) => item.label === label && item.key === name,
+  )
+  const isReadOnly = flow.role !== 'owner' && (readOnly || !canCollaboratorEdit)
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(
@@ -101,11 +116,16 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         // if schema source is defined, dynamic data is supported
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
-        addNewOption={schema.addNewOption}
+        addNewOption={
+          schema.addNewOption && !canCollaboratorEdit
+            ? schema.addNewOption
+            : undefined
+        }
         clickableLink={schema.clickableLink}
         label={label}
         placeholder={placeholder}
         variableTypes={schema.variableTypes}
+        readOnly={isReadOnly}
       />
     )
   }
@@ -151,7 +171,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         defaultValue={value}
         required={required}
         placeholder={placeholder}
-        readOnly={readOnly}
+        readOnly={isReadOnly}
         name={computedName}
         label={label}
         multiline={type === 'multiline'}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -59,7 +59,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
   const isNonEditableField = NON_EDITABLE_CONNECTION_FIELDS.some(
     (item) => item.label === label && item.key === name,
   )
-  const isReadOnly = readOnly || (flow.role !== 'owner' && isNonEditableField)
+  const isReadOnly = readOnly || (flow?.role !== 'owner' && isNonEditableField)
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -56,10 +56,10 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
    * such as slack channels, telegram chats, and excel files
    */
   const { flow } = useContext(EditorContext)
-  const canCollaboratorEdit = !NON_EDITABLE_CONNECTION_FIELDS.find(
+  const isNonEditableField = NON_EDITABLE_CONNECTION_FIELDS.some(
     (item) => item.label === label && item.key === name,
   )
-  const isReadOnly = flow.role !== 'owner' && (readOnly || !canCollaboratorEdit)
+  const isReadOnly = readOnly || (flow.role !== 'owner' && isNonEditableField)
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(
@@ -117,9 +117,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
         addNewOption={
-          schema.addNewOption && (flow.role === 'owner' || canCollaboratorEdit)
-            ? schema.addNewOption
-            : undefined
+          schema.addNewOption && !isReadOnly ? schema.addNewOption : undefined
         }
         clickableLink={schema.clickableLink}
         label={label}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -125,7 +125,6 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         label={label}
         placeholder={placeholder}
         variableTypes={schema.variableTypes}
-        readOnly={isReadOnly}
       />
     )
   }

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -62,7 +62,7 @@ interface IEditorContextValue {
     eventKey: string,
     connectionId?: string,
   ) => Promise<IStep>
-  onUpdateStep: (step: IStep) => Promise<IStep>
+  onUpdateStep: (step: IStep, onCompleted?: () => void) => Promise<IStep>
   allApps: IApp[]
   resetForm: () => void
   resetTimestamp: number
@@ -296,7 +296,7 @@ export const EditorProvider = ({
    */
   const [updateStep] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
-    async (step: IStep) => {
+    async (step: IStep, onCompleted?: () => void) => {
       const mutationInput: Record<string, unknown> = {
         id: step.id,
         key: step.key,
@@ -324,6 +324,7 @@ export const EditorProvider = ({
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
         update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
+        onCompleted: () => onCompleted?.(),
       })
 
       return updatedStep.data?.updateStep as IStep

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -40,6 +40,7 @@ interface IEditorContextValue {
   readOnly: boolean
   testExecutionSteps: IExecutionStep[]
   currentStepId: string | null
+  hasEditPermission: boolean
   hasForEach: boolean
   hasIfThen: boolean
   currentTestExecutionStep: IExecutionStep | null
@@ -71,6 +72,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   flow: {} as IFlow,
   flowId: '',
   currentStepId: null,
+  hasEditPermission: false,
   hasForEach: false,
   hasIfThen: false,
   currentTestExecutionStep: null,
@@ -400,6 +402,7 @@ export const EditorProvider = ({
       value={{
         allApps,
         currentStepId,
+        hasEditPermission: flow.role === 'owner' || flow.role === 'editor',
         hasForEach,
         hasIfThen,
         isDrawerOpen,
@@ -409,7 +412,7 @@ export const EditorProvider = ({
         flowId,
         currentTestExecutionStep,
         isTestExecuting,
-        readOnly,
+        readOnly: readOnly || flow.role === 'viewer',
         shouldWarnOnLeave,
         stepsWithVars,
         testExecutionSteps,

--- a/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
+++ b/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
@@ -35,7 +35,10 @@ export default function InvalidEditorPage() {
             textAlign={{ base: 'center', md: 'left' }}
             fontWeight="normal"
           >
-            Pipe not found, you may have transferred it to someone else 🤔
+            Pipe not found.
+            <br />
+            It might have been transferred to someone else, or you may no longer
+            have access. 🤔
           </Text>
           <Link
             textStyle="h6"

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -66,7 +66,7 @@ function FlowsList({
   return (
     <Box>
       {flows.map((flow) => (
-        <FlowRow key={flow.id} flow={flow} />
+        <FlowRow key={flow.id} flow={flow} showMenu={flow.role !== 'viewer'} />
       ))}
     </Box>
   )


### PR DESCRIPTION
__Note to reviewer__: this PR is purely to restrict interactions with fields based on roles. Can / cannot click on fields based on roles, but nothing can be saved at this point. The ability to add / update / delete step will come in subsequent PRs.

## TL;DR
This PR restricts user interactions in the Editor based on roles.
At this point, permissions are the most restrictive, and we gradually allow more flexibility for Editors as we incorporate the `flow_connections` in subsequent PRs.

## What changed?
- Added "View only" tag for pipes where the user is a viewer
- Disabled editing capabilities for viewers in the Editor; viewers will see a 'Published' view
- Restricted connection fields (Slack channels, Telegram chats, Excel files, etc.) from being edited by collaborators
- Disabled pipe transfer functionality for non-owners
- Updated the invalid editor page message to be more descriptive

## How to test?
Create a Pipe with various connections (Tiles, Telegram, LetterSG, Slack) and share with collaborators.
_basically test that fields that should not be editable cannot be edited_

- [ ] Editor
    - [ ] Tiles
      - [ ] Cannot create new Tile
      - [ ] Cannot create new Column
  - [ ] Can edit fields
  - [ ] Can click on Add step

- [ ] Viewer
  - [ ] Cannot edit any fields
 -  [ ] Can expand inputs to view the values
  - [ ] Can expand check step results

