### PR TITLE
chore: ld flags not evaluated

### DIFF
--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -16,7 +16,7 @@ interface RetryAllButtonProps {
 
 export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
   const flowId = execution.flow?.id
-  const { flags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
   const toast = useToast()
   const [isBulkRetrying, setIsBulkRetrying] = useState(false)
   const [hasBulkRetried, setHasBulkRetried] = useState(false)
@@ -53,7 +53,7 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
     }
   }, [flowId, bulkRetryExecutions, toast])
 
-  if (!flags?.[BULK_RETRY_EXECUTIONS_FLAG]) {
+  if (!getFlagValue(BULK_RETRY_EXECUTIONS_FLAG, false)) {
     return null
   }
 

--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllIterationsButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllIterationsButton.tsx
@@ -18,7 +18,7 @@ export const RetryAllIterationsButton = ({
   execution,
 }: RetryAllIterationsButtonProps) => {
   const executionId = execution.id
-  const { flags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
   const toast = useToast()
   const [isBulkRetrying, setIsBulkRetrying] = useState(false)
   const [hasBulkRetried, setHasBulkRetried] = useState(false)
@@ -61,7 +61,7 @@ export const RetryAllIterationsButton = ({
     }
   }, [toast, executionId, bulkRetryIterations])
 
-  if (!flags?.[BULK_RETRY_EXECUTIONS_FLAG]) {
+  if (!getFlagValue(BULK_RETRY_EXECUTIONS_FLAG, false)) {
     return null
   }
 

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -44,7 +44,7 @@ interface ChooseAppProps {
 
 export default function ChooseApp(props: ChooseAppProps) {
   const { apps, onSelectAppEvent } = props
-  const launchDarkly = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
   const { patchModalState, isTrigger, isLastStep, step, prevStepId } =
     useContext(FlowStepConfigurationContext)
 
@@ -55,7 +55,7 @@ export default function ChooseApp(props: ChooseAppProps) {
   })
 
   const [_, isInitializingIfThen] = useIfThenInitializer()
-  const isLoading = launchDarkly.isLoading || isInitializingIfThen
+  const isLoading = isInitializingIfThen
 
   const [searchQuery, setSearchQuery] = useState('')
 
@@ -81,12 +81,12 @@ export default function ChooseApp(props: ChooseAppProps) {
   )
 
   const toolboxActionsToDisplay = useMemo(() => {
-    if (isLoading || !launchDarkly.flags) {
+    if (isLoading) {
       return []
     }
 
     const ldToolboxAppFlag = getAppFlag(TOOLBOX_APP_KEY)
-    if (!launchDarkly.flags[ldToolboxAppFlag]) {
+    if (!getFlagValue(ldToolboxAppFlag, false)) {
       return []
     }
 
@@ -94,12 +94,12 @@ export default function ChooseApp(props: ChooseAppProps) {
       apps?.find((app) => app.key === TOOLBOX_APP_KEY)?.actions ?? []
     const filteredToolboxActions = toolboxActions.filter((action) => {
       // Filter away actions hidden behind feature flags
-      if (isLoading || !launchDarkly.flags) {
+      if (isLoading) {
         return true
       }
 
       const ldToolboxActionFlag = getAppActionFlag(TOOLBOX_APP_KEY, action.key)
-      return launchDarkly.flags[ldToolboxActionFlag] ?? true
+      return getFlagValue(ldToolboxActionFlag, true)
     })
 
     const fuzzySearchToolboxActions = fuzzysort
@@ -111,17 +111,17 @@ export default function ChooseApp(props: ChooseAppProps) {
       .map((result) => result.obj)
 
     return fuzzySearchToolboxActions
-  }, [apps, isLoading, launchDarkly.flags, searchQuery])
+  }, [apps, isLoading, getFlagValue, searchQuery])
 
   // Combine filtering and grouping logic into a single operation
   const groupedApps = useMemo(() => {
     const filteredApps = apps?.filter((app) => {
       // Filter away apps hidden behind feature flags
-      if (isLoading || !launchDarkly.flags || !app?.key) {
+      if (isLoading || !app?.key) {
         return true
       }
       const ldAppFlag = getAppFlag(app.key)
-      return launchDarkly.flags[ldAppFlag] ?? true
+      return getFlagValue(ldAppFlag, true)
     })
 
     // Note: Separate toolbox app from other apps because we filter toolbox actions separately
@@ -160,13 +160,7 @@ export default function ChooseApp(props: ChooseAppProps) {
       }
       return a[0].localeCompare(b[0])
     })
-  }, [
-    apps,
-    launchDarkly.flags,
-    isLoading,
-    searchQuery,
-    toolboxActionsToDisplay,
-  ])
+  }, [apps, getFlagValue, isLoading, searchQuery, toolboxActionsToDisplay])
 
   return (
     <>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseEvent.tsx
@@ -21,14 +21,12 @@ interface ChooseEventProps {
 export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
   const { onSelectAppEvent } = props
 
-  const launchDarkly = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
 
   const { modalState, isTrigger, patchModalState } = useContext(
     FlowStepConfigurationContext,
   )
   const { selectedApp } = modalState
-
-  const isLoading = launchDarkly.isLoading
 
   const filteredTriggersOrActions = useMemo(() => {
     if (!selectedApp) {
@@ -40,15 +38,15 @@ export default function ChooseEvent(props: ChooseEventProps): JSX.Element {
       : selectedApp.actions ?? []
     return triggersOrActions?.filter((triggerOrAction: ITrigger | IAction) => {
       // Filter away triggers or actions hidden behind feature flags
-      if (isLoading || !launchDarkly.flags || !selectedApp.key) {
+      if (!selectedApp.key) {
         return true
       }
       const launchDarklyKey = isTrigger
         ? getAppTriggerFlag(selectedApp.key, triggerOrAction.key)
         : getAppActionFlag(selectedApp.key, triggerOrAction.key)
-      return launchDarkly.flags[launchDarklyKey] ?? true
+      return getFlagValue(launchDarklyKey, true)
     })
-  }, [selectedApp, isTrigger, launchDarkly.flags, isLoading])
+  }, [selectedApp, isTrigger, getFlagValue])
 
   const onBack = useCallback(() => {
     patchModalState({

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -1,7 +1,6 @@
 import { IFlow, IStep } from '@plumber/types'
 
 import { useContext } from 'react'
-import { LDFlagSet } from 'launchdarkly-js-client-sdk'
 
 import { BranchContext } from '@/components/FlowStepGroup/Content/IfThen/BranchContext'
 import { NESTED_IFTHEN_FEATURE_FLAG } from '@/config/flags'
@@ -97,18 +96,21 @@ function isIfThenSelectable({
   depth,
   hasIfThen,
   isLastStep,
-  ldFlags,
+  getFlagValue,
 }: {
   depth: number
   hasIfThen: boolean
   isLastStep: boolean
-  ldFlags: LDFlagSet | null
+  getFlagValue: (
+    flagKey: string,
+    defaultValue?: boolean | string,
+  ) => boolean | string
 }) {
   if (!isLastStep || hasIfThen) {
     return false
   }
 
-  const canUseNestedBranch = ldFlags?.[NESTED_IFTHEN_FEATURE_FLAG] ?? false
+  const canUseNestedBranch = getFlagValue(NESTED_IFTHEN_FEATURE_FLAG, false)
   if (canUseNestedBranch) {
     return true
   }
@@ -128,14 +130,14 @@ export const useIsAppSelectable = ({
 }): Record<string, boolean> => {
   const { depth } = useContext(BranchContext)
   const { flow, hasIfThen } = useContext(EditorContext)
-  const { flags: ldFlags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
 
   return {
     [TOOLBOX_ACTIONS.IfThen]: isIfThenSelectable({
       depth,
       hasIfThen,
       isLastStep,
-      ldFlags,
+      getFlagValue,
     }),
     [TOOLBOX_ACTIONS.ForEach]: isForEachSelectable({
       flow,

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -24,7 +24,7 @@ type FlowSubstepProps = {
 
 function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const { isTrigger, substep, step, selectedActionOrTrigger } = props
-  const { flags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
   const formContext = useFormContext()
   const {
     executeTestStep,
@@ -63,13 +63,14 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   const argsToDisplay = useMemo(
     () =>
       args?.filter((arg) => {
-        if (!flags) {
-          return true
-        }
-        const flag = getInputFlag(selectedActionOrTrigger?.key ?? '', arg.key)
-        return !flags[flag] || +step.createdAt <= flags[flag]
+        const inputFlag = getInputFlag(
+          selectedActionOrTrigger?.key ?? '',
+          arg.key,
+        )
+        const flagValue = getFlagValue(inputFlag, false)
+        return !flagValue || +step.createdAt <= flagValue
       }) || [],
-    [args, flags, step.createdAt, selectedActionOrTrigger],
+    [args, step.createdAt, selectedActionOrTrigger, getFlagValue],
   )
 
   useEffect(() => {

--- a/packages/frontend/src/components/LoginForm/index.tsx
+++ b/packages/frontend/src/components/LoginForm/index.tsx
@@ -17,7 +17,7 @@ import SgidLoginSection from './SgidLoginSection'
 import SsoLoginSection from './SsoLoginSection'
 
 export const LoginForm = (): JSX.Element => {
-  const { flags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
 
   const headers = useResponseHeaders()
 
@@ -55,12 +55,12 @@ export const LoginForm = (): JSX.Element => {
     }
   }
 
-  const shouldShowSgidLogin = flags?.[SGID_FEATURE_FLAG]
+  const shouldShowSgidLogin = getFlagValue(SGID_FEATURE_FLAG, false)
   // show sso login if request is from OGP office wifi or in dev
   const shouldShowSsoLogin =
     (headers[RESPONSE_HEADERS.OGP_INTERNAL_HEADER] === 'true' ||
       appConfig.isDev) &&
-    flags?.[SSO_FEATURE_FLAG]
+    getFlagValue(SSO_FEATURE_FLAG, false)
 
   return (
     <form onSubmit={handleSubmit}>

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -10,7 +10,7 @@ const SESSION_STORAGE_HIDE_BANNER_KEY = 'hide-banner'
 
 const SiteWideBanner = (): JSX.Element | null => {
   const [bannerMessage, setBannerMessage] = useState(EMPTY_BANNER_MESSAGE)
-  const launchDarkly = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
 
   const closeBanner = useCallback(() => {
     setBannerMessage(EMPTY_BANNER_MESSAGE)
@@ -20,7 +20,7 @@ const SiteWideBanner = (): JSX.Element | null => {
   // check for feature flag (takes time to load) to display banner
   useEffect(() => {
     // message needs to be fetched everytime the page is re-rendered
-    const message = launchDarkly.getFlagValue(BANNER_TEXT_FLAG, '')
+    const message = getFlagValue(BANNER_TEXT_FLAG, '')
     const bannerMessageStored = getItemForSession(
       SESSION_STORAGE_HIDE_BANNER_KEY,
     )
@@ -29,7 +29,7 @@ const SiteWideBanner = (): JSX.Element | null => {
     } else {
       setBannerMessage(EMPTY_BANNER_MESSAGE)
     }
-  }, [launchDarkly])
+  }, [getFlagValue])
 
   if (bannerMessage === EMPTY_BANNER_MESSAGE) {
     return null

--- a/packages/frontend/src/components/SiteWideBanner/index.tsx
+++ b/packages/frontend/src/components/SiteWideBanner/index.tsx
@@ -19,17 +19,15 @@ const SiteWideBanner = (): JSX.Element | null => {
 
   // check for feature flag (takes time to load) to display banner
   useEffect(() => {
-    if (launchDarkly.flags) {
-      // message needs to be fetched everytime the page is re-rendered
-      const message = launchDarkly.flags[BANNER_TEXT_FLAG]
-      const bannerMessageStored = getItemForSession(
-        SESSION_STORAGE_HIDE_BANNER_KEY,
-      )
-      if (message !== bannerMessageStored) {
-        setBannerMessage(message)
-      } else {
-        setBannerMessage(EMPTY_BANNER_MESSAGE)
-      }
+    // message needs to be fetched everytime the page is re-rendered
+    const message = launchDarkly.getFlagValue(BANNER_TEXT_FLAG, '')
+    const bannerMessageStored = getItemForSession(
+      SESSION_STORAGE_HIDE_BANNER_KEY,
+    )
+    if (message !== bannerMessageStored) {
+      setBannerMessage(message)
+    } else {
+      setBannerMessage(EMPTY_BANNER_MESSAGE)
     }
   }, [launchDarkly])
 

--- a/packages/frontend/src/contexts/LaunchDarkly.tsx
+++ b/packages/frontend/src/contexts/LaunchDarkly.tsx
@@ -1,10 +1,13 @@
 import type { ReactNode } from 'react'
 import { createContext, useEffect, useState } from 'react'
-import type { LDContext, LDFlagSet } from 'launchdarkly-js-client-sdk'
+import { Center } from '@chakra-ui/react'
+import { datadogRum } from '@datadog/browser-rum'
+import type { LDContext, LDEvaluationDetail } from 'launchdarkly-js-client-sdk'
 import { basicLogger as LDLogger } from 'launchdarkly-js-client-sdk'
 import type { ProviderConfig as LDProviderConfig } from 'launchdarkly-react-client-sdk'
 import { useLDClient, withLDProvider } from 'launchdarkly-react-client-sdk'
 
+import PrimarySpinner from '@/components/PrimarySpinner'
 import appConfig from '@/config/app'
 import type { AuthenticationContextParams } from '@/contexts/Authentication'
 import useAuthentication from '@/hooks/useAuthentication'
@@ -14,17 +17,18 @@ import useAuthentication from '@/hooks/useAuthentication'
  * convenience data (e.g. loaded flags, whether we're still loading data).
  */
 export interface LaunchDarklyContextData {
-  isLoading: boolean
   error: Error | null
 
-  // Null on first init, or if there was an error.
-  flags: LDFlagSet | null
+  // Function to get flag value that ensures evaluation is tracked
+  getFlagValue: (
+    flagKey: string,
+    defaultValue?: LDEvaluationDetail['value'],
+  ) => LDEvaluationDetail['value']
 }
 
 export const LaunchDarklyContext = createContext<LaunchDarklyContextData>({
-  isLoading: false,
-  flags: null,
   error: null,
+  getFlagValue: () => null,
 })
 
 const ANON_LD_CONTEXT: LDContext = {
@@ -41,6 +45,17 @@ const INITIAL_SETTINGS: LDProviderConfig = {
     // Don't need live updates; our user machines are already slow enough. Will
     // ask users to manually refresh instead.
     streaming: false,
+
+    // Add DataDog RUM inspector for automatic flag evaluation tracking
+    inspectors: [
+      {
+        type: 'flag-used',
+        name: 'dd-inspector',
+        method: (key: string, detail: LDEvaluationDetail) => {
+          datadogRum.addFeatureFlagEvaluation(key, detail.value)
+        },
+      },
+    ],
   },
   reactOptions: {
     useCamelCaseFlagKeys: false,
@@ -73,11 +88,11 @@ function LaunchDarklySetup({ children }: { children: ReactNode }) {
 }
 
 function LaunchDarklyLDContextManager({ children }: { children: ReactNode }) {
+  const [isLoading, setIsLoading] = useState(true)
   const [reactContextData, setReactContextData] =
     useState<LaunchDarklyContextData>({
-      isLoading: true,
-      flags: null,
       error: null,
+      getFlagValue: () => '',
     })
 
   const { currentUser } = useAuthentication()
@@ -88,18 +103,37 @@ function LaunchDarklyLDContextManager({ children }: { children: ReactNode }) {
       return
     }
 
-    ldClient.identify(getLDContext(currentUser), undefined, (error, flags) => {
+    ldClient.identify(getLDContext(currentUser), undefined, (error) => {
+      setIsLoading(false)
       setReactContextData({
-        isLoading: false,
-        flags: error ? null : flags,
         error,
+        getFlagValue: (flagKey: string, defaultValue?: boolean | string) => {
+          if (!ldClient || error) {
+            return defaultValue
+          }
+          try {
+            // Use variation so that evaluation is tracked on LD dashboard
+            // we choose this over variationDetail as its slightly faster
+            // and we do not need the additiona evaluation information on the client
+            return ldClient.variation(flagKey, defaultValue)
+          } catch (e) {
+            console.warn(`Failed to get variation for flag ${flagKey}:`, e)
+            return defaultValue
+          }
+        },
       })
     })
   }, [currentUser, ldClient])
 
   return (
     <LaunchDarklyContext.Provider value={reactContextData}>
-      {children}
+      {isLoading ? (
+        <Center h="100vh">
+          <PrimarySpinner fontSize="4xl" />
+        </Center>
+      ) : (
+        children
+      )}
     </LaunchDarklyContext.Provider>
   )
 }

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -40,6 +40,7 @@ if (['prod', 'staging'].includes(appConfig.env)) {
     // set tracking consent to not-granted by default
     // only start tracking when user is authenticated
     trackingConsent: 'not-granted' as const,
+    enableExperimentalFeatures: ['feature_flags'],
   })
 }
 root.render(

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -22,16 +22,17 @@ const TEMPLATES_TITLE = 'Templates'
 const TEMPLATES_COUNT = 9
 
 export default function Templates(): JSX.Element {
-  const { flags: ldFlags } = useContext(LaunchDarklyContext)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
   const { data, loading: templatesLoading } = useQuery(GET_TEMPLATES)
 
   // TODO (kevinkim-ogp): remove this when for-each is released to all users
   // we do this to avoid adding extra flags or parameters into the query
   const templates: ITemplate[] =
     data?.getTemplates?.filter((template: ITemplate) => {
-      if (ldFlags?.app_toolbox_action_forEach) {
+      const forEachFlag = getFlagValue('app_toolbox_action_forEach', false)
+      if (forEachFlag) {
         return template.id !== '65e90f41-b605-4e83-bcd7-e4d2e349299d' // SCHEDULE_REMINDERS_TEMPLAT
-      } else if (!ldFlags?.app_toolbox_action_forEach) {
+      } else if (!forEachFlag) {
         return template.id !== 'b8dd6c22-3578-460d-89e2-e2062b3601f2' // FOR_EACH_REMINDER_TEMPLATE
       }
       return true

--- a/packages/frontend/src/pages/Tile/layouts/TileLayout.tsx
+++ b/packages/frontend/src/pages/Tile/layouts/TileLayout.tsx
@@ -1,9 +1,6 @@
-import { Suspense, useContext } from 'react'
-import { Center } from '@chakra-ui/react'
+import { Suspense } from 'react'
 
-import PrimarySpinner from '@/components/PrimarySpinner'
 import RedirectToLogin from '@/components/RedirectToLogin'
-import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import useAuthentication from '@/hooks/useAuthentication'
 
 type TileLayoutProps = {
@@ -16,15 +13,6 @@ export default function TileLayout({
   publicLayout,
 }: TileLayoutProps): JSX.Element {
   const { currentUser } = useAuthentication()
-  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
-
-  if (isFlagsLoading || !flags) {
-    return (
-      <Center h="100vh">
-        <PrimarySpinner fontSize="6xl" />
-      </Center>
-    )
-  }
 
   if (!publicLayout && !currentUser) {
     return <RedirectToLogin />


### PR DESCRIPTION
## Problem
LD dashboard did not reflect feature flag evaluations.
Cannot tell which user each flag was evaluated for.

## Solution
* use `variation()` to get the flag value instead of reading from all flags:
  * returns the flag value
  * registers evaluation with LaunchDarkly servers
  * shows up in LaunchDarkly dashboard
  * lightweight and fast as it reads from the cache; does not make an additional API call
* use Datadog RUM's feature flag feature to check evaluations by user

## Tests
Test that flags are being evaluated correctly:
- [ ] Should only see Apps that you are allowed to see (e.g., some users should not see GatherSG / AISAY etc)
- [ ] Only Plumbers should see the bulk retry button in the Executions page
- [ ] Only should see the SSO login on OGP wifi
- [ ] Test that banner still works as intended
