### PR TITLE
chore: add yyyy-mm-dd option to date formatter

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -36,6 +36,7 @@ describe('convert date time', () => {
     { toFormat: 'dd LLL yyyy', expectedResult: '01 Apr 2024' },
     { toFormat: 'dd LLLL yyyy', expectedResult: '01 April 2024' },
     { toFormat: 'yyyy/LL/dd', expectedResult: '2024/04/01' },
+    { toFormat: 'yyyy-LL-dd', expectedResult: '2024-04-01' },
     { toFormat: 'hh:mm a', expectedResult: '12:05 pm' },
     { toFormat: 'hh:mm:ss a', expectedResult: '12:05:10 pm' },
     { toFormat: 'dd LLL yyyy hh:mm a', expectedResult: '01 Apr 2024 12:05 pm' },
@@ -94,6 +95,12 @@ describe('convert date time', () => {
       inputValue: '2024/04/01',
       toFormat: 'hh:mm a',
       expectedResult: '12:00 am',
+    },
+    {
+      inputFormat: 'yyyy-LL-dd',
+      inputValue: '2024-04-01',
+      toFormat: 'dd/LL/yy',
+      expectedResult: '01/04/24',
     },
     {
       inputFormat: 'hh:mm a',

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-format-options.ts
@@ -9,6 +9,7 @@ export const commonDateFormats = [
   'dd LLL yyyy',
   'dd LLLL yyyy',
   'yyyy/LL/dd',
+  'yyyy-LL-dd',
   'hh:mm a',
   'hh:mm:ss a',
   'dd LLL yyyy hh:mm a',
@@ -42,6 +43,11 @@ export const commonDateFormatOptions = [
     label: 'YYYY/MM/DD',
     description: '2024/03/25',
     value: ensureZodEnumValue(formatStringsEnum, 'yyyy/LL/dd'),
+  },
+  {
+    label: 'YYYY-MM-DD',
+    description: '2024-03-25',
+    value: ensureZodEnumValue(formatStringsEnum, 'yyyy-LL-dd'),
   },
   {
     label: 'HH:mm (am/pm)',


### PR DESCRIPTION
## TL;DR
Add additional option `yyyy-mm-dd` option to the date formatter.

## Screenshots
<img width="5088" height="3324" alt="image" src="https://github.com/user-attachments/assets/09f415fb-ff3f-406e-8c57-72f9ca8056b3" />


## Tests
- [ ] Use the new option, ensure that date is formatted correctly.

