### PR TITLE
PLU-507: FormSG error message when form is not public

### DIFF
--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -37,10 +37,12 @@ const testConnection: QueryResolvers['testConnection'] = async (
 
   // Verify connection
   let isStillVerified
+  let errorMessage
   try {
     isStillVerified = !!(await app.auth.isStillVerified($))
   } catch (err) {
     isStillVerified = false
+    errorMessage = err.message
     logger.error(`Error verifying CONNECTION ID: ${params.connectionId}`, {
       event: 'test-connection',
       flowId: params.flowId,
@@ -56,7 +58,7 @@ const testConnection: QueryResolvers['testConnection'] = async (
 
   // if testing outside of the editor, it does not verify registration (e.g. setting of webhook url)
   if (!isStillVerified || !params.flowId) {
-    return { connectionVerified: isStillVerified }
+    return { connectionVerified: isStillVerified, message: errorMessage }
   }
 
   // TODO (ogp-weeloong): We should actually _disallow_ testing connections


### PR DESCRIPTION
## Problem
Unclear when form is not open to responses after form has been connected.

## Solution
Returns the error message so that it is displayed on the UI.

## Before & After Screenshots

**BEFORE**:
<img width="1145" height="230" alt="Screenshot 2025-09-22 at 8 25 24 PM" src="https://github.com/user-attachments/assets/288733ee-112f-4bf7-bb4c-20a0886739be" />

<img width="634" height="375" alt="Screenshot 2025-09-22 at 8 25 31 PM" src="https://github.com/user-attachments/assets/3b0f59d1-b46a-4e53-85a1-02f543a1b6e1" />


**AFTER**:
<img width="898" height="296" alt="Screenshot 2025-09-22 at 6 34 17 PM" src="https://github.com/user-attachments/assets/0afbaf30-07d8-471d-abb8-6b964568f2ec" />

<img width="638" height="447" alt="Screenshot 2025-09-22 at 6 34 24 PM" src="https://github.com/user-attachments/assets/5f9dc0c1-bd84-4116-b4d6-1bbd312b7eb4" />


## Tests
- [ ] Existing functionalities work
  - [ ] Can add new form
  - [ ] Can change form
  - [ ] Can reconnect form
  - [ ] "Ensure form is public" is shown correctly when attempting to connect a new form that is closed
- [ ] Updated error message
  - [ ] "Ensure form is public" is shown correctly for a form that has already been connected
