### PR TITLE
refactor: show warnings for AI responses

### DIFF
--- a/packages/backend/src/apps/aisay/actions/use-generalised-model/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/aisay/actions/use-generalised-model/get-data-out-metadata.ts
@@ -19,6 +19,7 @@ async function getDataOutMetadata(
     const fieldName = prompts[index]
     fieldsMetadata[key] = {
       label: fieldName,
+      type: 'ai_response',
     }
   })
 

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -108,8 +108,13 @@ export default function FlowStepTestController(
   } = useContext(EditorContext)
   const formContext = useFormContext()
 
-  const { isIfThenStep, isTrigger, selectedActionOrTrigger, substeps } =
-    useStepMetadata(allApps, step)
+  const {
+    isIfThenStep,
+    isTrigger,
+    selectedActionOrTrigger,
+    substeps,
+    isAiStep,
+  } = useStepMetadata(allApps, step)
 
   const {
     isTestSuccessful,
@@ -143,6 +148,7 @@ export default function FlowStepTestController(
     isTestExecuting,
     stepId: step.id,
     testVariables,
+    isAiStep,
   })
 
   const infoBoxIcon = useMemo(() => {
@@ -154,6 +160,13 @@ export default function FlowStepTestController(
     if (infoBoxVariant === 'unstyled') {
       return <></>
     }
+
+    // NOTE: for any AI step, always show the warning info circle
+    // put this after 'unstyled' so that the loading state does not show the warning icon
+    if (isAiStep) {
+      return <Icon as={BxsInfoCircle} color="yellow.100" {...props} />
+    }
+
     if (infoBoxVariant === 'error') {
       return <Icon as={BxsErrorCircle} color="red.500" {...props} />
     }
@@ -161,7 +174,7 @@ export default function FlowStepTestController(
       return <Icon as={BxsCheckCircle} color="green.500" {...props} />
     }
     return <Icon as={BxsInfoCircle} color="blue.500" {...props} />
-  }, [infoBoxVariant])
+  }, [infoBoxVariant, isAiStep])
 
   const isStepUnchecked = infoBoxVariant === 'unstyled'
 

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -271,6 +271,7 @@ export function getInfoBoxDetails({
   isTestExecuting,
   stepId,
   testVariables,
+  isAiStep,
 }: {
   isDirty: boolean
   isIfThenStep: boolean
@@ -279,9 +280,19 @@ export function getInfoBoxDetails({
   isTestExecuting: boolean
   stepId: string
   testVariables: Variable[] | null
+  isAiStep: boolean
 }): [InfoboxProps['variant'], React.ReactNode] {
   if (isTestExecuting) {
     return ['unstyled', 'Checking step...']
+  }
+
+  if (isAiStep) {
+    return [
+      'warning',
+      <Text key={`${stepId}-ai-warning-text`}>
+        AI can make mistakes. Check your responses across multiple test cases.
+      </Text>,
+    ]
   }
 
   if (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty)) {

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -290,7 +290,8 @@ export function getInfoBoxDetails({
     return [
       'warning',
       <Text key={`${stepId}-ai-warning-text`}>
-        AI can make mistakes. Check your responses across multiple test cases.
+        AI can make mistakes. Check the response{' '}
+        {!isDirty && 'across multiple test cases'}
       </Text>,
     ]
   }

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -50,6 +50,12 @@ function VariableTag({
           label: 'Tile Row ID',
           tooltip: `This variable can be used in Tile's Update Single Row action`,
         }
+      case 'ai_response':
+        return {
+          label: 'AI response',
+          tooltip:
+            'This variable is AI-generated. Check for errors before using it.',
+        }
       default:
         return {
           label: null,

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -53,8 +53,7 @@ function VariableTag({
       case 'ai_response':
         return {
           label: 'AI response',
-          tooltip:
-            'This variable is AI-generated. Check for errors before using it.',
+          tooltip: 'This is AI-generated. Check for errors before using it.',
         }
       default:
         return {

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -16,6 +16,7 @@ export const VISIBLE_VARIABLE_TYPES: TDataOutMetadatumType[] = [
   'text',
   'array',
   'tile_row_id',
+  'ai_response',
 ]
 
 export interface StepWithVariables {

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -5,6 +5,11 @@ import { useMemo } from 'react'
 import getStepName from '@/helpers/getStepName'
 import { isIfThenStep as checkIfThenStep } from '@/helpers/toolbox'
 
+enum AI_ACTIONS {
+  Pair = 'pair',
+  Aisay = 'aisay',
+}
+
 interface UseStepMetadataResult {
   app: IApp | undefined
   selectedActionOrTrigger: IAction | ITrigger | undefined
@@ -18,6 +23,11 @@ interface UseStepMetadataResult {
   stepName: string
   substeps: ISubstep[]
   shouldShowDragHandle?: boolean
+  isAiStep: boolean
+}
+
+function isAiStep(step: IStep): boolean {
+  return Object.values(AI_ACTIONS).includes(step?.appKey as AI_ACTIONS) ?? false
 }
 
 export function useStepMetadata(
@@ -95,5 +105,6 @@ export function useStepMetadata(
       : defaultCaption ?? '',
     substeps,
     shouldShowDragHandle,
+    isAiStep: step ? isAiStep(step) : false,
   }
 }

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -27,7 +27,7 @@ interface UseStepMetadataResult {
 }
 
 function isAiStep(step: IStep): boolean {
-  return Object.values(AI_ACTIONS).includes(step?.appKey as AI_ACTIONS) ?? false
+  return Object.values(AI_ACTIONS).includes(step?.appKey as AI_ACTIONS)
 }
 
 export function useStepMetadata(

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -60,6 +60,7 @@ export type TDataOutMetadatumType =
   | 'array'
   | 'tile_row_id'
   | 'table'
+  | 'ai_response'
 
 /**
  * This should only be defined on _leaf_ nodes (i.e. **primitive array


### PR DESCRIPTION
## TL;DR
Added `ai_response` type to identify AI-generated variables and display appropriate warnings to users.

This change helps users identify AI-generated content and reminds them to verify the outputs before using them in critical workflows. By clearly marking AI responses and displaying appropriate warnings, we reduce the risk of users blindly trusting potentially incorrect AI-generated content.

## What changed?
- Added a new `ai_response` type to the `TDataOutMetadatumType` enum
- Created `getDataOutMetadata` for the Pair action + updated AISAY's `getDataOutMetadata`
- Added UI elements to warn users about AI-generated content:
  - Warning icon and message in the FlowStepTestController for AI steps
  - Special tag and tooltip for AI response variables in the VariablesList

## How to test?
Create a flow with an AI step (either Pair or AISAY)
 - [ ] Run a test on the step and observe the warning message: "AI can make mistakes. Check your responses across multiple test cases."
- [ ] Check that variables from AI steps are tagged as "AI response" with the tooltip: "This variable is AI-generated. Check for errors before using it."

## Screenshots

![Screenshot 2025-11-10 at 4.36.20 PM.png](https://app.graphite.com/user-attachments/assets/065fea84-b331-4fe9-a87c-41e41c8c3f8c.png)

![Screenshot 2025-11-10 at 4.36.27 PM.png](https://app.graphite.com/user-attachments/assets/c83862e0-0275-4d13-911c-3c2365c2af0f.png)

![Screenshot 2025-11-10 at 4.36.09 PM.png](https://app.graphite.com/user-attachments/assets/b6505640-f704-4460-b670-32cf0b578e9a.png)

