### PR TITLE
chore: hide all apps if launchdarkly errors out

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -116,6 +116,11 @@ export default function ChooseApp(props: ChooseAppProps) {
   // Combine filtering and grouping logic into a single operation
   const groupedApps = useMemo(() => {
     const filteredApps = apps?.filter((app) => {
+      // GUARDRAIL: in the event that launchDarkly.flags is not loaded, we do not show any apps.
+      // this should force the user to reload the page to fetch the flags.
+      if (!isLoading && !launchDarkly.flags) {
+        return false
+      }
       // Filter away apps hidden behind feature flags
       if (isLoading || !launchDarkly.flags || !app?.key) {
         return true

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -257,8 +257,13 @@ export default function ChooseApp(props: ChooseAppProps) {
               alignItems="center"
               py={8}
               color="base.content.medium"
+              flexDir="column"
+              gap={2}
             >
-              No apps found
+              No apps found.
+              <Text>
+                Something may have gone wrong. Please refresh and try again.
+              </Text>
             </Flex>
           ) : (
             groupedApps.map(([category, apps]) => (


### PR DESCRIPTION
## Problem
Users can see all apps if launchdarkly encounters an error.

## Solution
Hide all apps if there is a launchdarkly error to avoid users seeing a gated or deprecated application.
It should force users to refresh the page to refetch the launchdarkly flags and see the apps that they are allowed to access.

### Why make this change?
Avoid unintended usage of apps that are not available to users.

## How to test?
At `packages/frontend/src/contexts/LaunchDarkly.tsx`, set the flags to null at L94:
- [ ] Should not be able to see any apps after clicking on 'Add step'

Revert the change
- [ ] Should be able to see the apps that you are allowed to see.

## Screenshots
<img width="645" height="403" alt="Screenshot 2025-09-18 at 4 22 11 PM" src="https://github.com/user-attachments/assets/e0617565-7e66-4186-b750-c09a841717ce" />

