### PR TITLE
[COLLAB-19]: Refactor role to flow model

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteUploadedFile from '@/graphql/mutations/delete-uploaded-file'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './tiles/table.mock'
@@ -91,9 +92,7 @@ describe('deleteFromS3', () => {
     })
 
     await deleteUploadedFile(null, { id: fileToDelete }, context)
-    const postDeleteSteps = await context.currentUser
-      .$relatedQuery('steps')
-      .where({ flow_id: mockFlowId })
+    const postDeleteSteps = await Step.query().where({ flow_id: mockFlowId })
 
     postDeleteSteps.forEach((step) => {
       expect(step.parameters.attachments).not.toContain(fileToDelete)

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -19,7 +19,6 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
-      .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
         'steps.flow_id': input.flow.id,
@@ -37,7 +36,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         context,
         connectionId: input.connection.id,
         flowId: input.flow.id,
-        includeOwnConnections: step.role === 'owner',
+        includeOwnConnections: step.flow.role === 'owner',
         trx,
       })
 
@@ -99,7 +98,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
      * collaborator should be able to add their own connections,
      * it will be tied to this specific flow only
      */
-    if (step.role === 'owner') {
+    if (step.flow.role === 'owner') {
       const appKey = updatedStep?.appKey
 
       // tiles special handling

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -64,7 +64,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
    * - collaborator should be able to add their own Tiles
    */
   if (
-    step.role !== 'owner' &&
+    step.flow.role !== 'owner' &&
     APP_CONNECTION_FIELDS[step.appKey] &&
     APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
   ) {

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -1,4 +1,4 @@
-import { IFlowCollabRole, IJSONObject } from '@plumber/types'
+import { IJSONObject } from '@plumber/types'
 
 import { AES, enc } from 'crypto-js'
 import type { RelationMappings, Transaction } from 'objection'
@@ -7,6 +7,7 @@ import { ModelOptions, QueryContext } from 'objection'
 import appConfig from '@/config/app'
 
 import Base from './base'
+import Flow from './flow'
 import Step from './step'
 import User from './user'
 
@@ -20,7 +21,7 @@ class Connection extends Base {
   draft: boolean
   count?: number
   flowCount?: number
-  role?: IFlowCollabRole
+  flow?: Flow
   description?: string
 
   static tableName = 'connections'

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -1,5 +1,3 @@
-import { IFlowCollabRole } from '@plumber/types'
-
 import Base from './base'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
@@ -13,7 +11,6 @@ class Execution extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   status: ExecutionStatus
-  role?: IFlowCollabRole
 
   static tableName = 'executions'
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,5 +1,3 @@
-import { IFlowCollabRole } from '@plumber/types'
-
 import { Transaction } from 'objection'
 
 import Base from './base'
@@ -21,8 +19,7 @@ class FlowConnections extends Base {
   connection?: Connection
   table?: TableMetadata
   metadata: Record<string, any>
-
-  role?: IFlowCollabRole
+  flow?: Flow
 
   static tableName = 'flow_connections'
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,9 +1,4 @@
-import type {
-  IFlowCollabRole,
-  IJSONObject,
-  IStep,
-  IStepConfig,
-} from '@plumber/types'
+import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
 
 import {
   raw,
@@ -39,7 +34,6 @@ class Step extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   config: IStepConfig
-  role?: IFlowCollabRole
   updatedBy?: string
 
   static tableName = 'steps'

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -150,6 +150,26 @@ class User extends Base {
   }
 
   /**
+   * Generic method to add flow role information to any query that has a flow relation
+   * This can be used with modifyGraph to add role information to flow relations
+   */
+  withFlowRole(query: AnyQueryBuilder): AnyQueryBuilder {
+    const userId = this.id
+    return query
+      .withGraphFetched('flow')
+      .modifyGraph('flow', (flowQuery: any) => {
+        // this.applyFlowRoleSelection(flowQuery, userId)
+        flowQuery
+          .leftJoin('flow_collaborators as fc', function () {
+            this.on('fc.flow_id', 'flows.id')
+              .andOnNull('fc.deleted_at')
+              .andOnVal('fc.user_id', userId)
+          })
+          .select('flows.*', Flow.raw(ROLE_STMT, [userId]))
+      })
+  }
+
+  /**
    * we use this filter to check for two things:
    * 1. user is a valid owner or collaborator on this pipe
    * 2. user has the required permissions to work on this pipe
@@ -214,11 +234,10 @@ class User extends Base {
   }) {
     const userId = this.id
     const baseQuery = queryBuilder || Step.query(trx)
-    baseQuery
-      .select('steps.*', Step.raw(ROLE_STMT, [userId]))
-      .join('flows', 'flows.id', 'steps.flow_id')
+    baseQuery.select('steps.*').join('flows', 'flows.id', 'steps.flow_id')
 
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 
@@ -235,20 +254,8 @@ class User extends Base {
     const baseQuery = queryBuilder || Connection.query(trx)
     const allowedRoles = getAllowedCollaboratorRoles(requiredRole)
 
-    return baseQuery
-      .select(
-        'connections.*',
-        Connection.raw(
-          `
-          CASE
-            WHEN connections.user_id = ? THEN 'owner'
-            WHEN flows.user_id = ? THEN 'owner'
-            ELSE fc.role
-          END as role
-          `,
-          [userId, userId],
-        ),
-      )
+    baseQuery
+      .select('connections.*')
       .leftJoin(
         'flow_connections',
         'flow_connections.connection_id',
@@ -269,6 +276,9 @@ class User extends Base {
             this.whereNotNull('fc.role').andWhere('fc.role', 'in', allowedRoles)
           })
       })
+
+    this.withFlowRole(baseQuery)
+    return baseQuery
   }
 
   withAccessibleFlowConnections({
@@ -283,12 +293,13 @@ class User extends Base {
     const userId = this.id
     const baseQuery = queryBuilder || FlowConnections.query(trx)
     baseQuery
-      .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
+      .select('flow_connections.*')
       .join('flows', 'flows.id', 'flow_connections.flow_id')
 
     if (requiredRole) {
       this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
     }
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 
@@ -304,10 +315,11 @@ class User extends Base {
     const userId = this.id
     const baseQuery = queryBuilder || Execution.query(trx)
     baseQuery
-      .select('executions.*', Execution.raw(ROLE_STMT, [userId]))
+      .select('executions.*')
       .join('flows', 'flows.id', 'executions.flow_id')
 
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 }

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -270,7 +270,8 @@ class User extends Base {
           })
       })
 
-    this.withFlowRole(baseQuery)
+    // Note: withFlowRole is not called here because Connection model doesn't have a 'flow' relation
+    // The role information is already handled through the joins above
     return baseQuery
   }
 

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -60,6 +60,11 @@ class User extends Base {
   }
 
   static relationMappings = () => ({
+    /**
+     * NOTE: retain _connections_ and _flows_ relations as they are used to get the owner's
+     * connections and flows.
+     * It is displayed in the My Apps page.
+     */
     connections: {
       relation: Base.HasManyRelation,
       modelClass: Connection,
@@ -74,18 +79,6 @@ class User extends Base {
       join: {
         from: 'users.id',
         to: 'flows.user_id',
-      },
-    },
-    steps: {
-      relation: Base.ManyToManyRelation,
-      modelClass: Step,
-      join: {
-        from: 'users.id',
-        through: {
-          from: 'flows.user_id',
-          to: 'flows.id',
-        },
-        to: 'steps.flow_id',
       },
     },
     executions: {

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -53,7 +53,7 @@ export function useExecutionStepStatus({
     !isStepSuccessful &&
     !!jobId &&
     hasExecutionFailed &&
-    execution?.role !== 'viewer'
+    execution?.flow?.role !== 'viewer'
 
   const statusIcon = useMemo(() => {
     if (isPartialSuccess) {

--- a/packages/frontend/src/graphql/queries/get-execution.ts
+++ b/packages/frontend/src/graphql/queries/get-execution.ts
@@ -11,6 +11,7 @@ export const GET_EXECUTION = gql`
         id
         name
         active
+        role
       }
       status
       role

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -164,7 +164,6 @@ export interface IExecution {
   executionSteps: IExecutionStep[]
   updatedAt: string
   createdAt: string
-  role?: IFlowCollabRole
 }
 
 export interface IStepConfig {


### PR DESCRIPTION
### TL;DR

Refactored how flow roles are handled in the backend by moving role information to the flow relation instead of individual models.

### What changed?

- Added a new `withFlowRole` method to the User model that adds flow role information to any query with a flow relation
- Removed direct role fields from Connection, Execution, Step, and FlowConnections models
- Updated queries to use `flow.role` instead of the direct `role` property
- Modified the GraphQL queries to reflect these changes
- Fixed tests to align with the new role access pattern
- Removed unnecessary `withAccessibleConnections` calls in tests

### How to test?

- [x] Run the backend tests to ensure all functionality works as expected
- [x] Test flow collaborator functionality to verify that permission checks still work correctly
- [x] Verify that execution steps display correctly based on user roles
- [x] Test connection testing functionality to ensure it respects user permissions

### Why make this change?

This change improves code organization by centralizing role information in the flow relation rather than duplicating it across multiple models. This makes the codebase more maintainable and reduces the risk of inconsistent role information across different parts of the application.