### PR TITLE
PLU-542: Reordering columns in Tile affects for-each output

### DIFF
--- a/packages/backend/src/apps/formsg/common/process-table-field.ts
+++ b/packages/backend/src/apps/formsg/common/process-table-field.ts
@@ -10,9 +10,11 @@ type TableColumn = {
 }
 
 const createColumn = (label: string, index: number): TableColumn => {
-  const id = Buffer.from(label).toString('hex')
+  const id = Buffer.from(`Col ${index + 1}`).toString('hex')
   return {
-    id: Buffer.from(`Col ${index + 1}`).toString('hex'),
+    // NOTE: we keep this ID so that it still works even if the user tested
+    // the step with mock data previously
+    id,
     label,
     name: label,
     value: `data.rows.*.data.${id}`,

--- a/packages/backend/src/apps/formsg/common/process-table-field.ts
+++ b/packages/backend/src/apps/formsg/common/process-table-field.ts
@@ -9,10 +9,10 @@ type TableColumn = {
   value: string
 }
 
-const createColumn = (label: string): TableColumn => {
+const createColumn = (label: string, index: number): TableColumn => {
   const id = Buffer.from(label).toString('hex')
   return {
-    id,
+    id: Buffer.from(`Col ${index + 1}`).toString('hex'),
     label,
     name: label,
     value: `data.rows.*.data.${id}`,
@@ -29,8 +29,10 @@ export default function convertTableAnswerArrayToTableObject(
   const columns =
     // make sure that column names do not contain commas
     columnNamesArray.length === answerArray[0].length
-      ? columnNamesArray.map(createColumn)
-      : answerArray[0].map((_, index) => createColumn(`Col ${index + 1}`))
+      ? columnNamesArray.map((column, index) => createColumn(column, index))
+      : answerArray[0].map((_, index) =>
+          createColumn(`Col ${index + 1}`, index),
+        )
 
   /**
    * NOTE: we do not show table rows that do not have any data

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -17,7 +17,7 @@ import { dataOutSchema, parametersSchema } from './schemas'
 type DataOut = z.infer<typeof dataOutSchema>
 
 const action: IRawAction = {
-  name: 'Find table rows',
+  name: 'Find multiple table rows',
   key: 'getTableRows',
   description: 'Gets multiple rows of data from your Excel table',
   isNew: true,

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -252,7 +252,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData, 'array')
+      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -289,7 +289,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(excelData, 'array')
+      expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -321,7 +321,7 @@ describe('For each action', () => {
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(VALID_TABLE_DATA, 'array')
+      expect(mockedProcessItems).toHaveBeenCalledWith(VALID_TABLE_DATA)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -359,10 +359,7 @@ describe('For each action', () => {
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(
-        mockTableFieldData,
-        'array',
-      )
+      expect(mockedProcessItems).toHaveBeenCalledWith(mockTableFieldData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -450,10 +447,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(
-        VALID_TABLE_DATA,
-        'object',
-      )
+      expect(mockedProcessItems).toHaveBeenCalledWith(VALID_TABLE_DATA)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -490,7 +484,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(excelData, 'object')
+      expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -558,10 +552,7 @@ describe('For each action', () => {
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(
-        VALID_TABLE_DATA,
-        'object',
-      )
+      expect(mockedProcessItems).toHaveBeenCalledWith(VALID_TABLE_DATA)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -595,10 +586,7 @@ describe('For each action', () => {
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(
-        mockTableFieldData,
-        'object',
-      )
+      expect(mockedProcessItems).toHaveBeenCalledWith(mockTableFieldData)
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/index.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   isCheckboxItems,
+  ProcessedColumn,
   processItems,
 } from '@/apps/toolbox/common/get-for-each-variables'
 import StepError from '@/errors/step'
@@ -53,6 +54,38 @@ const MOCK_FLOW = [
   },
 ]
 
+const VALID_TABLE_DATA = {
+  rows: [
+    {
+      data: {
+        col1: 'value1',
+        col2: 'value2',
+      },
+      rowId: 'row-1',
+    },
+    {
+      data: {
+        col1: 'value3',
+        col2: 'value4',
+      },
+      rowId: 'row-2',
+    },
+  ],
+  columns: [
+    {
+      id: 'col1',
+      name: 'Column 1',
+      value: 'col1-value',
+    },
+    {
+      id: 'col2',
+      name: 'Column 2',
+      value: 'col2-value',
+    },
+  ],
+  inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+}
+
 describe('For each action', () => {
   let $: IGlobalVariable
 
@@ -77,6 +110,7 @@ describe('For each action', () => {
       execution: {
         testRun: false,
       },
+      getLastExecutionStep: vi.fn(),
       setActionItem: mocks.setActionItem,
     } as unknown as IGlobalVariable
   })
@@ -165,7 +199,7 @@ describe('For each action', () => {
     })
   })
 
-  describe('table input', () => {
+  describe('table input - backward compatibility with the old dataOut format', () => {
     const validTableData = {
       rows: [
         {
@@ -198,8 +232,15 @@ describe('For each action', () => {
       inputSource: FOR_EACH_INPUT_SOURCE.TILES,
     }
 
+    const DATA_OUT = {
+      dataOut: {
+        items: validTableData,
+      },
+    }
+
     it('should handle valid table input (Tiles)', async () => {
       $.step.parameters.items = validTableData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
 
       const processedResult = {
         rows: validTableData.rows,
@@ -211,7 +252,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
+      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData, 'array')
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -236,6 +277,7 @@ describe('For each action', () => {
       }
 
       $.step.parameters.items = excelData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
 
       const processedResult = {
         rows: excelData.rows,
@@ -247,7 +289,7 @@ describe('For each action', () => {
 
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(excelData)
+      expect(mockedProcessItems).toHaveBeenCalledWith(excelData, 'array')
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -266,19 +308,20 @@ describe('For each action', () => {
     })
 
     it('should handle valid table input (FormSG Table field)', async () => {
-      const mockTableFieldData = JSON.stringify(validTableData)
+      const mockTableFieldData = JSON.stringify(VALID_TABLE_DATA)
       $.step.parameters.items = mockTableFieldData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
 
       const processedResult = {
-        rows: validTableData.rows,
-        columns: validTableData.columns,
+        rows: VALID_TABLE_DATA.rows,
+        columns: VALID_TABLE_DATA.columns,
         inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
       }
 
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(validTableData)
+      expect(mockedProcessItems).toHaveBeenCalledWith(VALID_TABLE_DATA, 'array')
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -298,20 +341,28 @@ describe('For each action', () => {
     it('should handle FormSG Table field with no row data', async () => {
       const mockTableFieldData = {
         rows: [] as any[],
-        columns: validTableData.columns,
+        columns: VALID_TABLE_DATA.columns,
       }
       const stringifiedTableFieldData = JSON.stringify(mockTableFieldData)
 
       $.step.parameters.items = stringifiedTableFieldData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce({
+        dataOut: {
+          items: mockTableFieldData,
+        },
+      })
       const processedResult = {
         rows: [] as any[],
-        columns: validTableData.columns,
+        columns: VALID_TABLE_DATA.columns,
         inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
       }
       mockedProcessItems.mockReturnValue(processedResult)
       const result = await action.run($)
 
-      expect(mockedProcessItems).toHaveBeenCalledWith(mockTableFieldData)
+      expect(mockedProcessItems).toHaveBeenCalledWith(
+        mockTableFieldData,
+        'array',
+      )
       expect(mocks.setActionItem).toHaveBeenCalledWith({
         raw: {
           iteration: FOR_EACH_ITERATION_KEY,
@@ -354,6 +405,206 @@ describe('For each action', () => {
           iterations: 0,
           items: processedResult,
           inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'stop-execution',
+          stepId: 'for-each',
+        },
+      })
+    })
+  })
+
+  describe('table input - new dataOut format', () => {
+    const newColumns = {} as Record<string, ProcessedColumn>
+    VALID_TABLE_DATA.columns.forEach((column, index) => {
+      newColumns[column.id] = {
+        ...column,
+        value: `data.columns.${column.id}`,
+        order: index + 1,
+      }
+    })
+
+    const DATA_OUT = {
+      dataOut: {
+        items: {
+          ...VALID_TABLE_DATA,
+          columns: newColumns,
+        },
+      },
+    }
+
+    it('should handle valid table input (Tiles)', async () => {
+      $.step.parameters.items = VALID_TABLE_DATA
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
+
+      const processedResult = {
+        rows: VALID_TABLE_DATA.rows,
+        columns: newColumns,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      const result = await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(
+        VALID_TABLE_DATA,
+        'object',
+      )
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
+          iterations: 2,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+        },
+      })
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle valid table input (M365 Excel)', async () => {
+      const excelData = {
+        ...VALID_TABLE_DATA,
+        rows: VALID_TABLE_DATA.rows.map((row) => ({ data: row.data })), // No rowId for Excel
+        inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+      }
+
+      $.step.parameters.items = excelData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
+
+      const processedResult = {
+        rows: excelData.rows,
+        columns: newColumns,
+        inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      const result = await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(excelData, 'object')
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
+          iterations: 2,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle table input with empty rows', async () => {
+      const emptyTableData = {
+        rows: [] as any[],
+        columns: VALID_TABLE_DATA.columns,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+      }
+
+      $.step.parameters.items = emptyTableData
+
+      const processedResult = {
+        rows: [] as any[],
+        columns: newColumns,
+        inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+
+      const result = await action.run($)
+
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
+          iterations: 0,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+        },
+      })
+
+      expect(result).toEqual({
+        nextStep: {
+          command: 'stop-execution',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle valid table input (FormSG Table field)', async () => {
+      const mockTableFieldData = JSON.stringify(VALID_TABLE_DATA)
+      $.step.parameters.items = mockTableFieldData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
+
+      const processedResult = {
+        rows: VALID_TABLE_DATA.rows,
+        columns: newColumns,
+        inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
+      }
+
+      mockedProcessItems.mockReturnValue(processedResult)
+      const result = await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(
+        VALID_TABLE_DATA,
+        'object',
+      )
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
+          iterations: 2,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
+        },
+      })
+      expect(result).toEqual({
+        nextStep: {
+          command: 'start-for-each',
+          stepId: 'for-each',
+        },
+      })
+    })
+
+    it('should handle FormSG Table field with no row data', async () => {
+      const mockTableFieldData = {
+        rows: [] as any[],
+        columns: VALID_TABLE_DATA.columns,
+      }
+      const stringifiedTableFieldData = JSON.stringify(mockTableFieldData)
+
+      $.step.parameters.items = stringifiedTableFieldData
+      $.getLastExecutionStep = vi.fn().mockResolvedValueOnce(DATA_OUT)
+      const processedResult = {
+        rows: [] as any[],
+        columns: newColumns,
+        inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
+      }
+      mockedProcessItems.mockReturnValue(processedResult)
+      const result = await action.run($)
+
+      expect(mockedProcessItems).toHaveBeenCalledWith(
+        mockTableFieldData,
+        'object',
+      )
+      expect(mocks.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          iteration: FOR_EACH_ITERATION_KEY,
+          iterations: 0,
+          items: processedResult,
+          inputSource: FOR_EACH_INPUT_SOURCE.FORMSG_TABLE,
         },
       })
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/get-for-each-variables.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-for-each-variables.test.ts
@@ -55,7 +55,7 @@ describe('get-for-each-variables', () => {
     })
   })
 
-  describe('processItems - backward compatibility with the old dataOut format', () => {
+  describe('processItems', () => {
     it('should process tiles data (with UUID column IDs)', () => {
       const col1Id = randomUUID()
       const col2Id = randomUUID()
@@ -83,30 +83,42 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual(mockData.rows)
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
           order: 1,
         },
-        {
+        '1': {
           id: col2Id,
           name: 'Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
           order: 2,
         },
-        {
+        [col1Id]: {
+          id: col1Id,
+          name: 'Column 1',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
+        },
+        [col2Id]: {
+          id: col2Id,
+          name: 'Column 2',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+          order: 2,
+        },
+        rowId: {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
           order: 3,
         },
-      ])
+      })
     })
 
     it('should process tiles data (with ULID column IDs)', () => {
@@ -130,30 +142,42 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual(mockData.rows)
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
           order: 1,
         },
-        {
+        '1': {
           id: col2Id,
           name: 'Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
           order: 2,
         },
-        {
+        [col1Id]: {
+          id: col1Id,
+          name: 'Column 1',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
+        },
+        [col2Id]: {
+          id: col2Id,
+          name: 'Column 2',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+          order: 2,
+        },
+        rowId: {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
           order: 3,
         },
-      ])
+      })
     })
 
     it('should process m365-excel data (with regular column IDs)', () => {
@@ -187,24 +211,36 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual(mockData.rows)
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: 'col1',
           name: 'Excel Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
           order: 1,
         },
-        {
+        '1': {
           id: 'col2',
           name: 'Excel Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col2`,
           order: 2,
         },
-      ])
+        col1: {
+          id: 'col1',
+          name: 'Excel Column 1',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+          order: 1,
+        },
+        col2: {
+          id: 'col2',
+          name: 'Excel Column 2',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col2`,
+          order: 2,
+        },
+      })
     })
 
     it('should handle empty tiles rows', () => {
@@ -217,24 +253,30 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual([])
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
           order: 1,
         },
-        {
+        [col1Id]: {
+          id: col1Id,
+          name: 'Column 1',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
+        },
+        rowId: {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
           order: 2,
         },
-      ])
+      })
     })
 
     it('should handle empty rows', () => {
@@ -246,18 +288,24 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual([])
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: 'col1',
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
           order: 1,
         },
-      ])
+        col1: {
+          id: 'col1',
+          name: 'Column 1',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+          order: 1,
+        },
+      })
     })
 
     it('should handle empty columns', () => {
@@ -272,11 +320,11 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual(mockData.rows)
-      expect(result.columns).toEqual([])
+      expect(result.columns).toEqual({})
     })
 
     it('should handle single row with UUID column', () => {
@@ -300,23 +348,29 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-      expect(result.columns).toEqual([
-        {
+      expect(result.columns).toEqual({
+        '0': {
           id: colId,
           name: 'Single Column',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${colId}`,
           order: 1,
         },
-        {
+        [colId]: {
+          id: colId,
+          name: 'Single Column',
+          value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${colId}`,
+          order: 1,
+        },
+        rowId: {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
           order: 2,
         },
-      ])
+      })
     })
 
     it('should handle empty rows and columns', () => {
@@ -325,289 +379,11 @@ describe('get-for-each-variables', () => {
         columns: [] as any[],
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
-      const result = processItems(mockData, 'array')
+      const result = processItems(mockData)
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual([])
-      expect(result.columns).toEqual([])
+      expect(result.columns).toEqual({})
     })
-  })
-})
-
-describe('processItems - new dataOut format that can handle column reoder', () => {
-  it('should process tiles data (with UUID column IDs)', () => {
-    const col1Id = randomUUID()
-    const col2Id = randomUUID()
-    const mockData = {
-      rows: [
-        {
-          data: {
-            [col1Id]: 'Value 1',
-            [col2Id]: 'Value 2',
-          },
-          rowId: randomUUID(),
-        },
-        {
-          data: {
-            [col1Id]: 3,
-            [col2Id]: 4,
-          },
-          rowId: randomUUID(),
-        },
-      ],
-      columns: [
-        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
-        { id: col2Id, name: 'Column 2', value: `data.rows.*.data.${col2Id}` },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-    expect(result.rows).toEqual(mockData.rows)
-    expect(result.columns).toEqual({
-      [col1Id]: {
-        id: col1Id,
-        name: 'Column 1',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
-        order: 1,
-      },
-      [col2Id]: {
-        id: col2Id,
-        name: 'Column 2',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
-        order: 2,
-      },
-      rowId: {
-        id: 'rowId',
-        name: 'Row ID',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-        order: 3,
-      },
-    })
-  })
-
-  it('should process tiles data (with ULID column IDs)', () => {
-    // ULID format: 26 characters, base32 encoded
-    const col1Id = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
-    const col2Id = '01BX5ZZKBKACTAV9WEVGEMMVS0'
-    const mockData = {
-      rows: [
-        {
-          data: {
-            [col1Id]: 'Value 1',
-            [col2Id]: 'Value 2',
-          },
-          rowId: '01ARZ3NDEKTSV4RRFFQ69G5FAX',
-        },
-      ],
-      columns: [
-        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
-        { id: col2Id, name: 'Column 2', value: `data.rows.*.data.${col2Id}` },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-    expect(result.rows).toEqual(mockData.rows)
-    expect(result.columns).toEqual({
-      [col1Id]: {
-        id: col1Id,
-        name: 'Column 1',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
-        order: 1,
-      },
-      [col2Id]: {
-        id: col2Id,
-        name: 'Column 2',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
-        order: 2,
-      },
-      rowId: {
-        id: 'rowId',
-        name: 'Row ID',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-        order: 3,
-      },
-    })
-  })
-
-  it('should process m365-excel data (with regular column IDs)', () => {
-    const mockData = {
-      rows: [
-        {
-          data: {
-            col1: 1,
-            col2: 2,
-          },
-        },
-        {
-          data: {
-            col1: 'Excel Value 3',
-            col2: 'Excel Value 4',
-          },
-        },
-      ],
-      columns: [
-        {
-          id: 'col1',
-          name: 'Excel Column 1',
-          value: `data.rows.*.data.col1`,
-        },
-        {
-          id: 'col2',
-          name: 'Excel Column 2',
-          value: `data.rows.*.data.col2`,
-        },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
-    expect(result.rows).toEqual(mockData.rows)
-    expect(result.columns).toEqual({
-      col1: {
-        id: 'col1',
-        name: 'Excel Column 1',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
-        order: 1,
-      },
-      col2: {
-        id: 'col2',
-        name: 'Excel Column 2',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col2`,
-        order: 2,
-      },
-    })
-  })
-
-  it('should handle empty tiles rows', () => {
-    const col1Id = randomUUID()
-    const mockData = {
-      rows: [] as any[],
-      columns: [
-        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-    expect(result.rows).toEqual([])
-    expect(result.columns).toEqual({
-      [col1Id]: {
-        id: col1Id,
-        name: 'Column 1',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
-        order: 1,
-      },
-      rowId: {
-        id: 'rowId',
-        name: 'Row ID',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-        order: 2,
-      },
-    })
-  })
-
-  it('should handle empty rows', () => {
-    const mockData = {
-      rows: [] as any[],
-      columns: [
-        { id: 'col1', name: 'Column 1', value: `data.rows.*.data.col1` },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
-    expect(result.rows).toEqual([])
-    expect(result.columns).toEqual({
-      col1: {
-        id: 'col1',
-        name: 'Column 1',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
-        order: 1,
-      },
-    })
-  })
-
-  it('should handle empty columns', () => {
-    const mockData = {
-      rows: [
-        {
-          data: {},
-          rowId: 'row-1',
-        },
-      ],
-      columns: [] as any[],
-      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
-    expect(result.rows).toEqual(mockData.rows)
-    expect(result.columns).toEqual({})
-  })
-
-  it('should handle single row with UUID column', () => {
-    const colId = randomUUID()
-    const mockData = {
-      rows: [
-        {
-          data: {
-            [colId]: 'Single Value',
-          },
-          rowId: 'single-row',
-        },
-      ],
-      columns: [
-        {
-          id: colId,
-          name: 'Single Column',
-          value: `data.rows.*.data.${colId}`,
-        },
-      ],
-      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
-    }
-
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
-    expect(result.columns).toEqual({
-      [colId]: {
-        id: colId,
-        name: 'Single Column',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${colId}`,
-        order: 1,
-      },
-      rowId: {
-        id: 'rowId',
-        name: 'Row ID',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-        order: 2,
-      },
-    })
-  })
-
-  it('should handle empty rows and columns', () => {
-    const mockData = {
-      rows: [] as any[],
-      columns: [] as any[],
-      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
-    }
-    const result = processItems(mockData, 'object')
-
-    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
-    expect(result.rows).toEqual([])
-    expect(result.columns).toEqual({})
   })
 })

--- a/packages/backend/src/apps/toolbox/__tests__/common/get-for-each-variables.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-for-each-variables.test.ts
@@ -55,7 +55,7 @@ describe('get-for-each-variables', () => {
     })
   })
 
-  describe('processItems', () => {
+  describe('processItems - backward compatibility with the old dataOut format', () => {
     it('should process tiles data (with UUID column IDs)', () => {
       const col1Id = randomUUID()
       const col2Id = randomUUID()
@@ -83,7 +83,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual(mockData.rows)
@@ -92,16 +92,19 @@ describe('get-for-each-variables', () => {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
         },
         {
           id: col2Id,
           name: 'Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+          order: 2,
         },
         {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+          order: 3,
         },
       ])
     })
@@ -127,7 +130,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual(mockData.rows)
@@ -136,16 +139,19 @@ describe('get-for-each-variables', () => {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
         },
         {
           id: col2Id,
           name: 'Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+          order: 2,
         },
         {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+          order: 3,
         },
       ])
     })
@@ -181,7 +187,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual(mockData.rows)
@@ -190,11 +196,13 @@ describe('get-for-each-variables', () => {
           id: 'col1',
           name: 'Excel Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+          order: 1,
         },
         {
           id: 'col2',
           name: 'Excel Column 2',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col2`,
+          order: 2,
         },
       ])
     })
@@ -209,7 +217,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.rows).toEqual([])
@@ -218,11 +226,13 @@ describe('get-for-each-variables', () => {
           id: col1Id,
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+          order: 1,
         },
         {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+          order: 2,
         },
       ])
     })
@@ -236,7 +246,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual([])
@@ -245,6 +255,7 @@ describe('get-for-each-variables', () => {
           id: 'col1',
           name: 'Column 1',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+          order: 1,
         },
       ])
     })
@@ -261,7 +272,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual(mockData.rows)
@@ -289,7 +300,7 @@ describe('get-for-each-variables', () => {
         inputSource: FOR_EACH_INPUT_SOURCE.TILES,
       }
 
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
       expect(result.columns).toEqual([
@@ -297,11 +308,13 @@ describe('get-for-each-variables', () => {
           id: colId,
           name: 'Single Column',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${colId}`,
+          order: 1,
         },
         {
           id: 'rowId',
           name: 'Row ID',
           value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+          order: 2,
         },
       ])
     })
@@ -312,11 +325,289 @@ describe('get-for-each-variables', () => {
         columns: [] as any[],
         inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
       }
-      const result = processItems(mockData)
+      const result = processItems(mockData, 'array')
 
       expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
       expect(result.rows).toEqual([])
       expect(result.columns).toEqual([])
     })
+  })
+})
+
+describe('processItems - new dataOut format that can handle column reoder', () => {
+  it('should process tiles data (with UUID column IDs)', () => {
+    const col1Id = randomUUID()
+    const col2Id = randomUUID()
+    const mockData = {
+      rows: [
+        {
+          data: {
+            [col1Id]: 'Value 1',
+            [col2Id]: 'Value 2',
+          },
+          rowId: randomUUID(),
+        },
+        {
+          data: {
+            [col1Id]: 3,
+            [col2Id]: 4,
+          },
+          rowId: randomUUID(),
+        },
+      ],
+      columns: [
+        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
+        { id: col2Id, name: 'Column 2', value: `data.rows.*.data.${col2Id}` },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
+    expect(result.rows).toEqual(mockData.rows)
+    expect(result.columns).toEqual({
+      [col1Id]: {
+        id: col1Id,
+        name: 'Column 1',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+        order: 1,
+      },
+      [col2Id]: {
+        id: col2Id,
+        name: 'Column 2',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+        order: 2,
+      },
+      rowId: {
+        id: 'rowId',
+        name: 'Row ID',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+        order: 3,
+      },
+    })
+  })
+
+  it('should process tiles data (with ULID column IDs)', () => {
+    // ULID format: 26 characters, base32 encoded
+    const col1Id = '01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    const col2Id = '01BX5ZZKBKACTAV9WEVGEMMVS0'
+    const mockData = {
+      rows: [
+        {
+          data: {
+            [col1Id]: 'Value 1',
+            [col2Id]: 'Value 2',
+          },
+          rowId: '01ARZ3NDEKTSV4RRFFQ69G5FAX',
+        },
+      ],
+      columns: [
+        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
+        { id: col2Id, name: 'Column 2', value: `data.rows.*.data.${col2Id}` },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
+    expect(result.rows).toEqual(mockData.rows)
+    expect(result.columns).toEqual({
+      [col1Id]: {
+        id: col1Id,
+        name: 'Column 1',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+        order: 1,
+      },
+      [col2Id]: {
+        id: col2Id,
+        name: 'Column 2',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col2Id}`,
+        order: 2,
+      },
+      rowId: {
+        id: 'rowId',
+        name: 'Row ID',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+        order: 3,
+      },
+    })
+  })
+
+  it('should process m365-excel data (with regular column IDs)', () => {
+    const mockData = {
+      rows: [
+        {
+          data: {
+            col1: 1,
+            col2: 2,
+          },
+        },
+        {
+          data: {
+            col1: 'Excel Value 3',
+            col2: 'Excel Value 4',
+          },
+        },
+      ],
+      columns: [
+        {
+          id: 'col1',
+          name: 'Excel Column 1',
+          value: `data.rows.*.data.col1`,
+        },
+        {
+          id: 'col2',
+          name: 'Excel Column 2',
+          value: `data.rows.*.data.col2`,
+        },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
+    expect(result.rows).toEqual(mockData.rows)
+    expect(result.columns).toEqual({
+      col1: {
+        id: 'col1',
+        name: 'Excel Column 1',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+        order: 1,
+      },
+      col2: {
+        id: 'col2',
+        name: 'Excel Column 2',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col2`,
+        order: 2,
+      },
+    })
+  })
+
+  it('should handle empty tiles rows', () => {
+    const col1Id = randomUUID()
+    const mockData = {
+      rows: [] as any[],
+      columns: [
+        { id: col1Id, name: 'Column 1', value: `data.rows.*.data.${col1Id}` },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
+    expect(result.rows).toEqual([])
+    expect(result.columns).toEqual({
+      [col1Id]: {
+        id: col1Id,
+        name: 'Column 1',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${col1Id}`,
+        order: 1,
+      },
+      rowId: {
+        id: 'rowId',
+        name: 'Row ID',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+        order: 2,
+      },
+    })
+  })
+
+  it('should handle empty rows', () => {
+    const mockData = {
+      rows: [] as any[],
+      columns: [
+        { id: 'col1', name: 'Column 1', value: `data.rows.*.data.col1` },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
+    expect(result.rows).toEqual([])
+    expect(result.columns).toEqual({
+      col1: {
+        id: 'col1',
+        name: 'Column 1',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.col1`,
+        order: 1,
+      },
+    })
+  })
+
+  it('should handle empty columns', () => {
+    const mockData = {
+      rows: [
+        {
+          data: {},
+          rowId: 'row-1',
+        },
+      ],
+      columns: [] as any[],
+      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
+    expect(result.rows).toEqual(mockData.rows)
+    expect(result.columns).toEqual({})
+  })
+
+  it('should handle single row with UUID column', () => {
+    const colId = randomUUID()
+    const mockData = {
+      rows: [
+        {
+          data: {
+            [colId]: 'Single Value',
+          },
+          rowId: 'single-row',
+        },
+      ],
+      columns: [
+        {
+          id: colId,
+          name: 'Single Column',
+          value: `data.rows.*.data.${colId}`,
+        },
+      ],
+      inputSource: FOR_EACH_INPUT_SOURCE.TILES,
+    }
+
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.TILES)
+    expect(result.columns).toEqual({
+      [colId]: {
+        id: colId,
+        name: 'Single Column',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${colId}`,
+        order: 1,
+      },
+      rowId: {
+        id: 'rowId',
+        name: 'Row ID',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+        order: 2,
+      },
+    })
+  })
+
+  it('should handle empty rows and columns', () => {
+    const mockData = {
+      rows: [] as any[],
+      columns: [] as any[],
+      inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+    }
+    const result = processItems(mockData, 'object')
+
+    expect(result.inputSource).toBe(FOR_EACH_INPUT_SOURCE.M365_EXCEL)
+    expect(result.rows).toEqual([])
+    expect(result.columns).toEqual({})
   })
 })

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -54,19 +54,47 @@ async function getDataOutMetadata(
   }
 
   if (FOR_EACH_TABLE_SOURCES.includes(inputSource)) {
-    const columnsMetadata = items.columns.map((column, index) => ({
-      id: { isHidden: true },
-      name: { isHidden: true },
-      value: {
-        label: column.name,
-        displayedValue:
-          column.id === 'rowId'
-            ? items?.rows?.[0]?.rowId ?? ''
-            : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
-        order: index + 1,
-        type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
-      },
-    }))
+    let columnsMetadata: IDataOutMetadata[] | Record<string, IDataOutMetadata> =
+      {}
+
+    // NOTE: this is for backward compatibility with the old dataOut format
+    // TODO (kevinkim-ogp): remove this once all users have moved to the new format
+    if (typeof items.columns === 'object' && Array.isArray(items.columns)) {
+      columnsMetadata = items.columns.map((column, index) => ({
+        id: { isHidden: true },
+        name: { isHidden: true },
+        value: {
+          label: column.name,
+          displayedValue:
+            column.id === 'rowId'
+              ? items?.rows?.[0]?.rowId ?? ''
+              : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
+          order: index + 1,
+          type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
+        },
+      }))
+    } else {
+      const tempColumnsMetadata = {} as Record<string, IDataOutMetadata>
+      Object.entries(items.columns)
+        .sort((a, b) => a[1].order - b[1].order)
+        .forEach(([id, column], index) => {
+          tempColumnsMetadata[id] = {
+            id: { isHidden: true },
+            name: { isHidden: true },
+            value: {
+              label: column.name,
+              displayedValue:
+                column.id === 'rowId'
+                  ? items?.rows?.[0]?.rowId ?? ''
+                  : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
+              order: index + 1,
+              type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
+            },
+            order: { isHidden: true },
+          }
+        })
+      columnsMetadata = tempColumnsMetadata
+    }
 
     const rowsMetadata = items.rows.map(() => ({
       rowId: { isHidden: true },

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -78,6 +78,7 @@ async function getDataOutMetadata(
       Object.entries(items.columns)
         .sort((a, b) => a[1].order - b[1].order)
         .forEach(([id, column], index) => {
+          const isBackwardCompatibilityColumnId = !isNaN(Number(id))
           tempColumnsMetadata[id] = {
             id: { isHidden: true },
             name: { isHidden: true },
@@ -89,6 +90,7 @@ async function getDataOutMetadata(
                   : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
               order: index + 1,
               type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
+              isHiddenFromList: isBackwardCompatibilityColumnId,
             },
             order: { isHidden: true },
           }

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -1,4 +1,4 @@
-import { IRawAction } from '@plumber/types'
+import { IJSONObject, IRawAction } from '@plumber/types'
 
 import { ZodError } from 'zod'
 
@@ -9,6 +9,7 @@ import {
 } from '@/apps/toolbox/common/get-for-each-variables'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
 import {
@@ -66,6 +67,34 @@ const action: IRawAction = {
 
     try {
       const { items, inputSource, iterations } = parsedResult.data
+
+      /**
+       * NOTE (kevinkim-ogp): this is for backward compatibility with the old dataOut format
+       * the old dataOut format is an array of objects that store the column info
+       * while the new dataOut format which is unaffected by column order is an object
+       * TODO (kevinkim-ogp): remove this once all users have moved to the new format
+       */
+      let columnDataOutType: 'array' | 'object' = 'object'
+
+      // NOTE: we only need to check for the old dataOut format in non-test runs
+      // so that we can force users into the new dataOut format.
+      // existing executions still need to follow the old dataOut format
+      // so that the correct values are extracted from the correct columns
+      if (FOR_EACH_TABLE_SOURCES.includes(inputSource) && !testRun) {
+        const lastExecutionStep = await $.getLastExecutionStep()
+        columnDataOutType = Array.isArray(
+          (lastExecutionStep?.dataOut?.items as IJSONObject)?.columns,
+        )
+          ? 'array'
+          : 'object'
+
+        if (columnDataOutType === 'array') {
+          logger.info(
+            `Flow ${$.flow.id} using old dataOut format for table input`,
+          )
+        }
+      }
+
       const output: {
         iteration: string
         iterations: number
@@ -90,7 +119,10 @@ const action: IRawAction = {
         // table data is handled differently in processItems
         output['item'] = `items.${FOR_EACH_ITERATION_KEY}`
       } else if (FOR_EACH_TABLE_SOURCES.includes(inputSource)) {
-        const processedItems = processItems(items as MultipleRowObject)
+        const processedItems = processItems(
+          items as MultipleRowObject,
+          columnDataOutType, // TODO (kevinkim-ogp): remove this once all users have moved to the new format
+        )
         output.iterations = iterations
         output.items = processedItems
         output.inputSource = inputSource

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -1,4 +1,4 @@
-import { IJSONObject, IRawAction } from '@plumber/types'
+import { IRawAction } from '@plumber/types'
 
 import { ZodError } from 'zod'
 
@@ -9,7 +9,6 @@ import {
 } from '@/apps/toolbox/common/get-for-each-variables'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
-import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
 import {
@@ -68,33 +67,6 @@ const action: IRawAction = {
     try {
       const { items, inputSource, iterations } = parsedResult.data
 
-      /**
-       * NOTE (kevinkim-ogp): this is for backward compatibility with the old dataOut format
-       * the old dataOut format is an array of objects that store the column info
-       * while the new dataOut format which is unaffected by column order is an object
-       * TODO (kevinkim-ogp): remove this once all users have moved to the new format
-       */
-      let columnDataOutType: 'array' | 'object' = 'object'
-
-      // NOTE: we only need to check for the old dataOut format in non-test runs
-      // so that we can force users into the new dataOut format.
-      // existing executions still need to follow the old dataOut format
-      // so that the correct values are extracted from the correct columns
-      if (FOR_EACH_TABLE_SOURCES.includes(inputSource) && !testRun) {
-        const lastExecutionStep = await $.getLastExecutionStep()
-        columnDataOutType = Array.isArray(
-          (lastExecutionStep?.dataOut?.items as IJSONObject)?.columns,
-        )
-          ? 'array'
-          : 'object'
-
-        if (columnDataOutType === 'array') {
-          logger.info(
-            `Flow ${$.flow.id} using old dataOut format for table input`,
-          )
-        }
-      }
-
       const output: {
         iteration: string
         iterations: number
@@ -119,10 +91,7 @@ const action: IRawAction = {
         // table data is handled differently in processItems
         output['item'] = `items.${FOR_EACH_ITERATION_KEY}`
       } else if (FOR_EACH_TABLE_SOURCES.includes(inputSource)) {
-        const processedItems = processItems(
-          items as MultipleRowObject,
-          columnDataOutType, // TODO (kevinkim-ogp): remove this once all users have moved to the new format
-        )
+        const processedItems = processItems(items as MultipleRowObject)
         output.iterations = iterations
         output.items = processedItems
         output.inputSource = inputSource

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -117,6 +117,7 @@ const dataOutTableSchema = z.object({
   inputSource: z.enum(FOR_EACH_TABLE_SOURCES),
 })
 
+// TODO (kevinkim-ogp): remove the union once all users have moved to the new dataOut format
 export const dataOutSchema = z.discriminatedUnion('inputSource', [
   baseDataOutSchema.extend({
     inputSource: z.literal(FOR_EACH_INPUT_SOURCE.STRING_ARRAY),

--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -96,6 +96,27 @@ export const inputSchema = z
     }
   })
 
+/* TODO (kevinkim-ogp): this is the new dataOut format for Tile columns
+ * This is the new dataOut format for the columns used in for each
+ * so that it respects the column order but is unaffected when users
+ * reorder the columns in the Tile
+ */
+const dataOutColumnSchema = z.record(
+  z.string(),
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    value: z.string(),
+    order: z.number(),
+  }),
+)
+
+const dataOutTableSchema = z.object({
+  rows: tableRowsSchema,
+  columns: dataOutColumnSchema,
+  inputSource: z.enum(FOR_EACH_TABLE_SOURCES),
+})
+
 export const dataOutSchema = z.discriminatedUnion('inputSource', [
   baseDataOutSchema.extend({
     inputSource: z.literal(FOR_EACH_INPUT_SOURCE.STRING_ARRAY),
@@ -103,15 +124,15 @@ export const dataOutSchema = z.discriminatedUnion('inputSource', [
   }),
   baseDataOutSchema.extend({
     inputSource: z.literal(FOR_EACH_INPUT_SOURCE.M365_EXCEL),
-    items: tableSchema,
+    items: z.union([tableSchema, dataOutTableSchema]),
   }),
   baseDataOutSchema.extend({
     inputSource: z.literal(FOR_EACH_INPUT_SOURCE.TILES),
-    items: tableSchema,
+    items: z.union([tableSchema, dataOutTableSchema]),
   }),
   baseDataOutSchema.extend({
     inputSource: z.literal(FOR_EACH_INPUT_SOURCE.FORMSG_TABLE),
-    items: tableSchema,
+    items: z.union([tableSchema, dataOutTableSchema]),
   }),
 ])
 

--- a/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
+++ b/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
@@ -29,7 +29,7 @@ export function isCheckboxItems(items: any[]): boolean {
 
 function processColumns(
   data: MultipleRowObject,
-): Record<string, ProcessedColumn> | ProcessedColumn[] {
+): Record<string, ProcessedColumn> {
   const { columns, inputSource } = data
   if (columns.length === 0) {
     return {}

--- a/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
+++ b/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
@@ -3,10 +3,11 @@ import {
   FOR_EACH_ITERATION_KEY,
 } from '@/apps/toolbox/common/constants'
 
-interface ProcessedColumn {
+export interface ProcessedColumn {
   id: string
   name: string
   value: string
+  order: number
 }
 
 export interface MultipleRowObject {
@@ -26,32 +27,76 @@ export function isCheckboxItems(items: any[]): boolean {
   return Array.isArray(items) && items.every((item) => typeof item === 'string')
 }
 
-function processColumns(data: MultipleRowObject): ProcessedColumn[] {
+function processColumns(
+  data: MultipleRowObject,
+  columnDataOutType: 'array' | 'object', // TODO (kevinkim-ogp): remove this once all users have moved to the new format
+): Record<string, ProcessedColumn> | ProcessedColumn[] {
   const { columns, inputSource } = data
   if (columns.length === 0) {
-    return []
+    return columnDataOutType === 'array' ? [] : {}
   }
 
-  const processedColumns = columns.map((column: any) => ({
-    id: column.id,
-    name: column.name,
-    value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${column.id}`,
-  }))
+  /**
+   * NOTE: this is for backward compatibility with the old dataOut format
+   * which is unable to properly support reordering of Tiles or Excel columns
+   * as the columns are found by their relative position in an array
+   *
+   * TODO: remove this once all users have moved the new dataOut format
+   */
+  if (columnDataOutType === 'array') {
+    const processedColumns = columns.map((column: any, index: number) => ({
+      id: column.id,
+      name: column.name,
+      value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${column.id}`,
+      order: index + 1,
+    }))
 
-  // NOTE: only tiles will have rowId
+    // NOTE: only tiles will have rowId
+    if (inputSource === FOR_EACH_INPUT_SOURCE.TILES) {
+      processedColumns.push({
+        id: 'rowId',
+        name: 'Row ID',
+        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
+        order: columns.length + 1,
+      })
+    }
+    return processedColumns
+  }
+
+  /**
+   * NOTE: this is the new dataOut format for columns
+   * which is able to properly support reordering of Tiles or Excel columns
+   * it will still map to the correct column and value even if the columns are
+   * reordered as the columns are found by their IDs and not their relative
+   * position in an array
+   */
+  const processedColumns: Record<string, ProcessedColumn> = {}
+  columns.forEach((column: any, index: number) => {
+    processedColumns[column.id] = {
+      id: column.id,
+      name: column.name,
+      value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${column.id}`,
+      order: index + 1,
+    }
+  })
+
   if (inputSource === FOR_EACH_INPUT_SOURCE.TILES) {
-    processedColumns.push({
+    processedColumns['rowId'] = {
       id: 'rowId',
       name: 'Row ID',
       value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-    })
+      order: columns.length + 1,
+    }
   }
 
   return processedColumns
 }
 
-export function processItems(items: MultipleRowObject): any {
-  const processedColumns = processColumns(items)
+export function processItems(
+  items: MultipleRowObject,
+  columnDataOutType: 'array' | 'object', // TODO (kevinkim-ogp): remove this once all users have moved to the new format
+): any {
+  const processedColumns = processColumns(items, columnDataOutType)
   const processedItems = {
     rows: items.rows,
     columns: processedColumns,

--- a/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
+++ b/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
@@ -29,50 +29,29 @@ export function isCheckboxItems(items: any[]): boolean {
 
 function processColumns(
   data: MultipleRowObject,
-  columnDataOutType: 'array' | 'object', // TODO (kevinkim-ogp): remove this once all users have moved to the new format
 ): Record<string, ProcessedColumn> | ProcessedColumn[] {
   const { columns, inputSource } = data
   if (columns.length === 0) {
-    return columnDataOutType === 'array' ? [] : {}
+    return {}
   }
 
-  /**
-   * NOTE: this is for backward compatibility with the old dataOut format
-   * which is unable to properly support reordering of Tiles or Excel columns
-   * as the columns are found by their relative position in an array
-   *
-   * TODO: remove this once all users have moved the new dataOut format
-   */
-  if (columnDataOutType === 'array') {
-    const processedColumns = columns.map((column: any, index: number) => ({
+  const processedColumns: Record<string, ProcessedColumn> = {}
+  columns.forEach((column: any, index: number) => {
+    processedColumns[column.id] = {
       id: column.id,
       name: column.name,
       value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${column.id}`,
       order: index + 1,
-    }))
-
-    // NOTE: only tiles will have rowId
-    if (inputSource === FOR_EACH_INPUT_SOURCE.TILES) {
-      processedColumns.push({
-        id: 'rowId',
-        name: 'Row ID',
-        value: `items.rows.${FOR_EACH_ITERATION_KEY}.rowId`,
-        order: columns.length + 1,
-      })
     }
-    return processedColumns
-  }
 
-  /**
-   * NOTE: this is the new dataOut format for columns
-   * which is able to properly support reordering of Tiles or Excel columns
-   * it will still map to the correct column and value even if the columns are
-   * reordered as the columns are found by their IDs and not their relative
-   * position in an array
-   */
-  const processedColumns: Record<string, ProcessedColumn> = {}
-  columns.forEach((column: any, index: number) => {
-    processedColumns[column.id] = {
+    /**
+     * NOTE: this is for backward compatibility with the old dataOut format
+     * which was unable to properly support reordering of Tiles or Excel columns
+     * as the columns are found by their relative position in an array.
+     *
+     * TODO: remove this once all users have moved the new dataOut format
+     */
+    processedColumns[String(index)] = {
       id: column.id,
       name: column.name,
       value: `items.rows.${FOR_EACH_ITERATION_KEY}.data.${column.id}`,
@@ -92,11 +71,8 @@ function processColumns(
   return processedColumns
 }
 
-export function processItems(
-  items: MultipleRowObject,
-  columnDataOutType: 'array' | 'object', // TODO (kevinkim-ogp): remove this once all users have moved to the new format
-): any {
-  const processedColumns = processColumns(items, columnDataOutType)
+export function processItems(items: MultipleRowObject): any {
+  const processedColumns = processColumns(items)
   const processedItems = {
     rows: items.rows,
     columns: processedColumns,

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -61,7 +61,7 @@ function findAndSubstituteVariables(
    * this is for logging if users are still using the old format for for-each
    * we log this here so that it does not keep logging for each parameter that is computed
    */
-  if (/items.columns.\d+.value/g.test(rawValue)) {
+  if (/items.columns.\d+.value/.test(rawValue)) {
     logger.info('Pipe using old for each dataOut format', {
       event: 'for-each-old-dataOut-format',
       executionId: executionSteps[0].executionId,

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -6,6 +6,7 @@ import {
   computeForEachParameters,
   ForEachContext,
 } from '@/helpers/compute-for-each-parameters'
+import logger from '@/helpers/logger'
 import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
@@ -53,6 +54,18 @@ function findAndSubstituteVariables(
 
   if (typeof rawValue !== 'string') {
     return rawValue
+  }
+
+  /**
+   * TODO (kevinkim-ogp): remove this once all users have moved to the new dataOut format
+   * this is for logging if users are still using the old format for for-each
+   * we log this here so that it does not keep logging for each parameter that is computed
+   */
+  if (/items.columns.\d+.value/g.test(rawValue)) {
+    logger.info('Pipe using old for each dataOut format', {
+      event: 'for-each-old-dataOut-format',
+      executionId: executionSteps[0].executionId,
+    })
   }
 
   const parts = rawValue.split(variableRegExp)


### PR DESCRIPTION
## Problem
🐛 Reordering columns via Tiles UI causes the wrong value to be pulled after the for-each action is set up.
This was caused by columns being stored in the for each execution step's `dataOut` as an array and referenced by their relative position (`{{step.0000.items.columns.1.value}}`) in the array:
```
{
  "columns": [
    {
      "id": "column-1",
      "name": "Column 1",
      "value": "Value 1",
    },
    {
      "id": "column-2",
      "name": "Column 2",
      "value": "Value 2",
    }
  ]
}
```

## Solution
⚒️ Change to store the columns as an object where the column id is the key, with order being preserved in each column's object.
This ensures that we can access the columns based on the exact ID: `{{step.0000.items.columns.column-1.value}}`

```
{
  "columns": {
      "column-1": {
        "id": "column-1",
        "name": "Column 1",
        "value": "Value 1",
        "order": 1
      },
      "column-2": {
        "id": "column-2",
        "name": "Column 2",
        "order": 2
      }
    }
}
```

⚠️  There is however a drawback to this approach, where we need to cater for existing Pipes that have been set up with the previous `dataOut` structure during the beta.

To avoid any DB migration, think the best approach would be either to ask users to reconfigure their actions, aka 'Check step' again OR monitor periodically till we are certain that no other users are on the old `dataOut` format and remove it completely. If users reconfigure their steps, they will automatically be moved into the new `dataOut` format.

## Other changes
* Renamed 'Find table rows' to 'Find multiple table rows'

## How to test?
- [ ] FormSG Table
  - [ ] Verify that an EXISTING pipe using a FormSG table still works and can execute correctly
  - [ ] Verify that a NEW pipe using a FormSG table works and executes correctly
- [ ] Tiles
  - [ ] Verify that an EXISTING pipe using a Tiles multiple rows still works and can execute correctly
  - [ ] Verify that a NEW pipe using a Tiles multiple rows works and executes correctly
- [ ] M365-Excel
  - [ ] Verify that an EXISTING pipe using a Excel multiple rows still works and can execute correctly
  - [ ] Verify that a NEW pipe using a Excel multiple rows works and executes correctly
- [ ] FormSG checkbox
  - [ ] Sanity check that this still works (this PR should have no impact on checkboxes)
