### PR TITLE
[COLLAB-14.1]: Editor can duplicate and reorder step

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -81,6 +81,7 @@ describe('updateStepPositions mutation', () => {
       $query: vi.fn().mockReturnValue({
         patchAndFetch: flowPatchAndFetchSpy,
       }),
+      assertNotUpdatedSince: vi.fn(),
     }
 
     // Create fake steps with flow reference
@@ -115,7 +116,7 @@ describe('updateStepPositions mutation', () => {
 
     context = {
       currentUser: {
-        $relatedQuery: vi.fn().mockReturnValue(fakeQuery),
+        withAccessibleSteps: vi.fn().mockReturnValue(fakeQuery),
       },
     }
   })
@@ -139,6 +140,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
     }
 
     await updateStepPositions(null, { input }, context)
@@ -240,6 +244,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
     } as any
 
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
@@ -302,6 +309,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: '2021-01-01T00:00:00.000Z',
+      },
     }
 
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -37,7 +37,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
     const steps = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .whereIn('steps.id', stepIds)
       .orderBy('steps.position', 'asc')
@@ -48,6 +48,9 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
         'Pipe is active. Cannot update step in active pipe!',
       )
     }
+
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
 
     const foundStepIds = steps.map((step) => step.id)
     const missingStepIds = stepIds.filter(
@@ -72,8 +75,6 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       )
     }
 
-    const flow = steps[0].flow
-
     // Patch each step individually with its new position
     for (const stepPosition of stepPositions) {
       await Step.query(trx).findById(stepPosition.id).patch({
@@ -90,7 +91,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       .withGraphFetched('steps')
       .orderBy('steps.position', 'asc')
 
-    return updatedFlow.steps
+    return updatedFlow
   })
 
   return updatedPositions

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -85,7 +85,7 @@ type Mutation {
   deleteFlow(input: DeleteFlowInput): Boolean
   createStep(input: CreateStepInput): Step
   updateStep(input: UpdateStepInput): Step
-  updateStepPositions(input: UpdateStepPositionsInput): [Step]
+  updateStepPositions(input: UpdateStepPositionsInput): Flow
   deleteStep(input: DeleteStepInput): Flow
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
@@ -597,6 +597,7 @@ input StepPositionInput {
 
 input UpdateStepPositionsInput {
   stepPositions: [StepPositionInput!]!
+  flow: StepFlowInput!
 }
 
 input DeleteStepInput {

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -74,6 +74,7 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
       },
       flow: {
         id: flow.id,
+        updatedAt: flow.updatedAt,
       },
       appKey: step.appKey,
       key: step.key,
@@ -94,7 +95,7 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     const newStep = createdStep.data.createStep
     setCurrentStepId(newStep.id)
     onDrawerOpen()
-  }, [flow.id, step, createStep, setCurrentStepId, onDrawerOpen])
+  }, [flow, step, createStep, setCurrentStepId, onDrawerOpen])
 
   const {
     cancelRef,

--- a/packages/frontend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/frontend/src/graphql/mutations/update-step-positions.ts
@@ -3,8 +3,11 @@ import { graphql } from '@/graphql/__generated__'
 export const UPDATE_STEP_POSITIONS = graphql(`
   mutation UpdateStepPositions($input: UpdateStepPositionsInput!) {
     updateStepPositions(input: $input) {
-      id
-      position
+      updatedAt
+      steps {
+        id
+        position
+      }
     }
   }
 `)

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -1,8 +1,10 @@
 import { IStep } from '@plumber/types'
 
+import { useContext } from 'react'
 import { useMutation } from '@apollo/client'
 import { useToast } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
@@ -15,18 +17,26 @@ interface StepPositionInput {
 
 const useReorderSteps = (flowId: string) => {
   const toast = useToast()
-  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS)
+  const { flow } = useContext(EditorContext)
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    refetchQueries: [GET_FLOW],
+  })
 
   const handleReorderUpdate = async (stepPositions: StepPositionInput[]) => {
     try {
       await updateStepPositions({
-        variables: { input: { stepPositions } },
+        variables: {
+          input: { stepPositions, flow: { updatedAt: flow.updatedAt } },
+        },
         optimisticResponse: {
-          updateStepPositions: stepPositions.map((sp) => ({
-            id: sp.id,
-            position: sp.position,
-            __typename: 'Step' as const,
-          })),
+          updateStepPositions: {
+            updatedAt: flow.updatedAt,
+            steps: stepPositions.map((sp) => ({
+              id: sp.id,
+              position: sp.position,
+              __typename: 'Step' as const,
+            })),
+          },
         },
         update: (cache: any) => {
           // Update the cache with the new step positions optimistically


### PR DESCRIPTION
### TL;DR
Enable duplicate + reorder for collaborators with the check for flow's `updatedAt` to avoid multiple collaborators making changes at the same time.

### How to test?
Open flow in browser as Editor
- [ ] Editor can reorder steps

Open the same flow in two different browsers: 1 as owner, 1 as editor
Reorder steps in the first window and save then try to reorder steps in the second window without refreshing
- [ ] Error is thrown and steps cannot be reordered
