### PR TITLE
[COLLAB-2]: Create flow_connections table, model

### DIFF
--- a/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
+++ b/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
@@ -9,13 +9,13 @@ export async function up(knex: Knex): Promise<void> {
     table.uuid('connection_id').notNullable()
     // NOTE: addedBy is the user id of the user who added the connection to the flow
     table.uuid('added_by').references('id').inTable('users').notNullable()
-    table.enu('connection_type', ['connection', 'table']).notNullable()
+    table.string('connection_type').notNullable()
     table.timestamps(true, true)
     table.timestamp('deleted_at').nullable()
     table.jsonb('metadata').notNullable().defaultTo('{}')
 
-    // use the unique constraint to avoid duplicates
-    table.unique(['flow_id', 'connection_id'])
+    // use the primary key constraint to avoid duplicates
+    table.primary(['flow_id', 'connection_id'])
   })
 }
 

--- a/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
+++ b/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
@@ -3,15 +3,19 @@ import { Knex } from 'knex'
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('flow_connections', (table) => {
     table.uuid('flow_id').references('id').inTable('flows').notNullable()
-    // do not reference connections table as Tiles does not have a connection id
+    // NOTE: this connection_id refers to either:
+    // - the connection id of a connection in the connections table; OR
+    // - the id of a Tile
     table.uuid('connection_id').notNullable()
-    table.uuid('user_id').references('id').inTable('users').notNullable()
+    // NOTE: addedBy is the user id of the user who added the connection to the flow
+    table.uuid('added_by').references('id').inTable('users').notNullable()
+    table.enu('connection_type', ['connection', 'table']).notNullable()
     table.timestamps(true, true)
     table.timestamp('deleted_at').nullable()
     table.jsonb('metadata').notNullable().defaultTo('{}')
 
     // use the unique constraint to avoid duplicates
-    table.unique(['flow_id', 'connection_id', 'user_id'])
+    table.unique(['flow_id', 'connection_id'])
   })
 }
 

--- a/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
+++ b/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('flow_connections', (table) => {
+    table.uuid('flow_id').references('id').inTable('flows').notNullable()
+    // do not reference connections table as Tiles does not have a connection id
+    table.uuid('connection_id').notNullable()
+    table.uuid('user_id').references('id').inTable('users').notNullable()
+    table.timestamps(true, true)
+    table.timestamp('deleted_at').nullable()
+    table.jsonb('metadata').notNullable().defaultTo('{}')
+
+    // use the unique constraint to avoid duplicates
+    table.unique(['flow_id', 'connection_id', 'user_id'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('flow_connections')
+}

--- a/packages/backend/src/models/__tests__/flow-connections.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-connections.itest.ts
@@ -76,4 +76,20 @@ describe('FlowConnections model', () => {
       expect(flowConnections[0].connectionId).toBe(mockConnectionId)
     })
   })
+
+  it('should throw an error if the parameter key is invalid', () => {
+    expect(() => FlowConnections.validateParameterKey('invalid')).toThrow(
+      'Invalid parameter key: invalid',
+    )
+  })
+
+  it('should not throw an error if the parameter key is valid', () => {
+    expect(() => FlowConnections.validateParameterKey('fileId')).not.toThrow()
+    expect(() =>
+      FlowConnections.validateParameterKey('templateId'),
+    ).not.toThrow()
+    expect(() => FlowConnections.validateParameterKey('channel')).not.toThrow()
+    expect(() => FlowConnections.validateParameterKey('chatId')).not.toThrow()
+    expect(() => FlowConnections.validateParameterKey('tableId')).not.toThrow()
+  })
 })

--- a/packages/backend/src/models/__tests__/flow-connections.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-connections.itest.ts
@@ -1,0 +1,79 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { generateMockContext } from '@/graphql/__tests__/mutations/tiles/table.mock'
+import Context from '@/types/express/context'
+
+import Flow from '../flow'
+import FlowConnections from '../flow-connections'
+
+// Mock the FlowCollaborator model
+const mocks = vi.hoisted(() => ({
+  hasCollaborators: vi.fn(),
+}))
+
+vi.mock('../flow-collaborators', () => ({
+  default: {
+    hasCollaborators: mocks.hasCollaborators,
+  },
+}))
+
+describe('FlowConnections model', () => {
+  const mockFlowId = randomUUID()
+  const mockConnectionId = randomUUID()
+  const mockUserId = randomUUID()
+
+  let context: Context
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    context = await generateMockContext()
+    await Flow.query().insert({
+      id: mockFlowId,
+      name: 'Test Flow',
+      userId: context.currentUser.id,
+      active: false,
+    })
+  })
+
+  describe('addFlowConnection', () => {
+    it('should not perform the insert if there are no collaborators found', async () => {
+      mocks.hasCollaborators.mockResolvedValue(false)
+
+      const result = await FlowConnections.addFlowConnection({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        userId: mockUserId,
+      })
+
+      expect(mocks.hasCollaborators).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+      })
+      expect(result).toBeUndefined()
+    })
+
+    it('should insert if there are collaborators', async () => {
+      mocks.hasCollaborators.mockResolvedValue(true)
+      const mockConnectionId = randomUUID()
+      const result = await FlowConnections.addFlowConnection({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        userId: context.currentUser.id,
+      })
+
+      expect(mocks.hasCollaborators).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+      })
+      expect(result).toBeDefined()
+
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: mockFlowId,
+        user_id: context.currentUser.id,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].connectionId).toBe(mockConnectionId)
+    })
+  })
+})

--- a/packages/backend/src/models/__tests__/flow-connections.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-connections.itest.ts
@@ -7,17 +7,6 @@ import Context from '@/types/express/context'
 import Flow from '../flow'
 import FlowConnections from '../flow-connections'
 
-// Mock the FlowCollaborator model
-const mocks = vi.hoisted(() => ({
-  hasCollaborators: vi.fn(),
-}))
-
-vi.mock('../flow-collaborators', () => ({
-  default: {
-    hasCollaborators: mocks.hasCollaborators,
-  },
-}))
-
 describe('FlowConnections model', () => {
   const mockFlowId = randomUUID()
   const mockConnectionId = randomUUID()
@@ -39,57 +28,47 @@ describe('FlowConnections model', () => {
 
   describe('addFlowConnection', () => {
     it('should not perform the insert if there are no collaborators found', async () => {
-      mocks.hasCollaborators.mockResolvedValue(false)
+      const hasCollaboratorsSpy = vi
+        .spyOn(Flow, 'hasCollaborators')
+        .mockResolvedValue(false)
 
       const result = await FlowConnections.addFlowConnection({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        userId: mockUserId,
+        addedBy: mockUserId,
+        connectionType: 'connection',
       })
 
-      expect(mocks.hasCollaborators).toHaveBeenCalledWith({
+      expect(hasCollaboratorsSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
       })
       expect(result).toBeUndefined()
     })
 
     it('should insert if there are collaborators', async () => {
-      mocks.hasCollaborators.mockResolvedValue(true)
+      const hasCollaboratorsSpy = vi
+        .spyOn(Flow, 'hasCollaborators')
+        .mockResolvedValue(true)
       const mockConnectionId = randomUUID()
       const result = await FlowConnections.addFlowConnection({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        userId: context.currentUser.id,
+        addedBy: context.currentUser.id,
+        connectionType: 'connection',
       })
 
-      expect(mocks.hasCollaborators).toHaveBeenCalledWith({
+      expect(hasCollaboratorsSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
       })
       expect(result).toBeDefined()
 
       const flowConnections = await FlowConnections.query().where({
         flow_id: mockFlowId,
-        user_id: context.currentUser.id,
+        connection_id: mockConnectionId,
       })
 
       expect(flowConnections).toHaveLength(1)
       expect(flowConnections[0].connectionId).toBe(mockConnectionId)
     })
-  })
-
-  it('should throw an error if the parameter key is invalid', () => {
-    expect(() => FlowConnections.validateParameterKey('invalid')).toThrow(
-      'Invalid parameter key: invalid',
-    )
-  })
-
-  it('should not throw an error if the parameter key is valid', () => {
-    expect(() => FlowConnections.validateParameterKey('fileId')).not.toThrow()
-    expect(() =>
-      FlowConnections.validateParameterKey('templateId'),
-    ).not.toThrow()
-    expect(() => FlowConnections.validateParameterKey('channel')).not.toThrow()
-    expect(() => FlowConnections.validateParameterKey('chatId')).not.toThrow()
-    expect(() => FlowConnections.validateParameterKey('tableId')).not.toThrow()
   })
 })

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -118,6 +118,15 @@ class FlowCollaborator extends Base {
       return collaborator.role
     }
   }
+
+  static hasCollaborators = async ({ flowId }: { flowId: string }) => {
+    const collaborators = await this.query()
+      .where({
+        flow_id: flowId,
+      })
+      .whereNull('deleted_at')
+    return collaborators.length > 0
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -118,15 +118,6 @@ class FlowCollaborator extends Base {
       return collaborator.role
     }
   }
-
-  static hasCollaborators = async ({ flowId }: { flowId: string }) => {
-    const collaborators = await this.query()
-      .where({
-        flow_id: flowId,
-      })
-      .whereNull('deleted_at')
-    return collaborators.length > 0
-  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,0 +1,165 @@
+import { Transaction } from 'objection'
+
+import Base from './base'
+import Connection from './connection'
+import Flow from './flow'
+import FlowCollaborator from './flow-collaborators'
+import ExtendedQueryBuilder from './query-builder'
+import User from './user'
+
+class FlowConnections extends Base {
+  flowId!: string
+  connectionId!: string
+  userId!: string
+  connections: Connection[]
+  metadata: Record<string, any>
+
+  static tableName = 'flow_connections'
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      flowId: { type: 'string', format: 'uuid' },
+      connectionId: { type: 'string', format: 'uuid' },
+      userId: { type: 'string', format: 'uuid' },
+      metadata: { type: 'object' },
+    },
+  }
+
+  // Acts as a composite primary key
+  static get idColumn() {
+    return ['flow_id', 'connection_id', 'user_id']
+  }
+
+  static relationMappings = () => ({
+    flows: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Flow,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${Flow.tableName}.id`,
+      },
+    },
+    connections: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Connection,
+      join: {
+        from: `${this.tableName}.connection_id`,
+        to: `${Connection.tableName}.id`,
+      },
+    },
+    user: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: User,
+      join: {
+        from: `${this.tableName}.user_id`,
+        to: `${User.tableName}.id`,
+      },
+    },
+    collaborators: {
+      relation: Base.HasManyRelation,
+      modelClass: FlowCollaborator,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${FlowCollaborator.tableName}.flow_id`,
+      },
+    },
+  })
+
+  static withAccessible({
+    queryBuilder,
+    userId,
+    trx,
+  }: {
+    queryBuilder?: ExtendedQueryBuilder<FlowConnections, FlowConnections[]>
+    userId: string
+    trx?: Transaction
+  }) {
+    const baseQuery = queryBuilder || FlowConnections.query(trx)
+    return baseQuery
+      .join('flows', 'flow_connections.flow_id', 'flows.id')
+      .where(function () {
+        this.where('flows.user_id', userId).orWhereExists(function () {
+          this.select('*')
+            .from('flow_collaborators')
+            .whereRaw('flow_collaborators.flow_id = flows.id')
+            .where('flow_collaborators.user_id', userId)
+            .where('flow_collaborators.role', 'editor')
+            .whereNull('flow_collaborators.deleted_at')
+        })
+      })
+  }
+
+  /**
+   * NOTE: this function only adds the connection to the flow_connections table
+   * if there are collaborators for the flow
+   */
+  static addFlowConnection = async ({
+    flowId,
+    connectionId,
+    userId,
+  }: {
+    flowId: string
+    connectionId: string
+    userId: string
+  }) => {
+    const hasCollaborators = await FlowCollaborator.hasCollaborators({
+      flowId,
+    })
+
+    if (hasCollaborators) {
+      return await this.query()
+        .insert({
+          flowId,
+          connectionId,
+          userId,
+        })
+        .onConflict(['flow_id', 'connection_id', 'user_id'])
+        .ignore()
+    }
+  }
+
+  static patchFlowConnectionMetadata = async ({
+    flowId,
+    connectionId,
+    userId,
+    parameterKey,
+    parameterValue,
+  }: {
+    flowId: string
+    connectionId: string
+    userId: string
+    parameterKey: string
+    parameterValue: string
+  }) => {
+    return await this.query()
+      .where({
+        flow_id: flowId,
+        connection_id: connectionId,
+        user_id: userId,
+      })
+      .patch({
+        // ensure distinct metadata values, we do it in the query to avoid
+        // having additional queries to get the array, de-duplicate and then
+        // update the DB
+        metadata: FlowConnections.raw(
+          `
+            jsonb_set(
+              metadata,
+              '{${parameterKey}}',
+              (
+                SELECT jsonb_agg(DISTINCT e)
+                FROM jsonb_array_elements_text(
+                COALESCE(metadata->'${parameterKey}', '[]'::jsonb) || to_jsonb(ARRAY[?]::text[])
+                ) AS e
+              ),
+              true
+            )
+            `,
+          [parameterValue],
+        ),
+      })
+  }
+}
+
+export default FlowConnections

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,10 +1,7 @@
-import { Transaction } from 'objection'
-
 import Base from './base'
 import Connection from './connection'
 import Flow from './flow'
 import FlowCollaborator from './flow-collaborators'
-import ExtendedQueryBuilder from './query-builder'
 import TableMetadata from './table-metadata'
 import User from './user'
 
@@ -17,7 +14,7 @@ class FlowConnections extends Base {
   // NOTE: addedBy is the user id of the user who added the connection to the flow
   addedBy!: string
   connectionType!: 'connection' | 'table'
-  connection?: Connection | TableMetadata
+  connection?: Connection
   table?: TableMetadata
   metadata: Record<string, any>
 
@@ -82,30 +79,6 @@ class FlowConnections extends Base {
       },
     },
   })
-
-  static withAccessible({
-    queryBuilder,
-    userId,
-    trx,
-  }: {
-    queryBuilder?: ExtendedQueryBuilder<FlowConnections, FlowConnections[]>
-    userId: string
-    trx?: Transaction
-  }) {
-    const baseQuery = queryBuilder || FlowConnections.query(trx)
-    return baseQuery
-      .join('flows', 'flow_connections.flow_id', 'flows.id')
-      .where(function () {
-        this.where('flows.user_id', userId).orWhereExists(function () {
-          this.select('*')
-            .from('flow_collaborators')
-            .whereRaw('flow_collaborators.flow_id = flows.id')
-            .where('flow_collaborators.user_id', userId)
-            .where('flow_collaborators.role', 'editor')
-            .whereNull('flow_collaborators.deleted_at')
-        })
-      })
-  }
 
   /**
    * NOTE: this function only adds the connection to the flow_connections table

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -5,21 +5,20 @@ import Connection from './connection'
 import Flow from './flow'
 import FlowCollaborator from './flow-collaborators'
 import ExtendedQueryBuilder from './query-builder'
+import TableMetadata from './table-metadata'
 import User from './user'
-
-const VALID_PARAMETER_KEYS = [
-  'fileId',
-  'templateId',
-  'channel',
-  'chatId',
-  'tableId',
-]
 
 class FlowConnections extends Base {
   flowId!: string
+  // NOTE: this connection_id refers to either:
+  // - the connection id of a connection in the connections table; OR
+  // - the id of a Tile
   connectionId!: string
-  userId!: string
-  connections: Connection[]
+  // NOTE: addedBy is the user id of the user who added the connection to the flow
+  addedBy!: string
+  connectionType!: 'connection' | 'table'
+  connection?: Connection | TableMetadata
+  table?: TableMetadata
   metadata: Record<string, any>
 
   static tableName = 'flow_connections'
@@ -29,18 +28,19 @@ class FlowConnections extends Base {
     properties: {
       flowId: { type: 'string', format: 'uuid' },
       connectionId: { type: 'string', format: 'uuid' },
-      userId: { type: 'string', format: 'uuid' },
+      addedBy: { type: 'string', format: 'uuid' },
+      connectionType: { type: 'string', enum: ['connection', 'table'] },
       metadata: { type: 'object' },
     },
   }
 
   // Acts as a composite primary key
   static get idColumn() {
-    return ['flow_id', 'connection_id', 'user_id']
+    return ['flow_id', 'connection_id']
   }
 
   static relationMappings = () => ({
-    flows: {
+    flow: {
       relation: Base.BelongsToOneRelation,
       modelClass: Flow,
       join: {
@@ -48,7 +48,7 @@ class FlowConnections extends Base {
         to: `${Flow.tableName}.id`,
       },
     },
-    connections: {
+    connection: {
       relation: Base.BelongsToOneRelation,
       modelClass: Connection,
       join: {
@@ -56,11 +56,20 @@ class FlowConnections extends Base {
         to: `${Connection.tableName}.id`,
       },
     },
+    // When connection_id refers to a Tile table, this relation can be used
+    table: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: TableMetadata,
+      join: {
+        from: `${this.tableName}.connection_id`,
+        to: `${TableMetadata.tableName}.id`,
+      },
+    },
     user: {
       relation: Base.BelongsToOneRelation,
       modelClass: User,
       join: {
-        from: `${this.tableName}.user_id`,
+        from: `${this.tableName}.added_by`,
         to: `${User.tableName}.id`,
       },
     },
@@ -99,28 +108,21 @@ class FlowConnections extends Base {
   }
 
   /**
-   * Validate parameter key to avoid SQL injection
-   */
-  static validateParameterKey(parameterKey: string) {
-    if (!VALID_PARAMETER_KEYS.includes(parameterKey)) {
-      throw new Error(`Invalid parameter key: ${parameterKey}`)
-    }
-  }
-
-  /**
    * NOTE: this function only adds the connection to the flow_connections table
    * if there are collaborators for the flow
    */
   static addFlowConnection = async ({
     flowId,
     connectionId,
-    userId,
+    addedBy,
+    connectionType,
   }: {
     flowId: string
     connectionId: string
-    userId: string
+    addedBy: string
+    connectionType: 'connection' | 'table'
   }) => {
-    const hasCollaborators = await FlowCollaborator.hasCollaborators({
+    const hasCollaborators = await Flow.hasCollaborators({
       flowId,
     })
 
@@ -129,9 +131,10 @@ class FlowConnections extends Base {
         .insert({
           flowId,
           connectionId,
-          userId,
+          addedBy,
+          connectionType,
         })
-        .onConflict(['flow_id', 'connection_id', 'user_id'])
+        .onConflict(['flow_id', 'connection_id'])
         .ignore()
     }
   }
@@ -139,23 +142,18 @@ class FlowConnections extends Base {
   static patchFlowConnectionMetadata = async ({
     flowId,
     connectionId,
-    userId,
     parameterKey,
     parameterValue,
   }: {
     flowId: string
     connectionId: string
-    userId: string
     parameterKey: string
     parameterValue: string
   }) => {
-    this.validateParameterKey(parameterKey)
-
     return await this.query()
       .where({
         flow_id: flowId,
         connection_id: connectionId,
-        user_id: userId,
       })
       .patch({
         // ensure distinct metadata values, we do it in the query to avoid
@@ -178,6 +176,19 @@ class FlowConnections extends Base {
           [parameterValue],
         ),
       })
+  }
+
+  /**
+   * Returns the loaded connected resource (either Connection or TableMetadata), if present.
+   */
+  getConnection(): Connection | TableMetadata {
+    if (this.connectionType === 'connection') {
+      return this.connection
+    }
+    if (this.connectionType === 'table') {
+      return this.table
+    }
+    throw new Error('Connection type is not valid')
   }
 }
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -136,17 +136,17 @@ class FlowConnections extends Base {
           `
             jsonb_set(
               metadata,
-              '{${parameterKey}}',
+              ?::text[],
               (
                 SELECT jsonb_agg(DISTINCT e)
                 FROM jsonb_array_elements_text(
-                COALESCE(metadata->'${parameterKey}', '[]'::jsonb) || to_jsonb(ARRAY[?]::text[])
+                COALESCE(metadata->?, '[]'::jsonb) || to_jsonb(ARRAY[?]::text[])
                 ) AS e
               ),
               true
             )
             `,
-          [parameterValue],
+          [`{${parameterKey}}`, parameterKey, parameterValue],
         ),
       })
   }

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -7,6 +7,14 @@ import FlowCollaborator from './flow-collaborators'
 import ExtendedQueryBuilder from './query-builder'
 import User from './user'
 
+const VALID_PARAMETER_KEYS = [
+  'fileId',
+  'templateId',
+  'channel',
+  'chatId',
+  'tableId',
+]
+
 class FlowConnections extends Base {
   flowId!: string
   connectionId!: string
@@ -91,6 +99,15 @@ class FlowConnections extends Base {
   }
 
   /**
+   * Validate parameter key to avoid SQL injection
+   */
+  static validateParameterKey(parameterKey: string) {
+    if (!VALID_PARAMETER_KEYS.includes(parameterKey)) {
+      throw new Error(`Invalid parameter key: ${parameterKey}`)
+    }
+  }
+
+  /**
    * NOTE: this function only adds the connection to the flow_connections table
    * if there are collaborators for the flow
    */
@@ -132,6 +149,8 @@ class FlowConnections extends Base {
     parameterKey: string
     parameterValue: string
   }) => {
+    this.validateParameterKey(parameterKey)
+
     return await this.query()
       .where({
         flow_id: flowId,

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -1,6 +1,6 @@
 import { IFlowConfig } from '@plumber/types'
 
-import type { ModelOptions, QueryContext } from 'objection'
+import type { ModelOptions, QueryContext, Transaction } from 'objection'
 import { ValidationError } from 'objection'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
@@ -8,6 +8,7 @@ import { doesActionProcessFiles } from '@/helpers/actions'
 
 import Base from './base'
 import Execution from './execution'
+import FlowCollaborator from './flow-collaborators'
 import FlowTransfer from './flow-transfers'
 import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
@@ -113,6 +114,14 @@ class Flow extends Base {
         to: `${Execution.tableName}.id`,
       },
     },
+    collaborators: {
+      relation: Base.HasManyRelation,
+      modelClass: FlowCollaborator,
+      join: {
+        from: `${this.tableName}.id`,
+        to: `${FlowCollaborator.tableName}.flow_id`,
+      },
+    },
   })
 
   static hasAccess = async (
@@ -206,6 +215,22 @@ class Flow extends Base {
     )
 
     return actionFileFlags.some(Boolean)
+  }
+
+  static hasCollaborators = async ({
+    flowId,
+    trx,
+  }: {
+    flowId: string
+    trx?: Transaction
+  }) => {
+    const collaborators = await FlowCollaborator.query(trx)
+      .where({
+        flow_id: flowId,
+      })
+      .whereNull('deleted_at')
+
+    return collaborators.length > 0
   }
 }
 


### PR DESCRIPTION
### TL;DR

Added a new `flow_connections` table to track connections used in flows with collaborators.

### Why make this change?
This will help manage connection permissions and access control for collaborative flows.
It will allow:
* Editors to use connections that have already been added to the flow by the Owner
* Editors to add new steps that require connections by using the Owner's connection


### How to test?
Verify that the model is correct:
- [ ] Should add to `flow_connections` only if the Pipe has collaborators
- [ ] Should add not to `flow_connections` if the Pipe does not have any collaborators (not necessary)
- [ ] Verify that duplicate connection metadata is not added

