### PR TITLE
PLU-612: filter iterations for IterationSelector

### DIFF
--- a/packages/frontend/src/components/ExecutionGroup/index.tsx
+++ b/packages/frontend/src/components/ExecutionGroup/index.tsx
@@ -83,6 +83,19 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
     }
   }, [iterationMap, statusFilter])
 
+  // NOTE: filter the iteration map to only include iterations that match the status filter
+  const filteredIterationMap = useMemo(() => {
+    if (statusFilter === GroupStatusType.All) {
+      return iterationMap
+    }
+
+    return new Map(
+      [...iterationMap].filter(([_iteration, status]) => {
+        return status === statusFilter
+      }),
+    )
+  }, [iterationMap, statusFilter])
+
   const { app, appName } = useExecutionStepStatus({
     appKey: groupingStep?.appKey ?? '',
     status: !execution?.status
@@ -153,7 +166,7 @@ export default function ExecutionGroup(props: ExecutionGroupProps) {
           {iterationMap.size > 0 ? (
             <>
               <IterationSelector
-                iterationMap={iterationMap}
+                iterationMap={filteredIterationMap}
                 canRetryAll={groupStats.failure > 0}
                 execution={execution}
                 selectedIteration={selectedIteration}


### PR DESCRIPTION
## Problem
Executions page for each iteration selector does not take into account the status filter applied.

## Solution
Filter the iterations for the iteration selector

## Tests
- [ ] Apply filter, should only show that status in the iteration selector

## Before & After Screenshots

**BEFORE**:
<img width="1195" height="351" alt="Screenshot 2025-11-12 at 9 05 42 PM" src="https://github.com/user-attachments/assets/763574c1-1b0a-437d-baf2-ad726af805c4" />

<img width="1196" height="355" alt="Screenshot 2025-11-12 at 9 05 50 PM" src="https://github.com/user-attachments/assets/da94f9a9-11d0-4eb8-a8e0-692e88b10961" />

<img width="1198" height="356" alt="Screenshot 2025-11-12 at 9 05 58 PM" src="https://github.com/user-attachments/assets/38f6b55a-cbae-47fd-8281-3d75b87cccd6" />

**AFTER**:
<img width="1201" height="400" alt="Screenshot 2025-11-12 at 9 04 32 PM" src="https://github.com/user-attachments/assets/c2cee281-1477-43ce-9eea-e9945d0684fb" />


<img width="1197" height="372" alt="Screenshot 2025-11-12 at 9 04 38 PM" src="https://github.com/user-attachments/assets/f95f95ac-e7ef-4532-b766-6739219ede8e" />


<img width="1201" height="397" alt="Screenshot 2025-11-12 at 9 04 46 PM" src="https://github.com/user-attachments/assets/38d1db77-f7ee-416c-9338-4085d01569e1" />
