### PR TITLE
fix: temporarily disable dd test visibility

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -19,21 +19,21 @@ jobs:
       - run: npm ci
         env:
           NPM_TASKFORCESH_TOKEN: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
-      - name: Configure Datadog Test Visibility
-        env:
-          DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        uses: datadog/test-visibility-github-action@v1
-        with:
-          languages: js
-          service: ${{ secrets.DD_SERVICE_NAME }}
-          api_key: ${{ secrets.DD_API_KEY }}
+      # - name: Configure Datadog Test Visibility
+      #   env:
+      #     DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
+      #     DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      #   uses: datadog/test-visibility-github-action@v1
+      #   with:
+      #     languages: js
+      #     service: ${{ secrets.DD_SERVICE_NAME }}
+      #     api_key: ${{ secrets.DD_API_KEY }}
       - run: npm run lint
       - run: echo "✅ Your code has been linted."
       - run: npm run test
-        env:
-          # Required to allow Datadog to trace Vitest tests
-          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+        # env:
+        #   # Required to allow Datadog to trace Vitest tests
+        #   NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
       - run: echo "✅ All tests passed."
       - run: VITE_MODE=test npm run build
       - run: echo "✅ Your code has been built."


### PR DESCRIPTION
## Problem
GitHub workflow is failing due to:
```
⎯⎯⎯⎯⎯⎯ Unhandled Error ⎯⎯⎯⎯⎯⎯⎯
TypeError: Invalid value used in weak set
 ❯ threadHandler .datadog/lib/node_modules/dd-trace/packages/datadog-instrumentations/src/vitest.js:410:19
 ❯ Tinypool.run .datadog/lib/node_modules/dd-trace/packages/datadog-instrumentations/src/vitest.js:429:18
 ❯ runFiles node_modules/vitest/dist/chunks/coverage.DL5VHqXY.js:2793:16
 ❯ Object.runTests node_modules/vitest/dist/chunks/coverage.DL5VHqXY.js:2849:13
 ❯ executeTests node_modules/vitest/dist/chunks/coverage.DL5VHqXY.js:3421:4
 ❯ node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9638:6
 ❯ Vitest.runFiles node_modules/vitest/dist/chunks/cli-api.BkDphVBG.js:9666:10
```

## Solution
Temporarily disable the datadog test visibility until we can find the root cause and implement the fix. 
Tests still run after disabling the test visibility.
