### PR TITLE
[PLU-543]: test gathersg integration-2: add tag or untag case API

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
@@ -12,7 +12,7 @@ const MOCK_RESPONSE = {
   traceId: 'trace-987654321',
 }
 
-const MOCK_CASE_UUID = 'abcde12345'
+const MOCK_CASE_UUID = 'abcdefghijkl1234567890' // have to be 22 characters long
 const MOCK_TAG_VALUE = 'urgent'
 
 const mocks = vi.hoisted(() => ({
@@ -106,14 +106,14 @@ describe('tag or untag case', () => {
   it('should throw step error for invalid regex case uuid', async () => {
     $.step.parameters.caseUuid = 'invalid-uuid-with-dashes'
     await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
-      'Your case uuid is of an invalid format',
+      'Please enter a valid case uuid',
     )
   })
 
   it('should throw step error for empty case uuid', async () => {
     $.step.parameters.caseUuid = ''
     await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
-      'Your case uuid is of an invalid format',
+      'Please do not leave the case uuid empty',
     )
   })
 
@@ -127,7 +127,7 @@ describe('tag or untag case', () => {
   it('should throw step error for invalid parameters (whitespace only case uuid)', async () => {
     $.step.parameters.caseUuid = '   '
     await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
-      'Your case uuid is of an invalid format',
+      'Please do not leave the case uuid empty',
     )
   })
 

--- a/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
@@ -12,7 +12,7 @@ const MOCK_RESPONSE = {
   traceId: 'trace-987654321',
 }
 
-const MOCK_CASE_ID = 'case-uuid-456'
+const MOCK_CASE_UUID = 'abcde12345'
 const MOCK_TAG_VALUE = 'urgent'
 
 const mocks = vi.hoisted(() => ({
@@ -37,7 +37,7 @@ describe('tag or untag case', () => {
         appKey: 'gathersg',
         position: 2,
         parameters: {
-          caseId: MOCK_CASE_ID,
+          caseUuid: MOCK_CASE_UUID,
           tagOrUntag: true,
           tagValue: MOCK_TAG_VALUE,
         },
@@ -61,15 +61,15 @@ describe('tag or untag case', () => {
     await tagOrUntagCaseAction.run($)
 
     expect(mocks.httpPost).toHaveBeenCalledWith(
-      '/cases/:caseId/tag',
+      '/cases/:caseUuid/tag',
       {
-        caseId: MOCK_CASE_ID,
+        caseUuid: MOCK_CASE_UUID,
         tagOrUntag: true,
         tag: MOCK_TAG_VALUE,
       },
       {
         urlPathParams: {
-          caseId: MOCK_CASE_ID,
+          caseUuid: MOCK_CASE_UUID,
         },
       },
     )
@@ -80,15 +80,15 @@ describe('tag or untag case', () => {
     await tagOrUntagCaseAction.run($)
 
     expect(mocks.httpPost).toHaveBeenCalledWith(
-      '/cases/:caseId/untag',
+      '/cases/:caseUuid/untag',
       {
-        caseId: MOCK_CASE_ID,
+        caseUuid: MOCK_CASE_UUID,
         tagOrUntag: false,
         tag: MOCK_TAG_VALUE,
       },
       {
         urlPathParams: {
-          caseId: MOCK_CASE_ID,
+          caseUuid: MOCK_CASE_UUID,
         },
       },
     )
@@ -103,19 +103,32 @@ describe('tag or untag case', () => {
     })
   })
 
-  it('should throw step error for invalid parameters (empty case id)', async () => {
-    $.step.parameters.caseId = ''
-    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  it('should throw step error for invalid regex case uuid', async () => {
+    $.step.parameters.caseUuid = 'invalid-uuid-with-dashes'
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
+      'Your case uuid is of an invalid format',
+    )
   })
 
-  it('should throw step error for invalid parameters (empty tag value)', async () => {
+  it('should throw step error for empty case uuid', async () => {
+    $.step.parameters.caseUuid = ''
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
+      'Your case uuid is of an invalid format',
+    )
+  })
+
+  it('should throw step error for empty tag value', async () => {
     $.step.parameters.tagValue = ''
-    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
+      'Please do not leave the tag empty',
+    )
   })
 
-  it('should throw step error for invalid parameters (whitespace only case id)', async () => {
-    $.step.parameters.caseId = '   '
-    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  it('should throw step error for invalid parameters (whitespace only case uuid)', async () => {
+    $.step.parameters.caseUuid = '   '
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrow(
+      'Your case uuid is of an invalid format',
+    )
   })
 
   it('should throw step error for invalid parameters (whitespace only tag value)', async () => {
@@ -187,15 +200,15 @@ describe('tag or untag case', () => {
     await tagOrUntagCaseAction.run($)
 
     expect(mocks.httpPost).toHaveBeenCalledWith(
-      '/cases/:caseId/tag',
+      '/cases/:caseUuid/tag',
       {
-        caseId: MOCK_CASE_ID,
+        caseUuid: MOCK_CASE_UUID,
         tagOrUntag: true,
         tag: longTagValue,
       },
       {
         urlPathParams: {
-          caseId: MOCK_CASE_ID,
+          caseUuid: MOCK_CASE_UUID,
         },
       },
     )

--- a/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/tag-or-untag-case.test.ts
@@ -1,0 +1,203 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { AxiosError } from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
+
+import app from '../../..'
+import tagOrUntagCaseAction from '../../actions/tag-or-untag-case'
+
+const MOCK_RESPONSE = {
+  traceId: 'trace-987654321',
+}
+
+const MOCK_CASE_ID = 'case-uuid-456'
+const MOCK_TAG_VALUE = 'urgent'
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(() => ({
+    data: MOCK_RESPONSE,
+  })),
+}))
+
+describe('tag or untag case', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      auth: {
+        set: vi.fn(),
+        data: {
+          apiKey: 'sample-api-key',
+        },
+      },
+      step: {
+        id: '123',
+        appKey: 'gathersg',
+        position: 2,
+        parameters: {
+          caseId: MOCK_CASE_ID,
+          tagOrUntag: true,
+          tagValue: MOCK_TAG_VALUE,
+        },
+      },
+      flow: {
+        id: 'flow-id-123',
+      },
+      http: {
+        post: mocks.httpPost,
+      } as unknown as IGlobalVariable['http'],
+      setActionItem: vi.fn(),
+      app,
+    } as unknown as IGlobalVariable
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('builds the payload correctly for tagging a case', async () => {
+    await tagOrUntagCaseAction.run($)
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/cases/:caseId/tag',
+      {
+        caseId: MOCK_CASE_ID,
+        tagOrUntag: true,
+        tag: MOCK_TAG_VALUE,
+      },
+      {
+        urlPathParams: {
+          caseId: MOCK_CASE_ID,
+        },
+      },
+    )
+  })
+
+  it('builds the payload correctly for untagging a case', async () => {
+    $.step.parameters.tagOrUntag = false
+    await tagOrUntagCaseAction.run($)
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/cases/:caseId/untag',
+      {
+        caseId: MOCK_CASE_ID,
+        tagOrUntag: false,
+        tag: MOCK_TAG_VALUE,
+      },
+      {
+        urlPathParams: {
+          caseId: MOCK_CASE_ID,
+        },
+      },
+    )
+  })
+
+  it('parses the raw response correctly', async () => {
+    await tagOrUntagCaseAction.run($)
+    expect($.setActionItem).toBeCalledWith({
+      raw: {
+        traceId: MOCK_RESPONSE.traceId,
+      },
+    })
+  })
+
+  it('should throw step error for invalid parameters (empty case id)', async () => {
+    $.step.parameters.caseId = ''
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  })
+
+  it('should throw step error for invalid parameters (empty tag value)', async () => {
+    $.step.parameters.tagValue = ''
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  })
+
+  it('should throw step error for invalid parameters (whitespace only case id)', async () => {
+    $.step.parameters.caseId = '   '
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  })
+
+  it('should throw step error for invalid parameters (whitespace only tag value)', async () => {
+    $.step.parameters.tagValue = '   '
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  })
+
+  it('should throw step error for case not found', async () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            code: 'RESOURCE_NOT_FOUND',
+            message: 'Case not found',
+          },
+        },
+        status: 404,
+        statusText: 'Not Found',
+      },
+    } as AxiosError
+    const httpError = new HttpError(error)
+    mocks.httpPost.mockRejectedValueOnce(httpError)
+
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError()
+  })
+
+  it('should throw step error for invalid tag value', async () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            code: 'INVALID_INPUT',
+            message: 'Invalid tag value',
+          },
+        },
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    } as AxiosError
+    const httpError = new HttpError(error)
+    mocks.httpPost.mockRejectedValueOnce(httpError)
+
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError(
+      'Please check that you have configured your step correctly',
+    )
+  })
+
+  it('should throw step error for server error', async () => {
+    const error = {
+      response: {
+        data: {
+          message: 'Internal server error',
+        },
+        status: 500,
+        statusText: 'Internal Server Error',
+      },
+    } as AxiosError
+    const httpError = new HttpError(error)
+    mocks.httpPost.mockRejectedValueOnce(httpError)
+
+    await expect(tagOrUntagCaseAction.run($)).rejects.toThrowError(
+      'Please check that you have configured your step correctly',
+    )
+  })
+
+  it('should handle long tag values', async () => {
+    const longTagValue = 'a'.repeat(100)
+    $.step.parameters.tagValue = longTagValue
+    await tagOrUntagCaseAction.run($)
+
+    expect(mocks.httpPost).toHaveBeenCalledWith(
+      '/cases/:caseId/tag',
+      {
+        caseId: MOCK_CASE_ID,
+        tagOrUntag: true,
+        tag: longTagValue,
+      },
+      {
+        urlPathParams: {
+          caseId: MOCK_CASE_ID,
+        },
+      },
+    )
+  })
+})

--- a/packages/backend/src/apps/gathersg/actions/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/index.ts
@@ -1,3 +1,4 @@
+import tagOrUntagCase from './tag-or-untag-case'
 import updateCase from './update-case'
 
-export default [updateCase]
+export default [updateCase, tagOrUntagCase]

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -5,10 +5,9 @@ import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { GatherSGError } from '../../common/types'
-import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
-
 import { requestSchema, responseSchema } from './schema'
+import HttpError from '@/errors/http'
+import throwGatherSGStepError from '../../common/throw-errors'
 
 const action: IRawAction = {
   name: 'Tag/Untag case',
@@ -50,12 +49,6 @@ const action: IRawAction = {
 
   async run($) {
     try {
-      const { caseUuid } = $.step.parameters
-      // Validation to prevent path traversals
-      validateDynamicFieldsAndThrowError({
-        caseUuid: String(caseUuid),
-      })
-
       const payload = requestSchema.parse($.step.parameters)
       const { tagOrUntag } = payload
       const rawResponse = await $.http.post(
@@ -85,16 +78,8 @@ const action: IRawAction = {
         )
       }
 
-      // Case cannot be found
-      const { code, message } =
-        (error.response?.data?.error as GatherSGError) || {}
-      if (error.response?.status === 404 && code === 'RESOURCE_NOT_FOUND') {
-        throw new StepError(
-          message,
-          'Check that you have entered an existing case uuid.',
-          $.step.position,
-          $.app.name,
-        )
+      if (error instanceof HttpError) {
+        throwGatherSGStepError({ $, error })
       }
 
       throw new StepError(

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -6,20 +6,22 @@ import { fromZodError } from 'zod-validation-error'
 import StepError, { GenericSolution } from '@/errors/step'
 
 import { GatherSGError } from '../../common/types'
+import { validateDynamicFieldsAndThrowError } from '../../common/validate-dynamic-fields'
 
 import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
   name: 'Tag/Untag case',
   key: 'tagOrUntagCase',
-  description: 'Tag or untag a case based on the case id (UUID)',
+  description: 'Tag or untag a case based on the case uuid',
   arguments: [
     {
-      label: 'Case ID',
-      key: 'caseId',
+      label: 'Case UUID',
+      key: 'caseUuid',
       type: 'string' as const,
       description:
-        'You can only select a step variable here. You should be using a Tile to store your case IDs to make reference to.',
+        'You can only select a step variable here to make reference to.',
+
       required: true,
       variables: true,
       singleVariableSelection: true,
@@ -29,7 +31,7 @@ const action: IRawAction = {
       key: 'tagOrUntag',
       type: 'boolean-radio' as const,
       required: true,
-      description: 'Tag or Untag the case',
+      description: 'Tag or untag the case',
       value: true,
       options: [
         { label: 'Tag', value: true },
@@ -48,14 +50,20 @@ const action: IRawAction = {
 
   async run($) {
     try {
+      const { caseUuid } = $.step.parameters
+      // Validation to prevent path traversals
+      validateDynamicFieldsAndThrowError({
+        caseUuid: String(caseUuid),
+      })
+
       const payload = requestSchema.parse($.step.parameters)
       const { tagOrUntag } = payload
       const rawResponse = await $.http.post(
-        `/cases/:caseId/${tagOrUntag ? 'tag' : 'untag'}`,
+        `/cases/:caseUuid/${tagOrUntag ? 'tag' : 'untag'}`,
         payload,
         {
           urlPathParams: {
-            caseId: $.step.parameters.caseId,
+            caseUuid: $.step.parameters.caseUuid,
           },
         },
       )
@@ -79,11 +87,11 @@ const action: IRawAction = {
 
       // Case cannot be found
       const { code, message } =
-        (error.response.data?.error as GatherSGError) || {}
-      if (error.response.status === 404 && code === 'RESOURCE_NOT_FOUND') {
+        (error.response?.data?.error as GatherSGError) || {}
+      if (error.response?.status === 404 && code === 'RESOURCE_NOT_FOUND') {
         throw new StepError(
           message,
-          'Check that you have entered a valid case UUID.',
+          'Check that you have entered an existing case uuid.',
           $.step.position,
           $.app.name,
         )

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -1,0 +1,102 @@
+import type { IRawAction } from '@plumber/types'
+
+import { ZodError } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+
+import StepError, { GenericSolution } from '@/errors/step'
+
+import { GatherSGError } from '../../common/types'
+
+import { requestSchema, responseSchema } from './schema'
+
+const action: IRawAction = {
+  name: 'Tag/Untag case',
+  key: 'tagOrUntagCase',
+  description: 'Tag or untag a case based on the case id (UUID)',
+  arguments: [
+    {
+      label: 'Case ID',
+      key: 'caseId',
+      type: 'string' as const,
+      description:
+        'You can only select a step variable here. You should be using a Tile to store your case IDs to make reference to.',
+      required: true,
+      variables: true,
+      singleVariableSelection: true,
+    },
+    {
+      label: 'Tag or untag',
+      key: 'tagOrUntag',
+      type: 'boolean-radio' as const,
+      required: true,
+      description: 'Tag or Untag the case',
+      value: true,
+      options: [
+        { label: 'Tag', value: true },
+        { label: 'Untag', value: false },
+      ],
+    },
+    {
+      label: 'Tag value',
+      description: 'Key in a single tag value to be applied to the case',
+      key: 'tagValue',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+  ],
+
+  async run($) {
+    try {
+      const payload = requestSchema.parse($.step.parameters)
+      const { tagOrUntag } = payload
+      const rawResponse = await $.http.post(
+        `/cases/:caseId/${tagOrUntag ? 'tag' : 'untag'}`,
+        payload,
+        {
+          urlPathParams: {
+            caseId: $.step.parameters.caseId,
+          },
+        },
+      )
+      const response = responseSchema.parse(rawResponse.data)
+
+      $.setActionItem({
+        raw: {
+          ...response,
+        },
+      })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const firstError = fromZodError(error).details[0]
+        throw new StepError(
+          `${firstError.message}`,
+          GenericSolution.ReconfigureInvalidField,
+          $.step.position,
+          $.app.name,
+        )
+      }
+
+      // Case cannot be found
+      const { code, message } =
+        (error.response.data?.error as GatherSGError) || {}
+      if (error.response.status === 404 && code === 'RESOURCE_NOT_FOUND') {
+        throw new StepError(
+          message,
+          'Check that you have entered a valid case UUID.',
+          $.step.position,
+          $.app.name,
+        )
+      }
+
+      throw new StepError(
+        `An error occurred: '${error.message}'`,
+        'Please check that you have configured your step correctly',
+        $.step.position,
+        $.app.name,
+      )
+    }
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -3,11 +3,12 @@ import type { IRawAction } from '@plumber/types'
 import { ZodError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
+import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { requestSchema, responseSchema } from './schema'
-import HttpError from '@/errors/http'
 import throwGatherSGStepError from '../../common/throw-errors'
+
+import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
   name: 'Tag/Untag case',

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
@@ -2,8 +2,8 @@ import { z } from 'zod'
 
 export const requestSchema = z
   .object({
-    caseId: z.string().trim().min(1, {
-      message: 'Please do not leave the case id empty',
+    caseUuid: z.string().trim().min(1, {
+      message: 'Please do not leave the case uuid empty',
     }),
     tagOrUntag: z.boolean(),
     tagValue: z.string().trim().min(1, {
@@ -11,7 +11,7 @@ export const requestSchema = z
     }),
   })
   .transform((data) => ({
-    caseId: data.caseId,
+    caseUuid: data.caseUuid,
     tagOrUntag: data.tagOrUntag,
     tag: data.tagValue,
   }))

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod'
+import { CASE_UUID_REGEX } from '../../common/constants'
 
 export const requestSchema = z
   .object({
-    caseUuid: z.string().trim().min(1, {
-      message: 'Please do not leave the case uuid empty',
-    }),
+    caseUuid: z
+      .string()
+      .trim()
+      .min(1, {
+        message: 'Please do not leave the case uuid empty',
+      })
+      .regex(CASE_UUID_REGEX, {
+        message: 'Please enter a valid case uuid',
+      }),
     tagOrUntag: z.boolean(),
     tagValue: z.string().trim().min(1, {
       message: 'Please do not leave the tag empty',

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const requestSchema = z
+  .object({
+    caseId: z.string().trim().min(1, {
+      message: 'Please do not leave the case id empty',
+    }),
+    tagOrUntag: z.boolean(),
+    tagValue: z.string().trim().min(1, {
+      message: 'Please do not leave the tag empty',
+    }),
+  })
+  .transform((data) => ({
+    caseId: data.caseId,
+    tagOrUntag: data.tagOrUntag,
+    tag: data.tagValue,
+  }))
+
+// TODO: See if its possible to get more data from the response in the future if necessary
+export const responseSchema = z.object({
+  traceId: z.string(),
+})

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+
 import { CASE_UUID_REGEX } from '../../common/constants'
 
 export const requestSchema = z

--- a/packages/backend/src/apps/gathersg/common/throw-errors.ts
+++ b/packages/backend/src/apps/gathersg/common/throw-errors.ts
@@ -52,6 +52,17 @@ export default function throwGatherSGStepError({
     )
   }
 
+  // Case cannot be found
+  if (errorStatus === 404 && code === 'RESOURCE_NOT_FOUND') {
+    throw new StepError(
+      message,
+      'Check that you have entered an existing case uuid.',
+      position,
+      appName,
+      error,
+    )
+  }
+
   // catch all
   throw new StepError(
     `An error occurred: ${message}`,

--- a/packages/backend/src/apps/gathersg/index.ts
+++ b/packages/backend/src/apps/gathersg/index.ts
@@ -8,7 +8,7 @@ import dynamicData from './dynamic-data'
 const app: IApp = {
   name: 'GatherSG',
   key: 'gathersg',
-  description: 'Update a case', // Update description when there are more actions
+  description: 'Case management system',
   iconUrl: '{BASE_URL}/apps/gathersg/assets/favicon.svg',
   authDocUrl: 'https://gather.gov.sg/', // TODO: update this to our own guide when it is ready
   baseUrl: '',


### PR DESCRIPTION
## Problem

Add GatherSG integration to allow users to tag or untag a case through Plumber workflows.

## Solution

Implemented a new GatherSG app integration with the ability to update case information through the "Tag or untag case" action.

# Add Tag/Untag Case Action for GatherSG

This PR adds a new action to the GatherSG app that allows users to tag or untag cases by their ID. The implementation includes:
- New `tag-or-untag-case` action with validation and error handling
- Updated app description to better reflect its purpose as a case management system

The action supports both tagging and untagging operations with appropriate API endpoints and parameter validation.

## Screenshots

https://github.com/user-attachments/assets/97d900d1-b809-4f8b-a581-29dd3de63369



## Tests
- [ ] Tag case works
- [ ] Untag case works
- [ ] Throws error if case is not found