### PR TITLE
add poc for manual batching using job.progress

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/batch-run-hybrid.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/batch-run-hybrid.ts
@@ -1,0 +1,320 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import StepError from '@/errors/step'
+import {
+  generateErrorForActionOutput,
+  ProcessedJobData,
+} from '@/services/batch-action'
+import { JobProgress } from '@/workers/helpers/make-action-worker'
+
+import { sanitiseInputValue } from '../../common/sanitise-formula-input'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
+import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
+import WorkbookSession from '../../common/workbook-session'
+
+import { parametersSchema } from './schemas'
+
+type ColumnValue = {
+  columnName: string
+  value: string
+}
+
+// Small wrapper around constructMsGraphValuesArrayForRowWrite which throws
+// StepError. As StepError requires $, this helps avoid $ becoming viral through
+// our codebase.
+//
+// constructMsGraphValuesArrayForRowWrite is a generic helper function and
+// should not be restricted to codepaths with $.
+function buildRowUpdateArgs(
+  $: IGlobalVariable,
+  ...args: Parameters<typeof constructMsGraphValuesArrayForRowWrite>
+): ReturnType<typeof constructMsGraphValuesArrayForRowWrite> {
+  try {
+    return constructMsGraphValuesArrayForRowWrite(...args)
+  } catch (err) {
+    throw new StepError(
+      `Error creating table row: ${err.message}`,
+      'Double check that your step is configured correctly',
+      $.step.position,
+      $.app.name,
+    )
+  }
+}
+
+interface TableHeaderInfo {
+  rowIndex: number
+  columnNames: string[] // Ordered
+}
+
+async function createRowsIndividually(
+  session: WorkbookSession,
+  tableId: string,
+  tableHeaderInfo: TableHeaderInfo,
+  remainingJobsToProcessData: ProcessedJobData[],
+  startRowIndex: number,
+) {
+  let successfulRowsCount = 0
+  const results: Array<{
+    jobIndex: number
+    success: boolean
+    error?: string
+    sheetRowNumber?: number
+  }> = []
+
+  for (let i = 0; i < remainingJobsToProcessData.length; i++) {
+    const jobToProcessData = remainingJobsToProcessData[i]
+
+    try {
+      const rowValues = buildRowUpdateArgs(
+        jobToProcessData.$,
+        tableHeaderInfo.columnNames,
+        (jobToProcessData.$.step.parameters.columnValues as ColumnValue[]).map(
+          (col) => ({
+            columnName: col.columnName,
+            value: sanitiseInputValue(col.value),
+          }),
+        ),
+      )
+
+      // Create individual row
+      await session.request<{ index: number }>(
+        `/tables/${tableId}/rows`,
+        'post',
+        {
+          data: {
+            index: null,
+            values: [rowValues],
+          },
+        },
+      )
+
+      const sheetRowNumber = startRowIndex + successfulRowsCount + 1
+      successfulRowsCount++
+
+      results.push({
+        jobIndex: i,
+        success: true,
+        sheetRowNumber,
+      })
+    } catch (error) {
+      const errorMessage =
+        error?.response?.data?.error?.message ||
+        error.message ||
+        'Unknown error'
+      console.error(`Row ${i + 1} failed to create:`, error)
+
+      results.push({
+        jobIndex: i,
+        success: false,
+        error: errorMessage,
+      })
+    }
+  }
+
+  return results
+}
+
+async function batchRunHybrid(jobsToProcessData: ProcessedJobData[]) {
+  const remainingJobsToProcessData = []
+  for (const jobToProcessData of jobsToProcessData) {
+    const { $, job } = jobToProcessData
+    try {
+      const parametersParseResult = parametersSchema.safeParse(
+        $.step.parameters,
+      )
+
+      if (parametersParseResult.success === false) {
+        throw new StepError(
+          'There was a problem with the input.',
+          parametersParseResult.error.issues[0].message,
+          $.step?.position,
+          $.app.name,
+        )
+      }
+
+      const { fileId, tableId } = parametersParseResult.data
+
+      // Validation to prevent path traversals
+      validateDynamicFieldsAndThrowError({
+        fileId,
+        tableId,
+        $,
+      })
+
+      remainingJobsToProcessData.push(jobToProcessData)
+    } catch (error) {
+      $.actionOutput.error = generateErrorForActionOutput(error)
+      $.setExecutionError(error)
+      const newJobProgressData = {
+        ...(job.progress as JobProgress).jobProgressData,
+        $: $,
+      }
+      job.updateProgress({
+        jobProgressData: newJobProgressData,
+      })
+      continue
+    }
+  }
+
+  // acquire just one session for API calls
+  const { fileId, tableId } = remainingJobsToProcessData[0].$.step.parameters
+
+  const session = await WorkbookSession.acquire(
+    remainingJobsToProcessData[0].$,
+    fileId as string,
+  )
+
+  try {
+    const tableHeaderInfoResponse = await session.request<{
+      rowIndex: number
+      values: string[][] // Guaranteed to be length 1 at top level
+    }>(`/tables/${tableId}/headerRowRange?$select=rowIndex,values`, 'get')
+
+    const tableHeaderInfo: TableHeaderInfo = {
+      rowIndex: tableHeaderInfoResponse.data.rowIndex,
+      columnNames: tableHeaderInfoResponse.data.values[0],
+    }
+
+    const currentRowIndex = tableHeaderInfoResponse.data.rowIndex + 1
+
+    // Strategy 1: Try batch creation first (faster)
+    try {
+      console.log('Attempting batch creation...')
+
+      const createRowsResponse = await session.request<{ index: number }>(
+        `/tables/${tableId}/rows`,
+        'post',
+        {
+          data: {
+            index: null,
+            values: remainingJobsToProcessData.map((jobToProcessData) =>
+              buildRowUpdateArgs(
+                jobToProcessData.$,
+                tableHeaderInfo.columnNames,
+                (
+                  jobToProcessData.$.step.parameters
+                    .columnValues as ColumnValue[]
+                ).map((col) => ({
+                  columnName: col.columnName,
+                  value: sanitiseInputValue(col.value),
+                })),
+              ),
+            ),
+          },
+        },
+      )
+
+      // Batch success - update all jobs
+      const createRowsResponseData = createRowsResponse.data as any
+      const firstRowIndex =
+        tableHeaderInfoResponse.data.rowIndex + 1 + createRowsResponseData.index
+
+      for (let i = 0; i < remainingJobsToProcessData.length; i++) {
+        const jobToProcessData = remainingJobsToProcessData[i]
+        const { $, job } = jobToProcessData
+        const sheetRowNumber = firstRowIndex + i + 1
+
+        $.setActionItem({
+          raw: {
+            sheetRowNumber: sheetRowNumber,
+            success: true,
+            method: 'batch',
+          },
+        })
+
+        const newJobProgressData = {
+          ...(job.progress as JobProgress).jobProgressData,
+          $: $,
+        }
+        job.updateProgress({
+          jobProgressData: newJobProgressData,
+        })
+      }
+
+      console.log('Batch creation successful')
+    } catch (batchError) {
+      // Strategy 2: Batch failed, fall back to individual creation for detailed error reporting
+      console.log(
+        'Batch creation failed, falling back to individual creation:',
+        batchError,
+      )
+
+      const results = await createRowsIndividually(
+        session,
+        tableId as string,
+        tableHeaderInfo,
+        remainingJobsToProcessData,
+        currentRowIndex,
+      )
+
+      // Process results and update job progress
+      for (const result of results) {
+        const jobToProcessData = remainingJobsToProcessData[result.jobIndex]
+        const { $, job } = jobToProcessData
+
+        if (result.success) {
+          $.setActionItem({
+            raw: {
+              sheetRowNumber: result.sheetRowNumber,
+              success: true,
+              method: 'individual',
+              rowIndex: result.jobIndex + 1,
+            },
+          })
+        } else {
+          const detailedError = new StepError(
+            `Error creating table row ${result.jobIndex + 1}: ${result.error}`,
+            `Row ${
+              result.jobIndex + 1
+            } failed validation or contains invalid data. Please check the column values and try again.`,
+            $.step.position,
+            $.app.name,
+          )
+
+          $.actionOutput.error = generateErrorForActionOutput(detailedError)
+          $.setExecutionError(detailedError)
+
+          $.setActionItem({
+            raw: {
+              success: false,
+              rowIndex: result.jobIndex + 1,
+              error: result.error,
+              method: 'individual',
+              failedData: jobToProcessData.$.step.parameters.columnValues,
+            },
+          })
+        }
+
+        const newJobProgressData = {
+          ...(job.progress as JobProgress).jobProgressData,
+          $: $,
+        }
+        job.updateProgress({
+          jobProgressData: newJobProgressData,
+        })
+      }
+    }
+  } catch (error) {
+    // If the batch function fails at the session/table level
+    console.log('error with creation of rows...', error)
+    const firstJobToProcessData = remainingJobsToProcessData[0]
+    const { $, job } = firstJobToProcessData
+    $.actionOutput.error = generateErrorForActionOutput(error)
+    $.setExecutionError(error)
+    const newJobProgressData = {
+      ...(job.progress as JobProgress).jobProgressData,
+      $: $,
+    }
+    job.updateProgress({
+      jobProgressData: newJobProgressData,
+    })
+
+    for (let i = 1; i < remainingJobsToProcessData.length; i++) {
+      const jobToProcessData = remainingJobsToProcessData[i]
+      const { job } = jobToProcessData
+      job.updateProgress(0)
+    }
+  }
+}
+
+export default batchRunHybrid

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/batch-run.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/batch-run.ts
@@ -1,0 +1,182 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import StepError from '@/errors/step'
+import {
+  generateErrorForActionOutput,
+  ProcessedJobData,
+} from '@/services/batch-action'
+import { JobProgress } from '@/workers/helpers/make-action-worker'
+
+import { sanitiseInputValue } from '../../common/sanitise-formula-input'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
+import { constructMsGraphValuesArrayForRowWrite } from '../../common/workbook-helpers/tables'
+import WorkbookSession from '../../common/workbook-session'
+
+import { parametersSchema } from './schemas'
+
+type ColumnValue = {
+  columnName: string
+  value: string
+}
+
+// Small wrapper around constructMsGraphValuesArrayForRowWrite which throws
+// StepError. As StepError requires $, this helps avoid $ becoming viral through
+// our codebase.
+//
+// constructMsGraphValuesArrayForRowWrite is a generic helper function and
+// should not be restricted to codepaths with $.
+function buildRowUpdateArgs(
+  $: IGlobalVariable,
+  ...args: Parameters<typeof constructMsGraphValuesArrayForRowWrite>
+): ReturnType<typeof constructMsGraphValuesArrayForRowWrite> {
+  try {
+    return constructMsGraphValuesArrayForRowWrite(...args)
+  } catch (err) {
+    throw new StepError(
+      `Error creating table row: ${err.message}`,
+      'Double check that your step is configured correctly',
+      $.step.position,
+      $.app.name,
+    )
+  }
+}
+
+interface TableHeaderInfo {
+  rowIndex: number
+  columnNames: string[] // Ordered
+}
+
+async function batchRun(jobsToProcessData: ProcessedJobData[]) {
+  const remainingJobsToProcessData = []
+  for (const jobToProcessData of jobsToProcessData) {
+    const { $, job } = jobToProcessData
+    try {
+      const parametersParseResult = parametersSchema.safeParse(
+        $.step.parameters,
+      )
+
+      if (parametersParseResult.success === false) {
+        throw new StepError(
+          'There was a problem with the input.',
+          parametersParseResult.error.issues[0].message,
+          $.step?.position,
+          $.app.name,
+        )
+      }
+
+      const { fileId, tableId } = parametersParseResult.data
+
+      // Validation to prevent path traversals
+      validateDynamicFieldsAndThrowError({
+        fileId,
+        tableId,
+        $,
+      })
+
+      remainingJobsToProcessData.push(jobToProcessData)
+    } catch (error) {
+      // TODO: check whether to log error with the batch job timestamp
+      $.actionOutput.error = generateErrorForActionOutput(error)
+      $.setExecutionError(error)
+      const newJobProgressData = {
+        ...(job.progress as JobProgress).jobProgressData,
+        $: $,
+      }
+      job.updateProgress({
+        jobProgressData: newJobProgressData,
+      })
+      continue
+    }
+  }
+
+  // acquire just one session for 1 batch API call
+  const { fileId, tableId } = remainingJobsToProcessData[0].$.step.parameters
+
+  const session = await WorkbookSession.acquire(
+    remainingJobsToProcessData[0].$,
+    fileId as string,
+  )
+
+  /**
+   * Caveat: We cannot tell if any job in the batch would have invalid data for row creation in the batch API call, so refer to they batch-run-hybrid for the logic to fallback to individaul row creation if the batch call fails
+   */
+  try {
+    const tableHeaderInfoResponse = await session.request<{
+      rowIndex: number
+      values: string[][] // Guaranteed to be length 1 at top level
+    }>(`/tables/${tableId}/headerRowRange?$select=rowIndex,values`, 'get')
+    const tableHeaderInfo: TableHeaderInfo = {
+      rowIndex: tableHeaderInfoResponse.data.rowIndex,
+      columnNames: tableHeaderInfoResponse.data.values[0],
+    }
+
+    // Note: we disallow blacklisted formulas and sanitise when necessary
+    const createRowsResponse = await session.request<{ index: number }>(
+      `/tables/${tableId}/rows`,
+      'post',
+      {
+        data: {
+          index: null,
+          values: remainingJobsToProcessData.map((jobToProcessData) =>
+            buildRowUpdateArgs(
+              jobToProcessData.$,
+              tableHeaderInfo.columnNames,
+              (
+                jobToProcessData.$.step.parameters.columnValues as ColumnValue[]
+              ).map((col) => ({
+                columnName: col.columnName,
+                value: sanitiseInputValue(col.value),
+              })),
+            ),
+          ),
+        },
+      },
+    )
+
+    // TODO: use zod to parse the createRowsResponse.data
+    const createRowsResponseData = createRowsResponse.data as any
+    const firstRowIndex =
+      tableHeaderInfoResponse.data.rowIndex + 1 + createRowsResponseData.index
+
+    // reconsolidate the data for each job
+    for (let i = 0; i < remainingJobsToProcessData.length; i++) {
+      const jobToProcessData = remainingJobsToProcessData[i]
+      const { $, job } = jobToProcessData
+      const sheetRowNumber = firstRowIndex + i + 1
+      $.setActionItem({
+        raw: {
+          sheetRowNumber: sheetRowNumber,
+          success: true,
+        },
+      })
+      const newJobProgressData = {
+        ...(job.progress as JobProgress).jobProgressData,
+        $: $,
+      }
+      job.updateProgress({
+        jobProgressData: newJobProgressData,
+      })
+    }
+  } catch (error) {
+    // If the batch function fails because of the first job, only update the first job's progress and clear the rest to be processed again
+    const firstJobToProcessData = remainingJobsToProcessData[0]
+    const { $, job } = firstJobToProcessData
+    $.actionOutput.error = generateErrorForActionOutput(error)
+    $.setExecutionError(error)
+    const newJobProgressData = {
+      ...(job.progress as JobProgress).jobProgressData,
+      $: $,
+    }
+    job.updateProgress({
+      jobProgressData: newJobProgressData,
+    })
+
+    for (let i = 1; i < remainingJobsToProcessData.length; i++) {
+      const jobToProcessData = remainingJobsToProcessData[i]
+      const { job } = jobToProcessData
+      job.updateProgress(0)
+    }
+  }
+}
+
+export default batchRun

--- a/packages/backend/src/apps/m365-excel/queue/index.ts
+++ b/packages/backend/src/apps/m365-excel/queue/index.ts
@@ -16,25 +16,27 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
   jobData,
 ) => {
   const step = await Step.query().findById(jobData.stepId).throwIfNotFound()
-  const fileId = step.parameters['fileId'] as string
+  const tableId = step.parameters['tableId'] as string
 
-  if (!fileId) {
+  if (!tableId) {
     throw new Error(
-      `Expected fileId to be non-empty for step ${jobData.stepId}`,
+      `Expected tableId to be non-empty for step ${jobData.stepId}`,
     )
   }
 
-  // NOTE: File ID is only unique within the same SharePoint site and tenant.
+  // NOTE: Table ID is only unique within the same SharePoint site and tenant.
   // But since we only have one site per tenant, and we need a different per-app
   // queue for each tenant (each tenant may have different agreed-upon rate
-  // limits), we can avoid compleixty and simply set group ID to the file ID,
-  // instead of something like `${tenantId}-${siteId}-${fileId}`.
+  // limits), we can avoid complexity and simply set group ID to the table ID,
+  // instead of something like `${tenantId}-${siteId}-${tableId}`.
   //
-  // (The one app-queue per tenant thing isn't implemnented yet - for now, each
+  // (The one app-queue per tenant thing isn't implemented yet - for now, each
   // app can only have 1 per-app queue. We'll only do this if we ever need to
   // support more than 1 tenant.)
+  //
+  // The format will be: `${appKey}_${actionKey}_${tableId}` e.g. `m365-excel_createTableRow_1234567890`
   return {
-    id: fileId,
+    id: `${step.appKey}_${step.key}_${tableId}`,
   }
 }
 

--- a/packages/backend/src/config/batches.ts
+++ b/packages/backend/src/config/batches.ts
@@ -1,0 +1,22 @@
+import m365CreateTableRowBatchRun from '@/apps/m365-excel/actions/create-table-row/batch-run'
+import { ProcessedJobData } from '@/services/batch-action'
+
+/**
+ * Assumptions before thinking of using batching for an action in an app:
+ * - It should be using the same connection for all the jobs in the batch
+ * - It has to have a queue to group similar jobs to batch e.g. app_action key
+ *
+ * To introduce batching to an action in an app:
+ * 1. Add the app_action key to the BATCH_FUNCTIONS object
+ * 2. Add the batchRun function in the specific action folder in the app. Take note that you should be try-catching the batching API call inside this function to avoid the entire batch from failing without any proper handling.
+ * 3. Attach the batchRun function to this BATCH_RUN_FUNCTIONS object
+ */
+
+type BatchFunction = (jobsToProcessData: ProcessedJobData[]) => Promise<void>
+
+const m365AppKey = 'm365-excel'
+const m365CreateTableRowActionKey = 'createTableRow'
+
+export const BATCH_RUN_FUNCTIONS: Record<string, BatchFunction> = {
+  [`${m365AppKey}_${m365CreateTableRowActionKey}`]: m365CreateTableRowBatchRun,
+}

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -78,6 +78,7 @@ const globalVariable = async (
       appKey: step?.appKey,
       position: step?.position,
       parameters: step?.parameters || {},
+      key: step?.key,
     },
     nextStep: {
       id: nextStep?.id,
@@ -131,6 +132,9 @@ const globalVariable = async (
     },
     setActionItem: (actionItem: IActionItem) => {
       $.actionOutput.data = actionItem
+    },
+    setExecutionError: (error: Error) => {
+      $.executionError = error
     },
     user: flow?.user ?? user,
     metadata,

--- a/packages/backend/src/services/batch-action.ts
+++ b/packages/backend/src/services/batch-action.ts
@@ -1,0 +1,328 @@
+import {
+  IActionJobData,
+  IActionRunResult,
+  IGlobalVariable,
+  NextStepMetadata,
+} from '@plumber/types'
+
+import { Job, UnrecoverableError, WorkerPro } from '@taskforcesh/bullmq-pro'
+import { tracer } from 'dd-trace'
+
+import HttpError from '@/errors/http'
+import StepError from '@/errors/step'
+import { handleFailedStepAndThrow } from '@/helpers/actions'
+import {
+  ForEachContext,
+  getStepContext,
+} from '@/helpers/compute-for-each-parameters'
+import computeParameters from '@/helpers/compute-parameters'
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
+import globalVariable from '@/helpers/global-variable'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import { enqueueActionJob, makeActionJobId } from '@/queues/action'
+import processForEachStatus from '@/workers/helpers/for-each-status-manager'
+import {
+  BullMqOptions,
+  JobProgressData,
+} from '@/workers/helpers/make-action-worker'
+
+import getForEachMetadata from './helpers/get-for-each-metadata'
+
+export type ProcessedJobData = {
+  job: Job
+  $: IGlobalVariable
+  step: Step
+  execution: Execution
+  metadata: NextStepMetadata // not sure if this is needed
+  forEachContext: ForEachContext
+  batchJobTimestamp: string // to indicate the timestamp of the batch job???
+}
+
+/**
+ * This function is used to generate the error for the action output which will be stored in the $.actionOutput.error. This is to avoid the job failing before marking it as failed on the DB.
+ */
+export const generateErrorForActionOutput = (error: Error) => {
+  // logger.error(error) // TODO: check if this is needed
+  // log raw http error from StepError
+  if (error instanceof StepError && error.cause) {
+    logger.error(error.cause)
+  }
+  if (error instanceof HttpError) {
+    return {
+      details: error.details,
+      status: error.response.status,
+      statusText: error.response.statusText,
+    }
+  } else {
+    try {
+      return JSON.parse(error.message)
+    } catch {
+      return { error: error.message }
+    }
+  }
+}
+
+/**
+ * This function is used to pre-process the job data to prepare for the batchFunction
+ * It will mark the job as failed if the job data cannot be processed. Else, it will add the job to the jobsToProcessData array.
+ *
+ * For db error, missing execution, flow, step, etc..., we do not want to retry and process these jobs
+ */
+export const processJobDataForBatchFunction = async (
+  job: Job,
+  jobsToProcessData: ProcessedJobData[],
+  batchJobTimestamp: string,
+): Promise<void> => {
+  const { flowId, executionId, stepId, metadata = {} } = job.data
+
+  try {
+    const step = await Step.query().findById(stepId).throwIfNotFound()
+    const flow = await Flow.query()
+      .findById(flowId)
+      .withGraphJoined('user')
+      .withGraphFetched('steps')
+      .throwIfNotFound()
+    const execution = await Execution.query()
+      .findById(executionId)
+      .throwIfNotFound()
+
+    const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
+      getStepContext(flow, step)
+
+    // we use this to indicate an iteration in the for-each is complete
+    if (forEachStepPosition > -1 && isLastStep && metadata) {
+      metadata.isLastStep = true
+    }
+
+    // Only initialise $ global variable once for running batch job action later
+    const $ = await globalVariable({
+      flow,
+      app: await step.getApp(),
+      step: step,
+      connection: await step.$relatedQuery('connection'),
+      execution: execution,
+      metadata,
+    })
+
+    const priorExecutionSteps = await ExecutionStep.query().where({
+      execution_id: $.execution.id,
+      // only get successful execution steps
+      status: 'success',
+    })
+
+    const actionCommand = await step.getActionCommand()
+    const forEachContext: ForEachContext = {
+      executionStepMetadata: metadata,
+      forEachStepPosition,
+      stepPositions,
+      isForEachStep,
+    }
+
+    const computedParameters = computeParameters(
+      $.step.parameters,
+      priorExecutionSteps,
+      actionCommand.preprocessVariable,
+      forEachContext,
+    )
+
+    $.step.parameters = computedParameters
+
+    const processedJobData: ProcessedJobData = {
+      job,
+      $,
+      step,
+      execution,
+      metadata,
+      forEachContext,
+      batchJobTimestamp,
+    }
+    jobsToProcessData.push(processedJobData)
+    job.updateProgress({
+      jobProgressData: {
+        $,
+        forEachContext,
+        metadata,
+        step,
+        nextStep: await step.getNextStep(),
+        batchJobTimestamp,
+      },
+    })
+  } catch (error) {
+    // don't process this job, mark it as failed and move on to the next job
+    logger.error(`Failed to process job in batch`, {
+      error,
+      executionId,
+      stepId,
+      flowId,
+      jobId: job.id,
+      batchJobTimestamp,
+    })
+    const unrecoverableError = new UnrecoverableError(
+      error.message || 'Action failed to execute',
+    )
+    job.updateProgress({ unrecoverableError })
+  }
+}
+
+// Will never be a test run...
+export const processJobAfterBatchFunction = async (
+  job: Job,
+  jobProgressData: JobProgressData,
+  worker: WorkerPro<IActionJobData>,
+  bullMqOptions: BullMqOptions,
+) => {
+  // const { $, step, execution, metadata, forEachContext, batchJobTimestamp } =
+  //   jobToProcessData
+
+  const { $, forEachContext, metadata, step, nextStep, batchJobTimestamp } =
+    jobProgressData
+  try {
+    const span = tracer.scope().active()
+    const { queueName, isQueueDelayable } = bullMqOptions
+    const jobId = makeActionJobId(queueName, job.id)
+
+    const runResult: IActionRunResult = {} // this will be empty unless the batched job contains onlyContinueIf, forEach or ifThen
+
+    // No need for checking for PartialStepError?
+    /**
+     * During non-test runs and the error is a PartialStepError, we want to mark the step as successful
+     * so it continues to the next step
+     */
+    const status: ExecutionStep['status'] = $.actionOutput.error
+      ? 'failure'
+      : 'success'
+
+    // update metadata specially for for-each: TODO: check if this is needed
+    getForEachMetadata({
+      forEachContext,
+      metadata,
+      dataOut: $.actionOutput.data?.raw ?? null,
+      runResult,
+    })
+
+    const updatedMetadata: NextStepMetadata = {
+      ...metadata,
+      batchJobTimestamp,
+    }
+
+    const executionStep = await ExecutionStep.query().insertAndFetch({
+      executionId: $.execution.id,
+      stepId: $.step.id,
+      status,
+      dataIn: $.step.parameters, // This is the computed parameters
+      dataOut: $.actionOutput.data?.raw ?? null,
+      errorDetails: $.actionOutput.error ?? null,
+      appKey: $.app.key,
+      jobId,
+      key: step.key,
+      metadata: updatedMetadata,
+    })
+
+    // const executionStep = await execution
+    //   .$relatedQuery('executionSteps')
+    //   .insertAndFetch({
+    //     stepId: $.step.id,
+    //     status,
+    //     dataIn: $.step.parameters, // This is the computed parameters
+    //     dataOut: $.actionOutput.data?.raw ?? null,
+    //     errorDetails: $.actionOutput.error ?? null,
+    //     appKey: $.app.key,
+    //     jobId,
+    //     key: step.key,
+    //     metadata: updatedMetadata,
+    //   })
+
+    // No need to check for next step because should not have onlyContinueIf, forEach or ifThen
+    // const nextStep = await step.getNextStep()
+    const nextStepMetadata = {
+      ...runResult.nextStepMetadata,
+      ...updatedMetadata,
+    }
+
+    // After processing the batch function, we need to do the post processing similar to a single action job
+    if (executionStep.isFailed) {
+      if (nextStepMetadata?.iteration) {
+        await ExecutionStep.patchIterationStatus(
+          $.execution.id,
+          nextStepMetadata.iteration,
+          'failure',
+        )
+      }
+      // reset the progress to 0 before throwing the error
+      await job.updateProgress(0) // by right it should be reset on retry...
+      return handleFailedStepAndThrow({
+        errorDetails: executionStep.errorDetails,
+        executionError: $.executionError,
+        context: {
+          isQueueDelayable,
+          worker,
+          span,
+          job,
+        },
+      })
+    }
+
+    // Similar to single action job code...
+    if (!nextStep) {
+      const shouldContinue = await processForEachStatus({
+        executionId: $.execution.id,
+        currStep: step,
+        nextStepMetadata,
+      })
+
+      if (!shouldContinue) {
+        return
+      }
+
+      await Execution.setStatus($.execution.id, 'success')
+      return
+    }
+
+    const jobName = `${$.execution.id}-${nextStep.id}`
+
+    const jobPayload: IActionJobData = {
+      flowId: $.flow.id,
+      executionId: $.execution.id,
+      stepId: nextStep.id,
+      metadata: nextStepMetadata,
+    }
+
+    let jobOptions = DEFAULT_JOB_OPTIONS
+
+    if (step.appKey === 'delay') {
+      jobOptions = {
+        ...DEFAULT_JOB_OPTIONS,
+        delay: delayAsMilliseconds(step.key, executionStep.dataOut),
+      }
+    }
+
+    try {
+      await enqueueActionJob({
+        appKey: nextStep.appKey,
+        jobName,
+        jobData: jobPayload,
+        jobOptions,
+      })
+    } catch (error) {
+      // Don't retry if we failed to enqueue the next step (e.g. if
+      // getGroupConfigForJob throws an error)
+      throw new UnrecoverableError(error.message)
+    }
+  } catch (error) {
+    // don't process this job, mark it as failed and move on to the next job
+    logger.error(`Failed to process job after batch function results`, {
+      error,
+      executionId: $.execution.id,
+      stepId: step.id,
+      flowId: $.flow.id,
+      jobId: job.id,
+      batchJobTimestamp,
+    })
+    throw error
+  }
+}

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -1,4 +1,9 @@
-import type { IActionJobData, IAppQueue } from '@plumber/types'
+import type {
+  IActionJobData,
+  IAppQueue,
+  IGlobalVariable,
+  NextStepMetadata,
+} from '@plumber/types'
 
 import {
   UnrecoverableError,
@@ -7,10 +12,12 @@ import {
 } from '@taskforcesh/bullmq-pro'
 
 import appConfig from '@/config/app'
+import { BATCH_RUN_FUNCTIONS } from '@/config/batches'
 import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
 import { handleFailedStepAndThrow } from '@/helpers/actions'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
+import { ForEachContext } from '@/helpers/compute-for-each-parameters'
 import {
   DEFAULT_JOB_OPTIONS,
   MAXIMUM_JOB_ATTEMPTS,
@@ -26,8 +33,17 @@ import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
-import { enqueueActionJob, makeActionJobId } from '@/queues/action'
+import {
+  actionQueuesByName,
+  enqueueActionJob,
+  makeActionJobId,
+} from '@/queues/action'
 import { processAction } from '@/services/action'
+import {
+  ProcessedJobData,
+  processJobAfterBatchFunction,
+  processJobDataForBatchFunction,
+} from '@/services/batch-action'
 
 import processForEachStatus from './for-each-status-manager'
 
@@ -88,6 +104,40 @@ interface MakeActionWorkerParams {
   queueConfig: IAppQueue
 }
 
+export interface BullMqOptions {
+  queueName: string
+  workerOptions: WorkerProOptions
+  isQueueDelayable: boolean
+}
+
+export interface JobProgressData {
+  $: IGlobalVariable // all functions will be dropped
+  forEachContext: ForEachContext
+  metadata: NextStepMetadata
+  step: Step
+  nextStep: Step
+  batchJobTimestamp: string
+}
+
+export interface JobProgress {
+  error?: Error
+  // the remaining data to be processed
+  jobProgressData: Partial<JobProgressData>
+}
+
+// This is to extract the app_action key from the group id
+function splitOnLastDelimiter(str: string, delimiter: string) {
+  const lastIndex = str.lastIndexOf(delimiter)
+
+  if (lastIndex === -1) {
+    // Delimiter not found, return the original string
+    return str
+  } else {
+    // Return the part of the string before the last delimiter
+    return str.substring(0, lastIndex)
+  }
+}
+
 /**
  * Creates a worker for an action queue.
  *
@@ -110,6 +160,82 @@ export function makeActionWorker(
 
         const jobData = job.data
         const jobId = makeActionJobId(queueName, job.id)
+
+        // early termination if the job was processed by the batch function
+        if (job.progress !== 0 && JSON.stringify(job.progress) !== '{}') {
+          // Either it is an unrecoverable error before the batch function is called
+          const jobProgress: JobProgress = job.progress as JobProgress
+          if (jobProgress.error) {
+            throw jobProgress.error
+          } else {
+            // It was processed by the batch function, either it succeeded or failed
+            await processJobAfterBatchFunction(
+              job,
+              jobProgress.jobProgressData as JobProgressData,
+              worker,
+              {
+                queueName,
+                workerOptions,
+                isQueueDelayable,
+              },
+            )
+          }
+          return
+        }
+
+        // Check whether to do batching on the job, else just process the job normally
+        /**
+         * Check whether to do batching on the job
+         * 1. If a group exists in the queue
+         * 2. If the group id has a batch function attached to it
+         */
+        const queue = actionQueuesByName[queueName]
+        const groupId = job.opts?.group?.id ?? ''
+        const appActionKey = splitOnLastDelimiter(groupId, '_')
+        if (appActionKey in BATCH_RUN_FUNCTIONS) {
+          const batchRunFunction = BATCH_RUN_FUNCTIONS[appActionKey]
+          // TODO: check but im sure they are returning me in the newest to older order of insertion so need to reverse because workers still process FIFO unless priority is set
+          const jobsInGroup = (await queue.getGroupJobs(groupId, 0, 10)) // number of jobs to batch
+            .reverse()
+
+          const batchJobTimestamp = new Date(job.timestamp).toISOString()
+          const jobsToProcessData: ProcessedJobData[] = []
+          // pre-process current job first, throw unrecoverable error if error.
+          await processJobDataForBatchFunction(
+            job,
+            jobsToProcessData,
+            batchJobTimestamp,
+          )
+          // early termination if there is an error
+          const jobProgress: JobProgress = job.progress as JobProgress
+          if (jobProgress.error) {
+            throw jobProgress.error
+          }
+
+          for (const job of jobsInGroup) {
+            // pre-process job for the details, set unrecoverable error to progress
+            await processJobDataForBatchFunction(
+              job,
+              jobsToProcessData,
+              batchJobTimestamp,
+            )
+          }
+
+          // pass it into the batch run function, if error on the batch function, throw the error immediately... skip processing the rest...
+          // TODO: decide whether to throw the error immediately or not...
+          await batchRunFunction(jobsToProcessData)
+
+          // do not insert execution step and enqueue next job yet for the remaining jobs, only do it when the job gets processed respectively: to ensure the jobs get queued in the correct order based on the steps in the flow
+
+          // process current job in the group
+          await processJobAfterBatchFunction(
+            job,
+            jobProgress.jobProgressData as JobProgressData,
+            worker,
+            { queueName, workerOptions, isQueueDelayable },
+          )
+          return
+        }
 
         // The reason why we dont add .throwIfNotFound() here is to prevent job
         // retries delegating the error throwing and handling to processAction

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -851,6 +851,7 @@ export type IGlobalVariable = {
     appKey: string
     position: number
     parameters: IJSONObject
+    key?: string // backward compatibility in case some steps still have no key
   }
   nextStep?: {
     id: string
@@ -875,8 +876,10 @@ export type IGlobalVariable = {
   webhookUrl?: string
   triggerOutput?: ITriggerOutput
   actionOutput?: IActionOutput
+  executionError?: Error
   pushTriggerItem?: (triggerItem: ITriggerItem) => Promise<void>
   setActionItem?: (actionItem: IActionItem) => void
+  setExecutionError?: (error: Error) => void
 
   /**
    * If this is non-null, it contains details of the pipe owner if this is


### PR DESCRIPTION
For future reference when we handroll manual batching

## Problem

Implement batch processing for Excel table row creation to improve performance when handling multiple rows.

Closes #XXX

## Solution

Added batch processing capability for the Excel "Create Table Row" action to efficiently handle multiple row insertions in a single API call.

**Features**:

- Implemented a hybrid batch processing approach that first attempts to create multiple rows in a single API call
- Added fallback to individual row creation when batch operations fail, with detailed error reporting
- Created a configurable batch processing framework that can be extended to other actions

**Improvements**:

- Enhanced queue grouping to use table ID instead of file ID for better job organization
- Optimized performance by reducing the number of API calls needed for multiple row insertions
- Added detailed error handling and reporting for both batch and individual operations

## Tests

- Test batch creation of multiple rows in an Excel table
- Test fallback to individual row creation when batch operation fails
- Verify error handling and reporting for both scenarios

## Deploy Notes

**New files**:
- `batch-run.ts` and `batch-run-hybrid.ts` for Excel table row creation
- `batches.ts` configuration for batch processing

**New dependencies**:

- None

**New dev dependencies**:

- None