### PR TITLE
HOTFIX: tile dynamodb isEmpty filter not respecting NULL values

### DIFF
--- a/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
+++ b/packages/backend/src/models/tiles/dynamodb/__tests__/table-row/functions.itest.ts
@@ -258,6 +258,34 @@ describe('dynamodb table row functions', () => {
       expect(rows8.length).toEqual(1000)
     })
 
+    it('empty filter should work with empty string, null and undefined', async () => {
+      const dataArray: any[] = []
+      ;['', null, 123, 'abc'].forEach((value, index) => {
+        dataArray.push({
+          a: `${index}`,
+          b: value,
+        })
+      })
+      dataArray.push({
+        a: `undefined value`,
+      })
+      await createTableRows({ tableId: dummyTable.id, dataArray })
+
+      // Empty
+      const { rows } = await getTableRows({
+        tableId: dummyTable.id,
+        columnIds: ['a', 'b'],
+        filters: [
+          {
+            columnId: 'b',
+            operator: TableRowFilterOperator.IsEmpty,
+            value: '',
+          },
+        ],
+      })
+      expect(rows.length).toEqual(3)
+    })
+
     it('should get relevant rows based on composite filters', async () => {
       const dataArray = []
       for (let i = 0; i < 1000; i++) {

--- a/packages/backend/src/models/tiles/dynamodb/table-row/functions.ts
+++ b/packages/backend/src/models/tiles/dynamodb/table-row/functions.ts
@@ -121,7 +121,10 @@ const addFiltersToQuery = (
 ): void => {
   if (filters?.length) {
     query.where(
-      ({ data }, { eq, begins, contains, gt, gte, lt, lte, notExists }) => {
+      (
+        { data },
+        { eq, begins, contains, gt, gte, lt, lte, notExists, type },
+      ) => {
         const whereExpressions: string[] = []
         for (const filter of filters) {
           const { columnId, operator, value } = filter
@@ -150,7 +153,9 @@ const addFiltersToQuery = (
               break
             case TableRowFilterOperator.IsEmpty:
               whereExpressions.push(
-                `(${eq(data[columnId], '')} OR ${notExists(data[columnId])})`,
+                `(${eq(data[columnId], '')} OR ${notExists(
+                  data[columnId],
+                )} OR ${type(data[columnId], 'NULL')})`,
               )
               break
           }


### PR DESCRIPTION
## Problem

Our current isEmpty filter for Tiles v1 only checks for empty string and missing values (undefined). However, when manually updating rows on the Tile frontend, it sets the empty cells to NULL which is not satisfied by our filter.

## Solution

Add NULL check to isEmpty filter