### PR TITLE
UI/UX improvement: modal behaviour when create step fails

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -143,11 +143,13 @@ export default function ChooseAndAddConnection(
           newStepIndex = updatedStep.position - 1
         }
         onClose()
-      } finally {
-        patchModalState({ isLoading: false })
         onDrawerOpen()
         setCurrentStepId(newStepId)
         setCurrentStepIndex(newStepIndex)
+      } catch (error) {
+        console.error('Error selecting app and event', error)
+      } finally {
+        patchModalState({ isLoading: false })
       }
     },
     [

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -105,42 +105,47 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       patchModalState({ isLoading: true })
       let newStepId = null
       let newStepIndex = null
-      if (prevStepId) {
-        const createdStep = await onCreateStep(
-          prevStepId,
-          app.key,
-          triggerOrAction.key,
-          excelConnection?.id || undefined,
-        )
-        newStepId = createdStep.id
-        newStepIndex = createdStep.position - 1
-      } else if (step) {
-        // account for the if-then edge case
-        if (
-          app.key === TOOLBOX_APP_KEY &&
-          triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
-        ) {
-          const ifThen = await initializeIfThen(step)
-          newStepId = ifThen.id
-          newStepIndex = ifThen.position - 1
-        } else {
-          const updatedStep = await onUpdateStep({
-            ...step,
-            appKey: app.key,
-            key: triggerOrAction.key,
-            connection: {
-              id: excelConnection?.id || undefined,
-            },
-          })
-          newStepId = updatedStep.id
-          newStepIndex = updatedStep.position - 1
+      try {
+        if (prevStepId) {
+          const createdStep = await onCreateStep(
+            prevStepId,
+            app.key,
+            triggerOrAction.key,
+            excelConnection?.id || undefined,
+          )
+          newStepId = createdStep.id
+          newStepIndex = createdStep.position - 1
+        } else if (step) {
+          // account for the if-then edge case
+          if (
+            app.key === TOOLBOX_APP_KEY &&
+            triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
+          ) {
+            const ifThen = await initializeIfThen(step)
+            newStepId = ifThen.id
+            newStepIndex = ifThen.position - 1
+          } else {
+            const updatedStep = await onUpdateStep({
+              ...step,
+              appKey: app.key,
+              key: triggerOrAction.key,
+              connection: {
+                id: excelConnection?.id || undefined,
+              },
+            })
+            newStepId = updatedStep.id
+            newStepIndex = updatedStep.position - 1
+          }
         }
+        onClose()
+        onDrawerOpen()
+        setCurrentStepId(newStepId)
+        setCurrentStepIndex(newStepIndex)
+      } catch (error) {
+        console.error('Error selecting app and event', error)
+      } finally {
+        patchModalState({ isLoading: false })
       }
-      patchModalState({ isLoading: false })
-      onClose()
-      onDrawerOpen()
-      setCurrentStepId(newStepId)
-      setCurrentStepIndex(newStepIndex)
     },
     [
       excelConnection?.verified,

--- a/packages/frontend/src/components/FlowStepConfigurationModal/LoadingOverlay.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/LoadingOverlay.tsx
@@ -1,0 +1,34 @@
+import { useContext } from 'react'
+import { Box, Spinner } from '@chakra-ui/react'
+
+import { useIfThenInitializer } from '@/helpers/toolbox'
+
+import { FlowStepConfigurationContext } from './FlowStepConfigurationContext'
+
+export default function LoadingOverlay(): JSX.Element {
+  const { modalState } = useContext(FlowStepConfigurationContext)
+  const { isLoading } = modalState
+  const [_, isInitializingIfThen] = useIfThenInitializer()
+
+  const isModalLoading = isLoading || isInitializingIfThen
+
+  if (!isModalLoading) {
+    return <></>
+  }
+
+  return (
+    <Box
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      bg="rgba(255, 255, 255, 0.8)"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Spinner size="xl" color="primary.500" thickness="4px" />
+    </Box>
+  )
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -1,11 +1,7 @@
 import type { IAction, IApp, IStep, ITrigger } from '@plumber/types'
 
 import { useContext } from 'react'
-import { Flex, Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
-
-import { useIfThenInitializer } from '@/helpers/toolbox'
-
-import PrimarySpinner from '../PrimarySpinner'
+import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 
 import ChooseAndAddConnection from './ChooseAndAddConnection'
 import ChooseAppAndEvent from './ChooseAppAndEvent'
@@ -14,6 +10,7 @@ import {
   FlowStepConfigurationContextProvider,
 } from './FlowStepConfigurationContext'
 import InvalidModalScreen from './InvalidModalScreen'
+import LoadingOverlay from './LoadingOverlay'
 
 interface FlowStepConfigurationModalProps {
   onClose: () => void
@@ -32,16 +29,8 @@ function FlowStepConfigurationModalContent({
   onClose: () => void
 }): JSX.Element {
   const { modalState } = useContext(FlowStepConfigurationContext)
-  const { currentScreen, isLoading } = modalState
-  const [_, isInitializingIfThen] = useIfThenInitializer()
+  const { currentScreen } = modalState
 
-  if (isLoading || isInitializingIfThen) {
-    return (
-      <Flex flexDir="column" alignItems="center" gap={6} my={12}>
-        <PrimarySpinner margin="auto" fontSize="4xl" />
-      </Flex>
-    )
-  }
   if (currentScreen === 'choose-app' || currentScreen === 'choose-event') {
     return <ChooseAppAndEvent onClose={onClose} />
   }
@@ -91,8 +80,10 @@ export default function FlowStepConfigurationModal(
           overflow="hidden"
           borderRadius="lg"
           py={8}
+          position="relative"
         >
           <FlowStepConfigurationModalContent onClose={onClose} />
+          <LoadingOverlay />
         </ModalContent>
       </Modal>
     </FlowStepConfigurationContextProvider>


### PR DESCRIPTION
## Problem
There is a minor inconsistency with the choose app / event / connection modal behaviour if create step fails:
1. If creating step without connection fails, modal does not close, and we are stuck with the spinner on screen. User can only exit if they hit 'esc'
2. If creating step with a connection fails, the modal remains open, and the right drawer opens without any fields

## Solution
1. Show a loading overlay instead of replacing the entire modal content
1. If creating step without connection fails, modal remains open and stays at the app / event that was chosen
1. If creating step with a connection fails, modal remains open at the choose connection page (no change here)

## How to test?
Happy flow
- [ ] Step without event can be created (e.g., Email by Postman, Formatter)
- [ ] Step with event can be created (e.g., Tiles)
- [ ] Step with connection can be created (e.g., Telegram, Slack)
Force the `createStep` mutation fail when it is called.
- [ ] Create step without event should fail and the modal remains open at the current position
- [ ] Create step with event should fail and remain at the select event page
- [ ] Create step with connection should fail and remain at the select connection page

## Screenshots
### Before

https://github.com/user-attachments/assets/ff7bee8b-df1d-4fb3-b560-6e6d0c5059a6



### After


https://github.com/user-attachments/assets/09ee6c38-9a41-4eb2-ae1f-0d3818386358

