### PR TITLE
[TILES-MIGRATION-2]: update row backwards compat

### DIFF
--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -1,6 +1,7 @@
 import { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 import {
@@ -241,6 +242,19 @@ const action: IRawAction = {
         }
         if (e.message.includes('No rows to patch')) {
           // This means the corresponding row does not exist for pg
+          $.setActionItem({
+            raw: {
+              updated: false,
+            } satisfies UpdateRowOutput,
+          })
+          return
+        }
+        if (e.message.includes('Column oldRowId does not exist')) {
+          logger.error({
+            message: e.message,
+            event: 'updateSingleRow: oldRowId column does not exist',
+          })
+          // This means that the rowId is a uuid but there's no oldRowId column
           $.setActionItem({
             raw: {
               updated: false,

--- a/packages/backend/src/helpers/zod-utils.ts
+++ b/packages/backend/src/helpers/zod-utils.ts
@@ -36,3 +36,7 @@ export function firstZodParseError(error: ZodError): string {
     } field`
   }
 }
+
+export function isUUID(str: string): boolean {
+  return z.string().uuid().safeParse(str).success
+}

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { ulid } from 'ulid'
 import { beforeEach, describe, expect, it } from 'vitest'
 
@@ -15,6 +16,7 @@ import {
   TableRowFilterOperator,
   TableRowOutputWithTimestamps,
 } from '../../types'
+import { createTableColumns } from '../table-column-functions'
 import {
   createTableRow,
   createTableRows,
@@ -319,6 +321,77 @@ describe('table-row-functions', () => {
           },
         }),
       ).rejects.toThrow('Invalid value for add operation')
+    })
+
+    it('should update row for migrated tiles using oldRowId', async () => {
+      const oldRowId = randomUUID()
+      // await createTableColumns(dummyTable.id, ['oldRowId'])
+      await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: 'yorimo anata',
+          [dummyColumnIds[1]]: '123',
+          oldRowId,
+        },
+      })
+
+      const updatedRow = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId: oldRowId,
+        patchData: {
+          set: {
+            [dummyColumnIds[0]]: 'choco-minto',
+          },
+        },
+      })
+      expect(updatedRow.data[dummyColumnIds[0]]).toBe('choco-minto')
+    })
+    it('should update row for migrated tiles using new rowId', async () => {
+      const oldRowId = randomUUID()
+      await createTableColumns(dummyTable.id, ['oldRowId'])
+      const createdRow = await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: 'yorimo anata',
+          [dummyColumnIds[1]]: '123',
+          oldRowId,
+        },
+      })
+
+      const updatedRow2 = await patchTableRow({
+        tableId: dummyTable.id,
+        rowId: createdRow.rowId,
+        patchData: {
+          set: {
+            [dummyColumnIds[0]]: 'strawberry-minto',
+          },
+        },
+      })
+
+      expect(updatedRow2.data[dummyColumnIds[0]]).toBe('strawberry-minto')
+    })
+
+    it('should throw an error if the oldRowId is not found', async () => {
+      await createTableColumns(dummyTable.id, ['oldRowId'])
+      await createTableRow({
+        tableId: dummyTable.id,
+        data: {
+          [dummyColumnIds[0]]: 'yorimo anata',
+          [dummyColumnIds[1]]: '123',
+          oldRowId: randomUUID(),
+        },
+      })
+      await expect(
+        patchTableRow({
+          tableId: dummyTable.id,
+          rowId: randomUUID(),
+          patchData: {
+            set: {
+              [dummyColumnIds[0]]: 'strawberry-minto',
+            },
+          },
+        }),
+      ).rejects.toThrow()
     })
   })
 

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -325,7 +325,7 @@ describe('table-row-functions', () => {
 
     it('should update row for migrated tiles using oldRowId', async () => {
       const oldRowId = randomUUID()
-      // await createTableColumns(dummyTable.id, ['oldRowId'])
+      await createTableColumns(dummyTable.id, ['oldRowId'])
       await createTableRow({
         tableId: dummyTable.id,
         data: {

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -3,6 +3,7 @@ import { monotonicFactory, ulid } from 'ulid'
 
 import { tilesClient } from '@/config/tiles-database'
 import logger from '@/helpers/logger'
+import { isUUID } from '@/helpers/zod-utils'
 
 import {
   CreateRowInput,
@@ -106,7 +107,11 @@ export const patchTableRow = async ({
   patchData,
 }: PatchRowInput): Promise<TableRowItem> => {
   try {
-    const query = tilesClient(tableId).where({ rowId: rowIdToUse })
+    // For backwards compat
+    const shouldUseOldRowId = isUUID(rowIdToUse)
+    const query = tilesClient(tableId).where({
+      [shouldUseOldRowId ? 'oldRowId' : 'rowId']: rowIdToUse,
+    })
 
     Object.entries(patchData.set || {}).forEach(
       ([key, value]: [string, string]) => {
@@ -153,8 +158,11 @@ export const patchTableRow = async ({
       throw new Error('No rows to patch')
     }
     return formatTableRow(res[0], tableId)
-  } catch (e: unknown) {
+  } catch (e: any) {
     logger.error(e)
+    if (e.code === '42703') {
+      throw new Error('Column oldRowId does not exist')
+    }
     throw e
   }
 }


### PR DESCRIPTION
## Problem
Migrated tiles should still be able to update row based on old row id (UUIDv4) format since it could be hardcoded.

## Solution
If row ID is of UUID format, attempt to look for row in the oldRowId column. The only action affected is updateRow, other actions should not need to be backwards compatible. Modifying of data via the tiles editor directly should also not rely on the old row id.