### PR TITLE
[COLLAB-12]: Editors can delete step

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -22,6 +22,7 @@ describe('deleteStep mutation', () => {
   let editor: User
   let viewer: User
   let nonCollaborator: User
+  let defaultFlowInput: { flow: { updatedAt: string } }
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   beforeEach(async () => {
@@ -48,6 +49,7 @@ describe('deleteStep mutation', () => {
       name: 'Test Flow',
       // additional flow properties as needed
     })
+    defaultFlowInput = { flow: { updatedAt: testFlow.updatedAt } }
 
     await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
     await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
@@ -112,14 +114,20 @@ describe('deleteStep mutation', () => {
     await expect(
       deleteStep(
         null,
-        { input: { ids: [testSteps[0].id, otherStep.id] } },
+        {
+          input: { ids: [testSteps[0].id, otherStep.id], ...defaultFlowInput },
+        },
         context,
       ),
     ).rejects.toThrow('All steps to be deleted must be from the same pipe!')
   })
 
   it('should delete a single trigger step and create a new one', async () => {
-    await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+      context,
+    )
 
     // Verify the trigger step was deleted and a new one was created
     const steps = await testFlow
@@ -135,7 +143,9 @@ describe('deleteStep mutation', () => {
   it('should delete contiguous action steps and update positions', async () => {
     await deleteStep(
       null,
-      { input: { ids: [testSteps[1].id, testSteps[2].id] } },
+      {
+        input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
+      },
       context,
     )
 
@@ -163,7 +173,9 @@ describe('deleteStep mutation', () => {
     await expect(
       deleteStep(
         null,
-        { input: { ids: [testSteps[1].id, fourthStep.id] } },
+        {
+          input: { ids: [testSteps[1].id, fourthStep.id], ...defaultFlowInput },
+        },
         context,
       ),
     ).rejects.toThrow('Must delete contiguous action steps!')
@@ -181,7 +193,11 @@ describe('deleteStep mutation', () => {
       { subject: `some subject {{step.${testSteps[1].id}.foo}}` },
     )
 
-    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
 
     // Verify the referencing step was invalidated
     const invalidatedStep = await Step.query().findById(referencingStep.id)
@@ -189,21 +205,31 @@ describe('deleteStep mutation', () => {
   })
 
   it('should call patchLastUpdated when deleting trigger step', async () => {
-    await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+      context,
+    )
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should call patchLastUpdated when deleting action steps', async () => {
     await deleteStep(
       null,
-      { input: { ids: [testSteps[1].id, testSteps[2].id] } },
+      {
+        input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
+      },
       context,
     )
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should allow owner to delete steps', async () => {
-    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
     const steps = await testFlow
       .$relatedQuery('steps')
       .orderBy('position', 'asc')
@@ -215,7 +241,11 @@ describe('deleteStep mutation', () => {
 
   it('should allow editor to delete steps', async () => {
     context.currentUser = editor
-    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
     const steps = await testFlow
       .$relatedQuery('steps')
       .orderBy('position', 'asc')
@@ -228,7 +258,11 @@ describe('deleteStep mutation', () => {
   it('should not allow non-collaborator to delete steps', async () => {
     context.currentUser = nonCollaborator
     await expect(
-      deleteStep(null, { input: { ids: [testSteps[0].id] } }, context),
+      deleteStep(
+        null,
+        { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+        context,
+      ),
     ).rejects.toThrow(NotFoundError)
 
     const steps = await testFlow
@@ -241,7 +275,11 @@ describe('deleteStep mutation', () => {
   it('should not allow viewer to delete steps', async () => {
     context.currentUser = viewer
     await expect(
-      deleteStep(null, { input: { ids: [testSteps[0].id] } }, context),
+      deleteStep(
+        null,
+        { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+        context,
+      ),
     ).rejects.toThrow(NotFoundError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -90,7 +90,7 @@ describe('deleteStep mutation', () => {
 
   it('should throw error when no steps to delete', async () => {
     await expect(
-      deleteStep(null, { input: { ids: [] } }, context),
+      deleteStep(null, { input: { ids: [], ...defaultFlowInput } }, context),
     ).rejects.toThrow('Nothing to delete')
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import deleteStep from '@/graphql/mutations/delete-step'
@@ -6,12 +7,21 @@ import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
-import { generateMockStep } from './flow.mock'
+import { generateMockContext } from './tiles/table.mock'
+import {
+  generateMockCollaborator,
+  generateMockStep,
+  generateMockUser,
+} from './flow.mock'
 
 describe('deleteStep mutation', () => {
   let context: Context
   let testFlow: Flow
   let testSteps: Step[]
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   beforeEach(async () => {
@@ -26,19 +36,21 @@ describe('deleteStep mutation', () => {
     await Step.query().delete()
     await Flow.query().delete()
 
-    const testUser = await User.query().findOne({ email: 'tester@open.gov.sg' })
-    context = {
-      req: null,
-      currentUser: testUser,
-      res: null,
-      isAdminOperation: false,
-    }
+    context = await generateMockContext()
+
+    owner = context.currentUser
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
 
     // Create a flow associated with the test user.
-    testFlow = await testUser.$relatedQuery('flows').insertAndFetch({
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
       name: 'Test Flow',
       // additional flow properties as needed
     })
+
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
 
     // Create test steps
     testSteps = await Promise.all([
@@ -188,5 +200,48 @@ describe('deleteStep mutation', () => {
       context,
     )
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should allow owner to delete steps', async () => {
+    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(2)
+    expect(steps[0].type).toBe('trigger')
+    expect(steps[0].position).toBe(1)
+  })
+
+  it('should allow editor to delete steps', async () => {
+    context.currentUser = editor
+    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(2)
+    expect(steps[0].type).toBe('trigger')
+    expect(steps[0].position).toBe(1)
+  })
+
+  it('should not allow non-collaborator to delete steps', async () => {
+    context.currentUser = nonCollaborator
+    await expect(
+      deleteStep(null, { input: { ids: [testSteps[0].id] } }, context),
+    ).rejects.toThrow(NotFoundError)
+
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(3)
+  })
+
+  it('should not allow viewer to delete steps', async () => {
+    context.currentUser = viewer
+    await expect(
+      deleteStep(null, { input: { ids: [testSteps[0].id] } }, context),
+    ).rejects.toThrow(NotFoundError)
   })
 })

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -32,7 +32,9 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       .withGraphFetched('flow')
       .whereIn('steps.id', params.input.ids)
       .orderBy('steps.position', 'asc')
-      .throwIfNotFound()
+      .throwIfNotFound({
+        message: 'Step not found. Refresh the page and try again.',
+      })
 
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -28,7 +28,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
     // Include SELECTs in transaction too just in case there's concurrent modification.
     const steps = await context.currentUser
-      .withAccessible({ type: 'step', trx, requiredRole: 'editor' })
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .whereIn('steps.id', params.input.ids)
       .orderBy('steps.position', 'asc')

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -20,7 +20,8 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
   params,
   context,
 ) => {
-  if (params.input.ids.length === 0) {
+  const { input } = params
+  if (input.ids.length === 0) {
     throw new Error('Nothing to delete')
   }
 
@@ -30,17 +31,18 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     const steps = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', params.input.ids)
+      .whereIn('steps.id', input.ids)
       .orderBy('steps.position', 'asc')
       .throwIfNotFound({
         message: 'Step not found. Refresh the page and try again.',
       })
 
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
+
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
     }
-
-    const flow = steps[0].flow
 
     //
     // ** IMPORTANT NOTE **

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -28,7 +28,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
     // Include SELECTs in transaction too just in case there's concurrent modification.
     const steps = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessible({ type: 'step', trx, requiredRole: 'editor' })
       .withGraphFetched('flow')
       .whereIn('steps.id', params.input.ids)
       .orderBy('steps.position', 'asc')

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -600,7 +600,7 @@ input UpdateStepPositionsInput {
 
 input DeleteStepInput {
   ids: [String!]!
-  flow: StepFlowInput
+  flow: StepFlowInput!
 }
 
 input RequestOtpInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -600,6 +600,7 @@ input UpdateStepPositionsInput {
 
 input DeleteStepInput {
   ids: [String!]!
+  flow: StepFlowInput
 }
 
 input RequestOtpInput {

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -70,7 +70,12 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
     async (e) => {
       e.stopPropagation()
 
-      await deleteStep({ variables: { input: { ids: [step.id] } } })
+      const deletedStep = await deleteStep({
+        variables: {
+          input: { ids: [step.id], flow: { updatedAt: flow.updatedAt } },
+        },
+      })
+      const updatedFlow = deletedStep.data?.deleteStep
       const { previousStep, nextStep } = findAdjacentSteps(
         flow?.steps,
         step.position,
@@ -82,7 +87,10 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
           variables: {
             input: {
               previousStep: { id: previousStep?.id },
-              flow: { id: flow.id },
+              flow: {
+                id: flow.id,
+                updatedAt: updatedFlow?.updatedAt,
+              },
             },
           },
         })

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -66,7 +66,9 @@ export default function Branch(props: BranchProps) {
   const deleteBranch = useCallback(async () => {
     const idsToDelete = branchSteps.map((step) => step.id)
     await deleteStep({
-      variables: { input: { ids: idsToDelete } },
+      variables: {
+        input: { ids: idsToDelete, flow: { updatedAt: flow.updatedAt } },
+      },
     })
 
     setCurrentStepId(null)
@@ -78,6 +80,7 @@ export default function Branch(props: BranchProps) {
     onDrawerClose,
     closeDeleteConfirmation,
     setCurrentStepId,
+    flow.updatedAt,
   ])
 
   const canAddStep = useMemo(() => allowAddStep(branchSteps), [branchSteps])

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
@@ -25,6 +25,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
 
   const { depth } = useContext(BranchContext)
   const {
+    flow,
     flowId,
     readOnly: isEditorReadOnly,
     setCurrentStepId,
@@ -60,6 +61,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           },
           flow: {
             id: flowId,
+            updatedAt: flow.updatedAt,
           },
           parameters: {
             depth,
@@ -79,6 +81,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           },
           flow: {
             id: flowId,
+            updatedAt: branchStep.data.createStep.flow.updatedAt,
           },
         },
       },
@@ -95,6 +98,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
     numBranches,
     onDrawerOpen,
     setCurrentStepId,
+    flow.updatedAt,
   ])
 
   return (

--- a/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
+++ b/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
@@ -1,9 +1,10 @@
 import { IStep } from '@plumber/types'
 
-import { MouseEventHandler, useCallback, useRef } from 'react'
+import { MouseEventHandler, useCallback, useContext, useRef } from 'react'
 import { useMutation } from '@apollo/client'
 import { useDisclosure } from '@chakra-ui/react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
@@ -13,6 +14,7 @@ const useDeleteStepConfirmation = (
   groupedSteps: IStep[][],
   branchSteps?: IStep[],
 ) => {
+  const { flow } = useContext(EditorContext)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef<HTMLButtonElement>(null)
 
@@ -29,6 +31,7 @@ const useDeleteStepConfirmation = (
   )
 
   const onDelete = useCallback(async () => {
+    const flowInput = { updatedAt: flow.updatedAt }
     if (type === TOOLBOX_ACTIONS.ForEach) {
       /**
        *  deleting the entire for-each deletes the entire for-each loop
@@ -37,16 +40,16 @@ const useDeleteStepConfirmation = (
       const flatSteps = groupedSteps.flat()
       const idsToDelete = flatSteps.map((step) => step.id)
       await deleteStep({
-        variables: { input: { ids: idsToDelete } },
+        variables: { input: { ids: idsToDelete, flow: flowInput } },
       })
     } else if (type === TOOLBOX_ACTIONS.IfThen && branchSteps) {
       const idsToDelete = branchSteps.map((step) => step.id)
       await deleteStep({
-        variables: { input: { ids: idsToDelete } },
+        variables: { input: { ids: idsToDelete, flow: flowInput } },
       })
     }
     onClose()
-  }, [branchSteps, deleteStep, groupedSteps, onClose, type])
+  }, [branchSteps, deleteStep, flow.updatedAt, groupedSteps, onClose, type])
 
   return {
     cancelRef,

--- a/packages/frontend/src/graphql/mutations/delete-step.ts
+++ b/packages/frontend/src/graphql/mutations/delete-step.ts
@@ -4,6 +4,7 @@ export const DELETE_STEP = graphql(`
   mutation DeleteStep($input: DeleteStepInput) {
     deleteStep(input: $input) {
       id
+      updatedAt
       steps {
         id
       }


### PR DESCRIPTION
### TL;DR
Added permission checks to the `deleteStep` mutation to ensure only owners and editors can delete steps.

### What changed?

- Modified the `deleteStep` mutation to use `withAccessible` with the required role of 'editor' instead of directly querying related steps
- Added tests to verify permission behaviour:
  - Owners can delete steps
  - Editors can delete steps
  - Viewers cannot delete steps
  - Non-collaborators cannot delete steps

### How to test?
- [ ] Owner can delete steps
- [ ] Editor can delete steps
- [ ] Viewer CANNOT delete steps
- [ ] Non-collaborator should not even see the pipe (unauthorised)
