### PR TITLE
PLU-596: Elevated Telegram ETIMEDOUT during tcp.connect

### DIFF
--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -1,6 +1,7 @@
 import { IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 
 import { escapeMarkdown, sanitizeMarkdown } from '../../common/markdown-v1'
 import { throwSendMessageError } from '../../common/throw-errors'
@@ -88,6 +89,10 @@ const action: IRawAction = {
     }
     try {
       const response = await $.http.post('/sendMessage', payload)
+      // logging for debugging
+      logger.info(
+        `Telegram ip success: ${response.request?.socket?.remoteAddress}`,
+      )
       $.setActionItem({
         raw: response.data,
       })

--- a/packages/backend/src/apps/telegram-bot/common/force-ipv4.ts
+++ b/packages/backend/src/apps/telegram-bot/common/force-ipv4.ts
@@ -1,0 +1,22 @@
+import { TBeforeRequest } from '@plumber/types'
+
+import https from 'https'
+
+// Singleton HTTPS agent configured for IPv4 only
+// This helps avoid DNS timeout issues with Telegram's API
+const httpsAgent = new https.Agent({
+  family: 4, // Force IPv4 resolution
+  keepAlive: true,
+  timeout: 30000, // 30 second timeout
+})
+
+const forceIpv4: TBeforeRequest = async ($, requestConfig) => {
+  // Only apply to HTTPS requests (Telegram API uses HTTPS)
+  if (requestConfig.baseURL?.startsWith('https://')) {
+    requestConfig.httpsAgent = httpsAgent
+  }
+
+  return requestConfig
+}
+
+export default forceIpv4

--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -26,6 +26,7 @@ export async function throwSendMessageError(
     err.message.includes('ETIMEDOUT') ||
     err.code === 'ETIMEDOUT'
   ) {
+    logger.error(`Telegram ip error: ${err.resolvedIp}`)
     throw new RetriableError({
       error: 'Timeout error. Telegram may be experiencing issues.',
       delayInMs: 'default',

--- a/packages/backend/src/apps/telegram-bot/dynamic-data/get-chat-ids.ts
+++ b/packages/backend/src/apps/telegram-bot/dynamic-data/get-chat-ids.ts
@@ -4,6 +4,8 @@ import {
   IGlobalVariable,
 } from '@plumber/types'
 
+import logger from '@/helpers/logger'
+
 import {
   HasTelegramChat,
   TelegramGetUpdatesResponse,
@@ -49,9 +51,11 @@ const dynamicData: IDynamicData = {
     const chatIdsMap: { name: string; value: string }[] = []
     const chatIdsSet = new Set<number>()
     try {
-      const { data } = await $.http.get<TelegramGetUpdatesResponse>(
+      const { data, request } = await $.http.get<TelegramGetUpdatesResponse>(
         getUpdatesApi,
       )
+      // logging for debugging
+      logger.info(`Telegram ip success: ${request?.socket?.remoteAddress}`)
 
       if (!data.result) {
         return {

--- a/packages/backend/src/apps/telegram-bot/index.ts
+++ b/packages/backend/src/apps/telegram-bot/index.ts
@@ -3,6 +3,7 @@ import { IApp } from '@plumber/types'
 import { getGenericAppQueue } from '@/queues/helpers/get-generic-app-queue'
 
 import addAuthHeader from './common/add-auth-header'
+import forceIpv4 from './common/force-ipv4'
 import rateLimitHandler from './common/interceptor/rate-limit'
 import actions from './actions'
 import auth from './auth'
@@ -17,7 +18,7 @@ const app: IApp = {
   baseUrl: 'https://telegram.org',
   apiBaseUrl: 'https://api.telegram.org',
   primaryColor: '2AABEE',
-  beforeRequest: [addAuthHeader],
+  beforeRequest: [forceIpv4, addAuthHeader],
   requestErrorHandler: rateLimitHandler,
   dynamicData,
   auth,

--- a/packages/backend/src/errors/http.ts
+++ b/packages/backend/src/errors/http.ts
@@ -7,6 +7,7 @@ import BaseError from './base'
 export default class HttpError extends BaseError {
   response: AxiosResponse
   code?: string
+  resolvedIp?: string
 
   constructor(error: AxiosError) {
     const computedError =
@@ -25,6 +26,9 @@ export default class HttpError extends BaseError {
 
     // Pass code along
     this.code = error.code
+
+    // add resolved ip for debugging
+    this.resolvedIp = error.request?.socket?.remoteAddress
 
     //
     // Only preserve selected headers to avoid storing sensitive data.


### PR DESCRIPTION
## Problem
Elevated Telegram ETIMEDOUT during tcp.connect

## Solution
Online threads suggest that the fix is to resolve using ipv4 instead of ipv6

https://community.n8n.io/t/solved-telegram-api-timeouts-ipv4-ipv6-dns-resolution-issue/170482

## Tests
- [ ] Can get telegram channels
- [ ] Can send telegram messages
