### PR TITLE
fix: allow add if-then immediately after for-each

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -69,7 +69,7 @@ export default function ForEach(props: ForEachProps) {
         <GroupStepWithAddButton
           step={conditionStep}
           canAddStep={true}
-          isLastStep={false}
+          isLastStep={hasNoActionSteps}
           allowReorder={false}
           showEmptyAction={hasNoActionSteps}
           canChildStepsReorder={actionSteps.length > 1}


### PR DESCRIPTION
## Problem
Bug: cannot add if-then step immediately after the for-each step.
Cause: misconfigured condition blocking the check for `isLastStep` which is used to determine whether certain apps can be added

## Solution
Use the `hasNoActionSteps` condition which correctly indicates whether it is `isLastStep` based on the steps in the pipe.

## Tests
Test that steps can still be added correctly
- [ ] If-then only can be added as a last step
  - [ ] Can add 1 if-then inside a for-each
  - [ ] Cannot add for-each inside if-then
- [ ] For-each can only be added as last step
  - [ ] Can only be added once
  - [ ] Cannot add delay inside for-each
- [ ] All other steps can be added


## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/53dcbf1d-db4e-4a46-bf01-023e516d7930


**AFTER**:

https://github.com/user-attachments/assets/cd178b6b-9103-4773-9a19-e06364da01d0

