### PR TITLE
PLU-613: FormSG signature field as 'Signature captured'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9269,9 +9269,9 @@
       }
     },
     "node_modules/@opengovsg/formsg-sdk": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.13.0.tgz",
-      "integrity": "sha512-rByyDeR98ubJbNSKk6zy98MmxFsiBqFTJqzLX3lWtQxDAJzcX17PCAdmi9U89riNff1H86yyCUvNtlUUJIVnDw==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.16.1.tgz",
+      "integrity": "sha512-yfNTdN4vI7Gs8KTdpqnQPSQ4bkn0worRWeP9UJwcJ172MfvcP+lxHfHBk06FMDA0yJ6fEG/Z+kaGb20WZb4XTA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.4",
@@ -30826,7 +30826,7 @@
         "@graphql-tools/schema": "10.0.25",
         "@graphql-tools/utils": "10.9.1",
         "@launchdarkly/node-server-sdk": "9.0.4",
-        "@opengovsg/formsg-sdk": "0.13.0",
+        "@opengovsg/formsg-sdk": "0.16.1",
         "@opengovsg/sgid-client": "2.3.0",
         "@plumber/types": "file:../types",
         "@taskforcesh/bullmq-pro": "7.7.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/schema": "10.0.25",
     "@graphql-tools/utils": "10.9.1",
     "@launchdarkly/node-server-sdk": "9.0.4",
-    "@opengovsg/formsg-sdk": "0.13.0",
+    "@opengovsg/formsg-sdk": "0.16.1",
     "@opengovsg/sgid-client": "2.3.0",
     "@plumber/types": "file:../types",
     "@taskforcesh/bullmq-pro": "7.7.1",

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -894,4 +894,69 @@ describe('decrypt form response', () => {
       )
     })
   })
+
+  describe('signature field', () => {
+    it('should handle signature field', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'signatureField',
+            fieldType: 'signature',
+            question: 'What is your signature?',
+            answerArray: [
+              'draw',
+              '[[[337.0390625,117.26171875,0.5],[337.40625,116.76953125,0.5],[346.09375,111.29296875,0.5],[365.546875,100.91796875,0.5],[384.28125,92.1328125,0.5]],[[398.95703125,140.91796875,0.5],[399.18359375,140.80078125,0.5]]]',
+            ],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            signatureField: {
+              fieldType: 'signature',
+              question: 'What is your signature?',
+              answer: 'Signature captured',
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+
+    it('should handle emptys ignature field', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'signatureField',
+            fieldType: 'signature',
+            question: 'What is your signature?',
+            answerArray: [],
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect($.request.body).toEqual(
+        expect.objectContaining({
+          fields: {
+            signatureField: {
+              fieldType: 'signature',
+              question: 'What is your signature?',
+              answer: '',
+              order: 1,
+            },
+          },
+        }),
+      )
+    })
+  })
 })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -120,6 +120,25 @@ export async function decryptFormResponse(
         rest.answer = rest.answer.replaceAll('\u0000', '')
       }
 
+      /**
+       * NOTE: special handling for signature field.
+       * FormSG returns an array of [['draw', <stringified array of coordinates>]] in the payload.
+       * However, it is reflected as 'Signature captured' when user downloads the submission
+       * data in csv directly from FormSG.
+       *
+       * To make this field usable, we do the same and return:
+       * - 'Signature captured' when the array is not empty.
+       * - '' when the array is empty.
+       */
+      if (formField.fieldType === 'signature') {
+        if (rest.answerArray.length === 0) {
+          rest.answer = ''
+        } else {
+          rest.answer = 'Signature captured'
+        }
+        delete rest.answerArray
+      }
+
       if (rest.answerArray && rest.answerArray.length > 0) {
         // Could be an array of strings (checkbox/address field) or a 2-D array of strings (table field)
         if (

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -160,6 +160,10 @@ async function getMockData($: IGlobalVariable) {
             convertTableAnswerArrayToTableObject(question, answerArray)
         }
 
+        if (data.responses[formFields[i]._id].fieldType === 'signature') {
+          data.responses[formFields[i]._id].answer = 'Signature captured'
+        }
+
         data.responses[formFields[i]._id].order = i + 1
         data.responses[formFields[i]._id].id = undefined
       }


### PR DESCRIPTION
## Problem
Plumber does not display FormSG signature field response in a usable manner:
<img width="861" height="155" alt="Screenshot 2025-11-14 at 5 50 14 PM" src="https://github.com/user-attachments/assets/d8831c41-09a9-4b2a-a53d-6936cf1a41d4" />

When user downloads submission data form FormSG, it is reflected as either:
- 'Signature captured' if there was a signature
- Empty string if no signature

## Solution
Manually process the signature field response data and return:
- 'Signature captured' if the `answerArray` is not empty
- Empty string if the `answerArray` is empty

## Other changes
Bumped `formsg-sdk` to `0.16.1` (latest version, which also incorporates the signature field) 

## How to test?
Create a form with signature field
- [ ] Mock data should show 'Signature captured'
Make a real submission
- [ ] Shows 'Signature captured' if signed
- [ ] Shows _Empty_ if not signed

## Screenshots
<img width="1512" height="804" alt="Screenshot 2025-11-14 at 6 53 53 PM" src="https://github.com/user-attachments/assets/5a977ea6-c4a7-47ed-bf52-b4363c2d44c2" />

<img width="1512" height="804" alt="Screenshot 2025-11-14 at 6 54 00 PM" src="https://github.com/user-attachments/assets/c8bc8f6b-44d6-4248-ab33-f0aac7444a03" />
