### PR TITLE
fix: stop dd rum when user not logged in

### DIFF
--- a/packages/frontend/src/contexts/Authentication.tsx
+++ b/packages/frontend/src/contexts/Authentication.tsx
@@ -39,10 +39,17 @@ export const AuthenticationProvider = ({
   const [logout] = useMutation(LOGOUT, {
     refetchQueries: [GET_CURRENT_USER],
     awaitRefetchQueries: true,
+    onCompleted: () => {
+      // force datadog rum to stop tracking once logged out
+      datadogRum.setTrackingConsent('not-granted')
+    },
   })
+
   useEffect(() => {
     if (currentUser) {
       datadogRum.setUser(currentUser)
+      // grant consent to start tracking once logged in
+      datadogRum.setTrackingConsent('granted')
     }
   }, [currentUser])
 

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -37,10 +37,9 @@ if (['prod', 'staging'].includes(appConfig.env)) {
     trackLongTasks: true,
     defaultPrivacyLevel: 'mask-user-input',
     version: appConfig.version,
-    beforeSend: (event) => {
-      // do not send if user is anonymous
-      return event.usr !== undefined
-    },
+    // set tracking consent to not-granted by default
+    // only start tracking when user is authenticated
+    trackingConsent: 'not-granted' as const,
   })
 }
 root.render(


### PR DESCRIPTION
## Problem
Plumber is still sending RUM session replays even though user is unauthenticated because `beforeSend` cannot be used to filter out events that should not be sent.

## Solution
* Set `trackingConsent: 'not-granted'` by default so that RUM session replays are not sent on load
* Only call `datadogRum.setTrackingConsent('granted')` when user is authenticated
* Call `datadogRum.setTrackingConsent('not-granted')` on logout to stop sending replays

## How to test?
Enable RUM on `development`
- [ ] Load page, should not see `rum-proxy.plumber.gov.sg` being called
- [ ] Login, should now see calls to `rum-proxy.plumber.gov.sg`, stay on the page and do some stuff so that a session recording is created
- [ ] Close the tab, reopen, should still be logged in, and still see calls to `rum-proxy.plumber.gov.sg`
- [ ] Logout, should not see any calls `rum-proxy.plumber.gov.sg`
- [ ] Login in to DD, should see your RUM session recorded