### PR TITLE
fix: allow GatherSG instant workflow from new form submission

### DIFF
--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -19,10 +19,16 @@ const schema = z
         name: z.string().min(1).optional(),
       })
       .optional(),
+    formsg: z
+      .object({
+        formId: z.string().min(1),
+        submissionId: z.string().min(1),
+      })
+      .optional(),
   })
   .refine(
     (data) => {
-      const { updatedBy, createdBy } = data || {}
+      const { updatedBy, createdBy, formsg } = data || {}
 
       // if both updatedBy and createdBy exist, only check updatedBy.email
       if (updatedBy && createdBy) {
@@ -36,6 +42,17 @@ const schema = z
 
       // if only createdBy exists, check for createdBy.email
       if (createdBy) {
+        // when the createdBy.name is 'FormSG', there will not be a createdBy.email
+        // as the case is created by a FormSG submission.
+        if (
+          createdBy?.name === 'FormSG' &&
+          formsg?.formId &&
+          formsg?.submissionId
+        ) {
+          return true
+        }
+
+        // otherwise, check for createdBy.email
         return !!createdBy.email
       }
 

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -318,6 +318,7 @@ export default function FlowStepTestController(
                       isDisabled={!isDirty}
                       mr={2}
                       w="auto"
+                      data-test="flow-substep-save-without-checking-button"
                     >
                       {!isDirty ? 'Saved' : 'Save without checking'}
                     </Button>
@@ -367,6 +368,7 @@ export default function FlowStepTestController(
                   isLoading={isSaving}
                   variant="clear"
                   onClick={handleSave}
+                  data-test="flow-substep-save-button"
                 >
                   {isDirty ? 'Save' : 'Saved'}
                 </Button>


### PR DESCRIPTION
## Problem
FormSG submissions via GatherSG were being blocked as the payload does not contain `createdBy.email` when the case is created by a new form submission

## Solution
* Updated the schema to check if `createdBy.name === 'FormSG'`, then it should also check for `formSg.formId` and `formSg.submissionId` to be sure that it is a valid FormSG trigger.

## Other changes
* Updated buttons with `data-test` parmaters for e2e tests

## How to test?
Create a case on GatherSG that is based on a FormSG submission.
Create a Pipe with a GatherSG trigger.
Create an instant workflow that is based on case creation and calls the Plumber webhook
- [ ] Make a FormSG submission and should receive the FormSG submission successfully when checking step