### PR TITLE
chore: reduce custom API max payload size to 2 MB

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/common/size-monitor.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/common/size-monitor.test.ts
@@ -50,9 +50,9 @@ describe('createSizeMonitor', () => {
     expect(mocks.warn).not.toHaveBeenCalled()
   })
 
-  it('errors when total size exceeds 20MB', async () => {
+  it('errors when total size exceeds 2 MB', async () => {
     const monitor = createSizeMonitor()
-    const overLimit = Buffer.alloc(20 * 1024 * 1024 + 1)
+    const overLimit = Buffer.alloc(2 * 1024 * 1024 + 1)
     await expect(writeBuffers(monitor, [overLimit])).rejects.toMatchObject({
       name: 'AxiosError',
       isAxiosError: true,

--- a/packages/backend/src/apps/custom-api/common/size-monitor.ts
+++ b/packages/backend/src/apps/custom-api/common/size-monitor.ts
@@ -2,9 +2,13 @@ import { Transform } from 'stream'
 
 import logger from '@/helpers/logger'
 
-const MAX_SIZE_IN_MB = 20
+/**
+ * NOTE: we set the limit to 2 MB to prevent abuse and protect frontend performance
+ * for large JSON payloads
+ */
+const MAX_SIZE_IN_MB = 2
 const MB = 1024 * 1024
-const MAX_CONTENT_LENGTH = MAX_SIZE_IN_MB * MB // 20MB
+const MAX_CONTENT_LENGTH = MAX_SIZE_IN_MB * MB
 const MAX_COMPRESSION_RATIO = 100 // Maximum compression ratio to prevent gzip bombs
 
 const ERROR_RESPONSE = {


### PR DESCRIPTION
## Problem
Large payloads may cause performance issues on the frontend.

## Solution
Reduce payload size to 2 MB, which is a reasonable size for a reasonably large payload from various sources such as data.gov.sg

## Tests
- [ ] Custom API calls should still work as per normal (most custom API actions receive less than 2 MB)
- [ ] Test with large payload (e.g., `https://api-production.data.gov.sg/v2/public/api/datasets/d_3f960c10fed6145404ca7b821f263b87/list-rows?limit=10000`, should get `Payload too large` error)

## Screenshots
<img width="896" height="449" alt="Screenshot 2025-09-19 at 9 45 47 AM" src="https://github.com/user-attachments/assets/6b90b89c-dc99-4b62-a7da-f6d7674c2cd4" />
