### PR TITLE
[COLLAB-11]: Editors can publish and unpublish

### DIFF
--- a/packages/backend/src/db/migrations/20250806004508_add_flows_updated_by.ts
+++ b/packages/backend/src/db/migrations/20250806004508_add_flows_updated_by.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('flows', (table) => {
+    table.uuid('updated_by').references('id').inTable('users').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('flows', (table) => {
+    table.dropColumn('updated_by')
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -7,6 +7,7 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
+import { BadUserInputError } from '@/errors/graphql-errors'
 import updateFlowStatus from '@/graphql/mutations/update-flow-status'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
@@ -31,6 +32,7 @@ describe('updateFlowStatus', () => {
   let nonCollaborator: User
   let fakeTriggerStep: any
   let patchSpy: ReturnType<typeof vi.fn>
+  let defaultInput: any
 
   beforeEach(async () => {
     vi.resetAllMocks()
@@ -52,9 +54,11 @@ describe('updateFlowStatus', () => {
       id: fakeFlowId,
       active: false,
       steps: [{ position: 1 }, { position: 2 }], // contiguous by default
+      updatedAt: new Date().toISOString(),
       // we will override $query to simulate patch operations
       $query: vi.fn(),
       getTriggerStep: vi.fn(),
+      assertNotUpdatedSince: vi.fn(),
     }
     patchSpy = vi.fn().mockResolvedValue(undefined)
     fakeFlow.$query.mockReturnValue({ patch: patchSpy })
@@ -91,14 +95,19 @@ describe('updateFlowStatus', () => {
       .fn()
       .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
     flowQueue.removeRepeatableByKey = vi.fn().mockResolvedValue(undefined)
+
+    defaultInput = {
+      id: fakeFlow.id,
+      active: true,
+      updatedAt: fakeFlow.updatedAt,
+    }
   })
 
   it('returns the flow without changes if the active status did not change', async () => {
     // Set the flow status to true and provide the same value in input.
     fakeFlow.active = true
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     expect(result).toEqual(fakeFlow)
     // The patch/update should not be triggered
@@ -111,9 +120,9 @@ describe('updateFlowStatus', () => {
     fakeFlow.active = false
     fakeFlow.steps = [{ position: 1 }, { position: 3 }]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-
-    await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow(
       'Step positions are out of order. Please contact support@plumber.gov.sg for help.',
     )
   })
@@ -126,9 +135,9 @@ describe('updateFlowStatus', () => {
       { position: 3, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
     ]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-
-    await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow(
       'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
     )
   })
@@ -138,8 +147,7 @@ describe('updateFlowStatus', () => {
     fakeFlow.active = false
     fakeFlow.steps = [{ position: 1 }, { position: 2 }]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     // Validate that we patched the flow with active true and publishedAt set to an ISO string.
     expect(patchSpy).toHaveBeenCalledWith({
@@ -175,8 +183,11 @@ describe('updateFlowStatus', () => {
       .fn()
       .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
 
-    const params = { input: { id: fakeFlow.id, active: false } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus(
+      {},
+      { input: { ...defaultInput, active: false } },
+      context,
+    )
 
     expect(patchSpy).toHaveBeenCalledWith({
       active: false,
@@ -200,8 +211,7 @@ describe('updateFlowStatus', () => {
       type: 'webhook',
     })
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     // The patch should still occur.
     expect(patchSpy).toHaveBeenCalledWith({
@@ -226,8 +236,11 @@ describe('updateFlowStatus', () => {
       type: 'webhook',
     })
 
-    const params = { input: { id: fakeFlow.id, active: false } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus(
+      {},
+      { input: { ...defaultInput, active: false } },
+      context,
+    )
 
     expect(patchSpy).toHaveBeenCalledWith({
       active: false,
@@ -246,8 +259,11 @@ describe('updateFlowStatus', () => {
 
   describe('access control', () => {
     it('should allow owner to update flow status', async () => {
-      const params = { input: { id: fakeFlow.id, active: true } }
-      const result = await updateFlowStatus({}, params, context)
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
       expect(result).toEqual(fakeFlow)
       expect(patchSpy).toHaveBeenCalledWith({
         active: true,
@@ -264,8 +280,11 @@ describe('updateFlowStatus', () => {
       context.currentUser.withAccessibleFlows = vi
         .fn()
         .mockReturnValue(fakeQuery)
-      const params = { input: { id: fakeFlow.id, active: true } }
-      const result = await updateFlowStatus({}, params, context)
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
       expect(result).toEqual(fakeFlow)
       expect(patchSpy).toHaveBeenCalledWith({
         active: true,
@@ -279,17 +298,68 @@ describe('updateFlowStatus', () => {
 
     it('should not allow viewer to update flow status', async () => {
       context.currentUser = viewer
-      const params = { input: { id: fakeFlow.id, active: true } }
-      await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
-        NotFoundError,
-      )
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(NotFoundError)
     })
 
     it('should not allow non-collaborator to update flow status', async () => {
       context.currentUser = nonCollaborator
-      const params = { input: { id: fakeFlow.id, active: true } }
-      await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
-        NotFoundError,
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('collaboration', () => {
+    it('should allow update to status if flow is up to date', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
+
+      // Mock assertNotUpdatedSince to not throw (timestamps match)
+      fakeFlow.assertNotUpdatedSince.mockImplementation(() => {
+        // No error thrown - timestamps match
+      })
+
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
+
+      expect(result).toEqual(fakeFlow)
+      expect(fakeFlow.assertNotUpdatedSince).toHaveBeenCalledWith(
+        defaultInput.updatedAt,
+      )
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: editor.id,
+      })
+    })
+
+    it('should not allow update to status if flow is not up to date', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
+
+      // Mock assertNotUpdatedSince to throw an error when timestamps don't match
+      fakeFlow.assertNotUpdatedSince.mockImplementation(() => {
+        throw new BadUserInputError(
+          'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+        )
+      })
+
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
     })
   })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import cronTimes from '@/apps/scheduler/common/cron-times'
@@ -10,7 +12,12 @@ import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import Flow from '@/models/flow'
+import User from '@/models/user'
 import flowQueue from '@/queues/flow'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockCollaborator, generateMockUser } from './flow.mock'
 
 // In these tests we simulate the chaining of queries on currentUser.$relatedQuery('flows')
 // and the additional methods on the flow: $query, getTriggerStep etc.
@@ -18,15 +25,31 @@ describe('updateFlowStatus', () => {
   let fakeFlow: any
   let fakeQuery: any
   let context: any
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
   let fakeTriggerStep: any
   let patchSpy: ReturnType<typeof vi.fn>
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create a real flow in the database first
+    const fakeFlowId = randomUUID()
+    await Flow.query().insert({
+      id: fakeFlowId,
+      name: 'Test Flow',
+      userId: owner.id,
+      active: false,
+    })
 
     // Create a fake flow object with default values.
     fakeFlow = {
-      id: 'flow-1',
+      id: fakeFlowId,
       active: false,
       steps: [{ position: 1 }, { position: 2 }], // contiguous by default
       // we will override $query to simulate patch operations
@@ -44,11 +67,14 @@ describe('updateFlowStatus', () => {
       throwIfNotFound: vi.fn().mockResolvedValue(fakeFlow),
     }
 
-    context = {
-      currentUser: {
-        $relatedQuery: vi.fn().mockReturnValue(fakeQuery),
-      },
-    }
+    context.currentUser.withAccessible = vi.fn().mockReturnValue(fakeQuery)
+
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    await generateMockCollaborator(fakeFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(fakeFlow.id, viewer.id, owner.id, 'viewer')
 
     // Set up a default fake trigger step returning a trigger command.
     fakeTriggerStep = {
@@ -122,6 +148,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: true,
       },
+      updatedBy: owner.id,
     })
 
     // jobName is constructed as "flow-<flow.id>"
@@ -157,6 +184,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: undefined,
       },
+      updatedBy: owner.id,
     })
 
     expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
@@ -182,6 +210,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: true,
       },
+      updatedBy: owner.id,
     })
 
     // But no job should be added when trigger type is webhook.
@@ -206,11 +235,60 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: undefined,
       },
+      updatedBy: owner.id,
     })
 
     // For webhook triggers no removal of a repeatable job should be attempted.
     expect(flowQueue.getRepeatableJobs).not.toHaveBeenCalled()
     expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
     expect(result).toEqual(fakeFlow)
+  })
+
+  describe('access control', () => {
+    it('should allow owner to update flow status', async () => {
+      const params = { input: { id: fakeFlow.id, active: true } }
+      const result = await updateFlowStatus({}, params, context)
+      expect(result).toEqual(fakeFlow)
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: owner.id,
+      })
+    })
+
+    it('should allow editor to update flow status', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessible = vi.fn().mockReturnValue(fakeQuery)
+      const params = { input: { id: fakeFlow.id, active: true } }
+      const result = await updateFlowStatus({}, params, context)
+      expect(result).toEqual(fakeFlow)
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: editor.id,
+      })
+    })
+
+    it('should not allow viewer to update flow status', async () => {
+      context.currentUser = viewer
+      const params = { input: { id: fakeFlow.id, active: true } }
+      await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+        NotFoundError,
+      )
+    })
+
+    it('should not allow non-collaborator to update flow status', async () => {
+      context.currentUser = nonCollaborator
+      const params = { input: { id: fakeFlow.id, active: true } }
+      await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+        NotFoundError,
+      )
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -67,7 +67,7 @@ describe('updateFlowStatus', () => {
       throwIfNotFound: vi.fn().mockResolvedValue(fakeFlow),
     }
 
-    context.currentUser.withAccessible = vi.fn().mockReturnValue(fakeQuery)
+    context.currentUser.withAccessibleFlows = vi.fn().mockReturnValue(fakeQuery)
 
     editor = await generateMockUser('editor')
     viewer = await generateMockUser('viewer')
@@ -261,7 +261,9 @@ describe('updateFlowStatus', () => {
 
     it('should allow editor to update flow status', async () => {
       context.currentUser = editor
-      context.currentUser.withAccessible = vi.fn().mockReturnValue(fakeQuery)
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
       const params = { input: { id: fakeFlow.id, active: true } }
       const result = await updateFlowStatus({}, params, context)
       expect(result).toEqual(fakeFlow)

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -39,7 +39,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   context,
 ) => {
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessible({ type: 'flow', requiredRole: 'editor' })
     .findOne({
       'flows.id': params.input.id,
     })
@@ -59,6 +59,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   await flow.$query().patch({
     active: params.input.active,
     publishedAt: params.input.active ? new Date().toISOString() : null,
+    updatedBy: context.currentUser.id,
     config: {
       ...flow.config,
       // When publishing: set to true if undefined else false

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -39,7 +39,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   context,
 ) => {
   const flow = await context.currentUser
-    .withAccessible({ type: 'flow', requiredRole: 'editor' })
+    .withAccessibleFlows({ requiredRole: 'editor' })
     .findOne({
       'flows.id': params.input.id,
     })

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -52,6 +52,8 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
     return flow
   }
 
+  flow.assertNotUpdatedSince(params.input.updatedAt)
+
   if (params.input.active) {
     validateFlowSteps(flow.steps)
   }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -514,6 +514,7 @@ input UpdateFlowInput {
 input UpdateFlowStatusInput {
   id: String!
   active: Boolean!
+  updatedAt: String!
 }
 
 enum NotificationFrequency {

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -27,6 +27,7 @@ class Flow extends Base {
   testExecution?: Execution
   user: User
   collaborators?: FlowCollaborator[]
+  updatedBy?: string
 
   // for typescript support when creating FlowCollaborator row in insertGraph
   role?: IFlowCollabRole

--- a/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
@@ -1,14 +1,17 @@
+import { useContext } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
 
 interface EditorSnackbarProps {
   isOpen: boolean
   handleUnpublish: () => void
-  isButtonDisabled: boolean
 }
 
 export default function EditorSnackbar(props: EditorSnackbarProps) {
-  const { isOpen, handleUnpublish, isButtonDisabled } = props
+  const { isOpen, handleUnpublish } = props
+  const { hasEditPermission } = useContext(EditorContext)
   const snackbarText = 'To edit this pipe, you need to unpublish it first'
   return (
     <Box
@@ -32,7 +35,7 @@ export default function EditorSnackbar(props: EditorSnackbarProps) {
           colorScheme="inverse"
           onClick={handleUnpublish}
           size={{ sm: 'sm', md: 'md' }}
-          isDisabled={isButtonDisabled}
+          isDisabled={!hasEditPermission}
         >
           Unpublish
         </Button>

--- a/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
@@ -4,10 +4,11 @@ import { Button } from '@opengovsg/design-system-react'
 interface EditorSnackbarProps {
   isOpen: boolean
   handleUnpublish: () => void
+  isButtonDisabled: boolean
 }
 
 export default function EditorSnackbar(props: EditorSnackbarProps) {
-  const { isOpen, handleUnpublish } = props
+  const { isOpen, handleUnpublish, isButtonDisabled } = props
   const snackbarText = 'To edit this pipe, you need to unpublish it first'
   return (
     <Box
@@ -31,6 +32,7 @@ export default function EditorSnackbar(props: EditorSnackbarProps) {
           colorScheme="inverse"
           onClick={handleUnpublish}
           size={{ sm: 'sm', md: 'md' }}
+          isDisabled={isButtonDisabled}
         >
           Unpublish
         </Button>

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -1,5 +1,4 @@
-import { IFlow } from '@plumber/types'
-
+import { useContext } from 'react'
 import { BiCog, BiInfoCircle } from 'react-icons/bi'
 import { HiOutlineDotsVertical } from 'react-icons/hi'
 import { Link } from 'react-router-dom'
@@ -12,6 +11,7 @@ import {
 } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
+import { EditorContext } from '@/contexts/Editor'
 
 import PublishButton from './PublishButton'
 
@@ -51,16 +51,15 @@ const GuideItem = ({ type }: { type: 'icon' | 'button' }) => {
 }
 
 const SettingsItem = ({
-  flowId,
   type,
   setLeaveToUrl,
   handleWarnOnLeave,
 }: {
-  flowId: string
   type: 'icon' | 'button'
   setLeaveToUrl: (url: string) => void
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
 }) => {
+  const { flowId } = useContext(EditorContext)
   if (type === 'button') {
     return (
       <Button
@@ -102,10 +101,6 @@ const SettingsItem = ({
 }
 
 interface EditorToolbarProps {
-  flowId: string
-  flow: IFlow
-  isFlowIncomplete: boolean
-  hasFlowTransfer: boolean
   loading: boolean
   shouldWarnOnLeave: boolean
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -1,27 +1,41 @@
-import { IFlow } from '@plumber/types'
-
+import { useContext, useMemo } from 'react'
 import { Skeleton, Spinner, Text } from '@chakra-ui/react'
 import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
+import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+
 export default function PublishButton({
-  flow,
-  hasFlowTransfer,
-  isFlowIncomplete,
   loading,
   shouldWarnOnLeave,
   handleWarnOnLeave,
   onFlowStatusUpdate,
   setShouldWarnOnPublish,
 }: {
-  flow: IFlow
-  hasFlowTransfer: boolean
-  isFlowIncomplete: boolean
   loading: boolean
   shouldWarnOnLeave: boolean
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
   onFlowStatusUpdate: (active: boolean) => void
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void
 }) {
+  const {
+    flow,
+    hasFlowTransfer,
+    isLoading: isEditorContextLoading,
+  } = useContext(EditorContext)
+
+  // disallow user from publishing pipe if any step is incomplete
+  const isFlowIncomplete = useMemo(
+    () =>
+      flow?.steps.length < 2 ||
+      flow?.steps.some((step) => step.status === 'incomplete') ||
+      // NOTE: toolbox apps should have action steps after them
+      // this is relevant in the for-each action where we use the EmptyFlowStepHeader
+      // instead of creating an empty step
+      flow?.steps[flow?.steps.length - 1].appKey === TOOLBOX_APP_KEY,
+    [flow?.steps],
+  )
+
   return (
     <TouchableTooltip
       label={
@@ -39,7 +53,7 @@ export default function PublishButton({
         isDisabled={
           isFlowIncomplete || hasFlowTransfer || flow.role === 'viewer'
         }
-        isLoading={loading}
+        isLoading={loading || isEditorContextLoading}
         spinner={<Spinner fontSize={24} />}
         size="sm"
         minW="120px" // set this to avoid button width changing on publish/unpublish

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -275,7 +275,6 @@ export default function EditorLayout() {
       </Flex>
 
       <EditorSnackbar
-        isButtonDisabled={flow.role === 'viewer'}
         isOpen={!!flow?.active}
         handleUnpublish={() => onFlowStatusUpdate(!flow.active)}
       />

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -109,18 +109,12 @@ export default function EditorLayout() {
           input: {
             id: flowId,
             active,
-          },
-        },
-        optimisticResponse: {
-          updateFlowStatus: {
-            __typename: 'Flow',
-            id: flow?.id,
-            active,
+            updatedAt: flow?.updatedAt,
           },
         },
       })
     },
-    [flow?.id, flowId, updateFlowStatus],
+    [flow?.updatedAt, flowId, updateFlowStatus],
   )
 
   const handleWarningClose = useCallback(() => {

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -281,6 +281,7 @@ export default function EditorLayout() {
       </Flex>
 
       <EditorSnackbar
+        isButtonDisabled={flow.role === 'viewer'}
         isOpen={!!flow?.active}
         handleUnpublish={() => onFlowStatusUpdate(!flow.active)}
       />

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,6 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
@@ -16,7 +16,6 @@ import { EditorProvider } from '@/contexts/Editor'
 import { UPDATE_FLOW } from '@/graphql/mutations/update-flow'
 import { UPDATE_FLOW_STATUS } from '@/graphql/mutations/update-flow-status'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
 
 import { EDITOR_MARGIN_TOP } from '../Editor/constants'
@@ -76,10 +75,6 @@ export default function EditorLayout() {
 
   const shouldOpenAnnouncementModal =
     localLatestTimestamp !== LATEST_ANNOUNCEMENT_MODAL_TIMESTAMP
-
-  // phase 1: add check to prevent user from publishing pipe after submitting request
-  const requestedEmail = flow?.pendingTransfer?.newOwner.email ?? ''
-  const hasFlowTransfer = requestedEmail !== ''
 
   const onFlowNameUpdate = useCallback(
     async (name: string) => {
@@ -147,18 +142,6 @@ export default function EditorLayout() {
     shouldWarnOnPublish,
   ])
 
-  // disallow user from publishing pipe if any step is incomplete
-  const isFlowIncomplete = useMemo(
-    () =>
-      flow?.steps.length < 2 ||
-      flow?.steps.some((step) => step.status === 'incomplete') ||
-      // NOTE: toolbox apps should have action steps after them
-      // this is relevant in the for-each action where we use the EmptyFlowStepHeader
-      // instead of creating an empty step
-      flow?.steps[flow?.steps.length - 1].appKey === TOOLBOX_APP_KEY,
-    [flow?.steps],
-  )
-
   // warn user of unsaved changes when they try to close or reload the browser
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -185,8 +168,6 @@ export default function EditorLayout() {
     return <InvalidEditorPage />
   }
 
-  const isEditorReadOnly =
-    hasFlowTransfer || flow?.active || flow?.role === 'viewer'
   if (!flowId || !flow) {
     return null
   }
@@ -197,7 +178,12 @@ export default function EditorLayout() {
   const shouldOpenDemoModal = showDemo === 'true' && !!demoVideoDetails
 
   return (
-    <>
+    <EditorProvider
+      flow={flow}
+      shouldWarnOnLeave={shouldWarnOnLeave}
+      setShouldWarnOnLeave={setShouldWarnOnLeave}
+      resetFormRef={resetFormRef}
+    >
       <Helmet>
         <title>{flow?.name} | Pipe</title>
       </Helmet>
@@ -241,10 +227,6 @@ export default function EditorLayout() {
             </Flex>
           </Flex>
           <EditorToolbar
-            flowId={flowId}
-            flow={flow}
-            isFlowIncomplete={isFlowIncomplete}
-            hasFlowTransfer={hasFlowTransfer}
             loading={loading}
             shouldWarnOnLeave={shouldWarnOnLeave}
             setShouldWarnOnPublish={setShouldWarnOnPublish}
@@ -261,16 +243,8 @@ export default function EditorLayout() {
           flex={1}
           overflowY="auto"
         >
-          <EditorProvider
-            readOnly={isEditorReadOnly}
-            flow={flow}
-            shouldWarnOnLeave={shouldWarnOnLeave}
-            setShouldWarnOnLeave={setShouldWarnOnLeave}
-            resetFormRef={resetFormRef}
-          >
-            <Editor />
-            {flow.active && flow.config?.showSurvey && <LensSurvey />}
-          </EditorProvider>
+          <Editor />
+          {flow.active && flow.config?.showSurvey && <LensSurvey />}
         </Container>
       </Flex>
 
@@ -299,6 +273,6 @@ export default function EditorLayout() {
         onClose={handleWarningClose}
         onLeave={onDiscardChanges}
       />
-    </>
+    </EditorProvider>
   )
 }

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/PublishedFlowInfobox.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/PublishedFlowInfobox.tsx
@@ -17,18 +17,12 @@ export default function PublishedFlowInfobox() {
           input: {
             id: flow.id,
             active,
-          },
-        },
-        optimisticResponse: {
-          updateFlowStatus: {
-            __typename: 'Flow',
-            id: flow.id,
-            active,
+            updatedAt: flow.updatedAt,
           },
         },
       })
     },
-    [flow.id, updateFlowStatus],
+    [flow.id, flow.updatedAt, updateFlowStatus],
   )
 
   return (

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -66,6 +66,8 @@ interface IEditorContextValue {
   allApps: IApp[]
   resetForm: () => void
   resetTimestamp: number
+  isLoading: boolean
+  hasFlowTransfer: boolean
 }
 
 export const EditorContext = createContext<IEditorContextValue>({
@@ -95,11 +97,12 @@ export const EditorContext = createContext<IEditorContextValue>({
   allApps: [],
   resetForm: () => null,
   resetTimestamp: 0,
+  isLoading: true,
+  hasFlowTransfer: false,
 })
 
 type EditorProviderProps = {
   children: ReactNode
-  readOnly: boolean
   flow: IFlow
   shouldWarnOnLeave: boolean
   setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
@@ -152,7 +155,6 @@ function updateHandlerFactory(
 }
 
 export const EditorProvider = ({
-  readOnly,
   flow,
   shouldWarnOnLeave,
   setShouldWarnOnLeave,
@@ -160,6 +162,11 @@ export const EditorProvider = ({
   children,
 }: EditorProviderProps) => {
   const isMobile = useIsMobile()
+
+  // flow transfer phase 1: add check to prevent user from publishing pipe after submitting request
+  const requestedEmail = flow?.pendingTransfer?.newOwner.email ?? ''
+  const hasFlowTransfer = requestedEmail !== ''
+  const readOnly = hasFlowTransfer || flow?.active || flow?.role === 'viewer'
 
   const flowId = flow.id
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
@@ -179,14 +186,13 @@ export const EditorProvider = ({
     [getAppsData?.getApps],
   )
 
-  const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
-    GET_TEST_EXECUTION_STEPS,
-    {
-      variables: {
-        flowId,
-      },
+  const { data, loading: isLoadingTestExecutionSteps } = useQuery<{
+    getTestExecutionSteps: IExecutionStep[]
+  }>(GET_TEST_EXECUTION_STEPS, {
+    variables: {
+      flowId,
     },
-  )
+  })
 
   const testExecutionSteps = useMemo(
     () => data?.getTestExecutionSteps ?? [],
@@ -220,9 +226,11 @@ export const EditorProvider = ({
    * CreateStep mutation
    */
 
-  const [createStep] = useMutation(CREATE_STEP, { refetchQueries: [GET_FLOW] })
+  const [createStep, { loading: isCreatingStep }] = useMutation(CREATE_STEP, {
+    refetchQueries: [GET_FLOW],
+  })
 
-  const [initializeIfThen] = useIfThenInitializer()
+  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
 
   // Add a step to the flow with the given appKey and eventKey
   const onCreateStep = useCallback(
@@ -294,7 +302,7 @@ export const EditorProvider = ({
   /**
    * UpdateStep mutation
    */
-  const [updateStep] = useMutation(UPDATE_STEP)
+  const [updateStep, { loading: isUpdatingStep }] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
     async (step: IStep, onCompleted?: () => void) => {
       const mutationInput: Record<string, unknown> = {
@@ -413,7 +421,7 @@ export const EditorProvider = ({
         flowId,
         currentTestExecutionStep,
         isTestExecuting,
-        readOnly: readOnly || flow.role === 'viewer',
+        readOnly,
         shouldWarnOnLeave,
         stepsWithVars,
         testExecutionSteps,
@@ -427,6 +435,13 @@ export const EditorProvider = ({
         setShouldWarnOnLeave,
         resetForm,
         resetTimestamp,
+        isLoading:
+          isLoadingAllApps ||
+          isLoadingTestExecutionSteps ||
+          isCreatingStep ||
+          isUpdatingStep ||
+          isInitializingIfThen,
+        hasFlowTransfer,
       }}
     >
       {children}

--- a/packages/frontend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/frontend/src/graphql/mutations/update-flow-status.ts
@@ -5,6 +5,7 @@ export const UPDATE_FLOW_STATUS = gql`
     updateFlowStatus(input: $input) {
       id
       active
+      updatedAt
     }
   }
 `


### PR DESCRIPTION
### TL;DR
Added ability for EDITORs to publish / unpublish Pipes.
Added tracking of who last updated a flow.

### What changed?

- Added a new database migration to add an `updated_by` column to the `flows` table that references the `users` table
- Modified the `updateFlowStatus` mutation to:
  - Record the current user's ID in the `updated_by` field when updating flow status
  - Use `withAccessible` instead of `$relatedQuery('flows')` to enforce proper access control
- Added access control tests to verify that:
  - Flow owners and editors can update flow status
  - Viewers and non-collaborators cannot update flow status

### How to test?
- [ ] Owner can publish / unpublish
- [ ] Editor can publish / unpublish
- [ ] Viewer CANNOT publish / unpublish
- [ ] Non-collaborator CANNOT publish / unpublish (should not even see the Pipe)
- [ ] Verify that the `updated_by` field is correctly populated with the ID of the user who made the update

### Why make this change?

This change improves accountability by tracking which user last updated a flow's status. It also enhances security by properly enforcing access control, ensuring that only users with appropriate permissions (owners and editors) can update flow status, while preventing viewers and non-collaborators from making changes.