### PR TITLE
[OG-3]: Refactor update case to use dynamic data for status options

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -23,15 +23,22 @@ const action: IRawAction = {
       description: 'Enter the case uuid you want to update',
       required: true,
       variables: true,
+      singleVariableSelection: true,
     },
     // TODO: see if it is possible to get all possible statuses from the API
     {
       label: 'Case status',
       key: 'caseStatus',
-      type: 'string' as const,
+      type: 'dropdown' as const,
       description: 'Enter the status you want to update the case to.',
       required: false,
-      variables: true,
+      variables: false,
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [{ name: 'key', value: 'getCaseStatuses' }],
+      },
     },
     {
       label: 'Case fields',


### PR DESCRIPTION
### TL;DR
Enhanced update case action:
* Use variable selection for the case uuid field (can still paste via mouse click)
* Use dropdown for case status

### How to test?
- [ ] Case UUID field allows only a single variable selection
- [ ] Case status field now shows as a dropdown with dynamically loaded options
  - [ ] Confirm that the dropdown displays the options correctly without showing option values
- [ ] Case is updated correctly