### PR TITLE
PLU-586: fix deleting of last character before variable

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
+++ b/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
@@ -110,8 +110,12 @@ export const StepVariable = Node.create<VariableOptions>({
         const { selection } = editor.state
         const { $head } = selection
 
-        // If cursor is right before a variable, delete the character before it
-        if ($head.nodeAfter?.type.name === this.name && $head.pos > 0) {
+        // If cursor is right before a variable and not at the start of a line
+        if (
+          $head.nodeAfter?.type.name === this.name &&
+          $head.pos > 0 &&
+          $head.parentOffset > 0
+        ) {
           editor.commands.deleteRange({ from: $head.pos - 1, to: $head.pos })
           return true
         }

--- a/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
+++ b/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
@@ -104,4 +104,20 @@ export const StepVariable = Node.create<VariableOptions>({
       },
     })
   },
+  addKeyboardShortcuts() {
+    return {
+      Backspace: ({ editor }) => {
+        const { selection } = editor.state
+        const { $head } = selection
+
+        // If cursor is right before a variable, delete the character before it
+        if ($head.nodeAfter?.type.name === this.name && $head.pos > 0) {
+          editor.commands.deleteRange({ from: $head.pos - 1, to: $head.pos })
+          return true
+        }
+
+        return false
+      },
+    }
+  },
 })

--- a/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
+++ b/packages/frontend/src/components/RichTextEditor/StepVariablePlugin.ts
@@ -106,17 +106,75 @@ export const StepVariable = Node.create<VariableOptions>({
   },
   addKeyboardShortcuts() {
     return {
+      /**
+       * NOTE: this is a fix for deleting text or whitespace before a variable node using Backspace key
+       *
+       * ROOT CAUSE:
+       * ProseMirror’s default Backspace logic is conservative at inline atom boundaries.
+       * Since the variable badge is an atom, Backspace right before it may prefer acting on the
+       * atom boundary or do nothing instead of removing the character immediately before the variable.
+       *
+       * FIX: overrides ambiguous boundary handling and ensures predictable Backspace semantics
+       * Checks that the caret is immediately before the variable and not at the start of the text block.
+       * Explicitly deletes one character to the left (from: $head.pos - 1, to: $head.pos).
+       */
       Backspace: ({ editor }) => {
         const { selection } = editor.state
         const { $head } = selection
 
-        // If cursor is right before a variable and not at the start of a line
         if (
+          // ensures we’re at a boundary right before the variable atom.
           $head.nodeAfter?.type.name === this.name &&
+          // ensures we’re not at the start of the current text block,
+          // where deleting left might merge blocks or have other structural effects.
           $head.pos > 0 &&
+          // extra safety so we don’t try to delete past the document start
           $head.parentOffset > 0
         ) {
           editor.commands.deleteRange({ from: $head.pos - 1, to: $head.pos })
+          return true
+        }
+
+        return false
+      },
+      /**
+       * NOTE: this is a fix for deleting text or whitespace before a variable node using Delete key
+       *
+       * ROOT CAUSE:
+       * ProseMirror’s default forward-delete is conservative at inline atom boundaries.
+       * The variable badge is an atom (atom: true, selectable: true).
+       * When the caret sits just before an inline atom, the built-in behavior prioritises the atom boundary
+       * over adjacent text and can either try to delete the atom or do nothing.
+       * As a result, the single character or whitespace immediately before the variable often won’t delete as expected.
+       *
+       * FIX:
+       * Override the ambiguous default behaviour around atom boundaries
+       * If the next node is text, it deletes exactly one character (including whitespace).
+       * Otherwise, if the next node is the variable atom, it deletes the atom.
+       */
+      Delete: ({ editor }) => {
+        const { selection } = editor.state
+        const { $head } = selection
+
+        const nextNode = $head.nodeAfter
+
+        // If the next node is a text node (including whitespace), delete the next character
+        // ensures the immediate content after the caret is a text node with at least one character (including whitespace)
+        if (nextNode?.isText && nextNode.text && nextNode.text.length > 0) {
+          editor.commands.deleteRange({ from: $head.pos, to: $head.pos + 1 })
+          return true
+        }
+
+        // If cursor is right before a variable node, delete the whole variable atom
+        // confirms the immediate next inline node is the variable atom.
+        if (nextNode?.type.name === this.name) {
+          // delete the entire atom using its nodeSize, preserving the atomic behavior of the variable badge
+          // and avoiding partial/invalid deletions.
+          const nodeSize = nextNode.nodeSize
+          editor.commands.deleteRange({
+            from: $head.pos,
+            to: $head.pos + nodeSize,
+          })
           return true
         }
 


### PR DESCRIPTION
## Problem
If there is a string in front of a variable e.g., `string <variable>`, attempting to delete `string ` using backspace does not work and results in `s<variable>`.
It can only be deleted if you highlight (select) `s` and hit backspace; or deleting everything altogether.

Apparently, the problem was caused by setting `atom: true` in the `StepVariablePlugin`:
* TipTap treats variables as atomic nodes (atom: true in the plugin definition)
* Atomic nodes are indivisible - TipTap doesn't know how to handle deletion around them by default
* The cursor gets "stuck" when positioned right before an atomic node
* Default backspace behaviour fails because TipTap's built-in logic doesn't handle this edge case

## Solution
* Intercept the backspace key before TipTap's default behaviour kicks in
* Handles the specific edge case where cursor is before a variable
* Uses TipTap's built-in deletion command instead of trying to manipulate the document manually
* Returns true to tell TipTap "I handled this, don't do your default behaviour"

## Tests
- [ ] RTE still works as intended, including using variables, replacing variables, formatting text, etc
- [ ] Can delete text in front of variables properly (using both `backspace` and `delete`)
- [ ] In multi-line editors, can delete new lines even if variable is the first thing on the line

## Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/a5c431bc-5b73-49cf-bdb1-c32d670780c7


**AFTER**:

https://github.com/user-attachments/assets/7a118abf-9663-4617-8e79-8f3581e21ec6

https://github.com/user-attachments/assets/77a69d5f-2378-4817-9e08-7551d897e5bb