### PR TITLE
PLU-513: purge nbsp and invalid characters from all inputs

### DIFF
--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react'
 import { Button, FormLabel, Input } from '@opengovsg/design-system-react'
 
+import { removeProblematicWhitespace } from '@/components/RichTextEditor/utils'
 import client from '@/graphql/client'
 import { CREATE_TABLE } from '@/graphql/mutations/tiles/create-table'
 import { UPDATE_TABLE } from '@/graphql/mutations/tiles/update-table'
@@ -129,7 +130,9 @@ function AddNewOptionalModal({
               <FormLabel isRequired>Name your tile</FormLabel>
               <Input
                 autoFocus
-                onChange={(e) => setInputValue(e.target.value)}
+                onChange={(e) =>
+                  setInputValue(removeProblematicWhitespace(e.target.value))
+                }
                 value={inputValue}
               />
               <Button

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -194,7 +194,7 @@ const Editor = ({
       }
       onChange(
         isRich
-          ? editor.getHTML()
+          ? removeProblematicWhitespace(editor.getHTML())
           : removeProblematicWhitespace(editor.getText()),
       )
     },

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -196,4 +196,10 @@ describe('removeProblematicWhitespace', () => {
     const input = 'Hello World'
     expect(removeProblematicWhitespace(input)).toEqual(input)
   })
+
+  it('should handle text with control characters', () => {
+    const input = 'Hello\x00World'
+    const expected = 'HelloWorld'
+    expect(removeProblematicWhitespace(input)).toEqual(expected)
+  })
 })

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -256,5 +256,8 @@ export function removeProblematicWhitespace(text: string): string {
       .replace(/(\u200B|\uFEFF|\u200C|\u200D|\u200E)/g, '')
       // Replace non-breaking space with regular space
       .replace(/\u00A0/g, ' ')
+      // Remove null character that breaks DB/JSON
+      // eslint-disable-next-line no-control-regex
+      .replace(/\x00/g, '')
   )
 }

--- a/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
+++ b/packages/frontend/src/components/SingleSelect/SingleSelectProvider.tsx
@@ -17,6 +17,8 @@ import {
   type UseComboboxStateChangeOptions,
 } from 'downshift'
 
+import { removeProblematicWhitespace } from '../RichTextEditor/utils'
+
 import { useLookupItems } from './hooks/useLookupItems'
 import { defaultFilter } from './utils/defaultFilter'
 import {
@@ -200,12 +202,15 @@ export const SingleSelectProvider = ({
 
   const handleInputChange = useCallback(
     (inputValue: string | undefined) => {
-      const filteredItems = getFilteredItems(inputValue)
+      const sanitisedInput = inputValue
+        ? removeProblematicWhitespace(inputValue)
+        : inputValue // if its undefined, we leave it as is
+      const filteredItems = getFilteredItems(sanitisedInput)
       if (freeSolo) {
-        addFreeSoloItem(filteredItems, inputValue)
+        addFreeSoloItem(filteredItems, sanitisedInput)
       }
       if (addNew?.type === 'inline') {
-        addInlineNewOption(filteredItems, inputValue)
+        addInlineNewOption(filteredItems, sanitisedInput)
       }
       setFilteredItems(filteredItems)
     },

--- a/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
+++ b/packages/frontend/src/components/SingleSelect/components/SelectCombobox/SelectCombobox.tsx
@@ -9,6 +9,8 @@ import {
 } from '@chakra-ui/react'
 import { Input } from '@opengovsg/design-system-react'
 
+import { removeProblematicWhitespace } from '@/components/RichTextEditor/utils'
+
 import { useSelectContext } from '../../SelectContext'
 import { itemToIcon, itemToLabelString } from '../../utils/itemUtils'
 
@@ -130,6 +132,9 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
               readOnly: !isSearchable || isReadOnly,
               required: isRequired,
               'aria-expanded': !!isOpen,
+              // NOTE: we need to sanitise here because
+              // the form's fieldValue is separate from this inputValue
+              value: removeProblematicWhitespace(inputValue),
             })}
           />
           <ToggleChevron />

--- a/packages/frontend/src/components/TextField/index.tsx
+++ b/packages/frontend/src/components/TextField/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@opengovsg/design-system-react'
 import copy from 'clipboard-copy'
 
+import { removeProblematicWhitespace } from '@/components/RichTextEditor/utils'
 import { EditorContext } from '@/contexts/Editor'
 
 const FIELD_MAX_LENGTH = {
@@ -26,9 +27,7 @@ type TextFieldProps = {
   description?: string
   required?: boolean
   multiline?: boolean
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => void
+  onChange?: (value: string) => void
   onBlur?: (
     event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void
@@ -91,9 +90,12 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
             <SelectedComponent
               {...field}
               placeholder={placeholder}
-              onChange={(...args) => {
-                controllerOnChange(...args)
-                onChange?.(...args)
+              onChange={(event) => {
+                const sanitised = removeProblematicWhitespace(
+                  event.target.value,
+                )
+                controllerOnChange(sanitised)
+                onChange?.(sanitised)
               }}
               onBlur={(...args) => {
                 controllerOnBlur()


### PR DESCRIPTION
## Problem
Invalid characters such as `\u00A0`, `\x00` could be copy-pasted by users into input fields.
This causes issues as some downstream services such as Postman SMS and our DB does not accept such encoding.
Also found that the input may convert the null character into `\x00`

Inputs where this may happen:
* Text field
* Rich text editor
* Autocomplete

## Solution
* Sanitise the inputs to replace these invalid characters / control characters

## Tests
**Rich text editor**
- [ ] Email by Postman: Paste text that contains invalid characters into the email body, invalid characters should be removed

**Text field**
- [ ] Tiles - create row: Paste text that contains invalid characters into the autocomplete to create a new column, invalid characters should be removed

**Autocomplete**
- [ ] Tiles - create row: Paste text that contains invalid characters into the modal input to create a new tile, invalid characters should be removed

## File with null character for testing

[string-w-null.txt](https://github.com/user-attachments/files/22793675/string-w-null.txt)
