### PR TITLE
[MRF-6] PLU-520: testStep for mrf actions should test multiple steps

### DIFF
--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -1,6 +1,14 @@
-import { IGlobalVariable, IRawAction } from '@plumber/types'
+import type { IGlobalVariable, IRawAction } from '@plumber/types'
 
-import getDataOutMetadata from '../../triggers/new-submission/get-data-out-metadata'
+import StepError from '@/errors/step'
+import ExecutionStep from '@/models/execution-step'
+import Step from '@/models/step'
+
+import getDataOutMetadata from '../../common/get-data-out-metadata'
+import {
+  type ParsedMrfWorkflowStep,
+  parsedMrfWorkflowStepSchema,
+} from '../../common/types'
 
 const action: IRawAction = {
   name: 'New form response',
@@ -10,8 +18,45 @@ const action: IRawAction = {
     'This is a hidden action that signifies a subsequent MRF submission',
   getDataOutMetadata,
 
-  async testRun(_$: IGlobalVariable) {
-    // TODO: this should run testRun for the trigger execution step
+  async testRun($: IGlobalVariable) {
+    // Gets the execution step of the trigger
+    const { mrf } = $.step.parameters as unknown as {
+      mrf: ParsedMrfWorkflowStep
+    }
+
+    if (!mrf || parsedMrfWorkflowStepSchema.safeParse(mrf).success === false) {
+      throw new StepError(
+        'Misconfigured MRF step',
+        'Reconnect your MRF form and try again.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    const triggerStep = await Step.query()
+      .findOne({
+        flow_id: $.flow.id,
+        type: 'trigger',
+        key: 'newSubmission',
+        app_key: 'formsg',
+      })
+      .throwIfNotFound()
+    const triggerExecutionStep = await ExecutionStep.query()
+      .where('step_id', triggerStep.id)
+      .andWhere('execution_id', $.execution.id)
+      .first()
+
+    if (!triggerExecutionStep) {
+      $.setActionItem({
+        raw: null,
+      })
+      return
+    }
+
+    $.setActionItem({
+      raw: triggerExecutionStep.dataOut,
+      meta: triggerExecutionStep.metadata,
+    })
   },
 }
 

--- a/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
@@ -10,7 +10,7 @@ import {
 import logger from '@/helpers/logger'
 import { parseS3Id } from '@/helpers/s3'
 
-import { ADDRESS_LABELS } from '../../common/constants'
+import { ADDRESS_LABELS } from './constants'
 
 function buildQuestionMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
   const question: IDataOutMetadatum = {
@@ -322,6 +322,7 @@ async function getDataOutMetadata(
   executionStep: IExecutionStep,
 ): Promise<IDataOutMetadata> {
   const data = executionStep.dataOut
+
   if (!data || !data.fields) {
     return null
   }

--- a/packages/backend/src/apps/formsg/common/process-table-field.ts
+++ b/packages/backend/src/apps/formsg/common/process-table-field.ts
@@ -1,6 +1,6 @@
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 
-import { extractLastTopLevelBracketContent } from '../triggers/new-submission/get-data-out-metadata'
+import { extractLastTopLevelBracketContent } from './get-data-out-metadata'
 
 type TableColumn = {
   id: string

--- a/packages/backend/src/apps/formsg/common/types.ts
+++ b/packages/backend/src/apps/formsg/common/types.ts
@@ -36,13 +36,15 @@ export interface FormSchema {
  * This will be stored in the step's parameters and
  * not modifiable by the user
  */
-export interface ParsedMrfWorkflowStep {
-  defaultStepName: string
-  formWorkflowStepId: string
-  type: 'static' | 'dynamic' | 'conditional'
-  fields?: string[]
-  approvalField?: string
-}
+export const parsedMrfWorkflowStepSchema = z.object({
+  defaultStepName: z.string(),
+  formWorkflowStepId: z.string(),
+  type: z.enum(['static', 'dynamic', 'conditional']),
+  fields: z.array(z.string()),
+  approvalField: z.string().optional(),
+})
+
+export type ParsedMrfWorkflowStep = z.infer<typeof parsedMrfWorkflowStepSchema>
 
 export interface ParsedMrfWorkflow {
   trigger: Omit<ParsedMrfWorkflowStep, 'approvalField'>

--- a/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
@@ -19,14 +19,18 @@ export async function createMrfSteps(
   await Step.transaction(async (trx) => {
     const triggerStepName = `MRF: ${trigger.defaultStepName}`
     // Update the trigger step parameters
-    await Step.query(trx).patchAndFetchById($.step.id, {
-      parameters: {
-        mrf: trigger,
+    const updatedTriggerStep = await Step.query(trx).patchAndFetchById(
+      $.step.id,
+      {
+        parameters: {
+          mrf: trigger,
+        },
+        config: raw(
+          `jsonb_set(config, '{stepName}', to_jsonb(?::text), true)`,
+          [triggerStepName],
+        ),
       },
-      config: raw(`jsonb_set(config, '{stepName}', to_jsonb(?::text), true)`, [
-        triggerStepName,
-      ]),
-    })
+    )
 
     const existingMrfSteps = await Step.query(trx)
       .where('flow_id', $.flow.id)
@@ -84,6 +88,7 @@ export async function createMrfSteps(
         const updatedStep = await Step.query(trx).patchAndFetchById(
           existingStep.id,
           {
+            connectionId: updatedTriggerStep.connectionId,
             parameters,
             config: raw(
               `jsonb_set(config, '{stepName}', to_jsonb(?::text), true)`,
@@ -106,6 +111,7 @@ export async function createMrfSteps(
           appKey: MRF_APP_KEY,
           key: MRF_KEY,
           position: newStepPosition,
+          connectionId: updatedTriggerStep.connectionId,
           parameters,
           config: {
             stepName,

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -6,11 +6,11 @@ import { z } from 'zod'
 import StepError from '@/errors/step'
 import ExecutionStep from '@/models/execution-step'
 
+import getDataOutMetadata from '../../common/get-data-out-metadata'
 import { getFormDetailsFromGlobalVariable } from '../../common/webhook-settings'
 
 import { createMrfSteps } from './create-mrf-steps'
 import { fetchFormSchema } from './fetch-form-schema'
-import getDataOutMetadata from './get-data-out-metadata'
 import getMockData from './get-mock-data'
 import { parseWorkflowData } from './get-workflow-data'
 
@@ -36,7 +36,6 @@ const trigger: IRawTrigger = {
     hideWebhookUrl: true,
     errorMsg:
       'Make a new submission to the form you connected and test the step again.',
-    mockDataMsg: 'The mock responses below are based on your form fields.',
   },
   arguments: [
     {
@@ -112,6 +111,7 @@ const trigger: IRawTrigger = {
     const formSchema = await fetchFormSchema($, formId)
 
     if (formSchema.form.responseMode === 'multirespondent') {
+      // Create MRF steps for multirespondent forms
       const mrfWorkflowData = await parseWorkflowData($, formSchema)
       await createMrfSteps($, mrfWorkflowData)
     }

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -57,7 +57,7 @@ describe('createStep mutation integration tests', async () => {
     testConnection = await testUser
       .$relatedQuery('connections')
       .insertAndFetch({
-        key: 'test-connection',
+        key: 'postman',
         formattedData: { test: 'data' },
         verified: true,
         draft: false,

--- a/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
@@ -20,6 +20,8 @@ const getMockResolvedValue = (userId: string) => {
     key: 'sendTransactionalEmail',
     appKey: 'postman',
     status: 'completed',
+    flowId: mockFlowId,
+    parameters: {},
     flow: {
       id: mockFlowId,
       userId,
@@ -30,6 +32,14 @@ const getMockResolvedValue = (userId: string) => {
     },
     $query: vi.fn().mockReturnValue({
       patch: vi.fn().mockResolvedValue({}),
+      patchAndFetch: vi.fn().mockResolvedValue({
+        id: mockStepId,
+        key: 'sendTransactionalEmail',
+        appKey: 'postman',
+        status: 'completed',
+        flowId: mockFlowId,
+        parameters: {},
+      }),
     }),
   }
 }
@@ -231,6 +241,7 @@ describe('executeStep mutation - access control', () => {
                 key: 'sendTransactionalEmail',
                 appKey: 'postman',
                 status: 'completed',
+                flowId: mockFlowId,
                 flow: {
                   id: mockFlowId,
                   userId: 'owner-user-id',
@@ -241,6 +252,14 @@ describe('executeStep mutation - access control', () => {
                 },
                 $query: vi.fn().mockReturnValue({
                   patch: vi.fn().mockResolvedValue({}),
+                  patchAndFetch: vi.fn().mockResolvedValue({
+                    id: mockStepId,
+                    key: 'sendTransactionalEmail',
+                    appKey: 'postman',
+                    status: 'completed',
+                    flowId: mockFlowId,
+                    parameters: {},
+                  }),
                 }),
               }),
             }),

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -624,8 +624,8 @@ describe('updateStep mutation', () => {
 
       const input = {
         ...genericInputParams,
-        appKey: 'slack',
         key: 'sendMessageToChannel',
+        appKey: 'slack',
         parameters: { channel: 'C1234567890' },
         connection: { id: mockConnectionId },
       }

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -1,5 +1,7 @@
 import { raw } from 'objection'
 
+import Flow from '@/models/flow'
+import Step from '@/models/step'
 import testStep from '@/services/test-step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -12,29 +14,84 @@ const executeStep: MutationResolvers['executeStep'] = async (
   const { stepId, testRunMetadata } = params.input
 
   // Just checking for permissions here
-  const stepToTest = await context.currentUser
+  let stepToTest = await context.currentUser
     .withAccessibleSteps({ requiredRole: 'editor' })
     .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()
+
+  const isMrf = stepToTest.appKey === 'formsg' && stepToTest.parameters.mrf
+
+  /**
+   * If it is an MRF step, we need to test all steps starting from the trigger step
+   * regardless of whether the trigger or action is being checked
+   */
+  if (isMrf) {
+    const mrfSteps = await Step.query()
+      .where('app_key', 'formsg')
+      .andWhere('flow_id', stepToTest.flowId)
+      .orderBy('position', 'asc')
+      .limit(1)
+
+    if (mrfSteps.length === 1) {
+      stepToTest = mrfSteps[0]
+    }
+  }
 
   const { executionStep, executionId } = await testStep({
     stepId: stepToTest.id,
     testRunMetadata,
   })
 
-  // Update flow to use the new test execution
-  await stepToTest.flow.$query().patch({
+  await Flow.query().patchAndFetchById(stepToTest.flowId, {
     testExecutionId: executionId,
   })
 
-  // Update step status
+  let shouldContinueTestingMrfSteps = false
+
   if (!executionStep.isFailed) {
-    await stepToTest.$query().patch({
+    const updatedStep = await stepToTest.$query().patchAndFetch({
+      // Update step status
       status: 'completed',
       // clear templateConfig in config when step is tested successfully
       config: raw(`config - 'templateConfig'`),
     })
+
+    // we check if the step is an MRF step again after testing
+    shouldContinueTestingMrfSteps = !!updatedStep.parameters.mrf
+  } else {
+    return executionStep
+  }
+
+  if (!shouldContinueTestingMrfSteps) {
+    return executionStep
+  }
+
+  /**
+   * Test remaining steps in the mrf flow
+   */
+  const remainingSteps = await Step.query()
+    .where('app_key', 'formsg')
+    .andWhere('flow_id', stepToTest.flowId)
+    .andWhere('type', 'action')
+    .orderBy('position', 'asc')
+
+  for (const remainingStep of remainingSteps) {
+    const { executionStep } = await testStep({
+      stepId: remainingStep.id,
+      testRunMetadata,
+    })
+
+    if (!executionStep.isFailed) {
+      await remainingStep.$query().patch({
+        // Update step status
+        status: 'completed',
+        // clear templateConfig in config when step is tested successfully
+        config: raw(`config - 'templateConfig'`),
+      })
+    } else {
+      break
+    }
   }
 
   return executionStep

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -759,7 +759,6 @@ type TriggerInstructions {
   afterUrlMsg: String
   hideWebhookUrl: Boolean
   errorMsg: String
-  mockDataMsg: String
 }
 
 type StepTransferDetails {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -170,6 +170,7 @@ export const processAction = async (options: ProcessActionOptions) => {
         : await actionCommand.run($, metadata)
     if (result) {
       runResult = result
+      metadata
     }
   } catch (error) {
     executionError = error
@@ -224,7 +225,7 @@ export const processAction = async (options: ProcessActionOptions) => {
       appKey: $.app.key,
       jobId,
       key: step.key,
-      metadata,
+      metadata: { ...metadata, ...$.actionOutput.data?.meta },
     })
 
   // TODO on Oct: remove this once the logging is not needed anymore

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -25,22 +25,6 @@ function getNoOutputMessage(
   return selectedActionOrTrigger?.webhookTriggerInstructions?.errorMsg ?? null
 }
 
-function getMockDataMessage(
-  selectedActionOrTrigger: TestResultsProps['selectedActionOrTrigger'],
-): string | null {
-  // Type guard for ITrigger
-  if (
-    !selectedActionOrTrigger ||
-    !('webhookTriggerInstructions' in selectedActionOrTrigger)
-  ) {
-    return null
-  }
-
-  return (
-    selectedActionOrTrigger?.webhookTriggerInstructions?.mockDataMsg ?? null
-  )
-}
-
 interface TestResultsProps {
   step: IStep
   selectedActionOrTrigger: ITrigger | IAction | undefined
@@ -65,6 +49,12 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
   const { testExecutionSteps } = useContext(EditorContext)
   const isForEachStep = step.key === TOOLBOX_ACTIONS.ForEach
 
+  const testResultMessage = isForEachStep
+    ? getForEachDataMessage(testExecutionSteps, step)
+    : isMock
+    ? 'The mock responses below are based on your form fields.'
+    : null
+
   const Content = () => {
     // No data only happens if user hasn't executed yet, or step returned null.
     if (!variables?.length) {
@@ -84,13 +74,9 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
 
     return (
       <Box w="100%">
-        {(isMock || isForEachStep) && (
+        {testResultMessage && (
           <Infobox variant="info">
-            <Text>
-              {isForEachStep
-                ? getForEachDataMessage(testExecutionSteps, step)
-                : getMockDataMessage(selectedActionOrTrigger)}
-            </Text>
+            <Text>{testResultMessage}</Text>
           </Infobox>
         )}
         <VariablesList variables={variables} customStyles={{ py: 0, px: 2 }} />

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -98,7 +98,6 @@ export const GET_APPS = gql`
           afterUrlMsg
           errorMsg
           hideWebhookUrl
-          mockDataMsg
         }
         substeps {
           key

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -694,7 +694,6 @@ export type ITriggerInstructions = Partial<{
   afterUrlMsg: string
   hideWebhookUrl: boolean
   errorMsg: string
-  mockDataMsg: string
 }>
 
 // TODO (mal): instructions is temporarily used to display no connection but to modify for phase 2
@@ -785,6 +784,7 @@ export interface IActionOutput {
 
 export interface IActionItem {
   raw: IJSONObject
+  meta?: IExecutionStepMetadata
 }
 
 export interface IBaseAction {


### PR DESCRIPTION
## Changes
- Modified execute-step to execute testRun for all MRF steps
- Updated the action processing to properly handle metadata from MRF submissions
- `createMrfSteps` should replicate the connectionId for all steps created

### refactor
- Created a schema validation for MRF workflow steps
- Removed the `mockDataMsg` field from trigger instructions, hardcode on frontend instead

### How to test?

1. Connect an MRF form
2. Click check step on any of the MRF steps, all fields should appear together with the mock data message
3. Verify that all MRF steps are properly connected and share the same connection ID


### What's not done?
- Filtering only editable fields for each step 

