### PR TITLE
fix misaligned divider in nested steps

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -83,7 +83,9 @@ export function HoverAddStepButton(
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           w={
-            (shouldShowDragHandle || canChildStepsReorder) && !isDrawerOpen
+            (shouldShowDragHandle || canChildStepsReorder) &&
+            !isDrawerOpen &&
+            !readOnly
               ? `calc(100% - ${NESTED_DRAG_HANDLE_WIDTH}px)`
               : 'full'
           }


### PR DESCRIPTION
## Problem
The divider between condition step and child steps are misaligned when in 'Published' state.

## Solution
Missing condition check to get the width.

## Before & After Screenshots

**BEFORE**:
<img width="1512" height="806" alt="Screenshot 2025-10-06 at 10 40 37 PM" src="https://github.com/user-attachments/assets/d5f0a420-2e41-479e-ba13-76e629b9e2db" />


**AFTER**:
<img width="1508" height="807" alt="Screenshot 2025-10-06 at 10 41 12 PM" src="https://github.com/user-attachments/assets/d6698007-6f55-4860-b537-46d4ee89007f" />


## Tests
- [ ] Divider is aligned across all nested steps in `Published` and `Unpublished` states
- [ ] Divider is aligned across all steps in `Published` and `Unpublished` states
