### PR TITLE
[AI-BUILDER-7] PLU-584 (backend): add api for chat streaming

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -1,0 +1,4 @@
+/**
+ * Feature flags
+ */
+export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG = 'ai-builder-prompt-config'

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -1,10 +1,7 @@
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type Context from '@/types/express/context'
-
 const mocks = vi.hoisted(() => ({
-  getAuthenticatedContext: vi.fn(),
   getLdFlagValue: vi.fn(),
   langfuseClient: {
     prompt: {
@@ -13,10 +10,6 @@ const mocks = vi.hoisted(() => ({
   },
   startActiveObservation: vi.fn(),
   streamText: vi.fn(),
-}))
-
-vi.mock('../middleware/authentication', () => ({
-  getAuthenticatedContext: mocks.getAuthenticatedContext,
 }))
 
 vi.mock('@/helpers/launch-darkly', () => ({
@@ -75,7 +68,7 @@ async function executeChatPostHandler(
   return postHandler(req, res)
 }
 
-describe('Chat Route Authentication', () => {
+describe('Chat Route Handler', () => {
   let mockReq: Partial<Request>
   let mockRes: Partial<Response>
 
@@ -113,19 +106,9 @@ describe('Chat Route Authentication', () => {
     vi.restoreAllMocks()
   })
 
-  describe('Authentication Requirements', () => {
-    it('should call getAuthenticatedContext on every request', async () => {
-      const mockContext: Context = {
-        req: mockReq as Request,
-        res: mockRes as Response,
-        currentUser: {
-          id: 'test-user-id',
-          email: 'test@plumber.gov.sg',
-        } as any,
-        isAdminOperation: false,
-      }
-
-      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
+  describe('Handler Behavior', () => {
+    it('should process authenticated requests', async () => {
+      // Context is set by middleware before reaching handler
       mocks.getLdFlagValue.mockResolvedValueOnce({
         chatPrompt: 'aids-chat-v0',
         version: 'production',
@@ -155,25 +138,26 @@ describe('Chat Route Authentication', () => {
 
       await executeChatPostHandler(mockReq, mockRes)
 
-      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'ai-builder-prompt-config',
+        'test@plumber.gov.sg',
+        expect.any(Object),
+      )
     })
 
-    it('should throw error when user is not authenticated', async () => {
-      mocks.getAuthenticatedContext.mockImplementationOnce(() => {
-        throw new Error('User must be authenticated')
-      })
+    it('should throw error when context is missing user', async () => {
+      // Simulate missing context (should be caught by middleware in production)
+      mockReq.context = undefined
 
-      await expect(executeChatPostHandler(mockReq, mockRes)).rejects.toThrow(
-        'User must be authenticated',
-      )
+      await expect(executeChatPostHandler(mockReq, mockRes)).rejects.toThrow()
 
-      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
-      // Should not reach getLdFlagValue since authentication failed
+      // Should not reach getLdFlagValue since context is missing
       expect(mocks.getLdFlagValue).not.toHaveBeenCalled()
     })
 
     it('should use authenticated user email for feature flag lookup', async () => {
-      const mockContext: Context = {
+      // Set context with different user email
+      mockReq.context = {
         req: mockReq as Request,
         res: mockRes as Response,
         currentUser: {
@@ -183,7 +167,6 @@ describe('Chat Route Authentication', () => {
         isAdminOperation: false,
       }
 
-      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
       mocks.getLdFlagValue.mockResolvedValueOnce({
         chatPrompt: 'aids-chat-v0',
         version: 'production',
@@ -220,22 +203,11 @@ describe('Chat Route Authentication', () => {
     })
 
     it('should validate request body before processing', async () => {
-      const mockContext: Context = {
-        req: mockReq as Request,
-        res: mockRes as Response,
-        currentUser: {
-          id: 'test-user-id',
-          email: 'test@plumber.gov.sg',
-        } as any,
-        isAdminOperation: false,
-      }
-
       // Invalid request body (empty messages)
       mockReq.body = {
         messages: [],
       }
 
-      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
       mocks.getLdFlagValue.mockResolvedValueOnce({
         chatPrompt: 'aids-chat-v0',
         version: 'production',
@@ -252,9 +224,10 @@ describe('Chat Route Authentication', () => {
 
   describe('Admin User Access', () => {
     it('handler can process admin requests (blocking handled by middleware)', async () => {
-      // Note: admin users are blocked by middleware before reaching this handler.
-      // This test verifies the handler itself can process admin contexts if they reach it.
-      const mockContext: Context = {
+      // Note: blockAdminOperations middleware blocks admin users
+      // before they reach this handler. This test verifies the handler itself
+      // has no admin-specific logic and would work if an admin context reached it.
+      mockReq.context = {
         req: mockReq as Request,
         res: mockRes as Response,
         currentUser: {
@@ -264,7 +237,6 @@ describe('Chat Route Authentication', () => {
         isAdminOperation: true,
       }
 
-      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
       mocks.getLdFlagValue.mockResolvedValueOnce({
         chatPrompt: 'aids-chat-v0',
         version: 'production',
@@ -293,7 +265,6 @@ describe('Chat Route Authentication', () => {
 
       await executeChatPostHandler(mockReq, mockRes)
 
-      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
       expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
         'ai-builder-prompt-config',
         'admin@plumber.gov.sg',

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -1,0 +1,302 @@
+import type { Request, Response } from 'express'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type Context from '@/types/express/context'
+
+const mocks = vi.hoisted(() => ({
+  getAuthenticatedContext: vi.fn(),
+  getLdFlagValue: vi.fn(),
+  langfuseClient: {
+    prompt: {
+      get: vi.fn(),
+    },
+  },
+  startActiveObservation: vi.fn(),
+  streamText: vi.fn(),
+}))
+
+vi.mock('../middleware/authentication', () => ({
+  getAuthenticatedContext: mocks.getAuthenticatedContext,
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
+
+vi.mock('@/helpers/langfuse', () => ({
+  langfuseClient: mocks.langfuseClient,
+}))
+
+vi.mock('@langfuse/tracing', () => ({
+  startActiveObservation: mocks.startActiveObservation,
+}))
+
+vi.mock('ai', () => ({
+  convertToModelMessages: vi.fn((msgs) => msgs),
+  smoothStream: vi.fn(() => ({})),
+  streamText: mocks.streamText,
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/helpers/pair', () => ({
+  model: {},
+  MODEL_TYPE: 'test-model',
+}))
+
+vi.mock('@/config/app', () => ({
+  default: {
+    appEnv: 'test',
+  },
+}))
+
+// Helper function to get and execute the POST handler from the chat router
+async function executeChatPostHandler(
+  req: Partial<Request>,
+  res: Partial<Response>,
+) {
+  const chatModule = await import('../chat')
+  const router = chatModule.default
+
+  // Extract the POST handler
+  const postHandler = (router as any).stack.find(
+    (layer: any) => layer.route?.methods?.post,
+  )?.route?.stack[0]?.handle
+
+  if (!postHandler) {
+    throw new Error('POST handler not found in chat router')
+  }
+
+  return postHandler(req, res)
+}
+
+describe('Chat Route Authentication', () => {
+  let mockReq: Partial<Request>
+  let mockRes: Partial<Response>
+
+  beforeEach(() => {
+    mockReq = {
+      body: {
+        messages: [
+          {
+            role: 'user',
+            parts: [{ type: 'text', text: 'Hello' }],
+          },
+        ],
+      },
+      context: {
+        currentUser: {
+          id: 'test-user-id',
+          email: 'test@plumber.gov.sg',
+        } as any,
+        isAdminOperation: false,
+      } as any,
+    } as Partial<Request>
+
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+      headersSent: false,
+      end: vi.fn(),
+    } as Partial<Response>
+
+    // Reset mocks
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('Authentication Requirements', () => {
+    it('should call getAuthenticatedContext on every request', async () => {
+      const mockContext: Context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'test-user-id',
+          email: 'test@plumber.gov.sg',
+        } as any,
+        isAdminOperation: false,
+      }
+
+      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        chatPrompt: 'aids-chat-v0',
+        version: 'production',
+      })
+      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+        prompt: 'test prompt',
+      })
+
+      // Mock streamText to return a mock result
+      const mockResult = {
+        pipeUIMessageStreamToResponse: vi.fn(),
+      }
+      mocks.startActiveObservation.mockImplementationOnce(
+        async (name, callback) => {
+          const mockTrace = {
+            updateTrace: vi.fn(),
+            startObservation: vi.fn(() => ({
+              update: vi.fn(),
+            })),
+            update: vi.fn(),
+            traceId: 'test-trace-id',
+          }
+          return await callback(mockTrace)
+        },
+      )
+      mocks.streamText.mockResolvedValueOnce(mockResult)
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
+    })
+
+    it('should throw error when user is not authenticated', async () => {
+      mocks.getAuthenticatedContext.mockImplementationOnce(() => {
+        throw new Error('User must be authenticated')
+      })
+
+      await expect(executeChatPostHandler(mockReq, mockRes)).rejects.toThrow(
+        'User must be authenticated',
+      )
+
+      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
+      // Should not reach getLdFlagValue since authentication failed
+      expect(mocks.getLdFlagValue).not.toHaveBeenCalled()
+    })
+
+    it('should use authenticated user email for feature flag lookup', async () => {
+      const mockContext: Context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'test-user-id',
+          email: 'feature-test@plumber.gov.sg',
+        } as any,
+        isAdminOperation: false,
+      }
+
+      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        chatPrompt: 'aids-chat-v0',
+        version: 'production',
+      })
+      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+        prompt: 'test prompt',
+      })
+
+      const mockResult = {
+        pipeUIMessageStreamToResponse: vi.fn(),
+      }
+      mocks.startActiveObservation.mockImplementationOnce(
+        async (name, callback) => {
+          const mockTrace = {
+            updateTrace: vi.fn(),
+            startObservation: vi.fn(() => ({
+              update: vi.fn(),
+            })),
+            update: vi.fn(),
+            traceId: 'test-trace-id',
+          }
+          return await callback(mockTrace)
+        },
+      )
+      mocks.streamText.mockResolvedValueOnce(mockResult)
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'ai-builder-prompt-config',
+        'feature-test@plumber.gov.sg',
+        expect.any(Object),
+      )
+    })
+
+    it('should validate request body before processing', async () => {
+      const mockContext: Context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'test-user-id',
+          email: 'test@plumber.gov.sg',
+        } as any,
+        isAdminOperation: false,
+      }
+
+      // Invalid request body (empty messages)
+      mockReq.body = {
+        messages: [],
+      }
+
+      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        chatPrompt: 'aids-chat-v0',
+        version: 'production',
+      })
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: 'Messages array is required',
+      })
+    })
+  })
+
+  describe('Admin User Access', () => {
+    it('should allow admin users to access the endpoint', async () => {
+      const mockContext: Context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'admin-user-id',
+          email: 'admin@plumber.gov.sg',
+        } as any,
+        isAdminOperation: true,
+      }
+
+      mocks.getAuthenticatedContext.mockReturnValueOnce(mockContext)
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        chatPrompt: 'aids-chat-v0',
+        version: 'production',
+      })
+      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+        prompt: 'test prompt',
+      })
+
+      const mockResult = {
+        pipeUIMessageStreamToResponse: vi.fn(),
+      }
+      mocks.startActiveObservation.mockImplementationOnce(
+        async (name, callback) => {
+          const mockTrace = {
+            updateTrace: vi.fn(),
+            startObservation: vi.fn(() => ({
+              update: vi.fn(),
+            })),
+            update: vi.fn(),
+            traceId: 'test-trace-id',
+          }
+          return await callback(mockTrace)
+        },
+      )
+      mocks.streamText.mockResolvedValueOnce(mockResult)
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      expect(mocks.getAuthenticatedContext).toHaveBeenCalledWith(mockReq)
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'ai-builder-prompt-config',
+        'admin@plumber.gov.sg',
+        expect.any(Object),
+      )
+    })
+  })
+})

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -251,7 +251,9 @@ describe('Chat Route Authentication', () => {
   })
 
   describe('Admin User Access', () => {
-    it('should allow admin users to access the endpoint', async () => {
+    it('handler can process admin requests (blocking handled by middleware)', async () => {
+      // Note: admin users are blocked by middleware before reaching this handler.
+      // This test verifies the handler itself can process admin contexts if they reach it.
       const mockContext: Context = {
         req: mockReq as Request,
         res: mockRes as Response,

--- a/packages/backend/src/routes/api/__tests__/middleware/authentication.test.ts
+++ b/packages/backend/src/routes/api/__tests__/middleware/authentication.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UnauthenticatedContext } from '@/types/express/context'
 
 import {
+  blockAdminOperations,
   getAuthenticatedContext,
   requireAuthentication,
   setCurrentUserContext,
@@ -238,6 +239,74 @@ describe('API Authentication Middleware', () => {
 
       expect(result).toEqual(mockContext)
       expect(result.isAdminOperation).toBe(true)
+    })
+  })
+
+  describe('blockAdminMutations', () => {
+    it('should block admin operations with 403', () => {
+      mockReq.context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'admin-user-id',
+          email: 'admin@plumber.gov.sg',
+        } as any,
+        isAdminOperation: true,
+      }
+
+      blockAdminOperations(mockReq as Request, mockRes as Response, mockNext)
+
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: 'Admin operations are read-only',
+      })
+      expect(mockNext).not.toHaveBeenCalled()
+    })
+
+    it('should allow non-admin operations', () => {
+      mockReq.context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'user-id',
+          email: 'user@example.com',
+        } as any,
+        isAdminOperation: false,
+      }
+
+      blockAdminOperations(mockReq as Request, mockRes as Response, mockNext)
+
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+
+    it('should allow requests without context', () => {
+      mockReq.context = undefined
+
+      blockAdminOperations(mockReq as Request, mockRes as Response, mockNext)
+
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledOnce()
+    })
+
+    it('should allow requests with isAdminOperation set to false', () => {
+      mockReq.context = {
+        req: mockReq as Request,
+        res: mockRes as Response,
+        currentUser: {
+          id: 'user-id',
+          email: 'user@example.com',
+        } as any,
+        isAdminOperation: false,
+      }
+
+      blockAdminOperations(mockReq as Request, mockRes as Response, mockNext)
+
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).not.toHaveBeenCalled()
+      expect(mockNext).toHaveBeenCalledOnce()
     })
   })
 })

--- a/packages/backend/src/routes/api/__tests__/middleware/authentication.test.ts
+++ b/packages/backend/src/routes/api/__tests__/middleware/authentication.test.ts
@@ -242,7 +242,7 @@ describe('API Authentication Middleware', () => {
     })
   })
 
-  describe('blockAdminMutations', () => {
+  describe('blockAdminOperations', () => {
     it('should block admin operations with 403', () => {
       mockReq.context = {
         req: mockReq as Request,

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -1,6 +1,6 @@
 import { startActiveObservation } from '@langfuse/tracing'
 import { convertToModelMessages, smoothStream, streamText } from 'ai'
-import type { Request, Response } from 'express'
+import type { Response } from 'express'
 import { Router } from 'express'
 
 import appConfig from '@/config/app'
@@ -8,8 +8,7 @@ import { langfuseClient } from '@/helpers/langfuse'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
-
-import { getAuthenticatedContext } from './middleware/authentication'
+import { AuthenticatedRequest } from '@/types/express/context'
 
 interface ChatRequest {
   messages: Array<{
@@ -20,9 +19,8 @@ interface ChatRequest {
   sessionId?: string
 }
 
-async function handleChatStream(req: Request, res: Response) {
-  const context = getAuthenticatedContext(req)
-
+async function handleChatStream(req: AuthenticatedRequest, res: Response) {
+  const context = req.context
   const promptConfig = await getLdFlagValue(
     'ai-builder-prompt-config',
     context.currentUser.email,

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -35,7 +35,7 @@ async function handleChatStream(req: Request, res: Response) {
   const { chatPrompt, version } = promptConfig
 
   try {
-    const { messages: rawMessages, userId, sessionId } = req.body as ChatRequest
+    const { messages: rawMessages, sessionId } = req.body as ChatRequest
 
     if (
       !rawMessages ||
@@ -61,7 +61,6 @@ async function handleChatStream(req: Request, res: Response) {
     })
 
     let traceId = ''
-    let generationId = ''
 
     // Setup observation and stream using AI SDK
     const result = await startActiveObservation(
@@ -70,7 +69,7 @@ async function handleChatStream(req: Request, res: Response) {
         trace.updateTrace({
           name: 'ai-chat-stream',
           sessionId: sessionId || 'unknown',
-          userId: userId || 'anonymous',
+          userId: context.currentUser.email || 'anonymous',
           input: { messages, prompt: lastUserMessage },
           tags: ['stream', 'rest-api'],
           environment: appConfig.appEnv,
@@ -91,8 +90,6 @@ async function handleChatStream(req: Request, res: Response) {
 
         // Capture IDs for client
         traceId = trace.traceId
-        // @ts-expect-error - observationId exists but not in types
-        generationId = generation.observationId
 
         return streamText({
           model,
@@ -106,8 +103,12 @@ async function handleChatStream(req: Request, res: Response) {
           onFinish: (event) => {
             logger.info('Stream finished', {
               traceId,
-              generationId,
               textLength: event.text.length,
+            })
+
+            trace.update({
+              output: { result: event.text },
+              level: 'DEFAULT',
             })
 
             generation
@@ -120,11 +121,6 @@ async function handleChatStream(req: Request, res: Response) {
                 },
               })
               .end()
-
-            trace.update({
-              output: { result: event.text },
-              level: 'DEFAULT',
-            })
           },
           onError: (error) => {
             const errorMessage =
@@ -132,8 +128,12 @@ async function handleChatStream(req: Request, res: Response) {
 
             logger.error('Error generating chat response', {
               traceId,
-              generationId,
               error: errorMessage,
+            })
+
+            trace.update({
+              output: { error: errorMessage },
+              level: 'ERROR',
             })
 
             generation
@@ -142,11 +142,6 @@ async function handleChatStream(req: Request, res: Response) {
                 level: 'ERROR',
               })
               .end()
-
-            trace.update({
-              output: { error: errorMessage },
-              level: 'ERROR',
-            })
           },
         })
       },
@@ -155,9 +150,11 @@ async function handleChatStream(req: Request, res: Response) {
     // Pipe the UI message stream to Express response
     // This uses the data stream protocol that DefaultChatTransport expects
     result.pipeUIMessageStreamToResponse(res, {
-      headers: {
-        ...(traceId && { 'X-Trace-Id': traceId }),
-        ...(generationId && { 'X-Generation-Id': generationId }),
+      messageMetadata: () => {
+        return {
+          traceId,
+          model: MODEL_TYPE,
+        }
       },
     })
   } catch (error) {

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -72,7 +72,7 @@ async function handleChatStream(req: Request, res: Response) {
           sessionId: sessionId || 'unknown',
           userId: userId || 'anonymous',
           input: { messages, prompt: lastUserMessage },
-          tags: ['sse', 'stream', 'rest-api'],
+          tags: ['stream', 'rest-api'],
           environment: appConfig.appEnv,
         })
 

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -1,0 +1,182 @@
+import { startActiveObservation } from '@langfuse/tracing'
+import { convertToModelMessages, smoothStream, streamText } from 'ai'
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+
+import appConfig from '@/config/app'
+import { langfuseClient } from '@/helpers/langfuse'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
+import logger from '@/helpers/logger'
+import { model, MODEL_TYPE } from '@/helpers/pair'
+
+import { getAuthenticatedContext } from './middleware/authentication'
+
+interface ChatRequest {
+  messages: Array<{
+    role: 'user' | 'assistant' | 'system'
+    parts: Array<{ type: 'text'; text: string }>
+  }>
+  userId?: string
+  sessionId?: string
+}
+
+async function handleChatStream(req: Request, res: Response) {
+  const context = getAuthenticatedContext(req)
+
+  const promptConfig = await getLdFlagValue(
+    'ai-builder-prompt-config',
+    context.currentUser.email,
+    {
+      chatPrompt: 'aids-chat-v0',
+      version: 'production',
+    },
+  )
+
+  const { chatPrompt, version } = promptConfig
+
+  try {
+    const { messages: rawMessages, userId, sessionId } = req.body as ChatRequest
+
+    if (
+      !rawMessages ||
+      !Array.isArray(rawMessages) ||
+      rawMessages.length === 0
+    ) {
+      res.status(400).json({ error: 'Messages array is required' })
+      return
+    }
+
+    // Convert UIMessages to ModelMessages
+    const messages = convertToModelMessages(rawMessages as any)
+
+    // Extract last user message text for tracking (simple text-only format)
+    const lastUserMessage = rawMessages
+      .filter((m) => m.role === 'user')
+      .map((m) => m.parts.find((p) => p.type === 'text')?.text || '')
+      .pop()
+
+    // Get the prompt from Langfuse
+    const prompt = await langfuseClient.prompt.get(chatPrompt, {
+      label: version,
+    })
+
+    let traceId = ''
+    let generationId = ''
+
+    // Setup observation and stream using AI SDK
+    const result = await startActiveObservation(
+      'ai-chat-stream',
+      async (trace) => {
+        trace.updateTrace({
+          name: 'ai-chat-stream',
+          sessionId: sessionId || 'unknown',
+          userId: userId || 'anonymous',
+          input: { messages, prompt: lastUserMessage },
+          tags: ['sse', 'stream', 'rest-api'],
+          environment: appConfig.appEnv,
+        })
+
+        const generation = trace.startObservation(
+          'ai-stream-generation',
+          {
+            model: MODEL_TYPE,
+            input: [{ role: 'system', content: prompt.prompt }, ...messages],
+          },
+          { asType: 'generation' },
+        )
+
+        generation.update({
+          prompt,
+        })
+
+        // Capture IDs for client
+        traceId = trace.traceId
+        // @ts-expect-error - observationId exists but not in types
+        generationId = generation.observationId
+
+        return streamText({
+          model,
+          messages: [{ role: 'system', content: prompt.prompt }, ...messages],
+          experimental_transform: smoothStream({
+            chunking: 'word', // Stream word-by-word for typing effect
+          }),
+          experimental_telemetry: {
+            isEnabled: true,
+          },
+          onFinish: (event) => {
+            logger.info('Stream finished', {
+              traceId,
+              generationId,
+              textLength: event.text.length,
+            })
+
+            generation
+              .update({
+                output: event.text,
+                usageDetails: {
+                  input: event.usage.inputTokens,
+                  output: event.usage.outputTokens,
+                  total: event.usage.totalTokens,
+                },
+              })
+              .end()
+
+            trace.update({
+              output: { result: event.text },
+              level: 'DEFAULT',
+            })
+          },
+          onError: (error) => {
+            const errorMessage =
+              error instanceof Error ? error.message : String(error)
+
+            logger.error('Error generating chat response', {
+              traceId,
+              generationId,
+              error: errorMessage,
+            })
+
+            generation
+              .update({
+                output: errorMessage,
+                level: 'ERROR',
+              })
+              .end()
+
+            trace.update({
+              output: { error: errorMessage },
+              level: 'ERROR',
+            })
+          },
+        })
+      },
+    )
+
+    // Pipe the UI message stream to Express response
+    // This uses the data stream protocol that DefaultChatTransport expects
+    result.pipeUIMessageStreamToResponse(res, {
+      headers: {
+        ...(traceId && { 'X-Trace-Id': traceId }),
+        ...(generationId && { 'X-Generation-Id': generationId }),
+      },
+    })
+  } catch (error) {
+    logger.error('Error in chat stream', { error })
+
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error occurred'
+
+    // If headers haven't been sent yet, send error response
+    if (!res.headersSent) {
+      res.status(500).json({ error: errorMessage })
+    } else {
+      res.end()
+    }
+  }
+}
+
+const router = Router()
+
+router.post('/', handleChatStream)
+
+export default router

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -71,7 +71,7 @@ async function handleChatStream(req: Request, res: Response) {
           sessionId: sessionId || 'unknown',
           userId: context.currentUser.email || 'anonymous',
           input: { messages, prompt: lastUserMessage },
-          tags: ['stream', 'rest-api'],
+          tags: ['ai-builder', 'chat', 'stream'],
           environment: appConfig.appEnv,
         })
 

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -27,7 +27,7 @@ async function handleChatStream(req: Request, res: Response) {
     'ai-builder-prompt-config',
     context.currentUser.email,
     {
-      chatPrompt: 'aids-chat-v0',
+      chatPrompt: 'ai-builder/chat',
       version: 'production',
     },
   )

--- a/packages/backend/src/routes/api/chat.ts
+++ b/packages/backend/src/routes/api/chat.ts
@@ -4,6 +4,7 @@ import type { Response } from 'express'
 import { Router } from 'express'
 
 import appConfig from '@/config/app'
+import { AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG } from '@/config/flags'
 import { langfuseClient } from '@/helpers/langfuse'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
@@ -15,14 +16,16 @@ interface ChatRequest {
     role: 'user' | 'assistant' | 'system'
     parts: Array<{ type: 'text'; text: string }>
   }>
-  userId?: string
+  /**
+   * sessionId: Datadog RUM session ID
+   */
   sessionId?: string
 }
 
 async function handleChatStream(req: AuthenticatedRequest, res: Response) {
   const context = req.context
   const promptConfig = await getLdFlagValue(
-    'ai-builder-prompt-config',
+    AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
     context.currentUser.email,
     {
       chatPrompt: 'ai-builder/chat',
@@ -45,7 +48,7 @@ async function handleChatStream(req: AuthenticatedRequest, res: Response) {
     }
 
     // Convert UIMessages to ModelMessages
-    const messages = convertToModelMessages(rawMessages as any)
+    const messages = convertToModelMessages(rawMessages)
 
     // Extract last user message text for tracking (simple text-only format)
     const lastUserMessage = rawMessages

--- a/packages/backend/src/routes/api/index.ts
+++ b/packages/backend/src/routes/api/index.ts
@@ -1,8 +1,17 @@
 import { Router } from 'express'
 
+import {
+  requireAuthentication,
+  setCurrentUserContext,
+} from './middleware/authentication'
 import chatRouter from './chat'
 
 const router = Router()
+
+// Apply authentication middleware to ALL API routes
+// This mirrors how GraphQL handles authentication via context
+router.use(setCurrentUserContext)
+router.use(requireAuthentication)
 
 // Mount individual API routes
 router.use('/chat', chatRouter)

--- a/packages/backend/src/routes/api/index.ts
+++ b/packages/backend/src/routes/api/index.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express'
 
+import chatRouter from './chat'
+
 const router = Router()
 
 // Mount individual API routes
+router.use('/chat', chatRouter)
 
 // Future routes can be added here:
 // router.use('/users', usersRouter)

--- a/packages/backend/src/routes/api/index.ts
+++ b/packages/backend/src/routes/api/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 
 import {
+  blockAdminOperations,
   requireAuthentication,
   setCurrentUserContext,
 } from './middleware/authentication'
@@ -12,6 +13,13 @@ const router = Router()
 // This mirrors how GraphQL handles authentication via context
 router.use(setCurrentUserContext)
 router.use(requireAuthentication)
+
+// Routes that allow admin operations must be mounted BEFORE this middleware
+// (none currently - all routes block admins by default)
+
+// Block ALL admin mutations by default (admins are read-only)
+// Individual routes that need admin write access should be mounted above
+router.use(blockAdminOperations)
 
 // Mount individual API routes
 router.use('/chat', chatRouter)

--- a/packages/backend/src/routes/api/middleware/authentication.ts
+++ b/packages/backend/src/routes/api/middleware/authentication.ts
@@ -49,3 +49,35 @@ export function getAuthenticatedContext(req: Request): Context {
 
   return req.context
 }
+
+/**
+ * Middleware to block admin operations from making mutations.
+ * Admins are limited to read-only operations by default.
+ * Returns 403 if the request is an admin operation.
+ */
+export function blockAdminOperations(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  if (req.context?.isAdminOperation) {
+    res.status(403).json({ error: 'Admin operations are read-only' })
+    return
+  }
+
+  next()
+}
+
+/**
+ * Middleware to allow admin operations (bypass the admin mutation block).
+ * Use this for specific endpoints where admins should have write access.
+ */
+export function allowAdminOperations(
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) {
+  // This middleware does nothing but can be used to explicitly allow admin operations
+  // by placing it before blockAdminMutations in the middleware chain
+  next()
+}

--- a/packages/backend/src/types/express/context.ts
+++ b/packages/backend/src/types/express/context.ts
@@ -14,4 +14,8 @@ interface Context extends UnauthenticatedContext {
   currentUser: User
 }
 
+export interface AuthenticatedRequest extends Request {
+  context: Context
+}
+
 export default Context


### PR DESCRIPTION
## TL;DR
Added a new chat API to stream LLM responses from Pair based on user inputs.

## What changed?

- Created a new `/api/chat` endpoint that handles streaming chat responses
- Added Langfuse integration for prompt management and observability
- Set up feature flag integration with Launch Darkly for prompt configuration

### How to test?

1. Send a POST request to `/api/chat` with a valid authentication token
2. Include a request body with the following structure:
   ```json
   {
     "messages": [
       {
         "role": "user",
         "parts": [{ "type": "text", "text": "Your message here" }]
       }
     ],
     "userId": "optional-user-id",
     "sessionId": "optional-session-id"
   }
   ```
3. Verify that the response is streamed back

