### PR TITLE
fix: update timezone format from en-sg to en-us

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -1,3 +1,5 @@
+import '@/types/luxon-extensions'
+
 import { type IGlobalVariable } from '@plumber/types'
 
 import { DateTime } from 'luxon'
@@ -180,8 +182,8 @@ describe('Delay until action', () => {
       expect(result).toBeFalsy()
       expect(mocks.setActionItem).toBeCalledWith({
         raw: {
-          delayUntil: DateTime.now().toFormat('dd MMM yyyy'),
-          delayUntilTime: DateTime.now().toFormat('HH:mm'),
+          delayUntil: DateTime.now().toPlumberFormat('dd MMM yyyy'),
+          delayUntilTime: DateTime.now().toPlumberFormat('HH:mm'),
         },
       })
     })

--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -11,6 +11,8 @@ import delayApp from '../index'
 const PAST_DATE = '2023-11-08'
 const VALID_DATE = '2026-12-31' // long long time later
 const VALID_TIME = '12:00'
+const VALID_DD_MMM_YYYY_SG = '01 Sept 2026' // test Sept format to convert to en-US
+const VALID_DD_MMM_YYYY_US = '01 Sep 2026'
 const DEFAULT_TIME = '00:00'
 const INVALID_TIME = '25:00'
 const INVALID_DATE = '2025-12-32'
@@ -86,6 +88,32 @@ describe('Delay until action', () => {
     expect(result).toBeFalsy()
     expect(mocks.setActionItem).toBeCalledWith({
       raw: { delayUntil: VALID_DATE, delayUntilTime: VALID_TIME },
+    })
+  })
+
+  it('returns void and maintains Sept format in en-US', async () => {
+    $.step.parameters = {
+      delayUntil: VALID_DD_MMM_YYYY_US,
+      delayUntilTime: VALID_TIME,
+    }
+
+    const result = await delayUntilAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayUntil: VALID_DD_MMM_YYYY_US, delayUntilTime: VALID_TIME },
+    })
+  })
+
+  it('returns void and converts Sept to en-US from en-SG', async () => {
+    $.step.parameters = {
+      delayUntil: VALID_DD_MMM_YYYY_SG,
+      delayUntilTime: VALID_TIME,
+    }
+
+    const result = await delayUntilAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { delayUntil: VALID_DD_MMM_YYYY_US, delayUntilTime: VALID_TIME },
     })
   })
 

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -61,8 +61,25 @@ const action: IRawAction = {
       delayUntilTimeString,
     )
 
+    // check if delayUntilString is of dd MMM yyyy format, if so, force en-US to maintain consistency with FormSG
+    let delayUntilStringUSFormatted = delayUntilString
+    // Try parsing with en-SG first (for "Sept"), then en-US (for "Sep"), this is for the test case to work because it is not aware of the en-US locale
+    let dateTime = DateTime.fromFormat(delayUntilString, 'dd MMM yyyy', {
+      locale: 'en-SG',
+    })
+    if (!dateTime.isValid) {
+      dateTime = DateTime.fromFormat(delayUntilString, 'dd MMM yyyy', {
+        locale: 'en-US',
+      })
+    }
+    if (dateTime.isValid) {
+      delayUntilStringUSFormatted = dateTime.toFormat('dd MMM yyyy', {
+        locale: 'en-US',
+      })
+    }
+
     let dataItem = {
-      delayUntil: delayUntilString,
+      delayUntil: delayUntilStringUSFormatted,
       delayUntilTime: delayUntilTimeString,
     }
 
@@ -85,7 +102,7 @@ const action: IRawAction = {
       if (isRetry) {
         const dateTimeNow = DateTime.now()
         dataItem = {
-          delayUntil: dateTimeNow.toFormat('dd MMM yyyy'),
+          delayUntil: dateTimeNow.toFormat('dd MMM yyyy', { locale: 'en-US' }), // Force en-US to maintain consistency with FormSG
           delayUntilTime: dateTimeNow.toFormat('HH:mm'),
         }
       } else {

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -33,7 +33,7 @@ const action: IRawAction = {
       key: 'delayUntil',
       type: 'string' as const,
       required: true,
-      description: 'Delay until the date. E.g. 25 Aug 2023',
+      description: 'Delay until the date. E.g. 05 Aug 2026',
       variables: true,
     },
     {
@@ -62,7 +62,7 @@ const action: IRawAction = {
     )
 
     // check if delayUntilString is of dd MMM yyyy format, if so, force en-US to maintain consistency with FormSG
-    let delayUntilStringUSFormatted = delayUntilString
+    let delayUntilFormatted = delayUntilString
     // Try parsing with en-SG first (for "Sept"), then en-US (for "Sep"), this is for the test case to work because it is not aware of the en-US locale
     let dateTime = DateTime.fromFormat(delayUntilString, 'dd MMM yyyy', {
       locale: 'en-SG',
@@ -73,13 +73,11 @@ const action: IRawAction = {
       })
     }
     if (dateTime.isValid) {
-      delayUntilStringUSFormatted = dateTime.toFormat('dd MMM yyyy', {
-        locale: 'en-US',
-      })
+      delayUntilFormatted = dateTime.toPlumberFormat('dd MMM yyyy')
     }
 
     let dataItem = {
-      delayUntil: delayUntilStringUSFormatted,
+      delayUntil: delayUntilFormatted,
       delayUntilTime: delayUntilTimeString,
     }
 
@@ -102,8 +100,8 @@ const action: IRawAction = {
       if (isRetry) {
         const dateTimeNow = DateTime.now()
         dataItem = {
-          delayUntil: dateTimeNow.toFormat('dd MMM yyyy', { locale: 'en-US' }), // Force en-US to maintain consistency with FormSG
-          delayUntilTime: dateTimeNow.toFormat('HH:mm'),
+          delayUntil: dateTimeNow.toPlumberFormat('dd MMM yyyy'),
+          delayUntilTime: dateTimeNow.toPlumberFormat('HH:mm'),
         }
       } else {
         throw new StepError(

--- a/packages/backend/src/apps/formatter/__tests__/date-time.add-subtract.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.add-subtract.test.ts
@@ -1,3 +1,5 @@
+import '@/types/luxon-extensions'
+
 import { IGlobalVariable } from '@plumber/types'
 
 import { Settings as LuxonSettings } from 'luxon'

--- a/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
@@ -1,3 +1,5 @@
+import '@/types/luxon-extensions'
+
 import { DateTime, Settings as LuxonSettings } from 'luxon'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -139,26 +139,41 @@ describe('convert date time', () => {
     })
   })
 
-  // check if dd LLL yyyy format is corrected to en-US all the time
-  it('maintains dd LLL yyyy format in en-US', () => {
+  it.each([
+    {
+      inputFormat: 'formsgDateField',
+      inputValue: '01 Sept 2025',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '01 Sep 2025',
+    },
+    {
+      inputFormat: 'formsgDateField',
+      inputValue: '02 Sep 2025',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '02 Sep 2025',
+    },
+    {
+      inputFormat: 'dd LLL yyyy hh:mm a',
+      inputValue: '03 Sep 2025 11:50 pm',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '03 Sep 2025',
+    },
+    {
+      inputFormat: 'dd LLL yyyy hh:mm:ss a',
+      inputValue: '04 Sept 2025 11:45:30 pm',
+      toFormat: 'dd LLL yyyy hh:mm a',
+      expectedResult: '04 Sep 2025 11:45 pm',
+    },
+  ])('converts dd MMM yyyy format from en-SG to en-US', (testParams) => {
+    const { inputFormat, inputValue, toFormat, expectedResult } = testParams
     $.step.parameters = {
-      dateTimeFormat: 'formsgDateField',
-      formatDateTimeToFormat: 'dd LLL yyyy',
+      dateTimeFormat: inputFormat,
+      formatDateTimeToFormat: toFormat,
     }
-    spec.transformData($, '01 Sep 2024')
-    expect(mocks.setActionItem).toBeCalledWith({
-      raw: { result: '01 Sep 2024' },
-    })
-  })
+    spec.transformData($, inputValue)
 
-  it('converts dd LLL yyyy format from en-SG to en-US', () => {
-    $.step.parameters = {
-      dateTimeFormat: 'formsgDateField',
-      formatDateTimeToFormat: 'dd LLL yyyy',
-    }
-    spec.transformData($, '01 Sept 2024')
     expect(mocks.setActionItem).toBeCalledWith({
-      raw: { result: '01 Sep 2024' },
+      raw: { result: expectedResult },
     })
   })
 })

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -138,4 +138,27 @@ describe('convert date time', () => {
       raw: { result: expectedResult },
     })
   })
+
+  // check if dd LLL yyyy format is corrected to en-US all the time
+  it('maintains dd LLL yyyy format in en-US', () => {
+    $.step.parameters = {
+      dateTimeFormat: 'formsgDateField',
+      formatDateTimeToFormat: 'dd LLL yyyy',
+    }
+    spec.transformData($, '01 Sep 2024')
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: '01 Sep 2024' },
+    })
+  })
+
+  it('converts dd LLL yyyy format from en-SG to en-US', () => {
+    $.step.parameters = {
+      dateTimeFormat: 'formsgDateField',
+      formatDateTimeToFormat: 'dd LLL yyyy',
+    }
+    spec.transformData($, '01 Sept 2024')
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: '01 Sep 2024' },
+    })
+  })
 })

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -1,3 +1,5 @@
+import '@/types/luxon-extensions'
+
 import { IGlobalVariable } from '@plumber/types'
 
 import { Settings as LuxonSettings } from 'luxon'

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -134,12 +134,6 @@ export function parseDateTime(
 ): DateTime {
   const result = formatConverters[dateTimeFormat].parse(valueToTransform)
 
-  if (dateTimeFormat === 'dd LLL yyyy' && !result.isValid) {
-    result = formatConverters[dateTimeFormat].parse(valueToTransform, {
-      locale: 'en-US',
-    })
-  }
-
   if (!result.isValid) {
     throw new Error(
       `${valueToTransform}' is not a valid ${formatConverters[dateTimeFormat].description}`,

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -58,7 +58,8 @@ const formatConverters = Object.assign({
       // en-US parsing failed, fall back to en-SG.
       return DateTime.fromFormat(input, 'dd MMM yyyy')
     },
-    stringify: (dateTime: DateTime): string => dateTime.toFormat('dd MMM yyyy'),
+    stringify: (dateTime: DateTime): string =>
+      dateTime.toPlumberFormat('dd MMM yyyy'),
   },
   ...Object.fromEntries(
     commonDateFormats
@@ -67,9 +68,19 @@ const formatConverters = Object.assign({
         format,
         {
           description: format,
-          parse: (input: string): DateTime =>
-            DateTime.fromFormat(input, format),
-          stringify: (dateTime: DateTime): string => dateTime.toFormat(format),
+          parse: (input: string): DateTime => {
+            const result = DateTime.fromFormat(input, format, {
+              locale: 'en-US',
+            })
+            if (result.isValid) {
+              return result
+            }
+            return DateTime.fromFormat(input, format, {
+              locale: 'en-SG',
+            })
+          },
+          stringify: (dateTime: DateTime): string =>
+            dateTime.toPlumberFormat(format),
         },
       ]),
   ),
@@ -122,6 +133,12 @@ export function parseDateTime(
   valueToTransform: string,
 ): DateTime {
   const result = formatConverters[dateTimeFormat].parse(valueToTransform)
+
+  if (dateTimeFormat === 'dd LLL yyyy' && !result.isValid) {
+    result = formatConverters[dateTimeFormat].parse(valueToTransform, {
+      locale: 'en-US',
+    })
+  }
 
   if (!result.isValid) {
     throw new Error(

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -1,6 +1,5 @@
 import type { IGlobalVariable } from '@plumber/types'
 
-import { DateTime } from 'luxon'
 import { ZodError } from 'zod'
 
 import StepError, { GenericSolution } from '@/errors/step'
@@ -36,22 +35,6 @@ function getParams($: IGlobalVariable) /* inferred return type */ {
   }
 }
 
-// helper function to check if format contains dd LLL yyyy, if so, force en-US to maintain consistency with FormSG
-function formatStringToUSLocale(formatString: string, dateTime: DateTime) {
-  switch (formatString) {
-    case 'dd LLL yyyy':
-    case 'dd LLL yyyy hh:mm a':
-    case 'dd LLL yyyy hh:mm:ss a': {
-      const dateTimeString = dateTime.toFormat(formatString, {
-        locale: 'en-SG', // TODO: ???
-      })
-      return dateTimeString
-    }
-    default:
-      return dateTime.toFormat(formatString)
-  }
-}
-
 export const spec = {
   id: 'formatDateTime',
 
@@ -67,13 +50,13 @@ export const spec = {
       const { dateTimeFormat, formatString } = getParams($)
       const dateTime = parseDateTime(dateTimeFormat, valueToTransform)
 
-      // check if format is dd LLL yyyy, if so, force en-US to maintain consistency with FormSG
       $.setActionItem({
         raw: {
-          result: formatStringToUSLocale(formatString, dateTime),
+          result: dateTime.toPlumberFormat(formatString),
         },
       })
     } catch (error) {
+      console.log('error', error)
       if (error instanceof StepError) {
         throw error
       }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -50,9 +50,13 @@ export const spec = {
       const { dateTimeFormat, formatString } = getParams($)
       const dateTime = parseDateTime(dateTimeFormat, valueToTransform)
 
+      // check if format is dd LLL yyyy, if so, force en-US to maintain consistency with FormSG
       $.setActionItem({
         raw: {
-          result: dateTime.toFormat(formatString),
+          result:
+            formatString === 'dd LLL yyyy'
+              ? dateTime.toFormat(formatString, { locale: 'en-US' })
+              : dateTime.toFormat(formatString),
         },
       })
     } catch (error) {

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -56,7 +56,6 @@ export const spec = {
         },
       })
     } catch (error) {
-      console.log('error', error)
       if (error instanceof StepError) {
         throw error
       }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -1,5 +1,6 @@
 import type { IGlobalVariable } from '@plumber/types'
 
+import { DateTime } from 'luxon'
 import { ZodError } from 'zod'
 
 import StepError, { GenericSolution } from '@/errors/step'
@@ -35,6 +36,22 @@ function getParams($: IGlobalVariable) /* inferred return type */ {
   }
 }
 
+// helper function to check if format contains dd LLL yyyy, if so, force en-US to maintain consistency with FormSG
+function formatStringToUSLocale(formatString: string, dateTime: DateTime) {
+  switch (formatString) {
+    case 'dd LLL yyyy':
+    case 'dd LLL yyyy hh:mm a':
+    case 'dd LLL yyyy hh:mm:ss a': {
+      const dateTimeString = dateTime.toFormat(formatString, {
+        locale: 'en-SG', // TODO: ???
+      })
+      return dateTimeString
+    }
+    default:
+      return dateTime.toFormat(formatString)
+  }
+}
+
 export const spec = {
   id: 'formatDateTime',
 
@@ -53,10 +70,7 @@ export const spec = {
       // check if format is dd LLL yyyy, if so, force en-US to maintain consistency with FormSG
       $.setActionItem({
         raw: {
-          result:
-            formatString === 'dd LLL yyyy'
-              ? dateTime.toFormat(formatString, { locale: 'en-US' })
-              : dateTime.toFormat(formatString),
+          result: formatStringToUSLocale(formatString, dateTime),
         },
       })
     } catch (error) {

--- a/packages/backend/src/apps/lettersg/actions/create-letter/schema.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/schema.ts
@@ -67,7 +67,7 @@ export const responseSchema = z
     // Have to set to en-US to process the month "Sep" while en-SG only accepts "Sept"
     createdAt: DateTime.fromFormat(data.createdAt, 'EEE MMM dd yyyy', {
       locale: 'en-US',
-    }).toFormat(
+    }).toPlumberFormat(
       'dd MMM yyyy', // format a time usable for other steps
     ),
   }))

--- a/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/schema.ts
@@ -172,7 +172,7 @@ export const requestSchema = z
     description: data.description,
     amount_in_cents: data.paymentAmountCents,
     metadata: data.metadata ?? {}, // PaySG requires at least an empty metadata object.
-    due_date: data.dueDate?.toFormat('dd-MMM-yyyy')?.toUpperCase(),
+    due_date: data.dueDate?.toPlumberFormat('dd-MMM-yyyy')?.toUpperCase(),
     return_url: data.returnUrl,
   }))
 

--- a/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
@@ -1,3 +1,5 @@
+import '@/types/luxon-extensions'
+
 import { DateTime } from 'luxon'
 import { describe, expect, it } from 'vitest'
 

--- a/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
+++ b/packages/backend/src/apps/scheduler/__tests__/common/get-date-time-object.test.ts
@@ -19,4 +19,11 @@ describe('Test get date time object format', () => {
       )
     })
   })
+
+  it('dd MMM yyyy format should be corrected to en-US', () => {
+    const dateTime = DateTime.local(2025, 9, 1)
+    expect(getDateTimeObjectRepresentation(dateTime).pretty_date).toEqual(
+      '01 Sep 2025',
+    )
+  })
 })

--- a/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
+++ b/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
@@ -8,7 +8,9 @@ export default function getDateTimeObjectRepresentation(dateTime: DateTime) {
   return {
     ...defaults,
     ISO_date_time: dateTime.toISO(),
-    pretty_date: dateTime.toFormat('dd MMM yyyy'),
+    pretty_date: dateTime.toFormat('dd MMM yyyy', {
+      locale: 'en-US', // Force en-US to maintain consistency with FormSG
+    }),
     pretty_time: dateTime.toLocaleString(DateTime.TIME_WITH_SECONDS),
     pretty_day_of_week: dateTime.toFormat('cccc'),
     day_of_week: dateTime.weekday,

--- a/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
+++ b/packages/backend/src/apps/scheduler/common/get-date-time-object.ts
@@ -8,11 +8,9 @@ export default function getDateTimeObjectRepresentation(dateTime: DateTime) {
   return {
     ...defaults,
     ISO_date_time: dateTime.toISO(),
-    pretty_date: dateTime.toFormat('dd MMM yyyy', {
-      locale: 'en-US', // Force en-US to maintain consistency with FormSG
-    }),
+    pretty_date: dateTime.toPlumberFormat('dd MMM yyyy'),
     pretty_time: dateTime.toLocaleString(DateTime.TIME_WITH_SECONDS),
-    pretty_day_of_week: dateTime.toFormat('cccc'),
+    pretty_day_of_week: dateTime.toPlumberFormat('cccc'),
     day_of_week: dateTime.weekday,
   } as IJSONObject
 }

--- a/packages/backend/src/config/app.ts
+++ b/packages/backend/src/config/app.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config'
+import '@/types/luxon-extensions'
 
 import { Settings as LuxonSettings } from 'luxon'
 import { URL } from 'node:url'

--- a/packages/backend/src/helpers/__tests__/generate-error-email.itest.ts
+++ b/packages/backend/src/helpers/__tests__/generate-error-email.itest.ts
@@ -29,7 +29,7 @@ vi.mock('luxon', () => {
         endOf: (_interval: string) => ({
           toMillis: () => endOfTimestamp, // 2030-10-10T23:59:59.000+08:00
         }),
-        toFormat: (_format: string) => '10 Oct 2030 at 11:59:00 PM',
+        toPlumberFormat: (_format: string) => '10 Oct 2030 at 11:59:00 PM',
       }),
     },
   }

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -18,7 +18,7 @@ export function createBodyErrorMessage(
   flowName: string,
   pipeId: string,
 ): string {
-  const currDateTime = DateTime.now().toFormat('MMM dd yyyy, hh:mm a')
+  const currDateTime = DateTime.now().toPlumberFormat('MMM dd yyyy, hh:mm a')
   const searchParams = new URLSearchParams()
   searchParams.set('status', 'failure')
 

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -28,19 +28,16 @@ import { enqueueActionJob } from '@/queues/action'
 import getForEachMetadata from './helpers/get-for-each-metadata'
 
 // TODO on Oct: remove this once the logging is not needed anymore
-const SEPT_KEYWORD_REGEX = / Sept /
+const SEPT_KEYWORD_REGEX = /Sept /
 
 function containsSeptKeyword(obj: IJSONValue): boolean {
   if (typeof obj === 'string') {
     return SEPT_KEYWORD_REGEX.test(obj)
   }
-  if (Array.isArray(obj)) {
-    return obj.some((item) => containsSeptKeyword(item))
+  if (typeof obj === 'object' && obj !== null) {
+    return SEPT_KEYWORD_REGEX.test(JSON.stringify(obj))
   }
 
-  if (obj !== null && typeof obj === 'object') {
-    return Object.values(obj).some((value) => containsSeptKeyword(value))
-  }
   return false
 }
 
@@ -231,16 +228,14 @@ export const processAction = async (options: ProcessActionOptions) => {
     })
 
   // TODO on Oct: remove this once the logging is not needed anymore
-  if (!testRun && status === 'failure') {
-    if (containsSeptKeyword($.step.parameters ?? {})) {
-      logger.info('Execution contains Sept keyword', {
-        event: 'execution-contains-sept-keyword',
-        stepId,
-        flowId,
-        executionId,
-        executionStepId: executionStep.id,
-      })
-    }
+  if (!testRun && containsSeptKeyword($.step.parameters ?? {})) {
+    logger.info('Execution contains Sept keyword', {
+      event: 'execution-contains-sept-keyword',
+      stepId,
+      flowId,
+      executionId,
+      executionStepId: executionStep.id,
+    })
   }
 
   let nextStep = null

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,4 +1,8 @@
-import { type IActionRunResult, TestRunStepMetadata } from '@plumber/types'
+import type {
+  IActionRunResult,
+  IJSONValue,
+  TestRunStepMetadata,
+} from '@plumber/types'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -22,6 +26,23 @@ import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 
 import getForEachMetadata from './helpers/get-for-each-metadata'
+
+// TODO on Oct: remove this once the logging is not needed anymore
+const SEPT_KEYWORD_REGEX = / Sept /
+
+function containsSeptKeyword(obj: IJSONValue): boolean {
+  if (typeof obj === 'string') {
+    return SEPT_KEYWORD_REGEX.test(obj)
+  }
+  if (Array.isArray(obj)) {
+    return obj.some((item) => containsSeptKeyword(item))
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    return Object.values(obj).some((value) => containsSeptKeyword(value))
+  }
+  return false
+}
 
 type ProcessActionOptions = {
   flowId: string
@@ -208,6 +229,19 @@ export const processAction = async (options: ProcessActionOptions) => {
       key: step.key,
       metadata,
     })
+
+  // TODO on Oct: remove this once the logging is not needed anymore
+  if (!testRun && status === 'failure') {
+    if (containsSeptKeyword($.step.parameters ?? {})) {
+      logger.info('Execution contains Sept keyword', {
+        event: 'execution-contains-sept-keyword',
+        stepId,
+        flowId,
+        executionId,
+        executionStepId: executionStep.id,
+      })
+    }
+  }
 
   let nextStep = null
   switch (runResult.nextStep?.command) {

--- a/packages/backend/src/types/luxon-extensions.ts
+++ b/packages/backend/src/types/luxon-extensions.ts
@@ -1,0 +1,17 @@
+import { DateTime, LocaleOptions } from 'luxon'
+
+declare module 'luxon' {
+  interface DateTime {
+    toPlumberFormat(fmt: string, opts?: LocaleOptions): string
+  }
+}
+
+DateTime.prototype.toPlumberFormat = function (
+  fmt: string,
+  opts?: LocaleOptions,
+): string {
+  return this.toFormat(fmt, {
+    locale: 'en-SG',
+    ...opts,
+  }).replace(/Sept(?!e)/, 'Sep')
+}

--- a/packages/backend/src/types/luxon-extensions.ts
+++ b/packages/backend/src/types/luxon-extensions.ts
@@ -3,6 +3,11 @@ import { DateTime, LocaleOptions } from 'luxon'
 declare module 'luxon' {
   interface DateTime {
     toPlumberFormat(fmt: string, opts?: LocaleOptions): string
+    /**
+     * @deprecated
+     * Use toPlumberFormat instead.
+     */
+    toFormat(fmt: string, opts?: LocaleOptions): string
   }
 }
 

--- a/packages/frontend/src/components/NewsDrawer/NewsItem.tsx
+++ b/packages/frontend/src/components/NewsDrawer/NewsItem.tsx
@@ -28,7 +28,9 @@ const DATE_FORMAT = 'dd MMM yyyy'
 
 export default function NewsItem(props: NewsItemProps) {
   const { date, tag, title, details, multimedia } = props
-  const formattedDate = DateTime.fromISO(date).toFormat(DATE_FORMAT)
+  const formattedDate = DateTime.fromISO(date).toFormat(DATE_FORMAT, {
+    locale: 'en-US',
+  })
   const displayedMultimedia = useMemo(() => {
     if (!multimedia) {
       return

--- a/packages/frontend/src/helpers/dateTime.ts
+++ b/packages/frontend/src/helpers/dateTime.ts
@@ -15,12 +15,25 @@ export function toPrettyDateString(
     return ''
   }
 
+  // Locale en-US is used to maintain consistency with FormSG
   switch (from) {
     case 'iso':
-      return DateTime.fromISO(date as string).toFormat('dd MMM yyyy h:mm a')
+      return DateTime.fromISO(date as string).toFormat('dd MMM yyyy h:mm a', {
+        locale: 'en-US',
+      })
     case 'ms':
-      return DateTime.fromMillis(date as number).toFormat('dd MMM yyyy h:mm a')
+      return DateTime.fromMillis(date as number).toFormat(
+        'dd MMM yyyy h:mm a',
+        {
+          locale: 'en-US',
+        },
+      )
     default:
-      return DateTime.fromMillis(date as number).toFormat('dd MMM yyyy h:mm a')
+      return DateTime.fromMillis(date as number).toFormat(
+        'dd MMM yyyy h:mm a',
+        {
+          locale: 'en-US',
+        },
+      )
   }
 }


### PR DESCRIPTION
## Problem
`en-SG` locale is: Sept
`en-US` locale is: Sep
right now: formsg, lettersg uses `en-US`
And our codebase defaults to `en-SG`

## Solution
- Keep the codebase to default to `en-SG` to ensure nothing breaks
- change to `en-US` for formatter, scheduler and delay until

**NOTE**
- This may break existing pipes that have records on `Sept` and relies on it but its a tradeoff that we have to make

## Tests
- [x] Scheduler actions all give `Sep` instead of `Sept`
- [x] Delay until will convert`Sept` to `Sep` and maintain the format for other months
- [ ] Delay until will still keep other formats e.g. `yyyy-MM-dd` and `dd/MM/yyyy` and leave it intact
- [x] Formatter will convert `dd MMM yyyy` correctly to `Sep` instead of `Sept`