### PR TITLE
PLU-588: redirect to correct unauthorised pages

### DIFF
--- a/packages/backend/src/errors/graphql-errors/index.ts
+++ b/packages/backend/src/errors/graphql-errors/index.ts
@@ -1,2 +1,3 @@
 export * from './bad-user-input'
 export * from './forbidden'
+export * from './unauthorised'

--- a/packages/backend/src/errors/graphql-errors/unauthorised.ts
+++ b/packages/backend/src/errors/graphql-errors/unauthorised.ts
@@ -1,0 +1,15 @@
+import { GraphQLError } from 'graphql/error'
+
+export class UnauthorisedError extends GraphQLError {
+  constructor() {
+    super('Not Authorised!', {
+      extensions: {
+        code: 'Not Authorised!',
+        message: 'Not Authorised!',
+        http: {
+          status: 401,
+        },
+      },
+    })
+  }
+}

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -3,6 +3,7 @@ import { createRateLimitRule, RedisStore } from 'graphql-rate-limit'
 import { allow, and, not, or, rule, shield } from 'graphql-shield'
 
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
+import { UnauthorisedError } from '@/errors/graphql-errors'
 import {
   getAdminTokenUser,
   getLoggedInUser,
@@ -46,6 +47,9 @@ export const setCurrentUserContext = async ({
 
 const isAuthenticated = rule()(
   async (_parent, _args, ctx: UnauthenticatedContext) => {
+    if (ctx.currentUser == null) {
+      throw new UnauthorisedError()
+    }
     return ctx.currentUser != null
   },
 )
@@ -110,6 +114,8 @@ const authentication = shield(
   },
   {
     allowExternalErrors: true,
+    // only affects shield authorisation failures
+    fallbackError: new UnauthorisedError(),
   },
 )
 

--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -10,7 +10,8 @@ import { applyMiddleware } from 'graphql-middleware'
 import { DBError } from 'objection'
 
 import appConfig from '@/config/app'
-import { BadUserInputError } from '@/errors/graphql-errors'
+import { BadUserInputError, UnauthorisedError } from '@/errors/graphql-errors'
+import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
 import { typeDefs } from '@/graphql/__generated__/typeDefs.generated'
 import resolvers from '@/graphql/resolvers'
 import authentication, { setCurrentUserContext } from '@/helpers/authentication'
@@ -95,6 +96,17 @@ export const server = new ApolloServer<UnauthenticatedContext>({
     // so we handle them here
     if (unwrapResolverError(error) instanceof DBError) {
       return { message: 'Internal server error', code: 'INTERNAL_SERVER_ERROR' }
+    }
+
+    if (unwrapResolverError(error) instanceof UnauthorisedError) {
+      return { message: 'Not Authorised!', code: 'NOT_AUTHORISED' }
+    }
+
+    if (unwrapResolverError(error) instanceof InvalidTileViewKeyError) {
+      return {
+        message: 'Invalid tile view only key',
+        code: 'INVALID_TILE_VIEW_KEY',
+      }
     }
 
     // NOTE: handles INTERNAL_SERVER_ERROR

--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -11,6 +11,42 @@ type ApolloProviderProps = {
   children: React.ReactNode
 }
 
+const SessionExpiredToast = () => {
+  return (
+    <Infobox
+      alignItems="center"
+      variant="warning"
+      justifyContent="space-between"
+      borderRadius="md"
+      border="1px solid"
+      w="500px"
+      maxW="90vw"
+      borderColor="interaction.warning.default"
+      style={{
+        padding: '0.5rem 1rem',
+      }}
+    >
+      <Flex w="100%" justifyContent="space-between" alignItems="center">
+        <Text>Session expired. Please login again.</Text>
+        <Button
+          colorScheme="yellow"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            const redirectQueryParam =
+              window.location.pathname + window.location.search
+            window.location.href = URLS.ADD_REDIRECT_TO_LOGIN(
+              encodeURIComponent(redirectQueryParam),
+            )
+          }}
+        >
+          Login
+        </Button>
+      </Flex>
+    </Infobox>
+  )
+}
+
 const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
   const toast = useToast()
 
@@ -21,39 +57,7 @@ const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
         duration: null,
         isClosable: false,
         position: 'top',
-        render: () => (
-          <Infobox
-            alignItems="center"
-            variant="warning"
-            justifyContent="space-between"
-            borderRadius="md"
-            border="1px solid"
-            w="500px"
-            maxW="90vw"
-            borderColor="interaction.warning.default"
-            style={{
-              padding: '0.5rem 1rem',
-            }}
-          >
-            <Flex w="100%" justifyContent="space-between" alignItems="center">
-              <Text>Session expired. Please login again.</Text>
-              <Button
-                colorScheme="yellow"
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const redirectQueryParam =
-                    window.location.pathname + window.location.search
-                  window.location.href = URLS.ADD_REDIRECT_TO_LOGIN(
-                    encodeURIComponent(redirectQueryParam),
-                  )
-                }}
-              >
-                Login
-              </Button>
-            </Flex>
-          </Infobox>
-        ),
+        render: SessionExpiredToast,
       })
     },
     [toast],

--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -1,7 +1,10 @@
-import * as React from 'react'
+import { useCallback, useMemo } from 'react'
 import { ApolloProvider as BaseApolloProvider } from '@apollo/client'
-import { useToast } from '@opengovsg/design-system-react'
+import { Flex, Text } from '@chakra-ui/react'
+import { Button, Infobox, useToast } from '@opengovsg/design-system-react'
 
+import { NOT_AUTHORISED } from '@/config/errors'
+import * as URLS from '@/config/urls'
 import { createClient } from '@/graphql/client'
 
 type ApolloProviderProps = {
@@ -11,12 +14,61 @@ type ApolloProviderProps = {
 const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
   const toast = useToast()
 
-  const onError = React.useCallback(
+  const showSessionExpiredToast = useCallback(
+    (id: string) => {
+      toast({
+        id,
+        duration: null,
+        isClosable: false,
+        position: 'top',
+        render: () => (
+          <Infobox
+            alignItems="center"
+            variant="warning"
+            justifyContent="space-between"
+            borderRadius="md"
+            border="1px solid"
+            w="500px"
+            maxW="90vw"
+            borderColor="interaction.warning.default"
+            style={{
+              padding: '0.5rem 1rem',
+            }}
+          >
+            <Flex w="100%" justifyContent="space-between" alignItems="center">
+              <Text>Session expired. Please login again.</Text>
+              <Button
+                colorScheme="yellow"
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  const redirectQueryParam =
+                    window.location.pathname + window.location.search
+                  window.location.href = URLS.ADD_REDIRECT_TO_LOGIN(
+                    encodeURIComponent(redirectQueryParam),
+                  )
+                }}
+              >
+                Login
+              </Button>
+            </Flex>
+          </Infobox>
+        ),
+      })
+    },
+    [toast],
+  )
+
+  const onError = useCallback(
     (message: string) => {
       // HACKFIX: we use this toast.isActive to prevent duplicate toasts from being shown.
       // there should be a better way to handle this from the ApolloClient.
       const id = `graphql-error-${message.slice(0, 15)}`
       if (!toast.isActive(id)) {
+        if (message === NOT_AUTHORISED) {
+          showSessionExpiredToast(id)
+          return
+        }
         toast({
           id,
           title: message,
@@ -29,10 +81,10 @@ const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
         })
       }
     },
-    [toast],
+    [showSessionExpiredToast, toast],
   )
 
-  const client = React.useMemo(() => {
+  const client = useMemo(() => {
     return createClient({
       onError,
     })

--- a/packages/frontend/src/graphql/link.ts
+++ b/packages/frontend/src/graphql/link.ts
@@ -32,8 +32,6 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
       if (autoSnackbar) {
         callback?.(NOT_AUTHORISED)
       }
-      // this form of navigation will refetch current user as well
-      window.location.href = URLS.LOGIN
       return
     }
 

--- a/packages/frontend/src/graphql/link.ts
+++ b/packages/frontend/src/graphql/link.ts
@@ -26,6 +26,17 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
     const context = operation.getContext()
     const autoSnackbar = context.autoSnackbar ?? true
 
+    // this should catch when user's session has expired or the user is not authorised
+    // return early since the status code is enough to identify the error
+    if (context.response.status === 401) {
+      if (autoSnackbar) {
+        callback?.(NOT_AUTHORISED)
+      }
+      // this form of navigation will refetch current user as well
+      window.location.href = URLS.LOGIN
+      return
+    }
+
     if (graphQLErrors) {
       graphQLErrors.forEach(({ message, locations, path }) => {
         if (autoSnackbar) {
@@ -37,10 +48,6 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
           `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
         )
 
-        if (message === NOT_AUTHORISED) {
-          // this form of navigation will refetch current user as well
-          window.location.href = URLS.LOGIN
-        }
         if (message === INVALID_TILE_VIEW_KEY) {
           window.location.href = URLS.UNAUTHORIZED_TILE
         }

--- a/packages/frontend/src/pages/Editor/index.tsx
+++ b/packages/frontend/src/pages/Editor/index.tsx
@@ -1,5 +1,12 @@
 import EditorLayout from '@/components/EditorLayout'
+import RedirectToLogin from '@/components/RedirectToLogin'
+import useAuthentication from '@/hooks/useAuthentication'
 
 export default function FlowEditor(): React.ReactElement {
+  const { currentUser } = useAuthentication()
+
+  if (!currentUser) {
+    return <RedirectToLogin />
+  }
   return <EditorLayout />
 }


### PR DESCRIPTION
## Problem
- does not get pushed to login when session expires
- does not get pushed to unauthorised tile page when tile view only link is invalid

## Solution
**Cause:** 
- error message received now looks like An error has occurred: Not authorised
- error link is trying for an exact match Not authorised 

**Solution**:
- returns a proper `401` status code that can be handled easily

## Why make this change?
By default, when graphql-shield blocks a request (when a rule returns false or throws an error), it throws a generic error that GraphQL interprets as an `INTERNAL_SERVER_ERROR`, so that it doesn't leak information about authorisation rules.

Without fallbackError, when shield blocks a request:
`Default shield behavior → Generic error → Apollo sees it as INTERNAL_SERVER_ERROR`
With fallbackError:
`Shield blocks request → Uses fallbackError → Apollo sees UNAUTHENTICATED → Plugin sets 401`

Other `INTERNAL_SERVER_ERROR` errors are NOT affected - These still throw normally:
- Database errors (DBError)
- Unexpected resolver errors
- Any other server errors


Only shield authorisation failures are affected - The fallbackError ONLY applies when:
- A shield rule returns false
- A shield rule throws an error that doesn't have a specific code

## How to test?
`401: Not authorised`: Login to Plumber, open a Pipe in a new tab, log out
- [ ] Should get redirected to login page

`Invalid tile view only link`: Generate a view-only link, open it in a new tab, delete the link
- [ ] Should get redirected to `tiles/unauthorized`