### PR TITLE
[COLLAB-15]: Collaborators can view executions

### DIFF
--- a/packages/backend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-execution-steps.ts
@@ -11,7 +11,7 @@ const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
 ) => {
   const execution = await context.currentUser
     .withAccessibleExecutions({ requiredRole: 'viewer' })
-    .join('execution_steps', 'execution_steps.execution_id', 'executions.id')
+    .withGraphFetched({ executionSteps: true })
     .withSoftDeleted()
     .findById(params.executionId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-execution-steps.ts
@@ -10,7 +10,8 @@ const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
   context,
 ) => {
   const execution = await context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
+    .join('execution_steps', 'execution_steps.execution_id', 'executions.id')
     .withSoftDeleted()
     .findById(params.executionId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/queries/get-execution.ts
+++ b/packages/backend/src/graphql/queries/get-execution.ts
@@ -6,7 +6,7 @@ const getExecution: QueryResolvers['getExecution'] = async (
   context,
 ) => {
   const execution = await context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
     .withGraphFetched({
       flow: {
         steps: true,

--- a/packages/backend/src/graphql/queries/get-executions.ts
+++ b/packages/backend/src/graphql/queries/get-executions.ts
@@ -11,7 +11,7 @@ const getExecutions: QueryResolvers['getExecutions'] = async (
 ) => {
   const filterBuilder = (builder: ExtendedQueryBuilder<Execution>) => {
     builder.where('test_run', false)
-    builder.where('flow_id', params.flowId)
+    builder.where('executions.flow_id', params.flowId)
 
     // null status means waiting
     if (params.status === null) {
@@ -22,7 +22,7 @@ const getExecutions: QueryResolvers['getExecutions'] = async (
   }
 
   const executionsQuery = context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
     .withGraphFetched({
       executionSteps: true,
     })

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -286,6 +286,27 @@ class User extends Base {
       .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
       .join('flows', 'flows.id', 'flow_connections.flow_id')
 
+    if (requiredRole) {
+      this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    }
+    return baseQuery
+  }
+
+  withAccessibleExecutions({
+    requiredRole,
+    queryBuilder,
+    trx,
+  }: {
+    requiredRole: IFlowCollabRole
+    queryBuilder?: ExtendedQueryBuilder<Execution, Execution[]>
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || Execution.query(trx)
+    baseQuery
+      .select('executions.*', Execution.raw(ROLE_STMT, [userId]))
+      .join('flows', 'flows.id', 'executions.flow_id')
+
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
     return baseQuery
   }


### PR DESCRIPTION
### TL;DR

Allow collaborators to view executions.

### What changed?
- Modified the `User` model to support access control for executions by extending the `withAccessible` method to handle the 'executions' type
- Updated GraphQL query resolvers `getExecution`, `getExecutions`, and `getExecutionSteps` to use the new access control mechanism

### How to test?
- [ ] Owner can view executions
- [ ] Editor can view executions
- [ ] Viewer can view executions