### PR TITLE
fix: remove nbsp from custom header values

### DIFF
--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod'
 
-import { sanitizeMarkdown } from '@/apps/telegram-bot/common/markdown-v1'
-
 export const requestSchema = z.object({
   customHeaders: z
     .array(
@@ -41,8 +39,7 @@ export const requestSchema = z.object({
         }
         seenFields.add(key)
 
-        const cleanV = value?.replaceAll(/\r?\n|\r/g, ' ') || ''
-        result[key] = sanitizeMarkdown(cleanV)
+        result[key] = value.replace(/\u00A0/g, ' ')
       }
       return result
     })

--- a/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/schema.ts
@@ -39,7 +39,7 @@ export const requestSchema = z.object({
         }
         seenFields.add(key)
 
-        result[key] = value.replace(/\u00A0/g, ' ')
+        result[key] = value?.replace(/\u00A0/g, ' ') || ''
       }
       return result
     })

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -48,6 +48,7 @@ import {
   genVariableInfoMap,
   getPopoverPlacement,
   GLOBAL_VARIABLE_REGEX,
+  removeProblematicWhitespace,
   singleLineEditorScroll,
   substituteOldTemplates,
 } from './utils'
@@ -189,7 +190,11 @@ const Editor = ({
         onChange('')
         return
       }
-      onChange(isRich ? editor.getHTML() : editor.getText())
+      onChange(
+        isRich
+          ? editor.getHTML()
+          : removeProblematicWhitespace(editor.getText()),
+      )
     },
     editable,
     // To simulate textarea and coordinate with dropdown input size

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -1,7 +1,7 @@
 import escapeHTML from 'escape-html'
 import { describe, expect, it } from 'vitest'
 
-import { substituteOldTemplates } from './utils'
+import { removeProblematicWhitespace, substituteOldTemplates } from './utils'
 
 const varInfo = new Map<
   string,
@@ -166,5 +166,34 @@ describe('replaceOldTemplates', () => {
     const expected =
       'Hello <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world! <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="mama">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span><br><span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="mama">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span>'
     expect(substituteOldTemplates(input, varInfo)).toEqual(expected)
+  })
+})
+
+describe('removeProblematicWhitespace', () => {
+  it('should remove non-breaking space', () => {
+    const input = 'Lorem​Ipsum​Dolor​Sit​Amet​Co'
+    const expected = 'LoremIpsumDolorSitAmetCo'
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should handle other problematic whitespace', () => {
+    const input = 'Hello\u200B\uFEFF\u200C\u200D\u200EWorld'
+    const expected = 'HelloWorld'
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should convert non-breaking space to regular space', () => {
+    const input = ' Hello World  '
+    const expected = ' Hello World  '
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should handle empty string', () => {
+    expect(removeProblematicWhitespace('')).toEqual('')
+  })
+
+  it('should handle text with no problematic characters', () => {
+    const input = 'Hello World'
+    expect(removeProblematicWhitespace(input)).toEqual(input)
   })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -245,3 +245,16 @@ export function scrollVariableIntoView(
     behavior: 'smooth',
   })
 }
+
+export function removeProblematicWhitespace(text: string): string {
+  if (!text) {
+    return ''
+  }
+  return (
+    text
+      // Remove zero-width spaces
+      .replace(/(\u200B|\uFEFF|\u200C|\u200D|\u200E)/g, '')
+      // Replace non-breaking space with regular space
+      .replace(/\u00A0/g, ' ')
+  )
+}


### PR DESCRIPTION
## Problem
Our editor adds `\u00A0` when user adds whitespace in the value for Custom API's custom header.
This causes Authorization headers to return unauthenticated despite the token being correct.
<img width="255" height="28" alt="Screenshot 2025-08-15 at 5 47 08 PM" src="https://github.com/user-attachments/assets/f7955779-bfd4-49b0-ba2f-1f3bc0c65cd5" />

## Solution
Replace the `\u00A0` with a simple ' ' in the schema.


## Tests
Should be able to call APIs with custom headers. Verify that the following work correctly, especially authorisation with bearer tokens:
- [ ] `Authorization: Bearer <some token>`
- [ ] Custom headers with whitespaces should not introduce special characters
