### PR TITLE
feat(frontend): RTE custom menu options

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -248,6 +248,9 @@ type ActionSubstepArgument {
 
   # Only for multirow
   subFields: [ActionSubstepArgument]
+
+  # Only for rich text
+  customRteMenuOptions: [String]
 }
 
 type DropdownClickableLink {
@@ -290,6 +293,7 @@ enum AppCategory {
   data
   communication
   logic
+  ai
   others
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -218,6 +218,30 @@ type DropdownAddNewOption {
   label: String!
 }
 
+enum RteMenuOption {
+  Bold
+  Italic
+  Underline
+  LinkSet
+  LinkRemove
+  Heading1
+  Heading2
+  Heading3
+  Heading4
+  ListBullet
+  ListOrdered
+  ImageAdd
+  TableAdd
+  ColumnAdd
+  ColumnRemove
+  RowAdd
+  RowRemove
+  FormatClear
+  Undo
+  Redo
+  Divider
+}
+
 type ActionSubstepArgument {
   label: String
   key: String
@@ -250,7 +274,7 @@ type ActionSubstepArgument {
   subFields: [ActionSubstepArgument]
 
   # Only for rich text
-  customRteMenuOptions: [String]
+  customRteMenuOptions: [RteMenuOption]
 }
 
 type DropdownClickableLink {

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -145,6 +145,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         variablesEnabled={variables}
         isRich
         noVariablesMessage={noVariablesMessage}
+        customRteMenuOptions={schema?.customRteMenuOptions}
       />
     )
   }

--- a/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
+++ b/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
@@ -1,5 +1,7 @@
 import './MenuBar.scss'
 
+import type { TRteMenuOption } from '@plumber/types'
+
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { LuHeading1, LuHeading2, LuHeading3, LuHeading4 } from 'react-icons/lu'
 import {
@@ -36,57 +38,36 @@ import { Editor } from '@tiptap/react'
 import { parse } from 'node-html-parser'
 
 import Form from '@/components/Form'
+import { RteMenuOption } from '@/graphql/__generated__/graphql'
 import { makeExternalLink } from '@/helpers/urls'
 
 import { simpleSubstitute, type VariableInfoMap } from './utils'
 import { BareEditor } from '.'
 
-enum MenuLabels {
-  Bold = 'Bold',
-  Italic = 'Italic',
-  Underline = 'Underline',
-  LinkSet = 'Set Link',
-  LinkRemove = 'Remove Link',
-  Heading1 = 'Heading 1',
-  Heading2 = 'Heading 2',
-  Heading3 = 'Heading 3',
-  Heading4 = 'Heading 4',
-  ListBullet = 'Bullet List',
-  ListOrdered = 'Ordered List',
-  ImageAdd = 'Add Image',
-  TableAdd = 'Add Table',
-  ColumnAdd = 'Add Column',
-  ColumnRemove = 'Remove Column',
-  RowAdd = 'Add Row',
-  RowRemove = 'Remove Row',
-  FormatClear = 'Clear Format',
-  Undo = 'Undo',
-  Redo = 'Redo',
-}
 const DEFAULT_MENU_BUTTONS = [
   {
-    label: MenuLabels.Bold,
+    label: RteMenuOption.Bold,
     onClick: (editor: Editor) => editor.chain().focus().toggleBold().run(),
     icon: <RiBold />,
     isActive: (editor: Editor) => editor.isActive('bold'),
   },
   {
-    label: MenuLabels.Italic,
+    label: RteMenuOption.Italic,
     onClick: (editor: Editor) => editor.chain().focus().toggleItalic().run(),
     icon: <RiItalic />,
     isActive: (editor: Editor) => editor.isActive('italic'),
   },
   {
-    label: MenuLabels.Underline,
+    label: RteMenuOption.Underline,
     icon: <RiUnderline />,
     onClick: (editor: Editor) => editor.chain().focus().toggleUnderline().run(),
     isActive: (editor: Editor) => editor.isActive('underline'),
   },
   {
-    label: 'divider',
+    label: RteMenuOption.Divider,
   },
   {
-    label: MenuLabels.LinkSet,
+    label: RteMenuOption.LinkSet,
     icon: <RiLink />,
     onClick: (editor: Editor) => {
       const previousUrl = editor.getAttributes('link').href
@@ -114,57 +95,57 @@ const DEFAULT_MENU_BUTTONS = [
     },
   },
   {
-    label: MenuLabels.LinkRemove,
+    label: RteMenuOption.LinkRemove,
     icon: <RiLinkUnlink />,
     onClick: (editor: Editor) => editor.chain().focus().unsetLink().run(),
   },
   {
-    label: 'divider',
+    label: RteMenuOption.Divider,
   },
   {
-    label: MenuLabels.Heading1,
+    label: RteMenuOption.Heading1,
     icon: <LuHeading1 />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleHeading({ level: 1 }).run(),
     isActive: (editor: Editor) => editor.isActive('heading', { level: 1 }),
   },
   {
-    label: MenuLabels.Heading2,
+    label: RteMenuOption.Heading2,
     icon: <LuHeading2 />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleHeading({ level: 2 }).run(),
     isActive: (editor: Editor) => editor.isActive('heading', { level: 2 }),
   },
   {
-    label: MenuLabels.Heading3,
+    label: RteMenuOption.Heading3,
     icon: <LuHeading3 />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleHeading({ level: 3 }).run(),
     isActive: (editor: Editor) => editor.isActive('heading', { level: 3 }),
   },
   {
-    label: MenuLabels.Heading4,
+    label: RteMenuOption.Heading4,
     icon: <LuHeading4 />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleHeading({ level: 4 }).run(),
     isActive: (editor: Editor) => editor.isActive('heading', { level: 4 }),
   },
   {
-    label: MenuLabels.ListBullet,
+    label: RteMenuOption.ListBullet,
     icon: <RiListUnordered />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleBulletList().run(),
     isActive: (editor: Editor) => editor.isActive('bulletList'),
   },
   {
-    label: MenuLabels.ListOrdered,
+    label: RteMenuOption.ListOrdered,
     icon: <RiListOrdered />,
     onClick: (editor: Editor) =>
       editor.chain().focus().toggleOrderedList().run(),
     isActive: (editor: Editor) => editor.isActive('orderedList'),
   },
   {
-    label: MenuLabels.ImageAdd,
+    label: RteMenuOption.ImageAdd,
     icon: <RiImageFill />,
     onClick: (editor: Editor) => {
       const url = window.prompt('URL')
@@ -175,10 +156,10 @@ const DEFAULT_MENU_BUTTONS = [
     },
   },
   {
-    label: 'divider',
+    label: RteMenuOption.Divider,
   },
   {
-    label: MenuLabels.TableAdd,
+    label: RteMenuOption.TableAdd,
     icon: <RiTableLine />,
     onClick: (editor: Editor) =>
       editor
@@ -188,49 +169,49 @@ const DEFAULT_MENU_BUTTONS = [
         .run(),
   },
   {
-    label: MenuLabels.ColumnAdd,
+    label: RteMenuOption.ColumnAdd,
     icon: <RiInsertColumnRight />,
     onClick: (editor: Editor) => editor.chain().focus().addColumnAfter().run(),
   },
   {
-    label: MenuLabels.ColumnRemove,
+    label: RteMenuOption.ColumnRemove,
     icon: <RiDeleteColumn />,
     onClick: (editor: Editor) => editor.chain().focus().deleteColumn().run(),
   },
   {
-    label: MenuLabels.RowAdd,
+    label: RteMenuOption.RowAdd,
     icon: <RiInsertRowBottom />,
     onClick: (editor: Editor) => editor.chain().focus().addRowAfter().run(),
   },
   {
-    label: MenuLabels.RowRemove,
+    label: RteMenuOption.RowRemove,
     icon: <RiDeleteRow />,
     onClick: (editor: Editor) => editor.chain().focus().deleteRow().run(),
   },
   {
-    label: 'divider',
+    label: RteMenuOption.Divider,
   },
   {
-    label: MenuLabels.FormatClear,
+    label: RteMenuOption.FormatClear,
     icon: <RiFormatClear />,
     onClick: (editor: Editor) =>
       editor.chain().focus().clearNodes().unsetAllMarks().run(),
   },
   {
-    label: MenuLabels.Undo,
+    label: RteMenuOption.Undo,
     icon: <RiArrowGoBackLine />,
     onClick: (editor: Editor) => editor.chain().focus().undo().run(),
   },
   {
-    label: MenuLabels.Redo,
+    label: RteMenuOption.Redo,
     icon: <RiArrowGoForwardLine />,
     onClick: (editor: Editor) => editor.chain().focus().redo().run(),
   },
 ]
 
-const dialogPlaceholders: Partial<Record<MenuLabels, string>> = {
-  [MenuLabels.LinkSet]: 'Enter a full URL with http prefix',
-  [MenuLabels.ImageAdd]:
+const dialogPlaceholders: Partial<Record<RteMenuOption, string>> = {
+  [RteMenuOption.LinkSet]: 'Enter a full URL with http prefix',
+  [RteMenuOption.ImageAdd]:
     'Enter direct image link (e.g. https://file.go.gov.sg/clipplumber.png)',
 }
 
@@ -238,7 +219,7 @@ interface MenuBarProps {
   editor: Editor | null
   variableMap: VariableInfoMap
   editable: boolean
-  customMenuOptions?: string[]
+  customMenuOptions?: TRteMenuOption[]
 }
 
 export const MenuBar = ({
@@ -254,7 +235,7 @@ export const MenuBar = ({
   } = useDisclosure()
   const cancelRef = useRef(null)
   const [dialogValue, setDialogValue] = useState('')
-  const [dialogLabel, setDialogLabel] = useState<MenuLabels | null>(null)
+  const [dialogLabel, setDialogLabel] = useState<RteMenuOption | null>(null)
 
   const onDialogClose = useCallback(() => {
     setDialogLabel(null)
@@ -262,22 +243,22 @@ export const MenuBar = ({
     onClose()
   }, [onClose])
 
-  const onClickOverrides: Partial<Record<MenuLabels, () => void>> = useMemo(
+  const onClickOverrides: Partial<Record<RteMenuOption, () => void>> = useMemo(
     () => ({
-      [MenuLabels.LinkSet]: () => {
+      [RteMenuOption.LinkSet]: () => {
         if (!editor) {
           return
         }
         const previousUrl = editor.getAttributes('link').href
-        setDialogLabel(MenuLabels.LinkSet)
+        setDialogLabel(RteMenuOption.LinkSet)
         setDialogValue(previousUrl)
         onDialogOpen()
       },
-      [MenuLabels.ImageAdd]: () => {
+      [RteMenuOption.ImageAdd]: () => {
         if (!editor) {
           return
         }
-        setDialogLabel(MenuLabels.ImageAdd)
+        setDialogLabel(RteMenuOption.ImageAdd)
         setDialogValue('')
         onDialogOpen()
       },
@@ -285,9 +266,9 @@ export const MenuBar = ({
     [editor, onDialogOpen],
   )
 
-  const dialogOnSubmits: Partial<Record<MenuLabels, () => void>> = useMemo(
+  const dialogOnSubmits: Partial<Record<RteMenuOption, () => void>> = useMemo(
     () => ({
-      [MenuLabels.LinkSet]: () => {
+      [RteMenuOption.LinkSet]: () => {
         if (!editor) {
           return
         }
@@ -312,7 +293,7 @@ export const MenuBar = ({
           .run()
         onDialogClose()
       },
-      [MenuLabels.ImageAdd]: () => {
+      [RteMenuOption.ImageAdd]: () => {
         if (!editor) {
           return
         }

--- a/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
+++ b/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
@@ -63,7 +63,7 @@ enum MenuLabels {
   Undo = 'Undo',
   Redo = 'Redo',
 }
-const menuButtons = [
+const DEFAULT_MENU_BUTTONS = [
   {
     label: MenuLabels.Bold,
     onClick: (editor: Editor) => editor.chain().focus().toggleBold().run(),
@@ -238,9 +238,15 @@ interface MenuBarProps {
   editor: Editor | null
   variableMap: VariableInfoMap
   editable: boolean
+  customMenuOptions?: string[]
 }
 
-export const MenuBar = ({ editor, variableMap, editable }: MenuBarProps) => {
+export const MenuBar = ({
+  editor,
+  variableMap,
+  editable,
+  customMenuOptions,
+}: MenuBarProps) => {
   const {
     isOpen: isDialogOpen,
     onClose,
@@ -320,6 +326,18 @@ export const MenuBar = ({ editor, variableMap, editable }: MenuBarProps) => {
     }),
     [editor, dialogValue, onDialogClose],
   )
+
+  const menuButtons = useMemo(() => {
+    if (customMenuOptions) {
+      return customMenuOptions
+        .map((option) =>
+          DEFAULT_MENU_BUTTONS.find(({ label }) => label === option),
+        )
+        .filter((button): button is NonNullable<typeof button> => !!button)
+    }
+
+    return DEFAULT_MENU_BUTTONS
+  }, [customMenuOptions])
 
   if (!editor) {
     return null

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -1,5 +1,6 @@
 import './RichTextEditor.scss'
 
+import type { TRteMenuOption } from '@plumber/types'
 import { TDataOutMetadatumType } from '@plumber/types'
 
 import { useCallback, useContext, useEffect, useMemo } from 'react'
@@ -100,7 +101,7 @@ interface EditorProps {
   autoFocus?: boolean
   singleVariableSelection?: boolean
   noVariablesMessage?: string
-  customRteMenuOptions?: string[]
+  customRteMenuOptions?: TRteMenuOption[]
 }
 const Editor = ({
   onChange,
@@ -351,7 +352,7 @@ interface RichTextEditorProps {
   autoFocus?: boolean
   singleVariableSelection?: boolean
   noVariablesMessage?: string
-  customRteMenuOptions?: string[]
+  customRteMenuOptions?: TRteMenuOption[]
 }
 const RichTextEditor = ({
   required,

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -100,6 +100,7 @@ interface EditorProps {
   autoFocus?: boolean
   singleVariableSelection?: boolean
   noVariablesMessage?: string
+  customRteMenuOptions?: string[]
 }
 const Editor = ({
   onChange,
@@ -114,6 +115,7 @@ const Editor = ({
   singleVariableSelection,
   autoFocus = false,
   noVariablesMessage,
+  customRteMenuOptions,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { allApps } = useContext(EditorContext)
@@ -292,6 +294,7 @@ const Editor = ({
                 editor={editor}
                 variableMap={varInfo}
                 editable={editable ?? false}
+                customMenuOptions={customRteMenuOptions}
               />
             )}
             <EditorContent
@@ -348,6 +351,7 @@ interface RichTextEditorProps {
   autoFocus?: boolean
   singleVariableSelection?: boolean
   noVariablesMessage?: string
+  customRteMenuOptions?: string[]
 }
 const RichTextEditor = ({
   required,
@@ -365,6 +369,7 @@ const RichTextEditor = ({
   autoFocus,
   singleVariableSelection,
   noVariablesMessage,
+  customRteMenuOptions,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -413,6 +418,7 @@ const RichTextEditor = ({
             autoFocus={shouldAutoFocus}
             singleVariableSelection={singleVariableSelection}
             noVariablesMessage={noVariablesMessage}
+            customRteMenuOptions={customRteMenuOptions}
           />
         )}
       />

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -226,6 +226,7 @@ export const GET_APPS = gql`
               url
             }
             singleVariableSelection
+            customRteMenuOptions
             # Only for multi-row
             subFields {
               label

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -454,6 +454,10 @@ export interface IFieldMultiRow extends IBaseField {
 export interface IFieldRichText extends IBaseField {
   type: 'rich-text'
   value?: string
+
+  // Specifies the order and what menu options to show in the RTE
+  // 'divider' is specified manually to determine when a divider should be shown
+  customRteMenuOptions?: string[]
 }
 
 export interface IFieldDragDrop extends IBaseField {
@@ -618,7 +622,7 @@ export interface IApp {
   setupMessage?: SetupMessage
 }
 
-export type AppCategory = 'data' | 'communication' | 'logic' | 'others'
+export type AppCategory = 'data' | 'communication' | 'logic' | 'others' | 'ai'
 
 export type TBeforeRequest = (
   $: IGlobalVariable,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -451,13 +451,36 @@ export interface IFieldMultiRow extends IBaseField {
   subFields: IField[]
 }
 
+export type TRteMenuOption =
+  | 'Bold'
+  | 'Italic'
+  | 'Underline'
+  | 'LinkSet'
+  | 'LinkRemove'
+  | 'Heading1'
+  | 'Heading2'
+  | 'Heading3'
+  | 'Heading4'
+  | 'ListBullet'
+  | 'ListOrdered'
+  | 'ImageAdd'
+  | 'TableAdd'
+  | 'ColumnAdd'
+  | 'ColumnRemove'
+  | 'RowAdd'
+  | 'RowRemove'
+  | 'FormatClear'
+  | 'Undo'
+  | 'Redo'
+  | 'Divider'
+
 export interface IFieldRichText extends IBaseField {
   type: 'rich-text'
   value?: string
 
   // Specifies the order and what menu options to show in the RTE
-  // 'divider' is specified manually to determine when a divider should be shown
-  customRteMenuOptions?: string[]
+  // 'Divider' is specified manually to determine when a divider should be shown
+  customRteMenuOptions?: TRteMenuOption[]
 }
 
 export interface IFieldDragDrop extends IBaseField {


### PR DESCRIPTION
## TL;DR

This PR is in preparation for the Pair action.
It allows the setting of custom menu options for the RTE.

## How to test

- [ ] Existing RTE works as intended (e.g., Postman email)
- [ ] Can set custom options for RTE, and options work as intended

In an action that uses RTE, set this:

```
customRteMenuOptions: [
        'Bold',
        'Italic',
        'Underline',
        'divider', // specify when to show a divider
        'Heading 1',
        'Heading 2',
        'Heading 3',
        'Heading 4',
        'Bullet List',
        'Ordered List',
        'divider',
        'Undo',
        'Redo',
],
```