### PR TITLE
[TILES-MIGRATION-1]: use env var to pause tiles endpoints

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -257,6 +257,10 @@
     {
       "name": "SSO_DISCOVERY_URL",
       "valueFrom": "plumber-<ENVIRONMENT>-sso-discovery-url"
+    },
+    {
+      "name": "TILES_UNDER_MAINTENANCE",
+      "valueFrom": "plumber-<ENVIRONMENT>-tiles-under-maintenance"
     }
   ]
 }

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -60,6 +60,7 @@ type AppConfig = {
     clientSecret: string
     discoveryUrl: string
   }
+  isTilesUnderMaintenance: boolean
 }
 
 const port = process.env.PORT || '3000'
@@ -134,6 +135,7 @@ const appConfig: AppConfig = {
     clientSecret: process.env.SSO_CLIENT_SECRET,
     discoveryUrl: process.env.SSO_DISCOVERY_URL,
   },
+  isTilesUnderMaintenance: process.env.TILES_UNDER_MAINTENANCE === 'true',
 }
 
 if (!appConfig.encryptionKey) {

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -1,5 +1,6 @@
 import { raw } from 'objection'
 
+import appConfig from '@/config/app'
 import testStep from '@/services/test-step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -17,6 +18,12 @@ const executeStep: MutationResolvers['executeStep'] = async (
     .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()
+
+  if (stepToTest.appKey === 'tiles' && appConfig.isTilesUnderMaintenance) {
+    throw new Error(
+      'Tiles is temporarily unavailable for maintenance. Please try again later.',
+    )
+  }
 
   const { executionStep, executionId } = await testStep({
     stepId: stepToTest.id,

--- a/packages/backend/src/graphql/mutations/tiles/index.ts
+++ b/packages/backend/src/graphql/mutations/tiles/index.ts
@@ -1,3 +1,5 @@
+import { withTilesMaintenanceCheck } from '@/helpers/temp/tiles-maintenance-check'
+
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
 import createRow from './create-row'
@@ -12,14 +14,14 @@ import updateTable from './update-table'
 import upsertTableCollaborator from './upsert-table-collaborator'
 
 export default {
-  createTable,
-  deleteTable,
-  updateTable,
-  createRow,
-  createRows,
-  updateRow,
-  deleteRows,
-  createShareableTableLink,
-  deleteTableCollaborator,
-  upsertTableCollaborator,
+  createTable: withTilesMaintenanceCheck(createTable),
+  deleteTable: withTilesMaintenanceCheck(deleteTable),
+  updateTable: withTilesMaintenanceCheck(updateTable),
+  createRow: withTilesMaintenanceCheck(createRow),
+  createRows: withTilesMaintenanceCheck(createRows),
+  updateRow: withTilesMaintenanceCheck(updateRow),
+  deleteRows: withTilesMaintenanceCheck(deleteRows),
+  createShareableTableLink: withTilesMaintenanceCheck(createShareableTableLink),
+  deleteTableCollaborator: withTilesMaintenanceCheck(deleteTableCollaborator),
+  upsertTableCollaborator: withTilesMaintenanceCheck(upsertTableCollaborator),
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/queries/tiles/index.ts
+++ b/packages/backend/src/graphql/queries/tiles/index.ts
@@ -1,3 +1,5 @@
+import { withTilesMaintenanceCheck } from '@/helpers/temp/tiles-maintenance-check'
+
 import type { QueryResolvers } from '../../__generated__/types.generated'
 
 import getAllRows from './get-all-rows'
@@ -6,8 +8,8 @@ import getTableConnections from './get-table-connections'
 import getTables from './get-tables'
 
 export default {
-  getTable,
-  getTableConnections,
-  getTables,
-  getAllRows,
+  getTable: withTilesMaintenanceCheck(getTable),
+  getTableConnections: withTilesMaintenanceCheck(getTableConnections),
+  getTables: withTilesMaintenanceCheck(getTables),
+  getAllRows: withTilesMaintenanceCheck(getAllRows),
 } satisfies QueryResolvers

--- a/packages/backend/src/helpers/temp/tiles-maintenance-check.ts
+++ b/packages/backend/src/helpers/temp/tiles-maintenance-check.ts
@@ -1,0 +1,14 @@
+import appConfig from '@/config/app'
+
+export const withTilesMaintenanceCheck = <T extends (...args: any[]) => any>(
+  resolver: T,
+): T => {
+  return ((...args: Parameters<T>) => {
+    if (appConfig.isTilesUnderMaintenance) {
+      throw new Error(
+        'Tiles is temporarily unavailable for maintenance. Please try again later.',
+      )
+    }
+    return resolver(...args)
+  }) as T
+}

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -326,7 +326,7 @@ export const EditorProvider = ({
   const [executeStep, { loading: isTestExecuting }] = useMutation(
     EXECUTE_STEP,
     {
-      context: { autoSnackbar: false },
+      context: { autoSnackbar: true },
       awaitRefetchQueries: true,
       refetchQueries: [GET_TEST_EXECUTION_STEPS, GET_FLOW],
       update(cache, { data }) {


### PR DESCRIPTION
## Problem
We need a way to pause changes to tiles from the UI.

## Solution
Introduce an env var to pause all Tile-related routes when it's set to `true`. 
Why not launch darkly flag? Introduces too much network calls and latencies to these endpoints.

### To test
Test that the following throws an error with a toast during maintenance
- [ ] Creating/Deletion of tile
- [ ] Updating/Inserting/Deleting of rows
- [ ] Ordering/Adding/Removing/Editing columns
- [ ] Creation of tile and column in inline pipe editor