### PR TITLE
fix: sanitize problematic whitespaces on tiptap editor

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -48,6 +48,7 @@ import {
   genVariableInfoMap,
   getPopoverPlacement,
   GLOBAL_VARIABLE_REGEX,
+  removeProblematicWhitespace,
   singleLineEditorScroll,
   substituteOldTemplates,
 } from './utils'
@@ -189,7 +190,11 @@ const Editor = ({
         onChange('')
         return
       }
-      onChange(isRich ? editor.getHTML() : editor.getText())
+      onChange(
+        isRich
+          ? editor.getHTML()
+          : removeProblematicWhitespace(editor.getText()),
+      )
     },
     editable,
     // To simulate textarea and coordinate with dropdown input size

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -1,7 +1,7 @@
 import escapeHTML from 'escape-html'
 import { describe, expect, it } from 'vitest'
 
-import { substituteOldTemplates } from './utils'
+import { removeProblematicWhitespace, substituteOldTemplates } from './utils'
 
 const varInfo = new Map<
   string,
@@ -166,5 +166,34 @@ describe('replaceOldTemplates', () => {
     const expected =
       'Hello <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> world! <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="mama">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span><br><span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello}}</span> <span data-type="variable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa" data-label="papa" data-value="mama">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.papa}}</span>'
     expect(substituteOldTemplates(input, varInfo)).toEqual(expected)
+  })
+})
+
+describe('removeProblematicWhitespace', () => {
+  it('should remove non-breaking space', () => {
+    const input = 'Lorem​Ipsum​Dolor​Sit​Amet​Co'
+    const expected = 'LoremIpsumDolorSitAmetCo'
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should handle other problematic whitespace', () => {
+    const input = 'Hello\u200B\uFEFF\u200C\u200D\u200EWorld'
+    const expected = 'HelloWorld'
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should convert non-breaking space to regular space', () => {
+    const input = ' Hello World  '
+    const expected = ' Hello World  '
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
+
+  it('should handle empty string', () => {
+    expect(removeProblematicWhitespace('')).toEqual('')
+  })
+
+  it('should handle text with no problematic characters', () => {
+    const input = 'Hello World'
+    expect(removeProblematicWhitespace(input)).toEqual(input)
   })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -245,3 +245,16 @@ export function scrollVariableIntoView(
     behavior: 'smooth',
   })
 }
+
+export function removeProblematicWhitespace(text: string): string {
+  if (!text) {
+    return ''
+  }
+  return (
+    text
+      // Remove zero-width spaces
+      .replace(/(\u200B|\uFEFF|\u200C|\u200D|\u200E)/g, '')
+      // Replace non-breaking space with regular space
+      .replace(/\u00A0/g, ' ')
+  )
+}


### PR DESCRIPTION
## Problem

This is a follow up from the parent PR to attempt to fix the rest of the input fields that may potentially face the same issue.

## Solution

This PR introduces a new utility function that removes problematic whitespaces such as non-breaking whitespaces and zero-width whitespaces. The RichTextEditor component will strip such characters onUpdate for all input fields except Postman's editor field.

### To test
- unit tests have been added
- to manually test:
   1. type some text followed by a variable into an input field
   1. copy the saved paramters from the db and paste into https://www.regextester.com/109937 to check