### PR TITLE
[MRF-2] PLU-520: parse formsg workflow data + refactor

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -17,13 +17,26 @@ const getLastExecutionStepMock = vi.fn()
 const mocks = vi.hoisted(() => ({
   getMockData: vi.fn(),
   getFormDetailsFromGlobalVariable: vi.fn(),
+  fetchFormSchema: vi.fn(() => {
+    return {
+      form: {
+        responseMode: 'storage',
+      },
+    }
+  }),
 }))
 
 vi.mock('../../triggers/new-submission/get-mock-data', () => ({
   default: mocks.getMockData,
 }))
 
+vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
+  fetchFormSchema: mocks.fetchFormSchema,
+}))
+
 vi.mock('../../common/webhook-settings', () => ({
+  registerWebhookUrl: vi.fn(),
+  verifyWebhookUrl: vi.fn(),
   getFormDetailsFromGlobalVariable: mocks.getFormDetailsFromGlobalVariable,
 }))
 

--- a/packages/backend/src/apps/formsg/common/types.ts
+++ b/packages/backend/src/apps/formsg/common/types.ts
@@ -1,37 +1,13 @@
 import { z } from 'zod'
 
-/**
- * This determines the kind of routing for this step
- * Static: routes to a fixed list of emails
- * Dynamic: routes based on a a specified email field
- * Conditional: routes based on a dropdown field which corresponds to a list of emails
- */
-const workflowTypeSpecificFields = z.discriminatedUnion('workflow_type', [
-  z.object({
-    workflow_type: z.literal('static'),
-    emails: z.array(z.string()),
-  }),
-  z.object({
-    workflow_type: z.literal('dynamic'),
-    // the email field to use for routing
-    field: z.string(),
-  }),
-  z.object({
-    workflow_type: z.literal('conditional'),
-    // the dropdown field to use for routing
-    conditional_field: z.string(),
-  }),
-])
-
 export const mrfWorkflowDataSchema = z.array(
-  z
-    .object({
-      _id: z.string(),
-      edit: z.array(z.string()),
-      step_name: z.string().optional(),
-      approval_field: z.string().optional(),
-    })
-    .and(workflowTypeSpecificFields),
+  z.object({
+    _id: z.string(),
+    edit: z.array(z.string()),
+    step_name: z.string().optional(),
+    approval_field: z.string().optional(),
+    workflow_type: z.enum(['static', 'dynamic', 'conditional']),
+  }),
 )
 
 export interface FormSchema {

--- a/packages/backend/src/apps/formsg/common/types.ts
+++ b/packages/backend/src/apps/formsg/common/types.ts
@@ -55,3 +55,20 @@ export interface FormSchema {
     }
   }
 }
+
+/**
+ * This will be stored in the step's parameters and
+ * not modifiable by the user
+ */
+export interface ParsedMrfWorkflowStep {
+  defaultStepName: string
+  formWorkflowStepId: string
+  type: 'static' | 'dynamic' | 'conditional'
+  fields?: string[]
+  approvalField?: string
+}
+
+export interface ParsedMrfWorkflow {
+  trigger: Omit<ParsedMrfWorkflowStep, 'approvalField'>
+  actions: ParsedMrfWorkflowStep[]
+}

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -3,6 +3,7 @@ import { IGlobalVariable } from '@plumber/types'
 import { DateTime } from 'luxon'
 import { customAlphabet } from 'nanoid/async'
 
+import logger from '@/helpers/logger'
 import { COMMON_S3_MOCK_FOLDER_PREFIX } from '@/helpers/s3'
 
 import { filterNric } from '../../auth/decrypt-form-response'
@@ -94,110 +95,113 @@ function generateMockPaymentData(products: Partial<PaymentProduct>[]) {
   }
 }
 
-async function getMockData($: IGlobalVariable) {
-  try {
-    const { formId } = getFormDetailsFromGlobalVariable($)
-
-    const [{ data }, { data: formDetails }] = await Promise.all([
-      $.http.get('/v3/forms/:formId/sample-submission', {
-        urlPathParams: {
-          formId,
-        },
-      }),
-      $.http.get('/v3/forms/:formId', {
-        urlPathParams: {
-          formId,
-        },
-      }),
-    ])
-
-    const formFields = formDetails.form.form_fields as Array<FormField>
-    for (let i = 0; i < formFields.length; i++) {
-      if (data.responses[formFields[i]._id]) {
-        const fieldType = data.responses[formFields[i]._id].fieldType
-        // forcefully include all checkbox options in the correct order
-        if (fieldType === 'checkbox') {
-          data.responses[formFields[i]._id].answerArray =
-            formFields[i].fieldOptions
-          // include the others option if available
-          if (formFields[i].othersRadioButton) {
-            data.responses[formFields[i]._id].answerArray.push(
-              'Others: Sample Input',
-            )
-          }
-        }
-
-        if (fieldType === 'signature') {
-          data.responses[formFields[i]._id].answer = 'Signature captured' // mock this to always be present regardless of whether the user has signed or not
-        }
-
-        // formsg payload doesnt contain these fields anyways, so we dont return in mock data
-        // this ensures that the question numbering remains consistent with the actual submission
-        if (fieldType === 'statement' || fieldType === 'image') {
-          delete data.responses[formFields[i]._id]
-          continue
-        }
-
-        if (fieldType === 'address') {
-          data.responses[formFields[i]._id].answerArray =
-            generateMockAddressData()
-        }
-
-        if (fieldType === 'attachment') {
-          data.responses[formFields[i]._id].answer = MOCK_ATTACHMENT_FILE_PATH
-        }
-
-        if (fieldType === 'nric') {
-          data.responses[formFields[i]._id].answer = filterNric(
-            $,
-            data.responses[formFields[i]._id].answer,
+function patchMockData(
+  mockData: Record<string, any>,
+  formDetails: Record<string, any>,
+  $: IGlobalVariable,
+) {
+  const formFields = formDetails.form.form_fields as Array<FormField>
+  for (let i = 0; i < formFields.length; i++) {
+    if (mockData.responses[formFields[i]._id]) {
+      // forcefully include all checkbox options in the correct order
+      if (mockData.responses[formFields[i]._id].fieldType === 'checkbox') {
+        mockData.responses[formFields[i]._id].answerArray =
+          formFields[i].fieldOptions
+        // include the others option if available
+        if (formFields[i].othersRadioButton) {
+          mockData.responses[formFields[i]._id].answerArray.push(
+            'Others: Sample Input',
           )
         }
-
-        if (fieldType === 'email') {
-          data.responses[formFields[i]._id].answer = $.user.email
-        }
-
-        // add a stringified version of the table data to the mock data
-        if (fieldType === 'table') {
-          const answerArray = data.responses[formFields[i]._id]
-            .answerArray as string[][]
-          const question = `${
-            data.responses[formFields[i]._id].question
-          } (${formFields[i].columns
-            ?.map((column, index) => column?.title ?? `Col ${index + 1}`)
-            .join(', ')})`
-
-          data.responses[formFields[i]._id].question = question
-          data.responses[formFields[i]._id].answer =
-            convertTableAnswerArrayToTableObject(question, answerArray)
-        }
-
-        if (fieldType === 'section' || fieldType === 'image') {
-          data.responses[formFields[i]._id].answer = ''
-        }
-
-        data.responses[formFields[i]._id].order = i + 1
-        data.responses[formFields[i]._id].id = undefined
       }
+
+      // formsg payload doesnt contain this anyways, so we dont return in mock data
+      if (
+        mockData.responses[formFields[i]._id].fieldType === 'statement' ||
+        mockData.responses[formFields[i]._id].fieldType === 'image'
+      ) {
+        delete mockData.responses[formFields[i]._id]
+        continue
+      }
+
+      if (mockData.responses[formFields[i]._id].fieldType === 'address') {
+        mockData.responses[formFields[i]._id].answerArray =
+          generateMockAddressData()
+      }
+
+      if (mockData.responses[formFields[i]._id].fieldType === 'attachment') {
+        mockData.responses[formFields[i]._id].answer = MOCK_ATTACHMENT_FILE_PATH
+      }
+
+      if (mockData.responses[formFields[i]._id].fieldType === 'nric') {
+        mockData.responses[formFields[i]._id].answer = filterNric(
+          $,
+          mockData.responses[formFields[i]._id].answer,
+        )
+      }
+
+      if (mockData.responses[formFields[i]._id].fieldType === 'email') {
+        mockData.responses[formFields[i]._id].answer = $.user.email
+      }
+
+      // add a stringified version of the table data to the mock data
+      if (mockData.responses[formFields[i]._id].fieldType === 'table') {
+        const answerArray = mockData.responses[formFields[i]._id]
+          .answerArray as string[][]
+        const question = `${
+          mockData.responses[formFields[i]._id].question
+        } (${formFields[i].columns
+          ?.map((column, index) => column?.title ?? `Col ${index + 1}`)
+          .join(', ')})`
+
+        mockData.responses[formFields[i]._id].question = question
+        mockData.responses[formFields[i]._id].answer =
+          convertTableAnswerArrayToTableObject(question, answerArray)
+      }
+
+      mockData.responses[formFields[i]._id].order = i + 1
+      mockData.responses[formFields[i]._id].id = undefined
     }
+  }
+  // There's actually no need to return since it's modifying in place
+  return mockData
+}
+
+async function getMockData(
+  $: IGlobalVariable,
+  formSchema: Record<string, any>,
+) {
+  const { formId } = getFormDetailsFromGlobalVariable($)
+  try {
+    const { data } = await $.http.get('/v3/forms/:formId/sample-submission', {
+      urlPathParams: {
+        formId,
+      },
+    })
 
     // generate bson-objectid using nanoid to avoid extra dependency
     const hexAlphabets = '0123456789abcdef'
     const idLength = 24
     const generateIdAsync = customAlphabet(hexAlphabets, idLength)
 
+    // this modifies (in-place) some of the values that formsg provides
+    patchMockData(data, formSchema, $)
+
     return {
       fields: data.responses,
       submissionId: await generateIdAsync(),
       submissionTime: DateTime.now().toISO(),
       formId,
-      ...(formDetails.form.isSubmitterIdCollectionEnabled &&
-        generateVerifiedSubmitterInfoData(formDetails.form.authType, $)),
-      ...(formDetails.form.payments_field.enabled &&
-        generateMockPaymentData(formDetails.form.payments_field.products)),
+      ...(formSchema.form.isSubmitterIdCollectionEnabled &&
+        generateVerifiedSubmitterInfoData(formSchema.form.authType, $)),
+      ...(formSchema.form.payments_field?.enabled &&
+        generateMockPaymentData(formSchema.form.payments_field.products)),
     }
   } catch (e) {
+    logger.error('Mock data generation error', {
+      error: e,
+      formId: formId,
+    })
     throw new Error(
       'Unable to generate mock form data. Please make an actual submission to proceed.',
     )

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
@@ -30,7 +30,7 @@ export function parseWorkflowData(
     parsedSteps.push({
       defaultStepName: step.step_name ?? `Step ${parsedSteps.length + 1}`,
       type: step.workflow_type,
-      fields: populatedFields,
+      fields: [...populatedFields],
       formWorkflowStepId: step._id,
       approvalField: step.approval_field,
     })

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
@@ -1,0 +1,43 @@
+import { IGlobalVariable } from '@/../../types'
+import StepError from '@/errors/step'
+
+import {
+  type FormSchema,
+  mrfWorkflowDataSchema,
+  type ParsedMrfWorkflow,
+  type ParsedMrfWorkflowStep,
+} from '../../common/types'
+
+export function parseWorkflowData(
+  $: IGlobalVariable,
+  formSchema: FormSchema,
+): ParsedMrfWorkflow | null {
+  const result = mrfWorkflowDataSchema.safeParse(formSchema.form.workflow)
+  if (!result.success) {
+    throw new StepError(
+      'Invalid MRF data',
+      'Reconnect your MRF form and try again.',
+      $.step.position,
+      $.app.name,
+    )
+  }
+
+  const parsedSteps: ParsedMrfWorkflowStep[] = []
+  const populatedFields: string[] = []
+
+  for (const step of result.data) {
+    populatedFields.push(...step.edit)
+    parsedSteps.push({
+      defaultStepName: step.step_name ?? `Step ${parsedSteps.length + 1}`,
+      type: step.workflow_type,
+      fields: populatedFields,
+      formWorkflowStepId: step._id,
+      approvalField: step.approval_field,
+    })
+  }
+
+  return {
+    trigger: parsedSteps[0],
+    actions: parsedSteps.slice(1),
+  }
+}

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -8,6 +8,7 @@ import ExecutionStep from '@/models/execution-step'
 
 import { getFormDetailsFromGlobalVariable } from '../../common/webhook-settings'
 
+import { fetchFormSchema } from './fetch-form-schema'
 import getDataOutMetadata from './get-data-out-metadata'
 import getMockData from './get-mock-data'
 
@@ -106,10 +107,12 @@ const trigger: IRawTrigger = {
     const shouldUseMockData =
       hasNoPastSubmission || testRunMetadataRes.data.preferMock
 
+    const formSchema = await fetchFormSchema($, formId)
+
     // if test with mock data is selected OR no past submission exists
     // we use mock data
     const testData = shouldUseMockData
-      ? await getMockData($)
+      ? await getMockData($, formSchema)
       : lastSubmittedTestExecutionStep?.dataOut
 
     // If for some reason the submission time is not available, use the createdAt time


### PR DESCRIPTION
## Changes
 
- Created a parseWorkflowData function to handle MRF workflow schema

### Refactors
- Refactored mock data generation:
  - Extracted `patchMockData` function from `getMockData`
  - Fetch form schema is now done before mock data generation

### How to test?

- No change in functionaility here, should still be able to connectio MRF + non-MRF forms