### PR TITLE
[COLLAB-18]: Pipe transfer

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from 'objection'
 import { vi } from 'vitest'
 
+import Connection from '@/models/connection'
 import User from '@/models/user'
 
 interface MockConnectionsRelatedQueryOptions {
@@ -17,17 +18,9 @@ export function mockConnectionsRelatedQuery(
     connectionNotFound = false,
   }: MockConnectionsRelatedQueryOptions,
 ) {
-  currentUser.$relatedQuery = vi.fn().mockImplementation((relation: string) => {
-    if (relation !== 'connections') {
-      return {
-        findOne: vi.fn().mockReturnValue({
-          throwIfNotFound: vi.fn().mockResolvedValue(null),
-        }),
-      }
-    }
-
-    return {
-      findOne: vi.fn().mockReturnValue({
+  vi.spyOn(Connection, 'query').mockReturnValue({
+    findById: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
         throwIfNotFound: connectionNotFound
           ? vi
               .fn()
@@ -36,6 +29,6 @@ export function mockConnectionsRelatedQuery(
               )
           : vi.fn().mockResolvedValue({ id: connectionId, key: connectionKey }),
       }),
-    }
-  })
+    }),
+  } as any)
 }

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto'
+import { AES } from 'crypto-js'
 import { beforeEach, describe, expect, it } from 'vitest'
 
+import appConfig from '@/config/app'
 import updateFlowTransferStatus from '@/graphql/mutations/update-flow-transfer-status'
 import Connection from '@/models/connection'
 import Execution from '@/models/execution'
@@ -189,7 +191,10 @@ describe('updateFlowTransferStatus', () => {
       await Connection.query().insert({
         id: excelConnectionId,
         key: 'm365-excel',
-        data: JSON.stringify({ accessToken: 'test-token' }),
+        data: AES.encrypt(
+          JSON.stringify({ accessToken: 'test-token' }),
+          appConfig.encryptionKey,
+        ).toString(),
         userId: owner.id,
       })
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import updateFlowTransferStatus from '@/graphql/mutations/update-flow-transfer-status'
+import Connection from '@/models/connection'
+import Flow from '@/models/flow'
+import FlowTransfer from '@/models/flow-transfers'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockFlow, generateMockUser } from './flow.mock'
+
+describe('updateFlowTransferStatus', () => {
+  let context: Context
+  let owner: User
+  let newOwner: User
+  let otherUser: User
+  let mockFlow: Flow
+  let transfer: FlowTransfer
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    owner = context.currentUser
+    newOwner = await generateMockUser('editor')
+    otherUser = await User.query().insert({
+      id: randomUUID(),
+      email: 'other@plumber.gov.sg',
+    })
+
+    mockFlow = await generateMockFlow(context, randomUUID())
+
+    // minimal one step to allow the approval path later
+    await Step.query().insert({
+      id: randomUUID(),
+      flowId: mockFlow.id,
+      key: 'sendMessage',
+      appKey: 'slack',
+      type: 'action',
+      position: 1,
+      parameters: { channel: 'general' },
+      status: 'completed',
+    })
+
+    transfer = await FlowTransfer.query().insert({
+      id: randomUUID(),
+      flowId: mockFlow.id,
+      oldOwnerId: owner.id,
+      newOwnerId: newOwner.id,
+      status: 'pending',
+    })
+  })
+
+  describe('error cases', () => {
+    it('should reject setting status back to pending', async () => {
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'pending' } },
+          context,
+        ),
+      ).rejects.toThrow('No updating of pipe transfer back to pending')
+    })
+
+    it('should throw if approving not by new owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'approved' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to new owner')
+    })
+
+    it('should throw if rejecting not by new owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'rejected' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to new owner')
+    })
+
+    it('should throw if cancelling not by old owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'cancelled' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to old owner')
+    })
+  })
+
+  describe('status-only updates', () => {
+    it('new owner can reject; only status is updated', async () => {
+      context.currentUser = newOwner
+      const res = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'rejected' } },
+        context,
+      )
+      expect(res.status).toBe('rejected')
+
+      const refreshedFlow = await Flow.query().findById(mockFlow.id)
+      expect(refreshedFlow.userId).toBe(owner.id)
+    })
+
+    it('old owner can cancel; only status is updated', async () => {
+      context.currentUser = owner
+      const res = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'cancelled' } },
+        context,
+      )
+      expect(res.status).toBe('cancelled')
+
+      const refreshedFlow = await Flow.query().findById(mockFlow.id)
+      expect(refreshedFlow.userId).toBe(owner.id)
+    })
+  })
+
+  describe('approval path', () => {
+    it('transfers ownership and duplicates connections referenced by steps', async () => {
+      // Create a connection and link it to an additional step to exercise duplication
+      const connectionId = randomUUID()
+      await User.query().findById(owner.id) // ensure owner exists
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: 'secret',
+        userId: owner.id,
+      })
+
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: mockFlow.id,
+        key: 'sendMessage2',
+        appKey: 'slack',
+        type: 'action',
+        position: 2,
+        parameters: { channel: 'random' },
+        status: 'completed',
+        connectionId,
+      })
+
+      context.currentUser = newOwner
+      const result = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'approved' } },
+        context,
+      )
+
+      expect(result.status).toBe('approved')
+
+      // Flow owner should be updated
+      const updatedFlow = await Flow.query().findById(mockFlow.id)
+      expect(updatedFlow.userId).toBe(newOwner.id)
+
+      // Steps with previous connectionId should now point to a different id
+      const steps = await Step.query().where('flow_id', mockFlow.id)
+      const hadOriginal = steps.some((s) => s.connectionId === connectionId)
+      expect(hadOriginal).toBe(false)
+
+      // The duplicated connection should exist with userId set to null
+      const remainingConnIds = steps
+        .map((s) => s.connectionId)
+        .filter((id): id is string => Boolean(id))
+      if (remainingConnIds.length > 0) {
+        const dupConn = await Connection.query().findById(remainingConnIds[0])
+        expect(dupConn).toBeTruthy()
+        expect(dupConn?.userId).toBeNull()
+      }
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import updateFlowTransferStatus from '@/graphql/mutations/update-flow-transfer-status'
 import Connection from '@/models/connection'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import FlowTransfer from '@/models/flow-transfers'
 import Step from '@/models/step'
@@ -176,6 +178,108 @@ describe('updateFlowTransferStatus', () => {
         expect(dupConn).toBeTruthy()
         expect(dupConn?.userId).toBeNull()
       }
+    })
+
+    it('marks excel steps as incomplete, nullifies connections, and deletes execution steps', async () => {
+      const excelConnectionId = randomUUID()
+      const excelStepId = randomUUID()
+      const executionId = randomUUID()
+
+      // Create an Excel connection
+      await Connection.query().insert({
+        id: excelConnectionId,
+        key: 'm365-excel',
+        data: JSON.stringify({ accessToken: 'test-token' }),
+        userId: owner.id,
+      })
+
+      // Create Excel step with connection and completed status
+
+      await Step.query().insert({
+        id: excelStepId,
+        flowId: mockFlow.id,
+        key: 'getTableRows',
+        appKey: 'm365-excel',
+        type: 'action',
+        position: 2,
+        parameters: { workbookId: 'test-wb', worksheetId: 'test-ws' },
+        status: 'completed',
+        connectionId: excelConnectionId,
+      })
+
+      // Create execution steps for both the Excel step and the original Slack step
+
+      await Execution.query().insert({
+        id: executionId,
+        flowId: mockFlow.id,
+        status: 'success',
+        testRun: false,
+      })
+      await ExecutionStep.query().insert({
+        id: randomUUID(),
+        executionId,
+        stepId: excelStepId,
+        status: 'success',
+        dataOut: { rows: [] },
+      })
+
+      const slackStepId = (
+        await Step.query()
+          .findOne({ flow_id: mockFlow.id, app_key: 'slack' })
+          .throwIfNotFound()
+      ).id
+
+      await ExecutionStep.query().insert({
+        id: randomUUID(),
+        executionId,
+        stepId: slackStepId,
+        status: 'success',
+        dataOut: { message: 'sent' },
+      })
+
+      // Verify initial state: Excel step has connection and is completed
+      const initialExcelStep = await Step.query().findById(excelStepId)
+      expect(initialExcelStep.connectionId).toBe(excelConnectionId)
+      expect(initialExcelStep.status).toBe('completed')
+
+      // Verify execution steps exist
+      const initialExecutionSteps = await ExecutionStep.query().whereIn(
+        'step_id',
+        [excelStepId, slackStepId],
+      )
+      expect(initialExecutionSteps.length).toBe(2)
+
+      // Approve the transfer
+      context.currentUser = newOwner
+      const result = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'approved' } },
+        context,
+      )
+      expect(result.status).toBe('approved')
+
+      // Verify Excel step is marked as incomplete and connection is nullified
+      const updatedExcelStep = await Step.query().findById(excelStepId)
+      expect(updatedExcelStep.status).toBe('incomplete')
+      expect(updatedExcelStep.connectionId).toBeNull()
+
+      // Verify all execution steps for Excel step are deleted
+      const excelExecutionSteps = await ExecutionStep.query().where(
+        'step_id',
+        excelStepId,
+      )
+      expect(excelExecutionSteps.length).toBe(0)
+
+      // Verify the original Excel connection still exists with userId intact
+      const originalConnection = await Connection.query().findById(
+        excelConnectionId,
+      )
+      expect(originalConnection).toBeTruthy()
+      expect(originalConnection.userId).toBe(owner.id)
+
+      // Verify non-Excel steps remain unaffected (Slack step should still work normally)
+      const slackStep = await Step.query().findById(slackStepId)
+      expect(slackStep.status).toBe('completed')
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -172,7 +172,7 @@ describe('updateStep mutation', () => {
     }
 
     mockConnectionsRelatedQuery(context.currentUser, {
-      connectionId: mockConnectionId,
+      connectionId: randomUUID(),
       connectionKey: 'postman',
       connectionNotFound: true,
     })

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -49,14 +49,19 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     // duplicate the steps and the variables
     const oldToNewStepIdsMap: Record<string, string> = {}
     for (const oldStep of flow.steps) {
+      // NOTE: should not duplicate connections that are shared
+      // userId is null in connections if the connection was shared in a Pipe
+      // and the pipe was subsequently transferred to another user
+      const shouldDuplicateConnection = oldStep.connection?.userId != null
+
       const duplicatedStep = await duplicatedFlow
         .$relatedQuery('steps', trx)
         .insert({
           key: oldStep.key,
           appKey: oldStep.appKey,
           type: oldStep.type,
-          connectionId: oldStep.connectionId,
-          connection: oldStep.connection,
+          connectionId: shouldDuplicateConnection ? oldStep.connectionId : null,
+          connection: shouldDuplicateConnection ? oldStep.connection : null,
           position: oldStep.position,
           parameters: updateStepVariables(
             oldStep.parameters,

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -2,6 +2,7 @@ import { BadUserInputError } from '@/errors/graphql-errors'
 import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
 import Connection from '@/models/connection'
+import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
@@ -101,29 +102,24 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
       // PRE-TRANSFER WORK
       // nullify connections for M365-excel
       // excel connections cannot be shared; the new owner should use their own connection
+      const excelStepIds = flow.steps
+        .filter((step) => step.appKey === 'm365-excel')
+        .map((step) => step.id)
       const numExcelNullified = await Step.query(trx)
         .patch({ connection: null, connectionId: null, status: 'incomplete' })
         .where('flow_id', flow.id)
         .whereNotNull('connection_id')
         .andWhere('app_key', 'm365-excel')
 
+      // invalidate the execution steps for the m365-excel actions
+      // so that it does not show as an error in the pipe editor
+      // there is no impact to executions history as they will still be visible
+      await ExecutionStep.query(trx).delete().whereIn('step_id', excelStepIds)
+
       // sanity check that only the connections belonging to the flow is nullified
-      if (numExcelNullified > flow.steps.length) {
+      if (numExcelNullified !== excelStepIds.length) {
         throw new Error(
           'Update query went wrong, please contact plumber@open.gov.sg for more support',
-        )
-      }
-
-      // set tiles actions to incomplete
-      const numIncompleteForTiles = await Step.query(trx)
-        .patch({ status: 'incomplete' })
-        .where('flow_id', flow.id)
-        .andWhere('app_key', 'tiles')
-
-      // sanity check
-      if (numIncompleteForTiles > flow.steps.length) {
-        throw new Error(
-          'Update tiles status query went wrong, please contact plumber@open.gov.sg for more support',
         )
       }
 

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -158,8 +158,11 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
 
                 // update or create flow connection using the duplicated connection
                 if (existingFlowConnection) {
-                  await FlowConnections.query(trx)
-                    .updateAndFetch({ connectionId: newConnectionId })
+                  await existingFlowConnection
+                    .$query(trx)
+                    .patchAndFetch({
+                      connectionId: newConnectionId,
+                    })
                     .where({
                       flow_id: flow.id,
                       connection_id: connectionId,

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -1,7 +1,13 @@
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
+import Connection from '@/models/connection'
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
 import FlowTransfer from '@/models/flow-transfers'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -20,12 +26,8 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
     }
 
     const flowTransfer = await FlowTransfer.query()
-      .findOne({
-        id,
-      })
-      .withGraphFetched({
-        newOwner: true,
-      })
+      .findOne({ id })
+      .withGraphFetched({ newOwner: true })
       .throwIfNotFound()
 
     // To prevent possible exploits: for approved/rejected status: check if new owner matches
@@ -63,19 +65,27 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
       .throwIfNotFound('Pipe to be transferred cannot be found')
 
     /**
-     * This transaction does 3 things to complete a flow transfer
-     * 1. Nullify all the connections in the flow (phase 1)
-     * 2. Update the flow id to the new owner
-     * 3. Update the flow transfer status to 'approved'
+     * This transaction does the following to complete a flow transfer:
+     * - Duplicate all connections in the connections table and nullify the user ids
+     *   (EXCEPT M365-excel: nullify all connections)
+     * - Patch the steps to reference the duplicate connection(s)
+     * - Share all connections and tables to flow_connections (if not already shared)
+     * - Add the new owner as an editor in the table (if not already an editor)
+     * - Update the flow id to the new owner
+     * - Update the flow transfer status to 'approved'
      */
     return await FlowTransfer.transaction(async (trx) => {
       // logging for recovery purposes
       const connectionIds: string[] = []
+      const tableIds: string[] = []
       const stepIds: string[] = []
       flow.steps.forEach((step) => {
         if (step.connectionId) {
           stepIds.push(step.id)
           connectionIds.push(step.connectionId)
+        }
+        if (step.parameters.tableId) {
+          tableIds.push(step.parameters.tableId as string)
         }
       })
 
@@ -84,23 +94,27 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
         flowTransferId: id,
         flowId: flow.id,
         connectionIds,
+        tableIds,
         stepIds,
       })
 
-      // nullify connections: both the connection and connectionId references and set status to incomplete
-      const numNullified = await Step.query(trx)
+      // PRE-TRANSFER WORK
+      // nullify connections for M365-excel
+      // excel connections cannot be shared; the new owner should use their own connection
+      const numExcelNullified = await Step.query(trx)
         .patch({ connection: null, connectionId: null, status: 'incomplete' })
         .where('flow_id', flow.id)
         .whereNotNull('connection_id')
+        .andWhere('app_key', 'm365-excel')
 
       // sanity check that only the connections belonging to the flow is nullified
-      if (numNullified !== connectionIds.length) {
+      if (numExcelNullified > flow.steps.length) {
         throw new Error(
           'Update query went wrong, please contact plumber@open.gov.sg for more support',
         )
       }
 
-      // additional update: set tiles actions to incomplete too
+      // set tiles actions to incomplete
       const numIncompleteForTiles = await Step.query(trx)
         .patch({ status: 'incomplete' })
         .where('flow_id', flow.id)
@@ -113,11 +127,169 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
         )
       }
 
-      // update to new owner id
-      await flow.$query(trx).patchAndFetch({
-        userId: context.currentUser.id,
+      // HANDLE CONNECTIONS
+      // get the connections and tables to be shared
+      // intentionally exclude m365-excel as the connection has been nullified
+      // and it should retain the user_id in the connections table
+      const connectionDetails = getConnectionDetails(
+        flow?.steps.filter((step) => step.appKey !== 'm365-excel'),
+      )
+      const sharedConnections = connectionDetails.connection
+      const sharedTables = connectionDetails.table
+
+      if (Object.keys(sharedConnections).length > 0) {
+        // duplicate the connections in the connections table and nullify the IDs
+        await Promise.all(
+          Object.entries(sharedConnections).map(
+            async ([connectionId, metadata]) => {
+              const duplicatedConnection = await Connection.duplicate(
+                connectionId,
+                trx,
+              )
+
+              if (duplicatedConnection) {
+                const { id: newConnectionId } = duplicatedConnection
+                const existingFlowConnection = await FlowConnections.query(
+                  trx,
+                ).findOne({
+                  flow_id: flow.id,
+                  connection_id: connectionId,
+                })
+
+                // update or create flow connection using the duplicated connection
+                if (existingFlowConnection) {
+                  await FlowConnections.query(trx)
+                    .updateAndFetch({ connectionId: newConnectionId })
+                    .where({
+                      flow_id: flow.id,
+                      connection_id: connectionId,
+                    })
+                } else {
+                  await FlowConnections.query(trx).insertAndFetch({
+                    flowId: flow.id,
+                    connectionId: newConnectionId,
+                    addedBy: flow.userId,
+                    connectionType: 'connection',
+                    metadata: metadata,
+                  })
+                }
+
+                // patch the steps to reference the duplicate connection(s)
+                await Step.query(trx)
+                  .patch({ connectionId: newConnectionId })
+                  .where('flow_id', flow.id)
+                  .whereNotNull('connection_id')
+                  .where('connection_id', connectionId)
+
+                return {
+                  flowId: flow.id,
+                  connectionId: newConnectionId,
+                  addedBy: flow.userId,
+                  connectionType: 'connection',
+                  metadata: metadata,
+                }
+              }
+            },
+          ),
+        )
+      }
+
+      // HANDLE TABLES
+      // table connections are not duplicated as the owner of the table stays the same
+      // the new owner only becomes an editor of the table
+      // if the table needs to be transferred, it should be done from the Tile
+      if (sharedTables.length > 0) {
+        const tableInserts = await Promise.all(
+          sharedTables.map(async (tableId) => {
+            try {
+              // there may be instances where the new pipe owner is already the owner of the table
+              // we catch the error but do nothing`
+              await TableCollaborator.addCollaborator({
+                userId: context.currentUser.id, // the new owner
+                tableId,
+                role: 'editor',
+                trx,
+              })
+            } catch (e) {
+              // do nothing if the new owner of the pipe is already the owner of the tile
+              if (
+                !(e instanceof BadUserInputError) &&
+                e.message !== 'Cannot change owner role'
+              ) {
+                throw new Error(e)
+              }
+            }
+
+            // always return the table
+            return {
+              flowId: flow.id,
+              connectionId: tableId,
+              addedBy: flow.userId,
+              connectionType: 'table' as const,
+            }
+          }),
+        )
+
+        // add all tables to the flow_connections table
+        await FlowConnections.query(trx)
+          .insert(tableInserts)
+          .onConflict(['flow_id', 'connection_id'])
+          .ignore()
+      }
+
+      // HANDLE FLOW COLLABORATORS
+      // - check if the current owner was once a collaborator
+      // - update the role if they were a collaborator
+      // - otherwise, create a new record
+      const existingCollaborator = await FlowCollaborator.query(trx)
+        .findOne({
+          flow_id: flow.id,
+          user_id: flow.userId,
+        })
+        .withSoftDeleted()
+
+      if (!existingCollaborator) {
+        await FlowCollaborator.query(trx).insert({
+          flowId: flow.id,
+          userId: flow.userId,
+          role: 'editor',
+          updatedBy: context.currentUser.id,
+        })
+      } else {
+        await existingCollaborator.$query(trx).patchAndFetch({
+          role: 'editor',
+          deletedAt: null,
+          updatedBy: context.currentUser.id,
+        })
+      }
+
+      // remove the new owner from the flow collaborators
+      const isNewOwnerCollaborator = await FlowCollaborator.query(trx).findOne({
+        flow_id: flow.id,
+        user_id: context.currentUser.id,
       })
 
+      if (isNewOwnerCollaborator) {
+        await FlowCollaborator.deleteCollaborator({
+          userId: context.currentUser.id,
+          flowId: flow.id,
+          trx,
+        })
+      }
+
+      // make the current owner a collaborator in the flow
+      await FlowCollaborator.upsertCollaborator({
+        userId: flow.userId,
+        flowId: flow.id,
+        role: 'editor',
+        updatedBy: context.currentUser.id,
+        trx,
+      })
+
+      // update the flow owner id
+      await flow.$query(trx).patchAndFetch({ userId: context.currentUser.id })
+
+      // FINALLY, MARK THE FLOW TRANSFER AS APPROVED AND COMPLETED
       return await flowTransfer.$query(trx).patchAndFetch({
         status,
       })

--- a/packages/backend/src/graphql/queries/get-app.ts
+++ b/packages/backend/src/graphql/queries/get-app.ts
@@ -1,4 +1,5 @@
 import App from '@/models/app'
+import Connection from '@/models/connection'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -21,26 +22,44 @@ const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
   }
 
   if (app.auth?.connectionType === 'user-added') {
-    // NOTE: only have flowId if the user is a collaborator
+    let sharedConnections: Connection[] = []
+    /**
+     * NOTE: flow id is only provided in the pipe editor.
+     * it is not provided at the 'My Apps' page, so no need to fetch shared connections
+     */
+
     if (params.flowId) {
+      const flow = await context.currentUser
+        .withAccessibleFlows({ requiredRole: 'viewer' })
+        .findById(params.flowId)
+        .throwIfNotFound({ message: 'Pipe not found' })
+
       const flowConnections = await context.currentUser
         .withAccessibleFlowConnections({ requiredRole: 'viewer' })
         .join('connections', 'connections.id', 'flow_connections.connection_id')
-        .withGraphJoined('connection')
+        .withGraphFetched('connection')
         .where({
           'flows.id': params.flowId,
           'connections.key': params.key,
           'connections.draft': false,
         })
 
-      return {
-        ...app,
-        connections: flowConnections.map(
-          (flowConnection) => flowConnection.connection,
-        ),
+      sharedConnections = flowConnections.map((flowConnection) =>
+        Object.assign(flowConnection.connection, {
+          description: 'This connection can only be used in this pipe.',
+        }),
+      )
+
+      if (flow.role === 'editor') {
+        return {
+          ...app,
+          connections: sharedConnections,
+        }
       }
     }
 
+    // if user is an owner, fetch all the connections
+    // if the user is an owner, fetch all the connections that the user owns
     const connections = await context.currentUser
       .$relatedQuery('connections')
       .select('connections.*')
@@ -53,9 +72,16 @@ const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
       .groupBy('connections.id')
       .orderBy('created_at', 'desc')
 
+    const mergedConnections = Object.values(
+      [...sharedConnections, ...connections].reduce((acc, obj) => {
+        acc[obj.id] = obj // last one wins
+        return acc
+      }, {} as Record<string, Connection>),
+    )
+
     return {
       ...app,
-      connections,
+      connections: mergedConnections,
     }
   }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -327,6 +327,7 @@ type Connection {
   app: App
   createdAt: String
   flowCount: Int
+  description: String
 }
 
 type ConnectionData {

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -142,4 +142,90 @@ describe('flow collaborators model', () => {
       expect(collaborators).toHaveLength(0)
     })
   })
+
+  describe('deleteCollaborator', () => {
+    it('should soft delete the collaborator and exclude from default queries', async () => {
+      const result = await FlowCollaborator.deleteCollaborator({
+        userId: editorUserId,
+        flowId,
+      })
+
+      expect(result).toBeDefined()
+
+      // Not returned by default queries
+      const collaborators = await FlowCollaborator.getCollaborators({ flowId })
+      expect(collaborators.map((c) => c.userId)).not.toContain(editorUserId)
+
+      // But still present when including soft deleted
+      const softDeleted = await FlowCollaborator.query()
+        .withSoftDeleted()
+        .findOne({ user_id: editorUserId, flow_id: flowId })
+      expect(softDeleted).toBeTruthy()
+      expect(softDeleted?.deletedAt).toBeTruthy()
+    })
+
+    it('should throw when deleting a non-existent collaborator', async () => {
+      await expect(
+        FlowCollaborator.deleteCollaborator({
+          userId: randomUUID(),
+          flowId,
+        }),
+      ).rejects.toThrow('No such collaborator found')
+    })
+  })
+
+  describe('upsertCollaborator', () => {
+    it('should create a new collaborator when none exists', async () => {
+      const newUser = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: 'newuser@plumber.gov.sg',
+      })
+
+      const newCollaborator = await FlowCollaborator.upsertCollaborator({
+        userId: newUser.id,
+        flowId,
+        role: 'viewer',
+        updatedBy: ownerUserId,
+      })
+
+      expect(newCollaborator.userId).toBe(newUser.id)
+      expect(newCollaborator.flowId).toBe(flowId)
+      expect(newCollaborator.role).toBe('viewer')
+
+      const collaborators = await FlowCollaborator.getCollaborators({ flowId })
+      expect(collaborators.map((c) => c.userId)).toContain(newUser.id)
+    })
+
+    it('should update role when collaborator exists (and restore if soft-deleted)', async () => {
+      // Soft delete existing viewer collaborator
+      await FlowCollaborator.deleteCollaborator({
+        userId: viewerUserId,
+        flowId,
+      })
+
+      // Ensure not returned by default queries
+      const before = await FlowCollaborator.getCollaborators({ flowId })
+      expect(before.map((c) => c.userId)).not.toContain(viewerUserId)
+
+      // Upsert should restore and update role
+      const updated = await FlowCollaborator.upsertCollaborator({
+        userId: viewerUserId,
+        flowId,
+        role: 'editor',
+        updatedBy: ownerUserId,
+      })
+
+      expect(updated.role).toBe('editor')
+
+      // Verify restored (not soft-deleted) and role changed
+      const withDeleted = await FlowCollaborator.query()
+        .withSoftDeleted()
+        .findOne({ user_id: viewerUserId, flow_id: flowId })
+      expect(withDeleted).toBeTruthy()
+      expect(withDeleted?.role).toBe('editor')
+
+      const after = await FlowCollaborator.getCollaborators({ flowId })
+      expect(after.map((c) => c.userId)).toContain(viewerUserId)
+    })
+  })
 })

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -1,7 +1,7 @@
 import { IFlowCollabRole, IJSONObject } from '@plumber/types'
 
 import { AES, enc } from 'crypto-js'
-import type { RelationMappings } from 'objection'
+import type { RelationMappings, Transaction } from 'objection'
 import { ModelOptions, QueryContext } from 'objection'
 
 import appConfig from '@/config/app'
@@ -21,6 +21,7 @@ class Connection extends Base {
   count?: number
   flowCount?: number
   role?: IFlowCollabRole
+  description?: string
 
   static tableName = 'connections'
 
@@ -33,7 +34,7 @@ class Connection extends Base {
       key: { type: 'string', minLength: 1, maxLength: 255 },
       data: { type: 'string' },
       formattedData: { type: 'object' },
-      userId: { type: 'string', format: 'uuid' },
+      userId: { type: 'string', format: 'uuid', nullable: true },
       verified: { type: 'boolean', default: false },
       draft: { type: 'boolean' },
     },
@@ -108,6 +109,39 @@ class Connection extends Base {
 
   async $afterFind(): Promise<void> {
     this.decryptData()
+  }
+
+  /**
+   * Duplicates a connection and sets the user id to null
+   * This is used during pipe transfer to ensure that the connection is still valid and
+   * can be used by the new owner even if the old owner is deleted
+   */
+  static duplicate = async (
+    connectionId: string,
+    trx?: Transaction,
+  ): Promise<Connection> => {
+    const connection = await this.query(trx).findOne({ id: connectionId })
+
+    if (!connection) {
+      throw new Error('Connection not found')
+    }
+
+    const {
+      id: _id,
+      createdAt: _createdAt,
+      updatedAt: _updatedAt,
+      userId,
+      ...rest
+    } = connection
+
+    // only need to duplicate if the connection has a user id
+    // it could already be null if the pipe has been transferred before
+    if (userId) {
+      return this.query(trx).insertAndFetch({
+        ...rest,
+        userId: null,
+      })
+    }
   }
 }
 

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -130,6 +130,58 @@ class FlowCollaborator extends Base {
       .where({ flow_id: flowId })
       .withGraphFetched('user')
   }
+
+  static deleteCollaborator = async ({
+    userId,
+    flowId,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    trx?: Transaction
+  }) => {
+    return await this.query(trx)
+      .delete()
+      .where({ user_id: userId, flow_id: flowId })
+      .returning('*')
+      .throwIfNotFound({ message: 'No such collaborator found' })
+  }
+
+  static upsertCollaborator = async ({
+    userId,
+    flowId,
+    role,
+    updatedBy,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    role: IFlowCollabRole
+    updatedBy: string
+    trx?: Transaction
+  }) => {
+    const collaboratorExists = await this.query(trx)
+      .findOne({ user_id: userId, flow_id: flowId })
+      .withSoftDeleted()
+
+    if (collaboratorExists) {
+      return await collaboratorExists
+        .$query(trx)
+        .patchAndFetch({
+          role,
+          deletedAt: null,
+          updatedBy,
+        })
+        .withSoftDeleted()
+    } else {
+      return await this.query(trx).insert({
+        userId,
+        flowId,
+        role,
+        updatedBy,
+      })
+    }
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -109,6 +109,17 @@ class FlowConnections extends Base {
     })
 
     if (hasCollaborators) {
+      // NOTE: somehow .onConflict().ignore() does not return an empty array
+      // on conflict, but actually returns the row its trying to insert
+      const existing = await this.query(trx).findOne({
+        flow_id: flowId,
+        connection_id: connectionId,
+      })
+
+      if (existing) {
+        return null
+      }
+
       return await this.query(trx)
         .insert({
           flowId,

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,5 +1,6 @@
 import { Transaction } from 'objection'
 
+import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Context from '@/types/express/context'
 
@@ -20,13 +21,25 @@ export const getConnection = async (params: GetConnectionParams) => {
   const { context, connectionId, includeOwnConnections, trx, flowId } = params
 
   if (includeOwnConnections) {
-    // this means that the user is the owner of the pipe
-    // it could be their own connection or a shared connection
+    // there are 2 types of connections that an owner can access:
+    // 1. the user is the owner of the pipe
+    //    it could be their own connection or a shared connection
+    // 2. the user is the owner of a pipe that has been transferred to them
+    //    it should include connections from the flow_connections table as well
     // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
     // will need to include connections from the flow_connections table
-    return await context.currentUser
-      .$relatedQuery('connections', trx)
-      .findOne({ 'connections.id': connectionId })
+
+    return await Connection.query(trx)
+      .findById(connectionId)
+      .where(function () {
+        // connection is either owned by the user
+        this.where('connections.user_id', context.currentUser.id).orWhereExists(
+          // or accessible via flow_connections table
+          FlowConnections.query(trx)
+            .whereColumn('flow_connections.connection_id', 'connections.id')
+            .where('flow_connections.flow_id', flowId),
+        )
+      })
       .throwIfNotFound({ message: 'Connection not found' })
   }
 

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -148,11 +148,10 @@ interface EditorToolbarProps {
 export default function EditorToolbar(props: EditorToolbarProps) {
   const { flowId } = useContext(EditorContext)
   // TODO: remove this once we open collaborators to all users
-  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
-  const settingsLink =
-    !isFlagsLoading && flags?.collaborators
-      ? URLS.FLOW_EDITOR_SHARE(flowId)
-      : URLS.FLOW_EDITOR_TRANSFERS(flowId)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const settingsLink = getFlagValue('collaborators', false)
+    ? URLS.FLOW_EDITOR_SHARE(flowId)
+    : URLS.FLOW_EDITOR_TRANSFERS(flowId)
 
   return (
     <>

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
@@ -1,8 +1,8 @@
 import { ITransferDetails } from '@plumber/types'
 
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { useQuery } from '@apollo/client'
-import { Center, Flex, Text } from '@chakra-ui/react'
+import { Box, Center, Flex, Link, Text } from '@chakra-ui/react'
 import { Badge, Infobox } from '@opengovsg/design-system-react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
@@ -11,6 +11,7 @@ import { GET_FLOW_TRANSFER_DETAILS } from '@/graphql/queries/get-flow-transfer-d
 
 function StepConnectionDisplay(props: ITransferDetails) {
   const { appName, position, connectionName, instructions } = props
+
   return (
     <Flex flexDir="column" gap={2}>
       <Badge colorScheme="warning">
@@ -28,6 +29,7 @@ function StepConnectionDisplay(props: ITransferDetails) {
 
 export default function FlowTransferConnections() {
   const { flow } = useContext(EditorSettingsContext)
+  const [showConnections, setShowConnections] = useState(false)
   // phase 1: just retrieve all transfer details to display (without instructions)
   const { data, loading } = useQuery(GET_FLOW_TRANSFER_DETAILS, {
     variables: {
@@ -51,22 +53,33 @@ export default function FlowTransferConnections() {
 
   return (
     <Infobox variant="warning">
-      <Flex flexDir="column" gap={6}>
+      <Flex flexDir="column" gap={2}>
         <Text textStyle="subhead-1">
           You will need to manually add the following connections on the new
           pipe owner&apos;s account for the pipe to continue working.
         </Text>
-
-        {flowTransferDetails.map(
-          ({ appName, position, connectionName, instructions }, index) => (
-            <StepConnectionDisplay
-              key={index}
-              appName={appName}
-              position={position}
-              connectionName={connectionName}
-              instructions={instructions}
-            />
-          ),
+        <Text
+          textStyle="body-1"
+          color="base.content.default"
+          as={Link}
+          onClick={() => setShowConnections(!showConnections)}
+        >
+          {showConnections ? 'Hide connections' : 'Show connections'}
+        </Text>
+        {showConnections && (
+          <Box>
+            {flowTransferDetails.map(
+              ({ appName, position, connectionName, instructions }, index) => (
+                <StepConnectionDisplay
+                  key={index}
+                  appName={appName}
+                  position={position}
+                  connectionName={connectionName}
+                  instructions={instructions}
+                />
+              ),
+            )}
+          </Box>
         )}
       </Flex>
     </Infobox>

--- a/packages/frontend/src/components/EditorSettings/index.tsx
+++ b/packages/frontend/src/components/EditorSettings/index.tsx
@@ -48,8 +48,8 @@ export default function EditorSettingsLayout(
   const { currentUser } = useAuthentication()
 
   // TODO: remove this once we open collaborators to all users
-  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
-  const showCollaborators = !isFlagsLoading && flags?.collaborators
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const showCollaborators = getFlagValue('collaborators', false)
 
   const { flowId } = useParams()
   const { data, loading, error } = useQuery(GET_FLOW_WITH_COLLABORATORS, {

--- a/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
+++ b/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
@@ -111,9 +111,10 @@ export default function FlowContextMenu(props: FlowContextMenuProps) {
           isClosable: true,
           position: 'top',
         })
+        onDialogClose()
       },
     })
-  }, [duplicateFlow, flow.id, toast])
+  }, [duplicateFlow, flow.id, toast, onDialogClose])
 
   const onDuplicateButtonClick = useCallback(
     (event: MouseEvent) => {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -57,6 +57,7 @@ export const optionGenerator = (
   return {
     label: screenName ?? 'Unnamed',
     value: connection?.id as string,
+    description: connection?.description ?? undefined,
   }
 }
 
@@ -85,7 +86,7 @@ export default function ChooseAndAddConnection(
   } = useQuery(GET_APP_CONNECTIONS, {
     variables: {
       key: selectedApp?.key,
-      flowId: flow.role !== 'owner' ? flowId : undefined,
+      flowId: flow.id,
     },
     skip: !selectedApp,
   })

--- a/packages/frontend/src/graphql/queries/get-app-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-app-connections.ts
@@ -13,6 +13,7 @@ export const GET_APP_CONNECTIONS = gql`
           screenName
           env
         }
+        description
         createdAt
       }
     }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -47,6 +47,7 @@ export interface IConnection {
   flowCount?: number
   appData?: IApp
   createdAt: string
+  description?: string
 }
 
 /**


### PR DESCRIPTION
## TL;DR

This PR enhances the pipe transfer by:

- making the current `Owner` an `Editor` of the Pipe
- sharing existing connections so that Pipe can still function

The UI also displays shared connections with a description indicating they're pipe-specific, and places connections in a collapsible box for better organization.

## What changed?

- Duplicates connections in the database and nullifies user IDs during transfer so that connections can still be used in the Pipe (with the exception of M365-Excel)
- Shares connections and tables to flow_connections
- Adds the new owner as an editor for tables
- Updates flow ownership and collaborator relationships
- Adds comprehensive tests for the transfer process

## How to test?

Create a Pipe with steps that require connections and Tiles, initiate a Pipe transfer.

- [x] Old owner is an `Editor` of the Pipe
- [x] Existing connections are duplicated in `connections` table without the `user_id`
- [x] Existing connections reference the duplicated connection ids in the `steps` and `flow_connections` tables
- [x] Pipe still works with the connections
    - [x] Connection can be verified
    - [x] Can check step
- [x] Existing collaborators can still modify the Pipe