### PR TITLE
chore: show exact date and time of execution

### DIFF
--- a/packages/frontend/src/components/ExecutionHeader/index.tsx
+++ b/packages/frontend/src/components/ExecutionHeader/index.tsx
@@ -4,7 +4,7 @@ import { Fragment, ReactElement, useCallback } from 'react'
 import { BiChevronLeft } from 'react-icons/bi'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Flex, Icon, Link, Stack, Text } from '@chakra-ui/react'
-import { Button, Tooltip } from '@opengovsg/design-system-react'
+import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
 import { DateTime } from 'luxon'
 
 import * as URLS from '@/config/urls'
@@ -95,12 +95,12 @@ function ExecutionDate(props: Pick<IExecution, 'createdAt'>) {
   const relativeCreatedAt = createdAt.toRelative()
 
   return (
-    <Tooltip
+    <TouchableTooltip
       label={createdAt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}
       aria-label="Created at tooltip"
     >
       <Text textStyle="body-1">{relativeCreatedAt}</Text>
-    </Tooltip>
+    </TouchableTooltip>
   )
 }
 

--- a/packages/frontend/src/components/ExecutionHeader/index.tsx
+++ b/packages/frontend/src/components/ExecutionHeader/index.tsx
@@ -4,7 +4,7 @@ import { Fragment, ReactElement, useCallback } from 'react'
 import { BiChevronLeft } from 'react-icons/bi'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { Flex, Icon, Link, Stack, Text } from '@chakra-ui/react'
-import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
+import { Button } from '@opengovsg/design-system-react'
 import { DateTime } from 'luxon'
 
 import * as URLS from '@/config/urls'
@@ -92,15 +92,11 @@ function ExecutionId(props: Pick<IExecution, 'id'>) {
 
 function ExecutionDate(props: Pick<IExecution, 'createdAt'>) {
   const createdAt = DateTime.fromMillis(parseInt(props.createdAt, 10))
-  const relativeCreatedAt = createdAt.toRelative()
 
   return (
-    <TouchableTooltip
-      label={createdAt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}
-      aria-label="Created at tooltip"
-    >
-      <Text textStyle="body-1">{relativeCreatedAt}</Text>
-    </TouchableTooltip>
+    <Text textStyle="body-1">
+      {createdAt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}
+    </Text>
   )
 }
 

--- a/packages/frontend/src/components/ExecutionRow/index.tsx
+++ b/packages/frontend/src/components/ExecutionRow/index.tsx
@@ -32,7 +32,6 @@ export default function ExecutionRow(props: ExecutionRowProps): ReactElement {
   const { flow, executionSteps } = execution
 
   const createdAt = DateTime.fromMillis(parseInt(execution.createdAt, 10))
-  const relativeCreatedAt = createdAt.toRelative()
 
   return (
     <Link
@@ -102,7 +101,7 @@ export default function ExecutionRow(props: ExecutionRowProps): ReactElement {
                   color="base.content.medium"
                   textStyle="body-2"
                 >
-                  executed {relativeCreatedAt}
+                  {createdAt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS)}
                 </Text>
               </VStack>
             </GridItem>


### PR DESCRIPTION
## Problem
Difficult to identify executions on executions page as the displayed time of execution is a relative time (3 days ago, 4 hours ago, etc.)

## Solution
Display the exact date and time of the execution: 9 Oct 2025, 9:08:53 pm.
Align each execution to also show the exact date and time of the execution.


## Before & After Screenshots

**BEFORE**:
<img width="1252" height="505" alt="Screenshot 2025-10-13 at 10 25 10 AM" src="https://github.com/user-attachments/assets/571e7dc4-7bb5-465e-98cd-5dbbd30bbeeb" />
<img width="1313" height="264" alt="Screenshot 2025-10-13 at 10 25 25 AM" src="https://github.com/user-attachments/assets/084bf835-60ac-40ea-89d4-241ac182682a" />


**AFTER**:
<img width="1251" height="500" alt="Screenshot 2025-10-13 at 10 25 38 AM" src="https://github.com/user-attachments/assets/6a4e725d-1376-42a2-bbba-1c187deb2ab2" />

<img width="1301" height="266" alt="Screenshot 2025-10-13 at 10 25 34 AM" src="https://github.com/user-attachments/assets/55fb2759-6c17-4817-aa79-3e644f33c1ef" />

## Tests
Sanity check:
- [ ] Executions are displayed in descending order
- [ ] Each execution displays the exact date and time directly
