### PR TITLE
fix: allow GatherSG to run after workflow updates case

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest'
-import type { SafeParseError } from 'zod'
 
 import schema from '../../auth/schema'
 
@@ -96,18 +95,36 @@ describe('gathersg auth schema', () => {
         },
       })
       expect(result.success).toBe(false)
-      if (!result.success) {
-        const { issues } = (result as SafeParseError<unknown>).error
-        expect(
-          issues.some((i) => i.message.includes('createdBy.email is required')),
-        ).toBe(true)
-      }
+    })
+
+    it('rejects createdBy with email null when not FormSG', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Regular User',
+          email: null,
+        },
+      })
+      expect(result.success).toBe(false)
     })
 
     it('rejects when both updatedBy and createdBy exist but updatedBy has no email', () => {
       const result = schema.safeParse({
         updatedBy: {
           name: 'Updater',
+        },
+        createdBy: {
+          email: 'creator@example.com',
+          name: 'Creator',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects when both updatedBy and createdBy exist but updatedBy email is null', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Updater',
+          email: null,
         },
         createdBy: {
           email: 'creator@example.com',
@@ -151,6 +168,19 @@ describe('gathersg auth schema', () => {
         },
         formsg: {
           formId: 'form-123',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects FormSG createdBy with submissionId null', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'FormSG',
+        },
+        formsg: {
+          formId: 'form-123',
+          submissionId: null,
         },
       })
       expect(result.success).toBe(false)

--- a/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
@@ -64,6 +64,19 @@ describe('gathersg auth schema', () => {
       })
       expect(result.success).toBe(true)
     })
+
+    it('accepts Workflow updatedBy with createdBy', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+        },
+        createdBy: {
+          email: 'creator@example.com',
+          name: 'Creator',
+        },
+      })
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('invalid cases - missing email', () => {
@@ -231,6 +244,32 @@ describe('gathersg auth schema', () => {
       const result = schema.safeParse({
         updatedBy: {
           name: 'Updater',
+        },
+        createdBy: {
+          email: 'creator@example.com',
+          name: 'Creator',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('Workflow invalid case', () => {
+    it('rejects updatedBy with name "Workflow" when email is present', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+          email: 'workflow@example.com',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects Workflow updatedBy when email is present even with valid createdBy', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+          email: 'workflow@example.com',
         },
         createdBy: {
           email: 'creator@example.com',

--- a/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
@@ -308,5 +308,39 @@ describe('gathersg auth schema', () => {
       })
       expect(result.success).toBe(false)
     })
+
+    it('rejects Workflow updatedBy without createdBy', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects Workflow updatedBy when createdBy is missing email', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+        },
+        createdBy: {
+          name: 'Creator',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects Workflow updatedBy when createdBy email is null', () => {
+      const result = schema.safeParse({
+        updatedBy: {
+          name: 'Workflow',
+        },
+        createdBy: {
+          email: null,
+          name: 'Creator',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
   })
 })

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -16,8 +16,8 @@ const schema = z
       .nullish(),
     createdBy: z
       .object({
-        email: z.string().min(1).optional(),
-        name: z.string().min(1).optional(),
+        email: z.string().min(1).nullish(),
+        name: z.string().min(1).nullish(),
       })
       .nullish(),
     formsg: z

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -36,15 +36,19 @@ const schema = z
         if (updatedBy.name === 'Workflow') {
           /**
            * SPECIAL CASE
-           * if the workflow had an update step before sending the webhook,
+           * if the workflow has an update step before calling the webhook,
            * the webhook will return with:
            * {
            *   updatedBy: {
            *     name: 'Workflow',
            *   },
            * }
+           *
+           * Best effort check that createdBy must contain both email and name
+           * to know that its not an API creating the case and an instant workflow
+           * calling Plumber again.
            */
-          return !updatedBy.email
+          return !updatedBy.email && !!createdBy?.email && !!createdBy?.name
         }
         return !!updatedBy.email
       }

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -1,22 +1,5 @@
 import { z } from 'zod'
 
-function validateUpdatedBy(updatedBy: { email?: string; name?: string }) {
-  /**
-   * SPECIAL CASE
-   * if the workflow had an update step before sending the webhook,
-   * the webhook will return with:
-   * {
-   *   updatedBy: {
-   *     name: 'Workflow',
-   *   },
-   * }
-   */
-  if (updatedBy.name === 'Workflow') {
-    return !updatedBy.email
-  }
-  return !!updatedBy.email
-}
-
 /**
  * check for potential infinite loop
  * if the webhook is not triggered by a user, it will not contain
@@ -50,7 +33,20 @@ const schema = z
 
       // if updatedBy exists, check updatedBy first
       if (updatedBy) {
-        return validateUpdatedBy(updatedBy)
+        if (updatedBy.name === 'Workflow') {
+          /**
+           * SPECIAL CASE
+           * if the workflow had an update step before sending the webhook,
+           * the webhook will return with:
+           * {
+           *   updatedBy: {
+           *     name: 'Workflow',
+           *   },
+           * }
+           */
+          return !updatedBy.email
+        }
+        return !!updatedBy.email
       }
 
       // if only createdBy exists, check for createdBy.email

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -1,5 +1,22 @@
 import { z } from 'zod'
 
+function validateUpdatedBy(updatedBy: { email?: string; name?: string }) {
+  /**
+   * SPECIAL CASE
+   * if the workflow had an update step before sending the webhook,
+   * the webhook will return with:
+   * {
+   *   updatedBy: {
+   *     name: 'Workflow',
+   *   },
+   * }
+   */
+  if (updatedBy.name === 'Workflow') {
+    return !updatedBy.email
+  }
+  return !!updatedBy.email
+}
+
 /**
  * check for potential infinite loop
  * if the webhook is not triggered by a user, it will not contain
@@ -9,7 +26,8 @@ const schema = z
   .object({
     updatedBy: z
       .object({
-        email: z.string().min(1),
+        // does not have email when update is done by an instant workflow
+        email: z.string().min(1).nullish(),
         name: z.string().min(1),
       })
       .nullish(),
@@ -30,14 +48,9 @@ const schema = z
     (data) => {
       const { updatedBy, createdBy, formsg } = data || {}
 
-      // if both updatedBy and createdBy exist, only check updatedBy.email
-      if (updatedBy && createdBy) {
-        return !!updatedBy.email
-      }
-
-      // if updatedBy exists, check for updatedBy.email
+      // if updatedBy exists, check updatedBy first
       if (updatedBy) {
-        return !!updatedBy.email
+        return validateUpdatedBy(updatedBy)
       }
 
       // if only createdBy exists, check for createdBy.email


### PR DESCRIPTION
## Problem
Plumber’s loop-guard currently uses a simple heuristic: if updatedBy.email is missing, it assumes the change came from an API key/automation and rejects the webhook to avoid infinite loops.

GatherSG’s “Update case → Send webhook” sequence sends:
```
{
  "updatedBy": {
    "name": "Workflow"
  }
}
```
No email ⇒ Plumber flags it as automation-originated ⇒ rejected.

## Solution
* Allow the Pipe to execute when its `updatedBy.name === 'Workflow'` and it contains both `createdBy.email` and `createdBy.name` to avoid potential infinite loop where API creates case and triggers an instant workflow back to Plumber

## Tests
- [ ] Create a GatherSG workflow with an update case first then send to webhook. Trigger the workflow and verify that Plumber receives the webhook call.
- [ ] Verify that despite this workflow, Plumber can still detect and block infinite loops.

