### PR TITLE
[COLLAB-10]: Editors can edit, save, and check step

### DIFF
--- a/packages/backend/src/db/migrations/20250806004700_add_steps_updated_by.ts
+++ b/packages/backend/src/db/migrations/20250806004700_add_steps_updated_by.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.uuid('updated_by').references('id').inTable('users').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.dropColumn('updated_by')
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
+import executeStep from '@/graphql/mutations/execute-step'
+import User from '@/models/user'
+import { TestStepOptions, TestStepResult } from '@/services/test-step'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+
+const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
+
+const getMockResolvedValue = (userId: string) => {
+  return {
+    id: mockStepId,
+    key: 'sendTransactionalEmail',
+    appKey: 'postman',
+    status: 'completed',
+    flow: {
+      id: mockFlowId,
+      userId,
+      testExecutionId: null as string | null,
+      $query: vi.fn().mockReturnValue({
+        patch: vi.fn().mockResolvedValue({}),
+      }),
+    },
+    $query: vi.fn().mockReturnValue({
+      patch: vi.fn().mockResolvedValue({}),
+    }),
+  }
+}
+
+vi.mock('@/services/test-step', () => ({
+  default: vi.fn(() => {
+    return {
+      executionStep: {
+        id: 'execution-step-1',
+        stepId: '8c2a70d1-e78b-431e-9069-a4d8f97883f7',
+        isFailed: false,
+      },
+      executionId: '8c2a70d1-e78b-431e-9069-a4d8f97883f8',
+    }
+  }),
+}))
+
+describe('executeStep mutation - access control', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testStepSpy: MockInstance<
+    (options: TestStepOptions) => Promise<TestStepResult>
+  >
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create test users
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    testStepSpy = vi.spyOn(await import('@/services/test-step'), 'default')
+  })
+
+  describe('access control', () => {
+    it('should allow owner to execute step successfully', async () => {
+      context.currentUser.withAccessible = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi
+                  .fn()
+                  .mockReturnValue(getMockResolvedValue(owner.id)),
+              }),
+            }),
+          }
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      const result = await executeStep(null, { input }, context)
+
+      expect(testStepSpy).toHaveBeenCalledWith({
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      })
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe('execution-step-1')
+    })
+
+    it('should allow editor to execute step successfully', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessible = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi
+                  .fn()
+                  .mockReturnValue(getMockResolvedValue(editor.id)),
+              }),
+            }),
+          }
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+      const result = await executeStep(null, { input }, context)
+
+      expect(testStepSpy).toHaveBeenCalledWith({
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      })
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe('execution-step-1')
+    })
+
+    it('should reject viewer from executing step', async () => {
+      context.currentUser = viewer
+      context.currentUser.withAccessible = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          throw new ForbiddenError(
+            'You do not have sufficient permissions for this pipe',
+          )
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+        ForbiddenError,
+      )
+    })
+
+    it('should reject non-collaborator from executing step', async () => {
+      context.currentUser = nonCollaborator
+      context.currentUser.withAccessible = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          throw new ForbiddenError(
+            'You do not have sufficient permissions for this pipe',
+          )
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+        ForbiddenError,
+      )
+    })
+  })
+
+  it('should require stepId input', async () => {
+    const input = {
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    context.currentUser.withAccessible = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        if (_type === 'step' && _requiredRole === 'editor') {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi.fn().mockReturnValue({
+                  id: mockStepId,
+                  key: 'sendTransactionalEmail',
+                  appKey: 'postman',
+                  status: 'completed',
+                  flow: {
+                    id: mockFlowId,
+                    userId: 'owner-user-id',
+                    testExecutionId: null,
+                    $query: vi.fn().mockReturnValue({
+                      patch: vi.fn().mockResolvedValue({}),
+                    }),
+                  },
+                  $query: vi.fn().mockReturnValue({
+                    patch: vi.fn().mockResolvedValue({}),
+                  }),
+                }),
+              }),
+            }),
+          }
+        }
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn().mockReturnValue(null),
+            }),
+          }),
+        }
+      })
+
+    await expect(executeStep(null, { input } as any, context)).rejects.toThrow()
+  })
+
+  it('should call testStep service with correct parameters', async () => {
+    context.currentUser.withAccessible = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn().mockReturnValue({
+                id: mockStepId,
+                key: 'sendTransactionalEmail',
+                appKey: 'postman',
+                status: 'completed',
+                flow: {
+                  id: mockFlowId,
+                  userId: 'owner-user-id',
+                  testExecutionId: null,
+                  $query: vi.fn().mockReturnValue({
+                    patch: vi.fn().mockResolvedValue({}),
+                  }),
+                },
+                $query: vi.fn().mockReturnValue({
+                  patch: vi.fn().mockResolvedValue({}),
+                }),
+              }),
+            }),
+          }),
+        }
+      })
+
+    const input = {
+      stepId: mockStepId,
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    await executeStep(null, { input }, context)
+
+    expect(testStepSpy).toHaveBeenCalledWith({
+      stepId: mockStepId,
+      testRunMetadata: { testKey: 'testValue' },
+    })
+  })
+
+  it('should throw error when step does not exist', async () => {
+    const input = {
+      stepId: 'non-existent-step-id',
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    context.currentUser.withAccessible = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn(() => {
+                throw new NotFoundError('Step not found')
+              }),
+            }),
+          }),
+        }
+      })
+
+    await expect(executeStep(null, { input }, context)).rejects.toThrow(
+      NotFoundError,
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
@@ -71,7 +72,7 @@ describe('executeStep mutation - access control', () => {
 
   describe('access control', () => {
     it('should allow owner to execute step successfully', async () => {
-      context.currentUser.withAccessible = vi
+      context.currentUser.withAccessibleSteps = vi
         .fn()
         .mockImplementation(({ _type, _requiredRole }) => {
           return {
@@ -103,7 +104,7 @@ describe('executeStep mutation - access control', () => {
 
     it('should allow editor to execute step successfully', async () => {
       context.currentUser = editor
-      context.currentUser.withAccessible = vi
+      context.currentUser.withAccessibleSteps = vi
         .fn()
         .mockImplementation(({ _type, _requiredRole }) => {
           return {
@@ -134,7 +135,7 @@ describe('executeStep mutation - access control', () => {
 
     it('should reject viewer from executing step', async () => {
       context.currentUser = viewer
-      context.currentUser.withAccessible = vi
+      context.currentUser.withAccessibleSteps = vi
         .fn()
         .mockImplementation(({ _type, _requiredRole }) => {
           throw new ForbiddenError(
@@ -154,7 +155,7 @@ describe('executeStep mutation - access control', () => {
 
     it('should reject non-collaborator from executing step', async () => {
       context.currentUser = nonCollaborator
-      context.currentUser.withAccessible = vi
+      context.currentUser.withAccessibleSteps = vi
         .fn()
         .mockImplementation(({ _type, _requiredRole }) => {
           throw new ForbiddenError(
@@ -178,7 +179,7 @@ describe('executeStep mutation - access control', () => {
       testRunMetadata: { testKey: 'testValue' },
     }
 
-    context.currentUser.withAccessible = vi
+    context.currentUser.withAccessibleSteps = vi
       .fn()
       .mockImplementation(({ _type, _requiredRole }) => {
         if (_type === 'step' && _requiredRole === 'editor') {
@@ -219,7 +220,7 @@ describe('executeStep mutation - access control', () => {
   })
 
   it('should call testStep service with correct parameters', async () => {
-    context.currentUser.withAccessible = vi
+    context.currentUser.withAccessibleSteps = vi
       .fn()
       .mockImplementation(({ _type, _requiredRole }) => {
         return {
@@ -262,11 +263,11 @@ describe('executeStep mutation - access control', () => {
 
   it('should throw error when step does not exist', async () => {
     const input = {
-      stepId: 'non-existent-step-id',
+      stepId: randomUUID(),
       testRunMetadata: { testKey: 'testValue' },
     }
 
-    context.currentUser.withAccessible = vi
+    context.currentUser.withAccessibleSteps = vi
       .fn()
       .mockImplementation(({ _type, _requiredRole }) => {
         return {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -680,6 +680,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'tiles',
+        connection: {},
         parameters: { tableId: mockTableId },
       }
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -130,13 +130,6 @@ describe('updateStep mutation', () => {
         connectionKey: 'postman',
         connectionId: mockConnectionId,
       })
-
-    context.currentUser.withAccessibleConnections =
-      createMockWithAccessibleConnections({
-        connectionId: mockConnectionId,
-        connectionKey: 'postman',
-        connectionNotFound: false,
-      })
   })
 
   it('should successfully update a step', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -127,6 +127,12 @@ describe('updateStep mutation', () => {
 
     context.currentUser.withAccessibleConnections =
       createMockWithAccessibleConnections({
+        connectionKey: 'postman',
+        connectionId: mockConnectionId,
+      })
+
+    context.currentUser.withAccessibleConnections =
+      createMockWithAccessibleConnections({
         connectionId: mockConnectionId,
         connectionKey: 'postman',
         connectionNotFound: false,
@@ -505,6 +511,12 @@ describe('updateStep mutation', () => {
 
       context.currentUser.withAccessibleConnections =
         createMockWithAccessibleConnections({
+          connectionKey: 'slack',
+          connectionId: mockConnectionId,
+        })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
           connectionId: mockConnectionId,
           connectionKey: 'slack',
         })
@@ -519,6 +531,12 @@ describe('updateStep mutation', () => {
         flowId: mockFlowId,
         flowUpdatedAt: testFlowISODateString,
       })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionKey: 'm365-excel',
+          connectionId: mockConnectionId,
+        })
 
       context.currentUser.withAccessibleConnections =
         createMockWithAccessibleConnections({

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -550,6 +550,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         parameterKey: 'fileId',
         parameterValue: '1234567890',
+        trx: expect.anything(),
       })
       expect(addSpy).not.toHaveBeenCalled()
     })
@@ -572,6 +573,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         addedBy: owner.id,
         connectionType: 'connection',
+        trx: expect.anything(),
       })
     })
 
@@ -590,6 +592,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         addedBy: owner.id,
         connectionType: 'connection',
+        trx: expect.anything(),
       })
       expect(patchSpy).not.toHaveBeenCalled()
     })
@@ -664,7 +667,15 @@ describe('updateStep mutation', () => {
         .spyOn(TableCollaborator, 'addCollaborator')
         .mockResolvedValue(undefined)
       const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
-      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+      const addSpy = vi
+        .spyOn(FlowConnections, 'addFlowConnection')
+        .mockResolvedValue({
+          flowId: mockFlowId,
+          connectionId: mockTableId,
+          addedBy: owner.id,
+          connectionType: 'table',
+          metadata: {},
+        } as any)
       const getCollaboratorsSpy = vi
         .spyOn(FlowCollaborator, 'getCollaborators')
         .mockResolvedValue([
@@ -703,7 +714,9 @@ describe('updateStep mutation', () => {
         connectionId: mockTableId,
         addedBy: owner.id,
         connectionType: 'table',
+        trx: expect.anything(),
       })
+      expect(getCollaboratorsSpy).toHaveBeenCalled()
       expect(getCollaboratorsSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         trx: expect.anything(),

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -148,6 +148,7 @@ describe('updateStep mutation', () => {
       parameters: { updatedParam: 'newValue' },
       status: 'completed',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -167,6 +168,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -225,6 +227,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'incomplete',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -243,6 +246,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'incomplete',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -261,6 +265,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: { stepName: 'Updated Step Name' },
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -279,6 +284,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: { stepName: '' },
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -315,6 +321,7 @@ describe('updateStep mutation', () => {
         stepName: 'Updated Step Name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      updatedBy: context.currentUser.id,
     })
 
     // Verify the existing templateConfig was preserved in the result
@@ -359,6 +366,7 @@ describe('updateStep mutation', () => {
         stepName: '',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      updatedBy: context.currentUser.id,
     })
 
     // Verify the existing templateConfig was preserved in the result
@@ -460,6 +468,7 @@ describe('updateStep mutation', () => {
           parameters: { updatedParam: 'newValue' },
           status: 'completed',
           config: {},
+          updatedBy: context.currentUser.id,
         })
       },
     )

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -13,7 +13,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
 
   // Just checking for permissions here
   const stepToTest = await context.currentUser
-    .$relatedQuery('steps')
+    .withAccessible({ type: 'step', requiredRole: 'editor' })
     .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -13,7 +13,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
 
   // Just checking for permissions here
   const stepToTest = await context.currentUser
-    .withAccessible({ type: 'step', requiredRole: 'editor' })
+    .withAccessibleSteps({ requiredRole: 'editor' })
     .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -64,6 +64,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         connectionId: input.connection.id,
         parameters: input.parameters,
         status: shouldInvalidate ? 'incomplete' : step.status,
+        updatedBy: context.currentUser.id,
         config: {
           ...existingConfig,
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,10 +1,10 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
-import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
+import {
+  addFlowConnection,
+  addFlowTableConnection,
+} from '@/helpers/add-flow-connection'
 import App from '@/models/app'
-import FlowCollaborator from '@/models/flow-collaborators'
-import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
-import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -95,59 +95,21 @@ const updateStep: MutationResolvers['updateStep'] = async (
      */
     if (step.role === 'owner') {
       const appKey = updatedStep?.appKey
-      /**
 
-       */
-      if (appKey && updatedStep?.parameters?.tableId) {
-        await FlowConnections.addFlowConnection({
+      // tiles special handling
+      if (appKey === 'tiles' && updatedStep?.parameters?.tableId) {
+        await addFlowTableConnection({
           flowId: updatedStep.flowId,
-          connectionId: updatedStep.parameters.tableId as string,
+          tableId: updatedStep.parameters.tableId as string,
           addedBy: context.currentUser.id,
-          connectionType: 'table',
-        })
-
-        const collaborators = await FlowCollaborator.getCollaborators({
-          flowId: updatedStep.flowId,
           trx,
         })
-
-        /**
-         * use Promise.all so that we use the addCollaborator function, which checks
-         * if the collaborator already exists to avoid duplicates
-         */
-        await Promise.all(
-          collaborators.map(async ({ userId, role }) => {
-            await TableCollaborator.addCollaborator({
-              userId,
-              tableId: updatedStep.parameters.tableId as string,
-              role,
-              trx,
-            })
-          }),
-        )
       } else if (updatedStep?.connectionId) {
-        const { parameterKey } = APP_CONNECTION_FIELDS?.[appKey] ?? {}
-
-        const userId = updatedStep?.connection?.userId
-        const connectionId = updatedStep?.connectionId
-
-        // only flow connections with a parameterKey specified need to have
-        // its metadata updated with the parameter value
-        if (updatedStep.parameters?.[parameterKey]) {
-          await FlowConnections.patchFlowConnectionMetadata({
-            flowId: updatedStep.flowId,
-            connectionId,
-            parameterKey,
-            parameterValue: updatedStep.parameters[parameterKey] as string,
-          })
-        } else {
-          await FlowConnections.addFlowConnection({
-            flowId: updatedStep.flowId,
-            connectionId,
-            addedBy: userId,
-            connectionType: 'connection',
-          })
-        }
+        await addFlowConnection({
+          step: updatedStep,
+          addedBy: context.currentUser.id,
+          trx,
+        })
       }
     }
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -77,17 +77,28 @@ const updateStep: MutationResolvers['updateStep'] = async (
       })
 
     /**
-     * NOTE: we need to update flow connections for specific apps:
-     *
+     * NOTE: we need to update flow connections for apps with connections:
      * Tiles:
      * 1. add the collaborator to the flow connections table
      * 2. add the collaborator to the table collaborators table
      *
+     * TODO (kevinkim-ogp): phase 2
+     * collaborator should be able to add their own tiles,
+     * and the owner will be added as an editor to the Tile
+     *
      * Other connections:
      * 1. add the collaborator to the flow connections table
+     *
+     * TODO (kevinkim-ogp): phase 2
+     * collaborator should be able to add their own connections,
+     * it will be tied to this specific flow only
      */
     if (step.role === 'owner') {
-      if (updatedStep.appKey === 'tiles' && updatedStep?.parameters?.tableId) {
+      const appKey = updatedStep?.appKey
+      /**
+
+       */
+      if (appKey && updatedStep?.parameters?.tableId) {
         await FlowConnections.addFlowConnection({
           flowId: updatedStep.flowId,
           connectionId: updatedStep.parameters.tableId as string,
@@ -114,13 +125,15 @@ const updateStep: MutationResolvers['updateStep'] = async (
             })
           }),
         )
-      } else if (APP_CONNECTION_FIELDS[updatedStep.appKey]) {
-        const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
+      } else if (updatedStep?.connectionId) {
+        const { parameterKey } = APP_CONNECTION_FIELDS?.[appKey] ?? {}
 
         const userId = updatedStep?.connection?.userId
         const connectionId = updatedStep?.connectionId
 
-        if (updatedStep.parameters[parameterKey]) {
+        // only flow connections with a parameterKey specified need to have
+        // its metadata updated with the parameter value
+        if (updatedStep.parameters?.[parameterKey]) {
           await FlowConnections.patchFlowConnectionMetadata({
             flowId: updatedStep.flowId,
             connectionId,

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,6 +1,7 @@
 import { IFlowCollabRole } from '@plumber/types'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
+import { addFlowTableConnection } from '@/helpers/add-flow-connection'
 import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
@@ -8,7 +9,6 @@ import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
-import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -71,26 +71,15 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           // add all connections to the flow_connections table
           // first time sharing is always by the owner
           // so we use the flow user_id
-          const connectionInserts = [
-            // Handle regular connections
-            ...Object.entries(connectionDetails.connection).map(
-              ([connectionId, metadata]) => ({
-                flowId,
-                connectionId,
-                addedBy: flow.userId,
-                connectionType: 'connection' as const,
-                metadata,
-              }),
-            ),
-            // Handle table connections (Tiles)
-            ...connectionDetails.table.map((tableId) => ({
-              flowId,
-              connectionId: tableId,
-              addedBy: flow.userId,
-              connectionType: 'table' as const,
-              metadata: {},
-            })),
-          ]
+          const connectionInserts = Object.entries(
+            connectionDetails.connection,
+          ).map(([connectionId, metadata]) => ({
+            flowId,
+            connectionId,
+            addedBy: flow.userId,
+            connectionType: 'connection' as const,
+            metadata,
+          }))
 
           if (connectionInserts.length > 0) {
             await FlowConnections.query(trx)
@@ -131,20 +120,17 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
         }
 
         /**
-         * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
-         * this ensures that the Tile appears in the dropdown when they are working
-         * on the flow
-         *
-         * use Promise.all so that we use the addCollaborator function, which checks
-         * if the collaborator already exists to avoid duplicates
+         * use Promise.all so that we use the addFlowTableConnection function, which checks
+         * if the collaborator already exists to avoid duplicates and adds the tile to
+         * flow_connections at the same time
          */
         if (connectionDetails.table.length > 0) {
           await Promise.all(
             connectionDetails.table.map(async (tableId) => {
-              await TableCollaborator.addCollaborator({
-                userId: collaboratorUser.id,
+              await addFlowTableConnection({
+                flowId,
                 tableId,
-                role,
+                addedBy: context.currentUser.id,
                 trx,
               })
             }),

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -1,10 +1,6 @@
 import apps from '@/apps'
-import {
-  APP_CONNECTION_FIELDS,
-  TILES_CONNECTION_ID,
-} from '@/helpers/get-shared-connection-details'
+import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import globalVariable from '@/helpers/global-variable'
-import FlowConnections from '@/models/flow-connections'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -54,22 +50,50 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
 
   const fetchedData = await command.run($)
 
-  // we should filter out the dynamic data to only show the options
-  // that have been shared with the user
+  /**
+   * COLLABORATORS
+   * filter out the dynamic data to only show the options that have been shared with the user
+   *
+   * Tiles:
+   * - only show the Tiles that have been shared
+   *
+   * Other connections:
+   * - only show the connections that have been shared
+   *
+   * TODO (kevinkim-ogp): phase 2
+   * - collaborator should be able to add their own Tiles
+   */
   if (
+    step.role !== 'owner' &&
     APP_CONNECTION_FIELDS[step.appKey] &&
-    APP_CONNECTION_FIELDS[step.appKey].dynamicDataKey === dynamicDataKey &&
-    step.role !== 'owner'
+    APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
   ) {
-    const flowConnections = await FlowConnections.withAccessible({
-      userId: context.currentUser.id,
-    }).where({
-      // SPECIAL CASE: Tiles does not have a connection id
-      // so we use a special connection id to store the dynamic data
-      connection_id:
-        app.key === 'tiles' ? TILES_CONNECTION_ID : step.connectionId,
-      flow_id: step.flowId,
-    })
+    const whereClause =
+      step.appKey === 'tiles'
+        ? {
+            connection_type: 'table',
+            flow_id: step.flowId,
+          }
+        : {
+            connection_id: step.connectionId,
+            flow_id: step.flowId,
+          }
+    const flowConnections = await context.currentUser
+      .withAccessible({
+        type: 'flow-connections',
+        requiredRole: 'viewer',
+      })
+      .where(whereClause)
+
+    // TILES SPECIAL CASE:
+    // tile ids are stored directly in the connection_id column
+    if (step.appKey === 'tiles') {
+      return fetchedData.data.filter((data) =>
+        flowConnections.some(
+          (flowConnection) => flowConnection.connectionId === data.value,
+        ),
+      )
+    }
 
     const allowedValues = flowConnections
       .map((flowConnection) => {

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -68,39 +68,43 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
     APP_CONNECTION_FIELDS[step.appKey] &&
     APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
   ) {
-    const flowConnections = await context.currentUser
-      .withAccessibleFlowConnections({ requiredRole: 'viewer' })
-      .where(
-        step.appKey === 'tiles'
-          ? {
-              connection_type: 'table',
-              'flow_connections.flow_id': step.flowId,
-            }
-          : {
-              connection_id: step.connectionId,
-              'flow_connections.flow_id': step.flowId,
-            },
-      )
+    switch (step.appKey) {
+      case 'tiles': {
+        const flowConnections = await context.currentUser
+          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+          .where({
+            connection_type: 'table',
+            'flow_connections.flow_id': step.flowId,
+          })
 
-    // TILES SPECIAL CASE:
-    // tile ids are stored directly in the connection_id column
-    if (step.appKey === 'tiles') {
-      return fetchedData.data.filter((data) =>
-        flowConnections.some(
-          (flowConnection) => flowConnection.connectionId === data.value,
-        ),
-      )
+        return fetchedData.data.filter((data) =>
+          flowConnections.some(
+            (flowConnection) => flowConnection.connectionId === data.value,
+          ),
+        )
+      }
+
+      default: {
+        const flowConnections = await context.currentUser
+          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+          .where({
+            connection_id: step.connectionId,
+            'flow_connections.flow_id': step.flowId,
+          })
+
+        const allowedValues = flowConnections
+          .map((flowConnection) => {
+            return flowConnection.metadata[
+              APP_CONNECTION_FIELDS[step.appKey].parameterKey
+            ]
+          })
+          .flat()
+
+        return fetchedData.data.filter((data) =>
+          allowedValues.includes(data.value),
+        )
+      }
     }
-
-    const allowedValues = flowConnections
-      .map((flowConnection) => {
-        return flowConnection.metadata[
-          APP_CONNECTION_FIELDS[step.appKey].parameterKey
-        ]
-      })
-      .flat()
-
-    return fetchedData.data.filter((data) => allowedValues.includes(data.value))
   }
 
   if (fetchedData.error) {

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -1,5 +1,10 @@
 import apps from '@/apps'
+import {
+  APP_CONNECTION_FIELDS,
+  TILES_CONNECTION_ID,
+} from '@/helpers/get-shared-connection-details'
 import globalVariable from '@/helpers/global-variable'
+import FlowConnections from '@/models/flow-connections'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -48,7 +53,34 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
   }
 
   const fetchedData = await command.run($)
-  // TODO (kevinkim-ogp): should filter out data that is not accessible to the user
+
+  // we should filter out the dynamic data to only show the options
+  // that have been shared with the user
+  if (
+    APP_CONNECTION_FIELDS[step.appKey] &&
+    APP_CONNECTION_FIELDS[step.appKey].dynamicDataKey === dynamicDataKey &&
+    step.role !== 'owner'
+  ) {
+    const flowConnections = await FlowConnections.withAccessible({
+      userId: context.currentUser.id,
+    }).where({
+      // SPECIAL CASE: Tiles does not have a connection id
+      // so we use a special connection id to store the dynamic data
+      connection_id:
+        app.key === 'tiles' ? TILES_CONNECTION_ID : step.connectionId,
+      flow_id: step.flowId,
+    })
+
+    const allowedValues = flowConnections
+      .map((flowConnection) => {
+        return flowConnection.metadata[
+          APP_CONNECTION_FIELDS[step.appKey].parameterKey
+        ]
+      })
+      .flat()
+
+    return fetchedData.data.filter((data) => allowedValues.includes(data.value))
+  }
 
   if (fetchedData.error) {
     throw new Error(JSON.stringify(fetchedData.error))

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -68,22 +68,19 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
     APP_CONNECTION_FIELDS[step.appKey] &&
     APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
   ) {
-    const whereClause =
-      step.appKey === 'tiles'
-        ? {
-            connection_type: 'table',
-            flow_id: step.flowId,
-          }
-        : {
-            connection_id: step.connectionId,
-            flow_id: step.flowId,
-          }
     const flowConnections = await context.currentUser
-      .withAccessible({
-        type: 'flow-connections',
-        requiredRole: 'viewer',
-      })
-      .where(whereClause)
+      .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+      .where(
+        step.appKey === 'tiles'
+          ? {
+              connection_type: 'table',
+              'flow_connections.flow_id': step.flowId,
+            }
+          : {
+              connection_id: step.connectionId,
+              'flow_connections.flow_id': step.flowId,
+            },
+      )
 
     // TILES SPECIAL CASE:
     // tile ids are stored directly in the connection_id column

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -1,0 +1,99 @@
+import { IStep } from '@plumber/types'
+
+import { Transaction } from 'objection'
+
+import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
+
+import { APP_CONNECTION_FIELDS } from './get-shared-connection-details'
+
+interface AddFlowConnectionParams {
+  step: IStep
+  addedBy: string
+  trx?: Transaction
+}
+
+interface AddTableFlowConnectionParams {
+  flowId: string
+  tableId: string
+  addedBy: string
+  trx?: Transaction
+}
+
+async function addFlowConnection({
+  step,
+  addedBy,
+  trx,
+}: AddFlowConnectionParams): Promise<void> {
+  const appKey = step.appKey
+  const { parameterKey } = APP_CONNECTION_FIELDS?.[appKey] ?? {}
+
+  const flowId = step.flowId
+  const connectionId = step?.connectionId
+
+  // only flow connections with a parameterKey specified need to have
+  // its metadata updated with the parameter value
+  if (step.parameters?.[parameterKey]) {
+    await FlowConnections.patchFlowConnectionMetadata({
+      flowId,
+      connectionId,
+      parameterKey,
+      parameterValue: step.parameters[parameterKey] as string,
+      trx,
+    })
+  } else {
+    await FlowConnections.addFlowConnection({
+      flowId,
+      connectionId,
+      addedBy,
+      connectionType: 'connection',
+      trx,
+    })
+  }
+}
+
+/**
+ * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
+ * this ensures that the Tile appears in the dropdown when they are working
+ * on the flow
+ */
+async function addFlowTableConnection({
+  flowId,
+  tableId,
+  addedBy,
+  trx,
+}: AddTableFlowConnectionParams): Promise<void> {
+  // first try to add the connection to the flow_connections table
+  const addedConnection = await FlowConnections.addFlowConnection({
+    flowId,
+    connectionId: tableId,
+    addedBy,
+    connectionType: 'table',
+    trx,
+  })
+
+  // only need to proceed if the tile was added to flow_connections
+  if (addedConnection) {
+    // then add the collaborators to the flow_collaborators table
+    const collaborators = await FlowCollaborator.getCollaborators({
+      flowId,
+      trx,
+    })
+
+    // use Promise.all so that we use the addCollaborator function, which checks
+    // if the collaborator already exists to avoid duplicates
+    await Promise.all(
+      collaborators.map(async ({ userId, role }) => {
+        await TableCollaborator.addCollaborator({
+          userId,
+          tableId,
+          role,
+          trx,
+        })
+      }),
+    )
+  }
+}
+
+export { addFlowConnection, addFlowTableConnection }

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -30,6 +30,7 @@ export const APP_CONNECTION_FIELDS: Record<
    */
   tiles: {
     parameterKey: 'tableId',
+    dynamicDataKey: 'listTables',
   },
 }
 

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -30,7 +30,6 @@ export const APP_CONNECTION_FIELDS: Record<
    */
   tiles: {
     parameterKey: 'tableId',
-    dynamicDataKey: 'listTables',
   },
 }
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -122,13 +122,15 @@ class FlowConnections extends Base {
     connectionId,
     parameterKey,
     parameterValue,
+    trx,
   }: {
     flowId: string
     connectionId: string
     parameterKey: string
     parameterValue: string
+    trx?: Transaction
   }) => {
-    return await this.query()
+    return await this.query(trx)
       .where({
         flow_id: flowId,
         connection_id: connectionId,

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -40,6 +40,7 @@ class Step extends Base {
   executionSteps: ExecutionStep[]
   config: IStepConfig
   role?: IFlowCollabRole
+  updatedBy?: string
 
   static tableName = 'steps'
 

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -14,6 +14,7 @@ import Base from './base'
 import Connection from './connection'
 import Execution from './execution'
 import Flow from './flow'
+import FlowConnections from './flow-connections'
 import FlowTransfer from './flow-transfers'
 import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
@@ -268,6 +269,25 @@ class User extends Base {
             this.whereNotNull('fc.role').andWhere('fc.role', 'in', allowedRoles)
           })
       })
+  }
+
+  withAccessibleFlowConnections({
+    requiredRole,
+    queryBuilder,
+    trx,
+  }: {
+    requiredRole: IFlowCollabRole
+    queryBuilder?: ExtendedQueryBuilder<FlowConnections, FlowConnections[]>
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || FlowConnections.query(trx)
+    baseQuery
+      .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
+      .join('flows', 'flows.id', 'flow_connections.flow_id')
+
+    this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    return baseQuery
   }
 }
 

--- a/packages/backend/src/services/test-step.ts
+++ b/packages/backend/src/services/test-step.ts
@@ -9,12 +9,12 @@ import { processAction } from '@/services/action'
 import { processFlow } from '@/services/flow'
 import { processTrigger } from '@/services/trigger'
 
-interface TestStepOptions {
+export interface TestStepOptions {
   stepId: string
   testRunMetadata?: TestRunStepMetadata
 }
 
-interface TestStepResult {
+export interface TestStepResult {
   executionStep: ExecutionStep
   executionId: string
 }

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -7,7 +7,10 @@ export const MIN_FLOW_STEP_WIDTH = '320px'
 
 /**
  * NOTE: there are certain fields that behave like connections
- * such as excel files
+ * we use this to manage two things:
+ * 1. which apps do not allow collaborators to edit their connections
+ * 2. which fields behave like connections
+ *
  * we do not allow collaborators to edit these fields
  * we use both the label and key as there are some
  * actions that have the same key but use different labels

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -56,10 +56,12 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
    * such as slack channels, telegram chats, and excel files
    */
   const { flow } = useContext(EditorContext)
-  const isNonEditableField = NON_EDITABLE_CONNECTION_FIELDS.some(
-    (item) => item.label === label && item.key === name,
-  )
-  const isReadOnly = readOnly || (flow?.role !== 'owner' && isNonEditableField)
+
+  const canCollaboratorAddNew =
+    !NON_EDITABLE_CONNECTION_FIELDS.find(
+      (item) => item.label === label && item.key === name,
+    ) && flow?.role === 'editor'
+  const isReadOnly = flow?.role !== 'owner' || readOnly
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(
@@ -117,7 +119,10 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
         addNewOption={
-          schema.addNewOption && !isReadOnly ? schema.addNewOption : undefined
+          schema.addNewOption &&
+          (flow.role === 'owner' || canCollaboratorAddNew)
+            ? schema.addNewOption
+            : undefined
         }
         clickableLink={schema.clickableLink}
         label={label}


### PR DESCRIPTION
### TL;DR
Added ability for EDITORs to edit, save, and check step, including dynamic data fields such as Tile, Slack channels, Telegram chats that have been shared.
Also added tracking of which user last updated the step.

_Note: CANNOT change connections here yet._

### What changed?
- Added a new database migration to add the `updated_by` column to the `steps` table, which references the `id` column in the `users` table
- Refactored access control in the `executeStep` and `updateStep` mutations to use the `withAccessible` method with proper role requirements
- Added tests for the access control in both mutations to ensure only users with appropriate permissions can execute or update steps

### How to test?
- [ ] Update a step in the UI and verify that the `updated_by` field is populated in the database with the current user's ID
- [ ]  Test access control by:
   - [ ]  Creating a flow with collaborators of different roles (editor, viewer)
   - [ ] Verify that editors can update and check steps
     - [ ] Verify that editor can change to a different Tile (owner needs to create a new action with a different Tile to 'share' the Tile with the editor)
   - [ ]  Verify that viewers cannot update or execute steps
