### PR TITLE
chore: add a temporary catch for unknown error

### DIFF
--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -5,6 +5,7 @@ import get from 'lodash.get'
 import HttpError from '@/errors/http'
 import RetriableError from '@/errors/retriable-error'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 import Step, { StepContext } from '@/models/step'
 
 export async function throwSendMessageError(
@@ -14,16 +15,34 @@ export async function throwSendMessageError(
   testRun: boolean,
 ): Promise<never> {
   const position = step.position
+  logger.error('Telegram bot error', {
+    error: err,
+  })
   // catch telegram errors with different error format for ETIMEDOUT and ECONNRESET: e.g. details: { error: 'connect ECONNREFUSED 127.0.0.1:3002' }
   const errorString = JSON.stringify(get(err, 'details.error', ''))
-  if (errorString.includes('ECONNRESET') || errorString.includes('ETIMEDOUT')) {
-    throw new StepError(
-      'Connection issues',
-      'Please retry in a few minutes because telegram is currently experiencing issues.',
-      position,
-      appName,
-      err,
-    )
+  if (
+    errorString.includes('ECONNRESET') ||
+    errorString.includes('ETIMEDOUT') ||
+    err.message.includes('ETIMEDOUT') ||
+    err.code === 'ETIMEDOUT'
+  ) {
+    throw new RetriableError({
+      error: 'Timeout error. Telegram may be experiencing issues.',
+      delayInMs: 'default',
+      delayType: 'step',
+    })
+  }
+
+  /**
+   * TODO: Temporary error handling since I cant find a way to catch the ETIMEDOUT error
+   */
+  const errorDetails = JSON.stringify(get(err, 'details', {}))
+  if (errorDetails === '{"error": "Error"}') {
+    throw new RetriableError({
+      error: 'Timeout error. Telegram may be experiencing issues.',
+      delayInMs: 'default',
+      delayType: 'step',
+    })
   }
 
   // catch telegram errors with proper http error format

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -6,6 +6,7 @@ import BaseError from './base'
 
 export default class HttpError extends BaseError {
   response: AxiosResponse
+  code?: string
 
   constructor(error: AxiosError) {
     const computedError =
@@ -21,6 +22,9 @@ export default class HttpError extends BaseError {
       config: error.config,
       headers: {},
     }
+
+    // Pass code along
+    this.code = error.code
 
     //
     // Only preserve selected headers to avoid storing sensitive data.


### PR DESCRIPTION
## Problem
Telegram is timing out for some reason but with an unknown error, so it's not automatically retrying

## Solution
Temporarily log entire error. Try retrying if generic error.