### PR TITLE
[OG-4]: Get case fields based on uuid for update case

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -23,7 +23,7 @@ const action: IRawAction = {
       label: 'Case type',
       key: 'caseType',
       type: 'dropdown' as const,
-      description: 'Enter the type of the case you want to create',
+      description: 'Select the type of the case you want to create',
       required: true,
       variables: false,
       showOptionValue: false,

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -17,24 +17,10 @@ const action: IRawAction = {
   description: 'Update a case based on the case uuid',
   arguments: [
     {
-      label: 'Case type',
-      key: 'caseType',
-      type: 'dropdown' as const,
-      description: 'Select the type of case you want to update',
-      required: false,
-      variables: false,
-      showOptionValue: false,
-      source: {
-        type: 'query' as const,
-        name: 'getDynamicData' as const,
-        arguments: [{ name: 'key', value: 'getCaseTypes' }],
-      },
-    },
-    {
       label: 'Case UUID',
       key: 'caseUuid',
       type: 'string' as const,
-      description: 'Enter the case uuid you want to update',
+      description: 'Select the case uuid you want to update.',
       required: true,
       variables: true,
       // we intentionally disable typing for case uuid as it is used in
@@ -46,7 +32,7 @@ const action: IRawAction = {
       label: 'Case status',
       key: 'caseStatus',
       type: 'dropdown' as const,
-      description: 'Enter the status you want to update the case to.',
+      description: 'Select the status you want to update the case to.',
       required: false,
       variables: false,
       showOptionValue: false,
@@ -82,8 +68,8 @@ const action: IRawAction = {
                 value: 'getCaseFields',
               },
               {
-                name: 'parameters.caseType',
-                value: '{parameters.caseType}',
+                name: 'parameters.caseUuid',
+                value: '{parameters.caseUuid}',
               },
             ],
           },

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -17,15 +17,31 @@ const action: IRawAction = {
   description: 'Update a case based on the case uuid',
   arguments: [
     {
+      label: 'Case type',
+      key: 'caseType',
+      type: 'dropdown' as const,
+      description: 'Select the type of case you want to update',
+      required: false,
+      variables: false,
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [{ name: 'key', value: 'getCaseTypes' }],
+      },
+    },
+    {
       label: 'Case UUID',
       key: 'caseUuid',
       type: 'string' as const,
       description: 'Enter the case uuid you want to update',
       required: true,
       variables: true,
+      // we intentionally disable typing for case uuid as it is used in
+      // to get dynamic data for case fields
+      // it can still be pasted via mouse click
       singleVariableSelection: true,
     },
-    // TODO: see if it is possible to get all possible statuses from the API
     {
       label: 'Case status',
       key: 'caseStatus',
@@ -64,6 +80,10 @@ const action: IRawAction = {
               {
                 name: 'key',
                 value: 'getCaseFields',
+              },
+              {
+                name: 'parameters.caseType',
+                value: '{parameters.caseType}',
               },
             ],
           },

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -5,9 +5,54 @@ import {
 } from '@plumber/types'
 
 import HttpError from '@/errors/http'
+import { computeForEachParameters } from '@/helpers/compute-for-each-parameters'
+import computeParameters, { variableRegExp } from '@/helpers/compute-parameters'
+import { getTestExecutionSteps } from '@/helpers/get-test-execution-steps'
 
 import { fetchCaseFields, GatherSGCaseField } from '../common/fetch-case-fields'
 import { GatherSGCase, GatherSGError } from '../common/types'
+
+const getCaseUuidFromVariable = async (
+  $: IGlobalVariable,
+  variable: string,
+) => {
+  let computedCaseUuid
+  const testExecutionSteps = await getTestExecutionSteps($.flow.id)
+
+  if (/items.columns/.test(variable)) {
+    // if variable from for each, then we compute slightly differently
+    const stepIdAndKeyPath = variable.replace(/{{step.|}}/g, '') as string
+    const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
+
+    const executionStep = testExecutionSteps.find((executionStep) => {
+      return executionStep.stepId === stepId
+    })
+
+    computedCaseUuid = computeForEachParameters({
+      data: executionStep?.dataOut,
+      keyPath: keyPaths.join('.'),
+      executionSteps: testExecutionSteps,
+      executionStep,
+      stepId,
+      forEachContext: {
+        executionStepMetadata: testExecutionSteps[0].metadata,
+        forEachStepPosition: 0,
+        isForEachStep: true,
+        stepPositions: {
+          [stepId]: 0,
+        },
+      },
+    })
+  } else {
+    const { caseUuid } = computeParameters(
+      { caseUuid: variable },
+      testExecutionSteps,
+    )
+    computedCaseUuid = caseUuid
+  }
+
+  return computedCaseUuid ?? '`'
+}
 
 const processCaseFields = (caseFields: GatherSGCaseField[]) => {
   return {
@@ -25,7 +70,7 @@ const dynamicData: IDynamicData = {
   name: 'Get Case Fields',
   async run($: IGlobalVariable): Promise<DynamicDataOutput> {
     try {
-      const { caseType: caseTypeUuid } = $.step.parameters
+      const { caseType: caseTypeUuid, caseUuid } = $.step.parameters
 
       if (caseTypeUuid) {
         // Fetch case fields using the determined case type UUID
@@ -35,6 +80,29 @@ const dynamicData: IDynamicData = {
         })
 
         return processCaseFields(filteredFields)
+      } else if (caseUuid) {
+        if (typeof caseUuid === 'string' && caseUuid.match(variableRegExp)) {
+          // if the case uuid is a variable, we need to compute the value
+          const computedCaseUuid = await getCaseUuidFromVariable($, caseUuid)
+
+          // use the case uuid to fetch the case data to derive the case type uuid
+          const { data: caseData } = await $.http.get<{ data: GatherSGCase }>(
+            `/cases/:caseUuid`,
+            {
+              urlPathParams: { caseUuid: computedCaseUuid as string },
+            },
+          )
+
+          const { filteredFields } = await fetchCaseFields({
+            $,
+            caseTypeUuid: caseData.data.type.uuid,
+          })
+          return processCaseFields(filteredFields)
+        }
+
+        return {
+          data: [],
+        }
       }
 
       // BACKWARD COMPATIBILITY: this gets the case fields from the latest case in gathersg

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -5,8 +5,9 @@ import {
 } from '@plumber/types'
 
 import HttpError from '@/errors/http'
+import { VARIABLE_REGEX } from '@/helpers/check-step-parameters'
 import { computeForEachParameters } from '@/helpers/compute-for-each-parameters'
-import computeParameters, { variableRegExp } from '@/helpers/compute-parameters'
+import computeParameters from '@/helpers/compute-parameters'
 import { getTestExecutionSteps } from '@/helpers/get-test-execution-steps'
 
 import { fetchCaseFields, GatherSGCaseField } from '../common/fetch-case-fields'
@@ -16,7 +17,6 @@ const getCaseUuidFromVariable = async (
   $: IGlobalVariable,
   variable: string,
 ) => {
-  let computedCaseUuid
   const testExecutionSteps = await getTestExecutionSteps($.flow.id)
 
   if (/items.columns/.test(variable)) {
@@ -28,7 +28,11 @@ const getCaseUuidFromVariable = async (
       return executionStep.stepId === stepId
     })
 
-    computedCaseUuid = computeForEachParameters({
+    if (!executionStep) {
+      return ''
+    }
+
+    return computeForEachParameters({
       data: executionStep?.dataOut,
       keyPath: keyPaths.join('.'),
       executionSteps: testExecutionSteps,
@@ -48,10 +52,8 @@ const getCaseUuidFromVariable = async (
       { caseUuid: variable },
       testExecutionSteps,
     )
-    computedCaseUuid = caseUuid
+    return caseUuid
   }
-
-  return computedCaseUuid ?? '`'
 }
 
 const processCaseFields = (caseFields: GatherSGCaseField[]) => {
@@ -81,7 +83,10 @@ const dynamicData: IDynamicData = {
 
         return processCaseFields(filteredFields)
       } else if (caseUuid) {
-        if (typeof caseUuid === 'string' && caseUuid.match(variableRegExp)) {
+        if (
+          typeof caseUuid === 'string' &&
+          caseUuid.match(`^${VARIABLE_REGEX.source}$`)
+        ) {
           // if the case uuid is a variable, we need to compute the value
           const computedCaseUuid = await getCaseUuidFromVariable($, caseUuid)
 

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -6,25 +6,18 @@ import {
 
 import HttpError from '@/errors/http'
 
-import { fetchCaseFields } from '../common/fetch-case-fields'
-import { GatherSGError } from '../common/types'
+import { fetchCaseFields, GatherSGCaseField } from '../common/fetch-case-fields'
+import { GatherSGCase, GatherSGError } from '../common/types'
 
-/**
- * Subset of result
- */
-interface GatherSGCase {
-  uuid: string
-  createdAt: string
-  updatedAt: string
-  status: {
-    uuid: string
-    name: string
-    color: string
-    isFinal: boolean
+const processCaseFields = (caseFields: GatherSGCaseField[]) => {
+  return {
+    data: caseFields.map((field) => {
+      return {
+        name: field.name,
+        value: field.name,
+      }
+    }),
   }
-  caseRef: string
-  fields: Record<string, string | string[] | null | number>
-  tags: string[]
 }
 
 const dynamicData: IDynamicData = {
@@ -35,24 +28,16 @@ const dynamicData: IDynamicData = {
       const { caseType: caseTypeUuid } = $.step.parameters
 
       if (caseTypeUuid) {
+        // Fetch case fields using the determined case type UUID
         const { filteredFields } = await fetchCaseFields({
           $,
           caseTypeUuid: caseTypeUuid as string,
         })
 
-        return {
-          data: filteredFields.map((field) => {
-            return {
-              name: field.name,
-              value: field.name,
-            }
-          }),
-        }
+        return processCaseFields(filteredFields)
       }
 
-      // TODO (kevinkim-ogp): this needs to be updated to use the caseUuid to fetch the fields
-      // of that specific case using /cases/{caseUuid}
-      // need to figure out how to do this with both string and computed parameters if the UUID is a variable
+      // BACKWARD COMPATIBILITY: this gets the case fields from the latest case in gathersg
       const { data: searchResult } = await $.http.post<{
         traceId: string
         total: number

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -11,7 +11,7 @@ import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
-export const variableRegExp =
+const variableRegExp =
   /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
 
 function findAndSubstituteVariables(

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -11,7 +11,7 @@ import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
-const variableRegExp =
+export const variableRegExp =
   /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
 
 function findAndSubstituteVariables(


### PR DESCRIPTION
## TL;DR
Fetches the case fields based on the case UUID that is selected or input.
Works with pasted case UUID and variables.

## Why make this change?
Ensures that the fields are valid for the selected case.
* Previous implementation fetched the fields based on the last case that was created in OG, but OG can have multiple case types.
* Reduces errors for user than if they were to manually type in the field


## Tests
- [ ] Correct fields are fetched for different case UUIDs
- [ ] Update case fetches correct fields with case uuid variable
- [ ] Update case fetches correct fields with case uuid variable from for each
