### PR TITLE
chore: adjust step widths, change cursor

### DIFF
--- a/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
+++ b/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
@@ -1,15 +1,16 @@
 import { Flex } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
 
-import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
+import { DRAG_HANDLE_WIDTH } from '../SortableList/components/SortableItem'
 
 interface FlowStepWrapperProps {
   children: React.ReactNode
-  isNested?: boolean
+  canChildStepsReorder?: boolean
+  allowReorder?: boolean
 }
 
 export default function FlowStepWrapper(props: FlowStepWrapperProps) {
-  const { children, isNested } = props
+  const { children, canChildStepsReorder, allowReorder } = props
   const isMobile = useIsMobile()
 
   return (
@@ -17,8 +18,11 @@ export default function FlowStepWrapper(props: FlowStepWrapperProps) {
       alignItems="center"
       display={isMobile ? 'block' : 'flex'}
       flexDir="column"
-      w="100%"
-      minW={isNested ? '100%' : MIN_FLOW_STEP_WIDTH}
+      w={
+        canChildStepsReorder && !allowReorder && !isMobile
+          ? `calc(100% - ${DRAG_HANDLE_WIDTH}px)`
+          : '100%'
+      }
     >
       {children}
     </Flex>

--- a/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
+++ b/packages/frontend/src/components/FlowStep/FlowStepWrapper.tsx
@@ -1,7 +1,7 @@
 import { Flex } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
 
-import { DRAG_HANDLE_WIDTH } from '../SortableList/components/SortableItem'
+import { NESTED_DRAG_HANDLE_WIDTH } from '../SortableList/components/SortableItem'
 
 interface FlowStepWrapperProps {
   children: React.ReactNode
@@ -20,7 +20,7 @@ export default function FlowStepWrapper(props: FlowStepWrapperProps) {
       flexDir="column"
       w={
         canChildStepsReorder && !allowReorder && !isMobile
-          ? `calc(100% - ${DRAG_HANDLE_WIDTH}px)`
+          ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
           : '100%'
       }
     >

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -35,12 +35,20 @@ type FlowStepProps = {
   isLastStep: boolean
   isNested?: boolean
   allowReorder?: boolean
+  // we use this to control the width of condition steps in if-then and for-each
+  canChildStepsReorder?: boolean
 }
 
 export default function FlowStep(
   props: FlowStepProps,
 ): React.ReactElement | null {
-  const { step, isLastStep, isNested, allowReorder = true } = props
+  const {
+    step,
+    isLastStep,
+    isNested,
+    allowReorder = true,
+    canChildStepsReorder = false,
+  } = props
 
   const {
     isOpen: isModalOpen,
@@ -67,11 +75,11 @@ export default function FlowStep(
     app,
     caption,
     isCompleted,
-    isIfThenStep,
     isTrigger,
     selectedActionOrTrigger,
     substeps,
-  } = useStepMetadata(allApps, step)
+    shouldShowDragHandle,
+  } = useStepMetadata(allApps, step, readOnly, allowReorder, isMobile)
 
   const {
     cancelRef,
@@ -140,19 +148,6 @@ export default function FlowStep(
     }
   }
 
-  /**
-   * NOTE: there are various conditions that determine whether the drag handle
-   * should be shown.
-   *
-   * - not read only
-   * - not in mobile view
-   * - step is not a trigger
-   * - step is not an if-then condition step
-   * - allowReorder is true
-   */
-  const shouldShowDragHandle =
-    !readOnly && !isTrigger && !isMobile && !isIfThenStep && allowReorder
-
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)
 
   // generate help message only if template config exists
@@ -178,7 +173,10 @@ export default function FlowStep(
   }
 
   return (
-    <FlowStepWrapper isNested={isNested}>
+    <FlowStepWrapper
+      canChildStepsReorder={canChildStepsReorder}
+      allowReorder={allowReorder}
+    >
       {!app ? (
         <EmptyFlowStepHeader
           isNested={isNested}
@@ -191,9 +189,7 @@ export default function FlowStep(
       ) : (
         <Flex flexDir="row" w="100%">
           <Flex
-            alignItems={
-              isNested && !shouldShowDragHandle ? 'flex-start' : 'center'
-            }
+            alignItems={isNested ? 'flex-start' : 'center'}
             justifyContent="center"
             flexDir="column"
             flex="1"

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -92,7 +92,7 @@ export default function ForEach(props: ForEachProps) {
                     canAddStep={true}
                     isLastStep={isLastStep}
                     isOverlay={isOverlay}
-                    allowReorder={true}
+                    allowReorder={actionSteps.length > 1}
                   />
                 </Flex>
               </SortableList.Item>

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -72,6 +72,7 @@ export default function ForEach(props: ForEachProps) {
           isLastStep={false}
           allowReorder={false}
           showEmptyAction={hasNoActionSteps}
+          canChildStepsReorder={actionSteps.length > 1}
         />
         <SortableList
           items={actionSteps.map((step, index) => ({

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -203,6 +203,8 @@ export default function Branch(props: BranchProps) {
           step={conditionStep}
           canAddStep={canAddStep}
           isLastStep={false}
+          allowReorder={false}
+          canChildStepsReorder={actionSteps.length > 1}
         />
         <SortableList
           items={actionSteps.map((step, index) => ({

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -7,7 +7,7 @@ import { Divider, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '@/components/EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
-import { DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
+import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
@@ -82,7 +82,7 @@ export function HoverAddStepButton(
           onMouseLeave={() => setIsHovered(false)}
           w={
             (shouldShowDragHandle || canChildStepsReorder) && !isMobile
-              ? `calc(100% - ${DRAG_HANDLE_WIDTH}px)`
+              ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
               : 'full'
           }
         >

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react'
+import { IStep } from '@plumber/types'
+
+import { useContext, useState } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Divider, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 
 import UnsavedChangesAlert from '@/components/Editor/UnsavedChangesAlert'
 import EmptyFlowStepHeader from '@/components/EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
+import { DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
+import { EditorContext } from '@/contexts/Editor'
+import { useStepMetadata } from '@/hooks/useStepMetadata'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import { hoverAddStepButtonStyles as styles } from './styles'
@@ -15,14 +20,34 @@ interface HoverAddStepButtonProps {
   isLastStep: boolean
   prevStepId: string
   showEmptyAction?: boolean
+  step: IStep
+  allowReorder?: boolean
+  canChildStepsReorder?: boolean
 }
 
 export function HoverAddStepButton(
   props: HoverAddStepButtonProps,
 ): JSX.Element {
-  const { isDisabled, isLastStep, prevStepId, showEmptyAction } = props
+  const {
+    isDisabled,
+    isLastStep,
+    prevStepId,
+    showEmptyAction,
+    step,
+    allowReorder,
+    canChildStepsReorder,
+  } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
+
+  const { allApps, readOnly, isMobile } = useContext(EditorContext)
+  const { shouldShowDragHandle } = useStepMetadata(
+    allApps,
+    step,
+    readOnly,
+    allowReorder,
+    isMobile,
+  )
 
   const {
     cancelRef,
@@ -55,6 +80,11 @@ export function HoverAddStepButton(
           pointerEvents={isDisabled ? 'none' : 'auto'}
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
+          w={
+            (shouldShowDragHandle || canChildStepsReorder) && !isMobile
+              ? `calc(100% - ${DRAG_HANDLE_WIDTH}px)`
+              : 'full'
+          }
         >
           {/* vertical line */}
           {!isLastStep && (

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/styles.ts
@@ -62,5 +62,6 @@ export const hoverAddStepButtonStyles = {
     variant: 'clear',
     size: 'xs',
     borderRadius: 'lg',
+    left: 0,
   },
 }

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -4,7 +4,7 @@ import { useContext } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
-import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 import { HoverAddStepButton } from '../Content/IfThen/HoverAddStepButton'
 
@@ -32,9 +32,7 @@ export default function GroupStepWithAddButton(
 
   // cannot delete the condition step
   const isDeletable =
-    step.appKey !== TOOLBOX_APP_KEY &&
-    step.key !== TOOLBOX_ACTIONS.IfThen &&
-    step.key !== TOOLBOX_ACTIONS.ForEach
+    step.key !== TOOLBOX_ACTIONS.IfThen && step.key !== TOOLBOX_ACTIONS.ForEach
 
   return (
     <>

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -15,6 +15,7 @@ interface GroupStepWithAddButtonProps {
   isOverlay?: boolean
   allowReorder?: boolean
   showEmptyAction?: boolean
+  canChildStepsReorder?: boolean
 }
 
 export default function GroupStepWithAddButton(
@@ -27,6 +28,7 @@ export default function GroupStepWithAddButton(
     isOverlay,
     allowReorder,
     showEmptyAction,
+    canChildStepsReorder,
   } = props
   const { isDrawerOpen, readOnly } = useContext(EditorContext)
 
@@ -43,6 +45,7 @@ export default function GroupStepWithAddButton(
         isNested={true}
         isLastStep={isLastStep}
         allowReorder={allowReorder}
+        canChildStepsReorder={canChildStepsReorder}
       />
       {!isOverlay && (
         <HoverAddStepButton
@@ -51,6 +54,9 @@ export default function GroupStepWithAddButton(
           isLastStep={isLastStep}
           prevStepId={step.id}
           showEmptyAction={showEmptyAction}
+          step={step}
+          allowReorder={allowReorder}
+          canChildStepsReorder={canChildStepsReorder}
         />
       )}
     </>

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -62,9 +62,20 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
     onDrawerClose()
   }, [deleteForEach, onDrawerClose])
 
+  // NOTE: we check if its inside the for-each
+  // so that if-then steps follow the same width of the nested actions
+  // when the drag handle is shown
+  const isInsideForEach = stepsBeforeGroup.some(
+    (step) => step.key === TOOLBOX_ACTIONS.ForEach,
+  )
+
   return (
     <Flex
-      w="100%"
+      w={
+        isInsideForEach && stepsBeforeGroup.length > 2
+          ? 'calc(100% - 16px)'
+          : '100%'
+      }
       alignItems="center"
       justifyContent={isDrawerOpen ? 'flex-start' : 'center'}
     >

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -5,6 +5,7 @@ import { BiTrash } from 'react-icons/bi'
 import { Box, Flex, Icon, Text } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
+import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/SortableItem'
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth, getToolboxIcon } from '@/helpers/editor'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
@@ -73,7 +74,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
     <Flex
       w={
         isInsideForEach && stepsBeforeGroup.length > 2
-          ? 'calc(100% - 16px)'
+          ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
           : '100%'
       }
       alignItems="center"

--- a/packages/frontend/src/components/SortableList/SortableList.css
+++ b/packages/frontend/src/components/SortableList/SortableList.css
@@ -4,3 +4,9 @@
   padding: 0;
   list-style: none;
 }
+
+/* Force cursor during active drag */
+body.is-dragging,
+body.is-dragging * {
+  cursor: grabbing !important;
+}

--- a/packages/frontend/src/components/SortableList/components/SortableItem/SortableItem.css
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/SortableItem.css
@@ -19,7 +19,7 @@
   justify-content: center;
   flex: 0 0 auto;
   touch-action: none;
-  cursor: var(--cursor, pointer);
+  cursor: var(--cursor, grab);
   border-radius: 5px;
   border: none;
   outline: none;

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -22,6 +22,8 @@ interface Context {
   isDragging: boolean
 }
 
+export const DRAG_HANDLE_WIDTH = 16
+
 const SortableItemContext = createContext<Context>({
   attributes: {},
   listeners: undefined,

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -22,7 +22,7 @@ interface Context {
   isDragging: boolean
 }
 
-export const DRAG_HANDLE_WIDTH = 16
+export const NESTED_DRAG_HANDLE_WIDTH = 16
 
 const SortableItemContext = createContext<Context>({
   attributes: {},

--- a/packages/frontend/src/components/SortableList/index.tsx
+++ b/packages/frontend/src/components/SortableList/index.tsx
@@ -55,6 +55,7 @@ export function SortableList<T extends BaseItem>({
       sensors={sensors}
       onDragStart={({ active }) => {
         setActive(active)
+        document?.body?.classList?.add('is-dragging')
       }}
       onDragEnd={({ active, over }) => {
         if (over && active.id !== over?.id) {
@@ -64,9 +65,11 @@ export function SortableList<T extends BaseItem>({
           onChange(arrayMove(items, activeIndex, overIndex))
         }
         setActive(null)
+        document?.body?.classList?.remove('is-dragging')
       }}
       onDragCancel={() => {
         setActive(null)
+        document?.body?.classList?.remove('is-dragging')
       }}
       modifiers={[
         restrictToVerticalAxis,

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -31,9 +31,7 @@ export const getFlowStepHeaderWidth = (
     return '100%'
   }
 
-  return isNested
-    ? 'calc(100% - 16px)' // 16px is the width of the drag handle
-    : '600px'
+  return isNested ? 'full' : '600px'
 }
 
 function isValidArgValue(value: IJSONValue): boolean {

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -17,11 +17,15 @@ interface UseStepMetadataResult {
   position: number
   stepName: string
   substeps: ISubstep[]
+  shouldShowDragHandle?: boolean
 }
 
 export function useStepMetadata(
   allApps: IApp[],
   step: IStep | undefined,
+  readOnly?: boolean,
+  allowReorder?: boolean,
+  isMobile?: boolean,
 ): UseStepMetadataResult {
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'
@@ -53,6 +57,20 @@ export function useStepMetadata(
     (substep: ISubstep) => substep.key === 'chooseConnection',
   )
 
+  /**
+   * NOTE: there are various conditions that determine whether the drag handle
+   * should be shown.
+   *
+   * - not read only
+   * - not in mobile view
+   * - step is not a trigger
+   * - step is not an if-then condition step
+   * - allowReorder is true
+   */
+  const shouldShowDragHandle = useMemo(() => {
+    return !readOnly && !isTrigger && !isMobile && !isIfThenStep && allowReorder
+  }, [readOnly, isTrigger, isMobile, isIfThenStep, allowReorder])
+
   return {
     app,
     selectedActionOrTrigger,
@@ -67,5 +85,6 @@ export function useStepMetadata(
       ? step.config.stepName
       : defaultCaption ?? '',
     substeps,
+    shouldShowDragHandle,
   }
 }


### PR DESCRIPTION
## TL;DR
CSS improvements:
* Use `grab` and `grabbing` cursor for the DragHandle
* Keep step widths the same as others when drag handle is shown

Fix:
* Make "Only continue if" deletable

## Screenshots
* Condition Step width matches child step with in If-then branches
![Screenshot 2025-09-18 at 12.36.39 PM.png](https://app.graphite.dev/user-attachments/assets/c3620535-adbc-4813-a52e-8921690d7490.png)

* If-then width matches for-each step widths
![Screenshot 2025-09-18 at 12.36.56 PM.png](https://app.graphite.dev/user-attachments/assets/89150639-61bd-4f34-b1b8-58e0bbcd5fcf.png)

![Screenshot 2025-09-18 at 12.37.16 PM.png](https://app.graphite.dev/user-attachments/assets/4c5345d4-a312-4c66-8e63-fed3180402b0.png)

