### PR TITLE
chore: bump axios and vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29872,9 +29872,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -30970,7 +30970,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^2.5.1",
         "type-fest": "4.10.3",
-        "vite": "^6.3.5",
+        "vite": "^6.3.6",
         "vite-plugin-dts": "^4.5.4",
         "vite-plugin-package-version": "1.1.0",
         "vite-tsconfig-paths": "^5.1.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14166,9 +14166,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
+      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -30832,7 +30832,7 @@
         "@taskforcesh/bullmq-pro": "7.7.1",
         "ajv-formats": "^2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.11.0",
+        "axios": "1.12.1",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.7",
         "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "overrides": {
-    "axios": "1.11.0",
+    "axios": "1.12.1",
     "graphql-rate-limit": {
       "@graphql-tools/utils": {
         "graphql": "16.11.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@taskforcesh/bullmq-pro": "7.7.1",
     "ajv-formats": "^2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.11.0",
+    "axios": "1.12.1",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.7",
     "copyfiles": "^2.4.1",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.5.1",
     "type-fest": "4.10.3",
-    "vite": "^6.3.5",
+    "vite": "^6.3.6",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-package-version": "1.1.0",
     "vite-tsconfig-paths": "^5.1.4"


### PR DESCRIPTION
## Addressing vulnerabilities in dependencies:
1. axios (https://github.com/advisories/GHSA-4hjh-wcwx-xvwj)
2. vite (https://github.com/advisories/GHSA-g4jq-h2w9-997c)

## How to test?
Axios
- [ ] Actions that make http requests still work

Vite
- [ ] Check that `npm run build` still works