### PR TITLE
[GET-APPS-1]: use cache-first

### DIFF
--- a/apps.d.ts
+++ b/apps.d.ts
@@ -1,0 +1,19 @@
+// Auto-generated types
+export interface App {
+  name: string;
+  key: string;
+  iconUrl: string;
+  authDocUrl: string;
+  baseUrl: string;
+  apiBaseUrl: string;
+  primaryColor: string;
+  actions: object;
+  description: string;
+  category: string;
+  docUrl: object;
+  isNewApp: object;
+  demoVideoDetails: object;
+  setupMessage: object;
+}
+
+export type Apps = App[];

--- a/apps.json
+++ b/apps.json
@@ -1,0 +1,9306 @@
+[
+  {
+    "name": "FormSG",
+    "key": "formsg",
+    "description": "Workflow starts when a new form response is received",
+    "iconUrl": "http://localhost:3000/apps/formsg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/formsg",
+    "baseUrl": "https://form.gov.sg",
+    "apiBaseUrl": "",
+    "primaryColor": "635bff",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "autoCheckStep": true,
+      "fields": [
+        {
+          "key": "formId",
+          "label": "Form URL",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "Click share on your form and copy the link. It should be in the format: https://form.gov.sg/654ab1234abc1a012345f1e0b",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "url",
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "privateKey",
+          "label": "Form Secret Key",
+          "type": "dragdrop",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": "Enter or drop your Secret Key here to continue",
+          "description": "This is the key you downloaded/saved when you created the form",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionRegistrationType": "per-step",
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Choose form to connect",
+        "addConnectionLabel": "Add new form"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "triggers": [
+      {
+        "name": "New form response",
+        "key": "newSubmission",
+        "type": "webhook",
+        "description": "This workflow starts when a new form response is received",
+        "webhookTriggerInstructions": {
+          "hideWebhookUrl": true,
+          "errorMsg": "Make a new submission to the form you connected and test the step again.",
+          "mockDataMsg": "The mock responses below are based on your form fields."
+        },
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "NRIC Filter",
+                "key": "nricFilter",
+                "type": "dropdown",
+                "required": false,
+                "description": "Choose how to handle NRIC/FINs",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "none",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Do nothing",
+                    "value": "none",
+                    "description": null
+                  },
+                  {
+                    "label": "Remove NRICs",
+                    "value": "remove",
+                    "description": null
+                  },
+                  {
+                    "label": "Mask NRICs, e.g. S1234567A → xxxxx567A",
+                    "value": "mask",
+                    "description": null
+                  },
+                  {
+                    "label": "Hash NRICs, e.g. S1234567A → 5f4dcc3b5aa765d61d8327deb882cf99",
+                    "value": "hash",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "actions": [],
+    "demoVideoDetails": {
+      "url": "https://demo.arcade.software/6cWULLTHkTH4XsSB1rs1?embed&show_copy_link=true",
+      "title": "Setting up FormSG"
+    },
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "category": null,
+    "setupMessage": null
+  },
+  {
+    "name": "Email by Postman",
+    "key": "postman",
+    "description": "Send emails via Postman",
+    "iconUrl": "http://localhost:3000/apps/postman/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/postman",
+    "baseUrl": "https://postman.gov.sg",
+    "apiBaseUrl": "https://api.postman.gov.sg",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Send email",
+        "key": "sendTransactionalEmail",
+        "description": "Sends an email using Postman",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Email subject",
+                "key": "subject",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Body",
+                "key": "body",
+                "type": "rich-text",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Recipient email(s)",
+                "key": "destinationEmail",
+                "type": "string",
+                "required": true,
+                "description": "Enter the email addresses of the main recipients, separated by commas.\nEach recipient will receive an individual email.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "CC recipient email(s)",
+                "key": "destinationEmailCc",
+                "type": "string",
+                "required": false,
+                "description": "Enter the email addresses to CC, separated by commas.\nCC recipients will receive a copy of the email for each main recipient.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": "CC recipient status is not tracked. Blacklisted CC recipients will be ignored, but the email will still be sent to other recipients.",
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sender name",
+                "key": "senderName",
+                "type": "string",
+                "required": true,
+                "description": "For e.g., HR department.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Reply-To email",
+                "key": "replyTo",
+                "type": "string",
+                "required": false,
+                "description": "If left blank, this will default to your email address. Only one email address is allowed.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Attachments",
+                "key": "attachments",
+                "type": "attachment",
+                "required": false,
+                "description": "Check supported file types [here](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).\nPlease note that the maximum file size for each file is 2MB, and the total size of all attachments cannot exceed 10MB.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "file"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "demoVideoDetails": {
+      "url": "https://demo.arcade.software/VppMAbGKfFXFEsKxnKiw?embed&show_copy_link=true",
+      "title": "Setting up Email by Postman"
+    },
+    "queue": {
+      "queueRateLimit": {
+        "duration": 1000,
+        "max": 169
+      },
+      "isQueueDelayable": true
+    },
+    "category": "communication",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "Scheduler",
+    "key": "scheduler",
+    "description": "Schedule a time for this workflow to begin",
+    "iconUrl": "http://localhost:3000/apps/scheduler/assets/favicon.svg",
+    "docUrl": "https://guide.plumber.gov.sg/user-guides/triggers/scheduler",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/scheduler",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "triggers": [
+      {
+        "name": "Schedule hourly",
+        "key": "everyHour",
+        "description": "Triggers every hour",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Trigger on weekends?",
+                "key": "triggersOnWeekend",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Should this workflow start on Saturday and Sunday?",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Yes",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "No",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule daily",
+        "key": "everyDay",
+        "description": "Triggers every day, choose a specific hour",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Trigger on weekends?",
+                "key": "triggersOnWeekend",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Should this workflow start on Saturday and Sunday?",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Yes",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "No",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule weekly",
+        "key": "everyWeek",
+        "description": "Triggers every week, choose a specific day and hour of the week",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Day of the week",
+                "key": "weekday",
+                "type": "dropdown",
+                "required": true,
+                "description": "What day of the week should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Monday",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "Tuesday",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "Wednesday",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "Thursday",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "Friday",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "Saturday",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "Sunday",
+                    "value": 0,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule monthly",
+        "key": "everyMonth",
+        "description": "Triggers every month, choose a specific day and hour of the month",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Day of the month",
+                "key": "day",
+                "type": "dropdown",
+                "required": true,
+                "description": "What day of the month should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "1",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "2",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "3",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "4",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "5",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "6",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "7",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "8",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "9",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23",
+                    "value": 23,
+                    "description": null
+                  },
+                  {
+                    "label": "24",
+                    "value": 24,
+                    "description": null
+                  },
+                  {
+                    "label": "25",
+                    "value": 25,
+                    "description": null
+                  },
+                  {
+                    "label": "26",
+                    "value": 26,
+                    "description": null
+                  },
+                  {
+                    "label": "27",
+                    "value": 27,
+                    "description": null
+                  },
+                  {
+                    "label": "28",
+                    "value": 28,
+                    "description": null
+                  },
+                  {
+                    "label": "29",
+                    "value": 29,
+                    "description": null
+                  },
+                  {
+                    "label": "30",
+                    "value": 30,
+                    "description": null
+                  },
+                  {
+                    "label": "31",
+                    "value": 31,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "category": null,
+    "setupMessage": null,
+    "actions": null,
+    "auth": null
+  },
+  {
+    "name": "Tiles",
+    "key": "tiles",
+    "description": "A simple built-in database to view, store and automate your data",
+    "iconUrl": "http://localhost:3000/apps/tiles/assets/favicon.svg",
+    "authDocUrl": "",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "",
+    "actions": [
+      {
+        "name": "Find single row",
+        "key": "findSingleRow",
+        "description": "Gets data of a single row from your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup conditions",
+                "key": "filters",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "If multiple rows meet the conditions, the oldest entry will be returned",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than ",
+                        "value": "gt",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": null
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": null
+                      },
+                      {
+                        "label": "Is empty",
+                        "value": "empty",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "operator",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Return most recent row instead?",
+                "key": "returnLastRow",
+                "type": "boolean-radio",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "No (Returns oldest row)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Yes (Returns most recent row)",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find multiple rows",
+        "key": "findMultipleRows",
+        "description": "Gets data of multiple rows from your tile",
+        "isNew": true,
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup conditions",
+                "key": "filters",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Only the first 500 rows that meet the conditions will be returned",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than ",
+                        "value": "gt",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": null
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": null
+                      },
+                      {
+                        "label": "Is empty",
+                        "value": "empty",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "operator",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Order of rows",
+                "key": "returnLastRowFirst",
+                "type": "boolean-radio",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Ascending (oldest first)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Descending (newest first)",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create row",
+        "key": "createTileRow",
+        "description": "Creates a new row in your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": {
+                  "id": "tiles-createTileRow-tableId",
+                  "type": "modal",
+                  "label": "Create a new tile"
+                },
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "New row data",
+                "key": "rowData",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Select or type to create a column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 3
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": {
+                      "id": "tiles-createTileRow-columnId",
+                      "type": "inline",
+                      "label": "Create a new column"
+                    },
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "cellValue",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 5,
+                      "minWidth": 0,
+                      "maxWidth": "62.5%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update single row",
+        "key": "updateSingleRow",
+        "description": "Updates a single row in your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row ID",
+                "key": "rowId",
+                "type": "string",
+                "required": true,
+                "description": "This can be retrieved from the Find Single Row action",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "tile_row_id"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row data",
+                "key": "rowData",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Enter the data to update the row with. Columns not specified will not be updated.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": false,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flexBasis": "71px"
+                    },
+                    "tooltipText": null,
+                    "value": "set",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "=",
+                        "value": "set",
+                        "description": "Set as"
+                      },
+                      {
+                        "label": "+",
+                        "value": "add",
+                        "description": "Add by (numbers only)"
+                      },
+                      {
+                        "label": "-",
+                        "value": "subtract",
+                        "description": "Subtract by (numbers only)"
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "cellValue",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "name": "List Tables",
+        "key": "listTables"
+      },
+      {
+        "name": "List Columns",
+        "key": "listColumns"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": false
+    },
+    "category": "data",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "M365 Excel",
+    "key": "m365-excel",
+    "description": "Create, find or update a row in a table",
+    "iconUrl": "http://localhost:3000/apps/m365-excel/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/m365-excel",
+    "baseUrl": "https://www.office.com",
+    "apiBaseUrl": "https://graph.microsoft.com",
+    "primaryColor": "000000",
+    "auth": {
+      "connectionType": "system-added",
+      "connectionRegistrationType": "global",
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to M365 Excel"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Create table row",
+        "key": "createTableRow",
+        "description": "Creates a new row in your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "New row data",
+                "key": "columnValues",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnName",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listTableColumns"
+                        },
+                        {
+                          "name": "parameters.fileId",
+                          "value": "{parameters.fileId}"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find table row",
+        "key": "getTableRow",
+        "description": "Gets a single row of data from your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "If multiple rows meet your condition, the topmost entry will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find multiple table rows",
+        "key": "getTableRows",
+        "description": "Gets multiple rows of data from your Excel table",
+        "isNew": true,
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Only the first 500 rows that meet the condition will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get cell values",
+        "key": "getCellValues",
+        "description": "Gets cell value(s) in your Excel spreadsheet",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be a file in your Plumber folder.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Worksheet",
+                "key": "worksheetId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listWorksheets"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "cells",
+                "type": "multirow",
+                "required": true,
+                "description": "Specify cells you want to get the values of. (Max 3)",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": "Cell Address (e.g. A1)",
+                    "key": "address",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": null,
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update table row",
+        "key": "updateTableRow",
+        "description": "Updates a single row of data in your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "If multiple rows meet your condition, the topmost entry will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row data",
+                "key": "columnsToUpdate",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Enter the data to update the row with. Columns not specified will not be updated",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnName",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listTableColumns"
+                        },
+                        {
+                          "name": "parameters.fileId",
+                          "value": "{parameters.fileId}"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value to write",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Write cell values",
+        "key": "writeCellValues",
+        "description": "Write values into your Excel worksheet's cells",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be a file in your Plumber folder.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Worksheet",
+                "key": "worksheetId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Worksheet to edit",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listWorksheets"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "cells",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify cells you want to write values to (max 3). Leave a value blank to clear the cell.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": "Cell Address (e.g. A1)",
+                    "key": "address",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": "Value",
+                    "key": "value",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "dynamicData": [
+      {
+        "name": "List Files",
+        "key": "listFiles"
+      },
+      {
+        "name": "List Table Columns",
+        "key": "listTableColumns"
+      },
+      {
+        "name": "List Tables",
+        "key": "listTables"
+      },
+      {
+        "name": "List Worksheets",
+        "key": "listWorksheets"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": true,
+      "queueRateLimit": {
+        "max": 1,
+        "duration": 1000
+      }
+    },
+    "setupMessage": {
+      "variant": "warning",
+      "messageBody": "There is a cap on total disk space and Excel actions across all Plumber users. To prevent disruption to your workflow, contact us if you have large files or need more than 100 Excel actions per hour.\n\nRead [our guide](https://guide.plumber.gov.sg/user-guides/actions/m365-excel) for more information."
+    },
+    "category": "data",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "triggers": null
+  },
+  {
+    "name": "Webhook",
+    "key": "webhook",
+    "description": "Workflow begins when Plumber receives data",
+    "iconUrl": "http://localhost:3000/apps/webhook/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/webhooks",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "triggers": [
+      {
+        "name": "Catch raw webhook",
+        "key": "catchRawWebhook",
+        "type": "webhook",
+        "description": "Triggers when the webhook receives a request",
+        "webhookTriggerInstructions": {
+          "beforeUrlMsg": "# 1. You'll need to configure your application with this webhook URL.",
+          "afterUrlMsg": "# 2. Send some data to the webhook URL after configuration. Then, click test step."
+        },
+        "substeps": [
+          {
+            "key": "testStep",
+            "name": "Test step",
+            "arguments": null
+          }
+        ]
+      }
+    ],
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "category": null,
+    "setupMessage": null,
+    "actions": null,
+    "auth": null
+  },
+  {
+    "name": "Toolbox",
+    "key": "toolbox",
+    "iconUrl": "http://localhost:3000/apps/toolbox/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/toolbox",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "For each item",
+        "key": "forEach",
+        "description": "Repeat actions for each item",
+        "groupsLaterSteps": true,
+        "isNew": true,
+        "linkToGuide": "https://guide.plumber.gov.sg/user-guides/actions/for-each-item-coming-soon",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Choose items",
+                "key": "items",
+                "type": "string",
+                "required": true,
+                "description": "Items you can choose from: Find multiple rows, Find multiple table rows, or checkboxes/table from your form.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "array",
+                  "table"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": " No variables available - add/check one of the following steps above: Find multiple rows, Find multiple table rows, or include a checkbox/table field in your FormSG.",
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": true,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "setupMessage": null
+      },
+      {
+        "name": "If-then",
+        "key": "ifThen",
+        "description": "Run different actions based on certain conditions",
+        "groupsLaterSteps": true,
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Branch Name",
+                "key": "branchName",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FILE A BUG IF YOU SEE THIS",
+                "key": "depth",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "op": "always_true",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Conditions",
+                "key": "conditions",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Every condition has to be satisfied for this branch to be taken.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "30%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "is",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Is or is not",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Is",
+                        "value": "is",
+                        "description": null
+                      },
+                      {
+                        "label": "Is not",
+                        "value": "not",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "condition",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Empty",
+                        "value": "empty",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": "Used for text"
+                      },
+                      {
+                        "label": "Greater than",
+                        "value": "gt",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Before",
+                        "value": "before",
+                        "description": "Used for dates"
+                      },
+                      {
+                        "label": "After",
+                        "value": "after",
+                        "description": "Used for dates"
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "text",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "30%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "condition",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Only continue if",
+        "key": "onlyContinueIf",
+        "description": "Only runs later actions if specified conditions are met",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Field",
+                "key": "field",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": {
+                  "flex": 3,
+                  "minWidth": 0,
+                  "maxWidth": "30%"
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Is or is not",
+                "key": "is",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": {
+                  "flex": 2
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Is",
+                    "value": "is",
+                    "description": null
+                  },
+                  {
+                    "label": "Is not",
+                    "value": "not",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Condition",
+                "key": "condition",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": {
+                  "flex": 2
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Equals to",
+                    "value": "equals",
+                    "description": null
+                  },
+                  {
+                    "label": "Empty",
+                    "value": "empty",
+                    "description": null
+                  },
+                  {
+                    "label": "Contains",
+                    "value": "contains",
+                    "description": "Used for text"
+                  },
+                  {
+                    "label": "Greater than",
+                    "value": "gt",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Greater than or equals to",
+                    "value": "gte",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Less than",
+                    "value": "lt",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Less than or equals to",
+                    "value": "lte",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Before",
+                    "value": "before",
+                    "description": "Used for dates"
+                  },
+                  {
+                    "label": "After",
+                    "value": "after",
+                    "description": "Used for dates"
+                  },
+                  {
+                    "label": "Begins with",
+                    "value": "begins",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Value",
+                "key": "text",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": {
+                  "flex": 3,
+                  "minWidth": 0,
+                  "maxWidth": "30%"
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "condition",
+                  "op": "equals",
+                  "fieldValue": "empty"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "description": "Use Plumber's built in tools like If-then and Only continue if to add more functionality to your pipes",
+    "category": "logic",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "GatherSG",
+    "key": "gathersg",
+    "description": "Case management system",
+    "iconUrl": "http://localhost:3000/apps/gathersg/assets/favicon.svg",
+    "authDocUrl": "https://gather.gov.sg/",
+    "baseUrl": "",
+    "apiBaseUrl": "https://gather.gov.sg/cms/api",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": null,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to GatherSG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Update case",
+        "key": "updateCase",
+        "description": "Update a case based on the case uuid",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case UUID",
+                "key": "caseUuid",
+                "type": "string",
+                "required": true,
+                "description": "Select the case uuid you want to update.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": true,
+                "subFields": null
+              },
+              {
+                "label": "Case status",
+                "key": "caseStatus",
+                "type": "dropdown",
+                "required": false,
+                "description": "Select the status you want to update the case to.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseStatuses"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case fields",
+                "key": "caseFields",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": true,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getCaseFields"
+                        },
+                        {
+                          "name": "parameters.caseUuid",
+                          "value": "{parameters.caseUuid}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "fieldType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field type",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1,
+                      "maxWidth": 140
+                    },
+                    "tooltipText": null,
+                    "value": "string",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Text",
+                        "value": "string",
+                        "description": null
+                      },
+                      {
+                        "label": "Number",
+                        "value": "number",
+                        "description": null
+                      },
+                      {
+                        "label": "Null",
+                        "value": "null",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "fieldType",
+                      "op": "equals",
+                      "fieldValue": "null"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Tag/Untag case",
+        "key": "tagOrUntagCase",
+        "description": "Tag or untag a case based on the case uuid",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case UUID",
+                "key": "caseUuid",
+                "type": "string",
+                "required": true,
+                "description": "Enter the case uuid you want to tag or untag",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Tag or untag",
+                "key": "tagOrUntag",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Tag or untag the case",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": true,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Tag",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "Untag",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Tag value",
+                "key": "tagValue",
+                "type": "string",
+                "required": true,
+                "description": "Key in a single tag value to be applied to the case",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create case",
+        "key": "createCase",
+        "description": "Create a case",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case type",
+                "key": "caseType",
+                "type": "dropdown",
+                "required": true,
+                "description": "Select the type of the case you want to create",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseTypes"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case status",
+                "key": "caseStatus",
+                "type": "dropdown",
+                "required": false,
+                "description": "Select the status you want to update the case to.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseStatuses"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "caseType",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case fields",
+                "key": "caseFields",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "caseType",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": true,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getCaseFields"
+                        },
+                        {
+                          "name": "parameters.caseType",
+                          "value": "{parameters.caseType}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "fieldType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field type",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1,
+                      "maxWidth": 140
+                    },
+                    "tooltipText": null,
+                    "value": "string",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Text",
+                        "value": "string",
+                        "description": null
+                      },
+                      {
+                        "label": "Number",
+                        "value": "number",
+                        "description": null
+                      },
+                      {
+                        "label": "Null",
+                        "value": "null",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "fieldType",
+                      "op": "equals",
+                      "fieldValue": "null"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "triggers": [
+      {
+        "name": "New instant workflow",
+        "key": "newInstantWorkflow",
+        "type": "webhook",
+        "noAuthRequired": true,
+        "description": "Executes this Pipe when an instant workflow is triggered from GatherSG",
+        "webhookTriggerInstructions": {
+          "beforeUrlMsg": "# 1. Configure your instant workflow using this webhook URL.",
+          "afterUrlMsg": "# 2. Trigger the instant workflow. Then, click check step."
+        },
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Encryption key",
+                "key": "encryptionKey",
+                "type": "string",
+                "required": false,
+                "description": "Enter the encryption key for your instant workflow and save it.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "dynamicData": [
+      {
+        "key": "getCaseFields",
+        "name": "Get Case Fields"
+      },
+      {
+        "key": "getCaseTypes",
+        "name": "Get Case Types"
+      },
+      {
+        "key": "getCaseStatuses",
+        "name": "Get Case Statuses"
+      }
+    ],
+    "category": "data",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null
+  },
+  {
+    "name": "Formatter",
+    "key": "formatter",
+    "description": "Manipulate your data, such as changing date formats or adding days to a date",
+    "iconUrl": "http://localhost:3000/apps/formatter/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/formatter",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Format date / time",
+        "key": "dateTime",
+        "description": "Format date and time values",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select how you want to transform your data",
+                "key": "transformId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Add/subtract time",
+                    "description": "Manipulate a date and/or time by adding/subtracting days, months, years, hours or minutes",
+                    "value": "addSubtractDateTime"
+                  },
+                  {
+                    "label": "Format",
+                    "description": "Change a date or time to a new format style",
+                    "value": "formatDateTime"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Value to transform",
+                "key": "valueToTransform",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Select the format of your value",
+                "key": "dateTimeFormat",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "FormSG Submission Time",
+                    "description": "2024-03-25T08:15:30.250+08:00",
+                    "value": "formsgSubmissionTime"
+                  },
+                  {
+                    "label": "FormSG Date Field - DD MMM YYYY",
+                    "description": "25 Mar 2024",
+                    "value": "formsgDateField"
+                  },
+                  {
+                    "label": "DD/MM/YY",
+                    "description": "25/03/24",
+                    "value": "dd/LL/yy"
+                  },
+                  {
+                    "label": "DD/MM/YYYY",
+                    "description": "25/03/2024",
+                    "value": "dd/LL/yyyy"
+                  },
+                  {
+                    "label": "DD MMMM YYYY",
+                    "description": "25 March 2024",
+                    "value": "dd LLLL yyyy"
+                  },
+                  {
+                    "label": "YYYY/MM/DD",
+                    "description": "2024/03/25",
+                    "value": "yyyy/LL/dd"
+                  },
+                  {
+                    "label": "YYYY-MM-DD",
+                    "description": "2024-03-25",
+                    "value": "yyyy-LL-dd"
+                  },
+                  {
+                    "label": "HH:mm (am/pm)",
+                    "description": "12:04 PM",
+                    "value": "hh:mm a"
+                  },
+                  {
+                    "label": "HH:mm:ss (am/pm)",
+                    "description": "12:04:05 pm",
+                    "value": "hh:mm:ss a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm (am/pm)",
+                    "description": "25 Mar 2024 12:04 pm",
+                    "value": "dd LLL yyyy hh:mm a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm:ss (am/pm)",
+                    "description": "25 Mar 2024 12:04:05 pm",
+                    "value": "dd LLL yyyy hh:mm:ss a"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Specify the amount of time you want to add or subtract",
+                "key": "addSubtractDateTimeOps",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "not_equals",
+                  "fieldValue": "addSubtractDateTime"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "opType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Add or subtract?",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Add",
+                        "value": "add",
+                        "description": null
+                      },
+                      {
+                        "label": "Subtract",
+                        "value": "subtract",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "timeAmount",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Amount of time to add or subtract (number)",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 4,
+                      "minWidth": 0,
+                      "maxWidth": "44%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "timeUnit",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Unit of time to add or subtract",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 3
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Seconds",
+                        "value": "seconds",
+                        "description": null
+                      },
+                      {
+                        "label": "Minutes",
+                        "value": "minutes",
+                        "description": null
+                      },
+                      {
+                        "label": "Hours",
+                        "value": "hours",
+                        "description": null
+                      },
+                      {
+                        "label": "Days",
+                        "value": "days",
+                        "description": null
+                      },
+                      {
+                        "label": "Months",
+                        "value": "months",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "What format do you want to transform value to?",
+                "key": "formatDateTimeToFormat",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "DD/MM/YY",
+                    "description": "25/03/24",
+                    "value": "dd/LL/yy"
+                  },
+                  {
+                    "label": "DD/MM/YYYY",
+                    "description": "25/03/2024",
+                    "value": "dd/LL/yyyy"
+                  },
+                  {
+                    "label": "DD MMM YYYY",
+                    "description": "25 Mar 2024",
+                    "value": "dd LLL yyyy"
+                  },
+                  {
+                    "label": "DD MMMM YYYY",
+                    "description": "25 March 2024",
+                    "value": "dd LLLL yyyy"
+                  },
+                  {
+                    "label": "YYYY/MM/DD",
+                    "description": "2024/03/25",
+                    "value": "yyyy/LL/dd"
+                  },
+                  {
+                    "label": "YYYY-MM-DD",
+                    "description": "2024-03-25",
+                    "value": "yyyy-LL-dd"
+                  },
+                  {
+                    "label": "HH:mm (am/pm)",
+                    "description": "12:04 PM",
+                    "value": "hh:mm a"
+                  },
+                  {
+                    "label": "HH:mm:ss (am/pm)",
+                    "description": "12:04:05 pm",
+                    "value": "hh:mm:ss a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm (am/pm)",
+                    "description": "25 Mar 2024 12:04 pm",
+                    "value": "dd LLL yyyy hh:mm a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm:ss (am/pm)",
+                    "description": "25 Mar 2024 12:04:05 pm",
+                    "value": "dd LLL yyyy hh:mm:ss a"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "not_equals",
+                  "fieldValue": "formatDateTime"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "data",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "Calculator",
+    "key": "calculator",
+    "iconUrl": "http://localhost:3000/apps/calculator/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/calculator",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Perform a calculation",
+        "key": "performCalculation",
+        "description": "Add, subtract, multiply or divide",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Number to transform",
+                "key": "firstNumber",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Math operation to perform",
+                "key": "op",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Add",
+                    "value": "add",
+                    "description": null
+                  },
+                  {
+                    "label": "Subtract",
+                    "value": "subtract",
+                    "description": null
+                  },
+                  {
+                    "label": "Multiply",
+                    "value": "multiply",
+                    "description": null
+                  },
+                  {
+                    "label": "Divide",
+                    "value": "divide",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": null,
+                "key": "secondNumber",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": "Value",
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Round number",
+        "key": "roundToDecimalPlaces",
+        "description": "Round up/down/off numbers with decimals",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Number to round",
+                "key": "value",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Rounding",
+                "key": "op",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Round Down",
+                    "value": "roundDown",
+                    "description": null
+                  },
+                  {
+                    "label": "Round Up",
+                    "value": "roundUp",
+                    "description": null
+                  },
+                  {
+                    "label": "Round Off",
+                    "value": "roundOff",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Decimal places",
+                "key": "toDecimalPlaces",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "description": "Perform calculations on numbers in your data",
+    "category": "data",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "Delay",
+    "key": "delay",
+    "description": "Delay execution of the next step by a specified amount of time or until a specified date",
+    "iconUrl": "http://localhost:3000/apps/delay/assets/favicon.svg",
+    "authDocUrl": "https://automatisch.io/docs/apps/delay/connection",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "001F52",
+    "actions": [
+      {
+        "name": "Delay for",
+        "key": "delayFor",
+        "description": "Delays the execution of the next action by a specified amount of time",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Delay for unit",
+                "key": "delayForUnit",
+                "type": "dropdown",
+                "required": true,
+                "description": "Delay for unit, e.g. minutes, hours, days, weeks.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Minutes",
+                    "value": "minutes",
+                    "description": null
+                  },
+                  {
+                    "label": "Hours",
+                    "value": "hours",
+                    "description": null
+                  },
+                  {
+                    "label": "Days",
+                    "value": "days",
+                    "description": null
+                  },
+                  {
+                    "label": "Weeks",
+                    "value": "weeks",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Delay for value",
+                "key": "delayForValue",
+                "type": "string",
+                "required": true,
+                "description": "Delay for value, use a number, e.g. 1, 2, 3.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Delay until",
+        "key": "delayUntil",
+        "description": "Delays the execution of the next action until a specified date",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Delay until (Date)",
+                "key": "delayUntil",
+                "type": "string",
+                "required": true,
+                "description": "Delay until the date. E.g. 05 Aug 2026",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Delay until (Time)",
+                "key": "delayUntilTime",
+                "type": "string",
+                "required": false,
+                "description": "Delay until the time (24h). E.g. 08:00, 23:00",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "PaySG",
+    "key": "paysg",
+    "description": "Create payment, get details of payments created and send emails to payees",
+    "iconUrl": "http://localhost:3000/apps/paysg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/paysg",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": null,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "paymentServiceId",
+          "label": "Payment Service ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to PaySG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Create payment",
+        "key": "createPayment",
+        "description": "Create a new PaySG payment",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Reference ID",
+                "key": "referenceId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payerName",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payerAddress",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payerIdentifier",
+                "type": "string",
+                "required": false,
+                "description": "Max 20 characters. e.g. NRIC",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payerEmail",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payment amount (in cents)",
+                "key": "paymentAmountCents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Due Date",
+                "key": "dueDate",
+                "type": "string",
+                "required": false,
+                "description": "Must be formatted in \"2-digit-day month 4-digit-year\" format (e.g. 02 Nov 2023)",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Return URL",
+                "key": "returnUrl",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Metadata",
+                "key": "metadata",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Key",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "40%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get payment",
+        "key": "getPayment",
+        "description": "Get details of a payment that has previously been created",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment ID",
+                "key": "paymentId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Send payment email",
+        "key": "sendEmail",
+        "description": "Send email to payee for a payment that has previously been created",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment ID",
+                "key": "paymentId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create payment form submission for one-time payment",
+        "key": "createPaymentFormSubmission",
+        "description": "Create a new submission for a payment form, and initiate a one-time payment",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment Form Link",
+                "key": "formId",
+                "type": "string",
+                "required": true,
+                "description": "This can be found on your PaySG payment services dashboard",
+                "placeholder": "e.g. https://pay.gov.sg/forms/aBC123Def456HijK789LMn",
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Form ID",
+                "key": "formsg_form_id",
+                "type": "string",
+                "required": true,
+                "description": "Input the variable corresponding to form ID here",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Submission ID",
+                "key": "formsg_submission_id",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Reference Field Answer",
+                "key": "nonce",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payer_name",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payer_email",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payer_address",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payer_identifier",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Amount (in cents)",
+                "key": "amount_in_cents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Additional responses",
+                "key": "responses",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "These will be included in reports exported from PaySG",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "question",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Question",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "answer",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Answer",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create payment form submission for subscription",
+        "key": "createPaymentFormSubmissionSubscription",
+        "description": "Create a new submission for a payment form, and initiate a subscription",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment Form Link",
+                "key": "formId",
+                "type": "string",
+                "required": true,
+                "description": "This can be found on your PaySG payment services dashboard",
+                "placeholder": "e.g. https://pay.gov.sg/forms/aBC123Def456HijK789LMn",
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Form ID",
+                "key": "formsg_form_id",
+                "type": "string",
+                "required": true,
+                "description": "Input the variable corresponding to form ID here",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Submission ID",
+                "key": "formsg_submission_id",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Reference Field Answer",
+                "key": "nonce",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payer_name",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payer_email",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payer_address",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payer_identifier",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Amount (in cents)",
+                "key": "amount_in_cents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Frequency",
+                "key": "frequency",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "monthly",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Monthly",
+                    "value": "monthly",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Additional responses",
+                "key": "responses",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "These will be included in reports exported from PaySG",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "question",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Question",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "answer",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Answer",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "LetterSG",
+    "key": "lettersg",
+    "description": "Create a letter",
+    "iconUrl": "http://localhost:3000/apps/lettersg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/lettersg",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": null,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to LetterSG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Create letter",
+        "key": "createLetter",
+        "description": "Create a new letter based on the template id input",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Template",
+                "key": "templateId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Choose the template you want for creating a letter. You need to have an existing template in your Letters account first.",
+                "placeholder": "Template",
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getTemplateIds"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Export as PDF",
+                "key": "shouldGeneratePdf",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Please add an \"Email by Postman\" action to send the letter. By default, recipients will receive a link to view the mobile-friendly digital letter. If necessary, they can download the letter as a PDF from the link.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Send the letter link directly (Recommended)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Export letter as PDF to send",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Personalised fields",
+                "key": "letterParams",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify values for each personalised field in your template.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getTemplateFields"
+                        },
+                        {
+                          "name": "parameters.templateId",
+                          "value": "{parameters.templateId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "key": "getTemplateFields",
+        "name": "Get Template Fields"
+      },
+      {
+        "key": "getTemplateIds",
+        "name": "Get Template IDs"
+      }
+    ],
+    "category": "communication",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "SMS by Postman",
+    "key": "postman-sms",
+    "description": "Send SMSes via Postman",
+    "iconUrl": "http://localhost:3000/apps/postman-sms/assets/favicon.svg",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/sms-by-postman",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": null,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "campaignId",
+          "label": "Campaign ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "url",
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Choose campaign to connect",
+        "addConnectionLabel": "Add new campaign"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Send SMS",
+        "key": "sendSms",
+        "description": "Sends an SMS under Gov.SG sender ID",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Recipient phone number",
+                "key": "recipient",
+                "type": "string",
+                "required": true,
+                "description": "Include country code prefix, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message Body",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "This corresponds to {{body}} in your campaign template. Max 1,000 characters",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "rate-limit",
+        "limit": {
+          "max": 3,
+          "duration": 1000
+        }
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "Telegram",
+    "key": "telegram-bot",
+    "description": "Send messages to a Telegram chat, group or channel",
+    "iconUrl": "http://localhost:3000/apps/telegram-bot/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/telegram",
+    "baseUrl": "https://telegram.org",
+    "apiBaseUrl": "https://api.telegram.org",
+    "primaryColor": "2AABEE",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "dynamicData": [
+      {
+        "key": "getTelegramChatIds",
+        "name": "Get Telegram Chat IDs"
+      }
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "token",
+          "label": "Bot token",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "Bot token which should be retrieved from @botfather.",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Telegram"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Send message",
+        "key": "sendMessage",
+        "description": "Sends a message to a Telegram chat",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Chat ID",
+                "key": "chatId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Chat, group or channel ID. ",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": true,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getTelegramChatIds"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message text",
+                "key": "text",
+                "type": "string",
+                "required": true,
+                "description": "Text of the message to be sent, 1-4096 characters. Markdown supported.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Disable notification?",
+                "key": "disableNotification",
+                "type": "boolean-radio",
+                "required": false,
+                "description": "Sends the message silently. Users will receive a notification with no sound.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Channel Topic",
+                "key": "topicId",
+                "type": "string",
+                "required": false,
+                "description": "Key in the topic id if present. Refer to our user guide for more info.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 3
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "Slack",
+    "key": "slack",
+    "description": "Send or find a message in a channel",
+    "iconUrl": "http://localhost:3000/apps/slack/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/slack",
+    "baseUrl": "https://slack.com",
+    "apiBaseUrl": "https://slack.com/api",
+    "primaryColor": "4a154b",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "oAuthRedirectUrl",
+          "label": "OAuth Redirect URL",
+          "type": "string",
+          "required": true,
+          "readOnly": true,
+          "value": "http://localhost:3001/app/slack/connections/add",
+          "placeholder": null,
+          "description": "When asked to input an OAuth callback or redirect URL in Slack OAuth, enter the URL below.",
+          "docUrl": null,
+          "clickToCopy": true,
+          "autoComplete": "url",
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "consumerKey",
+          "label": "API Key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "consumerSecret",
+          "label": "API Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Slack"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "generateAuthUrl",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        },
+        {
+          "type": "openWithPopup",
+          "name": "openAuthPopup",
+          "arguments": [
+            {
+              "name": "url",
+              "value": "{generateAuthUrl.url}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{openAuthPopup.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "generateAuthUrl",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "openWithPopup",
+          "name": "openAuthPopup",
+          "arguments": [
+            {
+              "name": "url",
+              "value": "{generateAuthUrl.url}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{openAuthPopup.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Find a message",
+        "key": "findMessage",
+        "description": "Finds a message in a Slack channel",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Search Query",
+                "key": "query",
+                "type": "string",
+                "required": true,
+                "description": "Search query to use for finding matching messages. See the Slack Search Documentation for more information on constructing a query.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sort by",
+                "key": "sortBy",
+                "type": "dropdown",
+                "required": true,
+                "description": "Sort messages by their match strength or by their date. Default is score.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "score",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Match strength",
+                    "value": "score",
+                    "description": null
+                  },
+                  {
+                    "label": "Message date time",
+                    "value": "timestamp",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sort direction",
+                "key": "sortDirection",
+                "type": "dropdown",
+                "required": true,
+                "description": "Sort matching messages in ascending or descending order. Default is descending.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "desc",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Descending (newest or best match first)",
+                    "value": "desc",
+                    "description": null
+                  },
+                  {
+                    "label": "Ascending (oldest or worst match first)",
+                    "value": "asc",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Send a message to channel",
+        "key": "sendMessageToChannel",
+        "description": "Sends a message to a specified Slack channel",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Channel",
+                "key": "channel",
+                "type": "dropdown",
+                "required": true,
+                "description": "Pick a channel to send the message to.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": true,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listChannels"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message text",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "The content of your new message.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Send as a bot?",
+                "key": "sendAsBot",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "If you choose no, this message will appear to come from you. Direct messages are always sent by bots.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Bot name",
+                "key": "botName",
+                "type": "string",
+                "required": false,
+                "description": "Specify the bot name which appears as a bold username above the message inside Slack. Defaults to Plumber.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "Plumber",
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "sendAsBot",
+                  "op": "equals",
+                  "fieldValue": false
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Bot icon",
+                "key": "botIcon",
+                "type": "string",
+                "required": false,
+                "description": "Either an image url or an emoji available to your team (surrounded by :). For example, https://example.com/icon_256.png or :robot_face:",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "sendAsBot",
+                  "op": "equals",
+                  "fieldValue": false
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "name": "List channels",
+        "key": "listChannels"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 3
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "AISAY",
+    "key": "aisay",
+    "category": "others",
+    "description": "Extract data from documents such as invoices, bank statements, cheques, and more",
+    "iconUrl": "http://localhost:3000/apps/aisay/assets/favicon.svg",
+    "authDocUrl": "",
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "clientId",
+          "label": "Client ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "clientSecret",
+          "label": "Client Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect your AISAY account",
+        "addConnectionLabel": "Add new account"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "baseUrl": "https://stg.ai.ff.gov.sg",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "actions": [
+      {
+        "name": "Extract data from all document types",
+        "key": "useGeneralisedModel",
+        "description": "Optimised for standard and non-standard documents",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Model type",
+                "key": "modelType",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "standard",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Standard",
+                    "value": "standard",
+                    "description": null
+                  },
+                  {
+                    "label": "Vision",
+                    "value": "DOC_EXTRACTION_V2",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "File",
+                "key": "file",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "file"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Prompts",
+                "key": "prompts",
+                "type": "multirow",
+                "required": true,
+                "description": "Enter prompts to specify how the data should be interpreted and extracted",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": "Add prompt",
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "prompt",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "E.g. Return the price of individual line items",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": null,
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": false
+    },
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "Custom API",
+    "key": "custom-api",
+    "description": "Make a HTTP request",
+    "iconUrl": "http://localhost:3000/apps/custom-api/assets/favicon.svg",
+    "authDocUrl": "",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "label",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": null,
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "headers",
+          "label": "Headers",
+          "type": "multiline",
+          "required": false,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "Enter your headers in this format: KEY=VALUE (one per line)",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Custom API"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "actions": [
+      {
+        "name": "Make a HTTP request",
+        "key": "httpRequest",
+        "description": "Makes a custom HTTP request of any method and body",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Method",
+                "key": "method",
+                "type": "dropdown",
+                "required": true,
+                "description": "The HTTP method we'll use to perform the request.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "GET",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "DELETE",
+                    "value": "DELETE",
+                    "description": null
+                  },
+                  {
+                    "label": "GET",
+                    "value": "GET",
+                    "description": null
+                  },
+                  {
+                    "label": "PATCH",
+                    "value": "PATCH",
+                    "description": null
+                  },
+                  {
+                    "label": "POST",
+                    "value": "POST",
+                    "description": null
+                  },
+                  {
+                    "label": "PUT",
+                    "value": "PUT",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "URL",
+                "key": "url",
+                "type": "string",
+                "required": true,
+                "description": "Any URL with a querystring will be re-encoded properly. Plumber URLs (e.g. https://plumber.gov.sg/webhooks/...) are prohibited.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Custom Headers",
+                "key": "customHeaders",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "Add custom headers here.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": "Add",
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Key",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Data",
+                "key": "data",
+                "type": "string",
+                "required": false,
+                "description": "Place raw JSON data here.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "setupMessage": null,
+    "triggers": null
+  },
+  {
+    "name": "Vault Workspace",
+    "key": "vault-workspace",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "iconUrl": "http://localhost:3000/apps/vault-workspace/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/vault-workspace",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Create row",
+        "key": "createRow",
+        "description": "Creates a new row in Vault Workspace table.",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Columns",
+                "key": "columns",
+                "type": "string",
+                "required": true,
+                "description": "Put a comma between each column. Enclose columns with double-quotes (\") if it contains commas. Columns can contain double quotes, but use single quotes if problems arise.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "values",
+                "type": "string",
+                "required": true,
+                "description": "Put a comma between each value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get table data",
+        "key": "getTableData",
+        "description": "Gets a single row data from a Vault Workspace table",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Lookup Column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should look for cells which match the Lookup Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update table data",
+        "key": "updateTableData",
+        "description": "Updates a single row in a Vault Workspace table",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Lookup Column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should look for cells which match the Lookup Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Update Column",
+                "key": "updateColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should update for cells with the Update Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Update Value",
+                "key": "updateValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "category": null,
+    "setupMessage": null,
+    "triggers": null,
+    "auth": null
+  },
+  {
+    "name": "Twilio",
+    "key": "twilio",
+    "iconUrl": "http://localhost:3000/apps/twilio/assets/favicon.svg",
+    "authDocUrl": "https://automatisch.io/docs/apps/twilio/connection",
+    "baseUrl": "https://twilio.com",
+    "apiBaseUrl": "https://api.twilio.com",
+    "primaryColor": "e1000f",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "accountSid",
+          "label": "Account SID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "Your Twilio Account SID can be found under Account Info section at https://console.twilio.com/",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "apiKeySid",
+          "label": "API Key SID (Optional)",
+          "type": "string",
+          "required": false,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "Your Twilio API Key SID can be found at https://www.twilio.com/console/project/api-keys",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": null,
+          "showOptionValue": null,
+          "options": null
+        },
+        {
+          "key": "authToken",
+          "label": "Auth Token / API Key Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "placeholder": null,
+          "description": "If an API Key SID was provided, please provide your API Key Secret. If not, please provide your account's auth token.",
+          "docUrl": null,
+          "clickToCopy": false,
+          "autoComplete": "off",
+          "showOptionValue": null,
+          "options": null
+        }
+      ],
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ],
+      "autoCheckStep": null
+    },
+    "actions": [
+      {
+        "name": "Send an SMS",
+        "key": "sendSms",
+        "description": "Sends an SMS with Twilio",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "From Number",
+                "key": "fromNumber",
+                "type": "string",
+                "required": true,
+                "description": "The number to send the SMS from or your Twilio Messaging Service ID. Include country code prefix if specifying number, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "To Number",
+                "key": "toNumber",
+                "type": "string",
+                "required": true,
+                "description": "The number to send the SMS to. Include country code prefix, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "The message to send.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "docUrl": null,
+    "connectionCount": null,
+    "isNewApp": null,
+    "demoVideoDetails": null,
+    "category": null,
+    "setupMessage": null,
+    "triggers": null
+  }
+]

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "plumber",
   "license": "AGPL-3.0",
   "scripts": {
+    "generate:apps": "ts-node -r tsconfig-paths/register --project packages/backend/tsconfig.json packages/scripts/generate-apps.ts",
     "postinstall": "npm run gqlc",
     "all": "concurrently -c auto",
     "setup": "npm run -w backend setup",

--- a/packages/frontend/src/assets/apps.json
+++ b/packages/frontend/src/assets/apps.json
@@ -1,0 +1,9058 @@
+[
+  {
+    "name": "FormSG",
+    "key": "formsg",
+    "description": "Workflow starts when a new form response is received",
+    "iconUrl": "http://localhost:3000/apps/formsg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/formsg",
+    "baseUrl": "https://form.gov.sg",
+    "apiBaseUrl": "",
+    "primaryColor": "635bff",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "autoCheckStep": true,
+      "fields": [
+        {
+          "key": "formId",
+          "label": "Form URL",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": "Click share on your form and copy the link. It should be in the format: https://form.gov.sg/654ab1234abc1a012345f1e0b",
+          "clickToCopy": false,
+          "autoComplete": "url"
+        },
+        {
+          "key": "privateKey",
+          "label": "Form Secret Key",
+          "type": "dragdrop",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": "This is the key you downloaded/saved when you created the form",
+          "placeholder": "Enter or drop your Secret Key here to continue",
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionRegistrationType": "per-step",
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Choose form to connect",
+        "addConnectionLabel": "Add new form"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "triggers": [
+      {
+        "name": "New form response",
+        "key": "newSubmission",
+        "type": "webhook",
+        "description": "This workflow starts when a new form response is received",
+        "webhookTriggerInstructions": {
+          "hideWebhookUrl": true,
+          "errorMsg": "Make a new submission to the form you connected and test the step again.",
+          "mockDataMsg": "The mock responses below are based on your form fields."
+        },
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "NRIC Filter",
+                "key": "nricFilter",
+                "type": "dropdown",
+                "required": false,
+                "description": "Choose how to handle NRIC/FINs",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "none",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Do nothing",
+                    "value": "none",
+                    "description": null
+                  },
+                  {
+                    "label": "Remove NRICs",
+                    "value": "remove",
+                    "description": null
+                  },
+                  {
+                    "label": "Mask NRICs, e.g. S1234567A → xxxxx567A",
+                    "value": "mask",
+                    "description": null
+                  },
+                  {
+                    "label": "Hash NRICs, e.g. S1234567A → 5f4dcc3b5aa765d61d8327deb882cf99",
+                    "value": "hash",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "actions": [],
+    "demoVideoDetails": {
+      "url": "https://demo.arcade.software/6cWULLTHkTH4XsSB1rs1?embed&show_copy_link=true",
+      "title": "Setting up FormSG"
+    }
+  },
+  {
+    "name": "Email by Postman",
+    "key": "postman",
+    "description": "Send emails via Postman",
+    "iconUrl": "http://localhost:3000/apps/postman/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/postman",
+    "baseUrl": "https://postman.gov.sg",
+    "apiBaseUrl": "https://api.postman.gov.sg",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Send email",
+        "key": "sendTransactionalEmail",
+        "description": "Sends an email using Postman",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Email subject",
+                "key": "subject",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Body",
+                "key": "body",
+                "type": "rich-text",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Recipient email(s)",
+                "key": "destinationEmail",
+                "type": "string",
+                "required": true,
+                "description": "Enter the email addresses of the main recipients, separated by commas.\nEach recipient will receive an individual email.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "CC recipient email(s)",
+                "key": "destinationEmailCc",
+                "type": "string",
+                "required": false,
+                "description": "Enter the email addresses to CC, separated by commas.\nCC recipients will receive a copy of the email for each main recipient.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": "CC recipient status is not tracked. Blacklisted CC recipients will be ignored, but the email will still be sent to other recipients.",
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sender name",
+                "key": "senderName",
+                "type": "string",
+                "required": true,
+                "description": "For e.g., HR department.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Reply-To email",
+                "key": "replyTo",
+                "type": "string",
+                "required": false,
+                "description": "If left blank, this will default to your email address. Only one email address is allowed.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Attachments",
+                "key": "attachments",
+                "type": "attachment",
+                "required": false,
+                "description": "Check supported file types [here](https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types).\nPlease note that the maximum file size for each file is 2MB, and the total size of all attachments cannot exceed 10MB.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "file"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "demoVideoDetails": {
+      "url": "https://demo.arcade.software/VppMAbGKfFXFEsKxnKiw?embed&show_copy_link=true",
+      "title": "Setting up Email by Postman"
+    },
+    "queue": {
+      "queueRateLimit": {
+        "duration": 1000,
+        "max": 169
+      },
+      "isQueueDelayable": true
+    },
+    "category": "communication",
+    "triggers": null
+  },
+  {
+    "name": "Scheduler",
+    "key": "scheduler",
+    "description": "Schedule a time for this workflow to begin",
+    "iconUrl": "http://localhost:3000/apps/scheduler/assets/favicon.svg",
+    "docUrl": "https://guide.plumber.gov.sg/user-guides/triggers/scheduler",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/scheduler",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "triggers": [
+      {
+        "name": "Schedule hourly",
+        "key": "everyHour",
+        "description": "Triggers every hour",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Trigger on weekends?",
+                "key": "triggersOnWeekend",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Should this workflow start on Saturday and Sunday?",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Yes",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "No",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule daily",
+        "key": "everyDay",
+        "description": "Triggers every day, choose a specific hour",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Trigger on weekends?",
+                "key": "triggersOnWeekend",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Should this workflow start on Saturday and Sunday?",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Yes",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "No",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule weekly",
+        "key": "everyWeek",
+        "description": "Triggers every week, choose a specific day and hour of the week",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Day of the week",
+                "key": "weekday",
+                "type": "dropdown",
+                "required": true,
+                "description": "What day of the week should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Monday",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "Tuesday",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "Wednesday",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "Thursday",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "Friday",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "Saturday",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "Sunday",
+                    "value": 0,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Schedule monthly",
+        "key": "everyMonth",
+        "description": "Triggers every month, choose a specific day and hour of the month",
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Day of the month",
+                "key": "day",
+                "type": "dropdown",
+                "required": true,
+                "description": "What day of the month should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "1",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "2",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "3",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "4",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "5",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "6",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "7",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "8",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "9",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23",
+                    "value": 23,
+                    "description": null
+                  },
+                  {
+                    "label": "24",
+                    "value": 24,
+                    "description": null
+                  },
+                  {
+                    "label": "25",
+                    "value": 25,
+                    "description": null
+                  },
+                  {
+                    "label": "26",
+                    "value": 26,
+                    "description": null
+                  },
+                  {
+                    "label": "27",
+                    "value": 27,
+                    "description": null
+                  },
+                  {
+                    "label": "28",
+                    "value": 28,
+                    "description": null
+                  },
+                  {
+                    "label": "29",
+                    "value": 29,
+                    "description": null
+                  },
+                  {
+                    "label": "30",
+                    "value": 30,
+                    "description": null
+                  },
+                  {
+                    "label": "31",
+                    "value": 31,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Time of day",
+                "key": "hour",
+                "type": "dropdown",
+                "required": true,
+                "description": "What time of day should this workflow start?",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "00:00",
+                    "value": 0,
+                    "description": null
+                  },
+                  {
+                    "label": "01:00",
+                    "value": 1,
+                    "description": null
+                  },
+                  {
+                    "label": "02:00",
+                    "value": 2,
+                    "description": null
+                  },
+                  {
+                    "label": "03:00",
+                    "value": 3,
+                    "description": null
+                  },
+                  {
+                    "label": "04:00",
+                    "value": 4,
+                    "description": null
+                  },
+                  {
+                    "label": "05:00",
+                    "value": 5,
+                    "description": null
+                  },
+                  {
+                    "label": "06:00",
+                    "value": 6,
+                    "description": null
+                  },
+                  {
+                    "label": "07:00",
+                    "value": 7,
+                    "description": null
+                  },
+                  {
+                    "label": "08:00",
+                    "value": 8,
+                    "description": null
+                  },
+                  {
+                    "label": "09:00",
+                    "value": 9,
+                    "description": null
+                  },
+                  {
+                    "label": "10:00",
+                    "value": 10,
+                    "description": null
+                  },
+                  {
+                    "label": "11:00",
+                    "value": 11,
+                    "description": null
+                  },
+                  {
+                    "label": "12:00",
+                    "value": 12,
+                    "description": null
+                  },
+                  {
+                    "label": "13:00",
+                    "value": 13,
+                    "description": null
+                  },
+                  {
+                    "label": "14:00",
+                    "value": 14,
+                    "description": null
+                  },
+                  {
+                    "label": "15:00",
+                    "value": 15,
+                    "description": null
+                  },
+                  {
+                    "label": "16:00",
+                    "value": 16,
+                    "description": null
+                  },
+                  {
+                    "label": "17:00",
+                    "value": 17,
+                    "description": null
+                  },
+                  {
+                    "label": "18:00",
+                    "value": 18,
+                    "description": null
+                  },
+                  {
+                    "label": "19:00",
+                    "value": 19,
+                    "description": null
+                  },
+                  {
+                    "label": "20:00",
+                    "value": 20,
+                    "description": null
+                  },
+                  {
+                    "label": "21:00",
+                    "value": 21,
+                    "description": null
+                  },
+                  {
+                    "label": "22:00",
+                    "value": 22,
+                    "description": null
+                  },
+                  {
+                    "label": "23:00",
+                    "value": 23,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "actions": null
+  },
+  {
+    "name": "Tiles",
+    "key": "tiles",
+    "description": "A simple built-in database to view, store and automate your data",
+    "iconUrl": "http://localhost:3000/apps/tiles/assets/favicon.svg",
+    "authDocUrl": "",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "",
+    "actions": [
+      {
+        "name": "Find single row",
+        "key": "findSingleRow",
+        "description": "Gets data of a single row from your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup conditions",
+                "key": "filters",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "If multiple rows meet the conditions, the oldest entry will be returned",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than ",
+                        "value": "gt",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": null
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": null
+                      },
+                      {
+                        "label": "Is empty",
+                        "value": "empty",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "operator",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Return most recent row instead?",
+                "key": "returnLastRow",
+                "type": "boolean-radio",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "No (Returns oldest row)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Yes (Returns most recent row)",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find multiple rows",
+        "key": "findMultipleRows",
+        "description": "Gets data of multiple rows from your tile",
+        "isNew": true,
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup conditions",
+                "key": "filters",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Only the first 500 rows that meet the conditions will be returned",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than ",
+                        "value": "gt",
+                        "description": null
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": null
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": null
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": null
+                      },
+                      {
+                        "label": "Is empty",
+                        "value": "empty",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "operator",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Order of rows",
+                "key": "returnLastRowFirst",
+                "type": "boolean-radio",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Ascending (oldest first)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Descending (newest first)",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create row",
+        "key": "createTileRow",
+        "description": "Creates a new row in your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": {
+                  "id": "tiles-createTileRow-tableId",
+                  "type": "modal",
+                  "label": "Create a new tile"
+                },
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "New row data",
+                "key": "rowData",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Select or type to create a column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 3
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": {
+                      "id": "tiles-createTileRow-columnId",
+                      "type": "inline",
+                      "label": "Create a new column"
+                    },
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "cellValue",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 5,
+                      "minWidth": 0,
+                      "maxWidth": "62.5%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update single row",
+        "key": "updateSingleRow",
+        "description": "Updates a single row in your tile",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select Tile",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": {
+                  "label": "View tile",
+                  "url": "/tiles/{value}"
+                },
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row ID",
+                "key": "rowId",
+                "type": "string",
+                "required": true,
+                "description": "This can be retrieved from the Find Single Row action",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "tile_row_id"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row data",
+                "key": "rowData",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Enter the data to update the row with. Columns not specified will not be updated.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnId",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listColumns"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "operator",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": false,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flexBasis": "71px"
+                    },
+                    "tooltipText": null,
+                    "value": "set",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "=",
+                        "value": "set",
+                        "description": "Set as"
+                      },
+                      {
+                        "label": "+",
+                        "value": "add",
+                        "description": "Add by (numbers only)"
+                      },
+                      {
+                        "label": "-",
+                        "value": "subtract",
+                        "description": "Subtract by (numbers only)"
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "cellValue",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "name": "List Tables",
+        "key": "listTables"
+      },
+      {
+        "name": "List Columns",
+        "key": "listColumns"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": false
+    },
+    "category": "data",
+    "triggers": null
+  },
+  {
+    "name": "M365 Excel",
+    "key": "m365-excel",
+    "description": "Create, find or update a row in a table",
+    "iconUrl": "http://localhost:3000/apps/m365-excel/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/m365-excel",
+    "baseUrl": "https://www.office.com",
+    "apiBaseUrl": "https://graph.microsoft.com",
+    "primaryColor": "000000",
+    "auth": {
+      "connectionType": "system-added",
+      "connectionRegistrationType": "global",
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to M365 Excel"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Create table row",
+        "key": "createTableRow",
+        "description": "Creates a new row in your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "New row data",
+                "key": "columnValues",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnName",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listTableColumns"
+                        },
+                        {
+                          "name": "parameters.fileId",
+                          "value": "{parameters.fileId}"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find table row",
+        "key": "getTableRow",
+        "description": "Gets a single row of data from your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "If multiple rows meet your condition, the topmost entry will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Find multiple table rows",
+        "key": "getTableRows",
+        "description": "Gets multiple rows of data from your Excel table",
+        "isNew": true,
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Only the first 500 rows that meet the condition will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get cell values",
+        "key": "getCellValues",
+        "description": "Gets cell value(s) in your Excel spreadsheet",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be a file in your Plumber folder.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Worksheet",
+                "key": "worksheetId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listWorksheets"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "cells",
+                "type": "multirow",
+                "required": true,
+                "description": "Specify cells you want to get the values of. (Max 3)",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": "Cell Address (e.g. A1)",
+                    "key": "address",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": null,
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update table row",
+        "key": "updateTableRow",
+        "description": "Updates a single row of data in your Excel table",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be an Excel file in the folder created for you",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Table",
+                "key": "tableId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Tables should not have more than 50,000 rows or 100,000 cells",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTables"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "If multiple rows meet your condition, the topmost entry will be returned",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listTableColumns"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    },
+                    {
+                      "name": "parameters.tableId",
+                      "value": "{parameters.tableId}"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": false,
+                "description": "Case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Row data",
+                "key": "columnsToUpdate",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Enter the data to update the row with. Columns not specified will not be updated",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "tableId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "columnName",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Column",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "listTableColumns"
+                        },
+                        {
+                          "name": "parameters.fileId",
+                          "value": "{parameters.fileId}"
+                        },
+                        {
+                          "name": "parameters.tableId",
+                          "value": "{parameters.tableId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value to write",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Write cell values",
+        "key": "writeCellValues",
+        "description": "Write values into your Excel worksheet's cells",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Excel File",
+                "key": "fileId",
+                "type": "dropdown",
+                "required": true,
+                "description": "This should be a file in your Plumber folder.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listFiles"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Worksheet",
+                "key": "worksheetId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Worksheet to edit",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listWorksheets"
+                    },
+                    {
+                      "name": "parameters.fileId",
+                      "value": "{parameters.fileId}"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "cells",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify cells you want to write values to (max 3). Leave a value blank to clear the cell.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": "Cell Address (e.g. A1)",
+                    "key": "address",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": "Value",
+                    "key": "value",
+                    "type": "string",
+                    "required": false,
+                    "description": null,
+                    "placeholder": null,
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "dynamicData": [
+      {
+        "name": "List Files",
+        "key": "listFiles"
+      },
+      {
+        "name": "List Table Columns",
+        "key": "listTableColumns"
+      },
+      {
+        "name": "List Tables",
+        "key": "listTables"
+      },
+      {
+        "name": "List Worksheets",
+        "key": "listWorksheets"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": true,
+      "queueRateLimit": {
+        "max": 1,
+        "duration": 1000
+      }
+    },
+    "setupMessage": {
+      "variant": "warning",
+      "messageBody": "There is a cap on total disk space and Excel actions across all Plumber users. To prevent disruption to your workflow, contact us if you have large files or need more than 100 Excel actions per hour.\n\nRead [our guide](https://guide.plumber.gov.sg/user-guides/actions/m365-excel) for more information."
+    },
+    "category": "data",
+    "triggers": null
+  },
+  {
+    "name": "Webhook",
+    "key": "webhook",
+    "description": "Workflow begins when Plumber receives data",
+    "iconUrl": "http://localhost:3000/apps/webhook/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/triggers/webhooks",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "triggers": [
+      {
+        "name": "Catch raw webhook",
+        "key": "catchRawWebhook",
+        "type": "webhook",
+        "description": "Triggers when the webhook receives a request",
+        "webhookTriggerInstructions": {
+          "beforeUrlMsg": "# 1. You'll need to configure your application with this webhook URL.",
+          "afterUrlMsg": "# 2. Send some data to the webhook URL after configuration. Then, click test step."
+        },
+        "substeps": [
+          {
+            "key": "testStep",
+            "name": "Test step",
+            "arguments": null
+          }
+        ]
+      }
+    ],
+    "actions": null
+  },
+  {
+    "name": "Toolbox",
+    "key": "toolbox",
+    "iconUrl": "http://localhost:3000/apps/toolbox/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/toolbox",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "For each item",
+        "key": "forEach",
+        "description": "Repeat actions for each item",
+        "groupsLaterSteps": true,
+        "isNew": true,
+        "linkToGuide": "https://guide.plumber.gov.sg/user-guides/actions/for-each-item-coming-soon",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Choose items",
+                "key": "items",
+                "type": "string",
+                "required": true,
+                "description": "Items you can choose from: Find multiple rows, Find multiple table rows, or checkboxes/table from your form.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "array",
+                  "table"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": " No variables available - add/check one of the following steps above: Find multiple rows, Find multiple table rows, or include a checkbox/table field in your FormSG.",
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": true,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "setupMessage": null
+      },
+      {
+        "name": "If-then",
+        "key": "ifThen",
+        "description": "Run different actions based on certain conditions",
+        "groupsLaterSteps": true,
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Branch Name",
+                "key": "branchName",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FILE A BUG IF YOU SEE THIS",
+                "key": "depth",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "op": "always_true",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Conditions",
+                "key": "conditions",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Every condition has to be satisfied for this branch to be taken.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "30%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "is",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Is or is not",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Is",
+                        "value": "is",
+                        "description": null
+                      },
+                      {
+                        "label": "Is not",
+                        "value": "not",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "condition",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Condition",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Equals to",
+                        "value": "equals",
+                        "description": null
+                      },
+                      {
+                        "label": "Empty",
+                        "value": "empty",
+                        "description": null
+                      },
+                      {
+                        "label": "Contains",
+                        "value": "contains",
+                        "description": "Used for text"
+                      },
+                      {
+                        "label": "Greater than",
+                        "value": "gt",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Greater than or equals to",
+                        "value": "gte",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Less than",
+                        "value": "lt",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Less than or equals to",
+                        "value": "lte",
+                        "description": "Used for numbers"
+                      },
+                      {
+                        "label": "Before",
+                        "value": "before",
+                        "description": "Used for dates"
+                      },
+                      {
+                        "label": "After",
+                        "value": "after",
+                        "description": "Used for dates"
+                      },
+                      {
+                        "label": "Begins with",
+                        "value": "begins",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "text",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "30%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "condition",
+                      "op": "equals",
+                      "fieldValue": "empty"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Only continue if",
+        "key": "onlyContinueIf",
+        "description": "Only runs later actions if specified conditions are met",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Field",
+                "key": "field",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": {
+                  "flex": 3,
+                  "minWidth": 0,
+                  "maxWidth": "30%"
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Is or is not",
+                "key": "is",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": {
+                  "flex": 2
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Is",
+                    "value": "is",
+                    "description": null
+                  },
+                  {
+                    "label": "Is not",
+                    "value": "not",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Condition",
+                "key": "condition",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": {
+                  "flex": 2
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Equals to",
+                    "value": "equals",
+                    "description": null
+                  },
+                  {
+                    "label": "Empty",
+                    "value": "empty",
+                    "description": null
+                  },
+                  {
+                    "label": "Contains",
+                    "value": "contains",
+                    "description": "Used for text"
+                  },
+                  {
+                    "label": "Greater than",
+                    "value": "gt",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Greater than or equals to",
+                    "value": "gte",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Less than",
+                    "value": "lt",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Less than or equals to",
+                    "value": "lte",
+                    "description": "Used for numbers"
+                  },
+                  {
+                    "label": "Before",
+                    "value": "before",
+                    "description": "Used for dates"
+                  },
+                  {
+                    "label": "After",
+                    "value": "after",
+                    "description": "Used for dates"
+                  },
+                  {
+                    "label": "Begins with",
+                    "value": "begins",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Value",
+                "key": "text",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": {
+                  "flex": 3,
+                  "minWidth": 0,
+                  "maxWidth": "30%"
+                },
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "condition",
+                  "op": "equals",
+                  "fieldValue": "empty"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "description": "Use Plumber's built in tools like If-then and Only continue if to add more functionality to your pipes",
+    "category": "logic",
+    "triggers": null
+  },
+  {
+    "name": "GatherSG",
+    "key": "gathersg",
+    "description": "Case management system",
+    "iconUrl": "http://localhost:3000/apps/gathersg/assets/favicon.svg",
+    "authDocUrl": "https://gather.gov.sg/",
+    "baseUrl": "",
+    "apiBaseUrl": "https://gather.gov.sg/cms/api",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to GatherSG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Update case",
+        "key": "updateCase",
+        "description": "Update a case based on the case uuid",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case UUID",
+                "key": "caseUuid",
+                "type": "string",
+                "required": true,
+                "description": "Select the case uuid you want to update.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": true,
+                "subFields": null
+              },
+              {
+                "label": "Case status",
+                "key": "caseStatus",
+                "type": "dropdown",
+                "required": false,
+                "description": "Select the status you want to update the case to.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseStatuses"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case fields",
+                "key": "caseFields",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": true,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getCaseFields"
+                        },
+                        {
+                          "name": "parameters.caseUuid",
+                          "value": "{parameters.caseUuid}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "fieldType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field type",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1,
+                      "maxWidth": 140
+                    },
+                    "tooltipText": null,
+                    "value": "string",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Text",
+                        "value": "string",
+                        "description": null
+                      },
+                      {
+                        "label": "Number",
+                        "value": "number",
+                        "description": null
+                      },
+                      {
+                        "label": "Null",
+                        "value": "null",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "fieldType",
+                      "op": "equals",
+                      "fieldValue": "null"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Tag/Untag case",
+        "key": "tagOrUntagCase",
+        "description": "Tag or untag a case based on the case uuid",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case UUID",
+                "key": "caseUuid",
+                "type": "string",
+                "required": true,
+                "description": "Enter the case uuid you want to tag or untag",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Tag or untag",
+                "key": "tagOrUntag",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Tag or untag the case",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": true,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Tag",
+                    "value": true,
+                    "description": null
+                  },
+                  {
+                    "label": "Untag",
+                    "value": false,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Tag value",
+                "key": "tagValue",
+                "type": "string",
+                "required": true,
+                "description": "Key in a single tag value to be applied to the case",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create case",
+        "key": "createCase",
+        "description": "Create a case",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Case type",
+                "key": "caseType",
+                "type": "dropdown",
+                "required": true,
+                "description": "Select the type of the case you want to create",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseTypes"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case status",
+                "key": "caseStatus",
+                "type": "dropdown",
+                "required": false,
+                "description": "Select the status you want to update the case to.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getCaseStatuses"
+                    }
+                  ]
+                },
+                "hiddenIf": {
+                  "fieldKey": "caseType",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Case fields",
+                "key": "caseFields",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify values for each field you want to update in your case. Note that fields that require an array of objects as a value are not supported yet.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "caseType",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": true,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getCaseFields"
+                        },
+                        {
+                          "name": "parameters.caseType",
+                          "value": "{parameters.caseType}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "fieldType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field type",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 1,
+                      "maxWidth": 140
+                    },
+                    "tooltipText": null,
+                    "value": "string",
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Text",
+                        "value": "string",
+                        "description": null
+                      },
+                      {
+                        "label": "Number",
+                        "value": "number",
+                        "description": null
+                      },
+                      {
+                        "label": "Null",
+                        "value": "null",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": {
+                      "fieldKey": "fieldType",
+                      "op": "equals",
+                      "fieldValue": "null"
+                    },
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "triggers": [
+      {
+        "name": "New instant workflow",
+        "key": "newInstantWorkflow",
+        "type": "webhook",
+        "noAuthRequired": true,
+        "description": "Executes this Pipe when an instant workflow is triggered from GatherSG",
+        "webhookTriggerInstructions": {
+          "beforeUrlMsg": "# 1. Configure your instant workflow using this webhook URL.",
+          "afterUrlMsg": "# 2. Trigger the instant workflow. Then, click check step."
+        },
+        "substeps": [
+          {
+            "key": "setUpTrigger",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Encryption key",
+                "key": "encryptionKey",
+                "type": "string",
+                "required": false,
+                "description": "Enter the encryption key for your instant workflow and save it.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "dynamicData": [
+      {
+        "key": "getCaseFields",
+        "name": "Get Case Fields"
+      },
+      {
+        "key": "getCaseTypes",
+        "name": "Get Case Types"
+      },
+      {
+        "key": "getCaseStatuses",
+        "name": "Get Case Statuses"
+      }
+    ],
+    "category": "data"
+  },
+  {
+    "name": "Formatter",
+    "key": "formatter",
+    "description": "Manipulate your data, such as changing date formats or adding days to a date",
+    "iconUrl": "http://localhost:3000/apps/formatter/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/formatter",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Format date / time",
+        "key": "dateTime",
+        "description": "Format date and time values",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Select how you want to transform your data",
+                "key": "transformId",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Add/subtract time",
+                    "description": "Manipulate a date and/or time by adding/subtracting days, months, years, hours or minutes",
+                    "value": "addSubtractDateTime"
+                  },
+                  {
+                    "label": "Format",
+                    "description": "Change a date or time to a new format style",
+                    "value": "formatDateTime"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Value to transform",
+                "key": "valueToTransform",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Select the format of your value",
+                "key": "dateTimeFormat",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "FormSG Submission Time",
+                    "description": "2024-03-25T08:15:30.250+08:00",
+                    "value": "formsgSubmissionTime"
+                  },
+                  {
+                    "label": "FormSG Date Field - DD MMM YYYY",
+                    "description": "25 Mar 2024",
+                    "value": "formsgDateField"
+                  },
+                  {
+                    "label": "DD/MM/YY",
+                    "description": "25/03/24",
+                    "value": "dd/LL/yy"
+                  },
+                  {
+                    "label": "DD/MM/YYYY",
+                    "description": "25/03/2024",
+                    "value": "dd/LL/yyyy"
+                  },
+                  {
+                    "label": "DD MMMM YYYY",
+                    "description": "25 March 2024",
+                    "value": "dd LLLL yyyy"
+                  },
+                  {
+                    "label": "YYYY/MM/DD",
+                    "description": "2024/03/25",
+                    "value": "yyyy/LL/dd"
+                  },
+                  {
+                    "label": "YYYY-MM-DD",
+                    "description": "2024-03-25",
+                    "value": "yyyy-LL-dd"
+                  },
+                  {
+                    "label": "HH:mm (am/pm)",
+                    "description": "12:04 PM",
+                    "value": "hh:mm a"
+                  },
+                  {
+                    "label": "HH:mm:ss (am/pm)",
+                    "description": "12:04:05 pm",
+                    "value": "hh:mm:ss a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm (am/pm)",
+                    "description": "25 Mar 2024 12:04 pm",
+                    "value": "dd LLL yyyy hh:mm a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm:ss (am/pm)",
+                    "description": "25 Mar 2024 12:04:05 pm",
+                    "value": "dd LLL yyyy hh:mm:ss a"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "is_empty",
+                  "fieldValue": null
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Specify the amount of time you want to add or subtract",
+                "key": "addSubtractDateTimeOps",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "not_equals",
+                  "fieldValue": "addSubtractDateTime"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "opType",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Add or subtract?",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Add",
+                        "value": "add",
+                        "description": null
+                      },
+                      {
+                        "label": "Subtract",
+                        "value": "subtract",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "timeAmount",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Amount of time to add or subtract (number)",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 4,
+                      "minWidth": 0,
+                      "maxWidth": "44%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "timeUnit",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Unit of time to add or subtract",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 3
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": [
+                      {
+                        "label": "Seconds",
+                        "value": "seconds",
+                        "description": null
+                      },
+                      {
+                        "label": "Minutes",
+                        "value": "minutes",
+                        "description": null
+                      },
+                      {
+                        "label": "Hours",
+                        "value": "hours",
+                        "description": null
+                      },
+                      {
+                        "label": "Days",
+                        "value": "days",
+                        "description": null
+                      },
+                      {
+                        "label": "Months",
+                        "value": "months",
+                        "description": null
+                      }
+                    ],
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "What format do you want to transform value to?",
+                "key": "formatDateTimeToFormat",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "DD/MM/YY",
+                    "description": "25/03/24",
+                    "value": "dd/LL/yy"
+                  },
+                  {
+                    "label": "DD/MM/YYYY",
+                    "description": "25/03/2024",
+                    "value": "dd/LL/yyyy"
+                  },
+                  {
+                    "label": "DD MMM YYYY",
+                    "description": "25 Mar 2024",
+                    "value": "dd LLL yyyy"
+                  },
+                  {
+                    "label": "DD MMMM YYYY",
+                    "description": "25 March 2024",
+                    "value": "dd LLLL yyyy"
+                  },
+                  {
+                    "label": "YYYY/MM/DD",
+                    "description": "2024/03/25",
+                    "value": "yyyy/LL/dd"
+                  },
+                  {
+                    "label": "YYYY-MM-DD",
+                    "description": "2024-03-25",
+                    "value": "yyyy-LL-dd"
+                  },
+                  {
+                    "label": "HH:mm (am/pm)",
+                    "description": "12:04 PM",
+                    "value": "hh:mm a"
+                  },
+                  {
+                    "label": "HH:mm:ss (am/pm)",
+                    "description": "12:04:05 pm",
+                    "value": "hh:mm:ss a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm (am/pm)",
+                    "description": "25 Mar 2024 12:04 pm",
+                    "value": "dd LLL yyyy hh:mm a"
+                  },
+                  {
+                    "label": "DD MMM YYYY HH:mm:ss (am/pm)",
+                    "description": "25 Mar 2024 12:04:05 pm",
+                    "value": "dd LLL yyyy hh:mm:ss a"
+                  }
+                ],
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "transformId",
+                  "op": "not_equals",
+                  "fieldValue": "formatDateTime"
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "data",
+    "triggers": null
+  },
+  {
+    "name": "Calculator",
+    "key": "calculator",
+    "iconUrl": "http://localhost:3000/apps/calculator/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/calculator",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Perform a calculation",
+        "key": "performCalculation",
+        "description": "Add, subtract, multiply or divide",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Number to transform",
+                "key": "firstNumber",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Math operation to perform",
+                "key": "op",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Add",
+                    "value": "add",
+                    "description": null
+                  },
+                  {
+                    "label": "Subtract",
+                    "value": "subtract",
+                    "description": null
+                  },
+                  {
+                    "label": "Multiply",
+                    "value": "multiply",
+                    "description": null
+                  },
+                  {
+                    "label": "Divide",
+                    "value": "divide",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": null,
+                "key": "secondNumber",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": "Value",
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Round number",
+        "key": "roundToDecimalPlaces",
+        "description": "Round up/down/off numbers with decimals",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Number to round",
+                "key": "value",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Rounding",
+                "key": "op",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Round Down",
+                    "value": "roundDown",
+                    "description": null
+                  },
+                  {
+                    "label": "Round Up",
+                    "value": "roundUp",
+                    "description": null
+                  },
+                  {
+                    "label": "Round Off",
+                    "value": "roundOff",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Decimal places",
+                "key": "toDecimalPlaces",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "description": "Perform calculations on numbers in your data",
+    "category": "data",
+    "triggers": null
+  },
+  {
+    "name": "Delay",
+    "key": "delay",
+    "description": "Delay execution of the next step by a specified amount of time or until a specified date",
+    "iconUrl": "http://localhost:3000/apps/delay/assets/favicon.svg",
+    "authDocUrl": "https://automatisch.io/docs/apps/delay/connection",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "001F52",
+    "actions": [
+      {
+        "name": "Delay for",
+        "key": "delayFor",
+        "description": "Delays the execution of the next action by a specified amount of time",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Delay for unit",
+                "key": "delayForUnit",
+                "type": "dropdown",
+                "required": true,
+                "description": "Delay for unit, e.g. minutes, hours, days, weeks.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Minutes",
+                    "value": "minutes",
+                    "description": null
+                  },
+                  {
+                    "label": "Hours",
+                    "value": "hours",
+                    "description": null
+                  },
+                  {
+                    "label": "Days",
+                    "value": "days",
+                    "description": null
+                  },
+                  {
+                    "label": "Weeks",
+                    "value": "weeks",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Delay for value",
+                "key": "delayForValue",
+                "type": "string",
+                "required": true,
+                "description": "Delay for value, use a number, e.g. 1, 2, 3.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Delay until",
+        "key": "delayUntil",
+        "description": "Delays the execution of the next action until a specified date",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Delay until (Date)",
+                "key": "delayUntil",
+                "type": "string",
+                "required": true,
+                "description": "Delay until the date. E.g. 05 Aug 2026",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Delay until (Time)",
+                "key": "delayUntilTime",
+                "type": "string",
+                "required": false,
+                "description": "Delay until the time (24h). E.g. 08:00, 23:00",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "triggers": null
+  },
+  {
+    "name": "PaySG",
+    "key": "paysg",
+    "description": "Create payment, get details of payments created and send emails to payees",
+    "iconUrl": "http://localhost:3000/apps/paysg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/paysg",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false
+        },
+        {
+          "key": "paymentServiceId",
+          "label": "Payment Service ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to PaySG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Create payment",
+        "key": "createPayment",
+        "description": "Create a new PaySG payment",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Reference ID",
+                "key": "referenceId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payerName",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payerAddress",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payerIdentifier",
+                "type": "string",
+                "required": false,
+                "description": "Max 20 characters. e.g. NRIC",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payerEmail",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payment amount (in cents)",
+                "key": "paymentAmountCents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Due Date",
+                "key": "dueDate",
+                "type": "string",
+                "required": false,
+                "description": "Must be formatted in \"2-digit-day month 4-digit-year\" format (e.g. 02 Nov 2023)",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Return URL",
+                "key": "returnUrl",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Metadata",
+                "key": "metadata",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Key",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2,
+                      "minWidth": 0,
+                      "maxWidth": "40%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get payment",
+        "key": "getPayment",
+        "description": "Get details of a payment that has previously been created",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment ID",
+                "key": "paymentId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Send payment email",
+        "key": "sendEmail",
+        "description": "Send email to payee for a payment that has previously been created",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment ID",
+                "key": "paymentId",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create payment form submission for one-time payment",
+        "key": "createPaymentFormSubmission",
+        "description": "Create a new submission for a payment form, and initiate a one-time payment",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment Form Link",
+                "key": "formId",
+                "type": "string",
+                "required": true,
+                "description": "This can be found on your PaySG payment services dashboard",
+                "placeholder": "e.g. https://pay.gov.sg/forms/aBC123Def456HijK789LMn",
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Form ID",
+                "key": "formsg_form_id",
+                "type": "string",
+                "required": true,
+                "description": "Input the variable corresponding to form ID here",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Submission ID",
+                "key": "formsg_submission_id",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Reference Field Answer",
+                "key": "nonce",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payer_name",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payer_email",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payer_address",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payer_identifier",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Amount (in cents)",
+                "key": "amount_in_cents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Additional responses",
+                "key": "responses",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "These will be included in reports exported from PaySG",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "question",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Question",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "answer",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Answer",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Create payment form submission for subscription",
+        "key": "createPaymentFormSubmissionSubscription",
+        "description": "Create a new submission for a payment form, and initiate a subscription",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Payment Form Link",
+                "key": "formId",
+                "type": "string",
+                "required": true,
+                "description": "This can be found on your PaySG payment services dashboard",
+                "placeholder": "e.g. https://pay.gov.sg/forms/aBC123Def456HijK789LMn",
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Form ID",
+                "key": "formsg_form_id",
+                "type": "string",
+                "required": true,
+                "description": "Input the variable corresponding to form ID here",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Submission ID",
+                "key": "formsg_submission_id",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "FormSG Reference Field Answer",
+                "key": "nonce",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Name",
+                "key": "payer_name",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Email",
+                "key": "payer_email",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Address",
+                "key": "payer_address",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Payer Identifier",
+                "key": "payer_identifier",
+                "type": "string",
+                "required": false,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Amount (in cents)",
+                "key": "amount_in_cents",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Frequency",
+                "key": "frequency",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "monthly",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Monthly",
+                    "value": "monthly",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Description",
+                "key": "description",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Additional responses",
+                "key": "responses",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "These will be included in reports exported from PaySG",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "question",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Question",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "answer",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Answer",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 1,
+                      "minWidth": 0,
+                      "maxWidth": "50%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "triggers": null
+  },
+  {
+    "name": "LetterSG",
+    "key": "lettersg",
+    "description": "Create a letter",
+    "iconUrl": "http://localhost:3000/apps/lettersg/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/lettersg",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to LetterSG"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Create letter",
+        "key": "createLetter",
+        "description": "Create a new letter based on the template id input",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Template",
+                "key": "templateId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Choose the template you want for creating a letter. You need to have an existing template in your Letters account first.",
+                "placeholder": "Template",
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getTemplateIds"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Export as PDF",
+                "key": "shouldGeneratePdf",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "Please add an \"Email by Postman\" action to send the letter. By default, recipients will receive a link to view the mobile-friendly digital letter. If necessary, they can download the letter as a PDF from the link.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Send the letter link directly (Recommended)",
+                    "value": false,
+                    "description": null
+                  },
+                  {
+                    "label": "Export letter as PDF to send",
+                    "value": true,
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Personalised fields",
+                "key": "letterParams",
+                "type": "multirow-multicol",
+                "required": true,
+                "description": "Specify values for each personalised field in your template.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "field",
+                    "type": "dropdown",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Field",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": false,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": {
+                      "type": "query",
+                      "name": "getDynamicData",
+                      "arguments": [
+                        {
+                          "name": "key",
+                          "value": "getTemplateFields"
+                        },
+                        {
+                          "name": "parameters.templateId",
+                          "value": "{parameters.templateId}"
+                        }
+                      ]
+                    },
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "key": "getTemplateFields",
+        "name": "Get Template Fields"
+      },
+      {
+        "key": "getTemplateIds",
+        "name": "Get Template IDs"
+      }
+    ],
+    "category": "communication",
+    "triggers": null
+  },
+  {
+    "name": "SMS by Postman",
+    "key": "postman-sms",
+    "description": "Send SMSes via Postman",
+    "iconUrl": "http://localhost:3000/apps/postman-sms/assets/favicon.svg",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/sms-by-postman",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "000000",
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "screenName",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false
+        },
+        {
+          "key": "campaignId",
+          "label": "Campaign ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false,
+          "autoComplete": "url"
+        },
+        {
+          "key": "apiKey",
+          "label": "API key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Choose campaign to connect",
+        "addConnectionLabel": "Add new campaign"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Send SMS",
+        "key": "sendSms",
+        "description": "Sends an SMS under Gov.SG sender ID",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Recipient phone number",
+                "key": "recipient",
+                "type": "string",
+                "required": true,
+                "description": "Include country code prefix, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message Body",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "This corresponds to {{body}} in your campaign template. Max 1,000 characters",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "rate-limit",
+        "limit": {
+          "max": 3,
+          "duration": 1000
+        }
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "triggers": null
+  },
+  {
+    "name": "Telegram",
+    "key": "telegram-bot",
+    "description": "Send messages to a Telegram chat, group or channel",
+    "iconUrl": "http://localhost:3000/apps/telegram-bot/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/telegram",
+    "baseUrl": "https://telegram.org",
+    "apiBaseUrl": "https://api.telegram.org",
+    "primaryColor": "2AABEE",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "dynamicData": [
+      {
+        "key": "getTelegramChatIds",
+        "name": "Get Telegram Chat IDs"
+      }
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "token",
+          "label": "Bot token",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": "Bot token which should be retrieved from @botfather.",
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Telegram"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Send message",
+        "key": "sendMessage",
+        "description": "Sends a message to a Telegram chat",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Chat ID",
+                "key": "chatId",
+                "type": "dropdown",
+                "required": true,
+                "description": "Chat, group or channel ID. ",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": true,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "getTelegramChatIds"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message text",
+                "key": "text",
+                "type": "string",
+                "required": true,
+                "description": "Text of the message to be sent, 1-4096 characters. Markdown supported.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Disable notification?",
+                "key": "disableNotification",
+                "type": "boolean-radio",
+                "required": false,
+                "description": "Sends the message silently. Users will receive a notification with no sound.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Channel Topic",
+                "key": "topicId",
+                "type": "string",
+                "required": false,
+                "description": "Key in the topic id if present. Refer to our user guide for more info.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 3
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "triggers": null
+  },
+  {
+    "name": "Slack",
+    "key": "slack",
+    "description": "Send or find a message in a channel",
+    "iconUrl": "http://localhost:3000/apps/slack/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/slack",
+    "baseUrl": "https://slack.com",
+    "apiBaseUrl": "https://slack.com/api",
+    "primaryColor": "4a154b",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "oAuthRedirectUrl",
+          "label": "OAuth Redirect URL",
+          "type": "string",
+          "required": true,
+          "readOnly": true,
+          "value": "http://localhost:3001/app/slack/connections/add",
+          "description": "When asked to input an OAuth callback or redirect URL in Slack OAuth, enter the URL below.",
+          "clickToCopy": true,
+          "autoComplete": "url"
+        },
+        {
+          "key": "consumerKey",
+          "label": "API Key",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": null,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        },
+        {
+          "key": "consumerSecret",
+          "label": "API Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": null,
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Slack"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "generateAuthUrl",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        },
+        {
+          "type": "openWithPopup",
+          "name": "openAuthPopup",
+          "arguments": [
+            {
+              "name": "url",
+              "value": "{generateAuthUrl.url}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{openAuthPopup.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "generateAuthUrl",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "openWithPopup",
+          "name": "openAuthPopup",
+          "arguments": [
+            {
+              "name": "url",
+              "value": "{generateAuthUrl.url}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{openAuthPopup.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Find a message",
+        "key": "findMessage",
+        "description": "Finds a message in a Slack channel",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Search Query",
+                "key": "query",
+                "type": "string",
+                "required": true,
+                "description": "Search query to use for finding matching messages. See the Slack Search Documentation for more information on constructing a query.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sort by",
+                "key": "sortBy",
+                "type": "dropdown",
+                "required": true,
+                "description": "Sort messages by their match strength or by their date. Default is score.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "score",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Match strength",
+                    "value": "score",
+                    "description": null
+                  },
+                  {
+                    "label": "Message date time",
+                    "value": "timestamp",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Sort direction",
+                "key": "sortDirection",
+                "type": "dropdown",
+                "required": true,
+                "description": "Sort matching messages in ascending or descending order. Default is descending.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "desc",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Descending (newest or best match first)",
+                    "value": "desc",
+                    "description": null
+                  },
+                  {
+                    "label": "Ascending (oldest or worst match first)",
+                    "value": "asc",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Send a message to channel",
+        "key": "sendMessageToChannel",
+        "description": "Sends a message to a specified Slack channel",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Channel",
+                "key": "channel",
+                "type": "dropdown",
+                "required": true,
+                "description": "Pick a channel to send the message to.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": true,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": {
+                  "type": "query",
+                  "name": "getDynamicData",
+                  "arguments": [
+                    {
+                      "name": "key",
+                      "value": "listChannels"
+                    }
+                  ]
+                },
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message text",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "The content of your new message.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Send as a bot?",
+                "key": "sendAsBot",
+                "type": "boolean-radio",
+                "required": true,
+                "description": "If you choose no, this message will appear to come from you. Direct messages are always sent by bots.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": false,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Bot name",
+                "key": "botName",
+                "type": "string",
+                "required": false,
+                "description": "Specify the bot name which appears as a bold username above the message inside Slack. Defaults to Plumber.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "Plumber",
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "sendAsBot",
+                  "op": "equals",
+                  "fieldValue": false
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Bot icon",
+                "key": "botIcon",
+                "type": "string",
+                "required": false,
+                "description": "Either an image url or an emoji available to your team (surrounded by :). For example, https://example.com/icon_256.png or :robot_face:",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": {
+                  "fieldKey": "sendAsBot",
+                  "op": "equals",
+                  "fieldValue": false
+                },
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "dynamicData": [
+      {
+        "name": "List channels",
+        "key": "listChannels"
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 3
+      },
+      "isQueueDelayable": false
+    },
+    "category": "communication",
+    "triggers": null
+  },
+  {
+    "name": "AISAY",
+    "key": "aisay",
+    "category": "others",
+    "description": "Extract data from documents such as invoices, bank statements, cheques, and more",
+    "iconUrl": "http://localhost:3000/apps/aisay/assets/favicon.svg",
+    "authDocUrl": "",
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "clientId",
+          "label": "Client ID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "clickToCopy": false
+        },
+        {
+          "key": "clientSecret",
+          "label": "Client Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "clickToCopy": false
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect your AISAY account",
+        "addConnectionLabel": "Add new account"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "baseUrl": "https://stg.ai.ff.gov.sg",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "actions": [
+      {
+        "name": "Extract data from all document types",
+        "key": "useGeneralisedModel",
+        "description": "Optimised for standard and non-standard documents",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Model type",
+                "key": "modelType",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "standard",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "Standard",
+                    "value": "standard",
+                    "description": null
+                  },
+                  {
+                    "label": "Vision",
+                    "value": "DOC_EXTRACTION_V2",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "File",
+                "key": "file",
+                "type": "dropdown",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": [
+                  "file"
+                ],
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Prompts",
+                "key": "prompts",
+                "type": "multirow",
+                "required": true,
+                "description": "Enter prompts to specify how the data should be interpreted and extracted",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": "Add prompt",
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "prompt",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "E.g. Return the price of individual line items",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": null,
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "queue": {
+      "groupLimits": {
+        "type": "concurrency",
+        "concurrency": 1
+      },
+      "isQueueDelayable": false
+    },
+    "triggers": null
+  },
+  {
+    "name": "Custom API",
+    "key": "custom-api",
+    "description": "Make a HTTP request",
+    "iconUrl": "http://localhost:3000/apps/custom-api/assets/favicon.svg",
+    "authDocUrl": "",
+    "beforeRequest": [
+      null,
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "label",
+          "label": "Label",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "clickToCopy": false
+        },
+        {
+          "key": "headers",
+          "label": "Headers",
+          "type": "multiline",
+          "required": false,
+          "readOnly": false,
+          "value": null,
+          "description": "Enter your headers in this format: KEY=VALUE (one per line)",
+          "clickToCopy": false
+        }
+      ],
+      "connectionModalLabel": {
+        "chooseConnectionLabel": "Connect to Custom API"
+      },
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "primaryColor": "0059F7",
+    "actions": [
+      {
+        "name": "Make a HTTP request",
+        "key": "httpRequest",
+        "description": "Makes a custom HTTP request of any method and body",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Method",
+                "key": "method",
+                "type": "dropdown",
+                "required": true,
+                "description": "The HTTP method we'll use to perform the request.",
+                "placeholder": null,
+                "variables": null,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": false,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": "GET",
+                "noVariablesMessage": null,
+                "options": [
+                  {
+                    "label": "DELETE",
+                    "value": "DELETE",
+                    "description": null
+                  },
+                  {
+                    "label": "GET",
+                    "value": "GET",
+                    "description": null
+                  },
+                  {
+                    "label": "PATCH",
+                    "value": "PATCH",
+                    "description": null
+                  },
+                  {
+                    "label": "POST",
+                    "value": "POST",
+                    "description": null
+                  },
+                  {
+                    "label": "PUT",
+                    "value": "PUT",
+                    "description": null
+                  }
+                ],
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "URL",
+                "key": "url",
+                "type": "string",
+                "required": true,
+                "description": "Any URL with a querystring will be re-encoded properly. Plumber URLs (e.g. https://plumber.gov.sg/webhooks/...) are prohibited.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Custom Headers",
+                "key": "customHeaders",
+                "type": "multirow-multicol",
+                "required": false,
+                "description": "Add custom headers here.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": "Add",
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": [
+                  {
+                    "label": null,
+                    "key": "key",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Key",
+                    "variables": false,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 2
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  },
+                  {
+                    "label": null,
+                    "key": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": null,
+                    "placeholder": "Value",
+                    "variables": true,
+                    "variableTypes": null,
+                    "allowArbitrary": null,
+                    "isSearchable": null,
+                    "addRowButtonText": null,
+                    "showOptionValue": null,
+                    "customStyle": {
+                      "flex": 3,
+                      "minWidth": 0,
+                      "maxWidth": "60%"
+                    },
+                    "tooltipText": null,
+                    "value": null,
+                    "noVariablesMessage": null,
+                    "options": null,
+                    "source": null,
+                    "hiddenIf": null,
+                    "addNewOption": null,
+                    "clickableLink": null,
+                    "singleVariableSelection": null,
+                    "subFields": null
+                  }
+                ]
+              },
+              {
+                "label": "Data",
+                "key": "data",
+                "type": "string",
+                "required": false,
+                "description": "Place raw JSON data here.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "category": "others",
+    "triggers": null
+  },
+  {
+    "name": "Vault Workspace",
+    "key": "vault-workspace",
+    "baseUrl": "",
+    "apiBaseUrl": "",
+    "iconUrl": "http://localhost:3000/apps/vault-workspace/assets/favicon.svg",
+    "authDocUrl": "https://guide.plumber.gov.sg/user-guides/actions/vault-workspace",
+    "primaryColor": "000000",
+    "actions": [
+      {
+        "name": "Create row",
+        "key": "createRow",
+        "description": "Creates a new row in Vault Workspace table.",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Columns",
+                "key": "columns",
+                "type": "string",
+                "required": true,
+                "description": "Put a comma between each column. Enclose columns with double-quotes (\") if it contains commas. Columns can contain double quotes, but use single quotes if problems arise.",
+                "placeholder": null,
+                "variables": false,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Values",
+                "key": "values",
+                "type": "string",
+                "required": true,
+                "description": "Put a comma between each value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Get table data",
+        "key": "getTableData",
+        "description": "Gets a single row data from a Vault Workspace table",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Lookup Column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should look for cells which match the Lookup Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      },
+      {
+        "name": "Update table data",
+        "key": "updateTableData",
+        "description": "Updates a single row in a Vault Workspace table",
+        "substeps": [
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "Lookup Column",
+                "key": "lookupColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should look for cells which match the Lookup Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Lookup Value",
+                "key": "lookupValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Update Column",
+                "key": "updateColumn",
+                "type": "dropdown",
+                "required": true,
+                "description": "Specify a column we should update for cells with the Update Value.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Update Value",
+                "key": "updateValue",
+                "type": "string",
+                "required": true,
+                "description": null,
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "triggers": null
+  },
+  {
+    "name": "Twilio",
+    "key": "twilio",
+    "iconUrl": "http://localhost:3000/apps/twilio/assets/favicon.svg",
+    "authDocUrl": "https://automatisch.io/docs/apps/twilio/connection",
+    "baseUrl": "https://twilio.com",
+    "apiBaseUrl": "https://api.twilio.com",
+    "primaryColor": "e1000f",
+    "beforeRequest": [
+      null
+    ],
+    "auth": {
+      "connectionType": "user-added",
+      "fields": [
+        {
+          "key": "accountSid",
+          "label": "Account SID",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": "Your Twilio Account SID can be found under Account Info section at https://console.twilio.com/",
+          "clickToCopy": false
+        },
+        {
+          "key": "apiKeySid",
+          "label": "API Key SID (Optional)",
+          "type": "string",
+          "required": false,
+          "readOnly": false,
+          "value": null,
+          "description": "Your Twilio API Key SID can be found at https://www.twilio.com/console/project/api-keys",
+          "clickToCopy": false
+        },
+        {
+          "key": "authToken",
+          "label": "Auth Token / API Key Secret",
+          "type": "string",
+          "required": true,
+          "readOnly": false,
+          "value": null,
+          "description": "If an API Key SID was provided, please provide your API Key Secret. If not, please provide your account's auth token.",
+          "clickToCopy": false,
+          "autoComplete": "off"
+        }
+      ],
+      "authenticationSteps": [
+        {
+          "type": "mutation",
+          "name": "createConnection",
+          "arguments": [
+            {
+              "name": "key",
+              "value": "{key}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{createConnection.id}"
+            }
+          ]
+        }
+      ],
+      "reconnectionSteps": [
+        {
+          "type": "mutation",
+          "name": "resetConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "updateConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            },
+            {
+              "name": "formattedData",
+              "value": "{fields.all}"
+            }
+          ]
+        },
+        {
+          "type": "mutation",
+          "name": "verifyConnection",
+          "arguments": [
+            {
+              "name": "id",
+              "value": "{connection.id}"
+            }
+          ]
+        }
+      ]
+    },
+    "actions": [
+      {
+        "name": "Send an SMS",
+        "key": "sendSms",
+        "description": "Sends an SMS with Twilio",
+        "substeps": [
+          {
+            "key": "chooseConnection",
+            "name": "Choose connection",
+            "arguments": null
+          },
+          {
+            "key": "setUpAction",
+            "name": "Set up step",
+            "arguments": [
+              {
+                "label": "From Number",
+                "key": "fromNumber",
+                "type": "string",
+                "required": true,
+                "description": "The number to send the SMS from or your Twilio Messaging Service ID. Include country code prefix if specifying number, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "To Number",
+                "key": "toNumber",
+                "type": "string",
+                "required": true,
+                "description": "The number to send the SMS to. Include country code prefix, e.g. +6581237123",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              },
+              {
+                "label": "Message",
+                "key": "message",
+                "type": "string",
+                "required": true,
+                "description": "The message to send.",
+                "placeholder": null,
+                "variables": true,
+                "variableTypes": null,
+                "allowArbitrary": null,
+                "isSearchable": null,
+                "addRowButtonText": null,
+                "showOptionValue": null,
+                "customStyle": null,
+                "tooltipText": null,
+                "value": null,
+                "noVariablesMessage": null,
+                "options": null,
+                "source": null,
+                "hiddenIf": null,
+                "addNewOption": null,
+                "clickableLink": null,
+                "singleVariableSelection": null,
+                "subFields": null
+              }
+            ]
+          }
+        ],
+        "isNew": null,
+        "groupsLaterSteps": null,
+        "linkToGuide": null,
+        "setupMessage": null
+      }
+    ],
+    "triggers": null
+  }
+]

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -160,7 +160,9 @@ export const EditorProvider = ({
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
-  const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
+  const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS, {
+    fetchPolicy: 'cache-first',
+  })
 
   const steps = flow?.steps ?? []
   const isEmptyPipe =

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -33,6 +33,7 @@ import {
   useIfThenInitializer,
 } from '@/helpers/toolbox'
 import { extractVariables, StepWithVariables } from '@/helpers/variables'
+import apps from '@/assets/apps.json'
 
 interface IEditorContextValue {
   flow: IFlow
@@ -160,9 +161,8 @@ export const EditorProvider = ({
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
-  const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS, {
-    fetchPolicy: 'cache-first',
-  })
+  // const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
+  // const apps =
 
   const steps = flow?.steps ?? []
   const isEmptyPipe =
@@ -171,10 +171,7 @@ export const EditorProvider = ({
   const hasForEach = flow?.steps.some((step) => isForEachStep(step))
   const hasIfThen = flow?.steps.some((step: IStep) => isIfThenStep(step))
 
-  const allApps = useMemo(
-    () => getAppsData?.getApps ?? [],
-    [getAppsData?.getApps],
-  )
+  const allApps = useMemo(() => apps ?? [], [apps])
 
   const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
     GET_TEST_EXECUTION_STEPS,
@@ -375,13 +372,13 @@ export const EditorProvider = ({
     }
   }, [resetForm, resetFormRef])
 
-  if (isLoadingAllApps) {
-    return (
-      <Center height="100vh" position="fixed" width="full" top={0} left={0}>
-        <PrimarySpinner fontSize="4xl" />
-      </Center>
-    )
-  }
+  // if (isLoadingAllApps) {
+  //   return (
+  //     <Center height="100vh" position="fixed" width="full" top={0} left={0}>
+  //       <PrimarySpinner fontSize="4xl" />
+  //     </Center>
+  //   )
+  // }
 
   return (
     <EditorContext.Provider

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -40,7 +40,9 @@ export default function Templates(): JSX.Element {
   const { templateId } = useParams()
   const template = templates?.find((template) => template.id === templateId)
 
-  const { data: appsData, loading: appsLoading } = useQuery(GET_APPS)
+  const { data: appsData, loading: appsLoading } = useQuery(GET_APPS, {
+    fetchPolicy: 'cache-first',
+  })
   const apps: IApp[] = appsData?.getApps ?? []
 
   return (

--- a/packages/scripts/extract-graphql-fields.ts
+++ b/packages/scripts/extract-graphql-fields.ts
@@ -1,0 +1,59 @@
+import fs from 'fs'
+import path from 'path'
+
+/**
+ * Extracts field names from a GraphQL query block
+ * This parses the GraphQL query syntax to find all requested fields
+ */
+function extractFieldsFromQuery(queryText: string, typeName: string): string[] {
+  // Find the block for the specified type (e.g., "arguments {")
+  const typeRegex = new RegExp(`${typeName}\\s*\\{([^}]+(?:\\{[^}]*\\}[^}]*)*)\\}`, 's')
+  const match = queryText.match(typeRegex)
+
+  if (!match) {
+    return []
+  }
+
+  const block = match[1]
+  const fields: string[] = []
+
+  // Extract field names (lines that don't contain { or #)
+  const lines = block.split('\n')
+  for (const line of lines) {
+    const trimmed = line.trim()
+    // Skip comments, empty lines, and lines with nested blocks
+    if (trimmed && !trimmed.startsWith('#') && !trimmed.includes('{')) {
+      fields.push(trimmed)
+    }
+  }
+
+  return fields
+}
+
+/**
+ * Reads the GraphQL query file and extracts all field names for substep arguments
+ */
+export function getSubstepArgumentFields(): string[] {
+  const queryPath = path.join(
+    __dirname,
+    '../frontend/src/graphql/queries/get-apps.ts',
+  )
+  const queryContent = fs.readFileSync(queryPath, 'utf-8')
+
+  // Extract fields from the "arguments" block in the query
+  return extractFieldsFromQuery(queryContent, 'arguments')
+}
+
+/**
+ * Reads the GraphQL query file and extracts all field names for auth fields
+ */
+export function getAuthFields(): string[] {
+  const queryPath = path.join(
+    __dirname,
+    '../frontend/src/graphql/queries/get-apps.ts',
+  )
+  const queryContent = fs.readFileSync(queryPath, 'utf-8')
+
+  // Extract fields from the "fields" block inside "auth"
+  return extractFieldsFromQuery(queryContent, 'fields')
+}

--- a/packages/scripts/generate-apps.ts
+++ b/packages/scripts/generate-apps.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+/**
+ * Build script to fetch apps and generate a static JSON file
+ * Run this during your build process to avoid runtime queries for static data
+ *
+ * IMPORTANT: This script generates a JSON file that replaces the GraphQL getApps query.
+ * When updating app data structure, ensure the normalization below matches what the
+ * frontend expects by checking the app usage in the frontend code.
+ */
+
+import dotenv from 'dotenv'
+import fs from 'fs'
+import path from 'path'
+
+// Load environment variables from backend .env file
+dotenv.config({ path: path.join(__dirname, '../backend/.env') })
+
+import type { IApp } from '@plumber/types'
+
+import App from '../backend/src/models/app'
+import {
+  TRIGGER_APPS_RANKING,
+  ACTION_APPS_RANKING,
+} from '../backend/src/graphql/queries/get-apps'
+
+// Configuration
+const OUTPUT_PATH =
+  process.env.OUTPUT_PATH || 'packages/frontend/src/assets/apps.json'
+
+function sortApps(apps: IApp[]): IApp[] {
+  // trade off for increased time complexity but easier to add a new app to the ranking
+  return apps.sort((a, b) => {
+    const firstPriority = a.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === a.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === a.key)
+    const secondPriority = b.triggers
+      ? TRIGGER_APPS_RANKING.findIndex((app) => app === b.key)
+      : ACTION_APPS_RANKING.findIndex((app) => app === b.key)
+
+    // sort by newApp flag, followed by priority
+    if (a.isNewApp && b.isNewApp) {
+      return firstPriority - secondPriority
+    }
+    if (a.isNewApp) {
+      return -1
+    }
+    if (b.isNewApp) {
+      return 1
+    }
+    return firstPriority - secondPriority
+  })
+}
+
+// Normalize field to ensure all GraphQL-queried fields exist
+function normalizeField(field: any): any {
+  return {
+    label: field.label ?? null,
+    key: field.key ?? null,
+    type: field.type ?? null,
+    required: field.required ?? null,
+    description: field.description ?? null,
+    placeholder: field.placeholder ?? null,
+    variables: field.variables ?? null,
+    variableTypes: field.variableTypes ?? null,
+    allowArbitrary: field.allowArbitrary ?? null,
+    isSearchable: field.isSearchable ?? null,
+    addRowButtonText: field.addRowButtonText ?? null,
+    showOptionValue: field.showOptionValue ?? null,
+    customStyle: field.customStyle ?? null,
+    tooltipText: field.tooltipText ?? null,
+    value: field.value ?? null,
+    noVariablesMessage: field.noVariablesMessage ?? null,
+    options: field.options
+      ? field.options.map((option: any) => ({
+          ...option,
+          description: option.description ?? null,
+        }))
+      : null,
+    source: field.source ?? null,
+    hiddenIf: field.hiddenIf
+      ? {
+          ...field.hiddenIf,
+          fieldValue: field.hiddenIf.fieldValue ?? null,
+        }
+      : null,
+    addNewOption: field.addNewOption ?? null,
+    clickableLink: field.clickableLink ?? null,
+    singleVariableSelection: field.singleVariableSelection ?? null,
+    subFields: field.subFields?.map(normalizeField) ?? null,
+  }
+}
+
+async function fetchApps() {
+  try {
+    console.log('Fetching apps...')
+
+    // Call App.findAll() directly like the GraphQL query does
+    const apps = sortApps(await App.findAll())
+
+    // Normalize apps to ensure all expected fields are present
+    // Convert undefined to null for proper JSON serialization
+    const normalizedApps = apps.map((app) => {
+      // Normalize substeps to ensure all have required fields
+      const normalizedTriggers = app.triggers?.map((trigger) => ({
+        ...trigger,
+        substeps: trigger.substeps?.map((substep) => ({
+          key: substep.key ?? null,
+          name: substep.name ?? null,
+          arguments: substep.arguments?.map(normalizeField) ?? null,
+        })),
+      }))
+
+      const normalizedActions = app.actions?.map((action) => ({
+        ...action,
+        isNew: action.isNew ?? null,
+        groupsLaterSteps: action.groupsLaterSteps ?? null,
+        linkToGuide: action.linkToGuide ?? null,
+        setupMessage: action.setupMessage ?? null,
+        substeps: action.substeps?.map((substep) => ({
+          key: substep.key ?? null,
+          name: substep.name ?? null,
+          arguments: substep.arguments?.map(normalizeField) ?? null,
+        })),
+      }))
+
+      return {
+        ...app,
+        triggers: app.triggers ? normalizedTriggers : null,
+        actions: app.actions ? normalizedActions : null,
+      }
+    })
+
+    return normalizedApps
+  } catch (error) {
+    console.error('Error fetching apps:', error)
+    throw error
+  }
+}
+
+async function generateAppsJson() {
+  try {
+    const apps = await fetchApps()
+
+    console.log(`Fetched ${apps.length} apps`)
+
+    // Ensure output directory exists
+    const outputDir = path.dirname(OUTPUT_PATH)
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true })
+    }
+
+    // Delete existing file for a clean generation
+    if (fs.existsSync(OUTPUT_PATH)) {
+      fs.unlinkSync(OUTPUT_PATH)
+      console.log(`Deleted existing ${OUTPUT_PATH}`)
+    }
+
+    // Write JSON file
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(apps, null, 2), 'utf-8')
+
+    console.log(`✓ Apps written to ${OUTPUT_PATH}`)
+    console.log('✓ Generation complete')
+    process.exit(0)
+  } catch (error) {
+    console.error('Failed to generate apps.json:', error)
+    process.exit(1)
+  }
+}
+
+// Run the script
+generateAppsJson()

--- a/packages/scripts/get-apps.ts
+++ b/packages/scripts/get-apps.ts
@@ -32,6 +32,7 @@ export const GET_APPS = gql`
       auth {
         connectionType
         connectionRegistrationType
+        autoCheckStep
         fields {
           key
           label
@@ -55,7 +56,7 @@ export const GET_APPS = gql`
           arguments {
             name
             value
-            # type
+            type
             properties {
               name
               value
@@ -68,7 +69,7 @@ export const GET_APPS = gql`
           arguments {
             name
             value
-            # type
+            type
             properties {
               name
               value
@@ -87,6 +88,7 @@ export const GET_APPS = gql`
         pollInterval
         description
         isNew
+        noAuthRequired
         setupMessage {
           variant
           messageBody


### PR DESCRIPTION
## Problem
* Slowness in `getApps` query 
* `getApps` is called every time a new Pipe is opened in the Editor

## Solution
Part 1 of the solution is to set `fetchPolicy: 'cache-first'`.
This fetches the apps on load and does not need to fetch the apps again when opening different Pipes.

## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/75dcef85-e232-4c63-b2d0-65da1fd1fea2


**AFTER**:

https://github.com/user-attachments/assets/89249520-ce92-44d3-b07f-b192febb9dc5


## Tests
- [ ] Apps are loaded correctly
- [ ] Apps can be used in Pipes

