### PR TITLE
[COLLAB-20]: fix duplicate branch

### DIFF
--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -11,6 +11,7 @@ import deleteFlow from './mutations/delete-flow'
 import deleteFlowCollaborator from './mutations/delete-flow-collaborator'
 import deleteStep from './mutations/delete-step'
 import deleteUploadedFile from './mutations/delete-uploaded-file'
+import duplicateBranch from './mutations/duplicate-branch'
 import duplicateFlow from './mutations/duplicate-flow'
 import executeStep from './mutations/execute-step'
 import generateAuthUrl from './mutations/generate-auth-url'
@@ -86,6 +87,7 @@ export default {
   loginWithSso,
   createFlowTransfer,
   updateFlowTransferStatus,
+  duplicateBranch,
   duplicateFlow,
   deleteUploadedFile,
   generatePresignedPost,

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -1,0 +1,104 @@
+import { raw } from 'objection'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import Step from '@/models/step'
+import { getConnection } from '@/services/connection'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { input } = params
+
+  return await Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    // validate user has access to the flow AND
+    // that the flow has not been updated since the client last fetched it
+    const flow = await context.currentUser
+      .withAccessibleFlows({ trx, requiredRole: 'editor' })
+      .findOne({
+        id: input.flow.id,
+      })
+      .throwIfNotFound()
+
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
+
+    // create all the steps in the transaction so that if any fails
+    // this entire query fails
+    const newSteps: Step[] = []
+    let previousStepId = input.previousStep.id
+    for (const branchStep of input.steps) {
+      const { connection, key, appKey, parameters, config } = branchStep
+
+      // if connectionId is specified, verify that the connection exists
+      // and the user has the appropriate permissions to use it
+      // user has to be an editor in the pipe
+      if (connection?.id) {
+        /**
+         * NOTE: with collaborators,
+         * Owner can use existing connections or add new connections to the pipe
+         * Editor can only use existing connections that have been shared to the pipe
+         * (TODO: phase 2) Editor will be able to add their own connections
+         */
+        const verifiedConnection = await getConnection({
+          context,
+          connectionId: connection?.id,
+          flowId: flow.id,
+          includeOwnConnections: flow.role === 'owner',
+          trx,
+        })
+
+        if (!verifiedConnection) {
+          throw new BadUserInputError('Connection not found')
+        }
+      }
+
+      const previousStep = await flow
+        .$relatedQuery('steps', trx)
+        .findOne({
+          id: previousStepId,
+        })
+        .throwIfNotFound()
+
+      await flow
+        .$relatedQuery('steps', trx)
+        .patch({
+          position: raw(`position + 1`),
+        })
+        .where('position', '>=', previousStep.position + 1)
+
+      const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
+        key,
+        appKey,
+        type: 'action',
+        position: previousStep.position + 1,
+        parameters,
+        connectionId: connection?.id,
+        config,
+      })
+
+      newSteps.push(step)
+      previousStepId = step.id
+
+      // NOTE: slight difference from createStep where createStep
+      // may need to add to flow_connections, but duplicateBranch does not
+      // as the connection would have already been added when the step
+      // was created in the original branch
+    }
+
+    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+
+    return {
+      steps: newSteps,
+      flow: {
+        updatedAt: updatedFlow.updatedAt,
+      },
+    }
+  })
+}
+
+export default duplicateBranch

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -103,6 +103,7 @@ type Mutation {
   loginWithSelectedSgid(
     input: LoginWithSelectedSgidInput!
   ): LoginWithSelectedSgidResult!
+  duplicateBranch(input: DuplicateBranchInput): DuplicateBranchResult
   duplicateFlow(input: DuplicateFlowInput): Flow
   # Flow collaborators
   upsertFlowCollaborator(input: FlowCollaboratorInput!): Boolean!
@@ -550,6 +551,12 @@ input DeleteFlowInput {
   id: String!
 }
 
+input DuplicateBranchInput {
+  flow: StepFlowInput
+  previousStep: PreviousStepInput
+  steps: [CreateStepInput]
+}
+
 input DuplicateFlowInput {
   id: String!
 }
@@ -828,6 +835,11 @@ type PaginatedExecutions {
 type PaginatedExecutionSteps {
   edges: [ExecutionStepEdge]!
   pageInfo: PageInfo!
+}
+
+type DuplicateBranchResult {
+  flow: Flow
+  steps: [Step]
 }
 
 enum DatabaseType {

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -5,10 +5,8 @@ import { useMutation } from '@apollo/client'
 import { useDisclosure } from '@chakra-ui/react'
 
 import { EditorContext } from '@/contexts/Editor'
-import client from '@/graphql/client'
-import { CREATE_STEP } from '@/graphql/mutations/create-step'
+import { DUPLICATE_BRANCH } from '@/graphql/mutations/duplicate-branch'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 export default function useDuplicateBranch(branchSteps: IStep[]) {
   const {
@@ -21,7 +19,10 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
   const { flow, isDrawerOpen, onDrawerOpen, setCurrentStepId } =
     useContext(EditorContext)
 
-  const [createStep] = useMutation(CREATE_STEP, { fetchPolicy: 'no-cache' })
+  const [duplicateBranch] = useMutation(DUPLICATE_BRANCH, {
+    fetchPolicy: 'no-cache',
+    refetchQueries: [GET_FLOW],
+  })
 
   const canDuplicateBranch = useMemo(() => {
     return (
@@ -30,7 +31,7 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     )
   }, [branchSteps])
 
-  const duplicateBranch = async () => {
+  const onDuplicateBranch = async () => {
     closeDuplicateConfirmation()
 
     if (branchSteps.length < 2) {
@@ -40,48 +41,37 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     setIsDuplicatingBranch(true)
 
     try {
-      let newConditionId = null
-      let previousStepId = branchSteps[branchSteps.length - 1]?.id
+      const previousStepId = branchSteps[branchSteps.length - 1]?.id
       if (!previousStepId) {
         return
       }
-      // Create steps sequentially to avoid serialization conflicts
-      for (const step of branchSteps) {
-        const { appKey, key, connection, parameters } = step
-        const { branchName, ...restParameters } = parameters
 
-        // use a new branch name
-        const newBranchName = `[COPY] ${branchName}`
-
-        const mutationInput = {
-          previousStep: { id: previousStepId },
-          flow: { id: flow.id },
-          appKey,
-          key,
-          ...(connection && { connection: { id: connection.id } }),
-          parameters: {
-            ...restParameters,
-            ...(branchName && { branchName: newBranchName }),
-          },
-        }
-
-        const createdStep = await createStep({
-          fetchPolicy: 'no-cache',
-          variables: { input: mutationInput },
-        })
-
-        if (key === TOOLBOX_ACTIONS.IfThen) {
-          newConditionId = createdStep.data.createStep.id
-        }
-
-        // use the new step id as the previous step id for the next step
-        previousStepId = createdStep.data.createStep.id
+      const mutationInput = {
+        flow: { id: flow.id, updatedAt: flow.updatedAt },
+        previousStep: { id: previousStepId },
+        steps: branchSteps.map((step) => {
+          const { appKey, key, connection, parameters } = step
+          const { branchName, ...restParameters } = parameters
+          const newBranchName = `[COPY] ${branchName}`
+          return {
+            key,
+            appKey,
+            ...(connection && { connection: { id: connection.id } }),
+            parameters: {
+              ...restParameters,
+              ...(branchName && { branchName: newBranchName }),
+            },
+          }
+        }),
       }
 
-      // Refetch flow data only once after all steps are created
-      await client.refetchQueries({ include: [GET_FLOW] })
+      const duplicatedBranch = await duplicateBranch({
+        variables: { input: mutationInput },
+      })
 
-      setCurrentStepId(newConditionId)
+      const newSteps = duplicatedBranch.data.duplicateBranch.steps
+
+      setCurrentStepId(newSteps[0].id)
       if (!isDrawerOpen) {
         onDrawerOpen()
       }
@@ -101,7 +91,7 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     duplicateConfirmationIsOpen,
     isDuplicatingBranch,
     closeDuplicateConfirmation,
-    duplicateBranch,
+    duplicateBranch: onDuplicateBranch,
     openDuplicateConfirmation,
   }
 }

--- a/packages/frontend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/frontend/src/graphql/mutations/duplicate-branch.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client'
+
+export const DUPLICATE_BRANCH = gql`
+  mutation DuplicateBranch($input: DuplicateBranchInput) {
+    duplicateBranch(input: $input) {
+      flow {
+        updatedAt
+      }
+      steps {
+        id
+        type
+        key
+        appKey
+        parameters
+        position
+        status
+        connection {
+          id
+        }
+        config {
+          stepName
+        }
+      }
+    }
+  }
+`

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -2,7 +2,6 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 import { useMutation } from '@apollo/client'
-import { useToast } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
@@ -16,7 +15,6 @@ interface StepPositionInput {
 }
 
 const useReorderSteps = (flowId: string) => {
-  const toast = useToast()
   const { flow } = useContext(EditorContext)
   const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
@@ -74,21 +72,6 @@ const useReorderSteps = (flowId: string) => {
               },
             })
           }
-        },
-        onError: (error) => {
-          toast({
-            title: 'Failed to reorder steps',
-            description: 'Your changes have been reverted. Please try again.',
-            status: 'error',
-            duration: 5000,
-            isClosable: true,
-            position: 'top',
-          })
-          console.error(
-            'Error updating step positions: ',
-            error,
-            JSON.stringify(stepPositions),
-          )
         },
       })
     } catch (error) {


### PR DESCRIPTION
## Problem
Cannot duplicate branch

## Solution
Added a new `duplicateBranch` mutation to duplicate multiple steps in a branch with a single API call.

### What changed?
Created a new GraphQL mutation `duplicateBranch` that duplicates multiple steps in a single transaction so that any failure will not create the branch at akll

### Why make this change?
The implementation ensures proper transaction handling, permission checking, and position updates for all steps in a single database transaction, which is more efficient than the previous approach of creating steps sequentially.

## How to test?
Create steps within an if-then branch
- [ ] Can duplicate branch with all steps and parameters
