### PR TITLE
[AI-ACTION-2]: Add tiptap-markdown to get markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13015,8 +13015,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/lodash": {
       "version": "4.17.20",
@@ -13062,7 +13061,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -13081,8 +13079,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -23183,7 +23180,6 @@
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -23645,7 +23641,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -23657,6 +23652,12 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
@@ -23923,8 +23924,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -25721,8 +25721,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -26569,7 +26568,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
       "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/markdown-it": "^14.0.0",
         "markdown-it": "^14.0.0",
@@ -26594,7 +26592,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -26783,7 +26780,6 @@
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -29412,6 +29408,46 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tiptap-markdown": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.8.10.tgz",
+      "integrity": "sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.3"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
+    },
     "node_modules/title-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
@@ -29909,8 +29945,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.6.1",
@@ -31567,6 +31602,7 @@
         "remark-breaks": "3.0.3",
         "remark-gfm": "3.0.1",
         "sass": "1.69.4",
+        "tiptap-markdown": "0.8.10",
         "typescript": "^5.5.4",
         "yup": "^0.32.11"
       },

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -231,6 +231,7 @@ type ActionSubstepArgument {
 
   # Only for rich text
   customRteMenuOptions: [String]
+  returnMarkdown: Boolean
 }
 
 type DropdownClickableLink {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -53,6 +53,7 @@
     "remark-breaks": "3.0.3",
     "remark-gfm": "3.0.1",
     "sass": "1.69.4",
+    "tiptap-markdown": "0.8.10",
     "typescript": "^5.5.4",
     "yup": "^0.32.11"
   },

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -146,6 +146,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         isRich
         noVariablesMessage={noVariablesMessage}
         customRteMenuOptions={schema?.customRteMenuOptions}
+        returnMarkdown={schema?.returnMarkdown}
       />
     )
   }

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -28,6 +28,7 @@ import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import escapeHtml from 'escape-html'
+import { Markdown } from 'tiptap-markdown'
 
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
@@ -85,6 +86,7 @@ const RICH_TEXT_EXTENSIONS = [
   ImageResize.configure({
     inline: true,
   }),
+  Markdown,
 ]
 
 interface EditorProps {
@@ -101,6 +103,7 @@ interface EditorProps {
   singleVariableSelection?: boolean
   noVariablesMessage?: string
   customRteMenuOptions?: string[]
+  returnMarkdown?: boolean
 }
 const Editor = ({
   onChange,
@@ -116,6 +119,7 @@ const Editor = ({
   autoFocus = false,
   noVariablesMessage,
   customRteMenuOptions,
+  returnMarkdown,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { allApps } = useContext(EditorContext)
@@ -196,7 +200,9 @@ const Editor = ({
       }
       onChange(
         isRich
-          ? removeProblematicWhitespace(editor.getHTML())
+          ? returnMarkdown
+            ? editor.storage.markdown.getMarkdown()
+            : removeProblematicWhitespace(editor.getHTML())
           : removeProblematicWhitespace(editor.getText()),
       )
     },
@@ -352,6 +358,7 @@ interface RichTextEditorProps {
   singleVariableSelection?: boolean
   noVariablesMessage?: string
   customRteMenuOptions?: string[]
+  returnMarkdown?: boolean
 }
 const RichTextEditor = ({
   required,
@@ -370,6 +377,7 @@ const RichTextEditor = ({
   singleVariableSelection,
   noVariablesMessage,
   customRteMenuOptions,
+  returnMarkdown,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -419,6 +427,7 @@ const RichTextEditor = ({
             singleVariableSelection={singleVariableSelection}
             noVariablesMessage={noVariablesMessage}
             customRteMenuOptions={customRteMenuOptions}
+            returnMarkdown={returnMarkdown}
           />
         )}
       />

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -227,6 +227,7 @@ export const GET_APPS = gql`
             }
             singleVariableSelection
             customRteMenuOptions
+            returnMarkdown
             # Only for multi-row
             subFields {
               label

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -452,6 +452,7 @@ export interface IFieldRichText extends IBaseField {
   // Specifies the order and what menu options to show in the RTE
   // 'divider' is specified manually to determine when a divider should be shown
   customRteMenuOptions?: string[]
+  returnMarkdown?: boolean
 }
 
 export interface IFieldDragDrop extends IBaseField {


### PR DESCRIPTION
### TL;DR
Added support for returning Markdown from RTE instead of HTML.
In preparation of Pair action as Markdown is more token-efficient and easier for LLMs to parse and generate consistently than HTML's verbose tag-based syntax.

### What changed?
- Added the `tiptap-markdown` package as a dependency
- Added a new `returnMarkdown` boolean option to rich text field configurations
- Modified the editor to return Markdown content when `returnMarkdown` is enabled

### How to test?
1. Create or edit an action with a rich text field
2. Set the `returnMarkdown` option to `true` in the field configuration
3. Enter content in the rich text editor
4. Verify that the field returns Markdown instead of HTML when submitted
