### PR TITLE
chore: prevent tall steps from blocking other steps

### DIFF
--- a/packages/frontend/src/components/Editor/styles.ts
+++ b/packages/frontend/src/components/Editor/styles.ts
@@ -8,7 +8,6 @@ export const editorStyles = {
     overflowX: 'hidden' as FlexProps['overflowX'],
     justifyContent: 'center',
     pos: 'relative' as FlexProps['pos'],
-    paddingX: 4,
   },
   stepHeaderContainer: {
     display: 'block',

--- a/packages/frontend/src/components/SortableList/index.tsx
+++ b/packages/frontend/src/components/SortableList/index.tsx
@@ -19,6 +19,7 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 
 import { DragHandle, SortableItem, SortableOverlay } from './components'
@@ -77,7 +78,7 @@ export function SortableList<T extends BaseItem>({
         restrictToWindowEdges,
       ]}
     >
-      <SortableContext items={items}>
+      <SortableContext items={items} strategy={verticalListSortingStrategy}>
         <ul className="SortableList" role="application">
           {items.map((item) => (
             <React.Fragment key={item.id}>


### PR DESCRIPTION
## Problem
* Template step would block other steps when being dragged

## Bugfix
Extra padding causing a gap between the screen and the scrollbar

## Solution
* Use `verticalListSortingStrategy`, which is a sorting strategy optimized for vertical lists (supports virtualized lists).
verticalListSortingStrategy computes transforms for vertical lists and is intended for use as the strategy prop on SortableContext. It’s optimized for single-column vertical layouts and supports virtualized lists (use instead of the default rectSortingStrategy when rendering long or virtualized vertical lists). 

## Before & After Screenshots

**BEFO
<img width="1512" height="812" alt="Screenshot 2025-09-23 at 6 24 10 PM" src="https://github.com/user-attachments/assets/38a13653-ea74-461a-a298-e755805b6257" />
RE**:


**AFTER**:
<img width="1920" height="961" alt="Screenshot 2025-09-23 at 6 39 14 PM" src="https://github.com/user-attachments/assets/68f4458c-a772-4cf6-9bf6-b40a082452c0" />


## Tests
- [ ] Reordering steps still work as intended
