### PR TITLE
fix: css fixes for app row

### DIFF
--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -55,7 +55,7 @@ function FlowRowTitle({
         <Text
           display="inline-block"
           w="100%"
-          maxW="95%"
+          whiteSpace="nowrap"
           color="base.content.medium"
           textStyle="body-2"
         >
@@ -95,7 +95,9 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
           flex={1}
           py={6}
           px={{ base: 3, md: 8 }}
-          display="block"
+          display="flex"
+          flexDir={{ base: 'column', md: 'row' }}
+          alignItems="stretch"
           minWidth="100%"
           overflow="hidden"
         >
@@ -125,7 +127,7 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
               )}
             </Flex>
           </Flex>
-          <Box display={{ base: 'flex', md: 'none' }} mt={6}>
+          <Box display={{ base: 'flex', md: 'none' }} mt={4}>
             <FlowRowTitle flow={flow} showTimestamp={showTimestamp} />
           </Box>
         </CardBody>

--- a/packages/frontend/src/pages/Tiles/components/style.ts
+++ b/packages/frontend/src/pages/Tiles/components/style.ts
@@ -8,6 +8,7 @@ export const flexStyles = {
       md: 'row',
     } as FlexProps['direction'],
     textStyle: 'body-2',
+    marginTop: 1,
   },
   usedInPipes: {
     alignItems: 'center',


### PR DESCRIPTION
## Before / After
1. date overflow
<img width="449" height="339" alt="image" src="https://github.com/user-attachments/assets/41c6d8fb-cb32-4b5d-8bed-7f9cfe20ae94" />
<img width="460" height="308" alt="image" src="https://github.com/user-attachments/assets/2b1de8ed-23b1-4bd6-8b23-488ecafa1865" />

2. title and timestamps too close
<img width="628" height="288" alt="image" src="https://github.com/user-attachments/assets/8db9d87c-4a12-4722-b3ae-1cbf59b273f7" />
<img width="632" height="301" alt="image" src="https://github.com/user-attachments/assets/cc9f82aa-45a0-4895-aa41-142246b1439e" />

3. not vertically centered
<img width="469" height="322" alt="image" src="https://github.com/user-attachments/assets/28a5f98c-bd02-4002-a678-5a53f7d8975e" />
<img width="523" height="308" alt="image" src="https://github.com/user-attachments/assets/218f935d-1fa0-429a-b90d-c5e39a523f75" />
