### PR TITLE
[COLLAB-8]: Owner update Step connection, Editor can save Step

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
@@ -11,7 +11,7 @@ export async function generateMockFlow(
   id: string,
   config?: Record<string, any>,
 ) {
-  await Flow.query().insert({
+  return await Flow.query().insertAndFetch({
     id,
     name: 'Test Flow',
     userId: context.currentUser.id,

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStep from '@/graphql/mutations/update-step'
 import { TILES_CONNECTION_ID } from '@/helpers/get-shared-connection-details'
+import Flow from '@/models/flow'
 import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
@@ -27,65 +28,15 @@ describe('updateStep mutation', () => {
   let editor: User
   let viewer: User
   let nonCollaborator: User
+  let testFlow: Flow
+  let testFlowISODateString: string
+  let testInputTimestampString: string
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
-  // Helper to create connection mock
-  const createConnectionMock = (connectionData: any = null) => ({
-    findOne: vi.fn().mockResolvedValue(connectionData),
-  })
-
-  // Helper to setup $relatedQuery mock
-  const setupRelatedQueryMock = (
-    stepData?: any,
-    connectionData: any = { id: mockConnectionId, key: 'postman' },
-  ) => {
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation, _trx) => {
-        if (relation === 'steps') {
-          return {
-            withGraphFetched: vi.fn().mockReturnValue({
-              findOne: vi.fn().mockReturnValue({
-                throwIfNotFound: vi.fn().mockImplementation(async (options) => {
-                  const result =
-                    stepData === null
-                      ? null
-                      : {
-                          id: mockStepId,
-                          key: 'sendTransactionalEmail',
-                          appKey: 'postman',
-                          status: 'completed',
-                          flow: {
-                            id: mockFlowId,
-                            patchLastUpdated: patchLastUpdatedSpy,
-                          },
-                          ...stepData,
-                        }
-
-                  if (result === null) {
-                    throw new NotFoundError(
-                      options?.message || 'Step not found',
-                    )
-                  }
-                  return result
-                }),
-              }),
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return createConnectionMock(connectionData)
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
-  }
-
-  const genericInputParams = {
+  let genericInputParams = {
     id: mockStepId,
-    flow: { id: mockFlowId },
+    flow: { id: mockFlowId, updatedAt: testFlowISODateString },
     key: 'sendTransactionalEmail',
     appKey: 'postman',
     parameters: { testParam: 'value' },
@@ -99,7 +50,7 @@ describe('updateStep mutation', () => {
     owner = context.currentUser
 
     // Set the global spy for patchFlowLastUpdated
-    setPatchFlowLastUpdatedSpy(patchFlowLastUpdatedSpy)
+    setPatchFlowLastUpdatedSpy(patchLastUpdatedSpy)
 
     // Create test users
     editor = await generateMockUser('editor')
@@ -107,7 +58,19 @@ describe('updateStep mutation', () => {
     nonCollaborator = await generateMockUser('nonCollaborator')
 
     // Create a test flow
-    await generateMockFlow(context, mockFlowId)
+    testFlow = await generateMockFlow(context, mockFlowId)
+    testFlowISODateString = testFlow.updatedAt
+    testInputTimestampString = String(new Date(testFlow.updatedAt).getTime())
+
+    // Set up the patchFlowLastUpdatedSpy to return an updated timestamp
+    patchLastUpdatedSpy.mockResolvedValue({
+      updatedAt: new Date(Date.now() + 1000).toISOString(), // 1 second later
+    })
+
+    genericInputParams = {
+      ...genericInputParams,
+      flow: { id: mockFlowId, updatedAt: testInputTimestampString },
+    }
 
     // Create a test step
     await generateMockStep(
@@ -129,7 +92,7 @@ describe('updateStep mutation', () => {
         ...data,
         connection: { id: mockConnectionId, userId: owner.id },
         flowId: mockFlowId,
-        flow: { userId: owner.id },
+        flow: { userId: owner.id, updatedAt: testFlowISODateString },
       }),
     }))
 
@@ -155,6 +118,8 @@ describe('updateStep mutation', () => {
       connectionKey: 'postman',
       stepId: mockStepId,
       connectionId: mockConnectionId,
+      flowId: mockFlowId,
+      flowUpdatedAt: testFlowISODateString,
     })
   })
 
@@ -211,6 +176,7 @@ describe('updateStep mutation', () => {
       stepId: mockStepId,
       connectionId: mockConnectionId,
       connectionNotFound: true,
+      flowUpdatedAt: testFlowISODateString,
     })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrowError(
@@ -234,6 +200,7 @@ describe('updateStep mutation', () => {
       stepId: mockStepId,
       connectionId: mockConnectionId,
       stepNotFound: true,
+      flowUpdatedAt: testFlowISODateString,
     })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
@@ -329,6 +296,7 @@ describe('updateStep mutation', () => {
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
       stepConnection: { id: mockConnectionId },
+      flowUpdatedAt: testFlowISODateString,
     })
 
     const input = {
@@ -376,6 +344,7 @@ describe('updateStep mutation', () => {
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
       stepConnection: { id: mockConnectionId },
+      flowUpdatedAt: testFlowISODateString,
     })
 
     const input = {
@@ -409,6 +378,17 @@ describe('updateStep mutation', () => {
   })
 
   it('should call patchLastUpdated when updating a step', async () => {
+    // Mock the access control to return step data (has access)
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+      flowUpdatedAt: testFlowISODateString,
+    })
     await updateStep(null, { input: { ...genericInputParams } }, context)
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
@@ -423,6 +403,64 @@ describe('updateStep mutation', () => {
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
+  })
+
+  describe('flow update validation', () => {
+    it('should throw error when input updatedAt does not match flow updatedAt', async () => {
+      const input = {
+        ...genericInputParams,
+        flow: {
+          id: mockFlowId,
+          updatedAt: String(Date.now() + 10000),
+        },
+      }
+
+      await expect(updateStep(null, { input }, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(updateStep(null, { input }, context)).rejects.toThrow(
+        'Pipe is outdated. Refresh the page and try again.',
+      )
+      expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+    })
+
+    it('should throw error when input updatedAt is after flow updatedAt', async () => {
+      const input = {
+        ...genericInputParams,
+        flow: {
+          id: mockFlowId,
+          updatedAt: String(Date.now() - 10000),
+        },
+      }
+
+      await expect(updateStep(null, { input }, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(updateStep(null, { input }, context)).rejects.toThrow(
+        'Pipe is outdated. Refresh the page and try again.',
+      )
+      expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+    })
+
+    it('should succeed when input updatedAt matches flow updatedAt', async () => {
+      const input = {
+        ...genericInputParams,
+        flow: {
+          id: mockFlowId,
+          updatedAt: testInputTimestampString,
+        },
+      }
+
+      await expect(updateStep(null, { input }, context)).resolves.not.toThrow()
+      expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        connectionId: mockConnectionId,
+        parameters: { testParam: 'value' },
+        status: 'completed',
+        config: {},
+      })
+    })
   })
 
   describe('access control', () => {
@@ -470,6 +508,7 @@ describe('updateStep mutation', () => {
           connectionKey: 'postman',
           stepId: mockStepId,
           connectionId: mockConnectionId,
+          flowUpdatedAt: testFlowISODateString,
         })
 
         await expect(
@@ -516,13 +555,14 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
       })
     })
 
     it('should call patchFlowConnectionMetadata when app has connection fields and parameter exists', async () => {
       const input = {
         id: mockStepId,
-        flow: { id: mockFlowId },
+        flow: { id: mockFlowId, updatedAt: testFlowISODateString },
         key: 'sendMessage',
         appKey: 'slack',
         parameters: { channel: 'C1234567890' },
@@ -577,6 +617,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'editor', // Not owner
+        flowUpdatedAt: testFlowISODateString,
       })
 
       const input = {
@@ -610,6 +651,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
       })
 
       const input = {
@@ -643,6 +685,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
       })
 
       const input = {
@@ -681,6 +724,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
       })
 
       const input = {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -3,12 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStep from '@/graphql/mutations/update-step'
+import { TILES_CONNECTION_ID } from '@/helpers/get-shared-connection-details'
 import Step from '@/models/step'
+import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
 
 import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+import {
+  createMockWithAccessible,
+  setPatchFlowLastUpdatedSpy,
+} from './with-accessible.mock'
 
 const mockConnectionId = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
@@ -16,6 +23,10 @@ const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 
 describe('updateStep mutation', () => {
   let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
@@ -85,6 +96,15 @@ describe('updateStep mutation', () => {
     vi.resetAllMocks()
     // Create a mock context with a current user
     context = await generateMockContext()
+    owner = context.currentUser
+
+    // Set the global spy for patchFlowLastUpdated
+    setPatchFlowLastUpdatedSpy(patchFlowLastUpdatedSpy)
+
+    // Create test users
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
 
     // Create a test flow
     await generateMockFlow(context, mockFlowId)
@@ -107,7 +127,9 @@ describe('updateStep mutation', () => {
       withGraphFetched: vi.fn().mockResolvedValue({
         id,
         ...data,
-        connection: { id: mockConnectionId },
+        connection: { id: mockConnectionId, userId: owner.id },
+        flowId: mockFlowId,
+        flow: { userId: owner.id },
       }),
     }))
 
@@ -124,8 +146,16 @@ describe('updateStep mutation', () => {
       patchAndFetchById: patchAndFetchByIdSpy,
     } as any)
 
-    // Setup default mock
-    setupRelatedQueryMock()
+    // Mock context.currentUser.withAccessible for steps
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+    })
   })
 
   it('should successfully update a step', async () => {
@@ -172,8 +202,16 @@ describe('updateStep mutation', () => {
       connection: { id: 'non-existent-connection' },
     }
 
-    // Override only the connections query
-    setupRelatedQueryMock(undefined, null)
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+      connectionNotFound: true,
+    })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrowError(
       BadUserInputError,
@@ -187,8 +225,16 @@ describe('updateStep mutation', () => {
       id: 'non-existent-step',
     }
 
-    // Override the steps query to return null
-    setupRelatedQueryMock(null, { id: mockConnectionId })
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+      stepNotFound: true,
+    })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       NotFoundError,
@@ -270,11 +316,19 @@ describe('updateStep mutation', () => {
 
   it('updating step name should not update template config', async () => {
     // Override the steps query to return template config
-    setupRelatedQueryMock({
-      config: {
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+      stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      stepConnection: { id: mockConnectionId },
     })
 
     const input = {
@@ -309,11 +363,19 @@ describe('updateStep mutation', () => {
 
   it('updating empty step name should not update template config', async () => {
     // Override the steps query to return template config
-    setupRelatedQueryMock({
-      config: {
+    context.currentUser.withAccessible = createMockWithAccessible({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      connectionKey: 'postman',
+      stepId: mockStepId,
+      connectionId: mockConnectionId,
+      stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      stepConnection: { id: mockConnectionId },
     })
 
     const input = {
@@ -361,5 +423,282 @@ describe('updateStep mutation', () => {
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
+  })
+
+  describe('access control', () => {
+    it.each(['nonCollaborator', 'viewer'])(
+      'should throw error if user does not have necessary permissions: %s',
+      async (role) => {
+        context.currentUser =
+          role === 'nonCollaborator' ? nonCollaborator : viewer
+        const input = { ...genericInputParams }
+
+        // Mock the access control to return null for step (no access)
+        context.currentUser.withAccessible = createMockWithAccessible({
+          owner,
+          currentUser: context.currentUser,
+          stepKey: 'sendTransactionalEmail',
+          stepAppKey: 'postman',
+          connectionKey: 'postman',
+          stepId: mockStepId,
+          connectionId: mockConnectionId,
+          stepNotFound: true,
+        })
+
+        await expect(updateStep(null, { input }, context)).rejects.toThrow(
+          BadUserInputError,
+        )
+        expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+      },
+    )
+
+    it.each(['editor', 'owner'])(
+      'should allow updating of step if user has the permissions: %s',
+      async (role) => {
+        context.currentUser = role === 'editor' ? editor : owner
+        const input = {
+          ...genericInputParams,
+          parameters: { updatedParam: 'newValue' },
+        }
+
+        // Mock the access control to return step data (has access)
+        context.currentUser.withAccessible = createMockWithAccessible({
+          owner,
+          currentUser: context.currentUser,
+          stepKey: 'sendTransactionalEmail',
+          stepAppKey: 'postman',
+          connectionKey: 'postman',
+          stepId: mockStepId,
+          connectionId: mockConnectionId,
+        })
+
+        await expect(
+          updateStep(null, { input }, context),
+        ).resolves.not.toThrow()
+        expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          connectionId: mockConnectionId,
+          parameters: { updatedParam: 'newValue' },
+          status: 'completed',
+          config: {},
+        })
+      },
+    )
+  })
+
+  describe('FlowConnections integration', () => {
+    let patchSpy: any
+    let addSpy: any
+
+    beforeEach(async () => {
+      // Mock FlowConnections methods
+      vi.mock('@/models/flow-connections', () => ({
+        default: {
+          patchFlowConnectionMetadata: vi.fn(),
+          addFlowConnection: vi.fn(),
+        },
+      }))
+
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendMessage',
+        stepAppKey: 'slack',
+        connectionKey: 'slack',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        stepRole: 'owner',
+      })
+    })
+
+    it('should call patchFlowConnectionMetadata when app has connection fields and parameter exists', async () => {
+      const input = {
+        id: mockStepId,
+        flow: { id: mockFlowId },
+        key: 'sendMessage',
+        appKey: 'slack',
+        parameters: { channel: 'C1234567890' },
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        userId: owner.id,
+        parameterKey: 'channel',
+        parameterValue: 'C1234567890',
+      })
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call addFlowConnection when app has connection fields but parameter does not exist', async () => {
+      const input = {
+        ...genericInputParams,
+        appKey: 'slack',
+        parameters: { message: 'Hello world' }, // No channel parameter
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(addSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        userId: owner.id,
+      })
+      expect(patchSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not call FlowConnections methods when step role is not owner', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with role 'editor' (not owner)
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendMessage',
+        stepAppKey: 'slack',
+        connectionKey: 'slack',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        stepRole: 'editor', // Not owner
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'slack',
+        parameters: { channel: 'C1234567890' },
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not call FlowConnections methods when app does not have connection fields', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with postman that doesn't have connection fields
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        connectionKey: 'postman',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        stepRole: 'owner',
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'postman',
+        parameters: { testParam: 'value' },
+        connection: {},
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call patchFlowConnectionMetadata for telegram-bot app with chatId parameter', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with telegram-bot app
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendMessage',
+        stepAppKey: 'telegram-bot',
+        connectionKey: 'telegram-bot',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        stepRole: 'owner',
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'telegram-bot',
+        parameters: { chatId: '123456789' },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        userId: owner.id,
+        parameterKey: 'chatId',
+        parameterValue: '123456789',
+      })
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call patchFlowConnectionMetadata for tiles app with tableId parameter', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with tiles app
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: owner,
+        stepKey: 'readAction',
+        stepAppKey: 'tiles',
+        connectionKey: 'tiles',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        stepRole: 'owner',
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'tiles',
+        parameters: { tableId: 'table-123' },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: TILES_CONNECTION_ID,
+        userId: owner.id,
+        parameterKey: 'tableId',
+        parameterValue: 'table-123',
+      })
+      expect(addSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,4 +1,3 @@
-import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
@@ -202,7 +201,7 @@ describe('updateStep mutation', () => {
     })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
-      NotFoundError,
+      BadUserInputError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
   })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -560,6 +560,36 @@ describe('updateStep mutation', () => {
       })
     })
 
+    it('should call patchFlowConnectionMetadata when its an excel app', async () => {
+      context.currentUser.withAccessible = createMockWithAccessible({
+        owner,
+        currentUser: context.currentUser,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        connectionKey: 'm365-excel',
+        stepId: mockStepId,
+        connectionId: mockConnectionId,
+        flowId: mockFlowId,
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'm365-excel',
+        parameters: { fileId: '1234567890' },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        parameterKey: 'fileId',
+        parameterValue: '1234567890',
+      })
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
     it('should call patchFlowConnectionMetadata when app has connection fields and parameter exists', async () => {
       const input = {
         id: mockStepId,
@@ -572,13 +602,13 @@ describe('updateStep mutation', () => {
 
       await updateStep(null, { input }, context)
 
-      expect(patchSpy).toHaveBeenCalledWith({
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        parameterKey: 'channel',
-        parameterValue: 'C1234567890',
+        addedBy: owner.id,
+        connectionType: 'connection',
       })
-      expect(addSpy).not.toHaveBeenCalled()
     })
 
     it('should call addFlowConnection when app has connection fields but parameter does not exist', async () => {
@@ -697,13 +727,13 @@ describe('updateStep mutation', () => {
 
       await updateStep(null, { input }, context)
 
-      expect(patchSpy).toHaveBeenCalledWith({
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        parameterKey: 'chatId',
-        parameterValue: '123456789',
+        addedBy: owner.id,
+        connectionType: 'connection',
       })
-      expect(addSpy).not.toHaveBeenCalled()
     })
 
     it('should call add to flow_connections and add table collaborator for tiles app with tableId parameter', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -16,7 +16,8 @@ import { generateMockUser } from './flow.mock'
 import {
   createMockWithAccessibleConnections,
   createMockWithAccessibleSteps,
-  setPatchFlowLastUpdatedSpy,
+  setAssertNotUpdatedSinceSpy,
+  setPatchLastUpdatedSpy,
 } from './with-accessible.mock'
 
 const mockConnectionId = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
@@ -34,6 +35,7 @@ describe('updateStep mutation', () => {
   let testInputTimestampString: string
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
+  const assertNotUpdatedSinceSpy = vi.fn().mockResolvedValue({})
 
   let genericInputParams = {
     id: mockStepId,
@@ -51,7 +53,8 @@ describe('updateStep mutation', () => {
     owner = context.currentUser
 
     // Set the global spy for patchFlowLastUpdated
-    setPatchFlowLastUpdatedSpy(patchLastUpdatedSpy)
+    setPatchLastUpdatedSpy(patchLastUpdatedSpy)
+    setAssertNotUpdatedSinceSpy(assertNotUpdatedSinceSpy)
 
     // Create test users
     editor = await generateMockUser('editor')
@@ -67,6 +70,7 @@ describe('updateStep mutation', () => {
     patchLastUpdatedSpy.mockResolvedValue({
       updatedAt: new Date(Date.now() + 1000).toISOString(), // 1 second later
     })
+    assertNotUpdatedSinceSpy.mockResolvedValue(true)
 
     genericInputParams = {
       ...genericInputParams,
@@ -391,64 +395,6 @@ describe('updateStep mutation', () => {
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
-  })
-
-  describe('flow update validation', () => {
-    it('should throw error when input updatedAt does not match flow updatedAt', async () => {
-      const input = {
-        ...genericInputParams,
-        flow: {
-          id: mockFlowId,
-          updatedAt: String(Date.now() + 10000),
-        },
-      }
-
-      await expect(updateStep(null, { input }, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(updateStep(null, { input }, context)).rejects.toThrow(
-        'Pipe is outdated. Refresh the page and try again.',
-      )
-      expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
-    })
-
-    it('should throw error when input updatedAt is after flow updatedAt', async () => {
-      const input = {
-        ...genericInputParams,
-        flow: {
-          id: mockFlowId,
-          updatedAt: String(Date.now() - 10000),
-        },
-      }
-
-      await expect(updateStep(null, { input }, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(updateStep(null, { input }, context)).rejects.toThrow(
-        'Pipe is outdated. Refresh the page and try again.',
-      )
-      expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
-    })
-
-    it('should succeed when input updatedAt matches flow updatedAt', async () => {
-      const input = {
-        ...genericInputParams,
-        flow: {
-          id: mockFlowId,
-          updatedAt: testInputTimestampString,
-        },
-      }
-
-      await expect(updateStep(null, { input }, context)).resolves.not.toThrow()
-      expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
-        key: 'sendTransactionalEmail',
-        appKey: 'postman',
-        connectionId: mockConnectionId,
-        parameters: { testParam: 'value' },
-        status: 'completed',
-        config: {},
-      })
-    })
   })
 
   describe('access control', () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -15,7 +15,8 @@ import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
 import { generateMockContext } from './tiles/table.mock'
 import { generateMockUser } from './flow.mock'
 import {
-  createMockWithAccessible,
+  createMockWithAccessibleConnections,
+  createMockWithAccessibleSteps,
   setPatchFlowLastUpdatedSpy,
 } from './with-accessible.mock'
 
@@ -111,17 +112,22 @@ describe('updateStep mutation', () => {
     } as any)
 
     // Mock context.currentUser.withAccessible for steps
-    context.currentUser.withAccessible = createMockWithAccessible({
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
       owner,
       currentUser: context.currentUser,
+      flowId: mockFlowId,
       stepKey: 'sendTransactionalEmail',
       stepAppKey: 'postman',
-      connectionKey: 'postman',
-      stepId: mockStepId,
-      connectionId: mockConnectionId,
-      flowId: mockFlowId,
+      stepConnection: { id: mockConnectionId, userId: owner.id },
       flowUpdatedAt: testFlowISODateString,
     })
+
+    context.currentUser.withAccessibleConnections =
+      createMockWithAccessibleConnections({
+        connectionId: mockConnectionId,
+        connectionKey: 'postman',
+        connectionNotFound: false,
+      })
   })
 
   it('should successfully update a step', async () => {
@@ -168,17 +174,12 @@ describe('updateStep mutation', () => {
       connection: { id: 'non-existent-connection' },
     }
 
-    context.currentUser.withAccessible = createMockWithAccessible({
-      owner,
-      currentUser: context.currentUser,
-      stepKey: 'sendTransactionalEmail',
-      stepAppKey: 'postman',
-      connectionKey: 'postman',
-      stepId: mockStepId,
-      connectionId: mockConnectionId,
-      connectionNotFound: true,
-      flowUpdatedAt: testFlowISODateString,
-    })
+    context.currentUser.withAccessibleConnections =
+      createMockWithAccessibleConnections({
+        connectionId: mockConnectionId,
+        connectionKey: 'postman',
+        connectionNotFound: true,
+      })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrowError(
       BadUserInputError,
@@ -192,16 +193,12 @@ describe('updateStep mutation', () => {
       id: 'non-existent-step',
     }
 
-    context.currentUser.withAccessible = createMockWithAccessible({
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
       owner,
       currentUser: context.currentUser,
       stepKey: 'sendTransactionalEmail',
       stepAppKey: 'postman',
-      connectionKey: 'postman',
-      stepId: mockStepId,
-      connectionId: mockConnectionId,
       stepNotFound: true,
-      flowUpdatedAt: testFlowISODateString,
     })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
@@ -284,14 +281,12 @@ describe('updateStep mutation', () => {
 
   it('updating step name should not update template config', async () => {
     // Override the steps query to return template config
-    context.currentUser.withAccessible = createMockWithAccessible({
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
       owner,
       currentUser: context.currentUser,
       stepKey: 'sendTransactionalEmail',
       stepAppKey: 'postman',
-      connectionKey: 'postman',
       stepId: mockStepId,
-      connectionId: mockConnectionId,
       stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
@@ -332,19 +327,15 @@ describe('updateStep mutation', () => {
 
   it('updating empty step name should not update template config', async () => {
     // Override the steps query to return template config
-    context.currentUser.withAccessible = createMockWithAccessible({
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
       owner,
       currentUser: context.currentUser,
       stepKey: 'sendTransactionalEmail',
       stepAppKey: 'postman',
-      connectionKey: 'postman',
-      stepId: mockStepId,
-      connectionId: mockConnectionId,
       stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
-      stepConnection: { id: mockConnectionId },
       flowUpdatedAt: testFlowISODateString,
     })
 
@@ -380,14 +371,11 @@ describe('updateStep mutation', () => {
 
   it('should call patchLastUpdated when updating a step', async () => {
     // Mock the access control to return step data (has access)
-    context.currentUser.withAccessible = createMockWithAccessible({
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
       owner,
       currentUser: context.currentUser,
       stepKey: 'sendTransactionalEmail',
       stepAppKey: 'postman',
-      connectionKey: 'postman',
-      stepId: mockStepId,
-      connectionId: mockConnectionId,
       flowUpdatedAt: testFlowISODateString,
     })
     await updateStep(null, { input: { ...genericInputParams } }, context)
@@ -473,16 +461,16 @@ describe('updateStep mutation', () => {
         const input = { ...genericInputParams }
 
         // Mock the access control to return null for step (no access)
-        context.currentUser.withAccessible = createMockWithAccessible({
-          owner,
-          currentUser: context.currentUser,
-          stepKey: 'sendTransactionalEmail',
-          stepAppKey: 'postman',
-          connectionKey: 'postman',
-          stepId: mockStepId,
-          connectionId: mockConnectionId,
-          stepNotFound: true,
-        })
+        context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps(
+          {
+            owner,
+            currentUser: context.currentUser,
+            stepKey: 'sendTransactionalEmail',
+            stepAppKey: 'postman',
+            stepNotFound: true,
+            flowUpdatedAt: testFlowISODateString,
+          },
+        )
 
         await expect(updateStep(null, { input }, context)).rejects.toThrow(
           BadUserInputError,
@@ -501,16 +489,21 @@ describe('updateStep mutation', () => {
         }
 
         // Mock the access control to return step data (has access)
-        context.currentUser.withAccessible = createMockWithAccessible({
-          owner,
-          currentUser: context.currentUser,
-          stepKey: 'sendTransactionalEmail',
-          stepAppKey: 'postman',
-          connectionKey: 'postman',
-          stepId: mockStepId,
-          connectionId: mockConnectionId,
-          flowUpdatedAt: testFlowISODateString,
-        })
+        context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps(
+          {
+            owner,
+            currentUser: context.currentUser,
+            stepKey: 'sendTransactionalEmail',
+            stepAppKey: 'postman',
+            flowUpdatedAt: testFlowISODateString,
+          },
+        )
+
+        context.currentUser.withAccessibleConnections =
+          createMockWithAccessibleConnections({
+            connectionId: mockConnectionId,
+            connectionKey: 'postman',
+          })
 
         await expect(
           updateStep(null, { input }, context),
@@ -546,32 +539,38 @@ describe('updateStep mutation', () => {
       patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
       addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
 
-      context.currentUser.withAccessible = createMockWithAccessible({
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
         stepKey: 'sendMessage',
         stepAppKey: 'slack',
-        connectionKey: 'slack',
-        stepId: mockStepId,
-        connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
       })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'slack',
+        })
     })
 
     it('should call patchFlowConnectionMetadata when its an excel app', async () => {
-      context.currentUser.withAccessible = createMockWithAccessible({
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: context.currentUser,
         stepKey: 'sendTransactionalEmail',
         stepAppKey: 'postman',
-        connectionKey: 'm365-excel',
-        stepId: mockStepId,
-        connectionId: mockConnectionId,
         flowId: mockFlowId,
         flowUpdatedAt: testFlowISODateString,
       })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'm365-excel',
+        })
 
       const input = {
         ...genericInputParams,
@@ -638,14 +637,11 @@ describe('updateStep mutation', () => {
       const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
 
       // Mock step with role 'editor' (not owner)
-      context.currentUser.withAccessible = createMockWithAccessible({
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
         stepKey: 'sendMessage',
         stepAppKey: 'slack',
-        connectionKey: 'slack',
-        stepId: mockStepId,
-        connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'editor', // Not owner
         flowUpdatedAt: testFlowISODateString,
@@ -672,15 +668,11 @@ describe('updateStep mutation', () => {
       const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
 
       // Mock step with postman that doesn't have connection fields
-      context.currentUser.withAccessible = createMockWithAccessible({
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
         stepKey: 'sendTransactionalEmail',
         stepAppKey: 'postman',
-        connectionKey: 'postman',
-        stepId: mockStepId,
-        connectionId: mockConnectionId,
-        flowId: mockFlowId,
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
       })
@@ -696,44 +688,6 @@ describe('updateStep mutation', () => {
 
       expect(patchSpy).not.toHaveBeenCalled()
       expect(addSpy).not.toHaveBeenCalled()
-    })
-
-    it('should call patchFlowConnectionMetadata for telegram-bot app with chatId parameter', async () => {
-      const { default: FlowConnections } = await import(
-        '@/models/flow-connections'
-      )
-      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
-      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
-
-      // Mock step with telegram-bot app
-      context.currentUser.withAccessible = createMockWithAccessible({
-        owner,
-        currentUser: owner,
-        stepKey: 'sendMessage',
-        stepAppKey: 'telegram-bot',
-        connectionKey: 'telegram-bot',
-        stepId: mockStepId,
-        connectionId: mockConnectionId,
-        flowId: mockFlowId,
-        stepRole: 'owner',
-        flowUpdatedAt: testFlowISODateString,
-      })
-
-      const input = {
-        ...genericInputParams,
-        appKey: 'telegram-bot',
-        parameters: { chatId: '123456789' },
-      }
-
-      await updateStep(null, { input }, context)
-
-      expect(patchSpy).not.toHaveBeenCalled()
-      expect(addSpy).toHaveBeenCalledWith({
-        flowId: mockFlowId,
-        connectionId: mockConnectionId,
-        addedBy: owner.id,
-        connectionType: 'connection',
-      })
     })
 
     it('should call add to flow_connections and add table collaborator for tiles app with tableId parameter', async () => {
@@ -754,17 +708,20 @@ describe('updateStep mutation', () => {
         ])
 
       // Mock step with tiles app
-      context.currentUser.withAccessible = createMockWithAccessible({
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
         stepKey: 'readAction',
         stepAppKey: 'tiles',
-        connectionKey: 'tiles',
-        stepId: mockStepId,
-        flowId: mockFlowId,
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
       })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'tiles',
+        })
 
       const input = {
         ...genericInputParams,

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStep from '@/graphql/mutations/update-step'
-import { TILES_CONNECTION_ID } from '@/helpers/get-shared-connection-details'
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -574,7 +575,6 @@ describe('updateStep mutation', () => {
       expect(patchSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        userId: owner.id,
         parameterKey: 'channel',
         parameterValue: 'C1234567890',
       })
@@ -594,7 +594,8 @@ describe('updateStep mutation', () => {
       expect(addSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        userId: owner.id,
+        addedBy: owner.id,
+        connectionType: 'connection',
       })
       expect(patchSpy).not.toHaveBeenCalled()
     })
@@ -699,19 +700,28 @@ describe('updateStep mutation', () => {
       expect(patchSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         connectionId: mockConnectionId,
-        userId: owner.id,
         parameterKey: 'chatId',
         parameterValue: '123456789',
       })
       expect(addSpy).not.toHaveBeenCalled()
     })
 
-    it('should call patchFlowConnectionMetadata for tiles app with tableId parameter', async () => {
+    it('should call add to flow_connections and add table collaborator for tiles app with tableId parameter', async () => {
+      const mockTableId = 'table-123'
       const { default: FlowConnections } = await import(
         '@/models/flow-connections'
       )
+      const addCollaboratorSpy = vi
+        .spyOn(TableCollaborator, 'addCollaborator')
+        .mockResolvedValue(undefined)
       const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
       const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+      const getCollaboratorsSpy = vi
+        .spyOn(FlowCollaborator, 'getCollaborators')
+        .mockResolvedValue([
+          { userId: editor.id, role: 'editor' } as any,
+          { userId: viewer.id, role: 'viewer' } as any,
+        ])
 
       // Mock step with tiles app
       context.currentUser.withAccessible = createMockWithAccessible({
@@ -721,7 +731,6 @@ describe('updateStep mutation', () => {
         stepAppKey: 'tiles',
         connectionKey: 'tiles',
         stepId: mockStepId,
-        connectionId: mockConnectionId,
         flowId: mockFlowId,
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
@@ -730,19 +739,35 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'tiles',
-        parameters: { tableId: 'table-123' },
+        parameters: { tableId: mockTableId },
       }
 
       await updateStep(null, { input }, context)
 
-      expect(patchSpy).toHaveBeenCalledWith({
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
-        connectionId: TILES_CONNECTION_ID,
-        userId: owner.id,
-        parameterKey: 'tableId',
-        parameterValue: 'table-123',
+        connectionId: mockTableId,
+        addedBy: owner.id,
+        connectionType: 'table',
       })
-      expect(addSpy).not.toHaveBeenCalled()
+      expect(getCollaboratorsSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        trx: expect.anything(),
+      })
+      expect(addCollaboratorSpy).toHaveBeenCalledTimes(2)
+      expect(addCollaboratorSpy).toHaveBeenCalledWith({
+        userId: editor.id,
+        tableId: mockTableId,
+        role: 'editor',
+        trx: expect.anything(),
+      })
+      expect(addCollaboratorSpy).toHaveBeenCalledWith({
+        userId: viewer.id,
+        tableId: mockTableId,
+        role: 'viewer',
+        trx: expect.anything(),
+      })
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -1,0 +1,99 @@
+import { vi } from 'vitest'
+
+import User from '@/models/user'
+
+let patchFlowLastUpdatedSpy: ReturnType<typeof vi.fn> | null = null
+
+export function setPatchFlowLastUpdatedSpy(spy: ReturnType<typeof vi.fn>) {
+  patchFlowLastUpdatedSpy = spy
+}
+
+interface MockWithAccessibleOptions {
+  owner: User
+  currentUser: User
+  stepKey: string
+  stepAppKey: string
+  connectionKey: string
+  stepId?: string
+  connectionId?: string
+  stepStatus?: string
+  stepRole?: string
+  flowId?: string
+  stepConfig?: Record<string, any>
+  stepConnection?: Record<string, any>
+  stepNotFound?: boolean
+  connectionNotFound?: boolean
+}
+
+const MOCK_STEP_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
+const MOCK_CONNECTION_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
+const MOCK_FLOW_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+
+/**
+ * Creates a reusable mock for context.currentUser.withAccessible
+ * @param options Configuration for the mock
+ * @returns Mock function for withAccessible
+ */
+export function createMockWithAccessible({
+  owner,
+  currentUser,
+  stepKey,
+  stepAppKey,
+  connectionKey,
+  stepId = MOCK_STEP_ID,
+  connectionId = MOCK_CONNECTION_ID,
+  stepStatus = 'completed',
+  stepRole = 'owner',
+  flowId = MOCK_FLOW_ID,
+  stepConfig = {},
+  stepConnection = { id: connectionId, userId: currentUser.id },
+  stepNotFound = false,
+  connectionNotFound = false,
+}: MockWithAccessibleOptions) {
+  return vi.fn().mockImplementation(({ type, _requiredRole }) => {
+    if (type === 'step') {
+      if (stepNotFound) {
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      }
+
+      return {
+        findOne: vi.fn().mockResolvedValue({
+          id: stepId,
+          key: stepKey,
+          appKey: stepAppKey,
+          status: stepStatus,
+          role: stepRole,
+          flowId,
+          connection: stepAppKey === 'tiles' ? {} : stepConnection,
+          config: stepConfig,
+          flow: {
+            userId: owner.id,
+          },
+          patchFlowLastUpdated:
+            patchFlowLastUpdatedSpy || vi.fn().mockResolvedValue({}),
+        }),
+      }
+    }
+
+    if (type === 'connection') {
+      if (connectionNotFound) {
+        return {
+          findOne: vi.fn().mockResolvedValue(null),
+        }
+      }
+
+      return {
+        findOne: vi.fn().mockResolvedValue({
+          id: connectionId,
+          key: connectionKey,
+        }),
+      }
+    }
+
+    return {
+      findOne: vi.fn().mockResolvedValue(null),
+    }
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -23,11 +23,13 @@ interface MockWithAccessibleOptions {
   stepConnection?: Record<string, any>
   stepNotFound?: boolean
   connectionNotFound?: boolean
+  flowUpdatedAt?: string
 }
 
 const MOCK_STEP_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 const MOCK_CONNECTION_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
 const MOCK_FLOW_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+const MOCK_FLOW_UPDATED_AT = '2021-01-01T00:00:00.000Z'
 
 /**
  * Creates a reusable mock for context.currentUser.withAccessible
@@ -49,16 +51,19 @@ export function createMockWithAccessible({
   stepConnection = { id: connectionId, userId: currentUser.id },
   stepNotFound = false,
   connectionNotFound = false,
+  flowUpdatedAt = MOCK_FLOW_UPDATED_AT,
 }: MockWithAccessibleOptions) {
   return vi.fn().mockImplementation(({ type, _requiredRole }) => {
     if (type === 'step') {
       if (stepNotFound) {
         return {
+          withGraphFetched: vi.fn().mockReturnThis(),
           findOne: vi.fn().mockResolvedValue(null),
         }
       }
 
       return {
+        withGraphFetched: vi.fn().mockReturnThis(),
         findOne: vi.fn().mockResolvedValue({
           id: stepId,
           key: stepKey,
@@ -70,6 +75,7 @@ export function createMockWithAccessible({
           config: stepConfig,
           flow: {
             userId: owner.id,
+            updatedAt: flowUpdatedAt,
           },
           patchFlowLastUpdated:
             patchFlowLastUpdatedSpy || vi.fn().mockResolvedValue({}),

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -8,98 +8,101 @@ export function setPatchFlowLastUpdatedSpy(spy: ReturnType<typeof vi.fn>) {
   patchFlowLastUpdatedSpy = spy
 }
 
-interface MockWithAccessibleOptions {
-  owner: User
-  currentUser: User
-  stepKey: string
-  stepAppKey: string
-  connectionKey: string
-  stepId?: string
-  connectionId?: string
-  stepStatus?: string
-  stepRole?: string
-  flowId?: string
-  stepConfig?: Record<string, any>
-  stepConnection?: Record<string, any>
-  stepNotFound?: boolean
-  connectionNotFound?: boolean
-  flowUpdatedAt?: string
-}
-
 const MOCK_STEP_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 const MOCK_CONNECTION_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
 const MOCK_FLOW_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
 const MOCK_FLOW_UPDATED_AT = '2021-01-01T00:00:00.000Z'
 
-/**
- * Creates a reusable mock for context.currentUser.withAccessible
- * @param options Configuration for the mock
- * @returns Mock function for withAccessible
- */
-export function createMockWithAccessible({
+interface MockWithAccessibleStepsOptions {
+  owner: User
+  currentUser: User
+  flowId?: string
+  stepId?: string
+  stepKey: string
+  stepAppKey: string
+  stepConnection?: Record<string, any>
+  stepStatus?: string
+  stepRole?: string
+  stepConfig?: Record<string, any>
+  stepNotFound?: boolean
+  flowUpdatedAt?: string
+}
+
+interface MockWithAccessibleConnectionsOptions {
+  connectionId: string
+  connectionKey: string
+  connectionNotFound?: boolean
+}
+
+export function createMockWithAccessibleSteps({
   owner,
   currentUser,
+  flowId = MOCK_FLOW_ID,
+  stepId = MOCK_STEP_ID,
   stepKey,
   stepAppKey,
-  connectionKey,
-  stepId = MOCK_STEP_ID,
-  connectionId = MOCK_CONNECTION_ID,
+  stepConnection = { id: MOCK_CONNECTION_ID, userId: currentUser.id },
   stepStatus = 'completed',
   stepRole = 'owner',
-  flowId = MOCK_FLOW_ID,
   stepConfig = {},
-  stepConnection = { id: connectionId, userId: currentUser.id },
   stepNotFound = false,
-  connectionNotFound = false,
   flowUpdatedAt = MOCK_FLOW_UPDATED_AT,
-}: MockWithAccessibleOptions) {
-  return vi.fn().mockImplementation(({ type, _requiredRole }) => {
-    if (type === 'step') {
-      if (stepNotFound) {
+}: MockWithAccessibleStepsOptions) {
+  return vi
+    .fn()
+    .mockImplementation(
+      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
+        if (stepNotFound) {
+          return {
+            withGraphFetched: vi.fn().mockReturnThis(),
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+
         return {
           withGraphFetched: vi.fn().mockReturnThis(),
-          findOne: vi.fn().mockResolvedValue(null),
+          findOne: vi.fn().mockResolvedValue({
+            id: stepId,
+            key: stepKey,
+            appKey: stepAppKey,
+            status: stepStatus,
+            role: stepRole,
+            flowId,
+            connection: stepAppKey === 'tiles' ? {} : stepConnection,
+            config: stepConfig,
+            flow: {
+              userId: owner.id,
+              updatedAt: flowUpdatedAt,
+            },
+            patchFlowLastUpdated:
+              patchFlowLastUpdatedSpy || vi.fn().mockResolvedValue({}),
+          }),
         }
-      }
+      },
+    )
+}
 
-      return {
-        withGraphFetched: vi.fn().mockReturnThis(),
-        findOne: vi.fn().mockResolvedValue({
-          id: stepId,
-          key: stepKey,
-          appKey: stepAppKey,
-          status: stepStatus,
-          role: stepRole,
-          flowId,
-          connection: stepAppKey === 'tiles' ? {} : stepConnection,
-          config: stepConfig,
-          flow: {
-            userId: owner.id,
-            updatedAt: flowUpdatedAt,
-          },
-          patchFlowLastUpdated:
-            patchFlowLastUpdatedSpy || vi.fn().mockResolvedValue({}),
-        }),
-      }
-    }
+export function createMockWithAccessibleConnections({
+  connectionId,
+  connectionKey,
+  connectionNotFound = false,
+}: MockWithAccessibleConnectionsOptions) {
+  return vi
+    .fn()
+    .mockImplementation(
+      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
+        if (connectionNotFound) {
+          return {
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
 
-    if (type === 'connection') {
-      if (connectionNotFound) {
         return {
-          findOne: vi.fn().mockResolvedValue(null),
+          findOne: vi.fn().mockResolvedValue({
+            id: connectionId,
+            key: connectionKey,
+          }),
         }
-      }
-
-      return {
-        findOne: vi.fn().mockResolvedValue({
-          id: connectionId,
-          key: connectionKey,
-        }),
-      }
-    }
-
-    return {
-      findOne: vi.fn().mockResolvedValue(null),
-    }
-  })
+      },
+    )
 }

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -2,10 +2,15 @@ import { vi } from 'vitest'
 
 import User from '@/models/user'
 
-let patchFlowLastUpdatedSpy: ReturnType<typeof vi.fn> | null = null
+let patchLastUpdatedSpy: ReturnType<typeof vi.fn> | null = null
+let assertNotUpdatedSinceSpy: ReturnType<typeof vi.fn> | null = null
 
-export function setPatchFlowLastUpdatedSpy(spy: ReturnType<typeof vi.fn>) {
-  patchFlowLastUpdatedSpy = spy
+export function setPatchLastUpdatedSpy(spy: ReturnType<typeof vi.fn>) {
+  patchLastUpdatedSpy = spy
+}
+
+export function setAssertNotUpdatedSinceSpy(spy: ReturnType<typeof vi.fn>) {
+  assertNotUpdatedSinceSpy = spy
 }
 
 const MOCK_STEP_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
@@ -73,9 +78,11 @@ export function createMockWithAccessibleSteps({
             flow: {
               userId: owner.id,
               updatedAt: flowUpdatedAt,
+              assertNotUpdatedSince:
+                assertNotUpdatedSinceSpy || vi.fn().mockResolvedValue({}),
+              patchLastUpdated:
+                patchLastUpdatedSpy || vi.fn().mockResolvedValue({}),
             },
-            patchFlowLastUpdated:
-              patchFlowLastUpdatedSpy || vi.fn().mockResolvedValue({}),
           }),
         }
       },

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -99,14 +99,20 @@ const updateStep: MutationResolvers['updateStep'] = async (
           trx,
         })
 
-        collaborators.map(async ({ userId, role }) => {
-          await TableCollaborator.addCollaborator({
-            userId,
-            tableId: updatedStep.parameters.tableId as string,
-            role,
-            trx,
-          })
-        })
+        /**
+         * use Promise.all so that we use the addCollaborator function, which checks
+         * if the collaborator already exists to avoid duplicates
+         */
+        await Promise.all(
+          collaborators.map(async ({ userId, role }) => {
+            await TableCollaborator.addCollaborator({
+              userId,
+              tableId: updatedStep.parameters.tableId as string,
+              role,
+              trx,
+            })
+          }),
+        )
       } else if (APP_CONNECTION_FIELDS[updatedStep.appKey]) {
         const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,4 +1,5 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
+import checkFlowUpdatable from '@/helpers/check-flow-updatable'
 import {
   APP_CONNECTION_FIELDS,
   TILES_CONNECTION_ID,
@@ -18,20 +19,23 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
-      .withAccessible({ type: 'step', requiredRole: 'editor', trx })
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
         flow_id: input.flow.id,
       })
+
     if (!step) {
       throw new BadUserInputError('Step not found')
     }
 
+    checkFlowUpdatable(input.flow.updatedAt, step.flow.updatedAt)
+
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
       const connection = await context.currentUser
-        .withAccessible({ type: 'connection', requiredRole: 'editor' })
+        .withAccessibleConnections({ requiredRole: 'editor' })
         .findOne({ 'connections.id': input.connection.id })
       // we check that the connection exists and is the same app
       if (!connection || connection.key !== input.appKey) {
@@ -79,10 +83,8 @@ const updateStep: MutationResolvers['updateStep'] = async (
     if (APP_CONNECTION_FIELDS[updatedStep.appKey] && step.role === 'owner') {
       const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
 
-      let userId = updatedStep?.connection?.userId
       let connectionId = updatedStep?.connectionId
       if (updatedStep.appKey === 'tiles') {
-        userId = updatedStep.flow.userId
         connectionId = TILES_CONNECTION_ID
       }
 
@@ -90,7 +92,6 @@ const updateStep: MutationResolvers['updateStep'] = async (
         await FlowConnections.patchFlowConnectionMetadata({
           flowId: updatedStep.flowId,
           connectionId,
-          userId,
           parameterKey,
           parameterValue: updatedStep.parameters[parameterKey] as string,
         })
@@ -98,15 +99,20 @@ const updateStep: MutationResolvers['updateStep'] = async (
         await FlowConnections.addFlowConnection({
           flowId: updatedStep.flowId,
           connectionId,
-          userId,
+          addedBy: context.currentUser.id,
+          connectionType: 'connection',
+          trx,
         })
       }
     }
 
     // update the flow's last updated
-    await step.flow.patchLastUpdated({ flowId: step.flowId, trx })
+    const updatedFlow = await step.flow.patchLastUpdated({
+      flowId: step.flowId,
+      trx,
+    })
 
-    return updatedStep
+    return { ...updatedStep, flow: { updatedAt: updatedFlow.updatedAt } }
   })
 
   return step

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -21,7 +21,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
       .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
-        flow_id: input.flow.id,
+        'steps.flow_id': input.flow.id,
       })
 
     if (!step) {

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,12 +1,10 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
-import checkFlowUpdatable from '@/helpers/check-flow-updatable'
-import {
-  APP_CONNECTION_FIELDS,
-  TILES_CONNECTION_ID,
-} from '@/helpers/get-shared-connection-details'
+import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import App from '@/models/app'
+import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -30,7 +28,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
       throw new BadUserInputError('Step not found')
     }
 
-    checkFlowUpdatable(input.flow.updatedAt, step.flow.updatedAt)
+    step.flow.assertNotUpdatedSince(input.flow.updatedAt)
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
@@ -79,30 +77,57 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
     /**
      * NOTE: we need to update flow connections for specific apps:
+     *
+     * Tiles:
+     * 1. add the collaborator to the flow connections table
+     * 2. add the collaborator to the table collaborators table
+     *
+     * Other connections:
+     * 1. add the collaborator to the flow connections table
      */
-    if (APP_CONNECTION_FIELDS[updatedStep.appKey] && step.role === 'owner') {
-      const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
-
-      let connectionId = updatedStep?.connectionId
-      if (updatedStep.appKey === 'tiles') {
-        connectionId = TILES_CONNECTION_ID
-      }
-
-      if (updatedStep.parameters[parameterKey]) {
-        await FlowConnections.patchFlowConnectionMetadata({
-          flowId: updatedStep.flowId,
-          connectionId,
-          parameterKey,
-          parameterValue: updatedStep.parameters[parameterKey] as string,
-        })
-      } else {
+    if (step.role === 'owner') {
+      if (updatedStep.appKey === 'tiles' && updatedStep?.parameters?.tableId) {
         await FlowConnections.addFlowConnection({
           flowId: updatedStep.flowId,
-          connectionId,
+          connectionId: updatedStep.parameters.tableId as string,
           addedBy: context.currentUser.id,
-          connectionType: 'connection',
+          connectionType: 'table',
+        })
+
+        const collaborators = await FlowCollaborator.getCollaborators({
+          flowId: updatedStep.flowId,
           trx,
         })
+
+        collaborators.map(async ({ userId, role }) => {
+          await TableCollaborator.addCollaborator({
+            userId,
+            tableId: updatedStep.parameters.tableId as string,
+            role,
+            trx,
+          })
+        })
+      } else if (APP_CONNECTION_FIELDS[updatedStep.appKey]) {
+        const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
+
+        const userId = updatedStep?.connection?.userId
+        const connectionId = updatedStep?.connectionId
+
+        if (updatedStep.parameters[parameterKey]) {
+          await FlowConnections.patchFlowConnectionMetadata({
+            flowId: updatedStep.flowId,
+            connectionId,
+            parameterKey,
+            parameterValue: updatedStep.parameters[parameterKey] as string,
+          })
+        } else {
+          await FlowConnections.addFlowConnection({
+            flowId: updatedStep.flowId,
+            connectionId,
+            addedBy: userId,
+            connectionType: 'connection',
+          })
+        }
       }
     }
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,5 +1,10 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
+import {
+  APP_CONNECTION_FIELDS,
+  TILES_CONNECTION_ID,
+} from '@/helpers/get-shared-connection-details'
 import App from '@/models/app'
+import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -13,19 +18,21 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessible({ type: 'step', requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
         flow_id: input.flow.id,
       })
-      .throwIfNotFound({ message: 'Step not found' })
+    if (!step) {
+      throw new BadUserInputError('Step not found')
+    }
 
     if (input.connection.id) {
-      // if connectionId is specified, verify that the connection exists and belongs to the user
+      // if connectionId is specified, verify that the connection exists
       const connection = await context.currentUser
-        .$relatedQuery('connections')
-        .findOne({ id: input.connection.id })
+        .withAccessible({ type: 'connection', requiredRole: 'editor' })
+        .findOne({ 'connections.id': input.connection.id })
       // we check that the connection exists and is the same app
       if (!connection || connection.key !== input.appKey) {
         throw new BadUserInputError('Connection not found')
@@ -61,7 +68,40 @@ const updateStep: MutationResolvers['updateStep'] = async (
           ...(stepName !== undefined ? { stepName } : {}),
         },
       })
-      .withGraphFetched('connection')
+      .withGraphFetched({
+        connection: true,
+        flow: true,
+      })
+
+    /**
+     * NOTE: we need to update flow connections for specific apps:
+     */
+    if (APP_CONNECTION_FIELDS[updatedStep.appKey] && step.role === 'owner') {
+      const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
+
+      let userId = updatedStep?.connection?.userId
+      let connectionId = updatedStep?.connectionId
+      if (updatedStep.appKey === 'tiles') {
+        userId = updatedStep.flow.userId
+        connectionId = TILES_CONNECTION_ID
+      }
+
+      if (updatedStep.parameters[parameterKey]) {
+        await FlowConnections.patchFlowConnectionMetadata({
+          flowId: updatedStep.flowId,
+          connectionId,
+          userId,
+          parameterKey,
+          parameterValue: updatedStep.parameters[parameterKey] as string,
+        })
+      } else {
+        await FlowConnections.addFlowConnection({
+          flowId: updatedStep.flowId,
+          connectionId,
+          userId,
+        })
+      }
+    }
 
     // update the flow's last updated
     await step.flow.patchLastUpdated({ flowId: step.flowId, trx })

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -109,4 +109,37 @@ describe('flow collaborators model', () => {
       }),
     ).rejects.toThrow('Flow not found')
   })
+
+  describe('getCollaborators', () => {
+    it('should return all collaborators for a flow', async () => {
+      const collaborators = await FlowCollaborator.getCollaborators({
+        flowId,
+      })
+
+      expect(collaborators).toHaveLength(2)
+      expect(collaborators.map((c) => c.userId)).toContain(editorUserId)
+      expect(collaborators.map((c) => c.userId)).toContain(viewerUserId)
+      expect(collaborators.map((c) => c.role)).toContain('editor')
+      expect(collaborators.map((c) => c.role)).toContain('viewer')
+      expect(collaborators[0].user).toBeDefined()
+      expect(collaborators[0].user.email).toBeDefined()
+      expect(collaborators[1].user).toBeDefined()
+      expect(collaborators[1].user.email).toBeDefined()
+    })
+
+    it('should return empty array when flow has no collaborators', async () => {
+      const newFlowId = randomUUID()
+      await Flow.query().insert({
+        id: newFlowId,
+        name: 'empty flow',
+        userId: ownerUserId,
+      })
+
+      const collaborators = await FlowCollaborator.getCollaborators({
+        flowId: newFlowId,
+      })
+
+      expect(collaborators).toHaveLength(0)
+    })
+  })
 })

--- a/packages/backend/src/models/__tests__/flow.test.ts
+++ b/packages/backend/src/models/__tests__/flow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors/bad-user-input'
+import Flow from '@/models/flow'
+
+describe('flow model', () => {
+  describe('assertNotUpdatedSince', () => {
+    it('should not throw when timestamps match', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      const clientUpdatedAt = String(updatedAt.getTime())
+
+      expect(() => flow.assertNotUpdatedSince(clientUpdatedAt)).not.toThrow()
+    })
+
+    it('should throw BadUserInputError when timestamps mismatch', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      const mismatched = String(updatedAt.getTime() + 1)
+
+      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrowError(
+        BadUserInputError,
+      )
+      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    })
+
+    it('should throw BadUserInputError when input is not a number', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrowError(
+        BadUserInputError,
+      )
+      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    })
+  })
+})

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -118,6 +118,18 @@ class FlowCollaborator extends Base {
       return collaborator.role
     }
   }
+
+  static getCollaborators = async ({
+    flowId,
+    trx,
+  }: {
+    flowId: string
+    trx?: Transaction
+  }) => {
+    return await this.query(trx)
+      .where({ flow_id: flowId })
+      .withGraphFetched('user')
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,4 +1,9 @@
-import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
+import type {
+  IFlowCollabRole,
+  IJSONObject,
+  IStep,
+  IStepConfig,
+} from '@plumber/types'
 
 import {
   raw,
@@ -34,6 +39,7 @@ class Step extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   config: IStepConfig
+  role?: IFlowCollabRole
 
   static tableName = 'steps'
 

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -96,9 +96,19 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      await onUpdateStep({
+      const result = await onUpdateStep({
         ...currentStep,
         status: isSubStepValid ? 'completed' : 'incomplete',
+      })
+
+      if (!result) {
+        throw new Error('Failed to save step')
+      }
+      toast({
+        title: 'Step saved successfully!',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
       })
     } catch (error) {
       console.error('Error saving step', error)
@@ -106,17 +116,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     } finally {
       setIsSaving(false)
     }
-  }, [formContext, onUpdateStep, substep])
-
-  const handleSave = useCallback(async () => {
-    await saveStep()
-    toast({
-      title: 'Step saved successfully!',
-      status: 'success',
-      duration: 2000,
-      isClosable: true,
-    })
-  }, [saveStep, toast])
+  }, [formContext, onUpdateStep, substep, toast])
 
   const handleSaveAndTest = useCallback(
     async (testRunMetadata?: Record<string, unknown>) => {
@@ -155,7 +155,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
         isSaving={isSaving}
         isTestResultOpen={isTestResultOpen}
         step={step}
-        handleSave={handleSave}
+        handleSave={saveStep}
         handleSaveAndTest={handleSaveAndTest}
         onTestResultOpen={onTestResultOpen}
         onTestResultClose={onTestResultClose}

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -107,18 +107,22 @@ type EditorProviderProps = {
 /**
  * Helper function to update the flow in the cache
  */
-function updateHandlerFactory(flowId: string, previousStepId: string) {
-  return function createStepUpdateHandler(cache: any, mutationResult: any) {
+function updateHandlerFactory(
+  flowId: string,
+  previousStepId: string,
+  mutationType: 'createStep' | 'updateStep' = 'createStep',
+) {
+  return function stepUpdateHandler(cache: any, mutationResult: any) {
     const { data } = mutationResult
-    const { createStep: createdStep } = data
+    const stepData = data[mutationType]
     const { getFlow: flow } = cache.readQuery({
       query: GET_FLOW,
       variables: { id: flowId },
     })
 
     // getFlow requires certain attributes to be returned
-    const completeCreatedStep = {
-      ...createdStep,
+    const completeStep = {
+      ...stepData,
       iconUrl: null,
       webhookUrl: null,
       config: {
@@ -131,8 +135,8 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
     }
 
     const steps = flow.steps.reduce((steps: any[], currentStep: any) => {
-      if (currentStep.id === previousStepId) {
-        return [...steps, currentStep, completeCreatedStep]
+      if (mutationType === 'createStep' && currentStep.id === previousStepId) {
+        return [...steps, currentStep, completeStep]
       }
 
       return [...steps, currentStep]
@@ -142,10 +146,21 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
       query: GET_FLOW,
       variables: { id: flowId },
       data: {
-        getFlow: { ...flow, updatedAt: createdStep.flow.updatedAt, steps },
+        getFlow: { ...flow, updatedAt: stepData.flow.updatedAt, steps },
       },
     })
   }
+}
+
+// NOTE: we read from the cache instead of the prop to get
+// the updatedAt of the flow, which is updated by the createStep mutation.
+// this is used to prevent users from updating the pipe when the steps are
+// outdated.
+function getCachedFlow(flowId: string) {
+  return client.readQuery({
+    query: GET_FLOW,
+    variables: { id: flowId },
+  })
 }
 
 export const EditorProvider = ({
@@ -229,14 +244,7 @@ export const EditorProvider = ({
       eventKey: string,
       connectionId?: string,
     ) => {
-      // NOTE: we read from the cache instead of the prop to get
-      // the updatedAt of the flow, which is updated by the createStep mutation.
-      // this is used to prevent users from updating the pipe when the steps are
-      // outdated.
-      const { getFlow: cachedFlow } = client.readQuery({
-        query: GET_FLOW,
-        variables: { id: flowId },
-      })
+      const { getFlow: cachedFlow } = getCachedFlow(flowId)
 
       const mutationInput = {
         previousStep: {
@@ -253,7 +261,7 @@ export const EditorProvider = ({
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flowId, previousStepId),
+        update: updateHandlerFactory(flowId, previousStepId, 'createStep'),
       })
 
       const newStep = createdStep.data.createStep
@@ -275,6 +283,9 @@ export const EditorProvider = ({
           const completeStepWithFlow = {
             ...completeStep,
             flowId: flowId,
+            flow: {
+              updatedAt: newStep.flow.updatedAt,
+            },
           }
           if (eventKey === TOOLBOX_ACTIONS.IfThen) {
             return (await initializeIfThen(
@@ -295,6 +306,8 @@ export const EditorProvider = ({
   const [updateStep] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
     async (step: IStep) => {
+      const { getFlow: cachedFlow } = getCachedFlow(flowId)
+
       const mutationInput: Record<string, unknown> = {
         id: step.id,
         key: step.key,
@@ -304,6 +317,7 @@ export const EditorProvider = ({
         },
         flow: {
           id: flowId,
+          updatedAt: cachedFlow.updatedAt,
         },
         config: {
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
@@ -320,6 +334,7 @@ export const EditorProvider = ({
 
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
+        update: updateHandlerFactory(flowId, step.id, 'updateStep'),
       })
 
       return updatedStep.data?.updateStep as IStep

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -152,17 +152,6 @@ function updateHandlerFactory(
   }
 }
 
-// NOTE: we read from the cache instead of the prop to get
-// the updatedAt of the flow, which is updated by the createStep mutation.
-// this is used to prevent users from updating the pipe when the steps are
-// outdated.
-function getCachedFlow(flowId: string) {
-  return client.readQuery({
-    query: GET_FLOW,
-    variables: { id: flowId },
-  })
-}
-
 export const EditorProvider = ({
   readOnly,
   flow,
@@ -244,15 +233,13 @@ export const EditorProvider = ({
       eventKey: string,
       connectionId?: string,
     ) => {
-      const { getFlow: cachedFlow } = getCachedFlow(flowId)
-
       const mutationInput = {
         previousStep: {
           id: previousStepId,
         },
         flow: {
           id: flowId,
-          updatedAt: cachedFlow.updatedAt,
+          updatedAt: flow.updatedAt,
         },
         appKey,
         key: eventKey,
@@ -297,7 +284,7 @@ export const EditorProvider = ({
 
       return newStep as IStep
     },
-    [createStep, flowId, initializeIfThen],
+    [createStep, flow, flowId, initializeIfThen],
   )
 
   /**
@@ -306,8 +293,6 @@ export const EditorProvider = ({
   const [updateStep] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
     async (step: IStep) => {
-      const { getFlow: cachedFlow } = getCachedFlow(flowId)
-
       const mutationInput: Record<string, unknown> = {
         id: step.id,
         key: step.key,
@@ -317,7 +302,7 @@ export const EditorProvider = ({
         },
         flow: {
           id: flowId,
-          updatedAt: cachedFlow.updatedAt,
+          updatedAt: flow.updatedAt,
         },
         config: {
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
@@ -339,7 +324,7 @@ export const EditorProvider = ({
 
       return updatedStep.data?.updateStep as IStep
     },
-    [updateStep, flowId],
+    [flowId, flow.updatedAt, updateStep],
   )
 
   /**

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -108,6 +108,7 @@ type EditorProviderProps = {
  * Helper function to update the flow in the cache
  */
 function updateHandlerFactory(
+  flow: IFlow,
   flowId: string,
   previousStepId: string,
   mutationType: 'createStep' | 'updateStep' = 'createStep',
@@ -115,10 +116,6 @@ function updateHandlerFactory(
   return function stepUpdateHandler(cache: any, mutationResult: any) {
     const { data } = mutationResult
     const stepData = data[mutationType]
-    const { getFlow: flow } = cache.readQuery({
-      query: GET_FLOW,
-      variables: { id: flowId },
-    })
 
     // getFlow requires certain attributes to be returned
     const completeStep = {
@@ -248,7 +245,12 @@ export const EditorProvider = ({
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flowId, previousStepId, 'createStep'),
+        update: updateHandlerFactory(
+          flow,
+          flowId,
+          previousStepId,
+          'createStep',
+        ),
       })
 
       const newStep = createdStep.data.createStep
@@ -319,12 +321,12 @@ export const EditorProvider = ({
 
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flowId, step.id, 'updateStep'),
+        update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
       })
 
       return updatedStep.data?.updateStep as IStep
     },
-    [flowId, flow.updatedAt, updateStep],
+    [flow, flowId, updateStep],
   )
 
   /**

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -20,6 +20,9 @@ export const UPDATE_STEP = graphql(`
           appEventKey
         }
       }
+      flow {
+        updatedAt
+      }
     }
   }
 `)

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -159,6 +159,7 @@ export function useIfThenInitializer(): [
             key: TOOLBOX_ACTIONS.IfThen,
             flow: {
               id: currStep.flowId,
+              updatedAt: currStep.flow.updatedAt,
             },
             parameters: {
               branchName: 'Branch 1',
@@ -170,6 +171,7 @@ export function useIfThenInitializer(): [
           },
         },
       })
+      const updatedFirstBranch = updateFirstBranch?.data?.updateStep
       const createSecondBranch = await createStep({
         variables: {
           input: {
@@ -180,6 +182,7 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: updatedFirstBranch?.flow?.updatedAt,
             },
             parameters: {
               depth,
@@ -188,6 +191,7 @@ export function useIfThenInitializer(): [
           },
         },
       })
+      const createdSecondBranch = createSecondBranch?.data?.createStep
       const [_firstBranch, secondBranch] = await Promise.all([
         updateFirstBranch,
         createSecondBranch,
@@ -199,7 +203,7 @@ export function useIfThenInitializer(): [
       //
       // FIXME (ogp-weeloong): Intentionally serial; need to fix createSteps to
       // enable concurrent updates on same pipe.
-      await createStep({
+      const createFirstStep = await createStep({
         variables: {
           input: {
             previousStep: {
@@ -207,10 +211,12 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: createdSecondBranch.flow.updatedAt,
             },
           },
         },
       })
+      const createdFirstStep = createFirstStep?.data?.createStep
       await createStep({
         variables: {
           input: {
@@ -219,6 +225,7 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: createdFirstStep?.flow?.updatedAt,
             },
           },
         },


### PR DESCRIPTION
### TL;DR
Refactored the `updateStep` mutation to add new connections to `flow_connections` when Owner makes edits to a Step in a shared Pipe.

### What changed?

- Replaced the `$relatedQuery` pattern with the `withAccessible` pattern for proper access control in the `updateStep` mutation
- Added support for different user roles (owner, editor, viewer) with appropriate permission checks
- Implemented integration with FlowConnections to update metadata for specific apps (Slack, Telegram, Tiles)
- Created a reusable mock helper (`createMockWithAccessible`) for testing access control
- Added handling for app-specific connection fields and parameter updates

### How to test?
1. Owner
   - [ ] Change a connection on a Step (e.g., Telegram), verify that it is added to `flow_connections`
   - [ ] Change a Tile that is used in a Step, verify that it is added to the `metadata` field in `flow_connections`

2. Editor
   - [ ] Can modify and save a Step (CANNOT check step yet)
   - [ ] Should only see Editor's own connections at this point.

3. Test outdated Pipe check: open two windows as different users of the Pipe
   - [ ] Update a step from window 1 (e.g. as an Owner)
   - [ ] Update the same step Pipe from window 2 (e.g., as an Editor) and observe that an error is thrown that Pipe is outdated. Refresh the page and try again
   - [ ] Update a different same step Pipe from window 2 (e.g., as an Editor) and observe that an error is thrown that Pipe is outdated. Refresh the page and try again
   - [ ] Refresh window 2 and create a step, this should succeed now

4. If-then branches can be created correctly (uses a mix of both create and update)
   - [ ] If-then branches are created correctly with the condition and first step
   - [ ] Outdated pipes cannot be modified after if-then branches are created