### PR TITLE
chore(frontend): expand ai test result

### DIFF
--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -118,7 +118,9 @@ export function VariableItem({
     }
   }, [variable.type, isExpanded])
 
-  const shouldShowToggle = variable.type === 'ai_response' && isOverflowing
+  // NOTE: we intentionally not show the toggle for suggestion variables
+  const shouldShowToggle =
+    variable.type === 'ai_response' && isOverflowing && !isSuggestionVariable
 
   return (
     <Box

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -1,6 +1,6 @@
 import { TDataOutMetadatumType } from '@plumber/types'
 
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { IconType } from 'react-icons/lib'
 import {
   Accordion,
@@ -25,6 +25,7 @@ import TableVariableItem from './TableVariableItem'
 
 const VARIABLE_ITEM_HEIGHT = 77
 const SUGGESTION_VARIABLE_ITEM_HEIGHT = 61
+const CHARACTER_LIMIT = 100
 
 function VariableTag({
   type,
@@ -97,12 +98,17 @@ export function VariableItem({
   isLast?: boolean
   withIcon?: IconType
 }): JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(false)
   const shouldShowBottomBorder = !withIcon && (onClick || isLast)
 
   const displayValue =
     variable.displayedValue ?? variable.value?.toString() ?? ''
 
   const isSuggestionVariable = onClick && !withIcon
+
+  const shouldShowToggle =
+    variable.type === 'ai_response' && displayValue.length > CHARACTER_LIMIT
+
   return (
     <Box
       key={`suggestion-${variable.name}`}
@@ -110,11 +116,15 @@ export function VariableItem({
       h={
         isSuggestionVariable
           ? SUGGESTION_VARIABLE_ITEM_HEIGHT
+          : shouldShowToggle
+          ? 'auto'
           : VARIABLE_ITEM_HEIGHT
       }
       maxH={
         isSuggestionVariable
           ? SUGGESTION_VARIABLE_ITEM_HEIGHT
+          : shouldShowToggle
+          ? 'auto'
           : VARIABLE_ITEM_HEIGHT
       }
       overflowY="hidden"
@@ -154,23 +164,41 @@ export function VariableItem({
       >
         {variable.label ?? variable.name} <VariableTag type={variable.type} />
       </Text>
-      <Flex alignItems="center" gap={2}>
-        <Text
-          textStyle="body-2"
-          color="base.content.medium"
-          whiteSpace="nowrap"
-          overflow="hidden"
-          textOverflow="ellipsis"
-          textDecoration={withIcon ? 'underline' : undefined}
-        >
-          {displayValue.length ? (
-            displayValue
-          ) : (
-            // padding right to ensure the 'y' is not cut off
-            <i style={{ opacity: 0.5, paddingRight: 2 }}>empty</i>
-          )}
-        </Text>
-        {withIcon && <Icon as={withIcon} />}
+      <Flex flexDirection="column" gap={1}>
+        <Flex alignItems="center" gap={2}>
+          <Text
+            textStyle="body-2"
+            color="base.content.medium"
+            whiteSpace={isExpanded ? 'pre-wrap' : 'nowrap'}
+            overflow={isExpanded ? 'visible' : 'hidden'}
+            textOverflow={isExpanded ? 'clip' : 'ellipsis'}
+            textDecoration={withIcon ? 'underline' : undefined}
+          >
+            {displayValue.length ? (
+              displayValue
+            ) : (
+              <i style={{ opacity: 0.5 }}>empty</i>
+            )}
+          </Text>
+          {withIcon && <Icon as={withIcon} />}
+        </Flex>
+        {shouldShowToggle && (
+          <Text
+            textStyle="body-2"
+            color="primary.500"
+            cursor="pointer"
+            _hover={{ textDecoration: 'underline' }}
+            onClick={(e) => {
+              e.stopPropagation()
+              setIsExpanded(!isExpanded)
+            }}
+            onMouseDown={(e) => {
+              e.stopPropagation()
+            }}
+          >
+            {isExpanded ? 'Show less' : 'Show more'}
+          </Text>
+        )}
       </Flex>
     </Box>
   )

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -1,6 +1,6 @@
 import { TDataOutMetadatumType } from '@plumber/types'
 
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { IconType } from 'react-icons/lib'
 import {
   Accordion,
@@ -25,7 +25,6 @@ import TableVariableItem from './TableVariableItem'
 
 const VARIABLE_ITEM_HEIGHT = 77
 const SUGGESTION_VARIABLE_ITEM_HEIGHT = 61
-const CHARACTER_LIMIT = 100
 
 function VariableTag({
   type,
@@ -99,6 +98,8 @@ export function VariableItem({
   withIcon?: IconType
 }): JSX.Element {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [isOverflowing, setIsOverflowing] = useState(false)
+  const textRef = useRef<HTMLParagraphElement>(null)
   const shouldShowBottomBorder = !withIcon && (onClick || isLast)
 
   const displayValue =
@@ -106,8 +107,18 @@ export function VariableItem({
 
   const isSuggestionVariable = onClick && !withIcon
 
-  const shouldShowToggle =
-    variable.type === 'ai_response' && displayValue.length > CHARACTER_LIMIT
+  // Check if text is overflowing after render
+  useEffect(() => {
+    if (variable.type === 'ai_response' && textRef.current && !isExpanded) {
+      const element = textRef.current
+      const isTextOverflowing =
+        element.scrollHeight > element.clientHeight ||
+        element.scrollWidth > element.clientWidth
+      setIsOverflowing(isTextOverflowing)
+    }
+  }, [variable.type, isExpanded])
+
+  const shouldShowToggle = variable.type === 'ai_response' && isOverflowing
 
   return (
     <Box
@@ -124,10 +135,10 @@ export function VariableItem({
         isSuggestionVariable
           ? SUGGESTION_VARIABLE_ITEM_HEIGHT
           : shouldShowToggle
-          ? 'auto'
+          ? undefined
           : VARIABLE_ITEM_HEIGHT
       }
-      overflowY="hidden"
+      overflowY={shouldShowToggle && isExpanded ? 'visible' : 'hidden'}
       padding={isSuggestionVariable ? '0.5rem 1rem' : '1rem'}
       borderBottom={shouldShowBottomBorder ? undefined : '1px solid #EDEDED'}
       _hover={
@@ -167,6 +178,7 @@ export function VariableItem({
       <Flex flexDirection="column" gap={1}>
         <Flex alignItems="center" gap={2}>
           <Text
+            ref={textRef}
             textStyle="body-2"
             color="base.content.medium"
             whiteSpace={isExpanded ? 'pre-wrap' : 'nowrap'}
@@ -241,6 +253,7 @@ export default function VariablesList(props: VariablesListProps) {
     getScrollElement: () => parentRef.current,
     estimateSize: () =>
       onClick ? SUGGESTION_VARIABLE_ITEM_HEIGHT : VARIABLE_ITEM_HEIGHT,
+    measureElement: (element) => element.getBoundingClientRect().height,
     overscan: 50,
   })
 
@@ -266,6 +279,7 @@ export default function VariablesList(props: VariablesListProps) {
             <Box
               key={virtualItem.key}
               data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
               position="absolute"
               top={0}
               left={0}


### PR DESCRIPTION
## TL;DR
* Add "Show more" toggle for AI response variables when text is overflowing.
* Use "Show more"  AI responses to expand to the text to full height when toggled.

## How to test?
- [ ] All other variable responses are still visible
- [ ] All other variables are truncated by ellipsis when text overflows
- [ ] AI responses have "Show more" when the text overflows
- [ ] AI responses when expanded do not block other variables

## Screenshots

![Screenshot 2025-11-18 at 10.02.27 PM.png](https://app.graphite.com/user-attachments/assets/8668b008-56a8-4d66-90d2-7fa019fcfab5.png)

![Screenshot 2025-11-18 at 10.02.31 PM.png](https://app.graphite.com/user-attachments/assets/897b6116-5b2b-4c1f-bbab-06076a16ea65.png)

![Screenshot 2025-11-18 at 10.02.34 PM.png](https://app.graphite.com/user-attachments/assets/6030fde5-d8da-4f7e-b5b4-405adf6bf115.png)

