### PR TITLE
[combine-batch-and-group-2]: add batch function for create table row

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/test-batch-run.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/test-batch-run.ts
@@ -1,0 +1,33 @@
+import StepError from '@/errors/step'
+import { generateErrorForActionOutput } from '@/services/batch-action'
+import { type ProcessedJobData } from '@/workers/helpers/process-batch-action-job'
+
+// This is a test batch run function to test the batching functionality
+export default async function testBatchRun(
+  jobsToProcessData: ProcessedJobData[],
+) {
+  // Capture error for every odd job
+  for (let i = 0; i < jobsToProcessData.length; i++) {
+    const jobToProcessData = jobsToProcessData[i]
+    const { $ } = jobToProcessData
+    try {
+      if (i % 2 === 1) {
+        throw new StepError(
+          'There was a problem with the input.',
+          'No solution found',
+          $.step?.position,
+          $.app.name,
+        )
+      }
+
+      $.setActionItem({
+        raw: {
+          success: true,
+        },
+      })
+    } catch (error) {
+      $.actionOutput.error = generateErrorForActionOutput(error)
+      $.executionError = error
+    }
+  }
+}

--- a/packages/backend/src/apps/m365-excel/queue/index.ts
+++ b/packages/backend/src/apps/m365-excel/queue/index.ts
@@ -15,26 +15,29 @@ import Step from '@/models/step'
 const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
   jobData,
 ) => {
+  // For batching, use the table id instead, and we will batch by action type to save on the API calls made to Microsoft Graph
   const step = await Step.query().findById(jobData.stepId).throwIfNotFound()
-  const fileId = step.parameters['fileId'] as string
+  const tableId = step.parameters['tableId'] as string
 
-  if (!fileId) {
+  if (!tableId) {
     throw new Error(
-      `Expected fileId to be non-empty for step ${jobData.stepId}`,
+      `Expected tableId to be non-empty for step ${jobData.stepId}`,
     )
   }
 
-  // NOTE: File ID is only unique within the same SharePoint site and tenant.
+  // NOTE: Table ID is only unique within the same SharePoint site and tenant.
   // But since we only have one site per tenant, and we need a different per-app
   // queue for each tenant (each tenant may have different agreed-upon rate
-  // limits), we can avoid compleixty and simply set group ID to the file ID,
-  // instead of something like `${tenantId}-${siteId}-${fileId}`.
+  // limits), we can avoid complexity and simply set group ID to the table ID,
+  // instead of something like `${tenantId}-${siteId}-${tableId}`.
   //
-  // (The one app-queue per tenant thing isn't implemnented yet - for now, each
+  // (The one app-queue per tenant thing isn't implemented yet - for now, each
   // app can only have 1 per-app queue. We'll only do this if we ever need to
   // support more than 1 tenant.)
+  //
+  // The format will be: `${appKey}_${actionKey}_${tableId}` e.g. `m365-excel_createTableRow_1234567890`
   return {
-    id: fileId,
+    id: `${step.appKey}_${step.key}_${tableId}`,
   }
 }
 

--- a/packages/backend/src/config/batches.ts
+++ b/packages/backend/src/config/batches.ts
@@ -1,3 +1,29 @@
+import m365CreateTableRowTestBatchRun from '@/apps/m365-excel/actions/create-table-row/test-batch-run'
+import { type ProcessedJobData } from '@/workers/helpers/process-batch-action-job'
+
+/**
+ * Assumptions before thinking of using batching for an action in an app:
+ * - It should be using the same connection for all the jobs in the batch
+ * - It has to have a queue to group similar jobs to batch e.g. app_action key
+ *
+ * To introduce batching to an action in an app:
+ * 1. Add the app key to the QUEUE_BATCH_SIZE object
+ * 2. Add the app_action key to the BATCH_FUNCTIONS object
+ * 3. Add the queue settings to the queue/index.ts file
+ * 4. Add the batchRun function in the specific action folder in the app. Take note that you should be try-catching the batching API call inside this function to avoid the entire batch from failing without any proper handling.
+ * 5. Attach the batchRun function to this BATCH_RUN_FUNCTIONS object
+ */
+
+type BatchFunction = (jobsToProcessData: ProcessedJobData[]) => Promise<void>
+
+const m365AppKey = 'm365-excel'
+const m365CreateTableRowActionKey = 'createTableRow'
+
 export const QUEUE_BATCH_SIZE = {
-  'm365-excel': 5, // TODO: Update this upon discussions, this should be equal to the group limit concurrency
+  [m365AppKey]: 5, // TODO: Update this upon discussions, this should be equal to the group limit concurrency
+}
+
+export const BATCH_RUN_FUNCTIONS: Record<string, BatchFunction> = {
+  [`${m365AppKey}_${m365CreateTableRowActionKey}`]:
+    m365CreateTableRowTestBatchRun, // TODO: Update this to the actual batch run function in next PR
 }

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -134,6 +134,9 @@ const globalVariable = async (
     },
     user: flow?.user ?? user,
     metadata,
+    setExecutionError: (error: Error) => {
+      $.executionError = error
+    },
   }
 
   if (request) {

--- a/packages/backend/src/services/batch-action.ts
+++ b/packages/backend/src/services/batch-action.ts
@@ -1,0 +1,303 @@
+import {
+  IActionJobData,
+  IActionRunResult,
+  NextStepMetadata,
+  type TestRunStepMetadata,
+} from '@plumber/types'
+
+import { Job, UnrecoverableError, WorkerPro } from '@taskforcesh/bullmq-pro'
+import { tracer } from 'dd-trace'
+
+import HttpError from '@/errors/http'
+import StepError from '@/errors/step'
+import { handleFailedStepAndThrow } from '@/helpers/actions'
+import {
+  ForEachContext,
+  getStepContext,
+} from '@/helpers/compute-for-each-parameters'
+import computeParameters from '@/helpers/compute-parameters'
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
+import globalVariable from '@/helpers/global-variable'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import { enqueueActionJob, makeActionJobId } from '@/queues/action'
+import processForEachStatus from '@/workers/helpers/for-each-status-manager'
+import { BullMqOptions } from '@/workers/helpers/make-action-worker'
+import { type ProcessedJobData } from '@/workers/helpers/process-batch-action-job'
+
+import getForEachMetadata from './helpers/get-for-each-metadata'
+
+export type ProcessBatchActionOptions = {
+  flowId: string
+  executionId: string
+  stepId: string
+  jobId?: string
+  testRun?: boolean
+  metadata?: TestRunStepMetadata
+}
+
+export type BatchJobResult = {
+  jobData: ProcessBatchActionOptions
+  success: boolean
+  executionStep?: ExecutionStep
+  error?: unknown
+}
+
+/**
+ * This function is used to generate the error for the action output which will be stored in the $.actionOutput.error. This is to avoid the job failing before marking it as failed on the DB.
+ */
+export const generateErrorForActionOutput = (error: Error) => {
+  logger.error(error)
+  // log raw http error from StepError
+  if (error instanceof StepError && error.cause) {
+    logger.error(error.cause)
+  }
+  if (error instanceof HttpError) {
+    return {
+      details: error.details,
+      status: error.response.status,
+      statusText: error.response.statusText,
+    }
+  } else {
+    try {
+      return JSON.parse(error.message)
+    } catch {
+      return { error: error.message }
+    }
+  }
+}
+
+/**
+ * This function is used to pre-process the job data to prepare for the batchFunction
+ * It will mark the job as failed if the job data cannot be processed. Else, it will add the job to the jobsToProcessData array.
+ *
+ * For db error, missing execution, flow, step, etc..., we do not want to retry and process these jobs
+ */
+export const processJobDataForBatchFunction = async (
+  job: Job,
+  jobsToProcessData: ProcessedJobData[],
+  batchJobTimestamp: string,
+): Promise<void> => {
+  const { flowId, executionId, stepId, metadata = {} } = job.data
+
+  try {
+    const step = await Step.query().findById(stepId).throwIfNotFound()
+    const flow = await Flow.query()
+      .findById(flowId)
+      .withGraphJoined('user')
+      .withGraphFetched('steps')
+      .throwIfNotFound()
+    const execution = await Execution.query()
+      .findById(executionId)
+      .throwIfNotFound()
+
+    const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
+      getStepContext(flow, step)
+
+    // we use this to indicate an iteration in the for-each is complete
+    if (forEachStepPosition > -1 && isLastStep && metadata) {
+      metadata.isLastStep = true
+    }
+
+    // Only initialise $ global variable once for running batch job action later
+    const $ = await globalVariable({
+      flow,
+      app: await step.getApp(),
+      step: step,
+      connection: await step.$relatedQuery('connection'),
+      execution: execution,
+      metadata,
+    })
+
+    const priorExecutionSteps = await ExecutionStep.query().where({
+      execution_id: $.execution.id,
+      // only get successful execution steps
+      status: 'success',
+    })
+
+    const actionCommand = await step.getActionCommand()
+    const forEachContext: ForEachContext = {
+      executionStepMetadata: metadata,
+      forEachStepPosition,
+      stepPositions,
+      isForEachStep,
+    }
+
+    const computedParameters = computeParameters(
+      $.step.parameters,
+      priorExecutionSteps,
+      actionCommand.preprocessVariable,
+      forEachContext,
+    )
+
+    $.step.parameters = computedParameters
+
+    jobsToProcessData.push({
+      job,
+      $,
+      step,
+      execution,
+      metadata,
+      forEachContext,
+    })
+  } catch (error) {
+    // don't process this job, mark it as failed and move on to the next job
+    logger.error(`Failed to process job in batch`, {
+      error,
+      executionId,
+      stepId,
+      flowId,
+      jobId: job.id,
+      batchJobTimestamp,
+    })
+    const unrecoverableError = new UnrecoverableError(
+      error.message || 'Action failed to execute',
+    )
+    job.updateProgress(unrecoverableError)
+    job.setAsFailed(unrecoverableError)
+  }
+}
+
+// Will never be a test run...
+export const processJobAfterBatchFunction = async (
+  jobToProcessData: ProcessedJobData,
+  batchJobTimestamp: string,
+  worker: WorkerPro<IActionJobData>,
+  bullMqOptions: BullMqOptions,
+) => {
+  const { job, $, step, execution, metadata, forEachContext } = jobToProcessData
+  try {
+    const span = tracer.scope().active()
+    const { queueName, isQueueDelayable } = bullMqOptions
+    const jobId = makeActionJobId(queueName, job.id)
+
+    const runResult: IActionRunResult = {} // this will be empty unless the batched job contains onlyContinueIf, forEach or ifThen
+
+    // No need for checking for PartialStepError?
+    /**
+     * During non-test runs and the error is a PartialStepError, we want to mark the step as successful
+     * so it continues to the next step
+     */
+    const status: ExecutionStep['status'] = $.actionOutput.error
+      ? 'failure'
+      : 'success'
+
+    // update metadata specially for for-each: TODO: check if this is needed
+    getForEachMetadata({
+      forEachContext,
+      metadata,
+      dataOut: $.actionOutput.data?.raw ?? null,
+      runResult,
+    })
+
+    const updatedMetadata: NextStepMetadata = {
+      ...metadata,
+      batchJobTimestamp,
+    }
+
+    const executionStep = await execution
+      .$relatedQuery('executionSteps')
+      .insertAndFetch({
+        stepId: $.step.id,
+        status,
+        dataIn: $.step.parameters, // This is the computed parameters
+        dataOut: $.actionOutput.data?.raw ?? null,
+        errorDetails: $.actionOutput.error ?? null,
+        appKey: $.app.key,
+        jobId,
+        key: step.key,
+        metadata: updatedMetadata,
+      })
+
+    // No need to check for next step because should not have onlyContinueIf, forEach or ifThen
+    const nextStep = await step.getNextStep()
+    const nextStepMetadata = {
+      ...runResult.nextStepMetadata,
+      ...updatedMetadata,
+    }
+
+    // After processing the batch function, we need to do the post processing similar to a single action job
+    if (executionStep.isFailed) {
+      if (nextStepMetadata?.iteration) {
+        await ExecutionStep.patchIterationStatus(
+          execution.id,
+          nextStepMetadata.iteration,
+          'failure',
+        )
+      }
+      return handleFailedStepAndThrow({
+        errorDetails: executionStep.errorDetails,
+        executionError: $.executionError,
+        context: {
+          isQueueDelayable,
+          worker,
+          span,
+          job,
+        },
+      })
+    }
+
+    // Similar to single action job code...
+    if (!nextStep) {
+      const shouldContinue = await processForEachStatus({
+        executionId: execution.id,
+        currStep: step,
+        nextStepMetadata,
+      })
+
+      if (!shouldContinue) {
+        return
+      }
+
+      await Execution.setStatus(execution.id, 'success')
+      return
+    }
+
+    const jobName = `${execution.id}-${nextStep.id}`
+
+    const jobPayload: IActionJobData = {
+      flowId: execution.flowId,
+      executionId: execution.id,
+      stepId: nextStep.id,
+      metadata: nextStepMetadata,
+    }
+
+    let jobOptions = DEFAULT_JOB_OPTIONS
+
+    if (step.appKey === 'delay') {
+      jobOptions = {
+        ...DEFAULT_JOB_OPTIONS,
+        delay: delayAsMilliseconds(step.key, executionStep.dataOut),
+      }
+    }
+
+    try {
+      await enqueueActionJob({
+        appKey: nextStep.appKey,
+        jobName,
+        jobData: jobPayload,
+        jobOptions,
+      })
+    } catch (error) {
+      // Don't retry if we failed to enqueue the next step (e.g. if
+      // getGroupConfigForJob throws an error)
+      throw new UnrecoverableError(error.message)
+    }
+  } catch (error) {
+    // don't process this job, mark it as failed and move on to the next job
+    logger.error(`Failed to process job after batch function results`, {
+      error,
+      executionId: execution.id,
+      stepId: step.id,
+      flowId: execution.flowId,
+      jobId: job.id,
+      batchJobTimestamp,
+    })
+    job.updateProgress(error)
+    job.setAsFailed(error)
+  }
+}

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -8,7 +8,7 @@ import {
 } from '@taskforcesh/bullmq-pro'
 
 import appConfig from '@/config/app'
-import { QUEUE_BATCH_SIZE } from '@/config/batches'
+import { BATCH_RUN_FUNCTIONS, QUEUE_BATCH_SIZE } from '@/config/batches'
 import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
@@ -16,6 +16,7 @@ import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 
 import { handleFailedActionJob } from './handle-failed-action-job'
+import { processBatchActionJob } from './process-batch-action-job'
 import { processSingleActionJob } from './process-single-action-job'
 
 function convertParamsToBullMqOptions(
@@ -88,6 +89,18 @@ export interface BullMqOptions {
   isQueueDelayable: boolean
 }
 
+function splitOnLastDelimiter(str: string, delimiter: string) {
+  const lastIndex = str.lastIndexOf(delimiter)
+
+  if (lastIndex === -1) {
+    // Delimiter not found, return the original string
+    return str
+  } else {
+    // Return the part of the string before the last delimiter
+    return str.substring(0, lastIndex)
+  }
+}
+
 /**
  * Creates a worker for an action queue.
  *
@@ -109,26 +122,49 @@ export function makeActionWorker(
         const jobsInBatch = batchedJob.getBatch()
 
         // perform batching for queues that support it, right now only M365 queue supports it
-        if (jobsInBatch.length > 1) {
-          // TODO: add batching logic here in next PR
+        if (jobsInBatch && jobsInBatch.length > 1) {
           /**
-           * This will be the logic for actions in a queue that does not support batching e.g. M365 queue allows batching for createTableRow but not for other actions.
-           *
-           * If the action does not allow batching, handle each job in the batch individually as if there was no batching. Mark the individual jobs as failed to not fail the wrapped batch job. The progress object is used to get the error later to handle it.
+           * Proceed with batching only after checking if the batchJob function exists for the specific action in the app e.g. M365 createTableRow
+           * This is done by obtaining the first part of the group id
            */
-          for (const job of jobsInBatch) {
-            try {
-              await processSingleActionJob(job, worker, {
-                queueName,
-                workerOptions,
-                isQueueDelayable,
-              })
-            } catch (err) {
-              job.updateProgress(err)
-              job.setAsFailed(err)
+          const firstJob = jobsInBatch[0]
+          const firstJobOptions = firstJob.opts
+          const groupID = firstJobOptions.group.id
+          const appActionKey = splitOnLastDelimiter(groupID, '_')
+          if (appActionKey in BATCH_RUN_FUNCTIONS) {
+            const batchFunction = BATCH_RUN_FUNCTIONS[appActionKey]
+            // use the batch job timestamp as a source of truth when logging
+            const batchJobTimestamp = new Date(
+              batchedJob.timestamp,
+            ).toISOString()
+
+            await processBatchActionJob({
+              jobsInBatch,
+              worker,
+              bullMqOptions: { queueName, workerOptions, isQueueDelayable },
+              batchJobTimestamp,
+              batchFunction,
+            })
+          } else {
+            /**
+             * This will be the logic for actions in a queue that does not support batching e.g. M365 queue allows batching for createTableRow but not for other actions.
+             *
+             * If the action does not allow batching, handle each job in the batch individually as if there was no batching. Mark the individual jobs as failed to not fail the wrapped batch job. The progress object is used to get the error later to handle it.
+             */
+            for (const job of jobsInBatch) {
+              try {
+                await processSingleActionJob(job, worker, {
+                  queueName,
+                  workerOptions,
+                  isQueueDelayable,
+                })
+              } catch (err) {
+                job.updateProgress(err)
+                job.setAsFailed(err)
+              }
             }
           }
-          return
+          return // need to return here to avoid processing the single job
         }
 
         // proceed with single job in the batch as per normal
@@ -145,7 +181,7 @@ export function makeActionWorker(
 
   worker.on('active', (batchedJob: JobPro<IActionJobData>) => {
     const jobsInBatch = batchedJob.getBatch()
-    if (jobsInBatch.length > 1) {
+    if (jobsInBatch && jobsInBatch.length > 1) {
       logger.info(`[${queueName}] JOB IDs: ${batchedJob.id} have started!`, {
         queueName,
         batchJobTimestamp: new Date(batchedJob.timestamp).toISOString(),
@@ -170,7 +206,7 @@ export function makeActionWorker(
 
   worker.on('completed', (batchedJob: JobPro<IActionJobData>) => {
     const jobsInBatch = batchedJob.getBatch()
-    if (jobsInBatch.length > 1) {
+    if (jobsInBatch && jobsInBatch.length > 1) {
       // track each individual job for failure and log it
       const failedJobsInBatch = jobsInBatch.filter(
         (subJob: Job) => subJob.failedReason,
@@ -238,7 +274,7 @@ export function makeActionWorker(
   worker.on('failed', async (batchedJob: JobPro<IActionJobData>, err) => {
     const jobsInBatch = batchedJob.getBatch()
     // This occurs when the wrapped batch job fails
-    if (jobsInBatch.length > 1) {
+    if (jobsInBatch && jobsInBatch.length > 1) {
       logger.error(`[${queueName}] JOB IDs: ${batchedJob.id} have failed!`, {
         err,
         queueName,

--- a/packages/backend/src/workers/helpers/process-batch-action-job.ts
+++ b/packages/backend/src/workers/helpers/process-batch-action-job.ts
@@ -1,0 +1,108 @@
+import {
+  IActionJobData,
+  IGlobalVariable,
+  NextStepMetadata,
+} from '@plumber/types'
+
+import { Job, UnrecoverableError, WorkerPro } from '@taskforcesh/bullmq-pro'
+import { tracer } from 'dd-trace'
+
+import appConfig from '@/config/app'
+import { ForEachContext } from '@/helpers/compute-for-each-parameters'
+import Execution from '@/models/execution'
+import Step from '@/models/step'
+import { makeActionJobId } from '@/queues/action'
+import {
+  processJobAfterBatchFunction,
+  processJobDataForBatchFunction,
+} from '@/services/batch-action'
+
+import { type BullMqOptions } from './make-action-worker'
+
+type ProcessBatchActionJobOptions = {
+  jobsInBatch: Job[]
+  worker: WorkerPro<IActionJobData>
+  bullMqOptions: BullMqOptions
+  batchJobTimestamp: string
+  batchFunction: (jobsToProcessData: ProcessedJobData[]) => Promise<void>
+}
+
+export type ProcessedJobData = {
+  job: Job
+  $: IGlobalVariable
+  step: Step
+  execution: Execution
+  metadata: NextStepMetadata // not sure if this is needed
+  forEachContext: ForEachContext
+}
+
+export const processBatchActionJob = async (
+  params: ProcessBatchActionJobOptions,
+) => {
+  const {
+    jobsInBatch,
+    worker,
+    bullMqOptions,
+    batchJobTimestamp,
+    batchFunction,
+  } = params
+  const { queueName } = bullMqOptions
+  const span = tracer.scope().active()
+
+  const jobsToProcessData: ProcessedJobData[] = []
+
+  // Part 1: Pre-process the job data for the batch function
+  for (const job of jobsInBatch) {
+    const jobData = job.data
+    const jobId = makeActionJobId(queueName, job.id)
+
+    // The reason why we dont add .throwIfNotFound() here is to prevent job
+    // retries delegating the error throwing and handling to processAction
+    // where it also queries for Step.
+    const currStep = await Step.query().findById(jobData.stepId)
+
+    span?.addTags({
+      queueName,
+      flowId: jobData.flowId,
+      executionId: jobData.executionId,
+      stepId: jobData.stepId,
+      actionKey: currStep?.key,
+      appKey: currStep?.appKey,
+      jobId,
+      jobEnqueueTime: job.timestamp,
+      jobDelay: job.opts?.delay ?? 0,
+      attempts: job.attemptsStarted,
+      timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
+      workerVersion: appConfig.version,
+      batchJobTimestamp,
+    })
+
+    // pre-process the jobs to process data, job.setAsFailed() if necessary (this is the code before processAction in singleActionJob till the testRun function)
+    await processJobDataForBatchFunction(
+      job,
+      jobsToProcessData,
+      batchJobTimestamp,
+    )
+  }
+
+  // Edge case where all jobs are failed to be processed, mark the batch job as failed
+  if (jobsToProcessData.length === 0) {
+    throw new UnrecoverableError('No jobs to process for batch function')
+  }
+
+  // Part 2: Perform the batch function on the remaining jobs
+  // perform the batchFunction on the remaining jobs, store the error in the $ first.
+  await batchFunction(jobsToProcessData)
+
+  // Part 3: Post-process the batch function results: from "testRun" or "run" in singleActionJob
+  // then use the error to populate the $.actionOutput.error for each job, and record the execution step... and return all the necessary data needed
+  // then post-process with the necessary data after processAction in singleActionJob and job.setAsFailed() if necessary
+  for (const jobToProcessData of jobsToProcessData) {
+    await processJobAfterBatchFunction(
+      jobToProcessData,
+      batchJobTimestamp,
+      worker,
+      bullMqOptions,
+    )
+  }
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -875,8 +875,10 @@ export type IGlobalVariable = {
   webhookUrl?: string
   triggerOutput?: ITriggerOutput
   actionOutput?: IActionOutput
+  executionError?: Error
   pushTriggerItem?: (triggerItem: ITriggerItem) => Promise<void>
   setActionItem?: (actionItem: IActionItem) => void
+  setExecutionError?: (error: Error) => void
 
   /**
    * If this is non-null, it contains details of the pipe owner if this is


### PR DESCRIPTION
Note: This is a draft when I thought that batching could work with groups... facepalm

### TL;DR

Added batch processing functionality for M365 Excel actions, starting with a test implementation for the createTableRow action.

### What changed?

- Implemented batch processing infrastructure for handling multiple jobs efficiently
- Created a test batch run function for the M365 Excel createTableRow action
- Updated queue configuration to group jobs by table ID and action type
- Added batch function registry in config/batches.ts
- Implemented helper functions for processing batch jobs:
  - Pre-processing job data
  - Executing batch functions
  - Post-processing results
- Enhanced global variable with error handling capabilities
- Added error handling and logging for batch operations

### How to test?

1. Create multiple Excel createTableRow actions that operate on the same table
2. Verify that these actions are batched together in the queue
3. Check that odd-numbered jobs in the batch fail with the test error message
4. Confirm that even-numbered jobs succeed
5. Verify logs show proper batch processing and error handling

### Why make this change?

Batching API calls to Microsoft Graph significantly improves performance and reduces the risk of hitting rate limits. By grouping similar operations that target the same table, we can optimize network requests and provide a more efficient experience, especially for workflows that create multiple rows in Excel tables.

GitHub Copilot: I've summarized the PR changes, focusing on the batch processing functionality for M365 Excel actions. The implementation includes the infrastructure for batching jobs, error handling, and a test implementation for the createTableRow action. This change will improve performance by reducing API calls to Microsoft Graph.