### PR TITLE
[MRF-3] PLU-520: introduce mrf action that cannot be added by user

### DIFF
--- a/packages/backend/src/apps/formsg/actions/index.ts
+++ b/packages/backend/src/apps/formsg/actions/index.ts
@@ -1,0 +1,3 @@
+import mrfSubmission from './mrf-submission'
+
+export default [mrfSubmission]

--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -1,0 +1,18 @@
+import { IGlobalVariable, IRawAction } from '@plumber/types'
+
+import getDataOutMetadata from '../../triggers/new-submission/get-data-out-metadata'
+
+const action: IRawAction = {
+  name: 'New form response',
+  key: 'mrfSubmission',
+  hiddenFromUser: true,
+  description:
+    'This is a hidden action that signifies a subsequent MRF submission',
+  getDataOutMetadata,
+
+  async testRun(_$: IGlobalVariable) {
+    // TODO: this should run testRun for the trigger execution step
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/formsg/index.ts
+++ b/packages/backend/src/apps/formsg/index.ts
@@ -1,6 +1,7 @@
 import type { IApp } from '@plumber/types'
 
 import beforeRequest from './common/before-request'
+import actions from './actions'
 import auth from './auth'
 import triggers from './triggers'
 
@@ -16,7 +17,7 @@ const app: IApp = {
   beforeRequest,
   auth,
   triggers,
-  actions: [],
+  actions,
   demoVideoDetails: {
     url: 'https://demo.arcade.software/6cWULLTHkTH4XsSB1rs1?embed&show_copy_link=true',
     title: 'Setting up FormSG',

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -123,8 +123,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
       },
     }
@@ -246,8 +246,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: 'invalid-id' }, // Non-existent step id
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
       },
     }
@@ -260,8 +260,8 @@ describe('createStep mutation integration tests', async () => {
 
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
-    expect(newStep.key).toBe('newStep')
-    expect(newStep.appKey).toBe('test-app')
+    expect(newStep.key).toBe('sendTransactionalEmail')
+    expect(newStep.appKey).toBe('postman')
     // New step's position should be previousStep.position + 1.
     expect(newStep.position).toBe(existingSteps[0].position + 1)
   })
@@ -272,8 +272,8 @@ describe('createStep mutation integration tests', async () => {
 
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
-    expect(newStep.key).toBe('newStep')
-    expect(newStep.appKey).toBe('test-app')
+    expect(newStep.key).toBe('sendTransactionalEmail')
+    expect(newStep.appKey).toBe('postman')
     // New step's position should be previousStep.position + 1.
     expect(newStep.position).toBe(existingSteps[0].position + 1)
   })
@@ -285,8 +285,8 @@ describe('createStep mutation integration tests', async () => {
       input: {
         flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
         connection: { id: testConnection.id },
         connectionRole: 'owner',
@@ -296,8 +296,8 @@ describe('createStep mutation integration tests', async () => {
     const newStep = await createStep(null, params, context)
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
-    expect(newStep.key).toBe('newStep')
-    expect(newStep.appKey).toBe('test-app')
+    expect(newStep.key).toBe('sendTransactionalEmail')
+    expect(newStep.appKey).toBe('postman')
     expect(newStep.position).toBe(existingSteps[0].position + 1)
   })
 
@@ -324,8 +324,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
         connection: { id: testConnection.id },
       },
@@ -353,8 +353,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
         connection: { id: randomUUID() },
       },
@@ -385,8 +385,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
         connection: { id: editorConnection.id },
       },
@@ -417,8 +417,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
         connection: { id: otherUserConnection.id },
       },
@@ -437,8 +437,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
         parameters: { newParam: 'value' },
       },
     }
@@ -458,8 +458,8 @@ describe('createStep mutation integration tests', async () => {
             updatedAt: testFlowTimestampString,
           },
           previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
           parameters: { newParam: 'value' },
         },
       }
@@ -467,7 +467,7 @@ describe('createStep mutation integration tests', async () => {
       const newStep = await createStep(null, params, context)
 
       expect(newStep).toBeDefined()
-      expect(newStep.key).toBe('newStep')
+      expect(newStep.key).toBe('sendTransactionalEmail')
     })
 
     it('should succeed when input.flow.updatedAt is different from flow.updatedAt for same user', async () => {
@@ -481,8 +481,8 @@ describe('createStep mutation integration tests', async () => {
             updatedAt: futureTimestamp,
           },
           previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
           parameters: { newParam: 'value' },
         },
       }
@@ -490,7 +490,7 @@ describe('createStep mutation integration tests', async () => {
       const newStep = await createStep(null, params, context)
 
       expect(newStep).toBeDefined()
-      expect(newStep.key).toBe('newStep')
+      expect(newStep.key).toBe('sendTransactionalEmail')
     })
 
     it('should throw when input.flow.updatedAt is different from flow.updatedAt for different user', async () => {
@@ -505,8 +505,8 @@ describe('createStep mutation integration tests', async () => {
             updatedAt: futureTimestamp,
           },
           previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
           parameters: { newParam: 'value' },
         },
       }
@@ -531,8 +531,8 @@ describe('createStep mutation integration tests', async () => {
             updatedAt: oldTimestamp,
           },
           previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
           parameters: { newParam: 'value' },
         },
       }
@@ -553,8 +553,8 @@ describe('createStep mutation integration tests', async () => {
             updatedAt: 'invalid-timestamp',
           },
           previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
           parameters: { newParam: 'value' },
         },
       }
@@ -562,7 +562,7 @@ describe('createStep mutation integration tests', async () => {
       const newStep = await createStep(null, params, context)
 
       expect(newStep).toBeDefined()
-      expect(newStep.key).toBe('newStep')
+      expect(newStep.key).toBe('sendTransactionalEmail')
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -138,8 +138,8 @@ describe('createStep mutation integration tests', async () => {
           updatedAt: testFlowTimestampString,
         },
         previousStep: { id: existingSteps[0].id },
-        key: 'newStep',
-        appKey: 'test-app',
+        key: 'sendMessage',
+        appKey: 'telegram-bot',
         parameters: { newParam: 'value' },
       },
     }
@@ -149,8 +149,8 @@ describe('createStep mutation integration tests', async () => {
     // Ensure the new step is returned as expected.
     expect(newStep).toBeDefined()
     expect(newStep.type).toBe('action')
-    expect(newStep.key).toBe('newStep')
-    expect(newStep.appKey).toBe('test-app')
+    expect(newStep.key).toBe('sendMessage')
+    expect(newStep.appKey).toBe('telegram-bot')
     // New step's position should be previousStep.position + 1.
     expect(newStep.position).toBe(existingSteps[0].position + 1)
 

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -206,20 +206,43 @@ describe('updateStep mutation', () => {
   it('should set status to incomplete when key or appKey changes', async () => {
     const input = {
       ...genericInputParams,
-      key: 'newKey',
+      key: 'sendMessage',
+      appKey: 'telegram-bot',
+      //  remove connection from input for testing purposes
+      connection: { id: null } as any,
     }
 
     await updateStep(null, { input }, context)
 
     expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
-      key: 'newKey',
-      appKey: 'postman',
-      connectionId: mockConnectionId,
+      key: 'sendMessage',
+      appKey: 'telegram-bot',
+      connectionId: null,
       parameters: { testParam: 'value' },
       status: 'incomplete',
       config: {},
       updatedBy: context.currentUser.id,
     })
+  })
+
+  it('should throw an error if the key or appKey is not found', async () => {
+    const input = {
+      ...genericInputParams,
+      key: 'invalidKey',
+    }
+
+    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+
+    const input2 = {
+      ...genericInputParams,
+      appKey: 'invalidAppKey',
+    }
+
+    await expect(updateStep(null, { input: input2 }, context)).rejects.toThrow(
+      BadUserInputError,
+    )
   })
 
   it('should set status to incomplete when explicitly requested', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -518,8 +518,8 @@ describe('updateStep mutation', () => {
       context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: context.currentUser,
-        stepKey: 'sendTransactionalEmail',
-        stepAppKey: 'postman',
+        stepKey: 'createTableRow',
+        stepAppKey: 'm365-excel',
         flowId: mockFlowId,
         flowUpdatedAt: testFlowISODateString,
       })
@@ -532,6 +532,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'm365-excel',
+        key: 'createTableRow',
         parameters: { fileId: '1234567890' },
       }
 
@@ -552,7 +553,7 @@ describe('updateStep mutation', () => {
       const input = {
         id: mockStepId,
         flow: { id: mockFlowId, updatedAt: testFlowISODateString },
-        key: 'sendMessage',
+        key: 'sendMessageToChannel',
         appKey: 'slack',
         parameters: { channel: 'C1234567890' },
         connection: { id: mockConnectionId },
@@ -574,6 +575,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'slack',
+        key: 'sendMessageToChannel',
         parameters: { message: 'Hello world' }, // No channel parameter
         connection: { id: mockConnectionId },
       }
@@ -601,7 +603,7 @@ describe('updateStep mutation', () => {
       context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
-        stepKey: 'sendMessage',
+        stepKey: 'sendMessageToChannel',
         stepAppKey: 'slack',
         flowId: mockFlowId,
         stepRole: 'editor', // Not owner
@@ -623,6 +625,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'slack',
+        key: 'sendMessageToChannel',
         parameters: { channel: 'C1234567890' },
         connection: { id: mockConnectionId },
       }
@@ -694,7 +697,7 @@ describe('updateStep mutation', () => {
       context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
         owner,
         currentUser: owner,
-        stepKey: 'readAction',
+        stepKey: 'createTileRow',
         stepAppKey: 'tiles',
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
@@ -703,6 +706,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'tiles',
+        key: 'createTileRow',
         connection: {},
         parameters: { tableId: mockTableId },
       }

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,6 +1,7 @@
 import { raw } from 'objection'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
+import logger from '@/helpers/logger'
 import App from '@/models/app'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
@@ -23,6 +24,15 @@ const createStep: MutationResolvers['createStep'] = async (
       input.appKey,
       input.key,
     )
+
+    if (!triggerOrAction) {
+      logger.error({
+        event: 'createStep: no such trigger or action',
+        appKey: input.appKey,
+        key: input.key,
+      })
+      throw new BadUserInputError('No such trigger or action')
+    }
 
     if ('hiddenFromUser' in triggerOrAction && triggerOrAction.hiddenFromUser) {
       throw new BadUserInputError('Action can only be created by system')

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -15,18 +15,19 @@ const createStep: MutationResolvers['createStep'] = async (
 ) => {
   const { input } = params
 
-  const triggerOrAction = await App.findTriggerOrActionByKey(
-    input.appKey,
-    input.key,
-  )
+  /**
+   * appKey and key are optional, we allow creating of empty step for if-then branches
+   */
+  if (input.appKey && input.key) {
+    const triggerOrAction = await App.findTriggerOrActionByKey(
+      input.appKey,
+      input.key,
+    )
 
-  if (!triggerOrAction) {
-    throw new BadUserInputError('No such trigger or action')
+    if ('hiddenFromUser' in triggerOrAction && triggerOrAction.hiddenFromUser) {
+      throw new BadUserInputError('Action can only be created by system')
+    }
   }
-  if ('hiddenFromUser' in triggerOrAction && triggerOrAction.hiddenFromUser) {
-    throw new BadUserInputError('Action can only be created by system')
-  }
-
   return await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,5 +1,7 @@
 import { raw } from 'objection'
 
+import { BadUserInputError } from '@/errors/graphql-errors'
+import App from '@/models/app'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
@@ -12,6 +14,18 @@ const createStep: MutationResolvers['createStep'] = async (
   context,
 ) => {
   const { input } = params
+
+  const triggerOrAction = await App.findTriggerOrActionByKey(
+    input.appKey,
+    input.key,
+  )
+
+  if (!triggerOrAction) {
+    throw new BadUserInputError('No such trigger or action')
+  }
+  if ('hiddenFromUser' in triggerOrAction && triggerOrAction.hiddenFromUser) {
+    throw new BadUserInputError('Action can only be created by system')
+  }
 
   return await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,3 +1,4 @@
+import { IAction } from '@/../../types'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import {
   addFlowConnection,
@@ -15,6 +16,14 @@ const updateStep: MutationResolvers['updateStep'] = async (
   context,
 ) => {
   const { input } = params
+
+  const triggerOrAction = await App.findTriggerOrActionByKey(
+    input.appKey,
+    input.key,
+  )
+  if (!triggerOrAction) {
+    throw new BadUserInputError('No such trigger or action')
+  }
 
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
@@ -52,8 +61,10 @@ const updateStep: MutationResolvers['updateStep'] = async (
     // NOTE: we use this function to first validate the step parameters
     // to avoid misuse and saving invalid step parameters
     if (step.type === 'action') {
-      const app = await App.findOneByKey(input.appKey)
-      const action = app?.actions?.find((action) => action.key === step.key)
+      const action = triggerOrAction as IAction
+      if (action?.hiddenFromUser) {
+        throw new BadUserInputError('Action can only be updated by system')
+      }
       action?.validateStepParameters?.(input.parameters)
     }
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -4,6 +4,7 @@ import {
   addFlowConnection,
   addFlowTableConnection,
 } from '@/helpers/add-flow-connection'
+import logger from '@/helpers/logger'
 import App from '@/models/app'
 import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
@@ -22,6 +23,11 @@ const updateStep: MutationResolvers['updateStep'] = async (
     input.key,
   )
   if (!triggerOrAction) {
+    logger.error({
+      event: 'updateStep: no such trigger or action',
+      appKey: input.appKey,
+      key: input.key,
+    })
     throw new BadUserInputError('No such trigger or action')
   }
 

--- a/packages/backend/src/graphql/queries/get-apps.ts
+++ b/packages/backend/src/graphql/queries/get-apps.ts
@@ -57,6 +57,7 @@ export const ACTION_APPS_RANKING = [
   customApiApp.key,
   vaultWorkspaceApp.key,
   twilioApp.key,
+  formsgApp.key,
 ]
 
 function sortApps(apps: IApp[]): IApp[] {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -174,6 +174,7 @@ type Action {
   name: String
   key: String
   description: String
+  hiddenFromUser: Boolean
   groupsLaterSteps: Boolean
   setupMessage: SetupMessage
   isNew: Boolean

--- a/packages/backend/src/models/app.ts
+++ b/packages/backend/src/models/app.ts
@@ -5,6 +5,7 @@ import { memoize } from 'lodash'
 import apps from '@/apps'
 import appInfoConverter from '@/helpers/app-info-converter'
 import getApp from '@/helpers/get-app'
+import logger from '@/helpers/logger'
 
 class App {
   static list = Object.keys(apps)
@@ -41,11 +42,21 @@ class App {
     appKey: string,
     key: string,
   ): Promise<ITrigger | IAction> {
-    const app = await this.findOneByKey(appKey)
-    return (
-      app.triggers?.find((trigger) => trigger.key === key) ||
-      app.actions?.find((action) => action.key === key)
-    )
+    try {
+      const app = await this.findOneByKey(appKey)
+      return (
+        app.triggers?.find((trigger) => trigger.key === key) ||
+        app.actions?.find((action) => action.key === key)
+      )
+    } catch {
+      logger.error({
+        event: 'findTriggerOrActionByKey',
+        message: 'No such trigger or action',
+        appKey,
+        key,
+      })
+      return null
+    }
   }
 
   static getAllAppsWithFunctions = memoize(async () => {

--- a/packages/backend/src/models/app.ts
+++ b/packages/backend/src/models/app.ts
@@ -1,4 +1,4 @@
-import { IApp } from '@plumber/types'
+import { IAction, IApp, ITrigger } from '@plumber/types'
 
 import { memoize } from 'lodash'
 
@@ -35,6 +35,17 @@ class App {
     const rawAppData = await getApp(key, stripFuncs)
 
     return appInfoConverter(rawAppData)
+  }
+
+  static async findTriggerOrActionByKey(
+    appKey: string,
+    key: string,
+  ): Promise<ITrigger | IAction> {
+    const app = await this.findOneByKey(appKey)
+    return (
+      app.triggers?.find((trigger) => trigger.key === key) ||
+      app.actions?.find((action) => action.key === key)
+    )
   }
 
   static getAllAppsWithFunctions = memoize(async () => {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/ChooseApp.tsx
@@ -288,13 +288,17 @@ export default function ChooseApp(props: ChooseAppProps) {
 
                     const triggersOrActions = isTrigger
                       ? app.triggers
-                      : app.actions
+                      : app.actions?.filter((action) => !action.hiddenFromUser)
                     const singleTriggerOrAction =
                       triggersOrActions?.length === 1
                         ? triggersOrActions[0]
                         : null
 
                     const isAppDisabled = appSelectableMap?.[app.key] === false
+
+                    if (!triggersOrActions?.length) {
+                      return null
+                    }
 
                     return (
                       <Flex

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -178,6 +178,7 @@ export const GET_APPS = gql`
         groupsLaterSteps
         isNew
         linkToGuide
+        hiddenFromUser
         substeps {
           key
           name

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -790,6 +790,8 @@ export interface IActionItem {
 export interface IBaseAction {
   name: string
   key: string
+  // can only be created by backend, not by user
+  hiddenFromUser?: boolean
   description: string
   isNew?: boolean
   run?(


### PR DESCRIPTION
## Changes

- Created a new `hidden` action `mrfSubmission` for FormSG app that handles subsequent MRF submissions
- Added validation to prevent users from creating or updating hidden actions
- Updated GraphQL schema to include `hiddenFromUser` property for actions
- Added a helper method in App model to find triggers or actions by key
- Modified the frontend to filter out hidden actions from the UI

### How to test?
- Add step modal should not show FormSG action
- Comment out the frontend filter, and try adding formsg action -> it should fail

### What's not done?
- Preventing reordering of hidden actions
- Preventing deletion of hidden actions
- Preventing step name change of hidden actions