### PR TITLE
chore: skip dd rum if on landing page and add version

### DIFF
--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -36,6 +36,14 @@ if (['prod', 'staging'].includes(appConfig.env)) {
     trackResources: true,
     trackLongTasks: true,
     defaultPrivacyLevel: 'mask-user-input',
+    version: appConfig.version,
+    beforeSend: (event) => {
+      const url = event?.view?.url
+      if (url && new URL(url).pathname === '/') {
+        return false // drop all landing-page events
+      }
+      return true
+    },
   })
 }
 root.render(

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -38,11 +38,8 @@ if (['prod', 'staging'].includes(appConfig.env)) {
     defaultPrivacyLevel: 'mask-user-input',
     version: appConfig.version,
     beforeSend: (event) => {
-      const url = event?.view?.url
-      if (url && new URL(url).pathname === '/') {
-        return false // drop all landing-page events
-      }
-      return true
+      // do not send if user is anonymous
+      return event.usr !== undefined
     },
   })
 }


### PR DESCRIPTION
## Problem
Cloudflare worker for datadog RUM proxy have been close to hitting limits recently.

## Solution
Do not send if user is not authenticated: the only pages accessible will be landing page, use cases, and Tiles read-only page.

## Other changes
* Add app version
