### PR TITLE
[COLLAB-4]: Automatically add connections when adding collaborator

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -8,6 +8,8 @@ import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
+import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -150,6 +152,11 @@ describe('upsert flow collaborator', () => {
 
     it('should automatically add connections to flow_connections table when first collaborator is added', async () => {
       const tilesTableId = randomUUID()
+      await TableMetadata.query().insert({
+        id: tilesTableId,
+        name: 'test table',
+        db: 'pg',
+      })
 
       await Step.query().insert([
         {
@@ -199,14 +206,11 @@ describe('upsert flow collaborator', () => {
         channel: ['general'],
       })
 
-      // Check tiles connection (uses special connection ID)
+      // Check tiles connection: table id is the connection id
       const tilesConnection = flowConnections.find(
-        (fc) => fc.connectionId === '00000000-0000-0000-0000-000000000000',
+        (fc) => fc.connectionId === tilesTableId,
       )
       expect(tilesConnection).toBeDefined()
-      expect(tilesConnection.metadata).toEqual({
-        tableId: [tilesTableId],
-      })
     })
 
     it('should not add connections again when subsequent collaborators are added', async () => {
@@ -353,6 +357,284 @@ describe('upsert flow collaborator', () => {
       })
 
       expect(flowConnections).toHaveLength(0)
+    })
+  })
+
+  describe('automatic table collaborator sharing', () => {
+    let tilesTableId1: string
+    let tilesTableId2: string
+
+    beforeEach(async () => {
+      tilesTableId1 = randomUUID()
+      tilesTableId2 = randomUUID()
+
+      await TableMetadata.query().insert([
+        {
+          id: tilesTableId1,
+          name: 'test table 1',
+          db: 'pg',
+        },
+        {
+          id: tilesTableId2,
+          name: 'test table 2',
+          db: 'pg',
+        },
+      ])
+
+      await TableCollaborator.query().insert([
+        {
+          tableId: tilesTableId1,
+          userId: context.currentUser.id,
+          role: 'owner',
+        },
+        {
+          tableId: tilesTableId2,
+          userId: context.currentUser.id,
+          role: 'owner',
+        },
+      ])
+    })
+
+    it('should automatically add table collaborators when flow has tiles steps', async () => {
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'updateTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId2 },
+          position: 2,
+        },
+      ])
+
+      // Add collaborator - this should trigger table collaborator sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that table collaborators were added
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+
+      expect(tableCollaborators).toHaveLength(2)
+
+      // Check first table collaborator
+      const table1Collaborator = tableCollaborators.find(
+        (tc) => tc.tableId === tilesTableId1,
+      )
+      expect(table1Collaborator).toBeDefined()
+      expect(table1Collaborator.role).toBe('editor')
+
+      // Check second table collaborator
+      const table2Collaborator = tableCollaborators.find(
+        (tc) => tc.tableId === tilesTableId2,
+      )
+      expect(table2Collaborator).toBeDefined()
+      expect(table2Collaborator.role).toBe('editor')
+    })
+
+    it('should add table collaborators with viewer role when collaborator is viewer', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      // Add viewer collaborator
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+        },
+        context,
+      )
+
+      // Check that table collaborator was added with viewer role
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: viewer.id,
+      })
+
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('viewer')
+    })
+
+    it('should handle flows with no tiles steps', async () => {
+      // Create a flow with no tiles steps
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        parameters: { channel: 'general' },
+        position: 1,
+      })
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no table collaborators were added
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(0)
+    })
+
+    it('should handle duplicate table IDs in steps', async () => {
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'updateTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 }, // Same table ID
+          position: 2,
+        },
+      ])
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that only one table collaborator was added (duplicates should be handled)
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+    })
+
+    it('should handle mixed connection and tiles steps', async () => {
+      const connectionId = randomUUID()
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: '1234',
+      })
+
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 2,
+        },
+      ])
+
+      // Add first collaborator - this should trigger both connection and table sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that both flow connections and table collaborators were added
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+
+      expect(flowConnections).toHaveLength(2)
+      expect(flowConnections[0].connectionId).toBe(connectionId)
+      expect(flowConnections[0].connectionType).toBe('connection')
+      expect(flowConnections[1].connectionId).toBe(tilesTableId1)
+      expect(flowConnections[1].connectionType).toBe('table')
+
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('editor')
+    })
+
+    it('should still add table collaborators when flow already has collaborators', async () => {
+      await FlowCollaborator.query().insert({
+        flowId: dummyFlow.id,
+        userId: viewer.id,
+        role: 'viewer',
+        updatedBy: context.currentUser.id,
+      })
+
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no table collaborators were added for the new collaborator
+      const tableCollaborators = await TableCollaborator.query().where({
+        table_id: tilesTableId1,
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -589,10 +589,17 @@ describe('upsert flow collaborator', () => {
       })
 
       expect(flowConnections).toHaveLength(2)
-      expect(flowConnections[0].connectionId).toBe(connectionId)
-      expect(flowConnections[0].connectionType).toBe('connection')
-      expect(flowConnections[1].connectionId).toBe(tilesTableId1)
-      expect(flowConnections[1].connectionType).toBe('table')
+
+      const connectionFlow = flowConnections.find(
+        (fc) => fc.connectionType === 'connection',
+      )
+      const tableFlow = flowConnections.find(
+        (fc) => fc.connectionType === 'table',
+      )
+      expect(connectionFlow).toBeDefined()
+      expect(connectionFlow?.connectionId).toBe(connectionId)
+      expect(tableFlow).toBeDefined()
+      expect(tableFlow?.connectionId).toBe(tilesTableId1)
 
       expect(tableCollaborators).toHaveLength(1)
       expect(tableCollaborators[0].tableId).toBe(tilesTableId1)

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -202,9 +202,7 @@ describe('upsert flow collaborator', () => {
         (fc) => fc.connectionId === connectionId,
       )
       expect(slackConnection).toBeDefined()
-      expect(slackConnection.metadata).toEqual({
-        channel: ['general'],
-      })
+      expect(slackConnection.metadata).toEqual({})
 
       // Check tiles connection: table id is the connection id
       const tilesConnection = flowConnections.find(
@@ -324,9 +322,7 @@ describe('upsert flow collaborator', () => {
       })
 
       expect(flowConnections).toHaveLength(1)
-      expect(flowConnections[0].metadata).toEqual({
-        channel: ['general'], // Should only appear once
-      })
+      expect(flowConnections[0].metadata).toEqual({})
     })
 
     it('should handle steps without connection gracefully', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -185,7 +185,7 @@ describe('upsert flow collaborator', () => {
       // Check that connections were added to flow_connections table
       const flowConnections = await FlowConnections.query().where({
         flow_id: dummyFlow.id,
-        user_id: dummyFlow.userId,
+        added_by: dummyFlow.userId,
       })
 
       expect(flowConnections).toHaveLength(2)
@@ -242,7 +242,7 @@ describe('upsert flow collaborator', () => {
       // Check that connections were only added once
       const flowConnections = await FlowConnections.query().where({
         flow_id: dummyFlow.id,
-        user_id: dummyFlow.userId,
+        added_by: dummyFlow.userId,
       })
 
       expect(flowConnections).toHaveLength(1)
@@ -273,7 +273,7 @@ describe('upsert flow collaborator', () => {
       // Check that no connections were added
       const flowConnections = await FlowConnections.query().where({
         flow_id: dummyFlow.id,
-        user_id: dummyFlow.userId,
+        added_by: dummyFlow.userId,
       })
 
       expect(flowConnections).toHaveLength(0)
@@ -316,7 +316,7 @@ describe('upsert flow collaborator', () => {
       // Check that duplicate values are handled correctly
       const flowConnections = await FlowConnections.query().where({
         flow_id: dummyFlow.id,
-        user_id: dummyFlow.userId,
+        added_by: dummyFlow.userId,
       })
 
       expect(flowConnections).toHaveLength(1)
@@ -349,7 +349,7 @@ describe('upsert flow collaborator', () => {
       // Check that the connection was still added (with empty metadata)
       const flowConnections = await FlowConnections.query().where({
         flow_id: dummyFlow.id,
-        user_id: dummyFlow.userId,
+        added_by: dummyFlow.userId,
       })
 
       expect(flowConnections).toHaveLength(0)

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import upsertFlowCollaborator from '@/graphql/mutations/upsert-flow-collaborator'
+import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
+import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -132,5 +135,224 @@ describe('upsert flow collaborator', () => {
     ).rejects.toThrowError(
       'You do not have sufficient permissions for this pipe',
     )
+  })
+
+  describe('automatic connection sharing', () => {
+    const connectionId = randomUUID()
+
+    beforeEach(async () => {
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: '1234',
+      })
+    })
+
+    it('should automatically add connections to flow_connections table when first collaborator is added', async () => {
+      const tilesTableId = randomUUID()
+
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId },
+          position: 2,
+        },
+      ])
+
+      // Add first collaborator - this should trigger connection sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that connections were added to flow_connections table
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        user_id: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(2)
+
+      // Check slack connection
+      const slackConnection = flowConnections.find(
+        (fc) => fc.connectionId === connectionId,
+      )
+      expect(slackConnection).toBeDefined()
+      expect(slackConnection.metadata).toEqual({
+        channel: ['general'],
+      })
+
+      // Check tiles connection (uses special connection ID)
+      const tilesConnection = flowConnections.find(
+        (fc) => fc.connectionId === '00000000-0000-0000-0000-000000000000',
+      )
+      expect(tilesConnection).toBeDefined()
+      expect(tilesConnection.metadata).toEqual({
+        tableId: [tilesTableId],
+      })
+    })
+
+    it('should not add connections again when subsequent collaborators are added', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        connectionId: connectionId,
+        parameters: { channel: 'general' },
+        position: 1,
+      })
+
+      // Add first collaborator - this should trigger connection sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Add second collaborator - this should NOT trigger connection sharing again
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+        },
+        context,
+      )
+
+      // Check that connections were only added once
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        user_id: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].connectionId).toBe(connectionId)
+    })
+
+    it('should handle flows with no connection steps', async () => {
+      // Create a flow with no connection steps
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'delay',
+        appKey: 'delay',
+        type: 'action',
+        parameters: { duration: 1000 },
+        position: 1,
+      })
+
+      // Add collaborator - this should not fail even with no connections
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no connections were added
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        user_id: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(0)
+    })
+
+    it('should handle duplicate parameter values in connection metadata', async () => {
+      // Create steps with duplicate channel values
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' }, // Duplicate channel
+          position: 2,
+        },
+      ])
+
+      // Add collaborator
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that duplicate values are handled correctly
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        user_id: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].metadata).toEqual({
+        channel: ['general'], // Should only appear once
+      })
+    })
+
+    it('should handle steps without connection gracefully', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        connectionId: null,
+        parameters: {},
+        position: 1,
+      })
+
+      // Add collaborator - this should not fail
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that the connection was still added (with empty metadata)
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        user_id: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(0)
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -8,6 +8,7 @@ import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -61,31 +62,42 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           trx,
         })
 
+        const flow = await Flow.query(trx)
+          .withGraphFetched('steps')
+          .findById(flowId)
+        const connectionDetails = getConnectionDetails(flow?.steps)
+
         if (!hasCollaborators) {
-          const flow = await Flow.query(trx)
-            .withGraphFetched('steps')
-            .findById(flowId)
-
-          const connectionDetails = getConnectionDetails(flow?.steps)
-
           // add all connections to the flow_connections table
           // first time sharing is always by the owner
           // so we use the flow user_id
-          await Promise.all(
-            Object.entries(connectionDetails).map(
-              async ([connectionId, metadata]) => {
-                await FlowConnections.query(trx)
-                  .insert({
-                    flowId,
-                    connectionId: connectionId ?? null,
-                    addedBy: flow.userId,
-                    metadata,
-                  })
-                  .onConflict(['flow_id', 'connection_id'])
-                  .ignore()
-              },
+          const connectionInserts = [
+            // Handle regular connections
+            ...Object.entries(connectionDetails.connection).map(
+              ([connectionId, metadata]) => ({
+                flowId,
+                connectionId,
+                addedBy: flow.userId,
+                connectionType: 'connection' as const,
+                metadata,
+              }),
             ),
-          )
+            // Handle table connections (Tiles)
+            ...connectionDetails.table.map((tableId) => ({
+              flowId,
+              connectionId: tableId,
+              addedBy: flow.userId,
+              connectionType: 'table' as const,
+              metadata: {},
+            })),
+          ]
+
+          if (connectionInserts.length > 0) {
+            await FlowConnections.query(trx)
+              .insert(connectionInserts)
+              .onConflict(['flow_id', 'connection_id'])
+              .ignore()
+          }
         }
 
         const collaboratorUser = await getOrCreateUser(validatedEmail)
@@ -116,6 +128,20 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
             role,
             updatedBy: context.currentUser.id,
           })
+        }
+
+        /**
+         * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
+         * this ensures that the Tile appears in the dropdown when they are working
+         * on the flow
+         */
+        if (connectionDetails.table.length > 0) {
+          const tableInserts = connectionDetails.table.map((tableId) => ({
+            tableId,
+            userId: collaboratorUser.id,
+            role,
+          }))
+          await TableCollaborator.query(trx).insert(tableInserts)
         }
       })
     } catch (error) {

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -58,6 +58,7 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
          */
         const hasCollaborators = await Flow.hasCollaborators({
           flowId,
+          trx,
         })
 
         if (!hasCollaborators) {

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -56,7 +56,7 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
          * 2. Connection metadata, i.e. fields that are like connections:
          *    see helpers/get-shared-connection-details.ts for more details
          */
-        const hasCollaborators = await FlowCollaborator.hasCollaborators({
+        const hasCollaborators = await Flow.hasCollaborators({
           flowId,
         })
 
@@ -77,10 +77,10 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
                   .insert({
                     flowId,
                     connectionId: connectionId ?? null,
-                    userId: flow.userId,
+                    addedBy: flow.userId,
                     metadata,
                   })
-                  .onConflict(['flow_id', 'connection_id', 'user_id'])
+                  .onConflict(['flow_id', 'connection_id'])
                   .ignore()
               },
             ),

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -3,8 +3,11 @@ import { IFlowCollabRole } from '@plumber/types'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
+import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -42,6 +45,47 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           requiredRole: 'editor',
           trx,
         })
+
+        /**
+         * NOTE: we only automatically add all connections
+         * in the Pipe to the flow_connections table the first time
+         * the Pipe is shared.
+         *
+         * What is added:
+         * 1. Connections
+         * 2. Connection metadata, i.e. fields that are like connections:
+         *    see helpers/get-shared-connection-details.ts for more details
+         */
+        const hasCollaborators = await FlowCollaborator.hasCollaborators({
+          flowId,
+        })
+
+        if (!hasCollaborators) {
+          const flow = await Flow.query(trx)
+            .withGraphFetched('steps')
+            .findById(flowId)
+
+          const connectionDetails = getConnectionDetails(flow?.steps)
+
+          // add all connections to the flow_connections table
+          // first time sharing is always by the owner
+          // so we use the flow user_id
+          await Promise.all(
+            Object.entries(connectionDetails).map(
+              async ([connectionId, metadata]) => {
+                await FlowConnections.query(trx)
+                  .insert({
+                    flowId,
+                    connectionId: connectionId ?? null,
+                    userId: flow.userId,
+                    metadata,
+                  })
+                  .onConflict(['flow_id', 'connection_id', 'user_id'])
+                  .ignore()
+              },
+            ),
+          )
+        }
 
         const collaboratorUser = await getOrCreateUser(validatedEmail)
         if (!collaboratorUser) {

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -134,14 +134,21 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
          * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
          * this ensures that the Tile appears in the dropdown when they are working
          * on the flow
+         *
+         * use Promise.all so that we use the addCollaborator function, which checks
+         * if the collaborator already exists to avoid duplicates
          */
         if (connectionDetails.table.length > 0) {
-          const tableInserts = connectionDetails.table.map((tableId) => ({
-            tableId,
-            userId: collaboratorUser.id,
-            role,
-          }))
-          await TableCollaborator.query(trx).insert(tableInserts)
+          await Promise.all(
+            connectionDetails.table.map(async (tableId) => {
+              await TableCollaborator.addCollaborator({
+                userId: collaboratorUser.id,
+                tableId,
+                role,
+                trx,
+              })
+            }),
+          )
         }
       })
     } catch (error) {

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -98,12 +98,8 @@ describe('getConnectionDetails', () => {
 
     expect(result).toEqual({
       connection: {
-        'slack-connection-id': {
-          channel: ['general'],
-        },
-        'telegram-connection-id': {
-          chatId: ['random'],
-        },
+        'slack-connection-id': {},
+        'telegram-connection-id': {},
       },
       table: [],
     })
@@ -132,15 +128,11 @@ describe('getConnectionDetails', () => {
 
     expect(result).toEqual({
       connection: {
-        'slack-connection-id': {
-          channel: ['general'],
-        },
+        'slack-connection-id': {},
         'm365-excel-connection-id': {
           fileId: ['file-123'],
         },
-        'lettersg-connection-id': {
-          templateId: ['template-456'],
-        },
+        'lettersg-connection-id': {},
       },
       table: [],
     })
@@ -169,9 +161,7 @@ describe('getConnectionDetails', () => {
 
     expect(result).toEqual({
       connection: {
-        'slack-connection-id': {
-          channel: ['general', 'random'],
-        },
+        'slack-connection-id': {},
       },
       table: [],
     })
@@ -217,9 +207,7 @@ describe('getConnectionDetails', () => {
 
     expect(result).toEqual({
       connection: {
-        'slack-connection-id': {
-          channel: [],
-        },
+        'slack-connection-id': {},
       },
       table: [],
     })
@@ -328,9 +316,7 @@ describe('getConnectionDetails', () => {
         connection: {
           'aisay-connection-id': {},
           'custom-api-connection-id': {},
-          'slack-connection-id': {
-            channel: ['general'],
-          },
+          'slack-connection-id': {},
           'm365-excel-connection-id': {
             fileId: ['file-123'],
           },

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -2,10 +2,7 @@ import { IStep } from '@plumber/types'
 
 import { describe, expect, it } from 'vitest'
 
-import {
-  getConnectionDetails,
-  TILES_CONNECTION_ID,
-} from '../get-shared-connection-details'
+import { getConnectionDetails } from '../get-shared-connection-details'
 
 describe('getConnectionDetails', () => {
   const createMockStep = (overrides: Partial<IStep> = {}): IStep => ({
@@ -50,9 +47,12 @@ describe('getConnectionDetails', () => {
 
     // Should return empty object since none of these apps have parameterKey defined
     expect(result).toEqual({
-      'aisay-connection-id': {},
-      'custom-api-connection-id': {},
-      'formsg-connection-id': {},
+      connection: {
+        'aisay-connection-id': {},
+        'custom-api-connection-id': {},
+        'formsg-connection-id': {},
+      },
+      table: [],
     })
   })
 
@@ -73,7 +73,10 @@ describe('getConnectionDetails', () => {
 
     // Should return empty object since paysg has empty APP_CONNECTION_FIELDS
     expect(result).toEqual({
-      'paysg-connection-id': {},
+      connection: {
+        'paysg-connection-id': {},
+      },
+      table: [],
     })
   })
 
@@ -94,12 +97,15 @@ describe('getConnectionDetails', () => {
     const result = getConnectionDetails(steps)
 
     expect(result).toEqual({
-      'slack-connection-id': {
-        channel: ['general'],
+      connection: {
+        'slack-connection-id': {
+          channel: ['general'],
+        },
+        'telegram-connection-id': {
+          chatId: ['random'],
+        },
       },
-      'telegram-connection-id': {
-        chatId: ['random'],
-      },
+      table: [],
     })
   })
 
@@ -125,15 +131,18 @@ describe('getConnectionDetails', () => {
     const result = getConnectionDetails(steps)
 
     expect(result).toEqual({
-      'slack-connection-id': {
-        channel: ['general'],
+      connection: {
+        'slack-connection-id': {
+          channel: ['general'],
+        },
+        'm365-excel-connection-id': {
+          fileId: ['file-123'],
+        },
+        'lettersg-connection-id': {
+          templateId: ['template-456'],
+        },
       },
-      'm365-excel-connection-id': {
-        fileId: ['file-123'],
-      },
-      'lettersg-connection-id': {
-        templateId: ['template-456'],
-      },
+      table: [],
     })
   })
 
@@ -159,9 +168,12 @@ describe('getConnectionDetails', () => {
     const result = getConnectionDetails(steps)
 
     expect(result).toEqual({
-      'slack-connection-id': {
-        channel: ['general', 'random'],
+      connection: {
+        'slack-connection-id': {
+          channel: ['general', 'random'],
+        },
       },
+      table: [],
     })
   })
 
@@ -181,7 +193,10 @@ describe('getConnectionDetails', () => {
 
     const result = getConnectionDetails(steps)
 
-    expect(result).toEqual({})
+    expect(result).toEqual({
+      connection: {},
+      table: [],
+    })
   })
 
   it('should handle steps with missing parameter values', () => {
@@ -201,14 +216,17 @@ describe('getConnectionDetails', () => {
     const result = getConnectionDetails(steps)
 
     expect(result).toEqual({
-      'slack-connection-id': {
-        channel: [],
+      connection: {
+        'slack-connection-id': {
+          channel: [],
+        },
       },
+      table: [],
     })
   })
 
   describe('special case: Tiles', () => {
-    it('should use TILES_CONNECTION_ID for tiles app regardless of connectionId', () => {
+    it('should use tableId for tiles app regardless of connectionId', () => {
       const steps: IStep[] = [
         createMockStep({
           appKey: 'tiles',
@@ -223,9 +241,8 @@ describe('getConnectionDetails', () => {
       const result = getConnectionDetails(steps)
 
       expect(result).toEqual({
-        [TILES_CONNECTION_ID]: {
-          tableId: ['table-123', 'table-456'],
-        },
+        connection: {},
+        table: ['table-123', 'table-456'],
       })
     })
 
@@ -240,9 +257,8 @@ describe('getConnectionDetails', () => {
       const result = getConnectionDetails(steps)
 
       expect(result).toEqual({
-        [TILES_CONNECTION_ID]: {
-          tableId: [],
-        },
+        connection: {},
+        table: [],
       })
     })
 
@@ -268,9 +284,8 @@ describe('getConnectionDetails', () => {
       const result = getConnectionDetails(steps)
 
       expect(result).toEqual({
-        [TILES_CONNECTION_ID]: {
-          tableId: ['table-123', 'table-456'],
-        },
+        connection: {},
+        table: ['table-123', 'table-456'],
       })
     })
   })
@@ -310,23 +325,26 @@ describe('getConnectionDetails', () => {
       const result = getConnectionDetails(steps)
 
       expect(result).toEqual({
-        'aisay-connection-id': {},
-        'custom-api-connection-id': {},
-        'slack-connection-id': {
-          channel: ['general'],
+        connection: {
+          'aisay-connection-id': {},
+          'custom-api-connection-id': {},
+          'slack-connection-id': {
+            channel: ['general'],
+          },
+          'm365-excel-connection-id': {
+            fileId: ['file-123'],
+          },
         },
-        'm365-excel-connection-id': {
-          fileId: ['file-123'],
-        },
-        [TILES_CONNECTION_ID]: {
-          tableId: ['table-123'],
-        },
+        table: ['table-123'],
       })
     })
 
     it('should handle empty steps array', () => {
       const result = getConnectionDetails([])
-      expect(result).toEqual({})
+      expect(result).toEqual({
+        connection: {},
+        table: [],
+      })
     })
 
     it('should handle steps with unknown appKey', () => {
@@ -342,7 +360,10 @@ describe('getConnectionDetails', () => {
 
       // Should return empty object since unknown app is not in APP_CONNECTION_FIELDS
       expect(result).toEqual({
-        'unknown-app-connection-id': {},
+        connection: {
+          'unknown-app-connection-id': {},
+        },
+        table: [],
       })
     })
   })

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -1,0 +1,349 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  getConnectionDetails,
+  TILES_CONNECTION_ID,
+} from '../get-shared-connection-details'
+
+describe('getConnectionDetails', () => {
+  const createMockStep = (overrides: Partial<IStep> = {}): IStep => ({
+    id: 'step-1',
+    flowId: 'flow-1',
+    appKey: 'slack',
+    type: 'action',
+    connectionId: null,
+    status: 'completed',
+    position: 1,
+    parameters: {},
+    connection: undefined,
+    flow: {} as any,
+    executionSteps: [],
+    config: {},
+    iconUrl: 'https://example.com/icon.svg',
+    webhookUrl: 'https://example.com/webhook',
+    createdAt: '2023-01-01T00:00:00Z',
+    ...overrides,
+  })
+
+  it('should not include any metadata for apps without connection fields', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'aisay',
+        connectionId: 'aisay-connection-id',
+        parameters: { someParam: 'value' },
+      }),
+      createMockStep({
+        appKey: 'custom-api',
+        connectionId: 'custom-api-connection-id',
+        parameters: { anotherParam: 'value2' },
+      }),
+      createMockStep({
+        appKey: 'formsg',
+        connectionId: 'formsg-connection-id',
+        parameters: { formParam: 'value3' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    // Should return empty object since none of these apps have parameterKey defined
+    expect(result).toEqual({
+      'aisay-connection-id': {},
+      'custom-api-connection-id': {},
+      'formsg-connection-id': {},
+    })
+  })
+
+  it('should not include metadata for apps without connection fields', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'paysg',
+        connectionId: 'paysg-connection-id',
+        parameters: {
+          fileId: 'file-123',
+          channel: 'general',
+          templateId: 'template-456',
+        },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    // Should return empty object since paysg has empty APP_CONNECTION_FIELDS
+    expect(result).toEqual({
+      'paysg-connection-id': {},
+    })
+  })
+
+  it('should include metadata for apps with parameterKey defined', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'telegram-bot',
+        connectionId: 'telegram-connection-id',
+        parameters: { chatId: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      'slack-connection-id': {
+        channel: ['general'],
+      },
+      'telegram-connection-id': {
+        chatId: ['random'],
+      },
+    })
+  })
+
+  it('should handle multiple connections with different parameter keys', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'm365-excel',
+        connectionId: 'm365-excel-connection-id',
+        parameters: { fileId: 'file-123' },
+      }),
+      createMockStep({
+        appKey: 'lettersg',
+        connectionId: 'lettersg-connection-id',
+        parameters: { templateId: 'template-456' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      'slack-connection-id': {
+        channel: ['general'],
+      },
+      'm365-excel-connection-id': {
+        fileId: ['file-123'],
+      },
+      'lettersg-connection-id': {
+        templateId: ['template-456'],
+      },
+    })
+  })
+
+  it('should not include duplicate parameter values for the same connection', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' }, // duplicate
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      'slack-connection-id': {
+        channel: ['general', 'random'],
+      },
+    })
+  })
+
+  it('should handle steps without connectionId', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'formatter',
+        connectionId: undefined,
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'custom-api',
+        connectionId: null,
+        parameters: { channel: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({})
+  })
+
+  it('should handle steps with missing parameter values', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: undefined },
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: '' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      'slack-connection-id': {
+        channel: [],
+      },
+    })
+  })
+
+  describe('special case: Tiles', () => {
+    it('should use TILES_CONNECTION_ID for tiles app regardless of connectionId', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-123' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-456' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        [TILES_CONNECTION_ID]: {
+          tableId: ['table-123', 'table-456'],
+        },
+      })
+    })
+
+    it('should handle tiles step with empty parameters', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          parameters: {},
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        [TILES_CONNECTION_ID]: {
+          tableId: [],
+        },
+      })
+    })
+
+    it('should not include duplicate tableIds for tiles', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-123' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-123' }, // duplicate
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-456' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        [TILES_CONNECTION_ID]: {
+          tableId: ['table-123', 'table-456'],
+        },
+      })
+    })
+  })
+
+  describe('mixed scenarios', () => {
+    it('should handle mix of apps with and without parameterKey defined', () => {
+      const steps: IStep[] = [
+        // Apps with empty APP_CONNECTION_FIELDS
+        createMockStep({
+          appKey: 'aisay',
+          connectionId: 'aisay-connection-id',
+          parameters: { someParam: 'value' },
+        }),
+        createMockStep({
+          appKey: 'custom-api',
+          connectionId: 'custom-api-connection-id',
+          parameters: { anotherParam: 'value2' },
+        }),
+        // Apps with parameterKey defined
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'slack-connection-id',
+          parameters: { channel: 'general' },
+        }),
+        createMockStep({
+          appKey: 'm365-excel',
+          connectionId: 'm365-excel-connection-id',
+          parameters: { fileId: 'file-123' },
+        }),
+        // Tiles app
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-123' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        'aisay-connection-id': {},
+        'custom-api-connection-id': {},
+        'slack-connection-id': {
+          channel: ['general'],
+        },
+        'm365-excel-connection-id': {
+          fileId: ['file-123'],
+        },
+        [TILES_CONNECTION_ID]: {
+          tableId: ['table-123'],
+        },
+      })
+    })
+
+    it('should handle empty steps array', () => {
+      const result = getConnectionDetails([])
+      expect(result).toEqual({})
+    })
+
+    it('should handle steps with unknown appKey', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'unknown-app' as any,
+          connectionId: 'unknown-app-connection-id',
+          parameters: { someParam: 'value' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      // Should return empty object since unknown app is not in APP_CONNECTION_FIELDS
+      expect(result).toEqual({
+        'unknown-app-connection-id': {},
+      })
+    })
+  })
+})

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -35,58 +35,59 @@ export const APP_CONNECTION_FIELDS: Record<
   },
 }
 
-export const TILES_CONNECTION_ID = '00000000-0000-0000-0000-000000000000'
-
 export function getConnectionDetails(steps: IStep[]): {
-  [connectionId: string]: {
-    [appKey: string]: string[]
-  }
-} {
-  const connections: {
+  connection: {
     [connectionId: string]: {
       [appKey: string]: string[]
     }
-  } = {}
+  }
+  table: string[]
+} {
+  const connections: {
+    connection: {
+      [connectionId: string]: {
+        [appKey: string]: string[]
+      }
+    }
+    table: string[]
+  } = {
+    connection: {},
+    table: [],
+  }
 
   steps.map((step) => {
     if (step.connectionId) {
-      connections[step.connectionId] ??= {}
+      connections.connection[step.connectionId] ??= {}
 
       const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
       const paramValue = step.parameters[paramKey] as string
 
       // only some apps need the metadata, so we only add it if the app has a parameter key
       if (paramKey) {
-        connections[step.connectionId][paramKey] ??= []
+        connections.connection[step.connectionId][paramKey] ??= []
 
         // push only if not already present
         if (
           paramValue &&
-          !connections[step.connectionId][paramKey].includes(paramValue)
+          !connections.connection[step.connectionId][paramKey].includes(
+            paramValue,
+          )
         ) {
-          connections[step.connectionId][paramKey].push(paramValue)
+          connections.connection[step.connectionId][paramKey].push(paramValue)
         }
       }
     }
 
     /**
      * SPECIAL CASE: Tiles does not have a connection id
-     * but we want to restrict the dynamic data to the tile id (tableId)
-     * so we use a special connection id to store the dynamic data
+     * so we use the tableId instead.
      */
     if (step.appKey === 'tiles') {
       const paramKey = APP_CONNECTION_FIELDS[step.appKey].parameterKey
       const paramValue = step.parameters[paramKey] as string
 
-      // create nested objects if missing
-      connections[TILES_CONNECTION_ID] ??= {}
-      connections[TILES_CONNECTION_ID][paramKey] ??= []
-
-      if (
-        paramValue &&
-        !connections[TILES_CONNECTION_ID][paramKey].includes(paramValue)
-      ) {
-        connections[TILES_CONNECTION_ID][paramKey].push(paramValue)
+      if (paramValue && !connections.table.includes(paramValue)) {
+        connections.table.push(paramValue)
       }
     }
   })

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -1,0 +1,85 @@
+import { IStep } from '@plumber/types'
+
+/**
+ * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
+ */
+export const APP_CONNECTION_FIELDS: Record<
+  IStep['appKey'],
+  {
+    parameterKey: string
+    dynamicDataKey: string
+  }
+> = {
+  lettersg: {
+    parameterKey: 'templateId',
+    dynamicDataKey: 'getTemplateIds',
+  },
+  slack: {
+    parameterKey: 'channel',
+    dynamicDataKey: 'listChannels',
+  },
+  'telegram-bot': {
+    parameterKey: 'chatId',
+    dynamicDataKey: 'listChats',
+  },
+  tiles: {
+    parameterKey: 'tableId',
+    dynamicDataKey: 'listTables',
+  },
+}
+
+export const TILES_CONNECTION_ID = '00000000-0000-0000-0000-000000000000'
+
+export function getConnectionDetails(steps: IStep[]): {
+  [connectionId: string]: {
+    [appKey: string]: string[]
+  }
+} {
+  const connections: {
+    [connectionId: string]: {
+      [appKey: string]: string[]
+    }
+  } = {}
+
+  steps.map((step) => {
+    if (step.connectionId) {
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey].parameterKey
+      const paramValue = step.parameters[paramKey] as string
+
+      // create nested objects if missing
+      connections[step.connectionId] ??= {}
+      connections[step.connectionId][paramKey] ??= []
+
+      // push only if not already present
+      if (
+        paramValue &&
+        !connections[step.connectionId][paramKey].includes(paramValue)
+      ) {
+        connections[step.connectionId][paramKey].push(paramValue)
+      }
+    }
+
+    /**
+     * SPECIAL CASE: Tiles does not have a connection id
+     * but we want to restrict the dynamic data to the tile id (tableId)
+     * so we use a special connection id to store the dynamic data
+     */
+    if (step.appKey === 'tiles') {
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey].parameterKey
+      const paramValue = step.parameters[paramKey] as string
+
+      // create nested objects if missing
+      connections[TILES_CONNECTION_ID] ??= {}
+      connections[TILES_CONNECTION_ID][paramKey] ??= []
+
+      if (
+        paramValue &&
+        !connections[TILES_CONNECTION_ID][paramKey].includes(paramValue)
+      ) {
+        connections[TILES_CONNECTION_ID][paramKey].push(paramValue)
+      }
+    }
+  })
+
+  return connections
+}

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -2,14 +2,21 @@ import { IStep } from '@plumber/types'
 
 /**
  * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
+ * we only need to app apps that have fields that behave like connections.
+ * apps that only have connections such as formsg or postman-sms
+ * do not need to be specified here
  */
 export const APP_CONNECTION_FIELDS: Record<
   IStep['appKey'],
   {
-    parameterKey: string
-    dynamicDataKey: string
+    parameterKey?: string
+    dynamicDataKey?: string
   }
 > = {
+  'm365-excel': {
+    parameterKey: 'fileId',
+    dynamicDataKey: 'listFiles',
+  },
   lettersg: {
     parameterKey: 'templateId',
     dynamicDataKey: 'getTemplateIds',
@@ -43,19 +50,22 @@ export function getConnectionDetails(steps: IStep[]): {
 
   steps.map((step) => {
     if (step.connectionId) {
-      const paramKey = APP_CONNECTION_FIELDS[step.appKey].parameterKey
+      connections[step.connectionId] ??= {}
+
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
       const paramValue = step.parameters[paramKey] as string
 
-      // create nested objects if missing
-      connections[step.connectionId] ??= {}
-      connections[step.connectionId][paramKey] ??= []
+      // only some apps need the metadata, so we only add it if the app has a parameter key
+      if (paramKey) {
+        connections[step.connectionId][paramKey] ??= []
 
-      // push only if not already present
-      if (
-        paramValue &&
-        !connections[step.connectionId][paramKey].includes(paramValue)
-      ) {
-        connections[step.connectionId][paramKey].push(paramValue)
+        // push only if not already present
+        if (
+          paramValue &&
+          !connections[step.connectionId][paramKey].includes(paramValue)
+        ) {
+          connections[step.connectionId][paramKey].push(paramValue)
+        }
       }
     }
 

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -4,7 +4,11 @@ import { IStep } from '@plumber/types'
  * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
  * we only need to app apps that have fields that behave like connections.
  * apps that only have connections such as formsg or postman-sms
- * do not need to be specified here
+ * do not need to be specified here.
+ *
+ * ONLY specify the parameterKey and dynamicDataKey for apps that have fields that need
+ * to be treated like connections, such as M365-Excel files, where we do not want the
+ * collaborator(s) to have access to all the files in the owner's Plumber SharePoint folder.
  */
 export const APP_CONNECTION_FIELDS: Record<
   IStep['appKey'],
@@ -17,18 +21,13 @@ export const APP_CONNECTION_FIELDS: Record<
     parameterKey: 'fileId',
     dynamicDataKey: 'listFiles',
   },
-  lettersg: {
-    parameterKey: 'templateId',
-    dynamicDataKey: 'getTemplateIds',
-  },
-  slack: {
-    parameterKey: 'channel',
-    dynamicDataKey: 'listChannels',
-  },
-  'telegram-bot': {
-    parameterKey: 'chatId',
-    dynamicDataKey: 'listChats',
-  },
+  lettersg: {},
+  slack: {},
+  'telegram-bot': {},
+  /**
+   * TILES SPECIAL CASE: tiles is handled differently as the table id is treated as the
+   * connection id in the flow_connections table.
+   */
   tiles: {
     parameterKey: 'tableId',
     dynamicDataKey: 'listTables',
@@ -83,7 +82,7 @@ export function getConnectionDetails(steps: IStep[]): {
      * so we use the tableId instead.
      */
     if (step.appKey === 'tiles') {
-      const paramKey = APP_CONNECTION_FIELDS[step.appKey].parameterKey
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
       const paramValue = step.parameters[paramKey] as string
 
       if (paramValue && !connections.table.includes(paramValue)) {

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -89,18 +89,21 @@ class FlowConnections extends Base {
     connectionId,
     addedBy,
     connectionType,
+    trx,
   }: {
     flowId: string
     connectionId: string
     addedBy: string
     connectionType: 'connection' | 'table'
+    trx?: Transaction
   }) => {
     const hasCollaborators = await Flow.hasCollaborators({
       flowId,
+      trx,
     })
 
     if (hasCollaborators) {
-      return await this.query()
+      return await this.query(trx)
         .insert({
           flowId,
           connectionId,

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,3 +1,5 @@
+import { Transaction } from 'objection'
+
 import Base from './base'
 import Connection from './connection'
 import Flow from './flow'

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -1,6 +1,8 @@
 import { IGlobalVariable, ITableCollabRole } from '@plumber/types'
 
-import { ForbiddenError } from '@/errors/graphql-errors'
+import { Transaction } from 'objection'
+
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
 
 import Base from './base'
@@ -82,6 +84,47 @@ class TableCollaborator extends Base {
       throw new ForbiddenError(
         'You do not have sufficient permissions for this tile',
       )
+    }
+  }
+
+  static addCollaborator = async ({
+    userId,
+    tableId,
+    role,
+    trx,
+  }: {
+    userId: string
+    tableId: string
+    role: ITableCollabRole
+    trx?: Transaction
+  }) => {
+    const existingCollaborator = await TableCollaborator.query(trx)
+      .findOne({
+        table_id: tableId,
+        user_id: userId,
+      })
+      .withSoftDeleted()
+
+    /**
+     * Upsert collaborator here
+     */
+    if (existingCollaborator) {
+      if (existingCollaborator.role === 'owner') {
+        throw new BadUserInputError('Cannot change owner role')
+      }
+      await existingCollaborator
+        .$query(trx)
+        .patchAndFetch({
+          role,
+          deletedAt: null,
+        })
+        .withSoftDeleted()
+    } else {
+      await TableCollaborator.query(trx).insert({
+        tableId,
+        userId,
+        role,
+      })
     }
   }
 }


### PR DESCRIPTION
## TL;DR 
This PR implements automatic connection sharing when a flow is first shared with a collaborator. When the first collaborator is added to a flow, the system now automatically:
1. Identifies all connections used in the flow
2. Adds these connections to the `flow_connections` table
3. Captures relevant metadata for each connection type, which are connection-like fields, such as:
   1. LetterSG: Templates
   1. M365-Excel: Files
   1. Slack: Channels
   1. Telegram: Chat IDs
   1. Tiles: Selected Tile

## What changed
The implementation includes:
- A new helper function `getConnectionDetails` to extract connection information from flow steps
- Special handling for Tiles app which uses a hard-coded connection ID
- Support for various app-specific connection fields (Slack channels, M365 Excel files, etc.)

## How to test
_Note: the UI will come in the next PR, for this PR, make sure that the functions to get shared connections are correct and connections are only added when adding a collaborator for the first time_
- [ ] All Apps with connection-like fields are covered
- [ ] Connection-like fields are retrieved correctly from the step parameters