### PR TITLE
chore: fixes and news item

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -67,6 +67,7 @@ describe('createStep mutation integration tests', async () => {
     testFlow = await testUser.$relatedQuery('flows').insertAndFetch({
       name: 'Test Flow',
       // additional flow properties as needed
+      updatedBy: owner.id,
     })
     testFlowTimestampString = String(new Date(testFlow.updatedAt).getTime())
 
@@ -448,7 +449,7 @@ describe('createStep mutation integration tests', async () => {
     expect((newStep as any).connectionId).toBeNull()
   })
 
-  describe('updatedAt validation', () => {
+  describe('updatedAt and updatedBy validation', () => {
     it('should succeed when input.flow.updatedAt matches flow.updatedAt (timestamp string)', async () => {
       const params = {
         input: {
@@ -469,10 +470,34 @@ describe('createStep mutation integration tests', async () => {
       expect(newStep.key).toBe('newStep')
     })
 
-    it('should throw when input.flow.updatedAt is different from flow.updatedAt (timestamp string)', async () => {
+    it('should succeed when input.flow.updatedAt is different from flow.updatedAt for same user', async () => {
       const futureTimestamp = (
         new Date(testFlow.updatedAt).getTime() + 1000
       ).toString()
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: futureTimestamp,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      const newStep = await createStep(null, params, context)
+
+      expect(newStep).toBeDefined()
+      expect(newStep.key).toBe('newStep')
+    })
+
+    it('should throw when input.flow.updatedAt is different from flow.updatedAt for different user', async () => {
+      const futureTimestamp = (
+        new Date(testFlow.updatedAt).getTime() + 1000
+      ).toString()
+      context.currentUser = editor
       const params = {
         input: {
           flow: {
@@ -494,35 +519,11 @@ describe('createStep mutation integration tests', async () => {
       )
     })
 
-    it('should throw when input.flow.updatedAt is different from flow.updatedAt (unix timestamp string)', async () => {
-      const futureUnixTimestamp = Math.floor(
-        (new Date(testFlow.updatedAt).getTime() + 1000) / 1000,
-      ).toString()
-      const params = {
-        input: {
-          flow: {
-            id: testFlow.id,
-            updatedAt: futureUnixTimestamp,
-          },
-          previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
-          parameters: { newParam: 'value' },
-        },
-      }
-
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        REFRESH_PIPE_MESSAGE,
-      )
-    })
-
-    it('should throw when input.flow.updatedAt is older than flow.updatedAt (timestamp string)', async () => {
+    it('should throw when input.flow.updatedAt is older than flow.updatedAt for different user', async () => {
       const oldTimestamp = (
         new Date(testFlow.updatedAt).getTime() - 5000
       ).toString()
+      context.currentUser = editor
       const params = {
         input: {
           flow: {
@@ -544,7 +545,7 @@ describe('createStep mutation integration tests', async () => {
       )
     })
 
-    it('should throw when input.flow.updatedAt is an invalid timestamp string', async () => {
+    it('should not throw when input.flow.updatedAt is an invalid timestamp string', async () => {
       const params = {
         input: {
           flow: {
@@ -558,12 +559,10 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        REFRESH_PIPE_MESSAGE,
-      )
+      const newStep = await createStep(null, params, context)
+
+      expect(newStep).toBeDefined()
+      expect(newStep.key).toBe('newStep')
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -332,6 +332,7 @@ describe('updateFlowStatus', () => {
       expect(result).toEqual(fakeFlow)
       expect(fakeFlow.assertNotUpdatedSince).toHaveBeenCalledWith(
         defaultInput.updatedAt,
+        editor.id,
       )
       expect(patchSpy).toHaveBeenCalledWith({
         active: true,

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -24,7 +24,7 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .throwIfNotFound()
 
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     // if connectionId is specified, verify that the connection exists
     // and the user has the appropriate permissions to use it
@@ -84,7 +84,11 @@ const createStep: MutationResolvers['createStep'] = async (
       })
     }
 
-    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+    const updatedFlow = await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return {
       ...step,

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -38,7 +38,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
 
     const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
@@ -114,7 +114,11 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    await flow.patchLastUpdated({ flowId: flow.id, trx })
+    await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return await flow
       .$query(trx)

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -25,7 +25,7 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       })
       .throwIfNotFound()
 
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     // create all the steps in the transaction so that if any fails
     // this entire query fails
@@ -90,7 +90,11 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       // was created in the original branch
     }
 
-    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+    const updatedFlow = await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return {
       steps: newSteps,

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -52,7 +52,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
     return flow
   }
 
-  flow.assertNotUpdatedSince(params.input.updatedAt)
+  flow.assertNotUpdatedSince(params.input.updatedAt, context.currentUser.id)
 
   if (params.input.active) {
     validateFlowSteps(flow.steps)

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -12,8 +12,12 @@ const updateFlow: MutationResolvers['updateFlow'] = async (
     })
     .throwIfNotFound()
 
+  flow.assertNotUpdatedSince(params.input.updatedAt, context.currentUser.id)
+
   return await flow.$query().patchAndFetch({
     name: params.input.name,
+    updatedAt: new Date().toISOString(),
+    updatedBy: context.currentUser.id,
   })
 }
 

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -50,7 +50,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     }
 
     const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     const foundStepIds = steps.map((step) => step.id)
     const missingStepIds = stepIds.filter(

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -28,7 +28,10 @@ const updateStep: MutationResolvers['updateStep'] = async (
       throw new BadUserInputError('Step not found')
     }
 
-    step.flow.assertNotUpdatedSince(input.flow.updatedAt)
+    step.flow.assertNotUpdatedSince(
+      input.flow.updatedAt,
+      context.currentUser.id,
+    )
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
@@ -121,11 +124,13 @@ const updateStep: MutationResolvers['updateStep'] = async (
     // update the flow's last updated
     const updatedFlow = await step.flow.patchLastUpdated({
       flowId: step.flowId,
+      updatedBy: context.currentUser.id,
       trx,
     })
 
     // do this instead of spreading the updatedStep so that it preserves the Model instance
     updatedStep.flow.updatedAt = updatedFlow.updatedAt
+    updatedStep.flow.updatedBy = context.currentUser.id
     return updatedStep
   })
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -514,6 +514,7 @@ input CreateTemplatedFlowInput {
 input UpdateFlowInput {
   id: String!
   name: String!
+  updatedAt: String!
 }
 
 input UpdateFlowStatusInput {

--- a/packages/backend/src/models/__tests__/flow.test.ts
+++ b/packages/backend/src/models/__tests__/flow.test.ts
@@ -1,9 +1,12 @@
+import { randomUUID } from 'crypto'
 import { describe, expect, it } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors/bad-user-input'
 import Flow from '@/models/flow'
 
 describe('flow model', () => {
+  const updatedBy = randomUUID()
+
   describe('assertNotUpdatedSince', () => {
     it('should not throw when timestamps match', () => {
       const flow = new Flow()
@@ -13,7 +16,9 @@ describe('flow model', () => {
 
       const clientUpdatedAt = String(updatedAt.getTime())
 
-      expect(() => flow.assertNotUpdatedSince(clientUpdatedAt)).not.toThrow()
+      expect(() =>
+        flow.assertNotUpdatedSince(clientUpdatedAt, updatedBy),
+      ).not.toThrow()
     })
 
     it('should throw BadUserInputError when timestamps mismatch', () => {
@@ -24,10 +29,10 @@ describe('flow model', () => {
 
       const mismatched = String(updatedAt.getTime() + 1)
 
-      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrowError(
-        BadUserInputError,
-      )
-      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrow(
+      expect(() =>
+        flow.assertNotUpdatedSince(mismatched, updatedBy),
+      ).toThrowError(BadUserInputError)
+      expect(() => flow.assertNotUpdatedSince(mismatched, updatedBy)).toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
     })
@@ -38,10 +43,12 @@ describe('flow model', () => {
 
       flow.updatedAt = updatedAt.toISOString()
 
-      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrowError(
-        BadUserInputError,
-      )
-      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrow(
+      expect(() =>
+        flow.assertNotUpdatedSince('not-a-number', updatedBy),
+      ).toThrowError(BadUserInputError)
+      expect(() =>
+        flow.assertNotUpdatedSince('not-a-number', updatedBy),
+      ).toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
     })

--- a/packages/backend/src/models/__tests__/step.itest.ts
+++ b/packages/backend/src/models/__tests__/step.itest.ts
@@ -5,6 +5,7 @@ import Step from '@/models/step'
 
 import Execution from '../execution'
 import Flow from '../flow'
+import User from '../user'
 
 const flowId = randomUUID()
 const stepId = randomUUID()
@@ -15,9 +16,14 @@ describe('step model', () => {
   let step: Step
 
   beforeEach(async () => {
+    const user = await User.query().insert({
+      id: randomUUID(),
+      email: 'test@example.com',
+    })
     await Flow.query().insert({
       id: flowId,
       name: 'test flow',
+      userId: user.id,
     })
     step = await Step.query()
       .insert({
@@ -171,8 +177,11 @@ describe('step model', () => {
     it('should patch the flow last updated', async () => {
       const flow = await step.$relatedQuery('flow')
       const originalUpdatedAt = flow.updatedAt
-
-      await flow.patchLastUpdated({ flowId: flow.id })
+      const updatedBy = flow.userId
+      await flow.patchLastUpdated({
+        flowId: flow.id,
+        updatedBy,
+      })
 
       const updatedFlow = await step.$relatedQuery('flow')
 
@@ -180,6 +189,7 @@ describe('step model', () => {
       expect(new Date(updatedFlow.updatedAt).getTime()).toBeGreaterThan(
         new Date(originalUpdatedAt).getTime(),
       )
+      expect(updatedFlow.updatedBy).toBe(updatedBy)
     })
   })
 })

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -50,6 +50,7 @@ class Flow extends Base {
       userId: { type: 'string', format: 'uuid' },
       remoteWebhookId: { type: 'string' },
       active: { type: 'boolean' },
+      updatedBy: { type: 'string', format: 'uuid' },
 
       config: {
         type: 'object',
@@ -251,19 +252,30 @@ class Flow extends Base {
 
   async patchLastUpdated({
     flowId,
+    updatedBy,
     trx,
   }: {
     flowId: string
+    updatedBy: string
     trx?: Transaction
   }) {
     return await this.$query(trx).patchAndFetchById(flowId, {
       updatedAt: new Date().toISOString(),
+      updatedBy,
     })
   }
 
-  assertNotUpdatedSince(clientUpdatedAt: string) {
+  assertNotUpdatedSince(clientUpdatedAt: string, updatedBy: string) {
     const inputTimestamp = Number(clientUpdatedAt)
     const flowTimestamp = new Date(this.updatedAt).getTime()
+    const flowLastUpdatedBy = this.updatedBy
+
+    // return early if the flow was last updated by the same user
+    // avoid potential issues where its a valid update by the same user
+    // but the client timestamp is not updated due to race condition or network issues
+    if (flowLastUpdatedBy === updatedBy) {
+      return true
+    }
 
     if (isNaN(inputTimestamp) || inputTimestamp !== flowTimestamp) {
       throw new BadUserInputError(

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -123,51 +123,45 @@ describe('Action worker', () => {
       expect(mocks.exponentialBackoffWithJitter).not.toBeCalled()
     })
 
-    it(
-      'retries retriable executions using our custom backoff strategy',
-      {
-        timeout: 20000,
-      },
-      async () => {
-        // Override max attempts to reduce test running time.
-        const maxAttempts = 3
+    it('retries retriable executions using our custom backoff strategy', async () => {
+      // Override max attempts to reduce test running time.
+      const maxAttempts = 3
 
-        mocks.processAction.mockResolvedValue({
-          executionStep: { isFailed: true },
-        })
-        mocks.handleFailedStepAndThrow.mockRejectedValue(
-          new RetriableError({
-            error: 'test retriable error',
-            delayInMs: 10,
-            delayType: 'step',
-          }),
-        )
+      mocks.processAction.mockResolvedValue({
+        executionStep: { isFailed: true },
+      })
+      mocks.handleFailedStepAndThrow.mockRejectedValue(
+        new RetriableError({
+          error: 'test retriable error',
+          delayInMs: 10,
+          delayType: 'step',
+        }),
+      )
 
-        const jobProcessed = new Promise<void>((resolve) => {
-          mainActionWorker.on('failed', async (job) => {
-            if (job.attemptsMade === maxAttempts) {
-              resolve()
-            }
-          })
+      const jobProcessed = new Promise<void>((resolve) => {
+        mainActionWorker.on('failed', async (job) => {
+          if (job.attemptsMade === maxAttempts) {
+            resolve()
+          }
         })
-        await enqueueActionJob({
-          appKey: null,
-          jobName: 'test-job',
-          jobData: {
-            flowId: 'test-flow-id',
-            executionId: 'test-exec-id',
-            stepId: 'test-step-id',
-          },
-          jobOptions: {
-            ...DEFAULT_JOB_OPTIONS,
-            attempts: maxAttempts,
-          },
-        })
-        await jobProcessed
+      })
+      await enqueueActionJob({
+        appKey: null,
+        jobName: 'test-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: {
+          ...DEFAULT_JOB_OPTIONS,
+          attempts: maxAttempts,
+        },
+      })
+      await jobProcessed
 
-        expect(mocks.exponentialBackoffWithJitter).toBeCalled()
-      },
-    )
+      expect(mocks.exponentialBackoffWithJitter).toBeCalled()
+    }, 20000)
 
     it('does not retry non-executable executions', async () => {
       mocks.processAction.mockResolvedValueOnce({

--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -13,15 +13,21 @@ const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
 
   const onError = React.useCallback(
     (message: string) => {
-      toast({
-        title: message,
-        description:
-          'If this error persists, contact us at support@plumber.gov.sg.',
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top',
-      })
+      // HACKFIX: we use this toast.isActive to prevent duplicate toasts from being shown.
+      // there should be a better way to handle this from the ApolloClient.
+      const id = `graphql-error-${message.slice(0, 15)}`
+      if (!toast.isActive(id)) {
+        toast({
+          id,
+          title: message,
+          description:
+            'If this error persists, contact us at support@plumber.gov.sg.',
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+          position: 'top',
+        })
+      }
     },
     [toast],
   )

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -83,13 +83,7 @@ export default function EditorLayout() {
           input: {
             id: flowId,
             name,
-          },
-        },
-        optimisticResponse: {
-          updateFlow: {
-            __typename: 'Flow',
-            id: flow?.id,
-            name,
+            updatedAt: flow?.updatedAt,
           },
         },
       })

--- a/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
@@ -116,11 +116,10 @@ const AddNewCollaborator = ({
             {role === 'editor' && <SharedConnections />}
 
             <Button
-              variant={role === 'owner' ? 'solid' : 'outline'}
-              colorScheme="red"
               type="submit"
               isLoading={isAdding}
               isDisabled={!isValid}
+              alignSelf="flex-end"
             >
               Add collaborator
             </Button>

--- a/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
@@ -61,7 +61,7 @@ const CollaboratorListRow = ({
   }
 
   return (
-    <Flex alignItems="center" w="100%" py={1} px={4}>
+    <Flex alignItems="center" w="100%" py={1}>
       <Text flex={1}>
         {collaborator.email}{' '}
         {isSelf && (

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -1,7 +1,7 @@
 import type { IFlow } from '@plumber/types'
 
 import { ReactElement } from 'react'
-import { BiChevronRight, BiSolidGroup } from 'react-icons/bi'
+import { BiChevronRight, BiGroup } from 'react-icons/bi'
 import { Link } from 'react-router-dom'
 import {
   Box,
@@ -53,7 +53,7 @@ function FlowRowTitle({
         >
           {flow?.name}
         </Text>
-        {isShared && <Icon boxSize={5} as={BiSolidGroup} />}
+        {isShared && <Icon boxSize={5} as={BiGroup} />}
       </Flex>
       {showTimestamp && (
         <Text

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -16,7 +16,7 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     tag: NEW_FEATURE_TAG,
     title: 'Collaborators — add editors and viewers to your pipes',
     details: dedent`
-      With collaborators, you can add editors or viewers to help build or troubleshoot your pipe. Read more about permissions and set up in our guide.
+      With collaborators, you can add editors or viewers to help build or troubleshoot your pipe. Read more about permissions and set up [here](https://guide.plumber.gov.sg/user-guides/pipe-settings#collaborators).
     `,
     multimedia: {
       url: 'https://file.go.gov.sg/plumber-collaborators-whats-new.png',

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -12,6 +12,14 @@ const IF_THEN_EXTERNAL_LINK =
 
 export const NEWS_ITEM_LIST: NewsItemProps[] = [
   {
+    date: '2025-11-21',
+    tag: NEW_FEATURE_TAG,
+    title: 'Collaborators — add editors and viewers to your pipes',
+    details: dedent`
+      With collaborators, you can add editors or viewers to help build or troubleshoot your pipe. Read more about permissions and set up in our guide.
+    `,
+  },
+  {
     date: '2025-09-22',
     tag: NEW_FEATURE_TAG,
     title: `For each item — automate reminders for events, tasks and more!`,

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -18,6 +18,9 @@ export const NEWS_ITEM_LIST: NewsItemProps[] = [
     details: dedent`
       With collaborators, you can add editors or viewers to help build or troubleshoot your pipe. Read more about permissions and set up in our guide.
     `,
+    multimedia: {
+      url: 'https://file.go.gov.sg/plumber-collaborators-whats-new.png',
+    },
   },
   {
     date: '2025-09-22',


### PR DESCRIPTION
## What changed?
* Added Collaborators to What's new
* Skip check for flow `updatedAt` if its the same user
* Change shared Pipe icon to `BiGroup`
* Update 'Add collaborator' button to be the same as 'Transfer Pipe'
* `assertNotUpdatedSince` for `updateFlow`
* Fix flaky test

## Tests
- [x] Error still throws when two collaborators attempt to edit the Pipe and clobber each other's changes
- [x] Can still add collaborator
- [x] What's new shows collaborators