### PR TITLE
[OG-3] Refactor update case

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/actions/update-case.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/update-case.test.ts
@@ -13,23 +13,55 @@ const MOCK_RESPONSE = {
 }
 
 const MOCK_CASE_UUID = '1234567890abcdefghijkl' // have to be 22 characters long
+const MOCK_CASE_TYPE_UUID = 'uuid-1234567890'
 const MOCK_CASE_STATUS = 'PENDING'
 const MOCK_CASE_FIELDS = [
-  { field: 'name', fieldType: 'string', value: 'Peter Parker' },
-  { field: 'age', fieldType: 'number', value: '30' },
-  { field: 'notes', fieldType: 'null', value: '' },
+  { field: 'name', value: 'Peter Parker' },
+  { field: 'age', value: '30' },
+  { field: 'notes', value: '' },
 ]
 
 const mocks = vi.hoisted(() => ({
   httpPatch: vi.fn(() => ({
     data: MOCK_RESPONSE,
   })),
+  httpGet: vi.fn(),
 }))
 
 describe('update case', () => {
   let $: IGlobalVariable
 
   beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+
+    // Set up the httpGet mock implementations
+    mocks.httpGet
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            uuid: MOCK_CASE_UUID,
+            type: {
+              uuid: MOCK_CASE_TYPE_UUID,
+            },
+          },
+        },
+      }))
+      .mockImplementationOnce(() => ({
+        data: {
+          data: {
+            uuid: MOCK_CASE_TYPE_UUID,
+            name: 'Case A',
+            version: 1,
+            fields: [
+              { name: 'name', type: 'text', optional: true },
+              { name: 'age', type: 'number', optional: true },
+              { name: 'notes', type: 'text', optional: true },
+            ],
+          },
+        },
+      }))
+
     $ = {
       auth: {
         set: vi.fn(),
@@ -52,6 +84,7 @@ describe('update case', () => {
       },
       http: {
         patch: mocks.httpPatch,
+        get: mocks.httpGet,
       } as unknown as IGlobalVariable['http'],
       setActionItem: vi.fn(),
       app,
@@ -68,12 +101,11 @@ describe('update case', () => {
     expect(mocks.httpPatch).toHaveBeenCalledWith(
       '/cases/:caseUuid',
       {
-        caseUuid: MOCK_CASE_UUID,
         status: MOCK_CASE_STATUS,
         fields: {
           name: 'Peter Parker',
           age: 30,
-          notes: null,
+          notes: '',
         },
       },
       {
@@ -92,7 +124,6 @@ describe('update case', () => {
     expect(mocks.httpPatch).toHaveBeenCalledWith(
       '/cases/:caseUuid',
       {
-        caseUuid: MOCK_CASE_UUID,
         status: MOCK_CASE_STATUS,
         fields: {},
       },
@@ -111,11 +142,10 @@ describe('update case', () => {
     expect(mocks.httpPatch).toHaveBeenCalledWith(
       '/cases/:caseUuid',
       {
-        caseUuid: MOCK_CASE_UUID,
         fields: {
           name: 'Peter Parker',
           age: 30,
-          notes: null,
+          notes: '',
         },
       },
       {
@@ -135,25 +165,43 @@ describe('update case', () => {
     })
   })
 
+  it('fetches case data and case fields before updating', async () => {
+    await updateCaseAction.run($)
+
+    // Verify that fetchCaseData is called (first GET call)
+    expect(mocks.httpGet).toHaveBeenNthCalledWith(1, '/cases/:caseUuid', {
+      urlPathParams: { caseUuid: MOCK_CASE_UUID },
+    })
+
+    // Verify that fetchCaseFields is called (second GET call)
+    expect(mocks.httpGet).toHaveBeenNthCalledWith(
+      2,
+      '/admin/caseTypes/:caseTypeUuid',
+      {
+        urlPathParams: { caseTypeUuid: MOCK_CASE_TYPE_UUID },
+      },
+    )
+  })
+
   it('should throw step error for invalid regex case uuid', async () => {
     $.step.parameters.caseUuid = 'invalid-uuid-with-dashes'
     await expect(updateCaseAction.run($)).rejects.toThrow(
-      'Please enter a valid case uuid',
+      'caseUuid: Invalid case uuid',
     )
   })
 
   it('should throw step error for empty case uuid', async () => {
     $.step.parameters.caseUuid = ''
     await expect(updateCaseAction.run($)).rejects.toThrow(
-      'Please do not leave the case uuid empty',
+      'caseUuid: Empty case uuid',
     )
   })
 
   it('should throw step error for empty field', async () => {
-    $.step.parameters.caseFields = [
-      { field: '', fieldType: 'string', value: 'test' },
-    ]
-    await expect(updateCaseAction.run($)).rejects.toThrow('Field empty')
+    $.step.parameters.caseFields = [{ field: '', value: 'test' }]
+    await expect(updateCaseAction.run($)).rejects.toThrow(
+      'caseFields: Field empty',
+    )
   })
 
   it('should throw step error for duplicate fields', async () => {
@@ -162,17 +210,13 @@ describe('update case', () => {
       { field: 'name', fieldType: 'string', value: 'Mary' },
     ]
     await expect(updateCaseAction.run($)).rejects.toThrow(
-      'name field is repeated',
+      'field: name field is repeated',
     )
   })
 
   it('should throw step error for invalid number field type', async () => {
-    $.step.parameters.caseFields = [
-      { field: 'age', fieldType: 'number', value: 'not-a-number' },
-    ]
-    await expect(updateCaseAction.run($)).rejects.toThrow(
-      'Invalid number type for field: age',
-    )
+    $.step.parameters.caseFields = [{ field: 'age', value: 'not-a-number' }]
+    await expect(updateCaseAction.run($)).rejects.toThrow('age: Invalid number')
   })
 
   it('should throw step error for case not found', async () => {
@@ -259,46 +303,22 @@ describe('update case', () => {
     )
   })
 
-  it('should handle null field type correctly', async () => {
-    $.step.parameters.caseFields = [
-      { field: 'deleted_at', fieldType: 'null', value: '' },
-    ]
-    await updateCaseAction.run($)
-
-    expect(mocks.httpPatch).toHaveBeenCalledWith(
-      '/cases/:caseUuid',
-      {
-        caseUuid: MOCK_CASE_UUID,
-        status: MOCK_CASE_STATUS,
-        fields: {
-          deleted_at: null,
-        },
-      },
-      {
-        urlPathParams: {
-          caseUuid: MOCK_CASE_UUID,
-        },
-      },
-    )
-  })
-
-  it('should handle mixed field types correctly', async () => {
+  it('backward compatibility: should still handle field types correctly', async () => {
     $.step.parameters.caseFields = [
       { field: 'name', fieldType: 'string', value: 'Bruce Wayne' },
       { field: 'age', fieldType: 'number', value: '25' },
-      { field: 'is_active', fieldType: 'null', value: '' },
+      { field: 'notes', value: 'Some notes' },
     ]
     await updateCaseAction.run($)
 
     expect(mocks.httpPatch).toHaveBeenCalledWith(
       '/cases/:caseUuid',
       {
-        caseUuid: MOCK_CASE_UUID,
         status: MOCK_CASE_STATUS,
         fields: {
           name: 'Bruce Wayne',
           age: 25,
-          is_active: null,
+          notes: 'Some notes',
         },
       },
       {

--- a/packages/backend/src/apps/gathersg/__tests__/common/schema-builder.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/common/schema-builder.test.ts
@@ -242,7 +242,7 @@ describe('buildFieldsSchema behavior', () => {
         { field: 'unknown', value: 1 },
       ]),
     )
-    const issue = issues.find((i) => i.path.join('.') === '1.field')
+    const issue = issues.find((i) => i.path.join('.') === 'caseFields')
     expect(issue?.message).toBe('Unrecognized field: "unknown"')
   })
 

--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -6,7 +6,7 @@ import { fromZodError } from 'zod-validation-error'
 import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
 
-import { fetchCaseFields } from '../../common/fetch-case-fields'
+import { fetchCaseFields } from '../../common/fetch-case-data'
 import { buildFieldsSchema } from '../../common/schema-builder'
 import throwGatherSGStepError from '../../common/throw-errors'
 

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -5,11 +5,12 @@ import { fromZodError } from 'zod-validation-error'
 
 import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
-import { ensureZodEnumValue } from '@/helpers/zod-utils'
 
+import { fetchCaseData, fetchCaseFields } from '../../common/fetch-case-data'
+import { buildFieldsSchema } from '../../common/schema-builder'
 import throwGatherSGStepError from '../../common/throw-errors'
 
-import { fieldTypeEnum, requestSchema, responseSchema } from './schema'
+import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
   name: 'Update case',
@@ -23,6 +24,7 @@ const action: IRawAction = {
       description: 'Enter the case uuid you want to update',
       required: true,
       variables: true,
+      singleVariableSelection: true,
     },
     // TODO: see if it is possible to get all possible statuses from the API
     {
@@ -49,7 +51,6 @@ const action: IRawAction = {
           showOptionValue: false,
           required: true,
           variables: false,
-          allowArbitrary: true,
           source: {
             type: 'query' as const,
             name: 'getDynamicData' as const,
@@ -58,33 +59,13 @@ const action: IRawAction = {
                 name: 'key',
                 value: 'getCaseFields',
               },
+              {
+                name: 'parameters.caseUuid',
+                value: '{parameters.caseUuid}',
+              },
             ],
           },
           customStyle: { flex: 2 },
-        },
-        {
-          placeholder: 'Field type',
-          key: 'fieldType',
-          type: 'dropdown' as const,
-          showOptionValue: false,
-          required: true,
-          value: 'string',
-          variables: false,
-          options: [
-            {
-              label: 'Text',
-              value: ensureZodEnumValue(fieldTypeEnum, 'string'),
-            },
-            {
-              label: 'Number',
-              value: ensureZodEnumValue(fieldTypeEnum, 'number'),
-            },
-            {
-              label: 'Null',
-              value: ensureZodEnumValue(fieldTypeEnum, 'null'),
-            },
-          ],
-          customStyle: { flex: 1, maxWidth: 140 },
         },
         {
           placeholder: 'Value',
@@ -105,11 +86,28 @@ const action: IRawAction = {
 
   async run($) {
     try {
-      const payload = requestSchema.parse($.step.parameters)
+      const parameters = requestSchema.parse($.step.parameters)
+      const { caseUuid, caseStatus, caseFields } = parameters
+
+      // Fetch case data to get the case type UUID
+      const caseData = await fetchCaseData({ $, caseUuid })
+      const caseTypeUuid = caseData.type.uuid
+      const { filteredFields } = await fetchCaseFields({
+        $,
+        caseTypeUuid,
+      })
+
+      // based on the fields in the case, we build the schema to parse the case fields
+      const fieldsSchema = buildFieldsSchema(filteredFields)
+      const fields = fieldsSchema.parse(caseFields)
+
+      const payload = {
+        ...(caseStatus && { status: caseStatus }),
+        fields,
+      }
+
       const rawResponse = await $.http.patch('/cases/:caseUuid', payload, {
-        urlPathParams: {
-          caseUuid: $.step.parameters.caseUuid,
-        },
+        urlPathParams: { caseUuid },
       })
       const response = responseSchema.parse(rawResponse.data)
 
@@ -122,7 +120,7 @@ const action: IRawAction = {
       if (error instanceof ZodError) {
         const firstError = fromZodError(error).details[0]
         throw new StepError(
-          `${firstError.message}`,
+          `${firstError.path[0]}: ${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
           $.step.position,
           $.app.name,

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -21,7 +21,7 @@ const action: IRawAction = {
       label: 'Case UUID',
       key: 'caseUuid',
       type: 'string' as const,
-      description: 'Enter the case uuid you want to update',
+      description: 'Select the case uuid you want to update',
       required: true,
       variables: true,
       singleVariableSelection: true,

--- a/packages/backend/src/apps/gathersg/actions/update-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/schema.ts
@@ -4,81 +4,24 @@ import { CASE_UUID_REGEX } from '../../common/constants'
 
 export const fieldTypeEnum = z.enum(['string', 'number', 'null'])
 
-export const requestSchema = z
-  .object({
-    caseUuid: z
-      .string()
-      .trim()
-      .min(1, {
-        message: 'Please do not leave the case uuid empty',
-      })
-      .regex(CASE_UUID_REGEX, {
-        message: 'Please enter a valid case uuid',
-      }),
-    caseStatus: z.string().trim().optional(),
-    caseFields: z
-      .array(
-        z.object({
-          field: z.string().trim().min(1, 'Field empty'),
-          // we add nullish here because defaultValue or value doesnt work properly in dropdown
-          fieldType: fieldTypeEnum.nullish(),
-          value: z.string().trim().nullish(),
-        }),
-      )
-      .transform((params, context) => {
-        const result: Record<string, string | number | null> =
-          Object.create(null)
-        const seenFields = new Set<string>()
-        for (const { field, fieldType, value } of params) {
-          /**
-           * No null fields are allowed
-           * For now, we allow them to keep the field empty to set back to null. But in the future, may need to have a way to set to null vs set to empty string
-           */
-          if (!field) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Field empty',
-            })
-            return z.NEVER
-          }
-
-          // catch duplicate fields
-          if (seenFields.has(field)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `${field} field is repeated`,
-              fatal: true,
-            })
-            return z.NEVER
-          }
-          seenFields.add(field)
-
-          // Right now, we will attempt to parse the value to the field type
-          if (fieldType === 'null') {
-            result[field] = null
-          } else if (fieldType === 'number') {
-            const parsedValue = Number(value)
-            if (isNaN(parsedValue)) {
-              context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Invalid number type for field: ${field}`,
-              })
-              return z.NEVER
-            }
-            result[field] = parsedValue
-          } else {
-            result[field] = value
-          }
-        }
-        return result
-      })
-      .nullish(),
-  })
-  .transform((data) => ({
-    caseUuid: data.caseUuid,
-    ...(data.caseStatus && { status: data.caseStatus }),
-    fields: data.caseFields,
-  }))
+export const requestSchema = z.object({
+  caseUuid: z
+    .string()
+    .trim()
+    .min(1, {
+      message: 'Empty case uuid',
+    })
+    .regex(CASE_UUID_REGEX, {
+      message: 'Invalid case uuid',
+    }),
+  caseStatus: z.string().trim().optional(),
+  caseFields: z.array(
+    z.object({
+      field: z.string().trim().min(1, 'Field empty'),
+      value: z.string().trim().nullish(),
+    }),
+  ),
+})
 
 // TODO: See if its possible to get more data from the response in the future if necessary
 export const responseSchema = z.object({

--- a/packages/backend/src/apps/gathersg/common/fetch-case-data.ts
+++ b/packages/backend/src/apps/gathersg/common/fetch-case-data.ts
@@ -1,6 +1,7 @@
 import { IGlobalVariable } from '@plumber/types'
 
 import { UNSUPPORTED_FIELDS } from './constants'
+import { GatherSGCase } from './types'
 
 export type GatherSGCaseField = {
   name: string
@@ -39,4 +40,20 @@ export const fetchCaseFields = async ({
     filteredFields,
     caseTypeName: data.data.name,
   }
+}
+
+export const fetchCaseData = async ({
+  $,
+  caseUuid,
+}: {
+  $: IGlobalVariable
+  caseUuid: string
+}) => {
+  const { data } = await $.http.get<{ data: GatherSGCase }>(
+    `/cases/:caseUuid`,
+    {
+      urlPathParams: { caseUuid },
+    },
+  )
+  return data.data
 }

--- a/packages/backend/src/apps/gathersg/common/schema-builder.ts
+++ b/packages/backend/src/apps/gathersg/common/schema-builder.ts
@@ -5,7 +5,7 @@ import {
   isValidDateTimeString,
   isValidTimeString,
 } from './datetime-validators'
-import { GatherSGCaseField } from './fetch-case-fields'
+import { GatherSGCaseField } from './fetch-case-data'
 
 const numberString = z.preprocess((val) => {
   if (typeof val === 'string') {
@@ -106,15 +106,29 @@ export const buildFieldsSchema = (
   return (
     z
       .array(entry)
-      // 1) Catch unknown field names early
+      // 1) Catch unknown field names and duplicate fields early
       .superRefine((entries, ctx) => {
-        entries.forEach((e, i) => {
+        const seenFields = new Set<string>()
+
+        entries.forEach((e) => {
+          // Check for unknown field names
           if (!fieldNames.has(e.field)) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              path: [i, 'field'],
+              path: ['caseFields'],
               message: `Unrecognized field: "${e.field}"`,
             })
+          }
+
+          // Check for duplicate field names
+          if (seenFields.has(e.field)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['field'],
+              message: `${e.field} field is repeated`,
+            })
+          } else {
+            seenFields.add(e.field)
           }
         })
       })

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -5,26 +5,25 @@ import {
 } from '@plumber/types'
 
 import HttpError from '@/errors/http'
+import computeParameters, { variableRegExp } from '@/helpers/compute-parameters'
+import { getTestExecutionSteps } from '@/helpers/get-test-execution-steps'
 
-import { fetchCaseFields } from '../common/fetch-case-fields'
+import {
+  fetchCaseData,
+  fetchCaseFields,
+  GatherSGCaseField,
+} from '../common/fetch-case-data'
 import { GatherSGError } from '../common/types'
 
-/**
- * Subset of result
- */
-interface GatherSGCase {
-  uuid: string
-  createdAt: string
-  updatedAt: string
-  status: {
-    uuid: string
-    name: string
-    color: string
-    isFinal: boolean
+const processCaseFields = (caseFields: GatherSGCaseField[]) => {
+  return {
+    data: caseFields.map((field) => {
+      return {
+        name: field.name,
+        value: field.name,
+      }
+    }),
   }
-  caseRef: string
-  fields: Record<string, string | string[] | null | number>
-  tags: string[]
 }
 
 const dynamicData: IDynamicData = {
@@ -32,60 +31,48 @@ const dynamicData: IDynamicData = {
   name: 'Get Case Fields',
   async run($: IGlobalVariable): Promise<DynamicDataOutput> {
     try {
-      const { caseType: caseTypeUuid } = $.step.parameters
+      const { caseType: caseTypeUuid, caseUuid: rawCaseUuid } =
+        $.step.parameters
 
+      let targetCaseTypeUuid: string
+
+      // Determine the case type UUID to use
       if (caseTypeUuid) {
-        const { filteredFields } = await fetchCaseFields({
-          $,
-          caseTypeUuid: caseTypeUuid as string,
-        })
+        // if the case type uuid is provided, we use it directly
+        // this happens for:
+        // - create case
+        targetCaseTypeUuid = caseTypeUuid as string
+      } else {
+        // if the case type uuid is not provided, we need to get it from the case uuid
+        // this happens for:
+        // - update case
+        let caseUuid = rawCaseUuid as string
 
-        return {
-          data: filteredFields.map((field) => {
-            return {
-              name: field.name,
-              value: field.name,
-            }
-          }),
+        if (typeof caseUuid === 'string' && caseUuid.match(variableRegExp)) {
+          // if the case uuid is a variable, we need to compute the value
+          const testExecutionSteps = await getTestExecutionSteps($.flow.id)
+          const { caseUuid: computedCaseUuid } = computeParameters(
+            { caseUuid },
+            testExecutionSteps,
+          )
+
+          caseUuid = computedCaseUuid as string
         }
+
+        // Fetch case data to get the case type UUID
+        const caseData = await fetchCaseData({ $, caseUuid })
+
+        // set the target case type uuid
+        targetCaseTypeUuid = caseData.type.uuid
       }
 
-      // TODO (kevinkim-ogp): this needs to be updated to use the caseUuid to fetch the fields
-      // of that specific case using /cases/{caseUuid}
-      // need to figure out how to do this with both string and computed parameters if the UUID is a variable
-      const { data: searchResult } = await $.http.post<{
-        traceId: string
-        total: number
-        data: GatherSGCase[]
-      }>('/cases/search', {
-        page: 1,
-        size: 1,
-        sort: 'createdAt',
-        order: 'desc',
+      // Fetch case fields using the determined case type UUID
+      const { filteredFields } = await fetchCaseFields({
+        $,
+        caseTypeUuid: targetCaseTypeUuid,
       })
 
-      /**
-       * No cases found
-       */
-      if (searchResult.data.length === 0) {
-        return {
-          data: [],
-        }
-      }
-
-      const caseFields: object = searchResult.data[0].fields
-      const updatedCaseFields: { name: string; value: string }[] = []
-      for (const [field, value] of Object.entries(caseFields)) {
-        // Right now, we cannot support adding of array of objects as a value so just going to exclude to not cause errors unnecessarily
-        if (Array.isArray(value)) {
-          continue
-        }
-        updatedCaseFields.push({ name: field, value: field })
-      }
-
-      return {
-        data: updatedCaseFields,
-      }
+      return processCaseFields(filteredFields)
     } catch (error) {
       if (error instanceof HttpError) {
         /**

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -11,7 +11,7 @@ import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
-const variableRegExp =
+export const variableRegExp =
   /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
 
 function findAndSubstituteVariables(


### PR DESCRIPTION
## TL;DR

This PR refactors the update-case action to:
- fetch case fields from the admin API instead of using the search endpoint
- improves handling of case UUID variables in dynamic data

## Key changes:
- Added a new function to fetch case data
- Improved field validation using the schema builder
- Simplified the case fields parameter by removing the fieldType property
- Added support for variable substitution when fetching case fields
- Disabled typing in the case uuid field (but can still paste using mouse click if required)

## How to test?
Fields:
- [ ] Fields are fetched based on the case uuid
- [ ] Can use variables in the case uuid field
- [ ] Fields are validated based on their types on GatherSG
- [ ] Can update case successfully