### PR TITLE
PLU-553: SSRF dns rebinding

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request-interceptors.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request-interceptors.test.ts
@@ -8,8 +8,8 @@ import app from '../..'
 import makeRequestAction from '../../actions/http-request'
 import {
   DISALLOWED_IP_RESOLVED_ERROR,
-  RECURSIVE_WEBHOOK_ERROR_NAME,
-} from '../../common/check-urls'
+  RECURSIVE_WEBHOOK_ERROR,
+} from '../../common/constants'
 
 const CF_REDIRECTION_WORKER_FOR_UNIT_TESTS =
   'https://http-request-unit-tester.plumber-wrench.workers.dev'
@@ -68,7 +68,7 @@ describe('http request interceptors', () => {
     $.step.parameters.method = 'GET'
     $.step.parameters.url = url
     await expect(makeRequestAction.run($)).rejects.toThrowError(
-      RECURSIVE_WEBHOOK_ERROR_NAME,
+      RECURSIVE_WEBHOOK_ERROR,
     )
   })
 
@@ -118,7 +118,7 @@ describe('http request interceptors', () => {
         redirectTo: url,
       })
       await expect(makeRequestAction.run($)).rejects.toThrowError(
-        RECURSIVE_WEBHOOK_ERROR_NAME,
+        RECURSIVE_WEBHOOK_ERROR,
       )
     })
 
@@ -128,7 +128,7 @@ describe('http request interceptors', () => {
       'http://localhost:3001',
       'http://127.0.0.1:8080',
       'http://192.168.0.1',
-    ])('should prevent internal IPs', async (url: string) => {
+    ])('should prevent internal IPs during redirects', async (url: string) => {
       $.step.parameters.method = 'POST'
       $.step.parameters.data = JSON.stringify({
         statusCode: 307,

--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -9,10 +9,10 @@ import StepError from '@/errors/step'
 import app from '../..'
 import makeRequestAction from '../../actions/http-request'
 import {
+  CUSTOM_API_TIMEOUT,
   DISALLOWED_IP_RESOLVED_ERROR,
-  RECURSIVE_WEBHOOK_ERROR_NAME,
-} from '../../common/check-urls'
-import { CUSTOM_API_TIMEOUT } from '../../common/constants'
+  RECURSIVE_WEBHOOK_ERROR,
+} from '../../common/constants'
 
 const mocks = vi.hoisted(() => ({
   httpRequest: vi.fn(),
@@ -22,9 +22,13 @@ const mocks = vi.hoisted(() => ({
   })),
 }))
 
-vi.mock('../../common/ip-resolver', () => ({
-  isUrlAllowed: mocks.isUrlAllowed,
-}))
+vi.mock('../../common/ip-resolver', () => {
+  const originalModule = vi.importActual('../../common/ip-resolver')
+  return {
+    ...originalModule,
+    safeAxiosLookup: mocks.isUrlAllowed,
+  }
+})
 
 vi.mock('@/models/step', () => ({
   default: {
@@ -68,7 +72,6 @@ describe('make http request', () => {
     $.step.parameters.data = 'meep meep'
     $.step.parameters.url = 'http://test.local/endpoint?1234'
     mocks.httpRequest.mockReturnValue('mock response')
-
     await makeRequestAction.run($).catch((): void => null)
     expect(mocks.httpRequest).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -227,7 +230,7 @@ describe('make http request', () => {
     $.step.parameters.method = 'GET'
     $.step.parameters.data = 'go crazy'
     $.step.parameters.url = 'http://beta.plumber.gov.sg'
-    const recursiveWebhookError = new Error(RECURSIVE_WEBHOOK_ERROR_NAME)
+    const recursiveWebhookError = new Error(RECURSIVE_WEBHOOK_ERROR)
     mocks.httpRequest.mockRejectedValueOnce(recursiveWebhookError)
     await expect(makeRequestAction.run($)).rejects.toThrowError(StepError)
   })

--- a/packages/backend/src/apps/custom-api/__tests__/common/ip-resolver.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/common/ip-resolver.test.ts
@@ -5,25 +5,19 @@ import { getIpFromHostname, isIpAllowed } from '../../common/ip-resolver'
 describe('IP resolvers', () => {
   describe('Get IP Async', () => {
     it('should be able to get ip address from urls with path', async () => {
-      const ip = await getIpFromHostname('https://mock.codes/200')
+      const ip = await getIpFromHostname('mock.codes')
       expect(ip).toBeDefined()
     })
 
-    it('should be able to get ip address from urls with subdomains, query params and port', async () => {
-      const ip = await getIpFromHostname(
-        'https://staging.plumber.gov.sg:443/webhooks/123?test=123',
+    it('should be able to get ip address from urls with subdomains', async () => {
+      const ip = await getIpFromHostname('staging.plumber.gov.sg')
+      expect(ip).toBeDefined()
+    })
+
+    it('should not be able to get ip address from ip', async () => {
+      await expect(getIpFromHostname(' 127.0.0.1')).rejects.toThrowError(
+        'Unable to resolve IP address for  127.0.0.1',
       )
-      expect(ip).toBeDefined()
-    })
-
-    it('should be able to get ip address from ip', async () => {
-      const ip = await getIpFromHostname('https://127.0.0.1')
-      expect(ip).toBe('127.0.0.1')
-    })
-
-    it('should be able to get ip address from ip', async () => {
-      const ip = await getIpFromHostname('https://1.1.1.1:443/test')
-      expect(ip).toBe('1.1.1.1')
     })
   })
 
@@ -34,6 +28,7 @@ describe('IP resolvers', () => {
       expect(isIpAllowed('172.31.0.1')).toBe(false)
       expect(isIpAllowed('127.0.0.1')).toBe(false)
       expect(isIpAllowed('192.168.0.1')).toBe(false)
+      expect(isIpAllowed('169.254.170.2')).toBe(false)
     })
 
     it('should result false for reserved/private IPv6s', () => {

--- a/packages/backend/src/apps/custom-api/__tests__/common/ip-resolver.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/common/ip-resolver.test.ts
@@ -1,28 +1,28 @@
 import { describe, expect, it } from 'vitest'
 
-import { getIpFromUrl, isIpAllowed } from '../../common/ip-resolver'
+import { getIpFromHostname, isIpAllowed } from '../../common/ip-resolver'
 
 describe('IP resolvers', () => {
   describe('Get IP Async', () => {
     it('should be able to get ip address from urls with path', async () => {
-      const ip = await getIpFromUrl('https://mock.codes/200')
+      const ip = await getIpFromHostname('https://mock.codes/200')
       expect(ip).toBeDefined()
     })
 
     it('should be able to get ip address from urls with subdomains, query params and port', async () => {
-      const ip = await getIpFromUrl(
+      const ip = await getIpFromHostname(
         'https://staging.plumber.gov.sg:443/webhooks/123?test=123',
       )
       expect(ip).toBeDefined()
     })
 
     it('should be able to get ip address from ip', async () => {
-      const ip = await getIpFromUrl('https://127.0.0.1')
+      const ip = await getIpFromHostname('https://127.0.0.1')
       expect(ip).toBe('127.0.0.1')
     })
 
     it('should be able to get ip address from ip', async () => {
-      const ip = await getIpFromUrl('https://1.1.1.1:443/test')
+      const ip = await getIpFromHostname('https://1.1.1.1:443/test')
       expect(ip).toBe('1.1.1.1')
     })
   })

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -7,10 +7,13 @@ import StepError, { GenericSolution } from '@/errors/step'
 import Step from '@/models/step'
 
 import {
+  CUSTOM_API_TIMEOUT,
   DISALLOWED_IP_RESOLVED_ERROR,
-  RECURSIVE_WEBHOOK_ERROR_NAME,
-} from '../../common/check-urls'
-import { CUSTOM_API_TIMEOUT } from '../../common/constants'
+  INVALID_PROTOCOL_ERROR,
+  INVALID_URL_ERROR,
+  RECURSIVE_WEBHOOK_ERROR,
+} from '../../common/constants'
+import { getIpFromHostname, isIpAllowed } from '../../common/ip-resolver'
 
 import { requestSchema } from './schema'
 
@@ -119,6 +122,16 @@ const action: IRawAction = {
         data: parsedData,
         maxRedirects: 0,
         headers: customHeaders,
+        // Prevent calling of internal IPs, e.g. aws metadata endpoint
+        lookup(hostname, _, cb) {
+          return getIpFromHostname(hostname).then((ip: string) => {
+            if (!isIpAllowed(ip)) {
+              cb(new Error(DISALLOWED_IP_RESOLVED_ERROR), null)
+              return
+            }
+            cb(null, ip)
+          })
+        },
         timeout,
         //  overwriting this to allow redirects to resolve
         validateStatus: (status) =>
@@ -166,18 +179,25 @@ const action: IRawAction = {
         )
       }
 
-      if (err.message === RECURSIVE_WEBHOOK_ERROR_NAME) {
+      if (err.message === RECURSIVE_WEBHOOK_ERROR) {
         throw new StepError(
-          RECURSIVE_WEBHOOK_ERROR_NAME,
+          RECURSIVE_WEBHOOK_ERROR,
           'Ensure that you are not redirecting back to a plumber URL.',
           $.step.position,
           $.app.name,
         )
       }
 
-      if (err.message === DISALLOWED_IP_RESOLVED_ERROR) {
-        throw new StepError(
+      if (
+        [
           DISALLOWED_IP_RESOLVED_ERROR,
+          INVALID_URL_ERROR,
+          INVALID_PROTOCOL_ERROR,
+          INVALID_PROTOCOL_ERROR,
+        ].includes(err.message)
+      ) {
+        throw new StepError(
+          err.message,
           'If you think this is a mistake, please contact us.',
           $.step.position,
           $.app.name,

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -13,7 +13,7 @@ import {
   INVALID_URL_ERROR,
   RECURSIVE_WEBHOOK_ERROR,
 } from '../../common/constants'
-import { getIpFromHostname, isIpAllowed } from '../../common/ip-resolver'
+import { safeAxiosLookup } from '../../common/ip-resolver'
 
 import { requestSchema } from './schema'
 
@@ -123,15 +123,7 @@ const action: IRawAction = {
         maxRedirects: 0,
         headers: customHeaders,
         // Prevent calling of internal IPs, e.g. aws metadata endpoint
-        lookup(hostname, _, cb) {
-          return getIpFromHostname(hostname).then((ip: string) => {
-            if (!isIpAllowed(ip)) {
-              cb(new Error(DISALLOWED_IP_RESOLVED_ERROR), null)
-              return
-            }
-            cb(null, ip)
-          })
-        },
+        lookup: safeAxiosLookup,
         timeout,
         //  overwriting this to allow redirects to resolve
         validateStatus: (status) =>
@@ -157,6 +149,9 @@ const action: IRawAction = {
           method:
             response.status === 301 || response.status === 302 ? 'GET' : method,
           data,
+          // Prevent calling of internal IPs, e.g. aws metadata endpoint
+          lookup: safeAxiosLookup,
+          headers: customHeaders,
           maxRedirects: 0,
         })
       }
@@ -192,7 +187,6 @@ const action: IRawAction = {
         [
           DISALLOWED_IP_RESOLVED_ERROR,
           INVALID_URL_ERROR,
-          INVALID_PROTOCOL_ERROR,
           INVALID_PROTOCOL_ERROR,
         ].includes(err.message)
       ) {

--- a/packages/backend/src/apps/custom-api/common/check-urls.ts
+++ b/packages/backend/src/apps/custom-api/common/check-urls.ts
@@ -1,24 +1,45 @@
 import { TBeforeRequest } from '@plumber/types'
 
-import { isUrlAllowed } from './ip-resolver'
+import { isIP } from 'net'
 
-export const RECURSIVE_WEBHOOK_ERROR_NAME =
-  'Recursively invoking Plumber webhooks is prohibited.'
+import logger from '@/helpers/logger'
 
-export const DISALLOWED_IP_RESOLVED_ERROR =
-  'The URL you are trying to call is not allowed.'
+import {
+  DISALLOWED_IP_RESOLVED_ERROR,
+  INVALID_URL_ERROR,
+  RECURSIVE_WEBHOOK_ERROR,
+} from './constants'
+import { isIpAllowed } from './ip-resolver'
 
 const checkUrls: TBeforeRequest = async ($, requestConfig) => {
   // Prohibit calling ourselves to prevent self-DoS.
   if (requestConfig.baseURL.toLowerCase().endsWith('plumber.gov.sg')) {
-    throw new Error(RECURSIVE_WEBHOOK_ERROR_NAME)
+    throw new Error(RECURSIVE_WEBHOOK_ERROR)
   }
 
-  // Prevent calling of internal IPs, e.g. aws metadata endpoint
-  if (!(await isUrlAllowed(requestConfig.baseURL))) {
+  let url
+  try {
+    url = new URL(requestConfig.baseURL)
+  } catch (e) {
+    throw new Error(INVALID_URL_ERROR)
+  }
+
+  // Not confident that this will not break pipes yet, so logging it for now
+  if (url.protocol !== 'https:') {
+    logger.warn('Non https url found', {
+      url: requestConfig.baseURL,
+      executionId: $.execution?.id,
+      flowId: $.flow?.id,
+      stepId: $.step?.id,
+    })
+  }
+
+  /**
+   * If hostname is IP, dns lookup will not be called so we check for forbidden IPs here as well
+   */
+  if (isIP(url.hostname) > 0 && !isIpAllowed(url.hostname)) {
     throw new Error(DISALLOWED_IP_RESOLVED_ERROR)
   }
-
   return requestConfig
 }
 

--- a/packages/backend/src/apps/custom-api/common/constants.ts
+++ b/packages/backend/src/apps/custom-api/common/constants.ts
@@ -1,2 +1,13 @@
 // Custom API Timeout
 export const CUSTOM_API_TIMEOUT = 1000 * 60 // in milliseconds
+
+export const RECURSIVE_WEBHOOK_ERROR =
+  'Recursively invoking Plumber webhooks is prohibited.'
+
+export const INVALID_PROTOCOL_ERROR =
+  'Please ensure your URL starts with https://.'
+
+export const INVALID_URL_ERROR = 'The URL you are trying to call is invalid.'
+
+export const DISALLOWED_IP_RESOLVED_ERROR =
+  'The URL you are trying to call is not allowed.'

--- a/packages/backend/src/apps/custom-api/common/ip-resolver.ts
+++ b/packages/backend/src/apps/custom-api/common/ip-resolver.ts
@@ -1,6 +1,8 @@
 import dns from 'dns'
 import ipaddr from 'ipaddr.js'
 
+import { DISALLOWED_IP_RESOLVED_ERROR } from './constants'
+
 export async function getIpFromHostname(hostname: string) {
   try {
     const { address } = await dns.promises.lookup(hostname)
@@ -29,4 +31,15 @@ export function isIpAllowed(ip: string) {
 
   // only allow unicast ips
   return ipRangeLabel === 'unicast'
+}
+
+export async function safeAxiosLookup(
+  hostname: string,
+  _options: object,
+): Promise<string> {
+  const ip = await getIpFromHostname(hostname)
+  if (!isIpAllowed(ip)) {
+    throw new Error(DISALLOWED_IP_RESOLVED_ERROR)
+  }
+  return ip
 }

--- a/packages/backend/src/apps/custom-api/common/ip-resolver.ts
+++ b/packages/backend/src/apps/custom-api/common/ip-resolver.ts
@@ -1,13 +1,12 @@
 import dns from 'dns'
 import ipaddr from 'ipaddr.js'
 
-export async function getIpFromUrl(url: string) {
+export async function getIpFromHostname(hostname: string) {
   try {
-    const { hostname } = new URL(url)
     const { address } = await dns.promises.lookup(hostname)
     return address
   } catch (e) {
-    throw new Error(`Unable to resolve IP address for ${url}`)
+    throw new Error(`Unable to resolve IP address for ${hostname}`)
   }
 }
 
@@ -30,13 +29,4 @@ export function isIpAllowed(ip: string) {
 
   // only allow unicast ips
   return ipRangeLabel === 'unicast'
-}
-
-export async function isUrlAllowed(url: string): Promise<boolean> {
-  try {
-    const ip = await getIpFromUrl(url)
-    return isIpAllowed(ip)
-  } catch (e) {
-    return false
-  }
 }

--- a/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
@@ -103,7 +103,7 @@ describe('dynamodb table row functions', () => {
           )
         }
         await createTableRows({ tableId: dummyTable.id, dataArray })
-      })
+      }, 20000)
       it(
         'should be able to paginate and get a large number of rows',
         {


### PR DESCRIPTION
## Address VAPT issue

- Moves check of valid IP address to DNS lookup callback of axios
- Also checks for valid IP if the url is already an IP (in this case, the lookup function wont be called)
- (optional) logs when a non-https url is called