### PR TITLE
fix: trim long sender names for postman email

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -188,4 +188,12 @@ describe('postman transactional email schema zod validation', () => {
       )
     },
   )
+
+  it('should trim long reply to email', () => {
+    validPayload.senderName = 'a'.repeat(256)
+    const validLength = 255 - ' <info@plumber.gov.sg>'.length
+    const result = transactionalEmailSchema.safeParse(validPayload)
+    assert(result.success === true)
+    expect(result.data.senderName).toEqual('a'.repeat(validLength))
+  })
 })

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -4,6 +4,7 @@ import validator from 'email-validator'
 import { uniq } from 'lodash'
 import { z } from 'zod'
 
+import appConfig from '@/config/app'
 import { parseS3Id } from '@/helpers/s3'
 
 import { POSTMAN_SUPPORTED_ATTACHMENTS_GUIDE_URL } from './constants'
@@ -121,7 +122,16 @@ export const transactionalEmailSchema = z.object({
     }
     return value.trim() === '' ? undefined : value.trim()
   }, z.string().email({ message: 'Invalid reply to email' }).optional()),
-  senderName: z.string().min(1, { message: 'Empty sender name' }).trim(),
+  senderName: z
+    .string()
+    .min(1, { message: 'Empty sender name' })
+    .trim()
+    // NOTE: we trim the sender name so that long sender names do not cause the email to fail.
+    // Postman limits the sender name to 255 characters.
+    // the API sends "{senderName} <info@plumber.gov.sg>" so it needs to be included in the calculation.
+    .transform((value) =>
+      value.substring(0, 255 - ` <${appConfig.postman.fromAddress}>`.length),
+    ),
   attachments: z.array(z.string()).transform((array, context) => {
     const result: string[] = []
     for (const value of array) {


### PR DESCRIPTION
## Problem

Sending transactional emails can cause downstream issues in Postman when sender names exceed 255 characters. This issue was discovered in a Pipe that used a variable from FormSG, where a user mistakenly entered incorrect information in a field intended for their name.

## Solution

Trim excessively long sender names to ensure emails can still be sent successfully. This is an edge case, as sender names are generally not expected to be that long.

## How to test?
Connect either a FormSG or a webhook to a Pipe, and use the variable in the Email by Postman step.
- [ ] Make a submission with extremely long sender name, email is still sent with the trimmed sender name
