### PR TITLE
fix: remove data body and content-type header when redirecting to GET…

### DIFF
--- a/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
+++ b/packages/backend/src/apps/custom-api/__tests__/actions/http-request.test.ts
@@ -163,10 +163,14 @@ describe('make http request', () => {
     expect(mocks.httpRequest).toHaveBeenCalledTimes(2)
   })
 
-  it('should follow redirect with GET if 301 or 302', async () => {
+  it('should follow redirect with GET if 301 or 302 without body and content-type header', async () => {
     mocks.isUrlAllowed.mockResolvedValueOnce(false)
     $.step.parameters.method = 'POST'
     $.step.parameters.data = 'meep meep'
+    $.step.parameters.customHeaders = [
+      { key: 'Content-Type', value: 'plain/text' },
+      { key: 'Key2', value: 'Value2' },
+    ]
     $.step.parameters.url = 'http://test.local/endpoint?1234'
     mocks.httpRequest.mockResolvedValue({
       status: 301,
@@ -180,6 +184,10 @@ describe('make http request', () => {
       expect.objectContaining({
         url: 'http://test.local/endpoint?1234',
         method: 'POST',
+        headers: {
+          'Content-Type': 'plain/text',
+          Key2: 'Value2',
+        },
         data: 'meep meep',
         responseType: 'stream',
       }),
@@ -188,7 +196,9 @@ describe('make http request', () => {
       expect.objectContaining({
         url: 'https://redirect.com',
         method: 'GET',
-        data: 'meep meep',
+        headers: {
+          Key2: 'Value2',
+        },
         responseType: 'stream',
       }),
     )

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -157,9 +157,10 @@ const action: IRawAction = {
         const redirectMethod =
           response.status === 301 || response.status === 302 ? 'GET' : method
 
-        if (redirectMethod === 'GET' && customHeaders) {
-          delete customHeaders['content-type']
-          delete customHeaders['Content-Type']
+        const redirectHeaders = customHeaders ? { ...customHeaders } : {}
+        if (redirectMethod === 'GET' && redirectHeaders) {
+          delete redirectHeaders['content-type']
+          delete redirectHeaders['Content-Type']
         }
 
         response = await $.http.request({
@@ -167,7 +168,7 @@ const action: IRawAction = {
           method: redirectMethod,
           // Only include data if the redirect method is not GET
           ...(redirectMethod !== 'GET' && { data: parsedData }),
-          headers: customHeaders,
+          headers: redirectHeaders,
           timeout,
           // Prevent calling of internal IPs, e.g. aws metadata endpoint
           lookup: safeAxiosLookup,

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -100,7 +100,6 @@ const action: IRawAction = {
 
   async run($) {
     const method = $.step.parameters.method as TMethod
-    const data = $.step.parameters.data as string
     const url = $.step.parameters.url as string
 
     // Check if the step has an admin override for the timeout
@@ -149,14 +148,29 @@ const action: IRawAction = {
         if (!response.headers?.location) {
           throw new Error('No location header')
         }
+
+        // ref: https://github.com/follow-redirects/follow-redirects/blob/21ef28a544c5e57f4c34b8476d75f2144609a1eb/index.js#L442
+        // if redirect method is GET, we need to delete the content-type header
+        // and drop body
+        // technically content-length header should also be dropped, but we dont set it
+        // manually
+        const redirectMethod =
+          response.status === 301 || response.status === 302 ? 'GET' : method
+
+        if (redirectMethod === 'GET' && customHeaders) {
+          delete customHeaders['content-type']
+          delete customHeaders['Content-Type']
+        }
+
         response = await $.http.request({
           url: response.headers.location,
-          method:
-            response.status === 301 || response.status === 302 ? 'GET' : method,
-          data,
+          method: redirectMethod,
+          // Only include data if the redirect method is not GET
+          ...(redirectMethod !== 'GET' && { data: parsedData }),
+          headers: customHeaders,
+          timeout,
           // Prevent calling of internal IPs, e.g. aws metadata endpoint
           lookup: safeAxiosLookup,
-          headers: customHeaders,
           maxRedirects: 0,
           // stream the response for custom api to protect against gzip bombs
           responseType: 'stream',


### PR DESCRIPTION
## Problem

Google app script returning 400

## Reason

We're sending the data/body after it's redirect to a GET request. 

## Solution

Follow axios (which relies on follow-redirects) behaviour:
If redirect request is GET:
- remove body
- remove headers starting with `content-`

## Reference
https://github.com/follow-redirects/follow-redirects/blob/main/index.js#L442