### PR TITLE
[COLLAB-22]: Error emails for collaborators

### DIFF
--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -32,7 +32,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
       },
     })
 
-    // duplicate the flow with the previous config (only keep notification frequency)
+    // duplicate the flow with the previous config (only keep notification frequency and notification recipients)
     delete prevConfig['duplicateCount']
     delete prevConfig['templateConfig']
     delete prevConfig['showSurvey']

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -32,11 +32,12 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
       },
     })
 
-    // duplicate the flow with the previous config (only keep notification frequency and notification recipients)
+    // duplicate the flow with the previous config (only keep notification frequency)
     delete prevConfig['duplicateCount']
     delete prevConfig['templateConfig']
     delete prevConfig['showSurvey']
     delete prevConfig['attachments']
+    delete prevConfig['errorConfig']['notificationRecipients']
 
     const duplicatedFlow = await context.currentUser
       .$relatedQuery('flows', trx)

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -37,7 +37,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     delete prevConfig['templateConfig']
     delete prevConfig['showSurvey']
     delete prevConfig['attachments']
-    delete prevConfig['errorConfig']['notificationRecipients']
+    delete prevConfig['errorConfig']
 
     const duplicatedFlow = await context.currentUser
       .$relatedQuery('flows', trx)

--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -10,6 +10,7 @@ type Params = {
   input: {
     id: string
     notificationFrequency: IFlowErrorConfig['notificationFrequency']
+    notificationRecipients: IFlowErrorConfig['notificationRecipients']
     showSurvey: boolean
     attachments?: IFlowAttachmentsConfig[]
   }
@@ -35,6 +36,13 @@ const updateFlowConfig = async (
     newConfig.errorConfig = {
       ...newConfig.errorConfig, // If ever undefined (should never be), it gets set to an empty object first
       notificationFrequency: params.input.notificationFrequency,
+    }
+  }
+
+  if (params.input.notificationRecipients !== undefined) {
+    newConfig.errorConfig = {
+      ...newConfig.errorConfig, // If ever undefined (should never be), it gets set to an empty object first
+      notificationRecipients: params.input.notificationRecipients,
     }
   }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -433,7 +433,7 @@ type FlowConfig {
 
 type FlowErrorConfig {
   notificationFrequency: NotificationFrequency!
-  notificationRecipients: [NotificationRecipients]
+  notificationRecipients: [NotificationRecipients]!
 }
 
 type FlowTemplateConfig {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -433,6 +433,7 @@ type FlowConfig {
 
 type FlowErrorConfig {
   notificationFrequency: NotificationFrequency!
+  notificationRecipients: [NotificationRecipients]
 }
 
 type FlowTemplateConfig {
@@ -526,6 +527,11 @@ enum NotificationFrequency {
   always
 }
 
+enum NotificationRecipients {
+  editor
+  viewer
+}
+
 input FlowAttachmentsConfigInput {
   name: String!
   displayedValue: String!
@@ -537,6 +543,7 @@ input FlowAttachmentsConfigInput {
 input UpdateFlowConfigInput {
   id: String!
   notificationFrequency: NotificationFrequency
+  notificationRecipients: [NotificationRecipients]
   showSurvey: Boolean
   hasLoadedOnce: Boolean
   attachments: [FlowAttachmentsConfigInput]

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -74,10 +74,14 @@ export async function sendErrorEmail(flow: Flow) {
   const currDatetime = DateTime.now()
   const ccList: string[] = []
 
-  // check which collaborators to CC in the error email
-  if (flow.collaborators && flow.collaborators.length > 0) {
-    const notificationRecipients = flow.config?.errorConfig
-      ?.notificationRecipients ?? ['editor', 'viewer']
+  // default to notify owner only if no collaborators are specified
+  const notificationRecipients =
+    flow.config?.errorConfig?.notificationRecipients ?? []
+  if (
+    notificationRecipients.length > 0 &&
+    flow.collaborators &&
+    flow.collaborators.length > 0
+  ) {
     const collaboratorsToCC = flow.collaborators
       .filter((collaborator) =>
         notificationRecipients.includes(

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -1,3 +1,5 @@
+import { NotificationRecipients } from '@plumber/types'
+
 import { DateTime } from 'luxon'
 
 import appConfig from '@/config/app'
@@ -70,6 +72,21 @@ export async function sendErrorEmail(flow: Flow) {
   const userEmail = flow.user.email
   const errorKey = `error-alert:${flowId}`
   const currDatetime = DateTime.now()
+  const ccList: string[] = []
+
+  // check which collaborators to CC in the error email
+  if (flow.collaborators && flow.collaborators.length > 0) {
+    const notificationRecipients = flow.config?.errorConfig
+      ?.notificationRecipients ?? ['editor', 'viewer']
+    const collaboratorsToCC = flow.collaborators
+      .filter((collaborator) =>
+        notificationRecipients.includes(
+          collaborator.role as NotificationRecipients,
+        ),
+      )
+      .map((collaborator) => collaborator.user.email)
+    ccList.push(...collaboratorsToCC)
+  }
 
   const errorDetails = {
     flowId,
@@ -83,6 +100,7 @@ export async function sendErrorEmail(flow: Flow) {
     body: createBodyErrorMessage(truncatedFlowName, flowId),
     recipient: userEmail,
     replyTo: 'support@plumber.gov.sg',
+    ...(ccList.length > 0 && { cc: ccList }),
   })
 
   await redisClient

--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -10,6 +10,7 @@ export interface PostmanEmailRequestBody {
   body: string
   recipient: string
   replyTo?: string
+  cc?: string[]
 }
 
 export async function sendEmail({
@@ -17,6 +18,7 @@ export async function sendEmail({
   body,
   recipient,
   replyTo,
+  cc,
 }: PostmanEmailRequestBody): Promise<void> {
   try {
     await axios.post(
@@ -28,6 +30,7 @@ export async function sendEmail({
         from: `Plumber <${appConfig.postman.fromAddress}>`,
         ...(replyTo && { reply_to: replyTo }),
         disable_tracking: true,
+        ...(cc && { cc }),
       },
       {
         headers: {

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -66,6 +66,13 @@ class Flow extends Base {
               notificationFrequency: {
                 type: 'string',
               },
+              notificationRecipients: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['editor', 'viewer'],
+                },
+              },
             },
           },
         },

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -271,7 +271,12 @@ export function makeActionWorker(
 
       const flow = await Flow.query()
         .findById(job.data.flowId)
-        .withGraphFetched('user')
+        .withGraphFetched({
+          user: true,
+          collaborators: {
+            user: true,
+          },
+        })
         .throwIfNotFound()
 
       const shouldAlwaysSendEmail =

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -16,6 +16,11 @@ enum Frequency {
   Always = 'always',
 }
 
+enum Recipient {
+  Editor = 'editor',
+  Viewer = 'viewer',
+}
+
 const frequencyOptions = [
   {
     label: 'First error on this pipe, one email notification per day',
@@ -26,6 +31,19 @@ const frequencyOptions = [
     value: Frequency.Always,
   },
 ]
+
+const recipientOptions = [
+  {
+    label: 'editor(s)',
+    value: 'editor',
+  },
+  {
+    label: 'viewer(s)',
+    value: 'viewer',
+  },
+]
+
+const DEFAULT_RECIPIENTS: NotificationRecipients[] = []
 
 const DEFAULT_FREQUENCY = Frequency.Once
 
@@ -70,16 +88,13 @@ function NotificationFormFields() {
           <Text textStyle="body-1">
             Collaborators will be CC-ed by default.
           </Text>
-          <FormControl key="editors">
-            <Checkbox {...register('notifyEditors')} isDisabled={isReadOnly}>
-              Notify editor(s)
-            </Checkbox>
-          </FormControl>
-          <FormControl key="viewers">
-            <Checkbox {...register('notifyViewers')} isDisabled={isReadOnly}>
-              Notify viewer(s)
-            </Checkbox>
-          </FormControl>
+          {recipientOptions.map((recipient) => (
+            <FormControl key={recipient.value}>
+              <Checkbox {...register(recipient.value)} isDisabled={isReadOnly}>
+                Notify {recipient.label}
+              </Checkbox>
+            </FormControl>
+          ))}
         </Stack>
       )}
       <Button
@@ -87,6 +102,7 @@ function NotificationFormFields() {
         w="fit-content"
         type="submit"
         isDisabled={!isDirty || isReadOnly}
+        alignSelf="flex-end"
       >
         {isDirty ? 'Save' : 'Saved'}
       </Button>
@@ -100,7 +116,7 @@ export default function Notifications() {
   const frequency =
     flow?.config?.errorConfig?.notificationFrequency ?? DEFAULT_FREQUENCY
   const notificationRecipients =
-    flow?.config?.errorConfig?.notificationRecipients ?? []
+    flow?.config?.errorConfig?.notificationRecipients ?? DEFAULT_RECIPIENTS
 
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const toast = useToast()
@@ -111,8 +127,8 @@ export default function Notifications() {
 
   const defaultValues = {
     frequency,
-    notifyEditors: notifyEveryone || notificationRecipients.includes('editor'),
-    notifyViewers: notifyEveryone || notificationRecipients.includes('viewer'),
+    editor: notifyEveryone || notificationRecipients.includes(Recipient.Editor),
+    viewer: notifyEveryone || notificationRecipients.includes(Recipient.Viewer),
   }
 
   const onFlowConfigUpdate = useCallback(
@@ -120,14 +136,16 @@ export default function Notifications() {
       frequency: Frequency,
       newNotificationRecipients: NotificationRecipients[],
     ) => {
+      const notificationRecipients =
+        newNotificationRecipients.length > 0
+          ? { notificationRecipients: newNotificationRecipients }
+          : undefined
       await updateFlowConfig({
         variables: {
           input: {
             id: flow.id,
             notificationFrequency: frequency,
-            ...(newNotificationRecipients.length > 0
-              ? { notificationRecipients: newNotificationRecipients }
-              : {}),
+            ...(notificationRecipients ? notificationRecipients : {}),
           },
         },
         optimisticResponse: {
@@ -137,9 +155,7 @@ export default function Notifications() {
             config: {
               errorConfig: {
                 notificationFrequency: frequency,
-                ...(newNotificationRecipients.length > 0
-                  ? { notificationRecipients: newNotificationRecipients }
-                  : {}),
+                ...(notificationRecipients ? notificationRecipients : {}),
               },
             },
           },
@@ -179,11 +195,11 @@ export default function Notifications() {
           defaultValues={defaultValues}
           onSubmit={(data: any) => {
             const newNotificationRecipients =
-              data.notifyEditors && data.notifyViewers
-                ? [] // Both selected = notify everyone (default)
+              data.editor && data.viewer
+                ? DEFAULT_RECIPIENTS // Both selected = notify everyone (default)
                 : [
-                    ...(data.notifyEditors ? ['editor'] : []),
-                    ...(data.notifyViewers ? ['viewer'] : []),
+                    ...(data.editor ? [Recipient.Editor] : []),
+                    ...(data.viewer ? [Recipient.Viewer] : []),
                   ]
 
             onFlowConfigUpdate(

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -49,6 +49,7 @@ const DEFAULT_FREQUENCY = Frequency.Once
 
 function NotificationFormFields() {
   const { flow } = useContext(EditorSettingsContext)
+  // NOTE: check is for greater than 1 because collaborators includes the owner
   const hasCollaborators =
     flow?.collaborators?.length && flow?.collaborators?.length > 1
   const isReadOnly = flow?.role === 'viewer'
@@ -182,7 +183,7 @@ export default function Notifications() {
       <Stack>
         <Form
           defaultValues={defaultValues}
-          onSubmit={(data: any) => {
+          onSubmit={(data) => {
             const newNotificationRecipients = [
               ...(data.editor ? [Recipient.Editor] : []),
               ...(data.viewer ? [Recipient.Viewer] : []),

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -84,10 +84,7 @@ function NotificationFormFields() {
       </FormControl>
       {hasCollaborators && (
         <Stack gap={0}>
-          <Text textStyle="subhead-1">Notify collaborators</Text>
-          <Text textStyle="body-1">
-            Collaborators will be CC-ed by default.
-          </Text>
+          <Text textStyle="subhead-1">Collaborators</Text>
           {recipientOptions.map((recipient) => (
             <FormControl key={recipient.value}>
               <Checkbox {...register(recipient.value)} isDisabled={isReadOnly}>
@@ -121,31 +118,23 @@ export default function Notifications() {
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const toast = useToast()
 
-  // Empty array or no recipients = notify everyone (both checked)
-  const notifyEveryone =
-    !notificationRecipients || notificationRecipients.length === 0
-
   const defaultValues = {
     frequency,
-    editor: notifyEveryone || notificationRecipients.includes(Recipient.Editor),
-    viewer: notifyEveryone || notificationRecipients.includes(Recipient.Viewer),
+    editor: notificationRecipients.includes(Recipient.Editor),
+    viewer: notificationRecipients.includes(Recipient.Viewer),
   }
 
   const onFlowConfigUpdate = useCallback(
     async (
       frequency: Frequency,
-      newNotificationRecipients: NotificationRecipients[],
+      notificationRecipients: NotificationRecipients[],
     ) => {
-      const notificationRecipients =
-        newNotificationRecipients.length > 0
-          ? { notificationRecipients: newNotificationRecipients }
-          : undefined
       await updateFlowConfig({
         variables: {
           input: {
             id: flow.id,
             notificationFrequency: frequency,
-            ...(notificationRecipients ? notificationRecipients : {}),
+            notificationRecipients,
           },
         },
         optimisticResponse: {
@@ -155,7 +144,7 @@ export default function Notifications() {
             config: {
               errorConfig: {
                 notificationFrequency: frequency,
-                ...(notificationRecipients ? notificationRecipients : {}),
+                notificationRecipients,
               },
             },
           },
@@ -194,17 +183,14 @@ export default function Notifications() {
         <Form
           defaultValues={defaultValues}
           onSubmit={(data: any) => {
-            const newNotificationRecipients =
-              data.editor && data.viewer
-                ? DEFAULT_RECIPIENTS // Both selected = notify everyone (default)
-                : [
-                    ...(data.editor ? [Recipient.Editor] : []),
-                    ...(data.viewer ? [Recipient.Viewer] : []),
-                  ]
+            const newNotificationRecipients = [
+              ...(data.editor ? [Recipient.Editor] : []),
+              ...(data.viewer ? [Recipient.Viewer] : []),
+            ]
 
             onFlowConfigUpdate(
               data.frequency as Frequency,
-              newNotificationRecipients as NotificationRecipients[],
+              newNotificationRecipients,
             )
           }}
         >

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -1,8 +1,13 @@
-import { useCallback, useContext, useMemo, useState } from 'react'
-import { useMutation } from '@apollo/client'
-import { Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
-import { Menu, useToast } from '@opengovsg/design-system-react'
+import { NotificationRecipients } from '@plumber/types'
 
+import { useCallback, useContext } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { useMutation } from '@apollo/client'
+import { Flex, FormControl, Skeleton, Stack, Text } from '@chakra-ui/react'
+import { Button, Checkbox, useToast } from '@opengovsg/design-system-react'
+
+import Form from '@/components/Form'
+import { SingleSelect } from '@/components/SingleSelect'
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { UPDATE_FLOW_CONFIG } from '@/graphql/mutations/update-flow-config'
 
@@ -24,22 +29,105 @@ const frequencyOptions = [
 
 const DEFAULT_FREQUENCY = Frequency.Once
 
+function NotificationFormFields() {
+  const { flow } = useContext(EditorSettingsContext)
+  const hasCollaborators =
+    flow?.collaborators?.length && flow?.collaborators?.length > 1
+  const isReadOnly = flow?.role === 'viewer'
+
+  const {
+    control,
+    register,
+    formState: { isDirty },
+  } = useFormContext()
+
+  return (
+    <Stack gap={2}>
+      <Text textStyle="subhead-1">Frequency</Text>
+      <FormControl key="frequency">
+        <Skeleton isLoaded={!!flow}>
+          <Controller
+            name="frequency"
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <SingleSelect
+                items={frequencyOptions}
+                isSearchable={false}
+                onChange={onChange}
+                value={value}
+                name={name}
+                isClearable={false}
+                colorScheme="secondary"
+                isDisabled={isReadOnly}
+              />
+            )}
+          />
+        </Skeleton>
+      </FormControl>
+      {hasCollaborators && (
+        <Stack gap={0}>
+          <Text textStyle="subhead-1">Notify collaborators</Text>
+          <Text textStyle="body-1">
+            Collaborators will be CC-ed by default.
+          </Text>
+          <FormControl key="editors">
+            <Checkbox {...register('notifyEditors')} isDisabled={isReadOnly}>
+              Notify editor(s)
+            </Checkbox>
+          </FormControl>
+          <FormControl key="viewers">
+            <Checkbox {...register('notifyViewers')} isDisabled={isReadOnly}>
+              Notify viewer(s)
+            </Checkbox>
+          </FormControl>
+        </Stack>
+      )}
+      <Button
+        size="sm"
+        w="fit-content"
+        type="submit"
+        isDisabled={!isDirty || isReadOnly}
+      >
+        {isDirty ? 'Save' : 'Saved'}
+      </Button>
+    </Stack>
+  )
+}
+
 export default function Notifications() {
   const { flow } = useContext(EditorSettingsContext)
 
   const frequency =
     flow?.config?.errorConfig?.notificationFrequency ?? DEFAULT_FREQUENCY
+  const notificationRecipients =
+    flow?.config?.errorConfig?.notificationRecipients ?? []
+
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const toast = useToast()
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+
+  // Empty array or no recipients = notify everyone (both checked)
+  const notifyEveryone =
+    !notificationRecipients || notificationRecipients.length === 0
+
+  const defaultValues = {
+    frequency,
+    notifyEditors: notifyEveryone || notificationRecipients.includes('editor'),
+    notifyViewers: notifyEveryone || notificationRecipients.includes('viewer'),
+  }
 
   const onFlowConfigUpdate = useCallback(
-    async (frequency: Frequency) => {
+    async (
+      frequency: Frequency,
+      newNotificationRecipients: NotificationRecipients[],
+    ) => {
       await updateFlowConfig({
         variables: {
           input: {
             id: flow.id,
             notificationFrequency: frequency,
+            ...(newNotificationRecipients.length > 0
+              ? { notificationRecipients: newNotificationRecipients }
+              : {}),
           },
         },
         optimisticResponse: {
@@ -49,18 +137,17 @@ export default function Notifications() {
             config: {
               errorConfig: {
                 notificationFrequency: frequency,
+                ...(newNotificationRecipients.length > 0
+                  ? { notificationRecipients: newNotificationRecipients }
+                  : {}),
               },
             },
           },
         },
       })
 
-      const displayLabel = frequencyOptions
-        .find((option) => option.value === frequency)
-        ?.label.toLowerCase()
-
       toast({
-        title: `You will now receive an email notification for ${displayLabel}`,
+        title: `Notifications settings saved!`,
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -68,21 +155,6 @@ export default function Notifications() {
       })
     },
     [flow.id, updateFlowConfig, toast],
-  )
-
-  const handleClick = useCallback(
-    (frequencyOption: Frequency) => {
-      // only update flow config if a different option is selected
-      if (frequencyOption !== frequency) {
-        onFlowConfigUpdate(frequencyOption)
-      }
-    },
-    [onFlowConfigUpdate, frequency],
-  )
-
-  const frequencyLabel = useMemo(
-    () => frequencyOptions.find((option) => option.value === frequency)?.label,
-    [frequency],
   )
 
   return (
@@ -103,42 +175,25 @@ export default function Notifications() {
         </Text>
       </Stack>
       <Stack>
-        <Text textStyle="subhead-1">Frequency</Text>
-        <Menu isStretch>
-          <Menu.Button variant="outline" colorScheme="secondary">
-            <Skeleton isLoaded={!!flow}>
-              <Text
-                textStyle="body-1"
-                color="base.content.default"
-                whiteSpace="nowrap"
-                overflow="hidden"
-                textOverflow="ellipsis"
-              >
-                {frequencyLabel}
-              </Text>
-            </Skeleton>
-          </Menu.Button>
-          <Menu.List>
-            {frequencyOptions.map((option, index) => (
-              <Menu.Item
-                key={index}
-                onClick={() => handleClick(option.value)}
-                onMouseEnter={() => setHoveredIndex(index)}
-                onMouseLeave={() => setHoveredIndex(null)}
-                sx={{
-                  bg:
-                    hoveredIndex === index ||
-                    (hoveredIndex === null && option.label === frequencyLabel)
-                      ? 'interaction.tinted.main.hover'
-                      : 'transparent',
-                  color: 'base.content.default',
-                }}
-              >
-                {option.label}
-              </Menu.Item>
-            ))}
-          </Menu.List>
-        </Menu>
+        <Form
+          defaultValues={defaultValues}
+          onSubmit={(data: any) => {
+            const newNotificationRecipients =
+              data.notifyEditors && data.notifyViewers
+                ? [] // Both selected = notify everyone (default)
+                : [
+                    ...(data.notifyEditors ? ['editor'] : []),
+                    ...(data.notifyViewers ? ['viewer'] : []),
+                  ]
+
+            onFlowConfigUpdate(
+              data.frequency as Frequency,
+              newNotificationRecipients as NotificationRecipients[],
+            )
+          }}
+        >
+          <NotificationFormFields />
+        </Form>
       </Stack>
     </Flex>
   )

--- a/packages/frontend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/frontend/src/graphql/mutations/duplicate-flow.ts
@@ -9,6 +9,7 @@ export const DUPLICATE_FLOW = gql`
       config {
         errorConfig {
           notificationFrequency
+          notificationRecipients
         }
         duplicateCount
       }

--- a/packages/frontend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/frontend/src/graphql/mutations/duplicate-flow.ts
@@ -9,7 +9,6 @@ export const DUPLICATE_FLOW = gql`
       config {
         errorConfig {
           notificationFrequency
-          notificationRecipients
         }
         duplicateCount
       }

--- a/packages/frontend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/frontend/src/graphql/mutations/update-flow-config.ts
@@ -7,6 +7,7 @@ export const UPDATE_FLOW_CONFIG = gql`
       config {
         errorConfig {
           notificationFrequency
+          notificationRecipients
         }
       }
     }

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -36,6 +36,7 @@ export const FLOW_FIELDS = gql`
     config {
       errorConfig {
         notificationFrequency
+        notificationRecipients
       }
       templateConfig {
         templateId

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -211,8 +211,10 @@ export interface IFlowConfig {
   attachments?: IFlowAttachmentsConfig[]
 }
 
+export type NotificationRecipients = 'editor' | 'viewer'
 export interface IFlowErrorConfig {
   notificationFrequency: 'once_per_day' | 'always'
+  notificationRecipients: NotificationRecipients[]
 }
 
 export interface IFlowTemplateConfig {


### PR DESCRIPTION
## TL;DR
This PR adds the ability to send error notification emails to collaborators based on their role (editor or viewer). 

Owners and Editors of Pipes that have been shared can configure whether to send Editor(s) and/or Viewer(s) email notifications when the Pipe encounters an error.

## Other changes
* Added a "Save" button to the notifications settings so that the flow config is only updated once the frequency and collaborators to notify have been selected

## How to test?
Share a Pipe with Editor(s) and Viewer(s), trigger an error in your Pipe
- [ ] Owner should always receive email
- [ ] Editor should be cc-ed in email if "Notify editor(s)" is checked
- [ ] Viewer should be cc-ed in email if "Notify viewer(s)" is checked

Frequency setting should still be respected
- [ ] Should receive email for every error if frequency is set to always
- [ ] Should only receive email for the first error if frequency is set to once per day