### PR TITLE
chore: link to executions page from editor and remove announcement modal

### DIFF
--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -1,6 +1,6 @@
 import { IFlow } from '@plumber/types'
 
-import { BiCog, BiInfoCircle } from 'react-icons/bi'
+import { BiCog, BiHistory, BiInfoCircle } from 'react-icons/bi'
 import { HiOutlineDotsVertical } from 'react-icons/hi'
 import { Link } from 'react-router-dom'
 import { Hide, HStack, MenuButton, MenuList, Show } from '@chakra-ui/react'
@@ -101,6 +101,45 @@ const SettingsItem = ({
   )
 }
 
+const ExecutionsItem = ({
+  flowId,
+  type,
+}: {
+  flowId: string
+  type: 'icon' | 'button'
+}) => {
+  if (type === 'button') {
+    return (
+      <Button
+        variant="clear"
+        aria-label="executions"
+        colorScheme="secondary"
+        as={Link}
+        to={URLS.EXECUTIONS_FOR_FLOW(flowId)}
+        w="100%"
+      >
+        Executions
+      </Button>
+    )
+  }
+  return (
+    <TouchableTooltip label="Executions" aria-label="executions-tooltip">
+      <IconButton
+        as={Link}
+        to={URLS.EXECUTIONS_FOR_FLOW(flowId)}
+        variant="clear"
+        aria-label="executions"
+        _hover={{
+          color: 'primary.500',
+          bg: 'interaction.muted.main.hover',
+        }}
+        icon={<BiHistory />}
+        colorScheme="secondary"
+      />
+    </TouchableTooltip>
+  )
+}
+
 interface EditorToolbarProps {
   flowId: string
   flow: IFlow
@@ -119,6 +158,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
     <>
       <Show above="md">
         <HStack>
+          <ExecutionsItem {...props} type="icon" />
           <GuideItem type="icon" />
           <SettingsItem {...props} type="icon" />
           <PublishButton {...props} />
@@ -140,6 +180,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
             gap={2}
             px={2}
           >
+            <ExecutionsItem {...props} type="button" />
             <GuideItem type="button" />
             <SettingsItem {...props} type="button" />
             <PublishButton {...props} />

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -279,7 +279,8 @@ export default function EditorLayout() {
         handleUnpublish={() => onFlowStatusUpdate(!flow.active)}
       />
 
-      {shouldOpenAnnouncementModal && (
+      {/* hardcoded to false to always hide announcement modal for now*/}
+      {shouldOpenAnnouncementModal && false && (
         <AnnouncementModal
           isOpen={shouldOpenAnnouncementModal}
           onClose={handleCloseAnnouncementModal}


### PR DESCRIPTION
## Changes
- Show executions icon button on top of editor
<img width="892" height="75" alt="image" src="https://github.com/user-attachments/assets/a6fc6eb4-8dc3-4117-ad23-3a119b08597f" />

- Remove announcement modal about UI refresh