### PR TITLE
PLU-554: Limit screen names

### DIFF
--- a/packages/backend/src/apps/custom-api/auth/auth-data.ts
+++ b/packages/backend/src/apps/custom-api/auth/auth-data.ts
@@ -6,7 +6,7 @@ import { screenNameSchema } from '@/helpers/app-auth-schema'
 
 const authDataSchema = z.object({
   label: screenNameSchema,
-  headers: z.string(),
+  headers: z.string().max(16000, 'Headers too long'),
 })
 
 export type AuthData = z.infer<typeof authDataSchema>

--- a/packages/backend/src/apps/custom-api/auth/auth-data.ts
+++ b/packages/backend/src/apps/custom-api/auth/auth-data.ts
@@ -1,0 +1,16 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { z } from 'zod'
+
+import { screenNameSchema } from '@/helpers/app-auth-schema'
+
+const authDataSchema = z.object({
+  label: screenNameSchema,
+  headers: z.string(),
+})
+
+export type AuthData = z.infer<typeof authDataSchema>
+
+export function validateAuthData($: IGlobalVariable): AuthData {
+  return authDataSchema.parse($.auth?.data)
+}

--- a/packages/backend/src/apps/custom-api/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/custom-api/auth/verify-credentials.ts
@@ -1,31 +1,46 @@
 import { IGlobalVariable } from '@plumber/types'
 
+import { ZodError } from 'zod'
+import { fromZodError } from 'zod-validation-error'
+
+import { validateAuthData } from './auth-data'
+
 const verifyCredentials = async ($: IGlobalVariable) => {
-  const stringifiedHeaders = $.auth.data.headers
+  try {
+    const authData = validateAuthData($)
 
-  let headers: Record<string, string> = {}
+    const stringifiedHeaders = authData.headers
 
-  if (stringifiedHeaders && typeof stringifiedHeaders === 'string') {
-    headers = stringifiedHeaders
-      .split('\n')
-      // split by first '='
-      .map((header) => header.trim().split('='))
-      .reduce((acc, [key, ...value]) => {
-        const trimmedKey = key.trim()
-        const trimmedValue = value.join('=').trim()
-        if (trimmedKey && trimmedValue) {
-          acc[trimmedKey] = trimmedValue
-          return acc
-        } else {
-          throw new Error('Malformed headers')
-        }
-      }, {} as Record<string, string>)
+    let headers: Record<string, string> = {}
+
+    if (stringifiedHeaders) {
+      headers = stringifiedHeaders
+        .split('\n')
+        // split by first '='
+        .map((header) => header.trim().split('='))
+        .reduce((acc, [key, ...value]) => {
+          const trimmedKey = key.trim()
+          const trimmedValue = value.join('=').trim()
+          if (trimmedKey && trimmedValue) {
+            acc[trimmedKey] = trimmedValue
+            return acc
+          } else {
+            throw new Error('Malformed headers')
+          }
+        }, {} as Record<string, string>)
+    }
+
+    await $.auth.set({
+      headers,
+      screenName: authData.label,
+    })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      // Auth data validation failed: throws message from first error
+      throw new Error(fromZodError(error).details[0].message)
+    }
+    throw error
   }
-
-  await $.auth.set({
-    headers,
-    screenName: $.auth.data.label,
-  })
 }
 
 export default verifyCredentials

--- a/packages/backend/src/apps/gathersg/auth/auth-data.ts
+++ b/packages/backend/src/apps/gathersg/auth/auth-data.ts
@@ -2,8 +2,10 @@ import { IGlobalVariable } from '@plumber/types'
 
 import { z } from 'zod'
 
+import { screenNameSchema } from '@/helpers/app-auth-schema'
+
 const authDataSchema = z.object({
-  screenName: z.string().min(1, 'Empty screen name'),
+  screenName: screenNameSchema,
   apiKey: z.string().min(1, 'Empty API key'),
 })
 

--- a/packages/backend/src/apps/gathersg/auth/auth-data.ts
+++ b/packages/backend/src/apps/gathersg/auth/auth-data.ts
@@ -6,7 +6,7 @@ import { screenNameSchema } from '@/helpers/app-auth-schema'
 
 const authDataSchema = z.object({
   screenName: screenNameSchema,
-  apiKey: z.string().min(1, 'Empty API key'),
+  apiKey: z.string().min(1, 'Empty API key').max(150),
 })
 
 export type AuthData = z.infer<typeof authDataSchema>

--- a/packages/backend/src/apps/lettersg/auth/auth-data.ts
+++ b/packages/backend/src/apps/lettersg/auth/auth-data.ts
@@ -2,8 +2,10 @@ import { IGlobalVariable } from '@plumber/types'
 
 import { z } from 'zod'
 
+import { screenNameSchema } from '@/helpers/app-auth-schema'
+
 const authDataSchema = z.object({
-  screenName: z.string().min(1, 'Empty screen name'),
+  screenName: screenNameSchema,
   apiKey: z.string().min(1, 'Empty API key'),
 })
 

--- a/packages/backend/src/apps/lettersg/auth/auth-data.ts
+++ b/packages/backend/src/apps/lettersg/auth/auth-data.ts
@@ -6,7 +6,7 @@ import { screenNameSchema } from '@/helpers/app-auth-schema'
 
 const authDataSchema = z.object({
   screenName: screenNameSchema,
-  apiKey: z.string().min(1, 'Empty API key'),
+  apiKey: z.string().min(1, 'Empty API key').max(150),
 })
 
 export type AuthData = z.infer<typeof authDataSchema>

--- a/packages/backend/src/apps/paysg/auth/auth-data.ts
+++ b/packages/backend/src/apps/paysg/auth/auth-data.ts
@@ -6,8 +6,12 @@ import { screenNameSchema } from '@/helpers/app-auth-schema'
 
 const authDataSchema = z.object({
   screenName: screenNameSchema,
-  apiKey: z.string().trim().min(1, 'Invalid PaySG API key'),
-  paymentServiceId: z.string().trim().min(1, 'Invalid Payment Service ID'),
+  apiKey: z.string().trim().min(1, 'Invalid PaySG API key').max(150),
+  paymentServiceId: z
+    .string()
+    .trim()
+    .min(1, 'Invalid Payment Service ID')
+    .max(150),
 })
 
 export type AuthData = z.infer<typeof authDataSchema>

--- a/packages/backend/src/apps/paysg/auth/auth-data.ts
+++ b/packages/backend/src/apps/paysg/auth/auth-data.ts
@@ -1,0 +1,17 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { z } from 'zod'
+
+import { screenNameSchema } from '@/helpers/app-auth-schema'
+
+const authDataSchema = z.object({
+  screenName: screenNameSchema,
+  apiKey: z.string().trim().min(1, 'Invalid PaySG API key'),
+  paymentServiceId: z.string().trim().min(1, 'Invalid Payment Service ID'),
+})
+
+export type AuthData = z.infer<typeof authDataSchema>
+
+export function validateAuthData($: IGlobalVariable): AuthData {
+  return authDataSchema.parse($.auth?.data)
+}

--- a/packages/backend/src/apps/paysg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/paysg/auth/verify-credentials.ts
@@ -2,27 +2,19 @@ import type { IGlobalVariable } from '@plumber/types'
 
 import { getEnvironmentFromApiKey, PaySgEnvironment } from '../common/api'
 
+import { validateAuthData } from './auth-data'
+
 export default async function verifyCredentials(
   $: IGlobalVariable,
 ): Promise<void> {
-  const authData = $.auth.data
-
-  if (!authData || !authData.apiKey) {
-    throw new Error('Invalid PaySG API key')
-  }
-
-  const paymentServiceId = authData.paymentServiceId as string
-
-  if (!paymentServiceId || typeof paymentServiceId !== 'string') {
-    throw new Error('Payment Service ID must be set')
-  }
+  const authData = validateAuthData($)
 
   try {
     await $.http.get(
       '/v1/payment-services/:paymentServiceId/payments?limit=1',
       {
         urlPathParams: {
-          paymentServiceId,
+          paymentServiceId: authData.paymentServiceId,
         },
       },
     )

--- a/packages/backend/src/apps/postman-sms/auth/schema.ts
+++ b/packages/backend/src/apps/postman-sms/auth/schema.ts
@@ -4,8 +4,8 @@ import { screenNameSchema } from '@/helpers/app-auth-schema'
 
 export const authDataSchema = z.object({
   screenName: screenNameSchema,
-  campaignId: z.string().trim(),
-  apiKey: z.string().trim(),
+  campaignId: z.string().trim().max(50),
+  apiKey: z.string().trim().max(50),
 })
 
 export type AuthData = z.infer<typeof authDataSchema>

--- a/packages/backend/src/apps/postman-sms/auth/schema.ts
+++ b/packages/backend/src/apps/postman-sms/auth/schema.ts
@@ -1,7 +1,9 @@
 import z from 'zod'
 
+import { screenNameSchema } from '@/helpers/app-auth-schema'
+
 export const authDataSchema = z.object({
-  screenName: z.string().trim(),
+  screenName: screenNameSchema,
   campaignId: z.string().trim(),
   apiKey: z.string().trim(),
 })

--- a/packages/backend/src/helpers/__tests__/app-auth-schema.test.ts
+++ b/packages/backend/src/helpers/__tests__/app-auth-schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { screenNameSchema } from '../app-auth-schema'
+
+describe('app-auth-schema', () => {
+  it('should validate the screen name', () => {
+    const result = screenNameSchema.safeParse('test')
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe('test')
+    }
+  })
+
+  it('should allow exactly 128 characters', () => {
+    const result = screenNameSchema.safeParse('a'.repeat(128))
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe('a'.repeat(128))
+    }
+  })
+
+  it('should fail if the screen name is too long', () => {
+    const result = screenNameSchema.safeParse('a'.repeat(129))
+    expect(result.success).toBe(false)
+    if (result.success === false) {
+      expect(result.error.errors[0].message).toBe('Screen name is too long')
+    }
+  })
+
+  it('should fail if the screen name is empty', () => {
+    const result = screenNameSchema.safeParse('')
+    expect(result.success).toBe(false)
+    if (result.success === false) {
+      expect(result.error.errors[0].message).toBe('Empty screen name')
+    }
+  })
+})

--- a/packages/backend/src/helpers/__tests__/app-auth-schema.test.ts
+++ b/packages/backend/src/helpers/__tests__/app-auth-schema.test.ts
@@ -23,7 +23,9 @@ describe('app-auth-schema', () => {
     const result = screenNameSchema.safeParse('a'.repeat(129))
     expect(result.success).toBe(false)
     if (result.success === false) {
-      expect(result.error.errors[0].message).toBe('Screen name is too long')
+      expect(result.error.errors[0].message).toBe(
+        'Connection label is too long',
+      )
     }
   })
 
@@ -31,7 +33,7 @@ describe('app-auth-schema', () => {
     const result = screenNameSchema.safeParse('')
     expect(result.success).toBe(false)
     if (result.success === false) {
-      expect(result.error.errors[0].message).toBe('Empty screen name')
+      expect(result.error.errors[0].message).toBe('Empty connection label')
     }
   })
 })

--- a/packages/backend/src/helpers/app-auth-schema.ts
+++ b/packages/backend/src/helpers/app-auth-schema.ts
@@ -8,5 +8,5 @@ const MAX_SCREEN_NAME_LENGTH = 128
 export const screenNameSchema = z
   .string()
   .trim()
-  .min(1, 'Empty screen name')
-  .max(MAX_SCREEN_NAME_LENGTH, 'Screen name is too long')
+  .min(1, 'Empty connection label')
+  .max(MAX_SCREEN_NAME_LENGTH, 'Connection label is too long')

--- a/packages/backend/src/helpers/app-auth-schema.ts
+++ b/packages/backend/src/helpers/app-auth-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+
+const MAX_SCREEN_NAME_LENGTH = 128
+
+/**
+ * NOTE: we use this schema to validate the screen name for all apps that have a screen name.
+ */
+export const screenNameSchema = z
+  .string()
+  .trim()
+  .min(1, 'Empty screen name')
+  .max(MAX_SCREEN_NAME_LENGTH, 'Screen name is too long')

--- a/packages/frontend/src/components/TextField/index.tsx
+++ b/packages/frontend/src/components/TextField/index.tsx
@@ -13,6 +13,10 @@ import copy from 'clipboard-copy'
 
 import { EditorContext } from '@/contexts/Editor'
 
+const FIELD_MAX_LENGTH = {
+  screenName: 128,
+}
+
 type TextFieldProps = {
   shouldUnregister?: boolean
   name: string
@@ -30,6 +34,10 @@ type TextFieldProps = {
   ) => void
   placeholder?: string
   defaultValue?: string
+}
+
+function getFieldMaxLength(name: string): number | undefined {
+  return FIELD_MAX_LENGTH[name as keyof typeof FIELD_MAX_LENGTH]
 }
 
 export default function TextField(props: TextFieldProps): React.ReactElement {
@@ -92,6 +100,7 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
                 onBlur?.(...args)
               }}
               isReadOnly={readOnly || disabled}
+              maxLength={getFieldMaxLength(name)}
             />
             {clickToCopy && (
               <InputRightElement>


### PR DESCRIPTION
## Problem
There is no limit on the screen names, which could potentially overwhelm the server when running the `getApp` query.

## Solution
* Introduced a shared `screenNameSchema` in `app-auth-schema.ts` to validate screen names with consistent rules (trimmed, min length 1, max length 128) across all relevant apps.
* Updated the authentication data schemas in `gathersg`, `lettersg`, and `postman-sms` apps to use the new `screenNameSchema`.
* Added new authentication data modules for `custom-api` and `paysg` apps, both using the centralized `screenNameSchema` for their screen name fields.

**Why a 128 character limit?**
- Connection information is encrypted and stored in Plumber’s database, and it is not recommended to decrypt all connections just to inspect the screen name that has been assigned.
- Avoid being too restrictive, but keeping it flexible enough so that old connections do not fail when actions are executed.

## Tests
- [ ] Adding connections without screen names still work
  - [ ] AISAY
  - [ ] FormSG
  - [ ] Slack
  - [ ] Telegram
- [ ] Validation is applied correctly to connections with user-input screen names
  - [ ] Custom API
  - [ ] GatherSG
  - [ ] LetterSG
  - [ ] PaySG
  - [ ] Postman SMS


