### PR TITLE
PLU-613: FormSG signature field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9268,6 +9268,17 @@
         "react-dom": "^18.2.0"
       }
     },
+    "node_modules/@opengovsg/formsg-sdk": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.16.1.tgz",
+      "integrity": "sha512-yfNTdN4vI7Gs8KTdpqnQPSQ4bkn0worRWeP9UJwcJ172MfvcP+lxHfHBk06FMDA0yJ6fEG/Z+kaGb20WZb4XTA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.6.4",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      }
+    },
     "node_modules/@opengovsg/sgid-client": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@opengovsg/sgid-client/-/sgid-client-2.3.0.tgz",
@@ -30815,7 +30826,7 @@
         "@graphql-tools/schema": "10.0.25",
         "@graphql-tools/utils": "10.9.1",
         "@launchdarkly/node-server-sdk": "9.0.4",
-        "@opengovsg/formsg-sdk": "0.14.0",
+        "@opengovsg/formsg-sdk": "0.16.1",
         "@opengovsg/sgid-client": "2.3.0",
         "@plumber/types": "file:../types",
         "@taskforcesh/bullmq-pro": "7.7.1",
@@ -30888,23 +30899,6 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "type-fest": "4.10.3"
-      }
-    },
-    "packages/backend/node_modules/@opengovsg/formsg-sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.14.0.tgz",
-      "integrity": "sha512-OeffeqTaAWwQfKViPj+vHNAZh6TQayq+rrymbFNHncGhBUHT3ZdTCfgw3A6hcJmzKlR0bNdU2NOiZStjxg0BiA==",
-      "dependencies": {
-        "axios": "^1.6.4",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
-    "packages/backend/node_modules/graphql": {
-      "version": "16.8.1",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "packages/frontend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9268,17 +9268,6 @@
         "react-dom": "^18.2.0"
       }
     },
-    "node_modules/@opengovsg/formsg-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.13.0.tgz",
-      "integrity": "sha512-rByyDeR98ubJbNSKk6zy98MmxFsiBqFTJqzLX3lWtQxDAJzcX17PCAdmi9U89riNff1H86yyCUvNtlUUJIVnDw==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.6.4",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
     "node_modules/@opengovsg/sgid-client": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@opengovsg/sgid-client/-/sgid-client-2.3.0.tgz",
@@ -30826,7 +30815,7 @@
         "@graphql-tools/schema": "10.0.25",
         "@graphql-tools/utils": "10.9.1",
         "@launchdarkly/node-server-sdk": "9.0.4",
-        "@opengovsg/formsg-sdk": "0.13.0",
+        "@opengovsg/formsg-sdk": "0.14.0",
         "@opengovsg/sgid-client": "2.3.0",
         "@plumber/types": "file:../types",
         "@taskforcesh/bullmq-pro": "7.7.1",
@@ -30899,6 +30888,23 @@
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "type-fest": "4.10.3"
+      }
+    },
+    "packages/backend/node_modules/@opengovsg/formsg-sdk": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.14.0.tgz",
+      "integrity": "sha512-OeffeqTaAWwQfKViPj+vHNAZh6TQayq+rrymbFNHncGhBUHT3ZdTCfgw3A6hcJmzKlR0bNdU2NOiZStjxg0BiA==",
+      "dependencies": {
+        "axios": "^1.6.4",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      }
+    },
+    "packages/backend/node_modules/graphql": {
+      "version": "16.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "packages/frontend": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/schema": "10.0.25",
     "@graphql-tools/utils": "10.9.1",
     "@launchdarkly/node-server-sdk": "9.0.4",
-    "@opengovsg/formsg-sdk": "0.14.0",
+    "@opengovsg/formsg-sdk": "0.16.1",
     "@opengovsg/sgid-client": "2.3.0",
     "@plumber/types": "file:../types",
     "@taskforcesh/bullmq-pro": "7.7.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/schema": "10.0.25",
     "@graphql-tools/utils": "10.9.1",
     "@launchdarkly/node-server-sdk": "9.0.4",
-    "@opengovsg/formsg-sdk": "0.13.0",
+    "@opengovsg/formsg-sdk": "0.14.0",
     "@opengovsg/sgid-client": "2.3.0",
     "@plumber/types": "file:../types",
     "@taskforcesh/bullmq-pro": "7.7.1",

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -894,4 +894,66 @@ describe('decrypt form response', () => {
       )
     })
   })
+
+  describe('signature field', () => {
+    it('should handle signature field with signature captured', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'signatureField',
+            fieldType: 'signature',
+            question: 'Please sign here',
+            answerArray: [1.1, 1.2, 1.3],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            signatureField: {
+              fieldType: 'signature',
+              question: 'Please sign here',
+              answer: 'Signature captured',
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle signature field without signature', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'signatureField',
+            fieldType: 'signature',
+            question: 'Please sign here',
+            answerArray: [],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            signatureField: {
+              fieldType: 'signature',
+              question: 'Please sign here',
+              answer: '',
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+  })
 })

--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -543,6 +543,15 @@ describe('new submission trigger for answer array fields', () => {
             order: 5,
             answerArray: ['51', 'BRAS BASAH ROAD', '', '', '189554'], // Some empty fields
           },
+          signatureField: {
+            question: 'Sign here',
+            fieldType: 'signature',
+            order: 6,
+            answerArray: [
+              'draw',
+              '[[123.45, 123.45, 0.5], [543.21, 543.21, 0.5]]',
+            ],
+          },
         },
       },
     } as unknown as IExecutionStep
@@ -620,6 +629,17 @@ describe('new submission trigger for answer array fields', () => {
         expect(addressMetadata[index].label).toEqual(
           `5.${index + 1}. ${label} - What is your address?`,
         )
+      })
+    })
+
+    it('Signature type: includes all metadata for signature fields but it is hidden', async () => {
+      const metadata = await trigger.getDataOutMetadata(executionStep)
+      const signatureMetadata = metadata.fields.signatureField
+        .answerArray as IDataOutMetadatum[]
+      expect(signatureMetadata).toHaveLength(2)
+      signatureMetadata.forEach((metadata, index) => {
+        expect(metadata.isHidden).toEqual(true)
+        expect(metadata.label).toEqual(`6.${index + 1}. Sign here`)
       })
     })
   })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -168,7 +168,7 @@ export async function decryptFormResponse(
       // Add signature status to the response regardless of whether the user has signed or not (optional field)
       if (rest.fieldType === 'signature') {
         const isSignaturePresent = (rest.answerArray as string[]).length > 0
-        rest.answer = isSignaturePresent ? 'signed' : 'unsigned'
+        rest.answer = isSignaturePresent ? 'Signature captured' : ''
       }
 
       // Note: the order may not be sequential; fields (e.g. NRIC) can be

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -136,7 +136,9 @@ export async function decryptFormResponse(
           )
         } else {
           rest.answerArray = (rest.answerArray as string[]).map((answer) =>
-            answer.replaceAll('\u0000', ''),
+            typeof answer === 'string'
+              ? answer.replaceAll('\u0000', '')
+              : answer,
           )
         }
       }
@@ -167,8 +169,9 @@ export async function decryptFormResponse(
 
       // Add signature status to the response regardless of whether the user has signed or not (optional field)
       if (rest.fieldType === 'signature') {
-        const isSignaturePresent = (rest.answerArray as string[]).length > 0
+        const isSignaturePresent = (rest.answerArray as string[])?.length > 0
         rest.answer = isSignaturePresent ? 'Signature captured' : ''
+        delete rest.answerArray // we dont need to store it
       }
 
       // Note: the order may not be sequential; fields (e.g. NRIC) can be

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -165,6 +165,12 @@ export async function decryptFormResponse(
         rest.answerArray = processLocalAddress(rest.answerArray as string[])
       }
 
+      // Add signature status to the response regardless of whether the user has signed or not (optional field)
+      if (rest.fieldType === 'signature') {
+        const isSignaturePresent = (rest.answerArray as string[]).length > 0
+        rest.answer = isSignaturePresent ? 'signed' : 'unsigned'
+      }
+
       // Note: the order may not be sequential; fields (e.g. NRIC) can be
       // omitted from the output.
       // Note: FormSG uses dot notation for field ids for MyInfo children

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-data-out-metadata.ts
@@ -24,7 +24,10 @@ function buildQuestionMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
     question.label = 'Header'
   }
 
-  if (fieldData.fieldType === 'attachment') {
+  if (
+    fieldData.fieldType === 'attachment' ||
+    fieldData.fieldType === 'signature'
+  ) {
     question['isHidden'] = true
   }
 
@@ -69,8 +72,8 @@ function isAnswerArrayValid(fieldData: IJSONObject): boolean {
   if (!fieldData.answerArray) {
     return false
   }
-  // strict check for only table, checkbox and address variables
-  const answerArrayFields = ['table', 'checkbox', 'address']
+  // strict check for only table, checkbox, address and signature variables
+  const answerArrayFields = ['table', 'checkbox', 'address', 'signature']
   return answerArrayFields.includes(fieldData.fieldType as string)
 }
 
@@ -83,6 +86,20 @@ function buildAnswerArrayForAddress(fieldData: IJSONObject): IDataOutMetadata {
     type: 'text',
     label: `${order}.${index + 1}. ${label} - ${question}`,
     order: order ? `${order}.${index + 1}` : null,
+  }))
+}
+
+// Hide all the labels for the signature field
+function buildAnswerArrayForSignature(
+  fieldData: IJSONObject,
+): IDataOutMetadata {
+  const { order, question } = fieldData
+  const answerArray = fieldData.answerArray as IJSONArray
+  return answerArray.map((_, index) => ({
+    type: 'text',
+    label: `${order}.${index + 1}. ${question}`,
+    order: order ? `${order}.${index + 1}` : null,
+    isHidden: true,
   }))
 }
 
@@ -209,6 +226,8 @@ function buildAnswerArrayMetadatum(
       return buildAnswerArrayForTable(fieldData)
     case 'address':
       return buildAnswerArrayForAddress(fieldData)
+    case 'signature':
+      return buildAnswerArrayForSignature(fieldData)
     default:
       logger.warn(`Answer array unknown fieldtype: ${fieldType}`, {
         fieldType,

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -126,9 +126,8 @@ async function getMockData($: IGlobalVariable) {
           }
         }
 
-        // hide signature because it is not useful for the user now
         if (fieldType === 'signature') {
-          delete data.responses[formFields[i]._id]
+          data.responses[formFields[i]._id].answer = 'signed' // mock this to always be present regardless of whether the user has signed or not
           continue
         }
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -127,7 +127,7 @@ async function getMockData($: IGlobalVariable) {
         }
 
         if (fieldType === 'signature') {
-          data.responses[formFields[i]._id].answer = 'signed' // mock this to always be present regardless of whether the user has signed or not
+          data.responses[formFields[i]._id].answer = 'Signature captured' // mock this to always be present regardless of whether the user has signed or not
           continue
         }
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -113,8 +113,9 @@ async function getMockData($: IGlobalVariable) {
     const formFields = formDetails.form.form_fields as Array<FormField>
     for (let i = 0; i < formFields.length; i++) {
       if (data.responses[formFields[i]._id]) {
+        const fieldType = data.responses[formFields[i]._id].fieldType
         // forcefully include all checkbox options in the correct order
-        if (data.responses[formFields[i]._id].fieldType === 'checkbox') {
+        if (fieldType === 'checkbox') {
           data.responses[formFields[i]._id].answerArray =
             formFields[i].fieldOptions
           // include the others option if available
@@ -125,34 +126,40 @@ async function getMockData($: IGlobalVariable) {
           }
         }
 
-        // formsg payload doesnt contain this anyways, so we dont return in mock data
-        if (data.responses[formFields[i]._id].fieldType === 'statement') {
+        // hide signature because it is not useful for the user now
+        if (fieldType === 'signature') {
           delete data.responses[formFields[i]._id]
           continue
         }
 
-        if (data.responses[formFields[i]._id].fieldType === 'address') {
+        // formsg payload doesnt contain this anyways, so we dont return in mock data
+        if (fieldType === 'statement') {
+          delete data.responses[formFields[i]._id]
+          continue
+        }
+
+        if (fieldType === 'address') {
           data.responses[formFields[i]._id].answerArray =
             generateMockAddressData()
         }
 
-        if (data.responses[formFields[i]._id].fieldType === 'attachment') {
+        if (fieldType === 'attachment') {
           data.responses[formFields[i]._id].answer = MOCK_ATTACHMENT_FILE_PATH
         }
 
-        if (data.responses[formFields[i]._id].fieldType === 'nric') {
+        if (fieldType === 'nric') {
           data.responses[formFields[i]._id].answer = filterNric(
             $,
             data.responses[formFields[i]._id].answer,
           )
         }
 
-        if (data.responses[formFields[i]._id].fieldType === 'email') {
+        if (fieldType === 'email') {
           data.responses[formFields[i]._id].answer = $.user.email
         }
 
         // add a stringified version of the table data to the mock data
-        if (data.responses[formFields[i]._id].fieldType === 'table') {
+        if (fieldType === 'table') {
           const answerArray = data.responses[formFields[i]._id]
             .answerArray as string[][]
           const question = data.responses[formFields[i]._id].question

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -128,7 +128,6 @@ async function getMockData($: IGlobalVariable) {
 
         if (fieldType === 'signature') {
           data.responses[formFields[i]._id].answer = 'Signature captured' // mock this to always be present regardless of whether the user has signed or not
-          continue
         }
 
         // formsg payload doesnt contain this anyways, so we dont return in mock data

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -156,7 +156,8 @@ export function VariableItem({
           {displayValue.length ? (
             displayValue
           ) : (
-            <i style={{ opacity: 0.5 }}>empty</i>
+            // padding right to ensure the 'y' is not cut off
+            <i style={{ opacity: 0.5, paddingRight: 2 }}>empty</i>
           )}
         </Text>
         {withIcon && <Icon as={withIcon} />}


### PR DESCRIPTION
## Problem

Right now we don't hide the submission data for signature field

## Solution

Add `isHidden` to every item in the array field that is given to us from formsg.
If the signature field is optional and not filled: return `unsigned`; else return `signed`

## Screenshots

**Before**

https://github.com/user-attachments/assets/6a92e4bd-b457-41a2-91af-330c3b171f72

**After**

https://github.com/user-attachments/assets/ec164b0d-1b24-4379-90dd-3ce963120d50




## Tests
- [ ] Check that existing fields still work and does not break for mock data
- [ ] Check that signature field gets removed for mock data
- [ ] Check that signature field gets hidden for actual form submission (both question and answer array)

