### PR TITLE
fix: throw http 400 when multipart request is invalid

### DIFF
--- a/packages/backend/src/routes/webhooks.ts
+++ b/packages/backend/src/routes/webhooks.ts
@@ -15,7 +15,7 @@ import logger from '@/helpers/logger'
 const router = Router()
 const uploadNone = multer().none()
 
-router.use((req, res, next) => {
+router.use((req, res, _next) => {
   uploadNone(req, res, (err) => {
     // file upload is not supported
     // handle error to prevent http 500 error
@@ -32,7 +32,7 @@ router.use((req, res, next) => {
       res.status(415).send('Invalid request, file upload is not supported.')
       return
     }
-    next(err)
+    res.status(400).send('Invalid multipart data')
   })
 })
 


### PR DESCRIPTION
## Problem

Invalid multipart requests are causing 5xx errors.

![image.png](https://app.graphite.dev/user-attachments/assets/bc3ac1fe-7154-4628-aa2f-f8a55c11da08.png)

## Solution

Instead of next(err), return a 400 status instead.