### PR TITLE
feat: add begins with condition for if-then

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
@@ -449,5 +449,29 @@ describe('If-then', () => {
         })
       },
     )
+
+    it.each([
+      { field: 'Hello', text: 'He', expectedResult: true },
+      { field: 'Hello', text: 'Me', expectedResult: false },
+      { field: 123, text: '12', expectedResult: true },
+      { field: 123, text: '32', expectedResult: false },
+    ])(
+      'should handle begins with condition',
+      async ({ field, text, expectedResult }) => {
+        $.step.parameters.conditions = [
+          {
+            field,
+            is: 'is',
+            condition: 'begins',
+            text,
+          },
+        ]
+
+        await ifThenAction.run($)
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isConditionMet: expectedResult },
+        })
+      },
+    )
   })
 })

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -90,6 +90,9 @@ export default function conditionIsTrue(conditionArgs: IJSONObject): boolean {
     case 'contains':
       result = field.toString().includes(value.toString())
       break
+    case 'begins':
+      result = field.toString().startsWith(value.toString())
+      break
     case 'empty':
       // `field` and `value` are a bit of a misnomer. They're both form fields
       // that the user inputs data into.  The "empty" condition is unary, so the

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -74,6 +74,10 @@ export default function getConditionArgs({
           value: 'after',
           description: 'Used for dates',
         },
+        {
+          label: 'Begins with',
+          value: 'begins',
+        },
       ],
       customStyle: { flex: 2 },
     },


### PR DESCRIPTION
## TL;DR
Adds a 'Begins with' condition for If-then, which works for strings and numbers.
Note that it is case sensitive.
This already exists in Tiles conditions, so just achieving parity.

## How to test
- [ ] Input a string, test that begins with works
- [ ] Input a number, test that begins with works

## Screenshots
<img width="998" height="449" alt="Screenshot 2025-08-27 at 11 32 33 AM" src="https://github.com/user-attachments/assets/0ebc1788-e75e-481b-8c4a-14ab7d99ec0f" />

<img width="1002" height="479" alt="Screenshot 2025-08-27 at 11 32 41 AM" src="https://github.com/user-attachments/assets/f80c8e94-646f-4d67-8359-960c586bd552" />

<img width="885" height="493" alt="Screenshot 2025-08-27 at 11 29 33 AM" src="https://github.com/user-attachments/assets/ad167ce9-fd55-4296-a085-219b3447e1b2" />

<img width="885" height="511" alt="Screenshot 2025-08-27 at 11 29 41 AM" src="https://github.com/user-attachments/assets/0dc67e48-4cc2-4a83-9290-825d01f160e9" />
