### PR TITLE
fix: numeric comparisons for tiles v2

### DIFF
--- a/packages/backend/src/models/tiles/pg/__tests__/helpers.test.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/helpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidNumericString } from '../helpers'
+
+describe('pg tiles helpers', () => {
+  it.each([
+    ['123'],
+    ['-123'],
+    ['0'],
+    ['5'],
+    ['0.123'],
+    ['-0.123'],
+    ['123.456'],
+    ['-123.456'],
+    ['-0.0000001'],
+    ['0.00'],
+  ])('should return true if the string is a valid numeric string', (value) => {
+    expect(isValidNumericString(value)).toBe(true)
+  })
+
+  it.each([
+    ['not a number'],
+    ['123.456.789'],
+    ['-.213'],
+    ['+23'],
+    ['00.379'],
+    ['01'],
+    ['00'],
+    ['00.00'],
+    ['1e6'],
+    ['99-99'],
+    ['--12'],
+  ])(
+    'should return false if the string is not a valid numeric string',
+    (value) => {
+      expect(isValidNumericString(value)).toBe(false)
+    },
+  )
+})

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -386,18 +386,23 @@ describe('table-row-functions', () => {
   describe('getTableRows', () => {
     let dataArray: Record<string, string>[]
     let rowIds: string[]
+    const NUM_ROWS = 9
     beforeEach(async () => {
       // Add test rows for filtering tests
-      dataArray = new Array(5).fill(0).map(() =>
+      dataArray = new Array(NUM_ROWS).fill(0).map(() =>
         generateMockTableRowData({
           columnIds: dummyColumnIds,
         }),
       )
-      dataArray[0][dummyColumnIds[3]] = '0'
+      dataArray[0][dummyColumnIds[3]] = '5'
       dataArray[1][dummyColumnIds[3]] = '10'
       dataArray[2][dummyColumnIds[3]] = '20'
       dataArray[3][dummyColumnIds[3]] = '30'
       dataArray[4][dummyColumnIds[3]] = '40'
+      dataArray[5][dummyColumnIds[3]] = '140'
+      dataArray[6][dummyColumnIds[3]] = 'abc'
+      dataArray[7][dummyColumnIds[3]] = 'def'
+      dataArray[8][dummyColumnIds[3]] = 'ghi'
       rowIds = await createTableRows({
         tableId: dummyTable.id,
         dataArray,
@@ -406,7 +411,7 @@ describe('table-row-functions', () => {
 
     it('should return all rows when no filters are specified', async () => {
       const result = await getTableRows({ tableId: dummyTable.id })
-      expect(result.rows).toHaveLength(5)
+      expect(result.rows).toHaveLength(NUM_ROWS)
     })
 
     it('should return only specified columns', async () => {
@@ -415,7 +420,7 @@ describe('table-row-functions', () => {
         columnIds: [dummyColumnIds[0]],
       })
 
-      expect(result.rows).toHaveLength(5)
+      expect(result.rows).toHaveLength(NUM_ROWS)
       expect(Object.keys(result.rows[0].data)).toEqual([dummyColumnIds[0]])
     })
 
@@ -458,42 +463,171 @@ describe('table-row-functions', () => {
           {
             columnId: dummyColumnIds[3],
             operator: TableRowFilterOperator.GreaterThan,
-            value: '25',
+            value: '20',
           },
         ],
       })
 
-      expect(result.rows).toHaveLength(2)
+      expect(result.rows).toHaveLength(3)
       expect(result.rows.map((r) => r.rowId).sort()).toEqual([
         rowIds[3],
         rowIds[4],
+        rowIds[5],
       ])
+
+      const result2 = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.GreaterThan,
+            value: 'abc',
+          },
+        ],
+      })
+
+      expect(result2.rows).toHaveLength(2)
+      expect(result2.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[7],
+        rowIds[8],
+      ])
+    })
+
+    it('should filter rows with greaterThanOrEquals operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.GreaterThanOrEquals,
+            value: '20',
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(4)
+      expect(result.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[2],
+        rowIds[3],
+        rowIds[4],
+        rowIds[5],
+      ])
+
+      const result2 = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.GreaterThanOrEquals,
+            value: 'abc',
+          },
+        ],
+      })
+
+      expect(result2.rows).toHaveLength(3)
+      expect(result2.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[6],
+        rowIds[7],
+        rowIds[8],
+      ])
+    })
+
+    it('should filter rows with lessThan operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.LessThan,
+            value: '30',
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(3)
+      expect(result.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[0],
+        rowIds[1],
+        rowIds[2],
+      ])
+
+      const result2 = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.LessThan,
+            value: 'aaa',
+          },
+        ],
+      })
+
+      expect(result2.rows).toHaveLength(6)
+      expect(result2.rows.map((r) => r.rowId).sort()).toEqual(
+        rowIds.slice(0, -3),
+      )
+    })
+
+    it('should filter rows with lessThanOrEquals operator', async () => {
+      const result = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.LessThanOrEquals,
+            value: '20',
+          },
+        ],
+      })
+
+      expect(result.rows).toHaveLength(3)
+      expect(result.rows.map((r) => r.rowId).sort()).toEqual([
+        rowIds[0],
+        rowIds[1],
+        rowIds[2],
+      ])
+
+      const result2 = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.LessThanOrEquals,
+            value: 'abc',
+          },
+        ],
+      })
+
+      expect(result2.rows).toHaveLength(7)
+      expect(result2.rows.map((r) => r.rowId).sort()).toEqual(
+        rowIds.slice(0, -2),
+      )
     })
 
     it('should return rows with pagination using scanLimit and cursor', async () => {
       // First page
       const firstPage = await getTableRows({
         tableId: dummyTable.id,
-        scanLimit: 2,
+        scanLimit: 4,
       })
 
-      expect(firstPage.rows).toHaveLength(2)
+      expect(firstPage.rows).toHaveLength(4)
       expect(firstPage.stringifiedCursor).not.toBeNull()
 
       // Second page
       const secondPage = await getTableRows({
         tableId: dummyTable.id,
-        scanLimit: 2,
+        scanLimit: 4,
         stringifiedCursor: firstPage.stringifiedCursor,
       })
 
-      expect(secondPage.rows).toHaveLength(2)
+      expect(secondPage.rows).toHaveLength(4)
       expect(secondPage.stringifiedCursor).not.toBeNull()
 
       // Third page
       const thirdPage = await getTableRows({
         tableId: dummyTable.id,
-        scanLimit: 2,
+        scanLimit: 4,
         stringifiedCursor: secondPage.stringifiedCursor,
       })
 
@@ -509,8 +643,8 @@ describe('table-row-functions', () => {
 
       // Since rows are ordered by rowId, which follows creation order,
       // we expect the names to be in reverse creation order
-      expect(result.rows[0].rowId).toBe(rowIds[4])
-      expect(result.rows[result.rows.length - 1].rowId).toBe(rowIds[0])
+      expect(result.rows[0].rowId).toBe(rowIds[NUM_ROWS - 1])
+      expect(result.rows[NUM_ROWS - 1].rowId).toBe(rowIds[0])
     })
   })
 

--- a/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
+++ b/packages/backend/src/models/tiles/pg/__tests__/table-row-functions.itest.ts
@@ -438,6 +438,20 @@ describe('table-row-functions', () => {
 
       expect(result.rows).toHaveLength(1)
       expect(result.rows[0].rowId).toBe(rowIds[0])
+
+      const result2 = await getTableRows({
+        tableId: dummyTable.id,
+        filters: [
+          {
+            columnId: dummyColumnIds[3],
+            operator: TableRowFilterOperator.Equals,
+            value: '5',
+          },
+        ],
+      })
+
+      expect(result2.rows).toHaveLength(1)
+      expect(result2.rows[0].rowId).toBe(rowIds[0])
     })
 
     it('should filter rows with contains operator', async () => {

--- a/packages/backend/src/models/tiles/pg/helpers.ts
+++ b/packages/backend/src/models/tiles/pg/helpers.ts
@@ -1,0 +1,11 @@
+// This regex is used to validate that a string is a valid number
+// It matches strings that start with an optional minus sign, followed by an optional zero,
+// or any number from 1 to 9 followed by any number of digits, optionally followed by a decimal point and any number of digits.
+// Examples: "123", "-456", "0.789", "-0.123", "123.456", "-456.789"
+
+export const VALID_NUMBER_REGEX_STRING = '^-?(0|[1-9]\\d*)(\\.\\d+)?$'
+export const VALID_NUMBER_REGEX = new RegExp(VALID_NUMBER_REGEX_STRING)
+
+export function isValidNumericString(value: string): boolean {
+  return VALID_NUMBER_REGEX.test(value) && !isNaN(+value)
+}

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -190,7 +190,26 @@ function addFiltersToQuery(
   query: Knex.QueryBuilder,
   filters: TableRowFilter[],
 ) {
+  // This regex is used to validate that a string is a valid number
+  // It matches strings that start with an optional minus sign, followed by an optional zero,
+  // or any number from 1 to 9 followed by any number of digits, optionally followed by a decimal point and any number of digits.
+  // Examples: "123", "-456", "0.789", "-0.123", "123.456", "-456.789"
+  const VALID_NUMBER_REGEX = '^-?(0|[1-9]\\d*)(\\.\\d+)?$'
+
   for (const filter of filters) {
+    const isValueNumber = !isNaN(+filter.value)
+
+    // use raw expression here to avoid type errors
+    let castedColumn: Knex.Raw = tilesClient.raw('??', [filter.columnId])
+    let castedValue: number | string = filter.value
+
+    // if the value to compare against is a number, we case the stored values to a number if
+    // they are valid numeric strings, or else we compare them string to string
+    if (isValueNumber) {
+      query.where(filter.columnId, '~', VALID_NUMBER_REGEX)
+      castedColumn = tilesClient.raw('??::numeric', [filter.columnId])
+      castedValue = +filter.value
+    }
     switch (filter.operator) {
       case TableRowFilterOperator.Equals:
         query.where(filter.columnId, '=', filter.value)
@@ -199,16 +218,16 @@ function addFiltersToQuery(
         query.where(filter.columnId, 'ilike', `%${filter.value}%`)
         break
       case TableRowFilterOperator.GreaterThan:
-        query.where(filter.columnId, '>', filter.value)
+        query.where(castedColumn, '>', castedValue)
         break
       case TableRowFilterOperator.GreaterThanOrEquals:
-        query.where(filter.columnId, '>=', filter.value)
+        query.where(castedColumn, '>=', castedValue)
         break
       case TableRowFilterOperator.LessThan:
-        query.where(filter.columnId, '<', filter.value)
+        query.where(castedColumn, '<', castedValue)
         break
       case TableRowFilterOperator.LessThanOrEquals:
-        query.where(filter.columnId, '<=', filter.value)
+        query.where(castedColumn, '<=', castedValue)
         break
       case TableRowFilterOperator.IsEmpty:
         query.where((builder) => {

--- a/packages/backend/src/models/tiles/pg/table-row-functions.ts
+++ b/packages/backend/src/models/tiles/pg/table-row-functions.ts
@@ -17,6 +17,8 @@ import {
   UpdateRowInput,
 } from '../types'
 
+import { isValidNumericString, VALID_NUMBER_REGEX_STRING } from './helpers'
+
 function formatTableRow(
   row: Record<string, string>,
   tableId: string,
@@ -127,7 +129,7 @@ export const patchTableRow = async ({
               +value,
             ]),
           )
-          .where(key, '~', '^[-+]?\\d*\\.?\\d+$')
+          .where(key, '~', VALID_NUMBER_REGEX_STRING)
       },
     )
 
@@ -144,7 +146,7 @@ export const patchTableRow = async ({
               +value,
             ]),
           )
-          .where(key, '~', '^[-+]?\\d*\\.?\\d+$')
+          .where(key, '~', VALID_NUMBER_REGEX_STRING)
       },
     )
 
@@ -190,26 +192,13 @@ function addFiltersToQuery(
   query: Knex.QueryBuilder,
   filters: TableRowFilter[],
 ) {
-  // This regex is used to validate that a string is a valid number
-  // It matches strings that start with an optional minus sign, followed by an optional zero,
-  // or any number from 1 to 9 followed by any number of digits, optionally followed by a decimal point and any number of digits.
-  // Examples: "123", "-456", "0.789", "-0.123", "123.456", "-456.789"
-  const VALID_NUMBER_REGEX = '^-?(0|[1-9]\\d*)(\\.\\d+)?$'
-
+  const NumericOperators = {
+    [TableRowFilterOperator.GreaterThan]: '>',
+    [TableRowFilterOperator.GreaterThanOrEquals]: '>=',
+    [TableRowFilterOperator.LessThan]: '<',
+    [TableRowFilterOperator.LessThanOrEquals]: '<=',
+  }
   for (const filter of filters) {
-    const isValueNumber = !isNaN(+filter.value)
-
-    // use raw expression here to avoid type errors
-    let castedColumn: Knex.Raw = tilesClient.raw('??', [filter.columnId])
-    let castedValue: number | string = filter.value
-
-    // if the value to compare against is a number, we case the stored values to a number if
-    // they are valid numeric strings, or else we compare them string to string
-    if (isValueNumber) {
-      query.where(filter.columnId, '~', VALID_NUMBER_REGEX)
-      castedColumn = tilesClient.raw('??::numeric', [filter.columnId])
-      castedValue = +filter.value
-    }
     switch (filter.operator) {
       case TableRowFilterOperator.Equals:
         query.where(filter.columnId, '=', filter.value)
@@ -218,17 +207,30 @@ function addFiltersToQuery(
         query.where(filter.columnId, 'ilike', `%${filter.value}%`)
         break
       case TableRowFilterOperator.GreaterThan:
-        query.where(castedColumn, '>', castedValue)
-        break
       case TableRowFilterOperator.GreaterThanOrEquals:
-        query.where(castedColumn, '>=', castedValue)
-        break
       case TableRowFilterOperator.LessThan:
-        query.where(castedColumn, '<', castedValue)
+      case TableRowFilterOperator.LessThanOrEquals: {
+        // if the value to compare against is a numeric string number,
+        // we cast the stored values to a number and compare numerically
+        if (isValidNumericString(filter.value)) {
+          query
+            .where(filter.columnId, '~', VALID_NUMBER_REGEX_STRING)
+            .andWhere(
+              tilesClient.raw('??::numeric', [filter.columnId]),
+              NumericOperators[filter.operator],
+              +filter.value,
+            )
+        } else {
+          // if the value to compare against is a string, we compare strings
+          // regardless of whether the stored value is a number or a string
+          query.where(
+            filter.columnId,
+            NumericOperators[filter.operator],
+            filter.value,
+          )
+        }
         break
-      case TableRowFilterOperator.LessThanOrEquals:
-        query.where(castedColumn, '<=', castedValue)
-        break
+      }
       case TableRowFilterOperator.IsEmpty:
         query.where((builder) => {
           builder.whereNull(filter.columnId).orWhere(filter.columnId, '')


### PR DESCRIPTION
###  Summary

Fix ed numeric comparisons for greater than, less than, and equals operators, to follow Tiles v1 logic

### What changed?

- When filter by >, >=, < and <= AND the value to compare against is a number (checked using NaN), we will cast the stored values in the column to a number and compare using the operators
- If vlaue to compare against is Not a Number, we will use the default lexicographical comparison in postgres.

### How to test?
- Create a tile, in one of the columns, add numbers of different length e.g. 5,10,11,27,200, mixed with some strings
- Use `find single row` numeric comparisons and test