### PR TITLE
PLU-589: pin js-tracer-version in ci

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -19,21 +19,23 @@ jobs:
       - run: npm ci
         env:
           NPM_TASKFORCESH_TOKEN: ${{ secrets.NPM_TASKFORCESH_TOKEN }}
-      # - name: Configure Datadog Test Visibility
-      #   env:
-      #     DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
-      #     DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      #   uses: datadog/test-visibility-github-action@v1
-      #   with:
-      #     languages: js
-      #     service: ${{ secrets.DD_SERVICE_NAME }}
-      #     api_key: ${{ secrets.DD_API_KEY }}
+      - name: Configure Datadog Test Visibility
+        env:
+          DD_SERVICE_NAME: ${{ secrets.DD_SERVICE_NAME }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        uses: datadog/test-visibility-github-action@v2
+        with:
+          languages: js
+          service: ${{ secrets.DD_SERVICE_NAME }}
+          api_key: ${{ secrets.DD_API_KEY }}
+          # we need to pin this for now since 5.68.0 breaks the ci
+          js-tracer-version: 5.67.0
       - run: npm run lint
       - run: echo "✅ Your code has been linted."
       - run: npm run test
-        # env:
-        #   # Required to allow Datadog to trace Vitest tests
-        #   NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+        env:
+          # Required to allow Datadog to trace Vitest tests
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
       - run: echo "✅ All tests passed."
       - run: VITE_MODE=test npm run build
       - run: echo "✅ Your code has been built."


### PR DESCRIPTION
## Problem

CI failing due to new dd-tracer version.

## Solution

Pin to last working version