### PR TITLE
[LOGS-2] Improve error handling on save and check step

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
@@ -19,23 +20,35 @@ describe('updateStep mutation', () => {
   const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   // Helper to create step mock with flow
-  const createStepMock = (stepData: any = {}) => ({
-    findOne: vi.fn().mockResolvedValue(
-      stepData === null
-        ? null
-        : {
-            id: mockStepId,
-            key: 'sendTransactionalEmail',
-            appKey: 'postman',
-            status: 'completed',
-            flow: {
-              id: mockFlowId,
-            },
-            patchFlowLastUpdated: patchFlowLastUpdatedSpy,
-            ...stepData,
-          },
-    ),
-  })
+  const createStepMock = (stepData: any = {}) => {
+    const throwIfNotFoundMock = vi.fn().mockImplementation(async (options) => {
+      const result =
+        stepData === null
+          ? null
+          : {
+              id: mockStepId,
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              status: 'completed',
+              flow: {
+                id: mockFlowId,
+              },
+              patchFlowLastUpdated: patchFlowLastUpdatedSpy,
+              ...stepData,
+            }
+
+      if (result === null) {
+        throw new NotFoundError(options?.message || 'Step not found')
+      }
+      return result
+    })
+
+    return {
+      findOne: vi.fn().mockReturnValue({
+        throwIfNotFound: throwIfNotFoundMock,
+      }),
+    }
+  }
 
   // Helper to create connection mock
   const createConnectionMock = (connectionData: any = null) => ({
@@ -49,7 +62,7 @@ describe('updateStep mutation', () => {
   ) => {
     context.currentUser.$relatedQuery = vi
       .fn()
-      .mockImplementation((relation) => {
+      .mockImplementation((relation, _trx) => {
         if (relation === 'steps') {
           return createStepMock(stepData)
         }
@@ -165,7 +178,7 @@ describe('updateStep mutation', () => {
     // Override only the connections query
     setupRelatedQueryMock(undefined, null)
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+    await expect(updateStep(null, { input }, context)).rejects.toThrowError(
       BadUserInputError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
@@ -181,7 +194,7 @@ describe('updateStep mutation', () => {
     setupRelatedQueryMock(null, { id: mockConnectionId })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
   })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -12,14 +12,13 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const { input } = params
 
   const step = await Step.transaction(async (trx) => {
-    const step = await context.currentUser.$relatedQuery('steps', trx).findOne({
-      'steps.id': input.id,
-      flow_id: input.flow.id,
-    })
-
-    if (!step) {
-      throw new BadUserInputError('Step not found')
-    }
+    const step = await context.currentUser
+      .$relatedQuery('steps', trx)
+      .findOne({
+        'steps.id': input.id,
+        flow_id: input.flow.id,
+      })
+      .throwIfNotFound({ message: 'Step not found' })
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists and belongs to the user

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -96,29 +96,17 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      const result = await onUpdateStep({
+      await onUpdateStep({
         ...currentStep,
         status: isSubStepValid ? 'completed' : 'incomplete',
       })
-
-      if (!result) {
-        throw new Error('Failed to save step')
-      }
     } catch (error) {
-      toast({
-        title: 'Error saving step',
-        description:
-          error instanceof Error
-            ? error.message
-            : 'An unexpected error occurred',
-        status: 'error',
-        duration: 5000,
-        isClosable: true,
-      })
+      console.error('Error saving step', error)
+      throw error // Re-throw the error so calling functions know saveStep failed
     } finally {
       setIsSaving(false)
     }
-  }, [formContext, onUpdateStep, substep, toast])
+  }, [formContext, onUpdateStep, substep])
 
   const handleSave = useCallback(async () => {
     await saveStep()
@@ -132,10 +120,14 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
 
   const handleSaveAndTest = useCallback(
     async (testRunMetadata?: Record<string, unknown>) => {
-      await saveStep()
-      await executeTestStep(testRunMetadata)
-      if (!isIfThenStep(step)) {
-        onTestResultOpen()
+      try {
+        await saveStep()
+        await executeTestStep(testRunMetadata)
+        if (!isIfThenStep(step)) {
+          onTestResultOpen()
+        }
+      } catch (error) {
+        console.error('Error saving and test step')
       }
     },
     [saveStep, executeTestStep, step, onTestResultOpen],

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -326,7 +326,6 @@ export const EditorProvider = ({
   const [executeStep, { loading: isTestExecuting }] = useMutation(
     EXECUTE_STEP,
     {
-      context: { autoSnackbar: false },
       awaitRefetchQueries: true,
       refetchQueries: [GET_TEST_EXECUTION_STEPS, GET_FLOW],
       update(cache, { data }) {


### PR DESCRIPTION
## TL;DR

* Fixes bug during 'Check step' where `executeStep` mutation still runs if `updateStep` failed
* Removed unnecessary toast notifications and throw directly from the onError handler in ApolloProvider

## How to test?
Happy flow
- [ ] Save step still works as expected
- [ ] Check step still executes both `updateStep` and `executeStep` mutations as expected

Unhappy flow
- [ ] When checking step `updateStep` mutation failure should throw error and NOT execute `executeStep`
- [ ] Should only have 1 error toast

## Screenshots

![Screenshot 2025-09-15 at 12.18.00 PM.png](https://app.graphite.dev/user-attachments/assets/5f206a12-f72f-4ef4-b72b-854713c7991d.png)

