### PR TITLE
[COLLAB-14]: Editor add step with shared connection

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -281,7 +281,7 @@ describe('createStep mutation integration tests', async () => {
 
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
         previousStep: { id: existingSteps[0].id },
         key: 'newStep',
         appKey: 'test-app',

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -82,6 +82,11 @@ describe('createStep mutation integration tests', async () => {
 
     await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
     await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
+    await FlowConnections.addFlowConnection({
+      flowId: testFlow.id,
+      connectionId: testConnection.id,
+      userId: owner.id,
+    })
 
     // Create a "previous" step in the flow with position 1.
     existingSteps = await testFlow.$relatedQuery('steps').insertAndFetch([
@@ -97,6 +102,7 @@ describe('createStep mutation integration tests', async () => {
         appKey: 'appKey',
         type: 'action',
         position: 2,
+        connectionId: testConnection.id,
         parameters: {},
       },
       {
@@ -267,6 +273,28 @@ describe('createStep mutation integration tests', async () => {
     expect(newStep.key).toBe('newStep')
     expect(newStep.appKey).toBe('test-app')
     // New step's position should be previousStep.position + 1.
+    expect(newStep.position).toBe(existingSteps[0].position + 1)
+  })
+
+  it('editor can create a new step with owner connection', async () => {
+    context.currentUser = editor
+
+    const params = {
+      input: {
+        flow: { id: testFlow.id },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: testConnection.id },
+      },
+    }
+
+    const newStep = await createStep(null, params, context)
+    expect(newStep).toBeDefined()
+    expect(newStep.type).toBe('action')
+    expect(newStep.key).toBe('newStep')
+    expect(newStep.appKey).toBe('test-app')
     expect(newStep.position).toBe(existingSteps[0].position + 1)
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -85,7 +85,8 @@ describe('createStep mutation integration tests', async () => {
     await FlowConnections.addFlowConnection({
       flowId: testFlow.id,
       connectionId: testConnection.id,
-      userId: owner.id,
+      addedBy: owner.id,
+      connectionType: 'connection',
     })
 
     // Create a "previous" step in the flow with position 1.
@@ -287,6 +288,7 @@ describe('createStep mutation integration tests', async () => {
         appKey: 'test-app',
         parameters: { newParam: 'value' },
         connection: { id: testConnection.id },
+        connectionRole: 'owner',
       },
     }
 

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -360,7 +360,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 
@@ -392,7 +392,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 
@@ -424,7 +424,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
@@ -1,0 +1,41 @@
+import { NotFoundError } from 'objection'
+import { vi } from 'vitest'
+
+import User from '@/models/user'
+
+interface MockConnectionsRelatedQueryOptions {
+  connectionId: string
+  connectionKey: string
+  connectionNotFound?: boolean
+}
+
+export function mockConnectionsRelatedQuery(
+  currentUser: User,
+  {
+    connectionId,
+    connectionKey,
+    connectionNotFound = false,
+  }: MockConnectionsRelatedQueryOptions,
+) {
+  currentUser.$relatedQuery = vi.fn().mockImplementation((relation: string) => {
+    if (relation !== 'connections') {
+      return {
+        findOne: vi.fn().mockReturnValue({
+          throwIfNotFound: vi.fn().mockResolvedValue(null),
+        }),
+      }
+    }
+
+    return {
+      findOne: vi.fn().mockReturnValue({
+        throwIfNotFound: connectionNotFound
+          ? vi
+              .fn()
+              .mockRejectedValue(
+                new NotFoundError({ message: 'Connection not found' }),
+              )
+          : vi.fn().mockResolvedValue({ id: connectionId, key: connectionKey }),
+      }),
+    }
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
@@ -167,7 +168,7 @@ describe('updateStep mutation', () => {
     const input = {
       ...genericInputParams,
       parameters: { testParam: 'value' },
-      connection: { id: 'non-existent-connection' },
+      connection: { id: randomUUID() },
     }
 
     context.currentUser.withAccessibleConnections =

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
@@ -14,8 +15,10 @@ import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
 
 import { generateMockContext } from './tiles/table.mock'
 import { generateMockUser } from './flow.mock'
+import { mockConnectionsRelatedQuery } from './related-query-mock'
 import {
   createMockWithAccessibleConnections,
+  createMockWithAccessibleFlowConnections,
   createMockWithAccessibleSteps,
   setAssertNotUpdatedSinceSpy,
   setPatchLastUpdatedSpy,
@@ -123,6 +126,17 @@ describe('updateStep mutation', () => {
         connectionKey: 'postman',
         connectionId: mockConnectionId,
       })
+
+    context.currentUser.withAccessibleFlowConnections =
+      createMockWithAccessibleFlowConnections({
+        connectionKey: 'postman',
+        connectionId: mockConnectionId,
+      })
+
+    mockConnectionsRelatedQuery(context.currentUser, {
+      connectionKey: 'postman',
+      connectionId: mockConnectionId,
+    })
   })
 
   it('should successfully update a step', async () => {
@@ -171,15 +185,14 @@ describe('updateStep mutation', () => {
       connection: { id: randomUUID() },
     }
 
-    context.currentUser.withAccessibleConnections =
-      createMockWithAccessibleConnections({
-        connectionId: mockConnectionId,
-        connectionKey: 'postman',
-        connectionNotFound: true,
-      })
+    mockConnectionsRelatedQuery(context.currentUser, {
+      connectionId: mockConnectionId,
+      connectionKey: 'postman',
+      connectionNotFound: true,
+    })
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrowError(
-      BadUserInputError,
+    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+      NotFoundError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
   })
@@ -444,11 +457,10 @@ describe('updateStep mutation', () => {
           },
         )
 
-        context.currentUser.withAccessibleConnections =
-          createMockWithAccessibleConnections({
-            connectionId: mockConnectionId,
-            connectionKey: 'postman',
-          })
+        mockConnectionsRelatedQuery(context.currentUser, {
+          connectionId: mockConnectionId,
+          connectionKey: 'postman',
+        })
 
         await expect(
           updateStep(null, { input }, context),
@@ -487,17 +499,10 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionKey: 'slack',
-          connectionId: mockConnectionId,
-        })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'slack',
-        })
+      mockConnectionsRelatedQuery(context.currentUser, {
+        connectionKey: 'slack',
+        connectionId: mockConnectionId,
+      })
     })
 
     it('should call patchFlowConnectionMetadata when its an excel app', async () => {
@@ -510,17 +515,10 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionKey: 'm365-excel',
-          connectionId: mockConnectionId,
-        })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'm365-excel',
-        })
+      mockConnectionsRelatedQuery(context.currentUser, {
+        connectionKey: 'm365-excel',
+        connectionId: mockConnectionId,
+      })
 
       const input = {
         ...genericInputParams,
@@ -606,6 +604,12 @@ describe('updateStep mutation', () => {
         parameters: { channel: 'C1234567890' },
         connection: { id: mockConnectionId },
       }
+
+      context.currentUser.withAccessibleFlowConnections =
+        createMockWithAccessibleFlowConnections({
+          connectionKey: 'slack',
+          connectionId: mockConnectionId,
+        })
 
       await updateStep(null, { input }, context)
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -101,14 +101,6 @@ describe('updateStep mutation', () => {
       }),
     }))
 
-    // Mock Step.transaction
-    vi.spyOn(Step, 'transaction').mockImplementation(async (callback) => {
-      const trx = {
-        raw: vi.fn().mockResolvedValue({}),
-      } as any
-      return callback(trx)
-    })
-
     // Mock Step.query
     vi.spyOn(Step, 'query').mockReturnValue({
       patchAndFetchById: patchAndFetchByIdSpy,
@@ -478,14 +470,6 @@ describe('updateStep mutation', () => {
     let addSpy: any
 
     beforeEach(async () => {
-      // Mock FlowConnections methods
-      vi.mock('@/models/flow-connections', () => ({
-        default: {
-          patchFlowConnectionMetadata: vi.fn(),
-          addFlowConnection: vi.fn(),
-        },
-      }))
-
       const { default: FlowConnections } = await import(
         '@/models/flow-connections'
       )

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -17,8 +17,6 @@ import { generateMockContext } from './tiles/table.mock'
 import { generateMockUser } from './flow.mock'
 import { mockConnectionsRelatedQuery } from './related-query-mock'
 import {
-  createMockWithAccessibleConnections,
-  createMockWithAccessibleFlowConnections,
   createMockWithAccessibleSteps,
   setAssertNotUpdatedSinceSpy,
   setPatchLastUpdatedSpy,
@@ -120,18 +118,6 @@ describe('updateStep mutation', () => {
       stepConnection: { id: mockConnectionId, userId: owner.id },
       flowUpdatedAt: testFlowISODateString,
     })
-
-    context.currentUser.withAccessibleConnections =
-      createMockWithAccessibleConnections({
-        connectionKey: 'postman',
-        connectionId: mockConnectionId,
-      })
-
-    context.currentUser.withAccessibleFlowConnections =
-      createMockWithAccessibleFlowConnections({
-        connectionKey: 'postman',
-        connectionId: mockConnectionId,
-      })
 
     mockConnectionsRelatedQuery(context.currentUser, {
       connectionKey: 'postman',
@@ -598,18 +584,24 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
+      // Mock FlowConnections query for getConnection validation
+      // Since role is 'editor', getConnection will query FlowConnections table
+      vi.spyOn(FlowConnections, 'query').mockReturnValue({
+        findOne: vi.fn().mockReturnValue({
+          withGraphFetched: vi.fn().mockReturnValue({
+            throwIfNotFound: vi.fn().mockResolvedValue({
+              connection: { id: mockConnectionId, key: 'slack' },
+            }),
+          }),
+        }),
+      } as any)
+
       const input = {
         ...genericInputParams,
         appKey: 'slack',
         parameters: { channel: 'C1234567890' },
         connection: { id: mockConnectionId },
       }
-
-      context.currentUser.withAccessibleFlowConnections =
-        createMockWithAccessibleFlowConnections({
-          connectionKey: 'slack',
-          connectionId: mockConnectionId,
-        })
 
       await updateStep(null, { input }, context)
 
@@ -681,12 +673,6 @@ describe('updateStep mutation', () => {
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
       })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'tiles',
-        })
 
       const input = {
         ...genericInputParams,

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -78,6 +78,7 @@ export function createMockWithAccessibleSteps({
             flow: {
               userId: owner.id,
               updatedAt: flowUpdatedAt,
+              role: stepRole,
               assertNotUpdatedSince:
                 assertNotUpdatedSinceSpy || vi.fn().mockResolvedValue({}),
               patchLastUpdated:
@@ -100,14 +101,46 @@ export function createMockWithAccessibleConnections({
       (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
         if (connectionNotFound) {
           return {
+            withGraphFetched: vi.fn().mockReturnThis(),
             findOne: vi.fn().mockResolvedValue(null),
           }
         }
 
         return {
+          withGraphFetched: vi.fn().mockReturnThis(),
           findOne: vi.fn().mockResolvedValue({
+            // when using withAccessibleFlowConnections, getFlowConnection returns the related `connection`
             id: connectionId,
             key: connectionKey,
+          }),
+        }
+      },
+    )
+}
+
+export function createMockWithAccessibleFlowConnections({
+  connectionId,
+  connectionKey,
+  connectionNotFound = false,
+}: MockWithAccessibleConnectionsOptions) {
+  return vi
+    .fn()
+    .mockImplementation(
+      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
+        if (connectionNotFound) {
+          return {
+            withGraphFetched: vi.fn().mockReturnThis(),
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+
+        return {
+          withGraphFetched: vi.fn().mockReturnThis(),
+          findOne: vi.fn().mockResolvedValue({
+            connection: {
+              id: connectionId,
+              key: connectionKey,
+            },
           }),
         }
       },

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -33,12 +33,6 @@ interface MockWithAccessibleStepsOptions {
   flowUpdatedAt?: string
 }
 
-interface MockWithAccessibleConnectionsOptions {
-  connectionId: string
-  connectionKey: string
-  connectionNotFound?: boolean
-}
-
 export function createMockWithAccessibleSteps({
   owner,
   currentUser,
@@ -83,63 +77,6 @@ export function createMockWithAccessibleSteps({
                 assertNotUpdatedSinceSpy || vi.fn().mockResolvedValue({}),
               patchLastUpdated:
                 patchLastUpdatedSpy || vi.fn().mockResolvedValue({}),
-            },
-          }),
-        }
-      },
-    )
-}
-
-export function createMockWithAccessibleConnections({
-  connectionId,
-  connectionKey,
-  connectionNotFound = false,
-}: MockWithAccessibleConnectionsOptions) {
-  return vi
-    .fn()
-    .mockImplementation(
-      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
-        if (connectionNotFound) {
-          return {
-            withGraphFetched: vi.fn().mockReturnThis(),
-            findOne: vi.fn().mockResolvedValue(null),
-          }
-        }
-
-        return {
-          withGraphFetched: vi.fn().mockReturnThis(),
-          findOne: vi.fn().mockResolvedValue({
-            // when using withAccessibleFlowConnections, getFlowConnection returns the related `connection`
-            id: connectionId,
-            key: connectionKey,
-          }),
-        }
-      },
-    )
-}
-
-export function createMockWithAccessibleFlowConnections({
-  connectionId,
-  connectionKey,
-  connectionNotFound = false,
-}: MockWithAccessibleConnectionsOptions) {
-  return vi
-    .fn()
-    .mockImplementation(
-      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
-        if (connectionNotFound) {
-          return {
-            withGraphFetched: vi.fn().mockReturnThis(),
-            findOne: vi.fn().mockResolvedValue(null),
-          }
-        }
-
-        return {
-          withGraphFetched: vi.fn().mockReturnThis(),
-          findOne: vi.fn().mockResolvedValue({
-            connection: {
-              id: connectionId,
-              key: connectionKey,
             },
           }),
         }

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -1,4 +1,5 @@
 import App from '@/models/app'
+import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -12,11 +13,29 @@ const createConnection: MutationResolvers['createConnection'] = async (
 ) => {
   await App.findOneByKey(params.input.key)
 
-  return await context.currentUser.$relatedQuery('connections').insert({
-    key: params.input.key,
-    formattedData: params.input.formattedData,
-    verified: false,
-  })
+  const newConnection = await context.currentUser
+    .$relatedQuery('connections')
+    .insert({
+      key: params.input.key,
+      formattedData: params.input.formattedData,
+      verified: false,
+    })
+
+  /**
+   * COLLABORATORS
+   * If the flowId is provided and the flow has collaborators, we add this to the flow_connections table.
+   * We add regardless of whether its a draft, so that it can be used by collaborators later.
+   */
+  if (params.input.flowId) {
+    await FlowConnections.addFlowConnection({
+      flowId: params.input.flowId,
+      connectionId: newConnection.id,
+      addedBy: context.currentUser.id,
+      connectionType: 'connection',
+    })
+  }
+
+  return newConnection
 }
 
 export default createConnection

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -4,6 +4,7 @@ import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
+import { getFlowConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -32,20 +33,30 @@ const createStep: MutationResolvers['createStep'] = async (
     // user has to be an editor in the pipe
     if (input.connection?.id) {
       let connection: Connection
+      /**
+       * NOTE: with collaborators,
+       * Owner can use existing connections or add new connections to the pipe
+       * Editor can only use existing connections that have been shared to the pipe
+       * (TODO: phase 2) Editor will be able to add their own connections
+       */
       if (flow.role === 'owner') {
         connection = await context.currentUser
           .$relatedQuery('connections')
           .findOne({ id: input.connection.id })
       } else if (flow.role === 'editor') {
-        connection = await context.currentUser
-          .withAccessibleConnections({
-            requiredRole: 'editor',
-            trx,
-          })
-          .findOne({
-            'connections.id': input.connection.id,
-            'flows.id': flow.id,
-          })
+        const flowConnection = await getFlowConnection({
+          context,
+          connectionId: input.connection.id,
+          flowId: flow.id,
+          requiredRole: 'editor',
+          trx,
+        })
+        if (!flowConnection) {
+          throw new ForbiddenError(
+            'User does not have permission to add connection',
+          )
+        }
+        connection = flowConnection.connection
       } else {
         throw new ForbiddenError(
           'User does not have permission to add connection',

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,6 +1,5 @@
 import { raw } from 'objection'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
@@ -37,18 +36,13 @@ const createStep: MutationResolvers['createStep'] = async (
        * Editor can only use existing connections that have been shared to the pipe
        * (TODO: phase 2) Editor will be able to add their own connections
        */
-      const connection = await getConnection({
+      await getConnection({
         context,
         connectionId: input.connection.id,
         flowId: flow.id,
-        role: flow.role,
-        requiredRole: 'editor',
+        includeOwnConnections: flow.role === 'owner',
         trx,
       })
-
-      if (!connection) {
-        throw new BadUserInputError('Connection not found')
-      }
     }
 
     const previousStep = await flow

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -37,10 +37,15 @@ const createStep: MutationResolvers['createStep'] = async (
           .$relatedQuery('connections')
           .findOne({ id: input.connection.id })
       } else if (flow.role === 'editor') {
-        // TODO (kevinkim-ogp): allow editors to create step with owner connections
-        throw new ForbiddenError(
-          'User does not have permission to add connection',
-        )
+        connection = await context.currentUser
+          .withAccessibleConnections({
+            requiredRole: 'editor',
+            trx,
+          })
+          .findOne({
+            'connections.id': input.connection.id,
+            'flows.id': flow.id,
+          })
       } else {
         throw new ForbiddenError(
           'User does not have permission to add connection',

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,10 +1,9 @@
 import { raw } from 'objection'
 
-import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
-import Connection from '@/models/connection'
+import { BadUserInputError } from '@/errors/graphql-errors'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
-import { getFlowConnection } from '@/services/connection'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -32,36 +31,20 @@ const createStep: MutationResolvers['createStep'] = async (
     // and the user has the appropriate permissions to use it
     // user has to be an editor in the pipe
     if (input.connection?.id) {
-      let connection: Connection
       /**
        * NOTE: with collaborators,
        * Owner can use existing connections or add new connections to the pipe
        * Editor can only use existing connections that have been shared to the pipe
        * (TODO: phase 2) Editor will be able to add their own connections
        */
-      if (flow.role === 'owner') {
-        connection = await context.currentUser
-          .$relatedQuery('connections')
-          .findOne({ id: input.connection.id })
-      } else if (flow.role === 'editor') {
-        const flowConnection = await getFlowConnection({
-          context,
-          connectionId: input.connection.id,
-          flowId: flow.id,
-          requiredRole: 'editor',
-          trx,
-        })
-        if (!flowConnection) {
-          throw new ForbiddenError(
-            'User does not have permission to add connection',
-          )
-        }
-        connection = flowConnection.connection
-      } else {
-        throw new ForbiddenError(
-          'User does not have permission to add connection',
-        )
-      }
+      const connection = await getConnection({
+        context,
+        connectionId: input.connection.id,
+        flowId: flow.id,
+        role: flow.role,
+        requiredRole: 'editor',
+        trx,
+      })
 
       if (!connection) {
         throw new BadUserInputError('Connection not found')

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -37,8 +37,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         context,
         connectionId: input.connection.id,
         flowId: input.flow.id,
-        role: step.flow.role,
-        requiredRole: 'editor',
+        includeOwnConnections: step.flow.role === 'owner',
         trx,
       })
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -5,6 +5,7 @@ import {
 } from '@/helpers/add-flow-connection'
 import App from '@/models/app'
 import Step from '@/models/step'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -32,9 +33,14 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
-      const connection = await context.currentUser
-        .withAccessibleConnections({ requiredRole: 'editor' })
-        .findOne({ 'connections.id': input.connection.id })
+      const connection = await getConnection({
+        context,
+        connectionId: input.connection.id,
+        flowId: input.flow.id,
+        requiredRole: 'editor',
+        trx,
+      })
+
       // we check that the connection exists and is the same app
       if (!connection || connection.key !== input.appKey) {
         throw new BadUserInputError('Connection not found')

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -37,6 +37,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         context,
         connectionId: input.connection.id,
         flowId: input.flow.id,
+        role: step.flow.role,
         requiredRole: 'editor',
         trx,
       })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -37,7 +37,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         context,
         connectionId: input.connection.id,
         flowId: input.flow.id,
-        includeOwnConnections: step.flow.role === 'owner',
+        includeOwnConnections: step.role === 'owner',
         trx,
       })
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -125,7 +125,9 @@ const updateStep: MutationResolvers['updateStep'] = async (
       trx,
     })
 
-    return { ...updatedStep, flow: { updatedAt: updatedFlow.updatedAt } }
+    // do this instead of spreading the updatedStep so that it preserves the Model instance
+    updatedStep.flow.updatedAt = updatedFlow.updatedAt
+    return updatedStep
   })
 
   return step

--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -1,4 +1,5 @@
 import apps from '@/apps'
+import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
 import User from '@/models/user'
@@ -11,14 +12,41 @@ const testConnection: QueryResolvers['testConnection'] = async (
   params,
   context,
 ) => {
-  let connection = await getConnection({
-    context,
-    connectionId: params.connectionId,
-    flowId: params.flowId,
-    requiredRole: 'viewer',
-  })
+  const { flowId, connectionId, supportsConnectionRegistration } = params
+  let connection
+  let flow
+  let userRole
 
-  const userRole = connection.role
+  if (flowId) {
+    // flowId is only provided when testing connection from the pipe editor
+    // check if user has access to the flow first
+    flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'viewer' })
+      .findById(flowId)
+
+    if (!flow) {
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this pipe',
+      )
+    }
+
+    userRole = flow.role
+
+    connection = await getConnection({
+      context,
+      connectionId: params.connectionId,
+      flowId: params.flowId,
+      includeOwnConnections: userRole === 'owner',
+    })
+  } else {
+    // if flowId is undefined, it is always the owner's connections
+    // as we testing from the My Apps page
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findOne({ id: connectionId })
+      .throwIfNotFound()
+    userRole = 'owner'
+  }
 
   const app = apps[connection.key]
   let $ = await globalVariable({
@@ -32,14 +60,7 @@ const testConnection: QueryResolvers['testConnection'] = async (
           }),
   })
 
-  if (params.flowId) {
-    // flowId is supplied when testing within the pipe editor
-    // it's used for formsg webhook verification for now
-    const flow = await context.currentUser
-      .withAccessibleFlows({ requiredRole: 'viewer' })
-      .findById(params.flowId)
-      .throwIfNotFound()
-
+  if (flowId) {
     $ = await globalVariable({
       connection,
       app,
@@ -56,9 +77,9 @@ const testConnection: QueryResolvers['testConnection'] = async (
   } catch (err) {
     isStillVerified = false
     errorMessage = err.message
-    logger.error(`Error verifying CONNECTION ID: ${params.connectionId}`, {
+    logger.error(`Error verifying CONNECTION ID: ${connectionId}`, {
       event: 'test-connection',
-      flowId: params.flowId,
+      flowId: flowId,
       errMessage: err.message,
       errStack: err.stack,
     })
@@ -70,11 +91,7 @@ const testConnection: QueryResolvers['testConnection'] = async (
   })
 
   // if testing outside of the editor, it does not verify registration (e.g. setting of webhook url)
-  if (
-    !isStillVerified ||
-    !params.flowId ||
-    !params.supportsConnectionRegistration
-  ) {
+  if (!isStillVerified || !flowId || !supportsConnectionRegistration) {
     return { connectionVerified: isStillVerified, message: errorMessage }
   }
 

--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -2,6 +2,7 @@ import apps from '@/apps'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
 import User from '@/models/user'
+import { getConnection } from '@/services/connection'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -10,12 +11,13 @@ const testConnection: QueryResolvers['testConnection'] = async (
   params,
   context,
 ) => {
-  let connection = await context.currentUser
-    .withAccessibleConnections({ requiredRole: 'viewer' })
-    .findOne({
-      'connections.id': params.connectionId,
-    })
-    .throwIfNotFound()
+  let connection = await getConnection({
+    context,
+    connectionId: params.connectionId,
+    flowId: params.flowId,
+    requiredRole: 'viewer',
+  })
+
   const userRole = connection.role
 
   const app = apps[connection.key]

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -470,6 +470,7 @@ type BulkRetryIterationsResult {
 input CreateConnectionInput {
   key: String!
   formattedData: JSONObject!
+  flowId: String
 }
 
 input GenerateAuthUrlInput {

--- a/packages/backend/src/helpers/add-authentication-steps.ts
+++ b/packages/backend/src/helpers/add-authentication-steps.ts
@@ -23,6 +23,10 @@ const authenticationStepsWithoutAuthUrl = [
         name: 'formattedData',
         value: '{fields.all}',
       },
+      {
+        name: 'flowId',
+        value: '{flowId}',
+      },
     ],
   },
   {
@@ -49,6 +53,10 @@ const authenticationStepsWithAuthUrl = [
       {
         name: 'formattedData',
         value: '{fields.all}',
+      },
+      {
+        name: 'flowId',
+        value: '{flowId}',
       },
     ],
   },

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,3 +1,5 @@
+import { IFlowCollabRole } from '@plumber/types'
+
 import { Transaction } from 'objection'
 
 import Base from './base'
@@ -19,6 +21,8 @@ class FlowConnections extends Base {
   connection?: Connection
   table?: TableMetadata
   metadata: Record<string, any>
+
+  role?: IFlowCollabRole
 
   static tableName = 'flow_connections'
 

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -52,11 +52,15 @@ export const getConnection = async (params: GetConnectionParams) => {
       .throwIfNotFound({ message: 'Connection not found' })
   }
 
-  if (userRole === 'editor') {
-    return getFlowConnection(params)
+  /**
+   * NOTE: editor and viewer can only access shared connections from the flow_connections table
+   */
+  const connection = getFlowConnection(params)
+  if (!connection) {
+    throw new NotFoundError({ message: 'Connection not found' })
   }
 
-  throw new NotFoundError({ message: 'Connection not found' })
+  return connection
 }
 
 /**

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -55,7 +55,7 @@ export const getConnection = async (params: GetConnectionParams) => {
   /**
    * NOTE: editor and viewer can only access shared connections from the flow_connections table
    */
-  const connection = getFlowConnection(params)
+  const connection = await getFlowConnection(params)
   if (!connection) {
     throw new NotFoundError({ message: 'Connection not found' })
   }

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,8 +1,7 @@
 import { IFlowCollabRole } from '@plumber/types'
 
-import { Transaction } from 'objection'
+import { NotFoundError, Transaction } from 'objection'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
 import Context from '@/types/express/context'
 
 type GetConnectionParams = {
@@ -10,6 +9,7 @@ type GetConnectionParams = {
   connectionId: string
   flowId: string
   requiredRole: IFlowCollabRole
+  role?: IFlowCollabRole
   trx?: Transaction
 }
 
@@ -22,35 +22,41 @@ type GetFlowConnectionParams = {
 }
 
 /**
- * NOTE: with the introduction of collaborators, we first look for the
- * connection in the flow_connections table as this would contain all the
- * connections that have been shared within a pipe.
- *
- * However, there may be connections that have not been shared yet
- * (e.g., when the owner is adding a new connection to the pipe) so
- * we need to fallback to the direct connection method.
+ * NOTE: with the introduction of collaborators, we use this helper function to fetch the connection
  */
 export const getConnection = async (params: GetConnectionParams) => {
-  const { context, connectionId, requiredRole, trx } = params
-  let connection
+  const { context, connectionId, role, trx, flowId } = params
+  let userRole = role
 
-  const flowConnection = await getFlowConnection(params)
+  // flowId is only present within the editor, which means we should know the role.
+  // the only time we would not know the role is when the connection is being added to the pipe
+  // so we fetch the role from the flow
+  if (flowId && !role) {
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor', trx })
+      .findOne({ 'flows.id': flowId })
+      .throwIfNotFound({ message: 'Flow not found' })
 
-  if (flowConnection) {
-    // shared connection
-    connection = flowConnection.connection
-  } else {
-    // connection has not been shared yet
-    connection = await context.currentUser
-      .withAccessibleConnections({ requiredRole, trx })
+    userRole = flow.role
+  }
+
+  // there are two scenarios where we can directly fetch the connection from the user
+  // 1. when flowId is not present, which means the connection is being retrieved from the my apps page
+  // 2. when the user is the owner of the pipe
+  // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
+  // will need to include connections from the flow_connections table
+  if (!flowId || userRole === 'owner') {
+    return context.currentUser
+      .$relatedQuery('connections', trx)
       .findOne({ 'connections.id': connectionId })
+      .throwIfNotFound({ message: 'Connection not found' })
   }
 
-  if (!connection) {
-    throw new BadUserInputError('Connection not found')
+  if (userRole === 'editor') {
+    return getFlowConnection(params)
   }
 
-  return connection
+  throw new NotFoundError({ message: 'Connection not found' })
 }
 
 /**
@@ -75,5 +81,5 @@ export const getFlowConnection = async ({
       'flow_connections.flow_id': flowId ?? null,
     })
 
-  return flowConnection
+  return flowConnection?.connection
 }

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -33,7 +33,7 @@ export const getConnection = async (params: GetConnectionParams) => {
   // so we fetch the role from the flow
   if (flowId && !role) {
     const flow = await context.currentUser
-      .withAccessibleFlows({ requiredRole: 'editor', trx })
+      .withAccessibleFlows({ requiredRole: 'viewer', trx })
       .findOne({ 'flows.id': flowId })
       .throwIfNotFound({ message: 'Flow not found' })
 

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,89 +1,43 @@
-import { IFlowCollabRole } from '@plumber/types'
+import { Transaction } from 'objection'
 
-import { NotFoundError, Transaction } from 'objection'
-
+import FlowConnections from '@/models/flow-connections'
 import Context from '@/types/express/context'
 
 type GetConnectionParams = {
   context: Context
   connectionId: string
   flowId: string
-  requiredRole: IFlowCollabRole
-  role?: IFlowCollabRole
-  trx?: Transaction
-}
-
-type GetFlowConnectionParams = {
-  context: Context
-  connectionId: string
-  flowId: string
-  requiredRole: IFlowCollabRole
+  includeOwnConnections?: boolean
   trx?: Transaction
 }
 
 /**
  * NOTE: with the introduction of collaborators, we use this helper function to fetch the connection
+ * we do not need to check the user's role again here as the role would have been checked
+ * before this function is called
  */
 export const getConnection = async (params: GetConnectionParams) => {
-  const { context, connectionId, role, trx, flowId } = params
-  let userRole = role
+  const { context, connectionId, includeOwnConnections, trx, flowId } = params
 
-  // flowId is only present within the editor, which means we should know the role.
-  // the only time we would not know the role is when the connection is being added to the pipe
-  // so we fetch the role from the flow
-  if (flowId && !role) {
-    const flow = await context.currentUser
-      .withAccessibleFlows({ requiredRole: 'viewer', trx })
-      .findOne({ 'flows.id': flowId })
-      .throwIfNotFound({ message: 'Flow not found' })
-
-    userRole = flow.role
-  }
-
-  // there are two scenarios where we can directly fetch the connection from the user
-  // 1. when flowId is not present, which means the connection is being retrieved from the my apps page
-  // 2. when the user is the owner of the pipe
-  // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
-  // will need to include connections from the flow_connections table
-  if (!flowId || userRole === 'owner') {
-    return context.currentUser
+  if (includeOwnConnections) {
+    // this means that the user is the owner of the pipe
+    // it could be their own connection or a shared connection
+    // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
+    // will need to include connections from the flow_connections table
+    return await context.currentUser
       .$relatedQuery('connections', trx)
       .findOne({ 'connections.id': connectionId })
       .throwIfNotFound({ message: 'Connection not found' })
   }
 
-  /**
-   * NOTE: editor and viewer can only access shared connections from the flow_connections table
-   */
-  const connection = await getFlowConnection(params)
-  if (!connection) {
-    throw new NotFoundError({ message: 'Connection not found' })
-  }
-
-  return connection
-}
-
-/**
- * Gets the connection that has been shared to the flow from the
- * flow_connections table.
- */
-export const getFlowConnection = async ({
-  context,
-  connectionId,
-  flowId,
-  requiredRole,
-  trx,
-}: GetFlowConnectionParams) => {
-  const flowConnection = await context.currentUser
-    .withAccessibleFlowConnections({
-      requiredRole,
-      trx,
+  // NOTE: editor and viewer can only access shared connections from the flow_connections table
+  const flowConnection = await FlowConnections.query(trx)
+    .findOne({
+      connection_id: connectionId,
+      flow_id: flowId,
     })
     .withGraphFetched('connection')
-    .findOne({
-      'flow_connections.connection_id': connectionId,
-      'flow_connections.flow_id': flowId ?? null,
-    })
+    .throwIfNotFound({ message: 'Connection not found' })
 
   return flowConnection?.connection
 }

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,0 +1,79 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import { Transaction } from 'objection'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import Context from '@/types/express/context'
+
+type GetConnectionParams = {
+  context: Context
+  connectionId: string
+  flowId: string
+  requiredRole: IFlowCollabRole
+  trx?: Transaction
+}
+
+type GetFlowConnectionParams = {
+  context: Context
+  connectionId: string
+  flowId: string
+  requiredRole: IFlowCollabRole
+  trx?: Transaction
+}
+
+/**
+ * NOTE: with the introduction of collaborators, we first look for the
+ * connection in the flow_connections table as this would contain all the
+ * connections that have been shared within a pipe.
+ *
+ * However, there may be connections that have not been shared yet
+ * (e.g., when the owner is adding a new connection to the pipe) so
+ * we need to fallback to the direct connection method.
+ */
+export const getConnection = async (params: GetConnectionParams) => {
+  const { context, connectionId, requiredRole, trx } = params
+  let connection
+
+  const flowConnection = await getFlowConnection(params)
+
+  if (flowConnection) {
+    // shared connection
+    connection = flowConnection.connection
+  } else {
+    // connection has not been shared yet
+    connection = await context.currentUser
+      .withAccessibleConnections({ requiredRole, trx })
+      .findOne({ 'connections.id': connectionId })
+  }
+
+  if (!connection) {
+    throw new BadUserInputError('Connection not found')
+  }
+
+  return connection
+}
+
+/**
+ * Gets the connection that has been shared to the flow from the
+ * flow_connections table.
+ */
+export const getFlowConnection = async ({
+  context,
+  connectionId,
+  flowId,
+  requiredRole,
+  trx,
+}: GetFlowConnectionParams) => {
+  const flowConnection = await context.currentUser
+    .withAccessibleFlowConnections({
+      requiredRole,
+      trx,
+    })
+    .withGraphFetched('connection')
+    .findOne({
+      'flow_connections.connection_id': connectionId,
+      'flow_connections.flow_id': flowId ?? null,
+    })
+
+  return flowConnection
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -11,6 +11,7 @@ import {
 
 import InputCreator from '@/components/InputCreator'
 import MarkdownRenderer from '@/components/MarkdownRenderer'
+import { EditorContext } from '@/contexts/Editor'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
 import { getOpenerOrigin } from '@/helpers/window'
@@ -42,6 +43,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
   const { modalState, patchModalState } = useContext(
     FlowStepConfigurationContext,
   )
+  const { flowId } = useContext(EditorContext)
   const { selectedApp } = modalState
   const { name, authDocUrl, key, auth } = selectedApp || {}
 
@@ -129,6 +131,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
       const response: Response = {
         key,
         fields: data,
+        flowId,
       }
 
       let stepIndex = 0
@@ -157,7 +160,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
 
       setInProgress(false)
     },
-    [key, steps, handleAddConnection],
+    [steps, key, flowId, handleAddConnection],
   )
 
   const onBack = () => patchModalState({ currentScreen: 'choose-connection' })

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -113,7 +113,6 @@ type EditorProviderProps = {
  * Helper function to update the flow in the cache
  */
 function updateHandlerFactory(
-  flow: IFlow,
   flowId: string,
   previousStepId: string,
   mutationType: 'createStep' | 'updateStep' = 'createStep',
@@ -121,6 +120,15 @@ function updateHandlerFactory(
   return function stepUpdateHandler(cache: any, mutationResult: any) {
     const { data } = mutationResult
     const stepData = data[mutationType]
+
+    // read the flow from the cache to avoid stale data when creating or updating steps
+    // we read from the cache instead of firing a getFlow query on every update
+    // to reduce the UI flicker
+    // TODO (kevinkim-ogp): should just be able to use the flow from the context
+    const { getFlow: flow } = cache.readQuery({
+      query: GET_FLOW,
+      variables: { id: flowId },
+    })
 
     // getFlow requires certain attributes to be returned
     const completeStep = {
@@ -255,12 +263,7 @@ export const EditorProvider = ({
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(
-          flow,
-          flowId,
-          previousStepId,
-          'createStep',
-        ),
+        update: updateHandlerFactory(flowId, previousStepId, 'createStep'),
       })
 
       const newStep = createdStep.data.createStep
@@ -331,7 +334,7 @@ export const EditorProvider = ({
 
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
+        update: updateHandlerFactory(flowId, step.id, 'updateStep'),
         onCompleted: () => onCompleted?.(),
       })
 


### PR DESCRIPTION
### TL;DR

Allow editors to create new steps with Owner connections.

### What changed?

- Modified the `createStep` mutation to allow editors to create steps using connections owned by the flow owner
- Added logic to check if the editor has access to the connection through the flow
- Added a test case to verify that editors can create steps with owner connections

**Additional change**
- Adds new connections to `flow_connections` if the Pipe has collaborators

### How to test?
First, create a NEW Pipe as an owner and add steps with connections, and add an Editor. (or use the same Pipe from the previous PR)
Then, login as an Editor and make sure the following works:
- [ ] Add new Step that requires connection
  - [ ] Connections that were shared by the Owner can be selected and used
  - [ ] Editor should not see own connections in the dropdown
  - [ ] Editor should not be able to add new connections
- [ ] Verify that the step is created and tested successfully with the connection

Adding new connection
- [ ] New connection added to `flow_connections` if Pipe has collaborators
  - [ ] Adds for FormSG
  - [ ] Adds for other connections such as Slack or Telegram