### PR TITLE
fix: show numeric hex-encoded columns

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -414,7 +414,7 @@ describe('getDataOutMetadata', () => {
     )
 
     it.each(['0', '123', '999'])(
-      'should not hide column when the the column name happens to be a number: %s',
+      'should not hide column when the column name happens to be a number: %s',
       async (columnName) => {
         const testHexColumnId = Buffer.from(columnName).toString('hex')
         const dataOut = {

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -351,6 +351,67 @@ describe('getDataOutMetadata', () => {
         },
       })
     })
+
+    it.each(['Recruiter', 'sixty', 'itty'])(
+      'should not hide column when the hex encoded column happens to be a number: %s',
+      async (columnName) => {
+        const testHexColumnId = Buffer.from(columnName).toString('hex')
+        const dataOut = {
+          iterations: 1,
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          items: {
+            columns: {
+              [testHexColumnId]: {
+                id: testHexColumnId,
+                name: columnName,
+                value: `items.rows.__ITERATION__.data.${testHexColumnId}`,
+                order: 1,
+              },
+            },
+            rows: [{ data: { [testHexColumnId]: 'Vaser' } }],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+        }
+        const executionStep = createMockExecutionStep(dataOut)
+        const result = await getDataOutMetadata(executionStep)
+
+        expect(result).toEqual({
+          iteration: {
+            label: 'Item number',
+            displayedValue: '1',
+          },
+          iterations: {
+            label: 'Items found',
+          },
+          inputSource: {
+            isHidden: true,
+          },
+          items: {
+            columns: {
+              [testHexColumnId]: {
+                id: { isHidden: true },
+                name: { isHidden: true },
+                order: { isHidden: true },
+                value: {
+                  label: columnName,
+                  displayedValue: 'Vaser',
+                  order: 1,
+                  type: 'text',
+                  isHiddenFromList: false,
+                },
+              },
+            },
+            rows: [
+              {
+                data: { isHidden: true },
+                rowId: { isHidden: true },
+              },
+            ],
+            inputSource: { isHidden: true },
+          },
+        })
+      },
+    )
   })
 
   describe('when inputSource is TILES', () => {

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -352,6 +352,19 @@ describe('getDataOutMetadata', () => {
       })
     })
 
+    const EXPECTED_RESULT = {
+      iteration: {
+        label: 'Item number',
+        displayedValue: '1',
+      },
+      iterations: { label: 'Items found' },
+      inputSource: { isHidden: true },
+      items: {
+        rows: [{ data: { isHidden: true }, rowId: { isHidden: true } }],
+        inputSource: { isHidden: true },
+      },
+    }
+
     it.each(['Recruiter', 'sixty', 'itty'])(
       'should not hide column when the hex encoded column happens to be a number: %s',
       async (columnName) => {
@@ -376,17 +389,9 @@ describe('getDataOutMetadata', () => {
         const result = await getDataOutMetadata(executionStep)
 
         expect(result).toEqual({
-          iteration: {
-            label: 'Item number',
-            displayedValue: '1',
-          },
-          iterations: {
-            label: 'Items found',
-          },
-          inputSource: {
-            isHidden: true,
-          },
+          ...EXPECTED_RESULT,
           items: {
+            ...EXPECTED_RESULT.items,
             columns: {
               [testHexColumnId]: {
                 id: { isHidden: true },
@@ -401,13 +406,52 @@ describe('getDataOutMetadata', () => {
                 },
               },
             },
-            rows: [
-              {
-                data: { isHidden: true },
-                rowId: { isHidden: true },
+          },
+        })
+      },
+    )
+
+    it.each(['Date Sent', 'Send Status'])(
+      'should not hide columns when the hex encoded column name contains an e and appears like scientific notation: %s',
+      async (columnName) => {
+        const testHexColumnId = Buffer.from(columnName).toString('hex')
+        const dataOut = {
+          iterations: 1,
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          items: {
+            columns: {
+              [testHexColumnId]: {
+                id: testHexColumnId,
+                name: columnName,
+                value: `items.rows.__ITERATION__.data.${testHexColumnId}`,
+                order: 1,
               },
-            ],
-            inputSource: { isHidden: true },
+            },
+            rows: [{ data: { [testHexColumnId]: 'Vaser' } }],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+        }
+        const executionStep = createMockExecutionStep(dataOut)
+        const result = await getDataOutMetadata(executionStep)
+
+        expect(result).toEqual({
+          ...EXPECTED_RESULT,
+          items: {
+            ...EXPECTED_RESULT.items,
+            columns: {
+              [testHexColumnId]: {
+                id: { isHidden: true },
+                name: { isHidden: true },
+                order: { isHidden: true },
+                value: {
+                  label: columnName,
+                  displayedValue: 'Vaser',
+                  order: 1,
+                  type: 'text',
+                  isHiddenFromList: false,
+                },
+              },
+            },
           },
         })
       },
@@ -437,17 +481,9 @@ describe('getDataOutMetadata', () => {
         const result = await getDataOutMetadata(executionStep)
 
         expect(result).toEqual({
-          iteration: {
-            label: 'Item number',
-            displayedValue: '1',
-          },
-          iterations: {
-            label: 'Items found',
-          },
-          inputSource: {
-            isHidden: true,
-          },
+          ...EXPECTED_RESULT,
           items: {
+            ...EXPECTED_RESULT.items,
             columns: {
               [testHexColumnId]: {
                 id: { isHidden: true },
@@ -462,13 +498,6 @@ describe('getDataOutMetadata', () => {
                 },
               },
             },
-            rows: [
-              {
-                data: { isHidden: true },
-                rowId: { isHidden: true },
-              },
-            ],
-            inputSource: { isHidden: true },
           },
         })
       },

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -412,6 +412,67 @@ describe('getDataOutMetadata', () => {
         })
       },
     )
+
+    it.each(['0', '123', '999'])(
+      'should not hide column when the the column name happens to be a number: %s',
+      async (columnName) => {
+        const testHexColumnId = Buffer.from(columnName).toString('hex')
+        const dataOut = {
+          iterations: 1,
+          inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          items: {
+            columns: {
+              [testHexColumnId]: {
+                id: testHexColumnId,
+                name: columnName,
+                value: `items.rows.__ITERATION__.data.${testHexColumnId}`,
+                order: 1,
+              },
+            },
+            rows: [{ data: { [testHexColumnId]: 'Vaser' } }],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+        }
+        const executionStep = createMockExecutionStep(dataOut)
+        const result = await getDataOutMetadata(executionStep)
+
+        expect(result).toEqual({
+          iteration: {
+            label: 'Item number',
+            displayedValue: '1',
+          },
+          iterations: {
+            label: 'Items found',
+          },
+          inputSource: {
+            isHidden: true,
+          },
+          items: {
+            columns: {
+              [testHexColumnId]: {
+                id: { isHidden: true },
+                name: { isHidden: true },
+                order: { isHidden: true },
+                value: {
+                  label: columnName,
+                  displayedValue: 'Vaser',
+                  order: 1,
+                  type: 'text',
+                  isHiddenFromList: false,
+                },
+              },
+            },
+            rows: [
+              {
+                data: { isHidden: true },
+                rowId: { isHidden: true },
+              },
+            ],
+            inputSource: { isHidden: true },
+          },
+        })
+      },
+    )
   })
 
   describe('when inputSource is TILES', () => {

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -431,7 +431,7 @@ describe('getDataOutMetadata', () => {
       },
     )
 
-    it.each(['0', '123', '999'])(
+    it.each(['0', '01', '1', '2', '123', '999', 'a'])(
       'should not hide column when the column name happens to be a number: %s',
       async (columnName) => {
         const testHexColumnId = Buffer.from(columnName).toString('hex')

--- a/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/for-each/get-data-out-metadata.test.ts
@@ -3,6 +3,19 @@ import { describe, expect, it } from 'vitest'
 import getDataOutMetadata from '../../../actions/for-each/get-data-out-metadata'
 import { FOR_EACH_INPUT_SOURCE } from '../../../common/constants'
 
+const GENERIC_TABLE_EXPECTED_RESULT = {
+  iteration: {
+    label: 'Item number',
+    displayedValue: '1',
+  },
+  iterations: { label: 'Items found' },
+  inputSource: { isHidden: true },
+  items: {
+    rows: [{ data: { isHidden: true }, rowId: { isHidden: true } }],
+    inputSource: { isHidden: true },
+  },
+}
+
 describe('getDataOutMetadata', () => {
   const createMockExecutionStep = (dataOut: any) => ({
     id: 'execution-step-id',
@@ -199,16 +212,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {
@@ -268,16 +272,8 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
+        iteration: { label: 'Item number', displayedValue: '' },
         items: {
           columns: [
             {
@@ -318,16 +314,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {
@@ -351,19 +338,6 @@ describe('getDataOutMetadata', () => {
         },
       })
     })
-
-    const EXPECTED_RESULT = {
-      iteration: {
-        label: 'Item number',
-        displayedValue: '1',
-      },
-      iterations: { label: 'Items found' },
-      inputSource: { isHidden: true },
-      items: {
-        rows: [{ data: { isHidden: true }, rowId: { isHidden: true } }],
-        inputSource: { isHidden: true },
-      },
-    }
 
     it.each(['Recruiter', 'sixty', 'itty'])(
       'should not hide column when the hex encoded column happens to be a number: %s',
@@ -389,9 +363,9 @@ describe('getDataOutMetadata', () => {
         const result = await getDataOutMetadata(executionStep)
 
         expect(result).toEqual({
-          ...EXPECTED_RESULT,
+          ...GENERIC_TABLE_EXPECTED_RESULT,
           items: {
-            ...EXPECTED_RESULT.items,
+            ...GENERIC_TABLE_EXPECTED_RESULT.items,
             columns: {
               [testHexColumnId]: {
                 id: { isHidden: true },
@@ -435,9 +409,9 @@ describe('getDataOutMetadata', () => {
         const result = await getDataOutMetadata(executionStep)
 
         expect(result).toEqual({
-          ...EXPECTED_RESULT,
+          ...GENERIC_TABLE_EXPECTED_RESULT,
           items: {
-            ...EXPECTED_RESULT.items,
+            ...GENERIC_TABLE_EXPECTED_RESULT.items,
             columns: {
               [testHexColumnId]: {
                 id: { isHidden: true },
@@ -481,9 +455,9 @@ describe('getDataOutMetadata', () => {
         const result = await getDataOutMetadata(executionStep)
 
         expect(result).toEqual({
-          ...EXPECTED_RESULT,
+          ...GENERIC_TABLE_EXPECTED_RESULT,
           items: {
-            ...EXPECTED_RESULT.items,
+            ...GENERIC_TABLE_EXPECTED_RESULT.items,
             columns: {
               [testHexColumnId]: {
                 id: { isHidden: true },
@@ -537,16 +511,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {
@@ -611,15 +576,10 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         iteration: {
           label: 'Item number',
           displayedValue: '',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
         },
         items: {
           columns: [
@@ -676,16 +636,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {
@@ -756,16 +707,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {
@@ -937,16 +879,7 @@ describe('getDataOutMetadata', () => {
       const result = await getDataOutMetadata(executionStep)
 
       expect(result).toEqual({
-        iteration: {
-          label: 'Item number',
-          displayedValue: '1',
-        },
-        iterations: {
-          label: 'Items found',
-        },
-        inputSource: {
-          isHidden: true,
-        },
+        ...GENERIC_TABLE_EXPECTED_RESULT,
         items: {
           columns: [
             {

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -2,6 +2,7 @@ import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
 import {
   FOR_EACH_INPUT_SOURCE,
+  FOR_EACH_MAX_ITERATIONS,
   FOR_EACH_TABLE_SOURCES,
 } from '../../common/constants'
 
@@ -78,7 +79,15 @@ async function getDataOutMetadata(
       Object.entries(items.columns)
         .sort((a, b) => a[1].order - b[1].order)
         .forEach(([id, column], index) => {
-          const isBackwardCompatibilityColumnId = !isNaN(Number(id))
+          /**
+           * NOTE: this is for backward compatibility with the old dataOut format
+           * we check that it is within the FOR_EACH_MAX_ITERATIONS as there are edge cases
+           * where the hex encoded columns from Excel is a number
+           *
+           * TODO (kevinkim-ogp): remove this once all users have moved to the new format
+           */
+          const isBackwardCompatibilityColumnId =
+            !isNaN(Number(id)) && Number(id) <= FOR_EACH_MAX_ITERATIONS
           tempColumnsMetadata[id] = {
             id: { isHidden: true },
             name: { isHidden: true },

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -2,23 +2,22 @@ import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
 
 import {
   FOR_EACH_INPUT_SOURCE,
-  FOR_EACH_MAX_ITERATIONS,
   FOR_EACH_TABLE_SOURCES,
 } from '../../common/constants'
 
 import { dataOutSchema } from './schema'
 
 // NOTE: this is for backward compatibility with the old dataOut format
-const isBackwardCompatibilityColumnId = (id: string, name: string) => {
-  // must be numeric and within legacy bounds
-  if (isNaN(Number(id)) || Number(id) > FOR_EACH_MAX_ITERATIONS) {
-    return false
+const isBackwardCompatibilityColumnId = (id: string, numColumns: number) => {
+  // must be numeric
+  // cannot have leading 0
+  // must only contain digits
+  // must be less than the number of columns
+  if (Number(id) < numColumns && !id.startsWith('0') && /^\d+$/.test(id)) {
+    return true
   }
 
-  // additional check: does the hex encoding of the column name NOT match this ID?
-  // handles edge cases where the hex encoded column name happens to be a number
-  const expectedHexKey = Buffer.from(name).toString('hex')
-  return id !== expectedHexKey
+  return false
 }
 
 async function getDataOutMetadata(
@@ -110,7 +109,7 @@ async function getDataOutMetadata(
                */
               isHiddenFromList: isBackwardCompatibilityColumnId(
                 id,
-                column.name,
+                Object.keys(items.columns).length,
               ),
             },
             order: { isHidden: true },

--- a/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/get-data-out-metadata.ts
@@ -8,6 +8,19 @@ import {
 
 import { dataOutSchema } from './schema'
 
+// NOTE: this is for backward compatibility with the old dataOut format
+const isBackwardCompatibilityColumnId = (id: string, name: string) => {
+  // must be numeric and within legacy bounds
+  if (isNaN(Number(id)) || Number(id) > FOR_EACH_MAX_ITERATIONS) {
+    return false
+  }
+
+  // additional check: does the hex encoding of the column name NOT match this ID?
+  // handles edge cases where the hex encoded column name happens to be a number
+  const expectedHexKey = Buffer.from(name).toString('hex')
+  return id !== expectedHexKey
+}
+
 async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
@@ -79,15 +92,6 @@ async function getDataOutMetadata(
       Object.entries(items.columns)
         .sort((a, b) => a[1].order - b[1].order)
         .forEach(([id, column], index) => {
-          /**
-           * NOTE: this is for backward compatibility with the old dataOut format
-           * we check that it is within the FOR_EACH_MAX_ITERATIONS as there are edge cases
-           * where the hex encoded columns from Excel is a number
-           *
-           * TODO (kevinkim-ogp): remove this once all users have moved to the new format
-           */
-          const isBackwardCompatibilityColumnId =
-            !isNaN(Number(id)) && Number(id) <= FOR_EACH_MAX_ITERATIONS
           tempColumnsMetadata[id] = {
             id: { isHidden: true },
             name: { isHidden: true },
@@ -99,7 +103,15 @@ async function getDataOutMetadata(
                   : String(items?.rows?.[0]?.data?.[column.id] ?? ''),
               order: index + 1,
               type: column.id === 'rowId' ? 'tile_row_id' : 'text', // NOTE: only tiles will have rowId
-              isHiddenFromList: isBackwardCompatibilityColumnId,
+              /**
+               * NOTE: this is for backward compatibility with the old dataOut format
+               *
+               * TODO (kevinkim-ogp): remove this once all users have moved to the new format
+               */
+              isHiddenFromList: isBackwardCompatibilityColumnId(
+                id,
+                column.name,
+              ),
             },
             order: { isHidden: true },
           }

--- a/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
+++ b/packages/backend/src/apps/toolbox/common/get-for-each-variables.ts
@@ -51,6 +51,11 @@ function processColumns(
      *
      * TODO: remove this once all users have moved the new dataOut format
      */
+    // do not override the real column id if it already exists
+    // e.g., when column name is '0', it encodes to '30' for m365-excel and formsg tables
+    if (processedColumns[String(index)]) {
+      return
+    }
     processedColumns[String(index)] = {
       id: column.id,
       name: column.name,


### PR DESCRIPTION
## Problem
When Excel column names are hex-encoded, they may become numeric strings. Our backward compatibility check
```
const isBackwardCompatibilityColumnId = !isNaN(Number(id))
```
then mistakenly hides these columns.

This happens when:
1. Column names encode into numeric-only hex strings (e.g., `recruiter`, `sixty`).
2. Column names that are encoded with `e` are interpreted like scientific notation (e.g., `53656e6420537461747573`, `446174652053656e74`
3. Column names are numeric themselves (e.g., `0`, `123`).

_This can also occur with FormSG table fields, but this PR addresses both M365 Excel and FormSG._

## Solution
Strengthen the backward compatibility check to ensure:
1. Column ID is numeric.
2. Column ID ≤ 500.
4. The column’s hex encoding matches its ID.

## How to test?
Create excel columns with numbers only or strings that encode into numeric-only strings.
Use Excel find multiple table rows and check step, then use in For each and check step.
- [ ] Columns appear in the test result
- [ ] Columns are selectable in the subsequent steps
- [ ] DB stores the correct step parameter (hex encoding, not array index).

Sanity check
- [ ] Tiles find multiple rows + For each still works
- [ ] FormSG table field + For each still works
