### PR TITLE
[MRF-14] PLU-520: (frontend) conditionally hide steps based on approval branch

### DIFF
--- a/packages/frontend/src/components/Editor/components/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/components/AddStepButton.tsx
@@ -73,7 +73,11 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
       {isHidden || (isDisabled && !isLastStep) ? (
         !isLastStep && (
           // If in between add button is disabled, we hide it
-          <Divider orientation="vertical" borderColor="base.divider.strong" />
+          <Divider
+            h={12}
+            orientation="vertical"
+            borderColor="base.divider.strong"
+          />
         )
       ) : (
         <>

--- a/packages/frontend/src/components/Editor/components/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/components/AddStepButton.tsx
@@ -1,5 +1,6 @@
-import { IStep } from '@plumber/types'
+import { IStep, IStepApprovalBranch } from '@plumber/types'
 
+import { useMemo } from 'react'
 import { BiPlus } from 'react-icons/bi'
 import { Box, Divider, useDisclosure } from '@chakra-ui/react'
 import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
@@ -16,11 +17,38 @@ interface AddStepButtonProps {
   isLastStep: boolean
   showEmptyAction: boolean
   step: IStep
+  approvalBranch: IStepApprovalBranch
 }
 
 export function AddStepButton(props: AddStepButtonProps): JSX.Element {
-  const { isHidden, isLastStep, step, isDisabled, showEmptyAction } = props
+  const {
+    isHidden,
+    isLastStep,
+    step,
+    isDisabled,
+    showEmptyAction,
+    approvalBranch,
+  } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const { dividerColor, iconBgColor } = useMemo(() => {
+    if (approvalBranch === undefined) {
+      return {
+        dividerColor: 'base.divider.strong',
+        iconBgColor: undefined,
+      }
+    }
+    if (approvalBranch === 'approve') {
+      return {
+        dividerColor: 'green.500',
+        iconBgColor: 'green.50',
+      }
+    }
+    return {
+      dividerColor: 'red.500',
+      iconBgColor: 'red.50',
+    }
+  }, [approvalBranch])
 
   const {
     cancelRef,
@@ -39,7 +67,8 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
       flexDir="column"
       alignItems="center"
       alignSelf="stretch"
-      h={showEmptyAction ? undefined : isHidden ? 12 : 16}
+      h="auto"
+      w="100%"
     >
       {isHidden || (isDisabled && !isLastStep) ? (
         !isLastStep && (
@@ -65,7 +94,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
           )}
           {/* Top vertical line */}
           <Box h={6}>
-            <Divider orientation="vertical" borderColor="base.divider.strong" />
+            <Divider orientation="vertical" borderColor={dividerColor} />
           </Box>
           <TouchableTooltip
             label={isDisabled ? '' : 'Add step'}
@@ -81,6 +110,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
               variant={isLastStep ? 'outline' : 'clear'}
               size="xs"
               color="interaction.sub.default"
+              bg={iconBgColor}
               borderRadius="full"
               pointerEvents={isDisabled ? 'none' : 'auto'}
               _hover={{
@@ -89,17 +119,14 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
               _active={{
                 bg: 'interaction.muted.neutral.active',
               }}
-              borderColor={isLastStep ? 'interaction.sub.default' : undefined}
+              borderColor={isLastStep ? dividerColor : undefined}
               h={8}
             />
           </TouchableTooltip>
           {/* Bottom vertical line */}
           {!isLastStep && (
             <Box h={6}>
-              <Divider
-                orientation="vertical"
-                borderColor="base.divider.strong"
-              />
+              <Divider orientation="vertical" borderColor={dividerColor} />
             </Box>
           )}
 

--- a/packages/frontend/src/components/Editor/components/DisabledFlowStep.tsx
+++ b/packages/frontend/src/components/Editor/components/DisabledFlowStep.tsx
@@ -1,0 +1,54 @@
+import { IStep } from '@plumber/types'
+
+import { useContext } from 'react'
+import { Flex } from '@chakra-ui/react'
+import { TouchableTooltip } from '@opengovsg/design-system-react'
+
+import StepAppIcon from '@/components/FlowStep/components/StepAppIcon'
+import StepCaptionAndDemo from '@/components/FlowStep/components/StepCaptionAndDemo'
+import { flowStepStyles } from '@/components/FlowStep/styles'
+import { EditorContext } from '@/contexts/Editor'
+import { getFlowStepHeaderWidth } from '@/helpers/editor'
+import { useStepMetadata } from '@/hooks/useStepMetadata'
+
+interface DisabledFlowStepProps {
+  step: IStep
+  tooltipText: string
+}
+
+export function DisabledFlowStep(props: DisabledFlowStepProps) {
+  const { step, tooltipText } = props
+
+  const { isMobile, isDrawerOpen } = useContext(EditorContext)
+
+  const { app, caption } = useStepMetadata(step)
+  const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, false)
+
+  return (
+    <Flex
+      flexDir="row"
+      alignItems="center"
+      width="100%"
+      display={isMobile ? 'block' : 'flex'}
+      my={4}
+    >
+      <TouchableTooltip label={tooltipText} wrapperStyles={{ width: '100%' }}>
+        <Flex
+          data-test="flow-step"
+          {...flowStepStyles.container}
+          h="64px"
+          w={headerWidth}
+        >
+          <Flex
+            {...flowStepStyles.topHeader}
+            opacity={0.4}
+            pointerEvents="none"
+          >
+            <StepAppIcon app={app} step={step} />
+            <StepCaptionAndDemo app={app} caption={caption} />
+          </Flex>
+        </Flex>
+      </TouchableTooltip>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -1,11 +1,15 @@
 import { IStep } from '@plumber/types'
 
+import { useContext } from 'react'
+
+import { MrfContext } from '@/contexts/MrfContext'
 import { FlowStep } from '@/exports/components'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import { ApproveReject } from '../../FlowStep/components/ApproveReject'
 
 import { AddStepButton } from './AddStepButton'
+import { DisabledFlowStep } from './DisabledFlowStep'
 
 export default function FlowStepWithAddButton({
   step,
@@ -30,7 +34,11 @@ export default function FlowStepWithAddButton({
     showEmptyAction: boolean
   }
 }) {
-  const { isApprovalStep } = useStepMetadata(step)
+  const { approvalBranches, disabledMrfStepToDisplay } = useContext(MrfContext)
+  const { isApprovalStep, approvalBranch } = useStepMetadata(step)
+  const approvalBranchForAddStep = approvalBranch ?? approvalBranches[step.id]
+
+  const shouldShowDisabledMrfStep = isLastStep && disabledMrfStepToDisplay
 
   return (
     <>
@@ -48,7 +56,16 @@ export default function FlowStepWithAddButton({
         isHidden={isHidden}
         isDisabled={isDisabled}
         showEmptyAction={showEmptyAction}
+        approvalBranch={approvalBranchForAddStep}
       />
+      {shouldShowDisabledMrfStep && (
+        <DisabledFlowStep
+          step={disabledMrfStepToDisplay}
+          tooltipText={
+            'This step will only happen if the previous MRF step is approved'
+          }
+        />
+      )}
     </>
   )
 }

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext } from 'react'
 import { Flex, Tab, TabList, TabProps, Tabs } from '@chakra-ui/react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 
 const tabStyle = (primaryColor: string): TabProps => {
@@ -24,6 +25,7 @@ const tabStyle = (primaryColor: string): TabProps => {
 }
 
 export function ApproveReject({ stepId }: { stepId: string }) {
+  const { setCurrentStepId, onDrawerClose } = useContext(EditorContext)
   const { approvalBranches, setApprovalBranch } = useContext(MrfContext)
 
   const isApproveBranch = approvalBranches[stepId] === 'approve'
@@ -31,8 +33,10 @@ export function ApproveReject({ stepId }: { stepId: string }) {
   const onChange = useCallback(
     (index: number) => {
       setApprovalBranch(stepId, index === 0 ? 'approve' : 'reject')
+      setCurrentStepId(null)
+      onDrawerClose()
     },
-    [stepId, setApprovalBranch],
+    [stepId, setApprovalBranch, setCurrentStepId, onDrawerClose],
   )
 
   return (

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -77,7 +77,6 @@ export default function FlowStep(
     substeps,
     shouldShowDragHandle,
     isDeletable,
-    approvalBranch,
   } = useStepMetadata(step, allowReorder)
 
   const {
@@ -233,9 +232,6 @@ export default function FlowStep(
               borderTopRadius={hasInfoBox ? 'none' : 'lg'}
               h={isNested ? '48px' : '64px'}
               w={headerWidth}
-              // approval branch can be approve, reject or undefined
-              // boxShadow specified in theme/foundations/shadows.ts
-              boxShadow={isNested ? 'none' : approvalBranch ?? undefined}
             >
               <Flex {...flowStepStyles.topHeader} onClick={handleClick}>
                 <StepAppIcon

--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -9,7 +9,6 @@ import { NESTED_DRAG_HANDLE_WIDTH } from '@/components/SortableList/components/S
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth, getToolboxIcon } from '@/helpers/editor'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
-import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import { MIN_FLOW_STEP_WIDTH } from '../Editor/constants'
 
@@ -28,7 +27,6 @@ interface FlowStepGroupProps {
 export default function FlowStepGroup(props: FlowStepGroupProps) {
   const { groupedSteps, stepsBeforeGroup } = props
   const { isDrawerOpen, isMobile, onDrawerClose } = useContext(EditorContext)
-  const { approvalBranch } = useStepMetadata(groupedSteps[0]?.[0])
 
   const { stepGroupType, stepGroupCaption } = useMemo(() => {
     let stepGroupType: string | null = null
@@ -87,10 +85,6 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
         display={isMobile ? 'block' : 'flex'}
         w={getFlowStepHeaderWidth(isDrawerOpen, isMobile)}
         minW={MIN_FLOW_STEP_WIDTH}
-        // approval branch can be approve, reject or undefined
-        // boxShadow specified in theme/foundations/shadows.ts
-        // we display for entire group instead of individual nested steps
-        boxShadow={approvalBranch ?? undefined}
       >
         <Box {...flowStepGroupStyles.header} w="100%">
           <Flex

--- a/packages/frontend/src/contexts/MrfContext.tsx
+++ b/packages/frontend/src/contexts/MrfContext.tsx
@@ -14,6 +14,7 @@ interface MrfContextReturnValue {
     [stepId: string]: IStepApprovalBranch
   }
   setApprovalBranch: (stepId: string, branch: IStepApprovalBranch) => void
+  disabledMrfStepToDisplay: IStep | null
 }
 
 export const MrfContext = createContext<MrfContextReturnValue>({
@@ -21,6 +22,7 @@ export const MrfContext = createContext<MrfContextReturnValue>({
   mrfApprovalSteps: [],
   approvalBranches: {},
   setApprovalBranch: () => null,
+  disabledMrfStepToDisplay: null,
 })
 
 interface MrfContextProviderProps {
@@ -29,6 +31,9 @@ interface MrfContextProviderProps {
 
 export const MrfContextProvider = ({ children }: MrfContextProviderProps) => {
   const { flow } = useContext(EditorContext)
+
+  const [disabledMrfStepToDisplay, setDisabledMrfStepToDisplay] =
+    useState<IStep | null>(null)
 
   const mrfSteps = flow.steps.filter(
     (step) => step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY,
@@ -52,6 +57,13 @@ export const MrfContextProvider = ({ children }: MrfContextProviderProps) => {
       ...prev,
       [stepId]: branch,
     }))
+    if (branch === 'reject') {
+      const nextMrfStepId =
+        mrfSteps[mrfSteps.findIndex((mrfStep) => mrfStep.id === stepId) + 1]
+      setDisabledMrfStepToDisplay(nextMrfStepId ?? null)
+    } else {
+      setDisabledMrfStepToDisplay(null)
+    }
   }
 
   return (
@@ -61,6 +73,7 @@ export const MrfContextProvider = ({ children }: MrfContextProviderProps) => {
         mrfApprovalSteps,
         approvalBranches,
         setApprovalBranch,
+        disabledMrfStepToDisplay,
       }}
     >
       {children}

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -6,6 +6,7 @@ import { createContext, useContext, useMemo } from 'react'
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
 import { EditorContext } from './Editor'
+import { MrfContext } from './MrfContext'
 
 export type StepToDisplayContextValue = {
   triggerStep: IStep | null
@@ -31,8 +32,38 @@ export function StepsToDisplayProvider({
   children,
 }: StepExecutionsProviderProps): JSX.Element {
   const { allApps, flow } = useContext(EditorContext)
+  const { approvalBranches } = useContext(MrfContext)
 
-  const steps = flow.steps
+  const allSteps = flow.steps
+
+  const stepsToDisplay = useMemo(() => {
+    let firstRejectBranchStepId: string | null = null
+    return allSteps.filter((step) => {
+      if (
+        firstRejectBranchStepId != null &&
+        step.config?.approval?.stepId !== firstRejectBranchStepId
+      ) {
+        return false
+      }
+
+      if (!firstRejectBranchStepId && approvalBranches[step.id] === 'reject') {
+        firstRejectBranchStepId = step.id
+        return true
+      }
+
+      if (!step.config?.approval) {
+        return true
+      }
+
+      const approvalConfigStepId = step.config?.approval?.stepId
+      const approvalConfigBranch = step.config?.approval?.branch
+
+      if (approvalBranches[approvalConfigStepId] === approvalConfigBranch) {
+        return true
+      }
+      return false
+    })
+  }, [allSteps, approvalBranches])
 
   const appsWithActions: IApp[] = allApps.filter(
     (app: IApp) => !!app.actions?.length,
@@ -57,7 +88,7 @@ export function StepsToDisplayProvider({
       return [null, [], []]
     }
 
-    const groupStepIdx = steps.findIndex((step, index) => {
+    const groupStepIdx = stepsToDisplay.findIndex((step, index) => {
       if (
         // We ignore the 1st step because it's either a trigger, or a
         // step-grouping action that is using a nested Editor to edit steps in
@@ -73,15 +104,18 @@ export function StepsToDisplayProvider({
 
     let branchesWithSteps: IStep[][] = []
     if (groupStepIdx !== -1) {
-      branchesWithSteps = extractBranchesWithSteps(steps.slice(groupStepIdx), 0)
+      branchesWithSteps = extractBranchesWithSteps(
+        stepsToDisplay.slice(groupStepIdx),
+        0,
+      )
     }
 
-    const triggerStep = steps[0]
+    const triggerStep = stepsToDisplay[0]
 
     return groupStepIdx === -1
-      ? [triggerStep, steps.slice(1), []]
-      : [triggerStep, steps.slice(1, groupStepIdx), branchesWithSteps]
-  }, [groupingActions, steps])
+      ? [triggerStep, stepsToDisplay.slice(1), []]
+      : [triggerStep, stepsToDisplay.slice(1, groupStepIdx), branchesWithSteps]
+  }, [groupingActions, stepsToDisplay])
 
   return (
     <StepsToDisplayContext.Provider


### PR DESCRIPTION
### Changes

- Added visual indicators for approval/reject branches with appropriate colors (green for approve, red for reject) <-- this will change later
- Modified the `AddStepButton` component to show colored dividers based on the approval branch
- Created a new `DisabledFlowStep` component to display steps that are disabled due to conditional logic
- Updated the workflow to hide steps that don't match the current approval branch selection
- Show disabled MRF steps when a previous MRF step is rejected
- Closes the drawer and deselects the current step when changing approval branches