### PR TITLE
chore: hex encode gathersg field names

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/auth/decrypt-response.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/decrypt-response.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { processFields } from '../../auth/decrypt-response'
+import { HEX_ENCODED_FIELD_PREFIX } from '../../common/constants'
+
+describe('processFields', () => {
+  it('should process fields with whitespace, -, _', () => {
+    const fields = {
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+      'field-email': 'john.doe@example.com',
+      field_email: 'john.doe@example.com',
+      'field email': 'john.doe@example.com',
+    }
+    const processedFields = processFields(fields)
+    expect(processedFields).toEqual(fields)
+  })
+
+  it.each([
+    'field / Email',
+    'field.email',
+    'field&email',
+    'field%email',
+    'field$email',
+    'field@email',
+    'field^email',
+    'field!email',
+    'field(email)',
+  ])('should hex encode fields with special characters', (field: string) => {
+    const fields = {
+      name: 'John Doe',
+      [field]: 'john.doe@example.com',
+    }
+    const hexEncodedField = `${HEX_ENCODED_FIELD_PREFIX}${Buffer.from(
+      field,
+    ).toString('hex')}`
+    const processedFields = processFields(fields)
+    expect(processedFields).toEqual({
+      name: 'John Doe',
+      [hexEncodedField]: 'john.doe@example.com',
+    })
+  })
+})

--- a/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
+++ b/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
@@ -35,7 +35,7 @@ function validateData(data: any, flowId: string, app: string) {
 
 export function processFields(fields: Record<string, any>) {
   const processedFields: Record<string, any> = {}
-  const invalidCharRegex = /[^\da-zA-Z0-9-_ ]/
+  const invalidCharRegex = /[^a-zA-Z0-9-_ ]/
   for (const [key, value] of Object.entries(fields)) {
     if (invalidCharRegex.test(key)) {
       const hexKey = `${HEX_ENCODED_FIELD_PREFIX}${Buffer.from(key).toString(

--- a/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
+++ b/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
@@ -28,6 +28,7 @@ function validateData(data: any, flowId: string, app: string) {
       'GatherSG: potential infinite loop! Webhook not triggered by user!',
     )
   }
+  return validationResult.data
 }
 
 function verifySignature(signature: string, basestring: string) {
@@ -77,11 +78,11 @@ export async function decryptResponse(
       ]).toString()
       const decryptedData = JSON.parse(decryptedStr)
 
-      validateData(decryptedData, $.flow.id, app)
+      const validatedData = validateData(decryptedData, $.flow.id, app)
 
       $.request.body = {
         app,
-        data: decryptedData,
+        data: validatedData, // use validatedData as it hex-encodes the field names
         signature,
         timestamp,
       }
@@ -91,7 +92,14 @@ export async function decryptResponse(
         internalId: getInternalId(decryptedData),
       }
     } else {
-      validateData(data, $.flow.id, app)
+      const validatedData = validateData(data, $.flow.id, app)
+
+      $.request.body = {
+        app,
+        data: validatedData, // use validatedData as it hex-encodes the field names
+        signature,
+        timestamp,
+      }
 
       return {
         verified: true,

--- a/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
+++ b/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
@@ -5,6 +5,8 @@ import crypto from 'crypto'
 import appConfig from '@/config/app'
 import logger from '@/helpers/logger'
 
+import { HEX_ENCODED_FIELD_PREFIX } from '../common/constants'
+
 import schema from './schema'
 
 function getInternalId(data: any) {
@@ -29,6 +31,22 @@ function validateData(data: any, flowId: string, app: string) {
     )
   }
   return validationResult.data
+}
+
+export function processFields(fields: Record<string, any>) {
+  const processedFields: Record<string, any> = {}
+  const invalidCharRegex = /[^\da-zA-Z0-9-_ ]/
+  for (const [key, value] of Object.entries(fields)) {
+    if (invalidCharRegex.test(key)) {
+      const hexKey = `${HEX_ENCODED_FIELD_PREFIX}${Buffer.from(key).toString(
+        'hex',
+      )}`
+      processedFields[hexKey] = value
+    } else {
+      processedFields[key] = value
+    }
+  }
+  return processedFields
 }
 
 function verifySignature(signature: string, basestring: string) {
@@ -77,12 +95,16 @@ export async function decryptResponse(
         decipher.final(),
       ]).toString()
       const decryptedData = JSON.parse(decryptedStr)
+      validateData(decryptedData, $.flow.id, app)
 
-      const validatedData = validateData(decryptedData, $.flow.id, app)
+      const processedFields = processFields(decryptedData.fields)
 
       $.request.body = {
         app,
-        data: validatedData, // use validatedData as it hex-encodes the field names
+        data: {
+          ...decryptedData,
+          fields: processedFields,
+        },
         signature,
         timestamp,
       }
@@ -92,11 +114,14 @@ export async function decryptResponse(
         internalId: getInternalId(decryptedData),
       }
     } else {
-      const validatedData = validateData(data, $.flow.id, app)
-
+      validateData(data, $.flow.id, app)
+      const processedFields = processFields(data.fields)
       $.request.body = {
         app,
-        data: validatedData, // use validatedData as it hex-encodes the field names
+        data: {
+          ...data,
+          fields: processedFields,
+        },
         signature,
         timestamp,
       }

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -65,26 +65,5 @@ const schema = z
         'When only createdBy exists, createdBy.email is required. When updatedBy exists, updatedBy.email is required.',
     },
   )
-  .transform((data) => {
-    /**
-     * GatherSG fields need to be hex-encoded as the field names
-     * could contain special characters that break our step variable.
-     *
-     * e.g., NRIC/FIN field name will break the step variable.
-     */
-    const hexEncodedFields: Record<string, any> = {}
-
-    if (data.fields) {
-      for (const [key, value] of Object.entries(data.fields)) {
-        const hexKey = Buffer.from(key).toString('hex')
-        hexEncodedFields[hexKey] = value
-      }
-    }
-
-    return {
-      ...data,
-      fields: hexEncodedFields,
-    }
-  })
 
 export default schema

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -25,6 +25,7 @@ const schema = z
         submissionId: z.string().min(1),
       })
       .nullish(),
+    fields: z.record(z.string(), z.any()).nullish(),
   })
   .refine(
     (data) => {
@@ -64,5 +65,26 @@ const schema = z
         'When only createdBy exists, createdBy.email is required. When updatedBy exists, updatedBy.email is required.',
     },
   )
+  .transform((data) => {
+    /**
+     * GatherSG fields need to be hex-encoded as the field names
+     * could contain special characters that break our step variable.
+     *
+     * e.g., NRIC/FIN field name will break the step variable.
+     */
+    const hexEncodedFields: Record<string, any> = {}
+
+    if (data.fields) {
+      for (const [key, value] of Object.entries(data.fields)) {
+        const hexKey = Buffer.from(key).toString('hex')
+        hexEncodedFields[hexKey] = value
+      }
+    }
+
+    return {
+      ...data,
+      fields: hexEncodedFields,
+    }
+  })
 
 export default schema

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -11,3 +11,6 @@ export const UNSUPPORTED_FIELDS = [
   'table', // array of objects
   'attachment',
 ]
+
+// Prefix for hex encoding field names that contain special characters
+export const HEX_ENCODED_FIELD_PREFIX = '__hexEncoded__'

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -13,4 +13,4 @@ export const UNSUPPORTED_FIELDS = [
 ]
 
 // Prefix for hex encoding field names that contain special characters
-export const HEX_ENCODED_FIELD_PREFIX = '__hexEncoded__'
+export const HEX_ENCODED_FIELD_PREFIX = '__HEX_ENCODED__'

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
@@ -1,0 +1,118 @@
+import { IDataOutMetadata, IExecutionStep, IJSONArray } from '@plumber/types'
+
+import { dataOutSchema } from './schema'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut: rawDataOut } = executionStep
+
+  if (!rawDataOut) {
+    return null
+  }
+
+  const parsedDataOut = dataOutSchema.safeParse(rawDataOut)
+  if (parsedDataOut.success === false) {
+    return null
+  }
+
+  const { data: dataOut } = parsedDataOut.data
+
+  const caseMetadata: IDataOutMetadata = {
+    app: { label: 'App' },
+    signature: { isHidden: true },
+    timestamp: { label: 'Timestamp' },
+  }
+
+  // handle formsg field
+  let formSgMetadata = Object.create(null)
+  if (dataOut.formsg) {
+    formSgMetadata.formId = { label: 'FormSG (form ID)' }
+    formSgMetadata.submissionId = { label: 'FormSG (submission ID)' }
+  } else {
+    formSgMetadata = { isHidden: true }
+  }
+
+  // handle createdBy field
+  let createdByMetadata = Object.create(null)
+  if (dataOut.createdBy) {
+    createdByMetadata.email = { label: 'Created by (email)' }
+    createdByMetadata.name = { label: 'Created by (name)' }
+  } else {
+    createdByMetadata = { isHidden: true }
+  }
+
+  // handle updatedBy field
+  let updatedByMetadata = Object.create(null)
+  if (dataOut.updatedBy) {
+    updatedByMetadata.email = { label: 'Updated by (email)' }
+    updatedByMetadata.name = { label: 'Updated by (name)' }
+  } else {
+    updatedByMetadata = { isHidden: true }
+  }
+
+  // handle hex-encoded field names from dataOut
+  const fieldsMetadata = Object.create(null)
+  if (dataOut.fields) {
+    for (const hexKey of Object.keys(dataOut.fields)) {
+      try {
+        // decode hex key to get the original column name
+        const decodedLabel = Buffer.from(hexKey, 'hex').toString('utf-8')
+        const fieldValue = dataOut.fields[hexKey]
+
+        // check if the value is an array
+        if (Array.isArray(fieldValue)) {
+          // check if it's an array of objects or an array of primitives
+          if (
+            fieldValue.length > 0 &&
+            typeof fieldValue[0] === 'object' &&
+            fieldValue[0] !== null
+          ) {
+            // array of objects - create nested object structure for each row
+            const array = fieldValue as IJSONArray
+            const rowsMetadata = Object.create(null)
+
+            for (let i = 0; i < array.length; i++) {
+              const rowObject = array[i]
+              const rowMetadata = Object.create(null)
+
+              if (typeof rowObject === 'object' && rowObject !== null) {
+                for (const nestedKey of Object.keys(rowObject)) {
+                  rowMetadata[nestedKey] = {
+                    type: 'text',
+                    label: `${decodedLabel} Row ${i + 1} ${nestedKey}`,
+                  }
+                }
+              }
+
+              rowsMetadata[i] = rowMetadata
+            }
+
+            fieldsMetadata[hexKey] = rowsMetadata
+          } else {
+            // array of primitives (strings, numbers, etc.) - treat as simple field
+            fieldsMetadata[hexKey] = { label: decodedLabel }
+          }
+        } else {
+          // not an array - treat as simple field
+          fieldsMetadata[hexKey] = { label: decodedLabel }
+        }
+      } catch (error) {
+        // if decoding fails, use the hex key as-is
+        fieldsMetadata[hexKey] = { label: hexKey }
+      }
+    }
+  }
+
+  return {
+    ...caseMetadata,
+    data: {
+      fields: fieldsMetadata,
+      formsg: formSgMetadata,
+      createdBy: createdByMetadata,
+      updatedBy: updatedByMetadata,
+    },
+  }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
@@ -1,5 +1,7 @@
 import { IDataOutMetadata, IExecutionStep, IJSONArray } from '@plumber/types'
 
+import { HEX_ENCODED_FIELD_PREFIX } from '../../common/constants'
+
 import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
@@ -51,14 +53,31 @@ async function getDataOutMetadata(
     updatedByMetadata = { isHidden: true }
   }
 
+  // handle finalisedBy field
+  let finalisedByMetadata = Object.create(null)
+  if (dataOut.finalisedBy) {
+    finalisedByMetadata.email = { label: 'Finalised by (email)' }
+    finalisedByMetadata.name = { label: 'Finalised by (name)' }
+  } else {
+    finalisedByMetadata = { isHidden: true }
+  }
+
   // handle hex-encoded field names from dataOut
   const fieldsMetadata = Object.create(null)
   if (dataOut.fields) {
-    for (const hexKey of Object.keys(dataOut.fields)) {
+    for (const key of Object.keys(dataOut.fields)) {
       try {
-        // decode hex key to get the original column name
-        const decodedLabel = Buffer.from(hexKey, 'hex').toString('utf-8')
-        const fieldValue = dataOut.fields[hexKey]
+        // decode hex encoded field name to get the original field name
+        let decodedLabel: string
+        if (key.startsWith(HEX_ENCODED_FIELD_PREFIX)) {
+          decodedLabel = Buffer.from(
+            key.replace(HEX_ENCODED_FIELD_PREFIX, ''),
+            'hex',
+          ).toString('utf-8')
+        } else {
+          decodedLabel = key
+        }
+        const fieldValue = dataOut.fields[decodedLabel]
 
         // check if the value is an array
         if (Array.isArray(fieldValue)) {
@@ -88,18 +107,18 @@ async function getDataOutMetadata(
               rowsMetadata[i] = rowMetadata
             }
 
-            fieldsMetadata[hexKey] = rowsMetadata
+            fieldsMetadata[key] = rowsMetadata
           } else {
             // array of primitives (strings, numbers, etc.) - treat as simple field
-            fieldsMetadata[hexKey] = { label: decodedLabel }
+            fieldsMetadata[key] = { label: decodedLabel }
           }
         } else {
           // not an array - treat as simple field
-          fieldsMetadata[hexKey] = { label: decodedLabel }
+          fieldsMetadata[key] = { label: decodedLabel }
         }
       } catch (error) {
         // if decoding fails, use the hex key as-is
-        fieldsMetadata[hexKey] = { label: hexKey }
+        fieldsMetadata[key] = { label: key }
       }
     }
   }
@@ -110,7 +129,18 @@ async function getDataOutMetadata(
       fields: fieldsMetadata,
       formsg: formSgMetadata,
       createdBy: createdByMetadata,
+      finalisedBy: finalisedByMetadata,
       updatedBy: updatedByMetadata,
+
+      caseRef: { label: 'Case ref' },
+      createdAt: { label: 'Created at' },
+      email: { isHidden: true }, // hide to avoid confusing user in case there is an email field
+      finalisedAt: { label: 'Finalised at' },
+      source: { label: 'Source' },
+      status: { label: 'Status' },
+      type: { label: 'Case type' },
+      updatedAt: { label: 'Updated at' },
+      uuid: { label: 'UUID' },
     },
   }
 }

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
@@ -4,6 +4,7 @@ import { type SafeParseError, type ZodIssue } from 'zod'
 
 import StepError from '@/errors/step'
 
+import getDataOutMetadata from './get-data-out-metadata'
 import { encryptionKeySchema } from './schema'
 
 const trigger: IRawTrigger = {
@@ -28,6 +29,8 @@ const trigger: IRawTrigger = {
       variables: false,
     },
   ],
+
+  getDataOutMetadata,
 
   async testRun($: IGlobalVariable) {
     const { encryptionKey } = $.step.parameters

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
@@ -45,6 +45,12 @@ export const dataOutSchema = z.object({
           name: z.string().min(1),
         })
         .nullish(),
+      finalisedBy: z
+        .object({
+          email: z.string().min(1).nullish(),
+          name: z.string().min(1),
+        })
+        .nullish(),
     })
     .nullish(),
 })

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
@@ -19,3 +19,32 @@ export const encryptionKeySchema = z
   .refine((value) => value === value.trim(), {
     message: 'not have leading or trailing whitespace',
   })
+
+export const dataOutSchema = z.object({
+  app: z.string().min(1),
+  signature: z.string().min(1),
+  timestamp: z.number(),
+  data: z
+    .object({
+      fields: z.record(z.string(), z.any()).nullish(),
+      formsg: z
+        .object({
+          formId: z.string().min(1),
+          submissionId: z.string().min(1),
+        })
+        .nullish(),
+      updatedBy: z
+        .object({
+          email: z.string().min(1).nullish(),
+          name: z.string().min(1),
+        })
+        .nullish(),
+      createdBy: z
+        .object({
+          email: z.string().min(1).nullish(),
+          name: z.string().min(1),
+        })
+        .nullish(),
+    })
+    .nullish(),
+})


### PR DESCRIPTION
## Problem

GatherSG field names could contain special characters that broke the step variables, e.g., `NRIC/FIN`.

## Solution

Hex-encode the field names so that they can be shown as-is and still be used properly as variables.

**What changed?**

- Hex-encodes all GatherSG field names
- Added `dataOutMetadata` for GatherSG trigger

## cgBefore & After Screenshots

**BEFORE**:
<img width="334" height="46" alt="Screenshot 2025-11-13 at 8 43 17 AM" src="https://github.com/user-attachments/assets/10890dee-9122-42d0-ad5a-05893b2d0b4c" />

**AFTER**:
<img width="883" height="115" alt="Screenshot 2025-11-13 at 8 43 48 AM" src="https://github.com/user-attachments/assets/767eaf78-d896-4900-bbe1-216122b6c66d" />

## Tests

Create field(s) in GatherSG with special characters such as `/`, trigger an instant workflow that sends the case to Plumber

- [ ] Verify that case fields are still displayed on the frontend with the original field names
- [ ] Verify that case fields with special characters can be used as variables in subsequent steps and do not break