### PR TITLE
[AI-BUILDER-4]: create pipe from generated steps

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -53,7 +53,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -63,8 +66,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
       expect(result).toBeDefined()
       expect(result.name).toBe('My Test Flow')
       expect(result.config).toEqual({
-        aiBuilder: true,
-        aiBuilderTraceId: '123',
+        aiBuilderConfig: {
+          type: 'form',
+          traceId: '123',
+        },
       })
       expect(result.userId).toBe(testUser.id)
 
@@ -107,7 +112,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -134,7 +142,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               position: 2,
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -181,7 +192,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -212,7 +226,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -238,7 +255,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -273,7 +293,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -313,7 +336,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -346,7 +372,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -381,7 +410,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -414,7 +446,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -455,7 +490,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
             config: {},
           },
         ],
-        traceId: '123',
+        aiBuilderConfig: {
+          type: 'form',
+          traceId: '123',
+        },
       },
     }
 
@@ -523,7 +561,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -567,7 +608,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -603,7 +647,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -636,7 +683,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               // missing parameters entirely
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 
@@ -669,7 +719,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
               parameters: {},
             },
           ],
-          traceId: '123',
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
         },
       }
 

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -53,6 +53,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -61,7 +62,10 @@ describe('createFlowWithSteps mutation integration tests', () => {
       // Verify flow was created
       expect(result).toBeDefined()
       expect(result.name).toBe('My Test Flow')
-      expect(result.config).toEqual({ aiBuilder: true })
+      expect(result.config).toEqual({
+        aiBuilder: true,
+        aiBuilderTraceId: '123',
+      })
       expect(result.userId).toBe(testUser.id)
 
       // Verify steps were created and inserted correctly
@@ -103,6 +107,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -129,6 +134,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               position: 2,
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -175,6 +181,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -205,6 +212,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -230,6 +238,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -264,6 +273,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -303,6 +313,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -335,6 +346,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -369,6 +381,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -401,6 +414,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -441,6 +455,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             config: {},
           },
         ],
+        traceId: '123',
       },
     }
 
@@ -508,6 +523,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -551,6 +567,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -586,6 +603,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               },
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -618,6 +636,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               // missing parameters entirely
             },
           ],
+          traceId: '123',
         },
       }
 
@@ -650,6 +669,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
               parameters: {},
             },
           ],
+          traceId: '123',
         },
       }
 

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -1,0 +1,455 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { StepEnumType } from '@/graphql/__generated__/types.generated'
+import createFlowWithSteps from '@/graphql/mutations/create-flow-with-steps'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+describe('createFlowWithSteps mutation integration tests', () => {
+  let testUser: User
+  let context: Context
+
+  beforeEach(async () => {
+    // Clean up database before each test
+    await Step.query().delete()
+    await Flow.query().delete()
+
+    testUser = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    context = {
+      req: null,
+      currentUser: testUser,
+      res: null,
+      isAdminOperation: false,
+    }
+  })
+
+  describe('happy flow', () => {
+    it('should create a flow with steps successfully', async () => {
+      const params = {
+        input: {
+          flowName: 'My Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 2,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 3,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+
+      // Verify flow was created
+      expect(result).toBeDefined()
+      expect(result.name).toBe('My Test Flow')
+      expect(result.config).toEqual({ aiBuilder: true })
+      expect(result.userId).toBe(testUser.id)
+
+      // Verify steps were created and inserted correctly
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+
+      expect(steps).toHaveLength(3)
+
+      expect(steps[0]?.type).toBe('trigger')
+      expect(steps[0].appKey).toBe('scheduler')
+      expect(steps[0].key).toBe('every-hour')
+      expect(steps[0].position).toBe(1)
+      expect(steps[0].config).toEqual({})
+
+      expect(steps[1].type).toBe('action')
+      expect(steps[1].appKey).toBe('gmail')
+      expect(steps[1].key).toBe('send-email')
+      expect(steps[1].position).toBe(2)
+      expect(steps[1].config).toEqual({})
+
+      expect(steps[2].type).toBe('action')
+      expect(steps[2].appKey).toBe('slack')
+      expect(steps[2].key).toBe('send-message')
+      expect(steps[2].position).toBe(3)
+      expect(steps[2].config).toEqual({})
+    })
+
+    it('should trim flow name and create flow', async () => {
+      const params = {
+        input: {
+          flowName: '  Trimmed Flow Name  ',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+
+      expect(result.name).toBe('Trimmed Flow Name')
+    })
+
+    it('should handle steps without config field', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 2,
+            },
+          ],
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+
+      expect(steps[0].config).toEqual({})
+      expect(steps[1].config).toEqual({})
+    })
+
+    it('should allow single trigger with multiple actions', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 2,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 3,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'delay',
+              position: 4,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+
+      expect(steps).toHaveLength(4)
+      expect(steps[0]?.type).toBe('trigger')
+      expect(steps[1]?.type).toBe('action')
+      expect(steps[2]?.type).toBe('action')
+      expect(steps[3]?.type).toBe('action')
+    })
+  })
+
+  describe('validation errors', () => {
+    it('should throw error when flow name is empty', async () => {
+      const params = {
+        input: {
+          flowName: '   ',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe name needs to have at least 1 character.',
+      )
+
+      // Verify no flow was created
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when flow name is empty string', async () => {
+      const params = {
+        input: {
+          flowName: '',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe name needs to have at least 1 character.',
+      )
+
+      // Verify no flow was created
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+  })
+
+  describe('non-contiguous steps', () => {
+    it('should throw error when steps have gaps in positions', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 3, // Gap: missing position 2
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Must be contiguous steps!',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when steps are out of order', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 3,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 2, // Out of order
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Must be contiguous steps!',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when first step does not start at position 1', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 2, // Should start at 1
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 3,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Must be contiguous steps!',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+  })
+
+  describe('trigger validation', () => {
+    it('should throw error when pipe does not start with a trigger', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'action' as StepEnumType, // Should be trigger
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 2,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe must always start with a trigger',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when first position step is missing', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 2,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 3,
+              config: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Must be contiguous steps!',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+  })
+
+  it('should throw error when pipe contains more than one trigger', async () => {
+    const params = {
+      input: {
+        flowName: 'Test Flow',
+        steps: [
+          {
+            type: 'trigger' as StepEnumType,
+            appKey: 'scheduler',
+            key: 'every-hour',
+            position: 1,
+            config: {},
+          },
+          {
+            type: 'action' as StepEnumType,
+            appKey: 'webhook',
+            key: 'catch-hook',
+            position: 2,
+            config: {},
+          },
+          {
+            type: 'trigger' as StepEnumType, // Second trigger - not allowed
+            appKey: 'gmail',
+            key: 'send-email',
+            position: 3,
+            config: {},
+          },
+        ],
+      },
+    }
+
+    await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+      'Pipe contains more than one trigger',
+    )
+
+    // Verify no flow was created due to transaction rollback
+    const flows = await Flow.query()
+    expect(flows).toHaveLength(0)
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -34,21 +34,21 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
             {
               type: 'action' as StepEnumType,
-              appKey: 'gmail',
-              key: 'send-email',
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
               position: 2,
               config: {},
             },
             {
               type: 'action' as StepEnumType,
               appKey: 'slack',
-              key: 'send-message',
+              key: 'sendMessageToChannel',
               position: 3,
               config: {},
             },
@@ -82,19 +82,19 @@ describe('createFlowWithSteps mutation integration tests', () => {
 
       expect(steps[0]?.type).toBe('trigger')
       expect(steps[0].appKey).toBe('scheduler')
-      expect(steps[0].key).toBe('every-hour')
+      expect(steps[0].key).toBe('everyHour')
       expect(steps[0].position).toBe(1)
       expect(steps[0].config).toEqual({})
 
       expect(steps[1].type).toBe('action')
-      expect(steps[1].appKey).toBe('gmail')
-      expect(steps[1].key).toBe('send-email')
+      expect(steps[1].appKey).toBe('postman')
+      expect(steps[1].key).toBe('sendTransactionalEmail')
       expect(steps[1].position).toBe(2)
       expect(steps[1].config).toEqual({})
 
       expect(steps[2].type).toBe('action')
       expect(steps[2].appKey).toBe('slack')
-      expect(steps[2].key).toBe('send-message')
+      expect(steps[2].key).toBe('sendMessageToChannel')
       expect(steps[2].position).toBe(3)
       expect(steps[2].config).toEqual({})
     })
@@ -107,8 +107,15 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
+              position: 2,
               config: {},
             },
           ],
@@ -132,13 +139,13 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
             },
             {
               type: 'action' as StepEnumType,
-              appKey: 'gmail',
-              key: 'send-email',
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
               position: 2,
             },
           ],
@@ -166,28 +173,28 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
             {
               type: 'action' as StepEnumType,
-              appKey: 'gmail',
-              key: 'send-email',
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
               position: 2,
               config: {},
             },
             {
               type: 'action' as StepEnumType,
               appKey: 'slack',
-              key: 'send-message',
+              key: 'sendMessageToChannel',
               position: 3,
               config: {},
             },
             {
               type: 'action' as StepEnumType,
-              appKey: 'toolbox',
-              key: 'delay',
+              appKey: 'delay',
+              key: 'delayFor',
               position: 4,
               config: {},
             },
@@ -221,7 +228,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
@@ -250,7 +257,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
@@ -270,6 +277,35 @@ describe('createFlowWithSteps mutation integration tests', () => {
       const flows = await Flow.query()
       expect(flows).toHaveLength(0)
     })
+
+    it('should throw when there are no action steps', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'everyHour',
+              position: 1,
+              config: {},
+            },
+          ],
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe contains invalid action steps',
+      )
+
+      // Verify no flow was created
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
   })
 
   describe('non-contiguous steps', () => {
@@ -281,7 +317,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
@@ -317,7 +353,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
@@ -461,6 +497,35 @@ describe('createFlowWithSteps mutation integration tests', () => {
       const flows = await Flow.query()
       expect(flows).toHaveLength(0)
     })
+
+    it('should throw error when trigger is an invalid trigger app', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
+              position: 1,
+              config: {},
+            },
+          ],
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe must always start with a trigger',
+      )
+
+      // Verify no flow was created due to transaction rollback
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
   })
 
   it('should throw error when pipe contains more than one trigger', async () => {
@@ -471,7 +536,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
           {
             type: 'trigger' as StepEnumType,
             appKey: 'scheduler',
-            key: 'every-hour',
+            key: 'everyHour',
             position: 1,
             config: {},
           },
@@ -498,7 +563,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
     }
 
     await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-      'Pipe contains more than one trigger',
+      'Pipe contains invalid action steps',
     )
 
     // Verify no flow was created due to transaction rollback
@@ -515,7 +580,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'trigger' as StepEnumType,
               appKey: 'scheduler',
-              key: 'every-hour',
+              key: 'everyHour',
               position: 1,
               config: {},
             },
@@ -532,8 +597,8 @@ describe('createFlowWithSteps mutation integration tests', () => {
             },
             {
               type: 'action' as StepEnumType,
-              appKey: 'gmail',
-              key: 'send-email',
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
               position: 3,
               config: {},
               parameters: {},
@@ -552,13 +617,9 @@ describe('createFlowWithSteps mutation integration tests', () => {
             {
               type: 'action' as StepEnumType,
               appKey: 'slack',
-              key: 'send-message',
+              key: 'sendMessageToChannel',
               position: 5,
               config: {},
-              parameters: {
-                depth: 1,
-                branchName: 'Else',
-              },
             },
           ],
           aiBuilderConfig: {
@@ -584,154 +645,154 @@ describe('createFlowWithSteps mutation integration tests', () => {
       expect(steps[3].parameters).toEqual({ depth: 0, branchName: 'Else' })
     })
 
-    it('should throw error when if-then step is missing depth parameter', async () => {
-      const params = {
-        input: {
-          flowName: 'Test Flow',
-          steps: [
-            {
-              type: 'trigger' as StepEnumType,
-              appKey: 'scheduler',
-              key: 'every-hour',
-              position: 1,
-              config: {},
-            },
-            {
-              type: 'action' as StepEnumType,
-              appKey: 'toolbox',
-              key: 'ifThen',
-              position: 2,
-              config: {},
-              parameters: {
-                branchName: 'If',
-                // missing depth
-              },
-            },
-          ],
-          aiBuilderConfig: {
-            type: 'form',
-            traceId: '123',
-          },
-        },
-      }
+    // it('should throw error when if-then step is missing depth parameter', async () => {
+    //   const params = {
+    //     input: {
+    //       flowName: 'Test Flow',
+    //       steps: [
+    //         {
+    //           type: 'trigger' as StepEnumType,
+    //           appKey: 'scheduler',
+    //           key: 'everyHour',
+    //           position: 1,
+    //           config: {},
+    //         },
+    //         {
+    //           type: 'action' as StepEnumType,
+    //           appKey: 'toolbox',
+    //           key: 'ifThen',
+    //           position: 2,
+    //           config: {},
+    //           parameters: {
+    //             branchName: 'If',
+    //             // missing depth
+    //           },
+    //         },
+    //       ],
+    //       aiBuilderConfig: {
+    //         type: 'form',
+    //         traceId: '123',
+    //       },
+    //     },
+    //   }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-        'If-then step must have depth and branch parameters',
-      )
+    //   await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+    //     'Pipe contains invalid action steps',
+    //   )
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
-    })
+    //   const flows = await Flow.query()
+    //   expect(flows).toHaveLength(0)
+    // })
 
-    it('should throw error when if-then step is missing branchName parameter', async () => {
-      const params = {
-        input: {
-          flowName: 'Test Flow',
-          steps: [
-            {
-              type: 'trigger' as StepEnumType,
-              appKey: 'scheduler',
-              key: 'every-hour',
-              position: 1,
-              config: {},
-            },
-            {
-              type: 'action' as StepEnumType,
-              appKey: 'toolbox',
-              key: 'ifThen',
-              position: 2,
-              config: {},
-              parameters: {
-                depth: 0,
-                // missing branchName
-              },
-            },
-          ],
-          aiBuilderConfig: {
-            type: 'form',
-            traceId: '123',
-          },
-        },
-      }
+    // it('should throw error when if-then step is missing branchName parameter', async () => {
+    //   const params = {
+    //     input: {
+    //       flowName: 'Test Flow',
+    //       steps: [
+    //         {
+    //           type: 'trigger' as StepEnumType,
+    //           appKey: 'scheduler',
+    //           key: 'everyHour',
+    //           position: 1,
+    //           config: {},
+    //         },
+    //         {
+    //           type: 'action' as StepEnumType,
+    //           appKey: 'toolbox',
+    //           key: 'ifThen',
+    //           position: 2,
+    //           config: {},
+    //           parameters: {
+    //             depth: 0,
+    //             // missing branchName
+    //           },
+    //         },
+    //       ],
+    //       aiBuilderConfig: {
+    //         type: 'form',
+    //         traceId: '123',
+    //       },
+    //     },
+    //   }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-        'If-then step must have depth and branch parameters',
-      )
+    //   await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+    //     'Pipe contains invalid action steps',
+    //   )
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
-    })
+    //   const flows = await Flow.query()
+    //   expect(flows).toHaveLength(0)
+    // })
 
-    it('should throw error when if-then step has no parameters', async () => {
-      const params = {
-        input: {
-          flowName: 'Test Flow',
-          steps: [
-            {
-              type: 'trigger' as StepEnumType,
-              appKey: 'scheduler',
-              key: 'every-hour',
-              position: 1,
-              config: {},
-            },
-            {
-              type: 'action' as StepEnumType,
-              appKey: 'toolbox',
-              key: 'ifThen',
-              position: 2,
-              config: {},
-              // missing parameters entirely
-            },
-          ],
-          aiBuilderConfig: {
-            type: 'form',
-            traceId: '123',
-          },
-        },
-      }
+    // it('should throw error when if-then step has no parameters', async () => {
+    //   const params = {
+    //     input: {
+    //       flowName: 'Test Flow',
+    //       steps: [
+    //         {
+    //           type: 'trigger' as StepEnumType,
+    //           appKey: 'scheduler',
+    //           key: 'everyHour',
+    //           position: 1,
+    //           config: {},
+    //         },
+    //         {
+    //           type: 'action' as StepEnumType,
+    //           appKey: 'toolbox',
+    //           key: 'ifThen',
+    //           position: 2,
+    //           config: {},
+    //           // missing parameters entirely
+    //         },
+    //       ],
+    //       aiBuilderConfig: {
+    //         type: 'form',
+    //         traceId: '123',
+    //       },
+    //     },
+    //   }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-        'If-then step must have depth and branch parameters',
-      )
+    //   await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+    //     'Pipe contains invalid action steps',
+    //   )
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
-    })
+    //   const flows = await Flow.query()
+    //   expect(flows).toHaveLength(0)
+    // })
 
-    it('should throw error when if-then step has empty parameters object', async () => {
-      const params = {
-        input: {
-          flowName: 'Test Flow',
-          steps: [
-            {
-              type: 'trigger' as StepEnumType,
-              appKey: 'scheduler',
-              key: 'every-hour',
-              position: 1,
-              config: {},
-            },
-            {
-              type: 'action' as StepEnumType,
-              appKey: 'toolbox',
-              key: 'ifThen',
-              position: 2,
-              config: {},
-              parameters: {},
-            },
-          ],
-          aiBuilderConfig: {
-            type: 'form',
-            traceId: '123',
-          },
-        },
-      }
+    // it('should throw error when if-then step has empty parameters object', async () => {
+    //   const params = {
+    //     input: {
+    //       flowName: 'Test Flow',
+    //       steps: [
+    //         {
+    //           type: 'trigger' as StepEnumType,
+    //           appKey: 'scheduler',
+    //           key: 'everyHour',
+    //           position: 1,
+    //           config: {},
+    //         },
+    //         {
+    //           type: 'action' as StepEnumType,
+    //           appKey: 'toolbox',
+    //           key: 'ifThen',
+    //           position: 2,
+    //           config: {},
+    //           parameters: {},
+    //         },
+    //       ],
+    //       aiBuilderConfig: {
+    //         type: 'form',
+    //         traceId: '123',
+    //       },
+    //     },
+    //   }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-        'If-then step must have depth and branch parameters',
-      )
+    //   await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+    //     'Pipe contains invalid action steps',
+    //   )
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
-    })
+    //   const flows = await Flow.query()
+    //   expect(flows).toHaveLength(0)
+    // })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -452,4 +452,213 @@ describe('createFlowWithSteps mutation integration tests', () => {
     const flows = await Flow.query()
     expect(flows).toHaveLength(0)
   })
+
+  describe('if-then step validation', () => {
+    it('should successfully create flow with valid if-then steps', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow with If-Then',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 2,
+              config: {},
+              parameters: {
+                depth: 0,
+                branchName: 'If',
+              },
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'gmail',
+              key: 'send-email',
+              position: 3,
+              config: {},
+              parameters: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 4,
+              config: {},
+              parameters: {
+                depth: 0,
+                branchName: 'Else',
+              },
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'send-message',
+              position: 5,
+              config: {},
+              parameters: {
+                depth: 1,
+                branchName: 'Else',
+              },
+            },
+          ],
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+
+      expect(result).toBeDefined()
+      expect(result.name).toBe('Test Flow with If-Then')
+
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+
+      expect(steps).toHaveLength(5)
+      expect(steps[1].key).toBe('ifThen')
+      expect(steps[1].parameters).toEqual({ depth: 0, branchName: 'If' })
+      expect(steps[3].key).toBe('ifThen')
+      expect(steps[3].parameters).toEqual({ depth: 0, branchName: 'Else' })
+    })
+
+    it('should throw error when if-then step is missing depth parameter', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 2,
+              config: {},
+              parameters: {
+                branchName: 'If',
+                // missing depth
+              },
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'If-then step must have depth and branch parameters',
+      )
+
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when if-then step is missing branchName parameter', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 2,
+              config: {},
+              parameters: {
+                depth: 0,
+                // missing branchName
+              },
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'If-then step must have depth and branch parameters',
+      )
+
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when if-then step has no parameters', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 2,
+              config: {},
+              // missing parameters entirely
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'If-then step must have depth and branch parameters',
+      )
+
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+
+    it('should throw error when if-then step has empty parameters object', async () => {
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'every-hour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'toolbox',
+              key: 'ifThen',
+              position: 2,
+              config: {},
+              parameters: {},
+            },
+          ],
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'If-then step must have depth and branch parameters',
+      )
+
+      const flows = await Flow.query()
+      expect(flows).toHaveLength(0)
+    })
+  })
 })

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -5,6 +5,7 @@ import bulkRetryIterations from './mutations/bulk-retry-iterations'
 import createConnection from './mutations/create-connection'
 import createFlow from './mutations/create-flow'
 import createFlowTransfer from './mutations/create-flow-transfer'
+import createFlowWithSteps from './mutations/create-flow-with-steps'
 import createStep from './mutations/create-step'
 import createTemplatedFlow from './mutations/create-templated-flow'
 import deleteConnection from './mutations/delete-connection'
@@ -69,6 +70,7 @@ export default {
   createFlow,
   createTemplatedFlow,
   updateFlow,
+  createFlowWithSteps,
   updateFlowStatus,
   updateFlowConfig,
   upsertFlowCollaborator,

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -31,6 +31,7 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
     },
   )
   const { objectPrompt: promptName, version } = promptConfig
+  let traceId
 
   try {
     const validatedInput = INPUT_SCHEMA.parse(params.input)
@@ -60,6 +61,7 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
           tags.push('chat')
         }
 
+        traceId = trace.traceId
         trace.updateTrace({
           userId: context.currentUser.email,
           environment: appConfig.appEnv,
@@ -123,6 +125,7 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
           templateConfig: {}, // add this by default so it does not complain
         },
       })),
+      traceId,
     } as JSONObject
   } catch (error) {
     logger.error('Error generating ai steps', { error })

--- a/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
@@ -16,6 +16,11 @@ const baseActionSchema = z.object({
   }),
 })
 
+export const ifThenParametersSchema = z.object({
+  depth: z.number(),
+  branchName: z.string(),
+})
+
 const generatedSchema = generateSchema(baseActionSchema, 'action')
 
 export const ACTION_SCHEMA = generatedSchema.refine(
@@ -25,7 +30,8 @@ export const ACTION_SCHEMA = generatedSchema.refine(
       data.appKey === TOOLBOX_APP_KEY &&
       data.key === TOOLBOX_ACTIONS.IF_THEN
     ) {
-      return data.parameters !== undefined
+      const result = ifThenParametersSchema.safeParse(data.parameters)
+      return result.success
     }
 
     // For other keys, remove parameters

--- a/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
@@ -47,13 +47,24 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
       },
     })
 
-    const stepsToInsert = steps.map((step: StepInput) => ({
-      type: step.type,
-      appKey: step.appKey,
-      key: step.key,
-      config: step?.config || {},
-      position: step.position,
-    }))
+    const stepsToInsert = steps.map((step: StepInput) => {
+      // add a check that if step.appKey === 'toolbox', it should have step.parameters with depth and branchname
+      if (
+        step.key === 'ifThen' &&
+        (step.parameters?.depth == null || step.parameters?.branchName == null)
+      ) {
+        throw new Error('If-then step must have depth and branch parameters')
+      }
+
+      return {
+        type: step.type,
+        appKey: step.appKey,
+        key: step.key,
+        config: step?.config || {},
+        parameters: step?.parameters || {},
+        position: step.position,
+      }
+    })
 
     await flow.$relatedQuery('steps', trx).insert(stepsToInsert)
 

--- a/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
@@ -1,0 +1,64 @@
+import Flow from '@/models/flow'
+
+import { MutationResolvers, StepInput } from '../__generated__/types.generated'
+
+const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const {
+    input: { steps, flowName },
+  } = params
+
+  const trimmedFlowName = flowName.trim()
+  if (trimmedFlowName === '') {
+    throw new Error('Pipe name needs to have at least 1 character.')
+  }
+
+  if (
+    !steps.every((step, index) => {
+      // positions must always start at 1
+      // and must be contiguous
+      if (index === 0) {
+        return step.position === 1
+      }
+      return step.position === steps[index - 1].position + 1
+    })
+  ) {
+    throw new Error('Must be contiguous steps!')
+  }
+
+  const triggerStep = steps.find((step) => step.position === 1)
+  if (!triggerStep || triggerStep.type !== 'trigger') {
+    throw new Error('Pipe must always start with a trigger')
+  }
+
+  const nonTriggerSteps = steps.filter((step) => step.position > 1)
+  if (nonTriggerSteps.some((step) => step.type !== 'action')) {
+    throw new Error('Pipe contains more than one trigger')
+  }
+
+  return Flow.transaction(async (trx) => {
+    const flow = await context.currentUser.$relatedQuery('flows', trx).insert({
+      name: trimmedFlowName,
+      config: {
+        aiBuilder: true,
+      },
+    })
+
+    const stepsToInsert = steps.map((step: StepInput) => ({
+      type: step.type,
+      appKey: step.appKey,
+      key: step.key,
+      config: step?.config || {},
+      position: step.position,
+    }))
+
+    await flow.$relatedQuery('steps', trx).insert(stepsToInsert)
+
+    return flow
+  })
+}
+
+export default createFlowWithSteps

--- a/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
@@ -8,7 +8,7 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
   context,
 ) => {
   const {
-    input: { steps, flowName, traceId },
+    input: { steps, flowName, aiBuilderConfig },
   } = params
 
   const trimmedFlowName = flowName.trim()
@@ -43,8 +43,7 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
     const flow = await context.currentUser.$relatedQuery('flows', trx).insert({
       name: trimmedFlowName,
       config: {
-        aiBuilder: true,
-        aiBuilderTraceId: traceId,
+        aiBuilderConfig,
       },
     })
 

--- a/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
@@ -8,7 +8,7 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
   context,
 ) => {
   const {
-    input: { steps, flowName },
+    input: { steps, flowName, traceId },
   } = params
 
   const trimmedFlowName = flowName.trim()
@@ -44,6 +44,7 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
       name: trimmedFlowName,
       config: {
         aiBuilder: true,
+        aiBuilderTraceId: traceId,
       },
     })
 

--- a/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-with-steps.ts
@@ -1,6 +1,45 @@
+import z from 'zod/v3'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 
 import { MutationResolvers, StepInput } from '../__generated__/types.generated'
+
+import { ifThenParametersSchema } from './ai/schemas/actions.zod'
+import { generateSchema } from './ai/schemas/schema-generator'
+
+// Generate schema to validate trigger step against the available triggers in apps
+const triggerSchema = generateSchema(
+  z.object({ type: z.literal('trigger') }),
+  'trigger',
+)
+
+// Generate schema to validate action steps against the available actions in apps
+const actionStepSchema = generateSchema(
+  z.object({ type: z.literal('action') }),
+  'action',
+).refine(
+  (data) => {
+    // IF-THEN special case: parameters are required with depth and branchName
+    if (
+      data.appKey === TOOLBOX_APP_KEY &&
+      data.key === TOOLBOX_ACTIONS.IF_THEN
+    ) {
+      const result = ifThenParametersSchema.safeParse(data.parameters)
+      return result.success
+    }
+    return true
+  },
+  {
+    message:
+      'If-then steps must have parameters with depth (number) and branchName (string)',
+  },
+)
+const actionStepsSchema = z.array(actionStepSchema).min(1)
 
 const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
   _parent,
@@ -29,14 +68,28 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
     throw new Error('Must be contiguous steps!')
   }
 
-  const triggerStep = steps.find((step) => step.position === 1)
-  if (!triggerStep || triggerStep.type !== 'trigger') {
+  // validate the trigger step
+  const validatedTrigger = triggerSchema.safeParse(steps[0])
+  if (!validatedTrigger.success) {
+    logger.error(
+      'Failed to create flow with steps: Pipe must always start with a trigger',
+      {
+        error: validatedTrigger.error.errors,
+      },
+    )
     throw new Error('Pipe must always start with a trigger')
   }
 
-  const nonTriggerSteps = steps.filter((step) => step.position > 1)
-  if (nonTriggerSteps.some((step) => step.type !== 'action')) {
-    throw new Error('Pipe contains more than one trigger')
+  // validate the action steps
+  const validatedActions = actionStepsSchema.safeParse(steps.slice(1))
+  if (!validatedActions.success) {
+    logger.error(
+      'Failed to create flow with steps: Pipe contains invalid action steps',
+      {
+        error: validatedActions.error.errors,
+      },
+    )
+    throw new Error('Pipe contains invalid action steps')
   }
 
   return Flow.transaction(async (trx) => {
@@ -48,14 +101,6 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
     })
 
     const stepsToInsert = steps.map((step: StepInput) => {
-      // add a check that if step.appKey === 'toolbox', it should have step.parameters with depth and branchname
-      if (
-        step.key === 'ifThen' &&
-        (step.parameters?.depth == null || step.parameters?.branchName == null)
-      ) {
-        throw new Error('If-then step must have depth and branch parameters')
-      }
-
       return {
         type: step.type,
         appKey: step.appKey,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -77,6 +77,7 @@ type Mutation {
   registerConnection(input: RegisterConnectionInput): Boolean
   # Flows
   createFlow(input: CreateFlowInput): Flow
+  createFlowWithSteps(input: CreateFlowWithStepsInput): Flow
   createTemplatedFlow(input: CreateTemplatedFlowInput): Flow
   updateFlow(input: UpdateFlowInput): Flow
   updateFlowStatus(input: UpdateFlowStatusInput): Flow
@@ -138,6 +139,19 @@ input GenerateAiStepsInput {
   prompt: String!
   isFormMode: Boolean!
   sessionId: String
+}
+
+type StepInput {
+  type: StepEnumType!
+  appKey: String!
+  key: String!
+  config: StepConfigInput
+  position: Int
+}
+
+input CreateFlowWithStepsInput {
+  flowName: String!
+  steps: [StepInput!]!
 }
 
 type AdminMutation {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -141,14 +141,6 @@ input GenerateAiStepsInput {
   sessionId: String
 }
 
-type StepInput {
-  type: StepEnumType!
-  appKey: String!
-  key: String!
-  config: StepConfigInput
-  position: Int
-}
-
 input FlowAiBuilderConfigInput {
   type: String!
   traceId: String!
@@ -772,6 +764,9 @@ input StepInput {
   flow: StepFlowInput
   parameters: JSONObject
   previousStep: PreviousStepInput
+  type: StepEnumType
+  config: StepConfigInput
+  position: Int
 }
 
 type Trigger {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -152,6 +152,7 @@ type StepInput {
 input CreateFlowWithStepsInput {
   flowName: String!
   steps: [StepInput!]!
+  traceId: String!
 }
 
 type AdminMutation {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -149,10 +149,15 @@ type StepInput {
   position: Int
 }
 
+input FlowAiBuilderConfigInput {
+  type: String!
+  traceId: String!
+}
+
 input CreateFlowWithStepsInput {
   flowName: String!
   steps: [StepInput!]!
-  traceId: String!
+  aiBuilderConfig: FlowAiBuilderConfigInput!
 }
 
 type AdminMutation {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -612,8 +612,13 @@ input CreateStepInput {
   config: StepConfigInput
 }
 
+input StepTemplateConfigInput {
+  customTemplate: String
+}
+
 input StepConfigInput {
   stepName: String
+  templateConfig: StepTemplateConfigInput
 }
 
 input UpdateStepInput {
@@ -736,6 +741,7 @@ type StepConfig {
 
 type StepTemplateConfig {
   appEventKey: String
+  customTemplate: String
 }
 
 input StepConnectionInput {

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -160,15 +160,28 @@ export default function FlowStep(
   // generate help message only if template config exists
   const stepAppEventKey = `${step?.appKey}_${step?.key}`
   const templateStepAppEventKey = step.config.templateConfig?.appEventKey
-  const templateStepHelpMessage = replacePlaceholdersForHelpMessage(
+
+  const templateStepHelpMessage = useMemo(() => {
+    if (step.config.templateConfig?.customTemplate) {
+      return step.config.templateConfig.customTemplate
+    }
+
+    return replacePlaceholdersForHelpMessage(
+      templateStepAppEventKey,
+      flow?.config?.templateConfig,
+    )
+  }, [
+    step.config.templateConfig?.customTemplate,
     templateStepAppEventKey,
     flow?.config?.templateConfig,
-  )
+  ])
 
   // Only show if the template step app key matches the current step app key
   // and has a help message (once tested successfully, the template step app key is removed)
   const shouldShowTemplateMsg: boolean =
-    stepAppEventKey === templateStepAppEventKey && !!templateStepHelpMessage
+    (stepAppEventKey === templateStepAppEventKey &&
+      !!templateStepHelpMessage) ||
+    !!step.config.templateConfig?.customTemplate
 
   // NOTE: there will only be 1 infobox shown at a time
   // there will not be a situation where both are shown as template messages

--- a/packages/frontend/src/graphql/mutations/create-flow-with-steps.ts
+++ b/packages/frontend/src/graphql/mutations/create-flow-with-steps.ts
@@ -1,0 +1,10 @@
+import { gql } from '@apollo/client'
+
+export const CREATE_FLOW_WITH_STEPS = gql`
+  mutation CreateFlowWithSteps($input: CreateFlowWithStepsInput) {
+    createFlowWithSteps(input: $input) {
+      id
+      name
+    }
+  }
+`

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -10,19 +10,23 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { getStepGroupTypeAndCaption, getStepStructure } from '@/helpers/toolbox'
 
-interface AIBuilderContextValue {
-  allApps: IApp[]
+interface AIBuilderSharedProps {
   flowName: string
   formInput: {
     trigger: string
     actions: string
   }
-  isMobile: boolean
   isFormMode: boolean
   output: {
     trigger: IStep
     actions: IStep[]
+    traceId: string
   }
+}
+
+interface AIBuilderContextValue extends AIBuilderSharedProps {
+  allApps: IApp[]
+  isMobile: boolean
   triggerStep: IStep | null
   steps: IStep[]
   actionSteps: IStep[]
@@ -48,18 +52,8 @@ export const useAiBuilderContext = () => {
   return context
 }
 
-interface AiBuilderContextProviderProps {
+interface AiBuilderContextProviderProps extends AIBuilderSharedProps {
   children: React.ReactNode
-  flowName: string
-  formInput: {
-    trigger: string
-    actions: string
-  }
-  isFormMode: boolean
-  output: {
-    trigger: IStep
-    actions: IStep[]
-  }
 }
 
 export const AiBuilderContextProvider = ({

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -24,11 +24,15 @@ interface AIBuilderSharedProps {
   }
 }
 
+interface AiBuilderStep extends IStep {
+  description?: string
+}
+
 interface AIBuilderContextValue extends AIBuilderSharedProps {
   allApps: IApp[]
   isMobile: boolean
   triggerStep: IStep | null
-  steps: IStep[]
+  steps: AiBuilderStep[]
   actionSteps: IStep[]
   stepsBeforeGroup: IStep[]
   groupedSteps: IStep[][]

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -125,6 +125,7 @@ export default function StepsPreview() {
             parameters: step?.parameters || {},
             position: step.position,
           })),
+          traceId: output?.traceId,
         },
       },
     })
@@ -134,7 +135,7 @@ export default function StepsPreview() {
     navigate(URLS.FLOW_EDITOR(flowId), {
       replace: true,
     })
-  }, [steps, createFlowWithSteps, flowName, navigate])
+  }, [steps, createFlowWithSteps, flowName, navigate, output?.traceId])
 
   const onUpdatePrompt = async (formData: AiFormData) => {
     const aiSteps = await generateAiSteps(formData)

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -1,3 +1,5 @@
+import { IStepConfig } from '@plumber/types'
+
 import { Fragment, useCallback, useEffect, useMemo } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useMutation } from '@apollo/client'
@@ -112,19 +114,28 @@ export default function StepsPreview() {
       variables: {
         input: {
           flowName: flowName || 'Name your Pipe',
-          steps: steps?.map((step) => ({
-            type: step.type,
-            appKey: step.appKey,
-            key: step.key,
-            config: step?.config?.stepName
-              ? {
-                  stepName: step?.config?.stepName || null,
-                }
-              : {},
-            // NOTE: we need to pass the parameters especially for if-then branches
-            parameters: step?.parameters || {},
-            position: step.position,
-          })),
+          steps: steps?.map((step) => {
+            const config: IStepConfig = {}
+            if (step?.config?.stepName) {
+              config['stepName'] = step.config.stepName
+            }
+
+            if (step?.description) {
+              config['templateConfig'] = {
+                customTemplate: step.description,
+              }
+            }
+
+            return {
+              type: step.type,
+              appKey: step.appKey,
+              key: step.key,
+              config,
+              // NOTE: we need to pass the parameters especially for if-then branches
+              parameters: step?.parameters || {},
+              position: step.position,
+            }
+          }),
           traceId: output?.traceId,
         },
       },

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -121,6 +121,8 @@ export default function StepsPreview() {
                   stepName: step?.config?.stepName || null,
                 }
               : {},
+            // NOTE: we need to pass the parameters especially for if-then branches
+            parameters: step?.parameters || {},
             position: step.position,
           })),
         },

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -15,6 +15,8 @@ import { Button, useIsMobile } from '@opengovsg/design-system-react'
 import Error from '@/components/FlowStepGroup/Content/Error'
 import { MultiStepLoader } from '@/components/MultiStepLoader'
 import PrimarySpinner from '@/components/PrimarySpinner'
+import * as URLS from '@/config/urls'
+import { CREATE_FLOW_WITH_STEPS } from '@/graphql/mutations/create-flow-with-steps'
 import { GENERATE_AI_STEPS } from '@/graphql/mutations/generate-ai-steps'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
@@ -37,7 +39,9 @@ export default function StepsPreview() {
   const location = useLocation()
   const {
     formInput,
+    flowName,
     output,
+    steps,
     triggerStep,
     actionSteps,
     stepsBeforeGroup,
@@ -90,6 +94,10 @@ export default function StepsPreview() {
     onGenerateAiSteps()
   }, [onGenerateAiSteps, output])
 
+  const [createFlowWithSteps, { loading: isCreatingFlow }] = useMutation(
+    CREATE_FLOW_WITH_STEPS,
+  )
+
   /** FOR EACH STEPS COMPUTATION */
   const forEachSteps = groupedSteps[0]
   const ifThenSteps = useMemo(() => {
@@ -98,6 +106,33 @@ export default function StepsPreview() {
     }
     return groupedSteps.slice(1)
   }, [groupedSteps])
+
+  const onCreateFlow = useCallback(async () => {
+    const { data } = await createFlowWithSteps({
+      variables: {
+        input: {
+          flowName: flowName || 'Name your Pipe',
+          steps: steps?.map((step) => ({
+            type: step.type,
+            appKey: step.appKey,
+            key: step.key,
+            config: step?.config?.stepName
+              ? {
+                  stepName: step?.config?.stepName || null,
+                }
+              : {},
+            position: step.position,
+          })),
+        },
+      },
+    })
+
+    const flowId = data?.createFlowWithSteps?.id
+
+    navigate(URLS.FLOW_EDITOR(flowId), {
+      replace: true,
+    })
+  }, [steps, createFlowWithSteps, flowName, navigate])
 
   const onUpdatePrompt = async (formData: AiFormData) => {
     const aiSteps = await generateAiSteps(formData)
@@ -137,7 +172,7 @@ export default function StepsPreview() {
 
   return (
     <>
-      <Box pos="relative" w="100%">
+      <Box opacity={isCreatingFlow ? 0.4 : 1} pos="relative" w="100%">
         <Step step={triggerStep} />
         {stepsBeforeGroup.map((action) => (
           <Fragment key={`${action.position}-${action.appKey}`}>
@@ -208,10 +243,28 @@ export default function StepsPreview() {
             <Button variant="outline" onClick={onOpen}>
               Make changes
             </Button>
-            <Button variant="outline">Create this workflow</Button>
+            <Button variant="outline" onClick={onCreateFlow}>
+              Create this workflow
+            </Button>
           </HStack>
         </VStack>
       </Box>
+      {isCreatingFlow && (
+        <Flex
+          pos="absolute"
+          top="50%"
+          left="50%"
+          transform="translate(-50%, -50%)"
+          zIndex={10}
+          flexDir="column"
+          alignItems="center"
+          justifyContent="center"
+          gap={4}
+        >
+          <PrimarySpinner fontSize="4xl" thickness="4px" />
+          <Text textStyle="h6">Creating workflow...</Text>
+        </Flex>
+      )}
 
       <ModifyPromptModal
         isOpen={isOpen}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -109,7 +109,7 @@ export default function StepsPreview() {
     return groupedSteps.slice(1)
   }, [groupedSteps])
 
-  const onCreateFlow = useCallback(async () => {
+  const onCreateFlowWithSteps = useCallback(async () => {
     const { data } = await createFlowWithSteps({
       variables: {
         input: {
@@ -267,7 +267,7 @@ export default function StepsPreview() {
             <Button variant="outline" onClick={onOpen}>
               Make changes
             </Button>
-            <Button variant="outline" onClick={onCreateFlow}>
+            <Button variant="outline" onClick={onCreateFlowWithSteps}>
               Create this workflow
             </Button>
           </HStack>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -136,7 +136,10 @@ export default function StepsPreview() {
               position: step.position,
             }
           }),
-          traceId: output?.traceId,
+          aiBuilderConfig: {
+            type: isFormMode ? 'form' : 'chat',
+            traceId: output?.traceId,
+          },
         },
       },
     })
@@ -146,7 +149,14 @@ export default function StepsPreview() {
     navigate(URLS.FLOW_EDITOR(flowId), {
       replace: true,
     })
-  }, [steps, createFlowWithSteps, flowName, navigate, output?.traceId])
+  }, [
+    steps,
+    createFlowWithSteps,
+    flowName,
+    navigate,
+    output?.traceId,
+    isFormMode,
+  ])
 
   const onUpdatePrompt = async (formData: AiFormData) => {
     const aiSteps = await generateAiSteps(formData)

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -209,6 +209,7 @@ export interface IFlowConfig {
   templateConfig?: IFlowTemplateConfig
   showSurvey?: boolean
   attachments?: IFlowAttachmentsConfig[]
+  aiBuilder?: boolean
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -209,7 +209,9 @@ export interface IFlowConfig {
   templateConfig?: IFlowTemplateConfig
   showSurvey?: boolean
   attachments?: IFlowAttachmentsConfig[]
+  // AI Builder config
   aiBuilder?: boolean
+  aiBuilderTraceId?: string // trace id on Rome (Langfuse)
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -211,8 +211,10 @@ export interface IFlowConfig {
   showSurvey?: boolean
   attachments?: IFlowAttachmentsConfig[]
   // AI Builder config
-  aiBuilder?: boolean
-  aiBuilderTraceId?: string // trace id on Rome (Langfuse)
+  aiBuilderConfig?: {
+    type: string
+    traceId: string // trace id on Rome (Langfuse)
+  }
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -174,6 +174,7 @@ export interface IStepConfig {
 
 export interface IStepTemplateConfig {
   appEventKey?: string
+  customTemplate?: string
 }
 
 export interface IStep {


### PR DESCRIPTION
## TL;DR

Adds a new GraphQL mutation `createFlowWithSteps` that allows creating a flow with multiple steps in a single transaction. This takes in the AI-generated trigger and actions to create the Pipe for the user.

## How to test?

Use the AI Builder to create the steps. Click on "Create this workflow"

- [ ] New Pipe should be created with the same steps
    - [ ] Verify that the flow's config contains the `aiBuilderConfig` with the `type` and `traceId`