### PR TITLE
PLU-472: Collaborators

### DIFF
--- a/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
+++ b/packages/backend/src/db/migrations/20250725070831_flow_collaborators.ts
@@ -1,0 +1,19 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('flow_collaborators', (table) => {
+    table.uuid('flow_id').references('id').inTable('flows').notNullable()
+    table.uuid('user_id').references('id').inTable('users').notNullable()
+    table.string('role').notNullable()
+    table.timestamps(true, true)
+    table.timestamp('deleted_at').nullable()
+    table.timestamp('last_accessed_at').notNullable().defaultTo(knex.fn.now())
+    table.uuid('updated_by').references('id').inTable('users').notNullable()
+
+    table.primary(['flow_id', 'user_id'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('flow_collaborators')
+}

--- a/packages/backend/src/db/migrations/20250806004508_add_flows_updated_by.ts
+++ b/packages/backend/src/db/migrations/20250806004508_add_flows_updated_by.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('flows', (table) => {
+    table.uuid('updated_by').references('id').inTable('users').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('flows', (table) => {
+    table.dropColumn('updated_by')
+  })
+}

--- a/packages/backend/src/db/migrations/20250806004700_add_steps_updated_by.ts
+++ b/packages/backend/src/db/migrations/20250806004700_add_steps_updated_by.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.uuid('updated_by').references('id').inTable('users').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('steps', (table) => {
+    table.dropColumn('updated_by')
+  })
+}

--- a/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
+++ b/packages/backend/src/db/migrations/20250819135354_flow_connections.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('flow_connections', (table) => {
+    table.uuid('flow_id').references('id').inTable('flows').notNullable()
+    // NOTE: this connection_id refers to either:
+    // - the connection id of a connection in the connections table; OR
+    // - the id of a Tile
+    table.uuid('connection_id').notNullable()
+    // NOTE: addedBy is the user id of the user who added the connection to the flow
+    table.uuid('added_by').references('id').inTable('users').notNullable()
+    table.string('connection_type').notNullable()
+    table.timestamps(true, true)
+    table.timestamp('deleted_at').nullable()
+    table.jsonb('metadata').notNullable().defaultTo('{}')
+
+    // use the primary key constraint to avoid duplicates
+    table.primary(['flow_id', 'connection_id'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('flow_connections')
+}

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -67,6 +67,7 @@ describe('createStep mutation integration tests', async () => {
     testFlow = await testUser.$relatedQuery('flows').insertAndFetch({
       name: 'Test Flow',
       // additional flow properties as needed
+      updatedBy: owner.id,
     })
     testFlowTimestampString = String(new Date(testFlow.updatedAt).getTime())
 
@@ -448,7 +449,7 @@ describe('createStep mutation integration tests', async () => {
     expect((newStep as any).connectionId).toBeNull()
   })
 
-  describe('updatedAt validation', () => {
+  describe('updatedAt and updatedBy validation', () => {
     it('should succeed when input.flow.updatedAt matches flow.updatedAt (timestamp string)', async () => {
       const params = {
         input: {
@@ -469,10 +470,34 @@ describe('createStep mutation integration tests', async () => {
       expect(newStep.key).toBe('newStep')
     })
 
-    it('should throw when input.flow.updatedAt is different from flow.updatedAt (timestamp string)', async () => {
+    it('should succeed when input.flow.updatedAt is different from flow.updatedAt for same user', async () => {
       const futureTimestamp = (
         new Date(testFlow.updatedAt).getTime() + 1000
       ).toString()
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: futureTimestamp,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      const newStep = await createStep(null, params, context)
+
+      expect(newStep).toBeDefined()
+      expect(newStep.key).toBe('newStep')
+    })
+
+    it('should throw when input.flow.updatedAt is different from flow.updatedAt for different user', async () => {
+      const futureTimestamp = (
+        new Date(testFlow.updatedAt).getTime() + 1000
+      ).toString()
+      context.currentUser = editor
       const params = {
         input: {
           flow: {
@@ -494,35 +519,11 @@ describe('createStep mutation integration tests', async () => {
       )
     })
 
-    it('should throw when input.flow.updatedAt is different from flow.updatedAt (unix timestamp string)', async () => {
-      const futureUnixTimestamp = Math.floor(
-        (new Date(testFlow.updatedAt).getTime() + 1000) / 1000,
-      ).toString()
-      const params = {
-        input: {
-          flow: {
-            id: testFlow.id,
-            updatedAt: futureUnixTimestamp,
-          },
-          previousStep: { id: existingSteps[0].id },
-          key: 'newStep',
-          appKey: 'test-app',
-          parameters: { newParam: 'value' },
-        },
-      }
-
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        REFRESH_PIPE_MESSAGE,
-      )
-    })
-
-    it('should throw when input.flow.updatedAt is older than flow.updatedAt (timestamp string)', async () => {
+    it('should throw when input.flow.updatedAt is older than flow.updatedAt for different user', async () => {
       const oldTimestamp = (
         new Date(testFlow.updatedAt).getTime() - 5000
       ).toString()
+      context.currentUser = editor
       const params = {
         input: {
           flow: {
@@ -544,7 +545,7 @@ describe('createStep mutation integration tests', async () => {
       )
     })
 
-    it('should throw when input.flow.updatedAt is an invalid timestamp string', async () => {
+    it('should not throw when input.flow.updatedAt is an invalid timestamp string', async () => {
       const params = {
         input: {
           flow: {
@@ -558,12 +559,10 @@ describe('createStep mutation integration tests', async () => {
         },
       }
 
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        BadUserInputError,
-      )
-      await expect(createStep(null, params, context)).rejects.toThrow(
-        REFRESH_PIPE_MESSAGE,
-      )
+      const newStep = await createStep(null, params, context)
+
+      expect(newStep).toBeDefined()
+      expect(newStep.key).toBe('newStep')
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -1,26 +1,46 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { BadUserInputError } from '@/errors/graphql-errors'
 import createStep from '@/graphql/mutations/create-step'
 import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
+
+import { generateMockCollaborator, generateMockUser } from './flow.mock'
+
+const REFRESH_PIPE_MESSAGE =
+  'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.'
 
 describe('createStep mutation integration tests', async () => {
   let testFlow: Flow
   let existingSteps: Step[]
   let context: Context
-  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testConnection: any
+  let testFlowTimestampString: string
+  let genericNewStepParams: {
+    input: {
+      flow: { id: string; updatedAt: string }
+      previousStep: { id: string }
+      key: string
+      appKey: string
+      parameters: Record<string, any>
+    }
+  }
 
   // Clean up (and seed) database before each test.
   beforeEach(async () => {
     vi.resetAllMocks()
 
-    vi.spyOn(Step.prototype, 'patchFlowLastUpdated').mockImplementation(
-      patchFlowLastUpdatedSpy,
-    )
-
     // Clear out all rows. Adjust deletion order if using foreign keys.
+    await FlowConnections.query().delete()
     await Step.query().delete()
     await Flow.query().delete()
 
@@ -31,12 +51,37 @@ describe('createStep mutation integration tests', async () => {
       res: null,
       isAdminOperation: false,
     }
+    owner = testUser
+
+    // Create a test connection
+    testConnection = await testUser
+      .$relatedQuery('connections')
+      .insertAndFetch({
+        key: 'test-connection',
+        formattedData: { test: 'data' },
+        verified: true,
+        draft: false,
+      })
 
     // Create a flow associated with the test user.
     testFlow = await testUser.$relatedQuery('flows').insertAndFetch({
       name: 'Test Flow',
       // additional flow properties as needed
     })
+    testFlowTimestampString = String(new Date(testFlow.updatedAt).getTime())
+
+    // Mock the patchLastUpdated method to return proper flow data
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockResolvedValue({
+      ...testFlow,
+      updatedAt: testFlow.updatedAt,
+    } as any)
+
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
 
     // Create a "previous" step in the flow with position 1.
     existingSteps = await testFlow.$relatedQuery('steps').insertAndFetch([
@@ -62,12 +107,28 @@ describe('createStep mutation integration tests', async () => {
         parameters: {},
       },
     ])
+
+    genericNewStepParams = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+      },
+    }
   })
 
   it('creates a new step correctly and shift later steps down', async () => {
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
         previousStep: { id: existingSteps[0].id },
         key: 'newStep',
         appKey: 'test-app',
@@ -103,7 +164,10 @@ describe('createStep mutation integration tests', async () => {
   it('should not shift steps if the previous step is the last step', async () => {
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
         previousStep: { id: existingSteps[2].id },
       },
     }
@@ -126,15 +190,20 @@ describe('createStep mutation integration tests', async () => {
     expect(steps.map((step) => step.position)).toEqual([1, 2, 3, 4])
   })
 
-  it('should call patchFlowLastUpdated when creating a step', async () => {
+  it('should call patchLastUpdated when creating a step', async () => {
+    const patchLastUpdatedSpy = vi.spyOn(Flow.prototype, 'patchLastUpdated')
+
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
         previousStep: { id: existingSteps[2].id },
       },
     }
     await createStep(null, params, context)
-    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
+    expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('throws an error if the flow does not belong to the current user', async () => {
@@ -147,7 +216,10 @@ describe('createStep mutation integration tests', async () => {
 
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
         previousStep: { id: existingSteps[0].id },
         key: 'key',
         appKey: 'appKey',
@@ -161,7 +233,10 @@ describe('createStep mutation integration tests', async () => {
   it('throws an error if the previous step is not found', async () => {
     const params = {
       input: {
-        flow: { id: testFlow.id },
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
         previousStep: { id: 'invalid-id' }, // Non-existent step id
         key: 'newStep',
         appKey: 'test-app',
@@ -170,5 +245,295 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow()
+  })
+
+  it('owner can create a new step', async () => {
+    const newStep = await createStep(null, genericNewStepParams, context)
+
+    expect(newStep).toBeDefined()
+    expect(newStep.type).toBe('action')
+    expect(newStep.key).toBe('newStep')
+    expect(newStep.appKey).toBe('test-app')
+    // New step's position should be previousStep.position + 1.
+    expect(newStep.position).toBe(existingSteps[0].position + 1)
+  })
+
+  it('editor can create a new step', async () => {
+    context.currentUser = editor
+    const newStep = await createStep(null, genericNewStepParams, context)
+
+    expect(newStep).toBeDefined()
+    expect(newStep.type).toBe('action')
+    expect(newStep.key).toBe('newStep')
+    expect(newStep.appKey).toBe('test-app')
+    // New step's position should be previousStep.position + 1.
+    expect(newStep.position).toBe(existingSteps[0].position + 1)
+  })
+
+  it('viewer should not be able to create a new step', async () => {
+    context.currentUser = viewer
+    await expect(
+      createStep(null, genericNewStepParams, context),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('non-collaborator should not be able to create a new step', async () => {
+    context.currentUser = nonCollaborator
+    await expect(
+      createStep(null, genericNewStepParams, context),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('creates a step with connection and adds flow connection for owner', async () => {
+    context.currentUser = owner
+    const params = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: testConnection.id },
+      },
+    }
+
+    const newStep = await createStep(null, params, context)
+
+    expect(newStep).toBeDefined()
+    expect((newStep as any).connectionId).toBe(testConnection.id)
+
+    // Verify flow connection was added
+    const flowConnection = await FlowConnections.query().findOne({
+      flow_id: testFlow.id,
+      connection_id: testConnection.id,
+      added_by: owner.id,
+    })
+    expect(flowConnection).toBeDefined()
+  })
+
+  it('throws error when connection does not exist', async () => {
+    const params = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: randomUUID() },
+      },
+    }
+
+    await expect(createStep(null, params, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+  })
+
+  // TODO (kevinkim-ogp): update this test when we allow editors to add their own connections to the Pipe
+  it('should not add step if connection is not owned by the owner', async () => {
+    context.currentUser = owner
+
+    const editorConnection = await editor
+      .$relatedQuery('connections')
+      .insertAndFetch({
+        key: 'editor-connection',
+        formattedData: { test: 'data' },
+        verified: true,
+        draft: false,
+      })
+
+    const params = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: editorConnection.id },
+      },
+    }
+
+    await expect(createStep(null, params, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+  })
+
+  it('throws error when user does not have access to connection', async () => {
+    // Create a connection owned by another user
+    const otherUser = await User.query().insertAndFetch({
+      email: 'other@example.com',
+    })
+    const otherUserConnection = await otherUser
+      .$relatedQuery('connections')
+      .insertAndFetch({
+        key: 'other-connection',
+        formattedData: { test: 'data' },
+        verified: true,
+      })
+
+    const params = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: otherUserConnection.id },
+      },
+    }
+
+    await expect(createStep(null, params, context)).rejects.toThrow(
+      BadUserInputError,
+    )
+  })
+
+  it('creates a step without connection when connection is not provided', async () => {
+    const params = {
+      input: {
+        flow: {
+          id: testFlow.id,
+          updatedAt: testFlowTimestampString,
+        },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+      },
+    }
+
+    const newStep = await createStep(null, params, context)
+
+    expect(newStep).toBeDefined()
+    expect((newStep as any).connectionId).toBeNull()
+  })
+
+  describe('updatedAt validation', () => {
+    it('should succeed when input.flow.updatedAt matches flow.updatedAt (timestamp string)', async () => {
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: testFlowTimestampString,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      const newStep = await createStep(null, params, context)
+
+      expect(newStep).toBeDefined()
+      expect(newStep.key).toBe('newStep')
+    })
+
+    it('should throw when input.flow.updatedAt is different from flow.updatedAt (timestamp string)', async () => {
+      const futureTimestamp = (
+        new Date(testFlow.updatedAt).getTime() + 1000
+      ).toString()
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: futureTimestamp,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        REFRESH_PIPE_MESSAGE,
+      )
+    })
+
+    it('should throw when input.flow.updatedAt is different from flow.updatedAt (unix timestamp string)', async () => {
+      const futureUnixTimestamp = Math.floor(
+        (new Date(testFlow.updatedAt).getTime() + 1000) / 1000,
+      ).toString()
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: futureUnixTimestamp,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        REFRESH_PIPE_MESSAGE,
+      )
+    })
+
+    it('should throw when input.flow.updatedAt is older than flow.updatedAt (timestamp string)', async () => {
+      const oldTimestamp = (
+        new Date(testFlow.updatedAt).getTime() - 5000
+      ).toString()
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: oldTimestamp,
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        REFRESH_PIPE_MESSAGE,
+      )
+    })
+
+    it('should throw when input.flow.updatedAt is an invalid timestamp string', async () => {
+      const params = {
+        input: {
+          flow: {
+            id: testFlow.id,
+            updatedAt: 'invalid-timestamp',
+          },
+          previousStep: { id: existingSteps[0].id },
+          key: 'newStep',
+          appKey: 'test-app',
+          parameters: { newParam: 'value' },
+        },
+      }
+
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        BadUserInputError,
+      )
+      await expect(createStep(null, params, context)).rejects.toThrow(
+        REFRESH_PIPE_MESSAGE,
+      )
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -82,6 +82,12 @@ describe('createStep mutation integration tests', async () => {
 
     await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
     await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
+    await FlowConnections.addFlowConnection({
+      flowId: testFlow.id,
+      connectionId: testConnection.id,
+      addedBy: owner.id,
+      connectionType: 'connection',
+    })
 
     // Create a "previous" step in the flow with position 1.
     existingSteps = await testFlow.$relatedQuery('steps').insertAndFetch([
@@ -97,6 +103,7 @@ describe('createStep mutation integration tests', async () => {
         appKey: 'appKey',
         type: 'action',
         position: 2,
+        connectionId: testConnection.id,
         parameters: {},
       },
       {
@@ -270,6 +277,29 @@ describe('createStep mutation integration tests', async () => {
     expect(newStep.position).toBe(existingSteps[0].position + 1)
   })
 
+  it('editor can create a new step with owner connection', async () => {
+    context.currentUser = editor
+
+    const params = {
+      input: {
+        flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
+        previousStep: { id: existingSteps[0].id },
+        key: 'newStep',
+        appKey: 'test-app',
+        parameters: { newParam: 'value' },
+        connection: { id: testConnection.id },
+        connectionRole: 'owner',
+      },
+    }
+
+    const newStep = await createStep(null, params, context)
+    expect(newStep).toBeDefined()
+    expect(newStep.type).toBe('action')
+    expect(newStep.key).toBe('newStep')
+    expect(newStep.appKey).toBe('test-app')
+    expect(newStep.position).toBe(existingSteps[0].position + 1)
+  })
+
   it('viewer should not be able to create a new step', async () => {
     context.currentUser = viewer
     await expect(
@@ -330,7 +360,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 
@@ -362,7 +392,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 
@@ -394,7 +424,7 @@ describe('createStep mutation integration tests', async () => {
     }
 
     await expect(createStep(null, params, context)).rejects.toThrow(
-      BadUserInputError,
+      NotFoundError,
     )
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-collaborator.itest.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import deleteFlowCollaborator from '@/graphql/mutations/delete-flow-collaborator'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+
+describe('delete flow collaborators', () => {
+  let context: Context
+  let dummyFlow: Flow
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  const editorUserId = randomUUID()
+  const viewerUserId = randomUUID()
+  const nonCollaboratorUserId = randomUUID()
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    owner = context.currentUser
+
+    editor = await User.query().insert({
+      id: editorUserId,
+      email: 'editor@plumber.gov.sg',
+    })
+
+    viewer = await User.query().insert({
+      id: viewerUserId,
+      email: 'viewer@plumber.gov.sg',
+    })
+
+    nonCollaborator = await User.query().insert({
+      id: nonCollaboratorUserId,
+      email: 'non-collaborator@plumber.gov.sg',
+    })
+
+    const mockFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'test flow',
+      userId: owner.id,
+    })
+
+    await FlowCollaborator.query().insert([
+      {
+        flowId: mockFlow.id,
+        userId: editorUserId,
+        role: 'editor',
+        updatedBy: context.currentUser.id,
+      },
+      {
+        flowId: mockFlow.id,
+        userId: viewerUserId,
+        role: 'viewer',
+        updatedBy: context.currentUser.id,
+      },
+    ])
+
+    dummyFlow = mockFlow
+  })
+
+  it('should be able to delete collaborators', async () => {
+    await deleteFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: viewer.email } },
+      context,
+    )
+    const flowCollaborators = await FlowCollaborator.query()
+      .where('flow_id', dummyFlow.id)
+      .where('deleted_at', null)
+
+    expect(flowCollaborators).toHaveLength(1)
+    const removedViewer = flowCollaborators.find(
+      (col) => col.email === viewer.email,
+    )
+    expect(removedViewer).toBeUndefined()
+  })
+
+  it('should throw an error if collaborator is not found', async () => {
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: 'viewer332@plumber.gov.sg' } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+  })
+
+  it('should throw an error when deleting oneself', async () => {
+    context.currentUser = editor
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: editor.email } },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('should throw an error if trying to delete owner', async () => {
+    context.currentUser = editor
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: owner.email } },
+        context,
+      ),
+    ).rejects.toThrowError('No such collaborator found') // owner does not exist in flow_collaborators table
+  })
+
+  it('should throw an error if user is not a collaborator', async () => {
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: nonCollaborator.email,
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrowError('No such collaborator found')
+  })
+
+  it('should throw an error if user does not have permission to delete collaborator', async () => {
+    context.currentUser = viewer
+    await expect(
+      deleteFlowCollaborator(
+        null,
+        { input: { flowId: dummyFlow.id, email: editor.email } },
+        context,
+      ),
+    ).rejects.toThrowError('You do not have sufficient permissions')
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -1,3 +1,4 @@
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import deleteStep from '@/graphql/mutations/delete-step'
@@ -6,12 +7,22 @@ import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
-import { generateMockStep } from './flow.mock'
+import { generateMockContext } from './tiles/table.mock'
+import {
+  generateMockCollaborator,
+  generateMockStep,
+  generateMockUser,
+} from './flow.mock'
 
 describe('deleteStep mutation', () => {
   let context: Context
   let testFlow: Flow
   let testSteps: Step[]
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let defaultFlowInput: { flow: { updatedAt: string } }
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   beforeEach(async () => {
@@ -26,19 +37,22 @@ describe('deleteStep mutation', () => {
     await Step.query().delete()
     await Flow.query().delete()
 
-    const testUser = await User.query().findOne({ email: 'tester@open.gov.sg' })
-    context = {
-      req: null,
-      currentUser: testUser,
-      res: null,
-      isAdminOperation: false,
-    }
+    context = await generateMockContext()
+
+    owner = context.currentUser
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
 
     // Create a flow associated with the test user.
-    testFlow = await testUser.$relatedQuery('flows').insertAndFetch({
+    testFlow = await owner.$relatedQuery('flows').insertAndFetch({
       name: 'Test Flow',
       // additional flow properties as needed
     })
+    defaultFlowInput = { flow: { updatedAt: testFlow.updatedAt } }
+
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
 
     // Create test steps
     testSteps = await Promise.all([
@@ -76,7 +90,7 @@ describe('deleteStep mutation', () => {
 
   it('should throw error when no steps to delete', async () => {
     await expect(
-      deleteStep(null, { input: { ids: [] } }, context),
+      deleteStep(null, { input: { ids: [], ...defaultFlowInput } }, context),
     ).rejects.toThrow('Nothing to delete')
   })
 
@@ -100,14 +114,20 @@ describe('deleteStep mutation', () => {
     await expect(
       deleteStep(
         null,
-        { input: { ids: [testSteps[0].id, otherStep.id] } },
+        {
+          input: { ids: [testSteps[0].id, otherStep.id], ...defaultFlowInput },
+        },
         context,
       ),
     ).rejects.toThrow('All steps to be deleted must be from the same pipe!')
   })
 
   it('should delete a single trigger step and create a new one', async () => {
-    await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+      context,
+    )
 
     // Verify the trigger step was deleted and a new one was created
     const steps = await testFlow
@@ -123,7 +143,9 @@ describe('deleteStep mutation', () => {
   it('should delete contiguous action steps and update positions', async () => {
     await deleteStep(
       null,
-      { input: { ids: [testSteps[1].id, testSteps[2].id] } },
+      {
+        input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
+      },
       context,
     )
 
@@ -151,7 +173,9 @@ describe('deleteStep mutation', () => {
     await expect(
       deleteStep(
         null,
-        { input: { ids: [testSteps[1].id, fourthStep.id] } },
+        {
+          input: { ids: [testSteps[1].id, fourthStep.id], ...defaultFlowInput },
+        },
         context,
       ),
     ).rejects.toThrow('Must delete contiguous action steps!')
@@ -169,7 +193,11 @@ describe('deleteStep mutation', () => {
       { subject: `some subject {{step.${testSteps[1].id}.foo}}` },
     )
 
-    await deleteStep(null, { input: { ids: [testSteps[1].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
 
     // Verify the referencing step was invalidated
     const invalidatedStep = await Step.query().findById(referencingStep.id)
@@ -177,16 +205,81 @@ describe('deleteStep mutation', () => {
   })
 
   it('should call patchLastUpdated when deleting trigger step', async () => {
-    await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+      context,
+    )
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should call patchLastUpdated when deleting action steps', async () => {
     await deleteStep(
       null,
-      { input: { ids: [testSteps[1].id, testSteps[2].id] } },
+      {
+        input: { ids: [testSteps[1].id, testSteps[2].id], ...defaultFlowInput },
+      },
       context,
     )
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should allow owner to delete steps', async () => {
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(2)
+    expect(steps[0].type).toBe('trigger')
+    expect(steps[0].position).toBe(1)
+  })
+
+  it('should allow editor to delete steps', async () => {
+    context.currentUser = editor
+    await deleteStep(
+      null,
+      { input: { ids: [testSteps[1].id], ...defaultFlowInput } },
+      context,
+    )
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(2)
+    expect(steps[0].type).toBe('trigger')
+    expect(steps[0].position).toBe(1)
+  })
+
+  it('should not allow non-collaborator to delete steps', async () => {
+    context.currentUser = nonCollaborator
+    await expect(
+      deleteStep(
+        null,
+        { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
+
+    const steps = await testFlow
+      .$relatedQuery('steps')
+      .orderBy('position', 'asc')
+
+    expect(steps).toHaveLength(3)
+  })
+
+  it('should not allow viewer to delete steps', async () => {
+    context.currentUser = viewer
+    await expect(
+      deleteStep(
+        null,
+        { input: { ids: [testSteps[0].id], ...defaultFlowInput } },
+        context,
+      ),
+    ).rejects.toThrow(NotFoundError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-step.itest.ts
@@ -12,14 +12,14 @@ describe('deleteStep mutation', () => {
   let context: Context
   let testFlow: Flow
   let testSteps: Step[]
-  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
+  const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   beforeEach(async () => {
     vi.resetAllMocks()
 
-    // Mock the patchFlowLastUpdated method
-    vi.spyOn(Step.prototype, 'patchFlowLastUpdated').mockImplementation(
-      patchFlowLastUpdatedSpy,
+    // Mock the patchLastUpdated method
+    vi.spyOn(Flow.prototype, 'patchLastUpdated').mockImplementation(
+      patchLastUpdatedSpy,
     )
 
     // Clear out all rows
@@ -176,17 +176,17 @@ describe('deleteStep mutation', () => {
     expect(invalidatedStep.status).toBe('incomplete')
   })
 
-  it('should call patchFlowLastUpdated when deleting trigger step', async () => {
+  it('should call patchLastUpdated when deleting trigger step', async () => {
     await deleteStep(null, { input: { ids: [testSteps[0].id] } }, context)
-    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
+    expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('should call patchFlowLastUpdated when deleting action steps', async () => {
+  it('should call patchLastUpdated when deleting action steps', async () => {
     await deleteStep(
       null,
       { input: { ids: [testSteps[1].id, testSteps[2].id] } },
       context,
     )
-    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
+    expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ForbiddenError } from '@/errors/graphql-errors'
 import deleteUploadedFile from '@/graphql/mutations/delete-uploaded-file'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './tiles/table.mock'
@@ -91,9 +92,7 @@ describe('deleteFromS3', () => {
     })
 
     await deleteUploadedFile(null, { id: fileToDelete }, context)
-    const postDeleteSteps = await context.currentUser
-      .$relatedQuery('steps')
-      .where({ flow_id: mockFlowId })
+    const postDeleteSteps = await Step.query().where({ flow_id: mockFlowId })
 
     postDeleteSteps.forEach((step) => {
       expect(step.parameters.attachments).not.toContain(fileToDelete)

--- a/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/execute-step.itest.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import { NotFoundError } from '@/errors/graphql-errors/not-found'
+import executeStep from '@/graphql/mutations/execute-step'
+import User from '@/models/user'
+import { TestStepOptions, TestStepResult } from '@/services/test-step'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+
+const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
+
+const getMockResolvedValue = (userId: string) => {
+  return {
+    id: mockStepId,
+    key: 'sendTransactionalEmail',
+    appKey: 'postman',
+    status: 'completed',
+    flow: {
+      id: mockFlowId,
+      userId,
+      testExecutionId: null as string | null,
+      $query: vi.fn().mockReturnValue({
+        patch: vi.fn().mockResolvedValue({}),
+      }),
+    },
+    $query: vi.fn().mockReturnValue({
+      patch: vi.fn().mockResolvedValue({}),
+    }),
+  }
+}
+
+vi.mock('@/services/test-step', () => ({
+  default: vi.fn(() => {
+    return {
+      executionStep: {
+        id: 'execution-step-1',
+        stepId: '8c2a70d1-e78b-431e-9069-a4d8f97883f7',
+        isFailed: false,
+      },
+      executionId: '8c2a70d1-e78b-431e-9069-a4d8f97883f8',
+    }
+  }),
+}))
+
+describe('executeStep mutation - access control', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testStepSpy: MockInstance<
+    (options: TestStepOptions) => Promise<TestStepResult>
+  >
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create test users
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    testStepSpy = vi.spyOn(await import('@/services/test-step'), 'default')
+  })
+
+  describe('access control', () => {
+    it('should allow owner to execute step successfully', async () => {
+      context.currentUser.withAccessibleSteps = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi
+                  .fn()
+                  .mockReturnValue(getMockResolvedValue(owner.id)),
+              }),
+            }),
+          }
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      const result = await executeStep(null, { input }, context)
+
+      expect(testStepSpy).toHaveBeenCalledWith({
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      })
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe('execution-step-1')
+    })
+
+    it('should allow editor to execute step successfully', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleSteps = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi
+                  .fn()
+                  .mockReturnValue(getMockResolvedValue(editor.id)),
+              }),
+            }),
+          }
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+      const result = await executeStep(null, { input }, context)
+
+      expect(testStepSpy).toHaveBeenCalledWith({
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      })
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe('execution-step-1')
+    })
+
+    it('should reject viewer from executing step', async () => {
+      context.currentUser = viewer
+      context.currentUser.withAccessibleSteps = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          throw new ForbiddenError(
+            'You do not have sufficient permissions for this pipe',
+          )
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+        ForbiddenError,
+      )
+    })
+
+    it('should reject non-collaborator from executing step', async () => {
+      context.currentUser = nonCollaborator
+      context.currentUser.withAccessibleSteps = vi
+        .fn()
+        .mockImplementation(({ _type, _requiredRole }) => {
+          throw new ForbiddenError(
+            'You do not have sufficient permissions for this pipe',
+          )
+        })
+
+      const input = {
+        stepId: mockStepId,
+        testRunMetadata: { testKey: 'testValue' },
+      }
+
+      await expect(executeStep(null, { input }, context)).rejects.toThrow(
+        ForbiddenError,
+      )
+    })
+  })
+
+  it('should require stepId input', async () => {
+    const input = {
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    context.currentUser.withAccessibleSteps = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        if (_type === 'step' && _requiredRole === 'editor') {
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findById: vi.fn().mockReturnValue({
+                throwIfNotFound: vi.fn().mockReturnValue({
+                  id: mockStepId,
+                  key: 'sendTransactionalEmail',
+                  appKey: 'postman',
+                  status: 'completed',
+                  flow: {
+                    id: mockFlowId,
+                    userId: 'owner-user-id',
+                    testExecutionId: null,
+                    $query: vi.fn().mockReturnValue({
+                      patch: vi.fn().mockResolvedValue({}),
+                    }),
+                  },
+                  $query: vi.fn().mockReturnValue({
+                    patch: vi.fn().mockResolvedValue({}),
+                  }),
+                }),
+              }),
+            }),
+          }
+        }
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn().mockReturnValue(null),
+            }),
+          }),
+        }
+      })
+
+    await expect(executeStep(null, { input } as any, context)).rejects.toThrow()
+  })
+
+  it('should call testStep service with correct parameters', async () => {
+    context.currentUser.withAccessibleSteps = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn().mockReturnValue({
+                id: mockStepId,
+                key: 'sendTransactionalEmail',
+                appKey: 'postman',
+                status: 'completed',
+                flow: {
+                  id: mockFlowId,
+                  userId: 'owner-user-id',
+                  testExecutionId: null,
+                  $query: vi.fn().mockReturnValue({
+                    patch: vi.fn().mockResolvedValue({}),
+                  }),
+                },
+                $query: vi.fn().mockReturnValue({
+                  patch: vi.fn().mockResolvedValue({}),
+                }),
+              }),
+            }),
+          }),
+        }
+      })
+
+    const input = {
+      stepId: mockStepId,
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    await executeStep(null, { input }, context)
+
+    expect(testStepSpy).toHaveBeenCalledWith({
+      stepId: mockStepId,
+      testRunMetadata: { testKey: 'testValue' },
+    })
+  })
+
+  it('should throw error when step does not exist', async () => {
+    const input = {
+      stepId: randomUUID(),
+      testRunMetadata: { testKey: 'testValue' },
+    }
+
+    context.currentUser.withAccessibleSteps = vi
+      .fn()
+      .mockImplementation(({ _type, _requiredRole }) => {
+        return {
+          withGraphFetched: vi.fn().mockReturnValue({
+            findById: vi.fn().mockReturnValue({
+              throwIfNotFound: vi.fn(() => {
+                throw new NotFoundError('Step not found')
+              }),
+            }),
+          }),
+        }
+      })
+
+    await expect(executeStep(null, { input }, context)).rejects.toThrow(
+      NotFoundError,
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from 'crypto'
+
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
 import Step from '@/models/step'
+import User from '@/models/user'
 import Context from '@/types/express/context'
 
 export async function generateMockFlow(
@@ -68,5 +72,28 @@ export async function generateMockStep(
     position,
     parameters: parameters ?? {},
     config: config ?? {},
+  })
+}
+
+export const generateMockUser = async (
+  type: 'owner' | 'editor' | 'viewer' | 'nonCollaborator',
+): Promise<User> => {
+  return await User.query().insert({
+    id: randomUUID(),
+    email: `${type}@plumber.gov.sg`,
+  })
+}
+
+export const generateMockCollaborator = async (
+  flowId: string,
+  userId: string,
+  updatedBy: string,
+  type: 'editor' | 'viewer',
+): Promise<FlowCollaborator> => {
+  return await FlowCollaborator.query().insert({
+    flowId,
+    userId,
+    role: type,
+    updatedBy,
   })
 }

--- a/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/flow.mock.ts
@@ -11,7 +11,7 @@ export async function generateMockFlow(
   id: string,
   config?: Record<string, any>,
 ) {
-  await Flow.query().insert({
+  return await Flow.query().insertAndFetch({
     id,
     name: 'Test Flow',
     userId: context.currentUser.id,

--- a/packages/backend/src/graphql/__tests__/mutations/get-test-execution-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/get-test-execution-steps.test.ts
@@ -5,7 +5,7 @@ import type Context from '@/types/express/context'
 
 const context = {
   currentUser: {
-    $relatedQuery: vi.fn(() => {
+    withAccessibleFlows: vi.fn(() => {
       return {
         withGraphFetched: vi.fn(() => {
           return {

--- a/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
@@ -1,6 +1,7 @@
 import { NotFoundError } from 'objection'
 import { vi } from 'vitest'
 
+import Connection from '@/models/connection'
 import User from '@/models/user'
 
 interface MockConnectionsRelatedQueryOptions {
@@ -17,17 +18,9 @@ export function mockConnectionsRelatedQuery(
     connectionNotFound = false,
   }: MockConnectionsRelatedQueryOptions,
 ) {
-  currentUser.$relatedQuery = vi.fn().mockImplementation((relation: string) => {
-    if (relation !== 'connections') {
-      return {
-        findOne: vi.fn().mockReturnValue({
-          throwIfNotFound: vi.fn().mockResolvedValue(null),
-        }),
-      }
-    }
-
-    return {
-      findOne: vi.fn().mockReturnValue({
+  vi.spyOn(Connection, 'query').mockReturnValue({
+    findById: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
         throwIfNotFound: connectionNotFound
           ? vi
               .fn()
@@ -36,6 +29,6 @@ export function mockConnectionsRelatedQuery(
               )
           : vi.fn().mockResolvedValue({ id: connectionId, key: connectionKey }),
       }),
-    }
-  })
+    }),
+  } as any)
 }

--- a/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/related-query-mock.ts
@@ -1,0 +1,41 @@
+import { NotFoundError } from 'objection'
+import { vi } from 'vitest'
+
+import User from '@/models/user'
+
+interface MockConnectionsRelatedQueryOptions {
+  connectionId: string
+  connectionKey: string
+  connectionNotFound?: boolean
+}
+
+export function mockConnectionsRelatedQuery(
+  currentUser: User,
+  {
+    connectionId,
+    connectionKey,
+    connectionNotFound = false,
+  }: MockConnectionsRelatedQueryOptions,
+) {
+  currentUser.$relatedQuery = vi.fn().mockImplementation((relation: string) => {
+    if (relation !== 'connections') {
+      return {
+        findOne: vi.fn().mockReturnValue({
+          throwIfNotFound: vi.fn().mockResolvedValue(null),
+        }),
+      }
+    }
+
+    return {
+      findOne: vi.fn().mockReturnValue({
+        throwIfNotFound: connectionNotFound
+          ? vi
+              .fn()
+              .mockRejectedValue(
+                new NotFoundError({ message: 'Connection not found' }),
+              )
+          : vi.fn().mockResolvedValue({ id: connectionId, key: connectionKey }),
+      }),
+    }
+  })
+}

--- a/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, MockInstance, vi } from 'vitest'
+
+import retryExecutionStep from '@/graphql/mutations/retry-execution-step'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+
+// Mock the action queue
+vi.mock('@/queues/action', () => ({
+  getActionJob: vi.fn(),
+}))
+
+describe('retryExecutionStep mutation', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let mockFlow: Flow
+  let mockExecution: Execution
+  let mockExecutionStep: ExecutionStep
+  let mockStep: Step
+  let getActionJobSpy: MockInstance
+  let mockJob: { retry: MockInstance }
+  let genericInputParams: { executionStepId: string }
+
+  beforeEach(async () => {
+    vi.resetAllMocks()
+
+    // Initialize mock job
+    mockJob = {
+      retry: vi.fn().mockResolvedValue(undefined),
+    }
+
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create test users
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    // Create test flow
+    mockFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'Test Flow',
+      userId: owner.id,
+      active: false,
+    })
+
+    // Create test step
+    mockStep = await Step.query().insert({
+      id: randomUUID(),
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      type: 'action',
+      flowId: mockFlow.id,
+      position: 1,
+      parameters: {},
+      status: 'completed',
+    })
+
+    // Create test execution
+    mockExecution = await Execution.query().insert({
+      id: randomUUID(),
+      flowId: mockFlow.id,
+      testRun: false,
+      internalId: 'test-execution-1',
+      status: 'failure',
+    })
+
+    // Create test execution step
+    mockExecutionStep = await ExecutionStep.query().insert({
+      id: randomUUID(),
+      executionId: mockExecution.id,
+      stepId: mockStep.id,
+      dataIn: {},
+      dataOut: {},
+      errorDetails: { message: 'Test error' },
+      status: 'failure',
+      appKey: 'postman',
+      jobId: 'test-job-id',
+      key: 'sendTransactionalEmail',
+      metadata: {},
+    })
+
+    // Create collaborators
+    await FlowCollaborator.query().insert([
+      {
+        flowId: mockFlow.id,
+        userId: editor.id,
+        role: 'editor',
+        updatedBy: owner.id,
+      },
+      {
+        flowId: mockFlow.id,
+        userId: viewer.id,
+        role: 'viewer',
+        updatedBy: owner.id,
+      },
+    ])
+
+    getActionJobSpy = vi.spyOn(await import('@/queues/action'), 'getActionJob')
+    getActionJobSpy.mockResolvedValue(mockJob)
+    genericInputParams = {
+      executionStepId: mockExecutionStep.id,
+    }
+  })
+
+  describe('authorization tests', () => {
+    it('should allow owner to retry execution step successfully', async () => {
+      const result = await retryExecutionStep(
+        null,
+        { input: genericInputParams },
+        context,
+      )
+
+      expect(result).toBe(true)
+      expect(getActionJobSpy).toHaveBeenCalledWith('test-job-id')
+      expect(mockJob.retry).toHaveBeenCalled()
+    })
+
+    it('should allow editor to retry execution step successfully', async () => {
+      context.currentUser = editor
+
+      const result = await retryExecutionStep(
+        null,
+        { input: genericInputParams },
+        context,
+      )
+
+      expect(result).toBe(true)
+      expect(getActionJobSpy).toHaveBeenCalledWith('test-job-id')
+      expect(mockJob.retry).toHaveBeenCalled()
+    })
+
+    it('should reject viewer from retrying execution step', async () => {
+      context.currentUser = viewer
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow(Error)
+    })
+
+    it('should reject non-collaborator from retrying execution step', async () => {
+      context.currentUser = nonCollaborator
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow(Error)
+    })
+  })
+
+  describe('execution step validation', () => {
+    it('should throw error when execution step is not found', async () => {
+      const input = {
+        executionStepId: randomUUID(), // Non-existent ID
+      }
+
+      await expect(
+        retryExecutionStep(null, { input }, context),
+      ).rejects.toThrow('Execution step not found')
+    })
+
+    it('should throw error when execution step has no job_id', async () => {
+      // Update execution step to have no job_id
+      await mockExecutionStep.$query().patch({ jobId: null })
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow('Execution step not found')
+    })
+
+    it('should throw error when execution step status is not failure', async () => {
+      // Update execution step to have success status
+      await mockExecutionStep.$query().patch({ status: 'success' })
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow('Execution step not found')
+    })
+  })
+
+  describe('job handling', () => {
+    it('should throw error when job is not found or expired', async () => {
+      getActionJobSpy.mockResolvedValue(null)
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow('Job not found or has expired')
+
+      // Verify that job_id was removed from execution step
+      const updatedExecutionStep = await ExecutionStep.query().findById(
+        mockExecutionStep.id,
+      )
+      expect(updatedExecutionStep.jobId).toBeNull()
+    })
+
+    it('should retry job successfully when job exists', async () => {
+      const input = {
+        executionStepId: mockExecutionStep.id,
+      }
+
+      const result = await retryExecutionStep(null, { input }, context)
+
+      expect(result).toBe(true)
+      expect(getActionJobSpy).toHaveBeenCalledWith('test-job-id')
+      expect(mockJob.retry).toHaveBeenCalled()
+    })
+  })
+
+  describe('execution status updates', () => {
+    it('should set execution status to null after successful retry', async () => {
+      await retryExecutionStep(null, { input: genericInputParams }, context)
+
+      const updatedExecution = await Execution.query().findById(
+        mockExecution.id,
+      )
+      expect(updatedExecution.status).toBeNull()
+    })
+  })
+
+  describe('for each handling', () => {
+    it('should handle execution step with iteration metadata', async () => {
+      // Update execution step to have iteration metadata
+      await mockExecutionStep.$query().patch({
+        metadata: { iteration: 1 },
+      })
+
+      const patchIterationStatusSpy = vi
+        .spyOn(ExecutionStep, 'patchIterationStatus')
+        .mockResolvedValue(undefined)
+
+      const result = await retryExecutionStep(
+        null,
+        { input: genericInputParams },
+        context,
+      )
+
+      expect(result).toBe(true)
+      expect(patchIterationStatusSpy).toHaveBeenCalledWith(
+        mockExecution.id,
+        1,
+        null,
+      )
+    })
+
+    it('should not call patchIterationStatus when no iteration metadata', async () => {
+      const patchIterationStatusSpy = vi
+        .spyOn(ExecutionStep, 'patchIterationStatus')
+        .mockResolvedValue(undefined)
+
+      await retryExecutionStep(null, { input: genericInputParams }, context)
+
+      expect(patchIterationStatusSpy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -332,6 +332,7 @@ describe('updateFlowStatus', () => {
       expect(result).toEqual(fakeFlow)
       expect(fakeFlow.assertNotUpdatedSince).toHaveBeenCalledWith(
         defaultInput.updatedAt,
+        editor.id,
       )
       expect(patchSpy).toHaveBeenCalledWith({
         active: true,

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import cronTimes from '@/apps/scheduler/common/cron-times'
@@ -5,12 +7,18 @@ import {
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
+import { BadUserInputError } from '@/errors/graphql-errors'
 import updateFlowStatus from '@/graphql/mutations/update-flow-status'
 import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import Flow from '@/models/flow'
+import User from '@/models/user'
 import flowQueue from '@/queues/flow'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockCollaborator, generateMockUser } from './flow.mock'
 
 // In these tests we simulate the chaining of queries on currentUser.$relatedQuery('flows')
 // and the additional methods on the flow: $query, getTriggerStep etc.
@@ -18,20 +26,39 @@ describe('updateFlowStatus', () => {
   let fakeFlow: any
   let fakeQuery: any
   let context: any
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
   let fakeTriggerStep: any
   let patchSpy: ReturnType<typeof vi.fn>
+  let defaultInput: any
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetAllMocks()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create a real flow in the database first
+    const fakeFlowId = randomUUID()
+    await Flow.query().insert({
+      id: fakeFlowId,
+      name: 'Test Flow',
+      userId: owner.id,
+      active: false,
+    })
 
     // Create a fake flow object with default values.
     fakeFlow = {
-      id: 'flow-1',
+      id: fakeFlowId,
       active: false,
       steps: [{ position: 1 }, { position: 2 }], // contiguous by default
+      updatedAt: new Date().toISOString(),
       // we will override $query to simulate patch operations
       $query: vi.fn(),
       getTriggerStep: vi.fn(),
+      assertNotUpdatedSince: vi.fn(),
     }
     patchSpy = vi.fn().mockResolvedValue(undefined)
     fakeFlow.$query.mockReturnValue({ patch: patchSpy })
@@ -44,11 +71,14 @@ describe('updateFlowStatus', () => {
       throwIfNotFound: vi.fn().mockResolvedValue(fakeFlow),
     }
 
-    context = {
-      currentUser: {
-        $relatedQuery: vi.fn().mockReturnValue(fakeQuery),
-      },
-    }
+    context.currentUser.withAccessibleFlows = vi.fn().mockReturnValue(fakeQuery)
+
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    await generateMockCollaborator(fakeFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(fakeFlow.id, viewer.id, owner.id, 'viewer')
 
     // Set up a default fake trigger step returning a trigger command.
     fakeTriggerStep = {
@@ -65,14 +95,19 @@ describe('updateFlowStatus', () => {
       .fn()
       .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
     flowQueue.removeRepeatableByKey = vi.fn().mockResolvedValue(undefined)
+
+    defaultInput = {
+      id: fakeFlow.id,
+      active: true,
+      updatedAt: fakeFlow.updatedAt,
+    }
   })
 
   it('returns the flow without changes if the active status did not change', async () => {
     // Set the flow status to true and provide the same value in input.
     fakeFlow.active = true
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     expect(result).toEqual(fakeFlow)
     // The patch/update should not be triggered
@@ -85,9 +120,9 @@ describe('updateFlowStatus', () => {
     fakeFlow.active = false
     fakeFlow.steps = [{ position: 1 }, { position: 3 }]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-
-    await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow(
       'Step positions are out of order. Please contact support@plumber.gov.sg for help.',
     )
   })
@@ -100,9 +135,9 @@ describe('updateFlowStatus', () => {
       { position: 3, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
     ]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-
-    await expect(updateFlowStatus({}, params, context)).rejects.toThrow(
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow(
       'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
     )
   })
@@ -112,8 +147,7 @@ describe('updateFlowStatus', () => {
     fakeFlow.active = false
     fakeFlow.steps = [{ position: 1 }, { position: 2 }]
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     // Validate that we patched the flow with active true and publishedAt set to an ISO string.
     expect(patchSpy).toHaveBeenCalledWith({
@@ -122,6 +156,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: true,
       },
+      updatedBy: owner.id,
     })
 
     // jobName is constructed as "flow-<flow.id>"
@@ -148,8 +183,11 @@ describe('updateFlowStatus', () => {
       .fn()
       .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
 
-    const params = { input: { id: fakeFlow.id, active: false } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus(
+      {},
+      { input: { ...defaultInput, active: false } },
+      context,
+    )
 
     expect(patchSpy).toHaveBeenCalledWith({
       active: false,
@@ -157,6 +195,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: undefined,
       },
+      updatedBy: owner.id,
     })
 
     expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
@@ -172,8 +211,7 @@ describe('updateFlowStatus', () => {
       type: 'webhook',
     })
 
-    const params = { input: { id: fakeFlow.id, active: true } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus({}, { input: defaultInput }, context)
 
     // The patch should still occur.
     expect(patchSpy).toHaveBeenCalledWith({
@@ -182,6 +220,7 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: true,
       },
+      updatedBy: owner.id,
     })
 
     // But no job should be added when trigger type is webhook.
@@ -197,8 +236,11 @@ describe('updateFlowStatus', () => {
       type: 'webhook',
     })
 
-    const params = { input: { id: fakeFlow.id, active: false } }
-    const result = await updateFlowStatus({}, params, context)
+    const result = await updateFlowStatus(
+      {},
+      { input: { ...defaultInput, active: false } },
+      context,
+    )
 
     expect(patchSpy).toHaveBeenCalledWith({
       active: false,
@@ -206,11 +248,119 @@ describe('updateFlowStatus', () => {
       config: {
         showSurvey: undefined,
       },
+      updatedBy: owner.id,
     })
 
     // For webhook triggers no removal of a repeatable job should be attempted.
     expect(flowQueue.getRepeatableJobs).not.toHaveBeenCalled()
     expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
     expect(result).toEqual(fakeFlow)
+  })
+
+  describe('access control', () => {
+    it('should allow owner to update flow status', async () => {
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
+      expect(result).toEqual(fakeFlow)
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: owner.id,
+      })
+    })
+
+    it('should allow editor to update flow status', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
+      expect(result).toEqual(fakeFlow)
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: editor.id,
+      })
+    })
+
+    it('should not allow viewer to update flow status', async () => {
+      context.currentUser = viewer
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(NotFoundError)
+    })
+
+    it('should not allow non-collaborator to update flow status', async () => {
+      context.currentUser = nonCollaborator
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(NotFoundError)
+    })
+  })
+
+  describe('collaboration', () => {
+    it('should allow update to status if flow is up to date', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
+
+      // Mock assertNotUpdatedSince to not throw (timestamps match)
+      fakeFlow.assertNotUpdatedSince.mockImplementation(() => {
+        // No error thrown - timestamps match
+      })
+
+      const result = await updateFlowStatus(
+        {},
+        { input: defaultInput },
+        context,
+      )
+
+      expect(result).toEqual(fakeFlow)
+      expect(fakeFlow.assertNotUpdatedSince).toHaveBeenCalledWith(
+        defaultInput.updatedAt,
+      )
+      expect(patchSpy).toHaveBeenCalledWith({
+        active: true,
+        publishedAt: expect.any(String),
+        config: {
+          showSurvey: true,
+        },
+        updatedBy: editor.id,
+      })
+    })
+
+    it('should not allow update to status if flow is not up to date', async () => {
+      context.currentUser = editor
+      context.currentUser.withAccessibleFlows = vi
+        .fn()
+        .mockReturnValue(fakeQuery)
+
+      // Mock assertNotUpdatedSince to throw an error when timestamps don't match
+      fakeFlow.assertNotUpdatedSince.mockImplementation(() => {
+        throw new BadUserInputError(
+          'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+        )
+      })
+
+      await expect(
+        updateFlowStatus({}, { input: defaultInput }, context),
+      ).rejects.toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { AES } from 'crypto-js'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import appConfig from '@/config/app'
 import updateFlowTransferStatus from '@/graphql/mutations/update-flow-transfer-status'
@@ -10,10 +10,11 @@ import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
 import FlowTransfer from '@/models/flow-transfers'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
-import { generateMockContext } from './tiles/table.mock'
+import { generateMockContext, generateMockTable } from './tiles/table.mock'
 import { generateMockFlow, generateMockUser } from './flow.mock'
 
 describe('updateFlowTransferStatus', () => {
@@ -285,6 +286,109 @@ describe('updateFlowTransferStatus', () => {
       // Verify non-Excel steps remain unaffected (Slack step should still work normally)
       const slackStep = await Step.query().findById(slackStepId)
       expect(slackStep.status).toBe('completed')
+    })
+
+    it('verifies old owner has editor access to table before adding new owner as collaborator', async () => {
+      const { table } = await generateMockTable({
+        userId: owner.id,
+        databaseType: 'pg',
+      })
+
+      // Create a tiles step that references the table
+      const tilesStepId = randomUUID()
+      await Step.query().insert({
+        id: tilesStepId,
+        flowId: mockFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        position: 2,
+        parameters: { rowData: [], tableId: table.id },
+        status: 'completed',
+      })
+
+      // Spy on hasAccess to verify it's called with correct parameters
+      const hasAccessSpy = vi
+        .spyOn(TableCollaborator, 'hasAccess')
+        .mockResolvedValue(undefined)
+
+      const addCollaboratorSpy = vi
+        .spyOn(TableCollaborator, 'addCollaborator')
+        .mockResolvedValue(undefined)
+
+      // Approve the transfer as new owner
+      context.currentUser = newOwner
+      const result = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'approved' } },
+        context,
+      )
+
+      expect(result.status).toBe('approved')
+
+      // Verify hasAccess was called with old owner's ID and 'editor' role
+      expect(hasAccessSpy).toHaveBeenCalledWith(
+        owner.id, // oldOwnerId
+        table.id, // tableId
+        'editor', // required role
+      )
+
+      // Verify addCollaborator was called to add new owner as editor
+      expect(addCollaboratorSpy).toHaveBeenCalledWith({
+        userId: newOwner.id,
+        tableId: table.id,
+        role: 'editor',
+        trx: expect.anything(),
+      })
+
+      hasAccessSpy.mockRestore()
+      addCollaboratorSpy.mockRestore()
+    })
+
+    it('throws error when old owner does not have editor access to table', async () => {
+      const { table } = await generateMockTable({
+        userId: owner.id,
+        databaseType: 'pg',
+      })
+
+      // Create a tiles step that references the table
+      const tilesStepId = randomUUID()
+      await Step.query().insert({
+        id: tilesStepId,
+        flowId: mockFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        position: 2,
+        parameters: { rowData: [], tableId: table.id },
+        status: 'completed',
+      })
+
+      // Mock hasAccess to throw ForbiddenError (old owner doesn't have access)
+      const { ForbiddenError } = await import('@/errors/graphql-errors')
+      const hasAccessSpy = vi
+        .spyOn(TableCollaborator, 'hasAccess')
+        .mockRejectedValue(
+          new ForbiddenError(
+            'You do not have sufficient permissions for this tile',
+          ),
+        )
+
+      // Approve the transfer as new owner
+      context.currentUser = newOwner
+
+      // Should throw an error indicating old owner lacks permissions
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'approved' } },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Previous owner does not have sufficient permissions to add you as an Editor of the Tile.',
+      )
+
+      hasAccessSpy.mockRestore()
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -1,0 +1,290 @@
+import { randomUUID } from 'crypto'
+import { AES } from 'crypto-js'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import appConfig from '@/config/app'
+import updateFlowTransferStatus from '@/graphql/mutations/update-flow-transfer-status'
+import Connection from '@/models/connection'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import FlowTransfer from '@/models/flow-transfers'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockFlow, generateMockUser } from './flow.mock'
+
+describe('updateFlowTransferStatus', () => {
+  let context: Context
+  let owner: User
+  let newOwner: User
+  let otherUser: User
+  let mockFlow: Flow
+  let transfer: FlowTransfer
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    owner = context.currentUser
+    newOwner = await generateMockUser('editor')
+    otherUser = await User.query().insert({
+      id: randomUUID(),
+      email: 'other@plumber.gov.sg',
+    })
+
+    mockFlow = await generateMockFlow(context, randomUUID())
+
+    // minimal one step to allow the approval path later
+    await Step.query().insert({
+      id: randomUUID(),
+      flowId: mockFlow.id,
+      key: 'sendMessage',
+      appKey: 'slack',
+      type: 'action',
+      position: 1,
+      parameters: { channel: 'general' },
+      status: 'completed',
+    })
+
+    transfer = await FlowTransfer.query().insert({
+      id: randomUUID(),
+      flowId: mockFlow.id,
+      oldOwnerId: owner.id,
+      newOwnerId: newOwner.id,
+      status: 'pending',
+    })
+  })
+
+  describe('error cases', () => {
+    it('should reject setting status back to pending', async () => {
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'pending' } },
+          context,
+        ),
+      ).rejects.toThrow('No updating of pipe transfer back to pending')
+    })
+
+    it('should throw if approving not by new owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'approved' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to new owner')
+    })
+
+    it('should throw if rejecting not by new owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'rejected' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to new owner')
+    })
+
+    it('should throw if cancelling not by old owner', async () => {
+      context.currentUser = otherUser
+      await expect(
+        updateFlowTransferStatus(
+          null,
+          { input: { id: transfer.id, status: 'cancelled' } },
+          context,
+        ),
+      ).rejects.toThrow('Pipe transfer request does not belong to old owner')
+    })
+  })
+
+  describe('status-only updates', () => {
+    it('new owner can reject; only status is updated', async () => {
+      context.currentUser = newOwner
+      const res = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'rejected' } },
+        context,
+      )
+      expect(res.status).toBe('rejected')
+
+      const refreshedFlow = await Flow.query().findById(mockFlow.id)
+      expect(refreshedFlow.userId).toBe(owner.id)
+    })
+
+    it('old owner can cancel; only status is updated', async () => {
+      context.currentUser = owner
+      const res = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'cancelled' } },
+        context,
+      )
+      expect(res.status).toBe('cancelled')
+
+      const refreshedFlow = await Flow.query().findById(mockFlow.id)
+      expect(refreshedFlow.userId).toBe(owner.id)
+    })
+  })
+
+  describe('approval path', () => {
+    it('transfers ownership and duplicates connections referenced by steps', async () => {
+      // Create a connection and link it to an additional step to exercise duplication
+      const connectionId = randomUUID()
+      await User.query().findById(owner.id) // ensure owner exists
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: 'secret',
+        userId: owner.id,
+      })
+
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: mockFlow.id,
+        key: 'sendMessage2',
+        appKey: 'slack',
+        type: 'action',
+        position: 2,
+        parameters: { channel: 'random' },
+        status: 'completed',
+        connectionId,
+      })
+
+      context.currentUser = newOwner
+      const result = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'approved' } },
+        context,
+      )
+
+      expect(result.status).toBe('approved')
+
+      // Flow owner should be updated
+      const updatedFlow = await Flow.query().findById(mockFlow.id)
+      expect(updatedFlow.userId).toBe(newOwner.id)
+
+      // Steps with previous connectionId should now point to a different id
+      const steps = await Step.query().where('flow_id', mockFlow.id)
+      const hadOriginal = steps.some((s) => s.connectionId === connectionId)
+      expect(hadOriginal).toBe(false)
+
+      // The duplicated connection should exist with userId set to null
+      const remainingConnIds = steps
+        .map((s) => s.connectionId)
+        .filter((id): id is string => Boolean(id))
+      if (remainingConnIds.length > 0) {
+        const dupConn = await Connection.query().findById(remainingConnIds[0])
+        expect(dupConn).toBeTruthy()
+        expect(dupConn?.userId).toBeNull()
+      }
+    })
+
+    it('marks excel steps as incomplete, nullifies connections, and deletes execution steps', async () => {
+      const excelConnectionId = randomUUID()
+      const excelStepId = randomUUID()
+      const executionId = randomUUID()
+
+      // Create an Excel connection
+      await Connection.query().insert({
+        id: excelConnectionId,
+        key: 'm365-excel',
+        data: AES.encrypt(
+          JSON.stringify({ accessToken: 'test-token' }),
+          appConfig.encryptionKey,
+        ).toString(),
+        userId: owner.id,
+      })
+
+      // Create Excel step with connection and completed status
+
+      await Step.query().insert({
+        id: excelStepId,
+        flowId: mockFlow.id,
+        key: 'getTableRows',
+        appKey: 'm365-excel',
+        type: 'action',
+        position: 2,
+        parameters: { workbookId: 'test-wb', worksheetId: 'test-ws' },
+        status: 'completed',
+        connectionId: excelConnectionId,
+      })
+
+      // Create execution steps for both the Excel step and the original Slack step
+
+      await Execution.query().insert({
+        id: executionId,
+        flowId: mockFlow.id,
+        status: 'success',
+        testRun: false,
+      })
+      await ExecutionStep.query().insert({
+        id: randomUUID(),
+        executionId,
+        stepId: excelStepId,
+        status: 'success',
+        dataOut: { rows: [] },
+      })
+
+      const slackStepId = (
+        await Step.query()
+          .findOne({ flow_id: mockFlow.id, app_key: 'slack' })
+          .throwIfNotFound()
+      ).id
+
+      await ExecutionStep.query().insert({
+        id: randomUUID(),
+        executionId,
+        stepId: slackStepId,
+        status: 'success',
+        dataOut: { message: 'sent' },
+      })
+
+      // Verify initial state: Excel step has connection and is completed
+      const initialExcelStep = await Step.query().findById(excelStepId)
+      expect(initialExcelStep.connectionId).toBe(excelConnectionId)
+      expect(initialExcelStep.status).toBe('completed')
+
+      // Verify execution steps exist
+      const initialExecutionSteps = await ExecutionStep.query().whereIn(
+        'step_id',
+        [excelStepId, slackStepId],
+      )
+      expect(initialExecutionSteps.length).toBe(2)
+
+      // Approve the transfer
+      context.currentUser = newOwner
+      const result = await updateFlowTransferStatus(
+        null,
+        { input: { id: transfer.id, status: 'approved' } },
+        context,
+      )
+      expect(result.status).toBe('approved')
+
+      // Verify Excel step is marked as incomplete and connection is nullified
+      const updatedExcelStep = await Step.query().findById(excelStepId)
+      expect(updatedExcelStep.status).toBe('incomplete')
+      expect(updatedExcelStep.connectionId).toBeNull()
+
+      // Verify all execution steps for Excel step are deleted
+      const excelExecutionSteps = await ExecutionStep.query().where(
+        'step_id',
+        excelStepId,
+      )
+      expect(excelExecutionSteps.length).toBe(0)
+
+      // Verify the original Excel connection still exists with userId intact
+      const originalConnection = await Connection.query().findById(
+        excelConnectionId,
+      )
+      expect(originalConnection).toBeTruthy()
+      expect(originalConnection.userId).toBe(owner.id)
+
+      // Verify non-Excel steps remain unaffected (Slack step should still work normally)
+      const slackStep = await Step.query().findById(slackStepId)
+      expect(slackStep.status).toBe('completed')
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -81,6 +81,7 @@ describe('updateStepPositions mutation', () => {
       $query: vi.fn().mockReturnValue({
         patchAndFetch: flowPatchAndFetchSpy,
       }),
+      assertNotUpdatedSince: vi.fn(),
     }
 
     // Create fake steps with flow reference
@@ -115,7 +116,7 @@ describe('updateStepPositions mutation', () => {
 
     context = {
       currentUser: {
-        $relatedQuery: vi.fn().mockReturnValue(fakeQuery),
+        withAccessibleSteps: vi.fn().mockReturnValue(fakeQuery),
       },
     }
   })
@@ -139,6 +140,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
     }
 
     await updateStepPositions(null, { input }, context)
@@ -240,6 +244,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
     } as any
 
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
@@ -302,6 +309,9 @@ describe('updateStepPositions mutation', () => {
           type: 'action' as const,
         },
       ],
+      flow: {
+        updatedAt: '2021-01-01T00:00:00.000Z',
+      },
     }
 
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -17,38 +17,7 @@ const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 describe('updateStep mutation', () => {
   let context: Context
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
-  const patchFlowLastUpdatedSpy = vi.fn().mockResolvedValue({})
-
-  // Helper to create step mock with flow
-  const createStepMock = (stepData: any = {}) => {
-    const throwIfNotFoundMock = vi.fn().mockImplementation(async (options) => {
-      const result =
-        stepData === null
-          ? null
-          : {
-              id: mockStepId,
-              key: 'sendTransactionalEmail',
-              appKey: 'postman',
-              status: 'completed',
-              flow: {
-                id: mockFlowId,
-              },
-              patchFlowLastUpdated: patchFlowLastUpdatedSpy,
-              ...stepData,
-            }
-
-      if (result === null) {
-        throw new NotFoundError(options?.message || 'Step not found')
-      }
-      return result
-    })
-
-    return {
-      findOne: vi.fn().mockReturnValue({
-        throwIfNotFound: throwIfNotFoundMock,
-      }),
-    }
-  }
+  const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
 
   // Helper to create connection mock
   const createConnectionMock = (connectionData: any = null) => ({
@@ -64,7 +33,35 @@ describe('updateStep mutation', () => {
       .fn()
       .mockImplementation((relation, _trx) => {
         if (relation === 'steps') {
-          return createStepMock(stepData)
+          return {
+            withGraphFetched: vi.fn().mockReturnValue({
+              findOne: vi.fn().mockReturnValue({
+                throwIfNotFound: vi.fn().mockImplementation(async (options) => {
+                  const result =
+                    stepData === null
+                      ? null
+                      : {
+                          id: mockStepId,
+                          key: 'sendTransactionalEmail',
+                          appKey: 'postman',
+                          status: 'completed',
+                          flow: {
+                            id: mockFlowId,
+                            patchLastUpdated: patchLastUpdatedSpy,
+                          },
+                          ...stepData,
+                        }
+
+                  if (result === null) {
+                    throw new NotFoundError(
+                      options?.message || 'Step not found',
+                    )
+                  }
+                  return result
+                }),
+              }),
+            }),
+          }
         }
         if (relation === 'connections') {
           return createConnectionMock(connectionData)
@@ -349,9 +346,9 @@ describe('updateStep mutation', () => {
     )
   })
 
-  it('should call patchFlowLastUpdated when updating a step', async () => {
+  it('should call patchLastUpdated when updating a step', async () => {
     await updateStep(null, { input: { ...genericInputParams } }, context)
-    expect(patchFlowLastUpdatedSpy).toHaveBeenCalledTimes(1)
+    expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
 
   it('should throw an error if the parameters are invalid', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -172,7 +172,7 @@ describe('updateStep mutation', () => {
     }
 
     mockConnectionsRelatedQuery(context.currentUser, {
-      connectionId: mockConnectionId,
+      connectionId: randomUUID(),
       connectionKey: 'postman',
       connectionNotFound: true,
     })

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
@@ -13,8 +15,8 @@ import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
 
 import { generateMockContext } from './tiles/table.mock'
 import { generateMockUser } from './flow.mock'
+import { mockConnectionsRelatedQuery } from './related-query-mock'
 import {
-  createMockWithAccessibleConnections,
   createMockWithAccessibleSteps,
   setAssertNotUpdatedSinceSpy,
   setPatchLastUpdatedSpy,
@@ -101,14 +103,6 @@ describe('updateStep mutation', () => {
       }),
     }))
 
-    // Mock Step.transaction
-    vi.spyOn(Step, 'transaction').mockImplementation(async (callback) => {
-      const trx = {
-        raw: vi.fn().mockResolvedValue({}),
-      } as any
-      return callback(trx)
-    })
-
     // Mock Step.query
     vi.spyOn(Step, 'query').mockReturnValue({
       patchAndFetchById: patchAndFetchByIdSpy,
@@ -125,11 +119,10 @@ describe('updateStep mutation', () => {
       flowUpdatedAt: testFlowISODateString,
     })
 
-    context.currentUser.withAccessibleConnections =
-      createMockWithAccessibleConnections({
-        connectionKey: 'postman',
-        connectionId: mockConnectionId,
-      })
+    mockConnectionsRelatedQuery(context.currentUser, {
+      connectionKey: 'postman',
+      connectionId: mockConnectionId,
+    })
   })
 
   it('should successfully update a step', async () => {
@@ -175,18 +168,17 @@ describe('updateStep mutation', () => {
     const input = {
       ...genericInputParams,
       parameters: { testParam: 'value' },
-      connection: { id: 'non-existent-connection' },
+      connection: { id: randomUUID() },
     }
 
-    context.currentUser.withAccessibleConnections =
-      createMockWithAccessibleConnections({
-        connectionId: mockConnectionId,
-        connectionKey: 'postman',
-        connectionNotFound: true,
-      })
+    mockConnectionsRelatedQuery(context.currentUser, {
+      connectionId: mockConnectionId,
+      connectionKey: 'postman',
+      connectionNotFound: true,
+    })
 
-    await expect(updateStep(null, { input }, context)).rejects.toThrowError(
-      BadUserInputError,
+    await expect(updateStep(null, { input }, context)).rejects.toThrow(
+      NotFoundError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
   })
@@ -451,11 +443,10 @@ describe('updateStep mutation', () => {
           },
         )
 
-        context.currentUser.withAccessibleConnections =
-          createMockWithAccessibleConnections({
-            connectionId: mockConnectionId,
-            connectionKey: 'postman',
-          })
+        mockConnectionsRelatedQuery(context.currentUser, {
+          connectionId: mockConnectionId,
+          connectionKey: 'postman',
+        })
 
         await expect(
           updateStep(null, { input }, context),
@@ -478,14 +469,6 @@ describe('updateStep mutation', () => {
     let addSpy: any
 
     beforeEach(async () => {
-      // Mock FlowConnections methods
-      vi.mock('@/models/flow-connections', () => ({
-        default: {
-          patchFlowConnectionMetadata: vi.fn(),
-          addFlowConnection: vi.fn(),
-        },
-      }))
-
       const { default: FlowConnections } = await import(
         '@/models/flow-connections'
       )
@@ -502,17 +485,10 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionKey: 'slack',
-          connectionId: mockConnectionId,
-        })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'slack',
-        })
+      mockConnectionsRelatedQuery(context.currentUser, {
+        connectionKey: 'slack',
+        connectionId: mockConnectionId,
+      })
     })
 
     it('should call patchFlowConnectionMetadata when its an excel app', async () => {
@@ -525,17 +501,10 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionKey: 'm365-excel',
-          connectionId: mockConnectionId,
-        })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'm365-excel',
-        })
+      mockConnectionsRelatedQuery(context.currentUser, {
+        connectionKey: 'm365-excel',
+        connectionId: mockConnectionId,
+      })
 
       const input = {
         ...genericInputParams,
@@ -615,6 +584,18 @@ describe('updateStep mutation', () => {
         flowUpdatedAt: testFlowISODateString,
       })
 
+      // Mock FlowConnections query for getConnection validation
+      // Since role is 'editor', getConnection will query FlowConnections table
+      vi.spyOn(FlowConnections, 'query').mockReturnValue({
+        findOne: vi.fn().mockReturnValue({
+          withGraphFetched: vi.fn().mockReturnValue({
+            throwIfNotFound: vi.fn().mockResolvedValue({
+              connection: { id: mockConnectionId, key: 'slack' },
+            }),
+          }),
+        }),
+      } as any)
+
       const input = {
         ...genericInputParams,
         appKey: 'slack',
@@ -692,12 +673,6 @@ describe('updateStep mutation', () => {
         stepRole: 'owner',
         flowUpdatedAt: testFlowISODateString,
       })
-
-      context.currentUser.withAccessibleConnections =
-        createMockWithAccessibleConnections({
-          connectionId: mockConnectionId,
-          connectionKey: 'tiles',
-        })
 
       const input = {
         ...genericInputParams,

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -640,10 +640,12 @@ describe('updateStep mutation', () => {
     })
 
     it('should call add to flow_connections and add table collaborator for tiles app with tableId parameter', async () => {
-      const mockTableId = 'table-123'
+      const mockTableId = randomUUID()
       const { default: FlowConnections } = await import(
         '@/models/flow-connections'
       )
+      // mock the check that the user has access to the tile
+      vi.spyOn(TableCollaborator, 'hasAccess').mockResolvedValue(undefined)
       const addCollaboratorSpy = vi
         .spyOn(TableCollaborator, 'addCollaborator')
         .mockResolvedValue(undefined)

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -127,9 +127,8 @@ describe('updateStep mutation', () => {
 
     context.currentUser.withAccessibleConnections =
       createMockWithAccessibleConnections({
-        connectionId: mockConnectionId,
         connectionKey: 'postman',
-        connectionNotFound: false,
+        connectionId: mockConnectionId,
       })
   })
 
@@ -148,6 +147,7 @@ describe('updateStep mutation', () => {
       parameters: { updatedParam: 'newValue' },
       status: 'completed',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -167,6 +167,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -225,6 +226,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'incomplete',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -243,6 +245,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'incomplete',
       config: {},
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -261,6 +264,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: { stepName: 'Updated Step Name' },
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -279,6 +283,7 @@ describe('updateStep mutation', () => {
       parameters: { testParam: 'value' },
       status: 'completed',
       config: { stepName: '' },
+      updatedBy: context.currentUser.id,
     })
   })
 
@@ -315,6 +320,7 @@ describe('updateStep mutation', () => {
         stepName: 'Updated Step Name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      updatedBy: context.currentUser.id,
     })
 
     // Verify the existing templateConfig was preserved in the result
@@ -359,6 +365,7 @@ describe('updateStep mutation', () => {
         stepName: '',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      updatedBy: context.currentUser.id,
     })
 
     // Verify the existing templateConfig was preserved in the result
@@ -460,6 +467,7 @@ describe('updateStep mutation', () => {
           parameters: { updatedParam: 'newValue' },
           status: 'completed',
           config: {},
+          updatedBy: context.currentUser.id,
         })
       },
     )
@@ -496,6 +504,12 @@ describe('updateStep mutation', () => {
 
       context.currentUser.withAccessibleConnections =
         createMockWithAccessibleConnections({
+          connectionKey: 'slack',
+          connectionId: mockConnectionId,
+        })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
           connectionId: mockConnectionId,
           connectionKey: 'slack',
         })
@@ -510,6 +524,12 @@ describe('updateStep mutation', () => {
         flowId: mockFlowId,
         flowUpdatedAt: testFlowISODateString,
       })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionKey: 'm365-excel',
+          connectionId: mockConnectionId,
+        })
 
       context.currentUser.withAccessibleConnections =
         createMockWithAccessibleConnections({
@@ -530,6 +550,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         parameterKey: 'fileId',
         parameterValue: '1234567890',
+        trx: expect.anything(),
       })
       expect(addSpy).not.toHaveBeenCalled()
     })
@@ -552,6 +573,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         addedBy: owner.id,
         connectionType: 'connection',
+        trx: expect.anything(),
       })
     })
 
@@ -570,6 +592,7 @@ describe('updateStep mutation', () => {
         connectionId: mockConnectionId,
         addedBy: owner.id,
         connectionType: 'connection',
+        trx: expect.anything(),
       })
       expect(patchSpy).not.toHaveBeenCalled()
     })
@@ -644,7 +667,15 @@ describe('updateStep mutation', () => {
         .spyOn(TableCollaborator, 'addCollaborator')
         .mockResolvedValue(undefined)
       const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
-      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+      const addSpy = vi
+        .spyOn(FlowConnections, 'addFlowConnection')
+        .mockResolvedValue({
+          flowId: mockFlowId,
+          connectionId: mockTableId,
+          addedBy: owner.id,
+          connectionType: 'table',
+          metadata: {},
+        } as any)
       const getCollaboratorsSpy = vi
         .spyOn(FlowCollaborator, 'getCollaborators')
         .mockResolvedValue([
@@ -671,6 +702,7 @@ describe('updateStep mutation', () => {
       const input = {
         ...genericInputParams,
         appKey: 'tiles',
+        connection: {},
         parameters: { tableId: mockTableId },
       }
 
@@ -682,7 +714,9 @@ describe('updateStep mutation', () => {
         connectionId: mockTableId,
         addedBy: owner.id,
         connectionType: 'table',
+        trx: expect.anything(),
       })
+      expect(getCollaboratorsSpy).toHaveBeenCalled()
       expect(getCollaboratorsSpy).toHaveBeenCalledWith({
         flowId: mockFlowId,
         trx: expect.anything(),

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -1,14 +1,24 @@
-import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStep from '@/graphql/mutations/update-step'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
+import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import { generateMockFlow, generateMockStep } from '../mutations/flow.mock'
 
 import { generateMockContext } from './tiles/table.mock'
+import { generateMockUser } from './flow.mock'
+import {
+  createMockWithAccessibleConnections,
+  createMockWithAccessibleSteps,
+  setAssertNotUpdatedSinceSpy,
+  setPatchLastUpdatedSpy,
+} from './with-accessible.mock'
 
 const mockConnectionId = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
@@ -16,65 +26,20 @@ const mockStepId = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
 
 describe('updateStep mutation', () => {
   let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testFlow: Flow
+  let testFlowISODateString: string
+  let testInputTimestampString: string
   let patchAndFetchByIdSpy: ReturnType<typeof vi.fn>
   const patchLastUpdatedSpy = vi.fn().mockResolvedValue({})
+  const assertNotUpdatedSinceSpy = vi.fn().mockResolvedValue({})
 
-  // Helper to create connection mock
-  const createConnectionMock = (connectionData: any = null) => ({
-    findOne: vi.fn().mockResolvedValue(connectionData),
-  })
-
-  // Helper to setup $relatedQuery mock
-  const setupRelatedQueryMock = (
-    stepData?: any,
-    connectionData: any = { id: mockConnectionId, key: 'postman' },
-  ) => {
-    context.currentUser.$relatedQuery = vi
-      .fn()
-      .mockImplementation((relation, _trx) => {
-        if (relation === 'steps') {
-          return {
-            withGraphFetched: vi.fn().mockReturnValue({
-              findOne: vi.fn().mockReturnValue({
-                throwIfNotFound: vi.fn().mockImplementation(async (options) => {
-                  const result =
-                    stepData === null
-                      ? null
-                      : {
-                          id: mockStepId,
-                          key: 'sendTransactionalEmail',
-                          appKey: 'postman',
-                          status: 'completed',
-                          flow: {
-                            id: mockFlowId,
-                            patchLastUpdated: patchLastUpdatedSpy,
-                          },
-                          ...stepData,
-                        }
-
-                  if (result === null) {
-                    throw new NotFoundError(
-                      options?.message || 'Step not found',
-                    )
-                  }
-                  return result
-                }),
-              }),
-            }),
-          }
-        }
-        if (relation === 'connections') {
-          return createConnectionMock(connectionData)
-        }
-        return {
-          findOne: vi.fn().mockResolvedValue(null),
-        }
-      })
-  }
-
-  const genericInputParams = {
+  let genericInputParams = {
     id: mockStepId,
-    flow: { id: mockFlowId },
+    flow: { id: mockFlowId, updatedAt: testFlowISODateString },
     key: 'sendTransactionalEmail',
     appKey: 'postman',
     parameters: { testParam: 'value' },
@@ -85,9 +50,32 @@ describe('updateStep mutation', () => {
     vi.resetAllMocks()
     // Create a mock context with a current user
     context = await generateMockContext()
+    owner = context.currentUser
+
+    // Set the global spy for patchFlowLastUpdated
+    setPatchLastUpdatedSpy(patchLastUpdatedSpy)
+    setAssertNotUpdatedSinceSpy(assertNotUpdatedSinceSpy)
+
+    // Create test users
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
 
     // Create a test flow
-    await generateMockFlow(context, mockFlowId)
+    testFlow = await generateMockFlow(context, mockFlowId)
+    testFlowISODateString = testFlow.updatedAt
+    testInputTimestampString = String(new Date(testFlow.updatedAt).getTime())
+
+    // Set up the patchFlowLastUpdatedSpy to return an updated timestamp
+    patchLastUpdatedSpy.mockResolvedValue({
+      updatedAt: new Date(Date.now() + 1000).toISOString(), // 1 second later
+    })
+    assertNotUpdatedSinceSpy.mockResolvedValue(true)
+
+    genericInputParams = {
+      ...genericInputParams,
+      flow: { id: mockFlowId, updatedAt: testInputTimestampString },
+    }
 
     // Create a test step
     await generateMockStep(
@@ -107,7 +95,9 @@ describe('updateStep mutation', () => {
       withGraphFetched: vi.fn().mockResolvedValue({
         id,
         ...data,
-        connection: { id: mockConnectionId },
+        connection: { id: mockConnectionId, userId: owner.id },
+        flowId: mockFlowId,
+        flow: { userId: owner.id, updatedAt: testFlowISODateString },
       }),
     }))
 
@@ -124,8 +114,23 @@ describe('updateStep mutation', () => {
       patchAndFetchById: patchAndFetchByIdSpy,
     } as any)
 
-    // Setup default mock
-    setupRelatedQueryMock()
+    // Mock context.currentUser.withAccessible for steps
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+      owner,
+      currentUser: context.currentUser,
+      flowId: mockFlowId,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      stepConnection: { id: mockConnectionId, userId: owner.id },
+      flowUpdatedAt: testFlowISODateString,
+    })
+
+    context.currentUser.withAccessibleConnections =
+      createMockWithAccessibleConnections({
+        connectionId: mockConnectionId,
+        connectionKey: 'postman',
+        connectionNotFound: false,
+      })
   })
 
   it('should successfully update a step', async () => {
@@ -172,8 +177,12 @@ describe('updateStep mutation', () => {
       connection: { id: 'non-existent-connection' },
     }
 
-    // Override only the connections query
-    setupRelatedQueryMock(undefined, null)
+    context.currentUser.withAccessibleConnections =
+      createMockWithAccessibleConnections({
+        connectionId: mockConnectionId,
+        connectionKey: 'postman',
+        connectionNotFound: true,
+      })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrowError(
       BadUserInputError,
@@ -187,11 +196,16 @@ describe('updateStep mutation', () => {
       id: 'non-existent-step',
     }
 
-    // Override the steps query to return null
-    setupRelatedQueryMock(null, { id: mockConnectionId })
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      stepNotFound: true,
+    })
 
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
-      NotFoundError,
+      BadUserInputError,
     )
     expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
   })
@@ -270,11 +284,18 @@ describe('updateStep mutation', () => {
 
   it('updating step name should not update template config', async () => {
     // Override the steps query to return template config
-    setupRelatedQueryMock({
-      config: {
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      stepId: mockStepId,
+      stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      stepConnection: { id: mockConnectionId },
+      flowUpdatedAt: testFlowISODateString,
     })
 
     const input = {
@@ -309,11 +330,16 @@ describe('updateStep mutation', () => {
 
   it('updating empty step name should not update template config', async () => {
     // Override the steps query to return template config
-    setupRelatedQueryMock({
-      config: {
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      stepConfig: {
         stepName: 'some-step-name',
         templateConfig: { appEventKey: 'existingAppEventKey' },
       },
+      flowUpdatedAt: testFlowISODateString,
     })
 
     const input = {
@@ -347,6 +373,14 @@ describe('updateStep mutation', () => {
   })
 
   it('should call patchLastUpdated when updating a step', async () => {
+    // Mock the access control to return step data (has access)
+    context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+      owner,
+      currentUser: context.currentUser,
+      stepKey: 'sendTransactionalEmail',
+      stepAppKey: 'postman',
+      flowUpdatedAt: testFlowISODateString,
+    })
     await updateStep(null, { input: { ...genericInputParams } }, context)
     expect(patchLastUpdatedSpy).toHaveBeenCalledTimes(1)
   })
@@ -361,5 +395,311 @@ describe('updateStep mutation', () => {
     await expect(updateStep(null, { input }, context)).rejects.toThrow(
       BadUserInputError,
     )
+  })
+
+  describe('access control', () => {
+    it.each(['nonCollaborator', 'viewer'])(
+      'should throw error if user does not have necessary permissions: %s',
+      async (role) => {
+        context.currentUser =
+          role === 'nonCollaborator' ? nonCollaborator : viewer
+        const input = { ...genericInputParams }
+
+        // Mock the access control to return null for step (no access)
+        context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps(
+          {
+            owner,
+            currentUser: context.currentUser,
+            stepKey: 'sendTransactionalEmail',
+            stepAppKey: 'postman',
+            stepNotFound: true,
+            flowUpdatedAt: testFlowISODateString,
+          },
+        )
+
+        await expect(updateStep(null, { input }, context)).rejects.toThrow(
+          BadUserInputError,
+        )
+        expect(patchAndFetchByIdSpy).not.toHaveBeenCalled()
+      },
+    )
+
+    it.each(['editor', 'owner'])(
+      'should allow updating of step if user has the permissions: %s',
+      async (role) => {
+        context.currentUser = role === 'editor' ? editor : owner
+        const input = {
+          ...genericInputParams,
+          parameters: { updatedParam: 'newValue' },
+        }
+
+        // Mock the access control to return step data (has access)
+        context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps(
+          {
+            owner,
+            currentUser: context.currentUser,
+            stepKey: 'sendTransactionalEmail',
+            stepAppKey: 'postman',
+            flowUpdatedAt: testFlowISODateString,
+          },
+        )
+
+        context.currentUser.withAccessibleConnections =
+          createMockWithAccessibleConnections({
+            connectionId: mockConnectionId,
+            connectionKey: 'postman',
+          })
+
+        await expect(
+          updateStep(null, { input }, context),
+        ).resolves.not.toThrow()
+        expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(mockStepId, {
+          key: 'sendTransactionalEmail',
+          appKey: 'postman',
+          connectionId: mockConnectionId,
+          parameters: { updatedParam: 'newValue' },
+          status: 'completed',
+          config: {},
+        })
+      },
+    )
+  })
+
+  describe('FlowConnections integration', () => {
+    let patchSpy: any
+    let addSpy: any
+
+    beforeEach(async () => {
+      // Mock FlowConnections methods
+      vi.mock('@/models/flow-connections', () => ({
+        default: {
+          patchFlowConnectionMetadata: vi.fn(),
+          addFlowConnection: vi.fn(),
+        },
+      }))
+
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendMessage',
+        stepAppKey: 'slack',
+        flowId: mockFlowId,
+        stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'slack',
+        })
+    })
+
+    it('should call patchFlowConnectionMetadata when its an excel app', async () => {
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: context.currentUser,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        flowId: mockFlowId,
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'm365-excel',
+        })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'm365-excel',
+        parameters: { fileId: '1234567890' },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        parameterKey: 'fileId',
+        parameterValue: '1234567890',
+      })
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call patchFlowConnectionMetadata when app has connection fields and parameter exists', async () => {
+      const input = {
+        id: mockStepId,
+        flow: { id: mockFlowId, updatedAt: testFlowISODateString },
+        key: 'sendMessage',
+        appKey: 'slack',
+        parameters: { channel: 'C1234567890' },
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        addedBy: owner.id,
+        connectionType: 'connection',
+      })
+    })
+
+    it('should call addFlowConnection when app has connection fields but parameter does not exist', async () => {
+      const input = {
+        ...genericInputParams,
+        appKey: 'slack',
+        parameters: { message: 'Hello world' }, // No channel parameter
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(addSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        addedBy: owner.id,
+        connectionType: 'connection',
+      })
+      expect(patchSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not call FlowConnections methods when step role is not owner', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with role 'editor' (not owner)
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendMessage',
+        stepAppKey: 'slack',
+        flowId: mockFlowId,
+        stepRole: 'editor', // Not owner
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'slack',
+        parameters: { channel: 'C1234567890' },
+        connection: { id: mockConnectionId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not call FlowConnections methods when app does not have connection fields', async () => {
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+
+      // Mock step with postman that doesn't have connection fields
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: owner,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'postman',
+        parameters: { testParam: 'value' },
+        connection: {},
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).not.toHaveBeenCalled()
+    })
+
+    it('should call add to flow_connections and add table collaborator for tiles app with tableId parameter', async () => {
+      const mockTableId = 'table-123'
+      const { default: FlowConnections } = await import(
+        '@/models/flow-connections'
+      )
+      const addCollaboratorSpy = vi
+        .spyOn(TableCollaborator, 'addCollaborator')
+        .mockResolvedValue(undefined)
+      const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
+      const addSpy = vi.spyOn(FlowConnections, 'addFlowConnection')
+      const getCollaboratorsSpy = vi
+        .spyOn(FlowCollaborator, 'getCollaborators')
+        .mockResolvedValue([
+          { userId: editor.id, role: 'editor' } as any,
+          { userId: viewer.id, role: 'viewer' } as any,
+        ])
+
+      // Mock step with tiles app
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: owner,
+        stepKey: 'readAction',
+        stepAppKey: 'tiles',
+        stepRole: 'owner',
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      context.currentUser.withAccessibleConnections =
+        createMockWithAccessibleConnections({
+          connectionId: mockConnectionId,
+          connectionKey: 'tiles',
+        })
+
+      const input = {
+        ...genericInputParams,
+        appKey: 'tiles',
+        parameters: { tableId: mockTableId },
+      }
+
+      await updateStep(null, { input }, context)
+
+      expect(patchSpy).not.toHaveBeenCalled()
+      expect(addSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        connectionId: mockTableId,
+        addedBy: owner.id,
+        connectionType: 'table',
+      })
+      expect(getCollaboratorsSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+        trx: expect.anything(),
+      })
+      expect(addCollaboratorSpy).toHaveBeenCalledTimes(2)
+      expect(addCollaboratorSpy).toHaveBeenCalledWith({
+        userId: editor.id,
+        tableId: mockTableId,
+        role: 'editor',
+        trx: expect.anything(),
+      })
+      expect(addCollaboratorSpy).toHaveBeenCalledWith({
+        userId: viewer.id,
+        tableId: mockTableId,
+        role: 'viewer',
+        trx: expect.anything(),
+      })
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -166,6 +166,12 @@ describe('upsert flow collaborator', () => {
         db: 'pg',
       })
 
+      await TableCollaborator.query().insert({
+        tableId: tilesTableId,
+        userId: context.currentUser.id,
+        role: 'owner',
+      })
+
       await Step.query().insert([
         {
           id: randomUUID(),
@@ -646,6 +652,90 @@ describe('upsert flow collaborator', () => {
         user_id: editor.id,
       })
       expect(tableCollaborators).toHaveLength(1)
+    })
+
+    it('should not allow adding collaborators if they are not an owner or editor of the tile', async () => {
+      // add a Tile step
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      // add the editor as a collaborator of the Pipe first
+      await FlowCollaborator.query().insert({
+        flowId: dummyFlow.id,
+        userId: editor.id,
+        role: 'editor',
+        updatedBy: context.currentUser.id,
+      })
+
+      // editor should not be able to add the viewer as the editor is not a collaborator of the tile
+      context.currentUser = editor
+      await expect(
+        upsertFlowCollaborator(
+          null,
+          {
+            input: {
+              flowId: dummyFlow.id,
+              email: viewer.email,
+              role: 'viewer',
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('You do not have sufficient permissions for this tile')
+    })
+
+    it('should not downgrade the role on Tiles when the Pipe collaborator is being downgraded from an Editor to a Viewer', async () => {
+      // add a Tile step
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      // add the editor as a collaborator of the Pipe first
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that only one table collaborator was added (duplicates should be handled)
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('editor')
+
+      // now we downgrade the Pipe collaborator from an Editor to a Viewer
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'viewer' },
+        },
+        context,
+      )
+
+      // Check that the table collaborator role was not downgraded
+      const tableCollaborators2 = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators2).toHaveLength(1)
+      expect(tableCollaborators2[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators2[0].role).toBe('editor')
     })
   })
 

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -3,8 +3,13 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import upsertFlowCollaborator from '@/graphql/mutations/upsert-flow-collaborator'
+import Connection from '@/models/connection'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
+import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
+import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 import Context from '@/types/express/context'
 
@@ -132,5 +137,507 @@ describe('upsert flow collaborator', () => {
     ).rejects.toThrowError(
       'You do not have sufficient permissions for this pipe',
     )
+  })
+
+  describe('automatic connection sharing', () => {
+    const connectionId = randomUUID()
+
+    beforeEach(async () => {
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: '1234',
+      })
+    })
+
+    it('should automatically add connections to flow_connections table when first collaborator is added', async () => {
+      const tilesTableId = randomUUID()
+      await TableMetadata.query().insert({
+        id: tilesTableId,
+        name: 'test table',
+        db: 'pg',
+      })
+
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId },
+          position: 2,
+        },
+      ])
+
+      // Add first collaborator - this should trigger connection sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that connections were added to flow_connections table
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(2)
+
+      // Check slack connection
+      const slackConnection = flowConnections.find(
+        (fc) => fc.connectionId === connectionId,
+      )
+      expect(slackConnection).toBeDefined()
+      expect(slackConnection.metadata).toEqual({})
+
+      // Check tiles connection: table id is the connection id
+      const tilesConnection = flowConnections.find(
+        (fc) => fc.connectionId === tilesTableId,
+      )
+      expect(tilesConnection).toBeDefined()
+    })
+
+    it('should not add connections again when subsequent collaborators are added', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        connectionId: connectionId,
+        parameters: { channel: 'general' },
+        position: 1,
+      })
+
+      // Add first collaborator - this should trigger connection sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Add second collaborator - this should NOT trigger connection sharing again
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+        },
+        context,
+      )
+
+      // Check that connections were only added once
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].connectionId).toBe(connectionId)
+    })
+
+    it('should handle flows with no connection steps', async () => {
+      // Create a flow with no connection steps
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'delay',
+        appKey: 'delay',
+        type: 'action',
+        parameters: { duration: 1000 },
+        position: 1,
+      })
+
+      // Add collaborator - this should not fail even with no connections
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no connections were added
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(0)
+    })
+
+    it('should handle duplicate parameter values in connection metadata', async () => {
+      // Create steps with duplicate channel values
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' }, // Duplicate channel
+          position: 2,
+        },
+      ])
+
+      // Add collaborator
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that duplicate values are handled correctly
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].metadata).toEqual({})
+    })
+
+    it('should handle steps without connection gracefully', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        connectionId: null,
+        parameters: {},
+        position: 1,
+      })
+
+      // Add collaborator - this should not fail
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that the connection was still added (with empty metadata)
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      expect(flowConnections).toHaveLength(0)
+    })
+  })
+
+  describe('automatic table collaborator sharing', () => {
+    let tilesTableId1: string
+    let tilesTableId2: string
+
+    beforeEach(async () => {
+      tilesTableId1 = randomUUID()
+      tilesTableId2 = randomUUID()
+
+      await TableMetadata.query().insert([
+        {
+          id: tilesTableId1,
+          name: 'test table 1',
+          db: 'pg',
+        },
+        {
+          id: tilesTableId2,
+          name: 'test table 2',
+          db: 'pg',
+        },
+      ])
+
+      await TableCollaborator.query().insert([
+        {
+          tableId: tilesTableId1,
+          userId: context.currentUser.id,
+          role: 'owner',
+        },
+        {
+          tableId: tilesTableId2,
+          userId: context.currentUser.id,
+          role: 'owner',
+        },
+      ])
+    })
+
+    it('should automatically add table collaborators when flow has tiles steps', async () => {
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'updateTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId2 },
+          position: 2,
+        },
+      ])
+
+      // Add collaborator - this should trigger table collaborator sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that table collaborators were added
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+
+      expect(tableCollaborators).toHaveLength(2)
+
+      // Check first table collaborator
+      const table1Collaborator = tableCollaborators.find(
+        (tc) => tc.tableId === tilesTableId1,
+      )
+      expect(table1Collaborator).toBeDefined()
+      expect(table1Collaborator.role).toBe('editor')
+
+      // Check second table collaborator
+      const table2Collaborator = tableCollaborators.find(
+        (tc) => tc.tableId === tilesTableId2,
+      )
+      expect(table2Collaborator).toBeDefined()
+      expect(table2Collaborator.role).toBe('editor')
+    })
+
+    it('should add table collaborators with viewer role when collaborator is viewer', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      // Add viewer collaborator
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+        },
+        context,
+      )
+
+      // Check that table collaborator was added with viewer role
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: viewer.id,
+      })
+
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('viewer')
+    })
+
+    it('should handle flows with no tiles steps', async () => {
+      // Create a flow with no tiles steps
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        parameters: { channel: 'general' },
+        position: 1,
+      })
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no table collaborators were added
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(0)
+    })
+
+    it('should handle duplicate table IDs in steps', async () => {
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'updateTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 }, // Same table ID
+          position: 2,
+        },
+      ])
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that only one table collaborator was added (duplicates should be handled)
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+    })
+
+    it('should handle mixed connection and tiles steps', async () => {
+      const connectionId = randomUUID()
+      await Connection.query().insert({
+        id: connectionId,
+        key: 'slack',
+        data: '1234',
+      })
+
+      await Step.query().insert([
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'sendMessage',
+          appKey: 'slack',
+          type: 'action',
+          connectionId: connectionId,
+          parameters: { channel: 'general' },
+          position: 1,
+        },
+        {
+          id: randomUUID(),
+          flowId: dummyFlow.id,
+          key: 'createTileRow',
+          appKey: 'tiles',
+          type: 'action',
+          parameters: { tableId: tilesTableId1 },
+          position: 2,
+        },
+      ])
+
+      // Add first collaborator - this should trigger both connection and table sharing
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that both flow connections and table collaborators were added
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+        added_by: dummyFlow.userId,
+      })
+
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+
+      expect(flowConnections).toHaveLength(2)
+
+      const connectionFlow = flowConnections.find(
+        (fc) => fc.connectionType === 'connection',
+      )
+      const tableFlow = flowConnections.find(
+        (fc) => fc.connectionType === 'table',
+      )
+      expect(connectionFlow).toBeDefined()
+      expect(connectionFlow?.connectionId).toBe(connectionId)
+      expect(tableFlow).toBeDefined()
+      expect(tableFlow?.connectionId).toBe(tilesTableId1)
+
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('editor')
+    })
+
+    it('should still add table collaborators when flow already has collaborators', async () => {
+      await FlowCollaborator.query().insert({
+        flowId: dummyFlow.id,
+        userId: viewer.id,
+        role: 'viewer',
+        updatedBy: context.currentUser.id,
+      })
+
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that no table collaborators were added for the new collaborator
+      const tableCollaborators = await TableCollaborator.query().where({
+        table_id: tilesTableId1,
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
+    })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import upsertFlowCollaborator from '@/graphql/mutations/upsert-flow-collaborator'
 import Connection from '@/models/connection'
 import Flow from '@/models/flow'
@@ -14,6 +14,14 @@ import User from '@/models/user'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './tiles/table.mock'
+
+const mocks = vi.hoisted(() => ({
+  getLdFlagValue: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getLdFlagValue: mocks.getLdFlagValue,
+}))
 
 describe('upsert flow collaborator', () => {
   let context: Context
@@ -639,5 +647,18 @@ describe('upsert flow collaborator', () => {
       })
       expect(tableCollaborators).toHaveLength(1)
     })
+  })
+
+  it('should not allow adding collaborators if collaborators flag is false', async () => {
+    mocks.getLdFlagValue.mockResolvedValue(false)
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      ),
+    ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import upsertFlowCollaborator from '@/graphql/mutations/upsert-flow-collaborator'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+
+describe('upsert flow collaborator', () => {
+  let context: Context
+  let dummyFlow: Flow
+  let editor: User
+  let viewer: User
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+
+    dummyFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'test flow',
+      userId: context.currentUser.id,
+    })
+
+    editor = await User.query().insert({
+      id: randomUUID(),
+      email: 'editor@plumber.gov.sg',
+    })
+
+    viewer = await User.query().insert({
+      id: randomUUID(),
+      email: 'viewer@plumber.gov.sg',
+    })
+  })
+
+  it('owner should be able to add new editor', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' } },
+      context,
+    )
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(editor.id)
+    expect(collaborators[0].role).toBe('editor')
+  })
+
+  it('owner should be able to add new viewer', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' } },
+      context,
+    )
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(viewer.id)
+    expect(collaborators[0].role).toBe('viewer')
+  })
+
+  it('should be able to update roles', async () => {
+    await upsertFlowCollaborator(
+      null,
+      { input: { flowId: dummyFlow.id, email: editor.email, role: 'viewer' } },
+      context,
+    )
+
+    const collaborators = await FlowCollaborator.query().where(
+      'flow_id',
+      dummyFlow.id,
+    )
+    expect(collaborators).toHaveLength(1)
+    expect(collaborators[0].userId).toBe(editor.id)
+    expect(collaborators[0].role).toBe('viewer')
+  })
+
+  it('should not allow editing role of owner', async () => {
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: context.currentUser.email,
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('should not allow editing of own role', async () => {
+    context.currentUser = editor
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: context.currentUser.email,
+            role: 'viewer',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow(BadUserInputError)
+  })
+
+  it('viewer should not be able to modify collaborator', async () => {
+    context.currentUser = viewer
+    await expect(
+      upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: 'new-user@plumber.gov.sg',
+            role: 'editor',
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrowError(
+      'You do not have sufficient permissions for this pipe',
+    )
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -1,0 +1,115 @@
+import { vi } from 'vitest'
+
+import User from '@/models/user'
+
+let patchLastUpdatedSpy: ReturnType<typeof vi.fn> | null = null
+let assertNotUpdatedSinceSpy: ReturnType<typeof vi.fn> | null = null
+
+export function setPatchLastUpdatedSpy(spy: ReturnType<typeof vi.fn>) {
+  patchLastUpdatedSpy = spy
+}
+
+export function setAssertNotUpdatedSinceSpy(spy: ReturnType<typeof vi.fn>) {
+  assertNotUpdatedSinceSpy = spy
+}
+
+const MOCK_STEP_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f7'
+const MOCK_CONNECTION_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f5'
+const MOCK_FLOW_ID = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
+const MOCK_FLOW_UPDATED_AT = '2021-01-01T00:00:00.000Z'
+
+interface MockWithAccessibleStepsOptions {
+  owner: User
+  currentUser: User
+  flowId?: string
+  stepId?: string
+  stepKey: string
+  stepAppKey: string
+  stepConnection?: Record<string, any>
+  stepStatus?: string
+  stepRole?: string
+  stepConfig?: Record<string, any>
+  stepNotFound?: boolean
+  flowUpdatedAt?: string
+}
+
+interface MockWithAccessibleConnectionsOptions {
+  connectionId: string
+  connectionKey: string
+  connectionNotFound?: boolean
+}
+
+export function createMockWithAccessibleSteps({
+  owner,
+  currentUser,
+  flowId = MOCK_FLOW_ID,
+  stepId = MOCK_STEP_ID,
+  stepKey,
+  stepAppKey,
+  stepConnection = { id: MOCK_CONNECTION_ID, userId: currentUser.id },
+  stepStatus = 'completed',
+  stepRole = 'owner',
+  stepConfig = {},
+  stepNotFound = false,
+  flowUpdatedAt = MOCK_FLOW_UPDATED_AT,
+}: MockWithAccessibleStepsOptions) {
+  return vi
+    .fn()
+    .mockImplementation(
+      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
+        if (stepNotFound) {
+          return {
+            withGraphFetched: vi.fn().mockReturnThis(),
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+
+        return {
+          withGraphFetched: vi.fn().mockReturnThis(),
+          findOne: vi.fn().mockResolvedValue({
+            id: stepId,
+            key: stepKey,
+            appKey: stepAppKey,
+            status: stepStatus,
+            role: stepRole,
+            flowId,
+            connection: stepAppKey === 'tiles' ? {} : stepConnection,
+            config: stepConfig,
+            flow: {
+              userId: owner.id,
+              updatedAt: flowUpdatedAt,
+              assertNotUpdatedSince:
+                assertNotUpdatedSinceSpy || vi.fn().mockResolvedValue({}),
+              patchLastUpdated:
+                patchLastUpdatedSpy || vi.fn().mockResolvedValue({}),
+            },
+          }),
+        }
+      },
+    )
+}
+
+export function createMockWithAccessibleConnections({
+  connectionId,
+  connectionKey,
+  connectionNotFound = false,
+}: MockWithAccessibleConnectionsOptions) {
+  return vi
+    .fn()
+    .mockImplementation(
+      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
+        if (connectionNotFound) {
+          return {
+            findOne: vi.fn().mockResolvedValue(null),
+          }
+        }
+
+        return {
+          findOne: vi.fn().mockResolvedValue({
+            id: connectionId,
+            key: connectionKey,
+          }),
+        }
+      },
+    )
+}

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -33,12 +33,6 @@ interface MockWithAccessibleStepsOptions {
   flowUpdatedAt?: string
 }
 
-interface MockWithAccessibleConnectionsOptions {
-  connectionId: string
-  connectionKey: string
-  connectionNotFound?: boolean
-}
-
 export function createMockWithAccessibleSteps({
   owner,
   currentUser,
@@ -78,36 +72,12 @@ export function createMockWithAccessibleSteps({
             flow: {
               userId: owner.id,
               updatedAt: flowUpdatedAt,
+              role: stepRole,
               assertNotUpdatedSince:
                 assertNotUpdatedSinceSpy || vi.fn().mockResolvedValue({}),
               patchLastUpdated:
                 patchLastUpdatedSpy || vi.fn().mockResolvedValue({}),
             },
-          }),
-        }
-      },
-    )
-}
-
-export function createMockWithAccessibleConnections({
-  connectionId,
-  connectionKey,
-  connectionNotFound = false,
-}: MockWithAccessibleConnectionsOptions) {
-  return vi
-    .fn()
-    .mockImplementation(
-      (_args?: { queryBuilder?: any; requiredRole?: string; trx?: any }) => {
-        if (connectionNotFound) {
-          return {
-            findOne: vi.fn().mockResolvedValue(null),
-          }
-        }
-
-        return {
-          findOne: vi.fn().mockResolvedValue({
-            id: connectionId,
-            key: connectionKey,
           }),
         }
       },

--- a/packages/backend/src/graphql/__tests__/queries/get-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-flow.itest.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'crypto'
+import { NotFoundError } from 'objection'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import flowResolvers from '@/graphql/custom-resolvers/flow'
+import getFlow from '@/graphql/queries/get-flow'
+import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import Step from '@/models/step'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from '../mutations/tiles/table.mock'
+
+describe('getFlow', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let mockFlow: Flow
+  let mockStep2: Step
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    owner = context.currentUser
+
+    // Create test users
+    editor = await User.query().insert({
+      id: randomUUID(),
+      email: 'editor@plumber.gov.sg',
+    })
+
+    viewer = await User.query().insert({
+      id: randomUUID(),
+      email: 'viewer@plumber.gov.sg',
+    })
+
+    nonCollaborator = await User.query().insert({
+      id: randomUUID(),
+      email: 'non-collaborator@plumber.gov.sg',
+    })
+
+    // Create test flow
+    mockFlow = await Flow.query().insert({
+      id: randomUUID(),
+      name: 'Test Flow',
+      userId: owner.id,
+      active: false,
+    })
+
+    // Create test steps
+    await Step.query().insert({
+      key: 'newSubmission',
+      appKey: 'formsg',
+      type: 'trigger',
+      flowId: mockFlow.id,
+      position: 1,
+      parameters: {},
+      status: 'completed',
+    })
+
+    mockStep2 = await Step.query().insert({
+      key: 'sendTransactionalEmail',
+      appKey: 'postman',
+      type: 'action',
+      flowId: mockFlow.id,
+      position: 2,
+      parameters: {},
+      status: 'completed',
+    })
+
+    // Create collaborators
+    await FlowCollaborator.query().insert([
+      {
+        flowId: mockFlow.id,
+        userId: editor.id,
+        role: 'editor',
+        updatedBy: owner.id,
+      },
+      {
+        flowId: mockFlow.id,
+        userId: viewer.id,
+        role: 'viewer',
+        updatedBy: owner.id,
+      },
+    ])
+  })
+
+  describe('successful flow retrieval', () => {
+    it('should return flow data for owner', async () => {
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      expect(result).toMatchObject({
+        id: mockFlow.id,
+        name: mockFlow.name,
+        userId: owner.id,
+        role: 'owner',
+      })
+
+      expect(result.steps).toHaveLength(2)
+      expect(result.steps[0].position).toBe(1)
+      expect(result.steps[1].position).toBe(2)
+
+      // Test collaborators by manually calling the custom resolver
+      const collaborators = await flowResolvers.collaborators(
+        result,
+        {},
+        context,
+      )
+      expect(collaborators).toHaveLength(3) // owner + editor + viewer
+      expect(collaborators).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            flowId: mockFlow.id,
+            userId: owner.id,
+            role: 'owner',
+          }),
+          expect.objectContaining({
+            flowId: mockFlow.id,
+            userId: editor.id,
+            role: 'editor',
+          }),
+          expect.objectContaining({
+            flowId: mockFlow.id,
+            userId: viewer.id,
+            role: 'viewer',
+          }),
+        ]),
+      )
+    })
+
+    it('should include owner as collaborator with correct role', async () => {
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      // Test collaborators by manually calling the custom resolver
+      const collaborators = await flowResolvers.collaborators(
+        result,
+        {},
+        context,
+      )
+      const ownerCollaborator = collaborators.find((c) => c.userId === owner.id)
+      expect(ownerCollaborator).toBeDefined()
+      expect(ownerCollaborator.role).toBe('owner')
+      expect(ownerCollaborator.flowId).toBe(mockFlow.id)
+    })
+
+    it('should return flow data for editor', async () => {
+      context.currentUser = editor
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      expect(result).toMatchObject({
+        id: mockFlow.id,
+        name: mockFlow.name,
+        role: 'editor',
+      })
+
+      expect(result.steps).toHaveLength(2)
+
+      // Test collaborators by manually calling the custom resolver
+      const collaborators = await flowResolvers.collaborators(
+        result,
+        {},
+        context,
+      )
+      expect(collaborators).toHaveLength(3)
+    })
+
+    it('should return flow data for viewer', async () => {
+      context.currentUser = viewer
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      expect(result).toMatchObject({
+        id: mockFlow.id,
+        name: mockFlow.name,
+        role: 'viewer',
+      })
+
+      expect(result.steps).toHaveLength(2)
+
+      // Test collaborators by manually calling the custom resolver
+      const collaborators = await flowResolvers.collaborators(
+        result,
+        {},
+        context,
+      )
+      expect(collaborators).toHaveLength(3)
+    })
+  })
+
+  describe('access control', () => {
+    it('should throw error for non-collaborator user', async () => {
+      context.currentUser = nonCollaborator
+
+      await expect(getFlow(null, { id: mockFlow.id }, context)).rejects.toThrow(
+        NotFoundError,
+      )
+    })
+
+    it('should throw error for non-existent flow', async () => {
+      const nonExistentFlowId = randomUUID()
+
+      await expect(
+        getFlow(null, { id: nonExistentFlowId }, context),
+      ).rejects.toThrow(NotFoundError)
+    })
+
+    it('should throw error for soft-deleted collaborator', async () => {
+      // Soft delete the editor
+      await FlowCollaborator.query()
+        .where('flow_id', mockFlow.id)
+        .where('user_id', editor.id)
+        .patch({ deletedAt: new Date().toISOString() })
+
+      context.currentUser = editor
+
+      await expect(getFlow(null, { id: mockFlow.id }, context)).rejects.toThrow(
+        NotFoundError,
+      )
+    })
+  })
+
+  describe('input validation', () => {
+    it('should throw error for invalid UUID format', async () => {
+      await expect(
+        getFlow(null, { id: 'invalid-uuid' }, context),
+      ).rejects.toThrow('Please provide a valid pipe ID in your URL.')
+    })
+
+    it('should throw error for non-string ID', async () => {
+      await expect(getFlow(null, { id: 123 as any }, context)).rejects.toThrow(
+        'Please provide a valid pipe ID in your URL.',
+      )
+    })
+
+    it('should throw error for empty string ID', async () => {
+      await expect(getFlow(null, { id: '' }, context)).rejects.toThrow(
+        'Please provide a valid pipe ID in your URL.',
+      )
+    })
+  })
+
+  describe('flow with pending transfer', () => {
+    it('should include pending transfer data', async () => {
+      // Create a pending transfer
+      const _newOwner = await User.query().insert({
+        email: 'new-owner@plumber.gov.sg',
+      })
+
+      // Note: This would require the FlowTransfer model to be imported
+      // For now, we'll test that the query structure supports it
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      expect(result).toMatchObject({
+        id: mockFlow.id,
+        name: mockFlow.name,
+        role: 'owner',
+      })
+    })
+  })
+
+  describe('flow with connections', () => {
+    it('should include connection data for steps', async () => {
+      const connection = await context.currentUser
+        .$relatedQuery('connections')
+        .insert({
+          key: 'postman',
+          formattedData: {},
+        })
+
+      await mockStep2.$query().patch({ connectionId: connection.id })
+
+      const result = await getFlow(null, { id: mockFlow.id }, context)
+
+      expect(result.steps).toHaveLength(2)
+      const stepWithConnection = result.steps.find((s) => s.id === mockStep2.id)
+      expect(stepWithConnection.connection).toBeDefined()
+      expect(stepWithConnection.connection.id).toBe(connection.id)
+    })
+  })
+})

--- a/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
@@ -8,7 +8,12 @@ const email: FlowCollaboratorResolver['email'] = async (parent) => {
     return parent?.user?.email
   }
 
-  // edge case: fallback to query if user relation is not loaded
+  /** edge case: fallback to query if user relation is not loaded
+   * * this may be used when the user relation is not loaded in the FlowCollaborator
+   *   object that is manually created in the flow custom resolver
+   * * queries that fetch the FlowCollaborator object but do not fetch the user relation
+   *   will not explicitly load the user relation
+   */
   const user = await parent
     .$relatedQuery('user')
     .select('email')

--- a/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow-collaborator.ts
@@ -1,0 +1,21 @@
+import type { Resolvers } from '../__generated__/types.generated'
+
+type FlowCollaboratorResolver = Resolvers['FlowCollaborator']
+
+const email: FlowCollaboratorResolver['email'] = async (parent) => {
+  // user is eagerly loaded in queries, we should use the loaded relation first
+  if (parent?.user?.email) {
+    return parent?.user?.email
+  }
+
+  // edge case: fallback to query if user relation is not loaded
+  const user = await parent
+    .$relatedQuery('user')
+    .select('email')
+    .throwIfNotFound()
+  return user.email
+}
+
+export default {
+  email,
+} satisfies FlowCollaboratorResolver

--- a/packages/backend/src/graphql/custom-resolvers/flow.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow.ts
@@ -1,4 +1,7 @@
+import sortBy from 'lodash/sortBy'
+
 import { TEMPLATES } from '@/db/storage'
+import FlowCollaborator from '@/models/flow-collaborators'
 
 import type { Resolvers } from '../__generated__/types.generated'
 
@@ -12,6 +15,39 @@ const template: FlowResolver['template'] = async (parent) => {
   return TEMPLATES.find((template) => template.id === templateId)
 }
 
+const collaborators: FlowResolver['collaborators'] = async (parent) => {
+  let collaborators = parent?.collaborators
+  if (!collaborators) {
+    const flowCollaborators = await FlowCollaborator.query()
+      .where({ flow_id: parent.id })
+      .withGraphFetched('user')
+    collaborators = flowCollaborators
+  }
+
+  // manually insert the owner as a collaborator
+  // as the owner lives separately in the flows table
+  const ownerCollaborator = new FlowCollaborator()
+  ownerCollaborator.flowId = parent.id
+  ownerCollaborator.userId = parent.userId
+  ownerCollaborator.role = 'owner'
+
+  return sortBy(
+    [ownerCollaborator, ...(collaborators ?? [])],
+    [
+      (collaborator) => {
+        return ['owner', 'editor', 'viewer'].indexOf(collaborator?.role)
+      },
+    ],
+  )
+}
+
+const role: FlowResolver['role'] = async (parent) => {
+  // Return the computed role from the query
+  return (parent as any)?.role || 'viewer'
+}
+
 export default {
   template,
+  collaborators,
+  role,
 } satisfies FlowResolver

--- a/packages/backend/src/graphql/custom-resolvers/index.ts
+++ b/packages/backend/src/graphql/custom-resolvers/index.ts
@@ -1,5 +1,6 @@
 import ExecutionStep from './execution-step'
 import Flow from './flow'
+import FlowCollaborator from './flow-collaborator'
 import TableMetadata from './table-metadata'
 
 /**
@@ -13,4 +14,4 @@ import TableMetadata from './table-metadata'
  * schema.gql-to-typescript.ts.
  */
 
-export default { ExecutionStep, TableMetadata, Flow }
+export default { ExecutionStep, TableMetadata, Flow, FlowCollaborator }

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -11,6 +11,7 @@ import deleteFlow from './mutations/delete-flow'
 import deleteFlowCollaborator from './mutations/delete-flow-collaborator'
 import deleteStep from './mutations/delete-step'
 import deleteUploadedFile from './mutations/delete-uploaded-file'
+import duplicateBranch from './mutations/duplicate-branch'
 import duplicateFlow from './mutations/duplicate-flow'
 import executeStep from './mutations/execute-step'
 import generateAuthUrl from './mutations/generate-auth-url'
@@ -86,6 +87,7 @@ export default {
   loginWithSso,
   createFlowTransfer,
   updateFlowTransferStatus,
+  duplicateBranch,
   duplicateFlow,
   deleteUploadedFile,
   generatePresignedPost,

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -8,6 +8,7 @@ import createStep from './mutations/create-step'
 import createTemplatedFlow from './mutations/create-templated-flow'
 import deleteConnection from './mutations/delete-connection'
 import deleteFlow from './mutations/delete-flow'
+import deleteFlowCollaborator from './mutations/delete-flow-collaborator'
 import deleteStep from './mutations/delete-step'
 import deleteUploadedFile from './mutations/delete-uploaded-file'
 import duplicateFlow from './mutations/duplicate-flow'
@@ -31,6 +32,7 @@ import updateFlowStatus from './mutations/update-flow-status'
 import updateFlowTransferStatus from './mutations/update-flow-transfer-status'
 import updateStep from './mutations/update-step'
 import updateStepPositions from './mutations/update-step-positions'
+import upsertFlowCollaborator from './mutations/upsert-flow-collaborator'
 import verifyConnection from './mutations/verify-connection'
 import verifyOtp from './mutations/verify-otp'
 
@@ -66,6 +68,8 @@ export default {
   updateFlow,
   updateFlowStatus,
   updateFlowConfig,
+  upsertFlowCollaborator,
+  deleteFlowCollaborator,
   executeStep,
   deleteFlow,
   createStep,

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -1,4 +1,5 @@
 import App from '@/models/app'
+import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -12,11 +13,29 @@ const createConnection: MutationResolvers['createConnection'] = async (
 ) => {
   await App.findOneByKey(params.input.key)
 
-  return await context.currentUser.$relatedQuery('connections').insert({
-    key: params.input.key,
-    formattedData: params.input.formattedData,
-    verified: false,
-  })
+  const newConnection = await context.currentUser
+    .$relatedQuery('connections')
+    .insert({
+      key: params.input.key,
+      formattedData: params.input.formattedData,
+      verified: false,
+    })
+
+  /**
+   * COLLABORATORS
+   * If the flowId is provided and the flow has collaborators, we add this to the flow_connections table.
+   * We add regardless of whether its a draft, so that it can be used by collaborators later.
+   */
+  if (params.input.flowId) {
+    await FlowConnections.addFlowConnection({
+      flowId: params.input.flowId,
+      connectionId: newConnection.id,
+      addedBy: context.currentUser.id,
+      connectionType: 'connection',
+    })
+  }
+
+  return newConnection
 }
 
 export default createConnection

--- a/packages/backend/src/graphql/mutations/create-flow-transfer.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-transfer.ts
@@ -1,4 +1,5 @@
 import FlowTransfer from '@/models/flow-transfers'
+import TableCollaborator from '@/models/table-collaborators'
 import User from '@/models/user'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -11,8 +12,9 @@ const createFlowTransfer: MutationResolvers['createFlowTransfer'] = async (
   const { flowId, newOwnerEmail } = params.input
 
   // check if flow belongs to the old owner first
-  await context.currentUser
+  const flow = await context.currentUser
     .$relatedQuery('flows')
+    .withGraphFetched('steps')
     .where('id', flowId)
     .throwIfNotFound('This pipe does not belong to you.')
 
@@ -48,6 +50,24 @@ const createFlowTransfer: MutationResolvers['createFlowTransfer'] = async (
       'Transfer has already been made. Please get the new owner to approve it.',
     )
   }
+
+  // COLLABORATORS:
+  // check that the current owner has the rights to make the new owner
+  // an editor of the Tile (if any)
+  const tilesSteps =
+    flow?.[0].steps?.filter((step) => step.appKey === 'tiles') ?? []
+
+  // check that the current owner has the rights to make the new owner
+  // an editor of all the Tiles in the Pipe
+  await Promise.all(
+    tilesSteps.map(async (step) => {
+      await TableCollaborator.hasAccess(
+        context.currentUser.id,
+        step.parameters.tableId as string,
+        'editor',
+      )
+    }),
+  )
 
   const newTransfer: FlowTransfer = await context.currentUser
     .$relatedQuery('sentFlowTransfers')

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,6 +1,8 @@
 import { raw } from 'objection'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
+import Connection from '@/models/connection'
+import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -15,23 +17,40 @@ const createStep: MutationResolvers['createStep'] = async (
   return await Step.transaction(async (trx) => {
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
-    if (input.connection?.id) {
-      // if connectionId is specified, verify that the connection exists and belongs to the user
-      const connection = await context.currentUser
-        .$relatedQuery('connections')
-        .findOne({ id: input.connection.id })
-      if (!connection) {
-        throw new BadUserInputError('Connection not found')
-      }
-    }
-
     // Put SELECTs in transaction just in case there's concurrent modification.
     const flow = await context.currentUser
-      .$relatedQuery('flows', trx)
+      .withAccessibleFlows({ trx, requiredRole: 'editor' })
       .findOne({
         id: input.flow.id,
       })
       .throwIfNotFound()
+
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
+
+    // if connectionId is specified, verify that the connection exists
+    // and the user has the appropriate permissions to use it
+    // user has to be an editor in the pipe
+    if (input.connection?.id) {
+      let connection: Connection
+      if (flow.role === 'owner') {
+        connection = await context.currentUser
+          .$relatedQuery('connections')
+          .findOne({ id: input.connection.id })
+      } else if (flow.role === 'editor') {
+        // TODO (kevinkim-ogp): allow editors to create step with owner connections
+        throw new ForbiddenError(
+          'User does not have permission to add connection',
+        )
+      } else {
+        throw new ForbiddenError(
+          'User does not have permission to add connection',
+        )
+      }
+
+      if (!connection) {
+        throw new BadUserInputError('Connection not found')
+      }
+    }
 
     const previousStep = await flow
       .$relatedQuery('steps', trx)
@@ -57,9 +76,29 @@ const createStep: MutationResolvers['createStep'] = async (
       config: input.config,
     })
 
-    await step.patchFlowLastUpdated(trx)
+    // NOTE: add flow connection to the flow_connections table
+    // only add by default if the user is the owner of the flow
+    // TODO (kevinkim-ogp): enhance this to allow editors to add connections
+    if (input.connection?.id && flow.userId === context.currentUser.id) {
+      await FlowConnections.addFlowConnection({
+        flowId: flow.id,
+        connectionId: input.connection.id,
+        addedBy: context.currentUser.id,
+        // it is always connection when creating a step since table is selected
+        // only after the step is created
+        connectionType: 'connection',
+        trx,
+      })
+    }
 
-    return step
+    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+
+    return {
+      ...step,
+      flow: {
+        updatedAt: updatedFlow.updatedAt,
+      },
+    }
   })
 }
 

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -24,7 +24,7 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .throwIfNotFound()
 
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     // if connectionId is specified, verify that the connection exists
     // and the user has the appropriate permissions to use it
@@ -84,7 +84,11 @@ const createStep: MutationResolvers['createStep'] = async (
       })
     }
 
-    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+    const updatedFlow = await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return {
       ...step,

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -1,9 +1,8 @@
 import { raw } from 'objection'
 
-import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
-import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -31,25 +30,19 @@ const createStep: MutationResolvers['createStep'] = async (
     // and the user has the appropriate permissions to use it
     // user has to be an editor in the pipe
     if (input.connection?.id) {
-      let connection: Connection
-      if (flow.role === 'owner') {
-        connection = await context.currentUser
-          .$relatedQuery('connections')
-          .findOne({ id: input.connection.id })
-      } else if (flow.role === 'editor') {
-        // TODO (kevinkim-ogp): allow editors to create step with owner connections
-        throw new ForbiddenError(
-          'User does not have permission to add connection',
-        )
-      } else {
-        throw new ForbiddenError(
-          'User does not have permission to add connection',
-        )
-      }
-
-      if (!connection) {
-        throw new BadUserInputError('Connection not found')
-      }
+      /**
+       * NOTE: with collaborators,
+       * Owner can use existing connections or add new connections to the pipe
+       * Editor can only use existing connections that have been shared to the pipe
+       * (TODO: phase 2) Editor will be able to add their own connections
+       */
+      await getConnection({
+        context,
+        connectionId: input.connection.id,
+        flowId: flow.id,
+        includeOwnConnections: flow.role === 'owner',
+        trx,
+      })
     }
 
     const previousStep = await flow

--- a/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,0 +1,63 @@
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { validateAndParseEmail } from '@/helpers/email-validator'
+import logger from '@/helpers/logger'
+import FlowCollaborator from '@/models/flow-collaborators'
+import User from '@/models/user'
+
+import { MutationResolvers } from '../__generated__/types.generated'
+
+const deleteFlowCollaborator: MutationResolvers['deleteFlowCollaborator'] =
+  async (_parent, params, context) => {
+    const { flowId, email } = params.input as {
+      flowId: string
+      email: string
+    }
+
+    const validatedEmail = await validateAndParseEmail(email)
+    if (!validatedEmail) {
+      throw new BadUserInputError('Invalid collaborator email')
+    }
+
+    if (validatedEmail === context.currentUser.email) {
+      throw new BadUserInputError('Cannot remove yourself')
+    }
+
+    // only editor or owner can delete collaborators
+    await FlowCollaborator.hasAccess({
+      userId: context.currentUser.id,
+      flowId,
+      requiredRole: 'editor',
+    })
+
+    const user = await User.query()
+      .findOne({
+        email: validatedEmail,
+      })
+      .throwIfNotFound('No such user found')
+
+    try {
+      await FlowCollaborator.query()
+        .delete()
+        .where({
+          flow_id: flowId,
+          user_id: user.id,
+        })
+        .returning('*')
+        .throwIfNotFound({ message: 'No such collaborator found' })
+    } catch (e) {
+      logger.error({
+        message: 'Failed to delete collaborator',
+        data: {
+          flowId,
+          email,
+        },
+        userId: context.currentUser.id,
+        error: e,
+      })
+      throw new Error(e.message ?? 'Failed to delete collaborator')
+    }
+
+    return true
+  }
+
+export default deleteFlowCollaborator

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -38,7 +38,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
       })
 
     const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
@@ -114,7 +114,11 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    await flow.patchLastUpdated({ flowId: flow.id, trx })
+    await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return await flow
       .$query(trx)

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -20,7 +20,8 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
   params,
   context,
 ) => {
-  if (params.input.ids.length === 0) {
+  const { input } = params
+  if (input.ids.length === 0) {
     throw new Error('Nothing to delete')
   }
 
@@ -28,17 +29,20 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
     // Include SELECTs in transaction too just in case there's concurrent modification.
     const steps = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
-      .whereIn('steps.id', params.input.ids)
+      .whereIn('steps.id', input.ids)
       .orderBy('steps.position', 'asc')
-      .throwIfNotFound()
+      .throwIfNotFound({
+        message: 'Step not found. Refresh the page and try again.',
+      })
+
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
 
     if (!steps.every((step) => step.flowId === steps[0].flowId)) {
       throw new Error('All steps to be deleted must be from the same pipe!')
     }
-
-    const flow = steps[0].flow
 
     //
     // ** IMPORTANT NOTE **

--- a/packages/backend/src/graphql/mutations/delete-step.ts
+++ b/packages/backend/src/graphql/mutations/delete-step.ts
@@ -110,7 +110,7 @@ const deleteStep: MutationResolvers['deleteStep'] = async (
         .patch({ position: raw(`position - ${steps.length}`) })
     }
 
-    await steps[0].patchFlowLastUpdated(trx)
+    await flow.patchLastUpdated({ flowId: flow.id, trx })
 
     return await flow
       .$query(trx)

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -1,0 +1,104 @@
+import { raw } from 'objection'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import Step from '@/models/step'
+import { getConnection } from '@/services/connection'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { input } = params
+
+  return await Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    // validate user has access to the flow AND
+    // that the flow has not been updated since the client last fetched it
+    const flow = await context.currentUser
+      .withAccessibleFlows({ trx, requiredRole: 'editor' })
+      .findOne({
+        id: input.flow.id,
+      })
+      .throwIfNotFound()
+
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
+
+    // create all the steps in the transaction so that if any fails
+    // this entire query fails
+    const newSteps: Step[] = []
+    let previousStepId = input.previousStep.id
+    for (const branchStep of input.steps) {
+      const { connection, key, appKey, parameters, config } = branchStep
+
+      // if connectionId is specified, verify that the connection exists
+      // and the user has the appropriate permissions to use it
+      // user has to be an editor in the pipe
+      if (connection?.id) {
+        /**
+         * NOTE: with collaborators,
+         * Owner can use existing connections or add new connections to the pipe
+         * Editor can only use existing connections that have been shared to the pipe
+         * (TODO: phase 2) Editor will be able to add their own connections
+         */
+        const verifiedConnection = await getConnection({
+          context,
+          connectionId: connection?.id,
+          flowId: flow.id,
+          includeOwnConnections: flow.role === 'owner',
+          trx,
+        })
+
+        if (!verifiedConnection) {
+          throw new BadUserInputError('Connection not found')
+        }
+      }
+
+      const previousStep = await flow
+        .$relatedQuery('steps', trx)
+        .findOne({
+          id: previousStepId,
+        })
+        .throwIfNotFound()
+
+      await flow
+        .$relatedQuery('steps', trx)
+        .patch({
+          position: raw(`position + 1`),
+        })
+        .where('position', '>=', previousStep.position + 1)
+
+      const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
+        key,
+        appKey,
+        type: 'action',
+        position: previousStep.position + 1,
+        parameters,
+        connectionId: connection?.id,
+        config,
+      })
+
+      newSteps.push(step)
+      previousStepId = step.id
+
+      // NOTE: slight difference from createStep where createStep
+      // may need to add to flow_connections, but duplicateBranch does not
+      // as the connection would have already been added when the step
+      // was created in the original branch
+    }
+
+    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+
+    return {
+      steps: newSteps,
+      flow: {
+        updatedAt: updatedFlow.updatedAt,
+      },
+    }
+  })
+}
+
+export default duplicateBranch

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -25,7 +25,7 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       })
       .throwIfNotFound()
 
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     // create all the steps in the transaction so that if any fails
     // this entire query fails
@@ -90,7 +90,11 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
       // was created in the original branch
     }
 
-    const updatedFlow = await flow.patchLastUpdated({ flowId: flow.id, trx })
+    const updatedFlow = await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: context.currentUser.id,
+      trx,
+    })
 
     return {
       steps: newSteps,

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -49,14 +49,19 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     // duplicate the steps and the variables
     const oldToNewStepIdsMap: Record<string, string> = {}
     for (const oldStep of flow.steps) {
+      // NOTE: should not duplicate connections that are shared
+      // userId is null in connections if the connection was shared in a Pipe
+      // and the pipe was subsequently transferred to another user
+      const shouldDuplicateConnection = oldStep.connection?.userId != null
+
       const duplicatedStep = await duplicatedFlow
         .$relatedQuery('steps', trx)
         .insert({
           key: oldStep.key,
           appKey: oldStep.appKey,
           type: oldStep.type,
-          connectionId: oldStep.connectionId,
-          connection: oldStep.connection,
+          connectionId: shouldDuplicateConnection ? oldStep.connectionId : null,
+          connection: shouldDuplicateConnection ? oldStep.connection : null,
           position: oldStep.position,
           parameters: updateStepVariables(
             oldStep.parameters,

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -37,6 +37,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     delete prevConfig['templateConfig']
     delete prevConfig['showSurvey']
     delete prevConfig['attachments']
+    delete prevConfig['errorConfig']
 
     const duplicatedFlow = await context.currentUser
       .$relatedQuery('flows', trx)

--- a/packages/backend/src/graphql/mutations/execute-step.ts
+++ b/packages/backend/src/graphql/mutations/execute-step.ts
@@ -13,7 +13,7 @@ const executeStep: MutationResolvers['executeStep'] = async (
 
   // Just checking for permissions here
   const stepToTest = await context.currentUser
-    .$relatedQuery('steps')
+    .withAccessibleSteps({ requiredRole: 'editor' })
     .withGraphFetched('flow')
     .findById(stepId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -17,7 +17,7 @@ const retryExecutionStep: MutationResolvers['retryExecutionStep'] = async (
     .where('status', 'failure')
     .whereExists(
       context.currentUser
-        .$relatedQuery('executions')
+        .withAccessibleExecutions({ requiredRole: 'editor' })
         .select(1)
         .where('executions.id', ref('execution_steps.execution_id')),
     )

--- a/packages/backend/src/graphql/mutations/retry-partial-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-partial-step.ts
@@ -16,7 +16,7 @@ const retryPartialStep: MutationResolvers['retryPartialStep'] = async (
     .withGraphJoined('execution')
     .whereExists(
       context.currentUser
-        .$relatedQuery('executions')
+        .withAccessibleExecutions({ requiredRole: 'editor' })
         .select(1)
         .where('executions.id', ref('execution_steps.execution_id')),
     )

--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -10,6 +10,7 @@ type Params = {
   input: {
     id: string
     notificationFrequency: IFlowErrorConfig['notificationFrequency']
+    notificationRecipients: IFlowErrorConfig['notificationRecipients']
     showSurvey: boolean
     attachments?: IFlowAttachmentsConfig[]
   }
@@ -35,6 +36,13 @@ const updateFlowConfig = async (
     newConfig.errorConfig = {
       ...newConfig.errorConfig, // If ever undefined (should never be), it gets set to an empty object first
       notificationFrequency: params.input.notificationFrequency,
+    }
+  }
+
+  if (params.input.notificationRecipients !== undefined) {
+    newConfig.errorConfig = {
+      ...newConfig.errorConfig, // If ever undefined (should never be), it gets set to an empty object first
+      notificationRecipients: params.input.notificationRecipients,
     }
   }
 

--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -21,11 +21,11 @@ const updateFlowConfig = async (
   context: Context,
 ) => {
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows({ requiredRole: 'editor' })
     .findOne({
       id: params.input.id,
     })
-    .throwIfNotFound()
+    .throwIfNotFound({ message: 'Not authorised!' })
 
   const newConfig: IFlowConfig = {
     ...flow.config,

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -39,7 +39,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   context,
 ) => {
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows({ requiredRole: 'editor' })
     .findOne({
       'flows.id': params.input.id,
     })
@@ -52,6 +52,8 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
     return flow
   }
 
+  flow.assertNotUpdatedSince(params.input.updatedAt)
+
   if (params.input.active) {
     validateFlowSteps(flow.steps)
   }
@@ -59,6 +61,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   await flow.$query().patch({
     active: params.input.active,
     publishedAt: params.input.active ? new Date().toISOString() : null,
+    updatedBy: context.currentUser.id,
     config: {
       ...flow.config,
       // When publishing: set to true if undefined else false

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -52,7 +52,7 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
     return flow
   }
 
-  flow.assertNotUpdatedSince(params.input.updatedAt)
+  flow.assertNotUpdatedSince(params.input.updatedAt, context.currentUser.id)
 
   if (params.input.active) {
     validateFlowSteps(flow.steps)

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -1,7 +1,14 @@
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
+import Connection from '@/models/connection'
+import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
 import FlowTransfer from '@/models/flow-transfers'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -20,12 +27,8 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
     }
 
     const flowTransfer = await FlowTransfer.query()
-      .findOne({
-        id,
-      })
-      .withGraphFetched({
-        newOwner: true,
-      })
+      .findOne({ id })
+      .withGraphFetched({ newOwner: true })
       .throwIfNotFound()
 
     // To prevent possible exploits: for approved/rejected status: check if new owner matches
@@ -63,19 +66,27 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
       .throwIfNotFound('Pipe to be transferred cannot be found')
 
     /**
-     * This transaction does 3 things to complete a flow transfer
-     * 1. Nullify all the connections in the flow (phase 1)
-     * 2. Update the flow id to the new owner
-     * 3. Update the flow transfer status to 'approved'
+     * This transaction does the following to complete a flow transfer:
+     * - Duplicate all connections in the connections table and nullify the user ids
+     *   (EXCEPT M365-excel: nullify all connections)
+     * - Patch the steps to reference the duplicate connection(s)
+     * - Share all connections and tables to flow_connections (if not already shared)
+     * - Add the new owner as an editor in the table (if not already an editor)
+     * - Update the flow id to the new owner
+     * - Update the flow transfer status to 'approved'
      */
     return await FlowTransfer.transaction(async (trx) => {
       // logging for recovery purposes
       const connectionIds: string[] = []
+      const tableIds: string[] = []
       const stepIds: string[] = []
       flow.steps.forEach((step) => {
         if (step.connectionId) {
           stepIds.push(step.id)
           connectionIds.push(step.connectionId)
+        }
+        if (step.parameters.tableId) {
+          tableIds.push(step.parameters.tableId as string)
         }
       })
 
@@ -84,40 +95,200 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
         flowTransferId: id,
         flowId: flow.id,
         connectionIds,
+        tableIds,
         stepIds,
       })
 
-      // nullify connections: both the connection and connectionId references and set status to incomplete
-      const numNullified = await Step.query(trx)
+      // PRE-TRANSFER WORK
+      // nullify connections for M365-excel
+      // excel connections cannot be shared; the new owner should use their own connection
+      const excelStepIds = flow.steps
+        .filter((step) => step.appKey === 'm365-excel')
+        .map((step) => step.id)
+      const numExcelNullified = await Step.query(trx)
         .patch({ connection: null, connectionId: null, status: 'incomplete' })
         .where('flow_id', flow.id)
         .whereNotNull('connection_id')
+        .andWhere('app_key', 'm365-excel')
+
+      // invalidate the execution steps for the m365-excel actions
+      // so that it does not show as an error in the pipe editor
+      // there is no impact to executions history as they will still be visible
+      await ExecutionStep.query(trx).delete().whereIn('step_id', excelStepIds)
 
       // sanity check that only the connections belonging to the flow is nullified
-      if (numNullified !== connectionIds.length) {
+      if (numExcelNullified !== excelStepIds.length) {
         throw new Error(
           'Update query went wrong, please contact plumber@open.gov.sg for more support',
         )
       }
 
-      // additional update: set tiles actions to incomplete too
-      const numIncompleteForTiles = await Step.query(trx)
-        .patch({ status: 'incomplete' })
-        .where('flow_id', flow.id)
-        .andWhere('app_key', 'tiles')
+      // HANDLE CONNECTIONS
+      // get the connections and tables to be shared
+      // intentionally exclude m365-excel as the connection has been nullified
+      // and it should retain the user_id in the connections table
+      const connectionDetails = getConnectionDetails(
+        flow?.steps.filter((step) => step.appKey !== 'm365-excel'),
+      )
+      const sharedConnections = connectionDetails.connection
+      const sharedTables = connectionDetails.table
 
-      // sanity check
-      if (numIncompleteForTiles > flow.steps.length) {
-        throw new Error(
-          'Update tiles status query went wrong, please contact plumber@open.gov.sg for more support',
+      if (Object.keys(sharedConnections).length > 0) {
+        // duplicate the connections in the connections table and nullify the IDs
+        await Promise.all(
+          Object.entries(sharedConnections).map(
+            async ([connectionId, metadata]) => {
+              const duplicatedConnection = await Connection.duplicate(
+                connectionId,
+                trx,
+              )
+
+              if (duplicatedConnection) {
+                const { id: newConnectionId } = duplicatedConnection
+                const existingFlowConnection = await FlowConnections.query(
+                  trx,
+                ).findOne({
+                  flow_id: flow.id,
+                  connection_id: connectionId,
+                })
+
+                // update or create flow connection using the duplicated connection
+                if (existingFlowConnection) {
+                  await existingFlowConnection
+                    .$query(trx)
+                    .patchAndFetch({
+                      connectionId: newConnectionId,
+                    })
+                    .where({
+                      flow_id: flow.id,
+                      connection_id: connectionId,
+                    })
+                } else {
+                  await FlowConnections.query(trx).insertAndFetch({
+                    flowId: flow.id,
+                    connectionId: newConnectionId,
+                    addedBy: flow.userId,
+                    connectionType: 'connection',
+                    metadata: metadata,
+                  })
+                }
+
+                // patch the steps to reference the duplicate connection(s)
+                await Step.query(trx)
+                  .patch({ connectionId: newConnectionId })
+                  .where('flow_id', flow.id)
+                  .whereNotNull('connection_id')
+                  .where('connection_id', connectionId)
+
+                return {
+                  flowId: flow.id,
+                  connectionId: newConnectionId,
+                  addedBy: flow.userId,
+                  connectionType: 'connection',
+                  metadata: metadata,
+                }
+              }
+            },
+          ),
         )
       }
 
-      // update to new owner id
-      await flow.$query(trx).patchAndFetch({
-        userId: context.currentUser.id,
+      // HANDLE TABLES
+      // table connections are not duplicated as the owner of the table stays the same
+      // the new owner only becomes an editor of the table
+      // if the table needs to be transferred, it should be done from the Tile
+      if (sharedTables.length > 0) {
+        const tableInserts = await Promise.all(
+          sharedTables.map(async (tableId) => {
+            try {
+              // there may be instances where the new pipe owner is already the owner of the table
+              // we catch the error but do nothing`
+              await TableCollaborator.addCollaborator({
+                userId: context.currentUser.id, // the new owner
+                tableId,
+                role: 'editor',
+                trx,
+              })
+            } catch (e) {
+              // do nothing if the new owner of the pipe is already the owner of the tile
+              if (
+                !(e instanceof BadUserInputError) &&
+                e.message !== 'Cannot change owner role'
+              ) {
+                throw new Error(e)
+              }
+            }
+
+            // always return the table
+            return {
+              flowId: flow.id,
+              connectionId: tableId,
+              addedBy: flow.userId,
+              connectionType: 'table' as const,
+            }
+          }),
+        )
+
+        // add all tables to the flow_connections table
+        await FlowConnections.query(trx)
+          .insert(tableInserts)
+          .onConflict(['flow_id', 'connection_id'])
+          .ignore()
+      }
+
+      // HANDLE FLOW COLLABORATORS
+      // - check if the current owner was once a collaborator
+      // - update the role if they were a collaborator
+      // - otherwise, create a new record
+      const existingCollaborator = await FlowCollaborator.query(trx)
+        .findOne({
+          flow_id: flow.id,
+          user_id: flow.userId,
+        })
+        .withSoftDeleted()
+
+      if (!existingCollaborator) {
+        await FlowCollaborator.query(trx).insert({
+          flowId: flow.id,
+          userId: flow.userId,
+          role: 'editor',
+          updatedBy: context.currentUser.id,
+        })
+      } else {
+        await existingCollaborator.$query(trx).patchAndFetch({
+          role: 'editor',
+          deletedAt: null,
+          updatedBy: context.currentUser.id,
+        })
+      }
+
+      // remove the new owner from the flow collaborators
+      const isNewOwnerCollaborator = await FlowCollaborator.query(trx).findOne({
+        flow_id: flow.id,
+        user_id: context.currentUser.id,
       })
 
+      if (isNewOwnerCollaborator) {
+        await FlowCollaborator.deleteCollaborator({
+          userId: context.currentUser.id,
+          flowId: flow.id,
+          trx,
+        })
+      }
+
+      // make the current owner a collaborator in the flow
+      await FlowCollaborator.upsertCollaborator({
+        userId: flow.userId,
+        flowId: flow.id,
+        role: 'editor',
+        updatedBy: context.currentUser.id,
+        trx,
+      })
+
+      // update the flow owner id
+      await flow.$query(trx).patchAndFetch({ userId: context.currentUser.id })
+
+      // FINALLY, MARK THE FLOW TRANSFER AS APPROVED AND COMPLETED
       return await flowTransfer.$query(trx).patchAndFetch({
         status,
       })

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -1,4 +1,4 @@
-import { BadUserInputError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
 import Connection from '@/models/connection'
@@ -201,6 +201,13 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
         const tableInserts = await Promise.all(
           sharedTables.map(async (tableId) => {
             try {
+              // the old owner should have the permissions to add the new owner as an editor of the table
+              await TableCollaborator.hasAccess(
+                flowTransfer.oldOwnerId,
+                tableId,
+                'editor',
+              )
+
               // there may be instances where the new pipe owner is already the owner of the table
               // we catch the error but do nothing`
               await TableCollaborator.addCollaborator({
@@ -210,6 +217,11 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
                 trx,
               })
             } catch (e) {
+              if (e instanceof ForbiddenError) {
+                throw new Error(
+                  'Previous owner does not have sufficient permissions to add you as an Editor of the Tile.',
+                )
+              }
               // do nothing if the new owner of the pipe is already the owner of the tile
               if (
                 !(e instanceof BadUserInputError) &&

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -12,8 +12,12 @@ const updateFlow: MutationResolvers['updateFlow'] = async (
     })
     .throwIfNotFound()
 
+  flow.assertNotUpdatedSince(params.input.updatedAt, context.currentUser.id)
+
   return await flow.$query().patchAndFetch({
     name: params.input.name,
+    updatedAt: new Date().toISOString(),
+    updatedBy: context.currentUser.id,
   })
 }
 

--- a/packages/backend/src/graphql/mutations/update-flow.ts
+++ b/packages/backend/src/graphql/mutations/update-flow.ts
@@ -6,7 +6,7 @@ const updateFlow: MutationResolvers['updateFlow'] = async (
   context,
 ) => {
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows({ requiredRole: 'editor' })
     .findOne({
       id: params.input.id,
     })

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -50,7 +50,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     }
 
     const flow = steps[0].flow
-    flow.assertNotUpdatedSince(input.flow.updatedAt)
+    flow.assertNotUpdatedSince(input.flow.updatedAt, context.currentUser.id)
 
     const foundStepIds = steps.map((step) => step.id)
     const missingStepIds = stepIds.filter(

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -37,7 +37,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
     await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
 
     const steps = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .whereIn('steps.id', stepIds)
       .orderBy('steps.position', 'asc')
@@ -48,6 +48,9 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
         'Pipe is active. Cannot update step in active pipe!',
       )
     }
+
+    const flow = steps[0].flow
+    flow.assertNotUpdatedSince(input.flow.updatedAt)
 
     const foundStepIds = steps.map((step) => step.id)
     const missingStepIds = stepIds.filter(
@@ -72,8 +75,6 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       )
     }
 
-    const flow = steps[0].flow
-
     // Patch each step individually with its new position
     for (const stepPosition of stepPositions) {
       await Step.query(trx).findById(stepPosition.id).patch({
@@ -90,7 +91,7 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
       .withGraphFetched('steps')
       .orderBy('steps.position', 'asc')
 
-    return updatedFlow.steps
+    return updatedFlow
   })
 
   return updatedPositions

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -5,6 +5,7 @@ import {
 } from '@/helpers/add-flow-connection'
 import App from '@/models/app'
 import Step from '@/models/step'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -32,9 +33,14 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
-      const connection = await context.currentUser
-        .withAccessibleConnections({ requiredRole: 'editor' })
-        .findOne({ 'connections.id': input.connection.id })
+      const connection = await getConnection({
+        context,
+        connectionId: input.connection.id,
+        flowId: input.flow.id,
+        includeOwnConnections: step.role === 'owner',
+        trx,
+      })
+
       // we check that the connection exists and is the same app
       if (!connection || connection.key !== input.appKey) {
         throw new BadUserInputError('Connection not found')
@@ -119,7 +125,9 @@ const updateStep: MutationResolvers['updateStep'] = async (
       trx,
     })
 
-    return { ...updatedStep, flow: { updatedAt: updatedFlow.updatedAt } }
+    // do this instead of spreading the updatedStep so that it preserves the Model instance
+    updatedStep.flow.updatedAt = updatedFlow.updatedAt
+    return updatedStep
   })
 
   return step

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,10 +1,10 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
-import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
+import {
+  addFlowConnection,
+  addFlowTableConnection,
+} from '@/helpers/add-flow-connection'
 import App from '@/models/app'
-import FlowCollaborator from '@/models/flow-collaborators'
-import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
-import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -64,6 +64,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         connectionId: input.connection.id,
         parameters: input.parameters,
         status: shouldInvalidate ? 'incomplete' : step.status,
+        updatedBy: context.currentUser.id,
         config: {
           ...existingConfig,
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
@@ -76,64 +77,39 @@ const updateStep: MutationResolvers['updateStep'] = async (
       })
 
     /**
-     * NOTE: we need to update flow connections for specific apps:
-     *
+     * NOTE: we need to update flow connections for apps with connections:
      * Tiles:
      * 1. add the collaborator to the flow connections table
      * 2. add the collaborator to the table collaborators table
      *
+     * TODO (kevinkim-ogp): phase 2
+     * collaborator should be able to add their own tiles,
+     * and the owner will be added as an editor to the Tile
+     *
      * Other connections:
      * 1. add the collaborator to the flow connections table
+     *
+     * TODO (kevinkim-ogp): phase 2
+     * collaborator should be able to add their own connections,
+     * it will be tied to this specific flow only
      */
     if (step.role === 'owner') {
-      if (updatedStep.appKey === 'tiles' && updatedStep?.parameters?.tableId) {
-        await FlowConnections.addFlowConnection({
-          flowId: updatedStep.flowId,
-          connectionId: updatedStep.parameters.tableId as string,
-          addedBy: context.currentUser.id,
-          connectionType: 'table',
-        })
+      const appKey = updatedStep?.appKey
 
-        const collaborators = await FlowCollaborator.getCollaborators({
+      // tiles special handling
+      if (appKey === 'tiles' && updatedStep?.parameters?.tableId) {
+        await addFlowTableConnection({
           flowId: updatedStep.flowId,
+          tableId: updatedStep.parameters.tableId as string,
+          addedBy: context.currentUser.id,
           trx,
         })
-
-        /**
-         * use Promise.all so that we use the addCollaborator function, which checks
-         * if the collaborator already exists to avoid duplicates
-         */
-        await Promise.all(
-          collaborators.map(async ({ userId, role }) => {
-            await TableCollaborator.addCollaborator({
-              userId,
-              tableId: updatedStep.parameters.tableId as string,
-              role,
-              trx,
-            })
-          }),
-        )
-      } else if (APP_CONNECTION_FIELDS[updatedStep.appKey]) {
-        const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
-
-        const userId = updatedStep?.connection?.userId
-        const connectionId = updatedStep?.connectionId
-
-        if (updatedStep.parameters[parameterKey]) {
-          await FlowConnections.patchFlowConnectionMetadata({
-            flowId: updatedStep.flowId,
-            connectionId,
-            parameterKey,
-            parameterValue: updatedStep.parameters[parameterKey] as string,
-          })
-        } else {
-          await FlowConnections.addFlowConnection({
-            flowId: updatedStep.flowId,
-            connectionId,
-            addedBy: userId,
-            connectionType: 'connection',
-          })
-        }
+      } else if (updatedStep?.connectionId) {
+        await addFlowConnection({
+          step: updatedStep,
+          addedBy: context.currentUser.id,
+          trx,
+        })
       }
     }
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -28,7 +28,10 @@ const updateStep: MutationResolvers['updateStep'] = async (
       throw new BadUserInputError('Step not found')
     }
 
-    step.flow.assertNotUpdatedSince(input.flow.updatedAt)
+    step.flow.assertNotUpdatedSince(
+      input.flow.updatedAt,
+      context.currentUser.id,
+    )
 
     if (input.connection.id) {
       // if connectionId is specified, verify that the connection exists
@@ -121,11 +124,13 @@ const updateStep: MutationResolvers['updateStep'] = async (
     // update the flow's last updated
     const updatedFlow = await step.flow.patchLastUpdated({
       flowId: step.flowId,
+      updatedBy: context.currentUser.id,
       trx,
     })
 
     // do this instead of spreading the updatedStep so that it preserves the Model instance
     updatedStep.flow.updatedAt = updatedFlow.updatedAt
+    updatedStep.flow.updatedBy = context.currentUser.id
     return updatedStep
   })
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -14,6 +14,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
       .$relatedQuery('steps', trx)
+      .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
         flow_id: input.flow.id,
@@ -63,7 +64,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
       .withGraphFetched('connection')
 
     // update the flow's last updated
-    await step.patchFlowLastUpdated(trx)
+    await step.flow.patchLastUpdated({ flowId: step.flowId, trx })
 
     return updatedStep
   })

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -19,7 +19,6 @@ const updateStep: MutationResolvers['updateStep'] = async (
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
       .withAccessibleSteps({ requiredRole: 'editor', trx })
-      .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
         'steps.flow_id': input.flow.id,
@@ -37,7 +36,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
         context,
         connectionId: input.connection.id,
         flowId: input.flow.id,
-        includeOwnConnections: step.role === 'owner',
+        includeOwnConnections: step.flow.role === 'owner',
         trx,
       })
 
@@ -99,7 +98,7 @@ const updateStep: MutationResolvers['updateStep'] = async (
      * collaborator should be able to add their own connections,
      * it will be tied to this specific flow only
      */
-    if (step.role === 'owner') {
+    if (step.flow.role === 'owner') {
       const appKey = updatedStep?.appKey
 
       // tiles special handling

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,6 +1,10 @@
 import { BadUserInputError } from '@/errors/graphql-errors'
+import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import App from '@/models/app'
+import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
 import Step from '@/models/step'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -13,19 +17,24 @@ const updateStep: MutationResolvers['updateStep'] = async (
 
   const step = await Step.transaction(async (trx) => {
     const step = await context.currentUser
-      .$relatedQuery('steps', trx)
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
       .withGraphFetched('flow')
       .findOne({
         'steps.id': input.id,
-        flow_id: input.flow.id,
+        'steps.flow_id': input.flow.id,
       })
-      .throwIfNotFound({ message: 'Step not found' })
+
+    if (!step) {
+      throw new BadUserInputError('Step not found')
+    }
+
+    step.flow.assertNotUpdatedSince(input.flow.updatedAt)
 
     if (input.connection.id) {
-      // if connectionId is specified, verify that the connection exists and belongs to the user
+      // if connectionId is specified, verify that the connection exists
       const connection = await context.currentUser
-        .$relatedQuery('connections')
-        .findOne({ id: input.connection.id })
+        .withAccessibleConnections({ requiredRole: 'editor' })
+        .findOne({ 'connections.id': input.connection.id })
       // we check that the connection exists and is the same app
       if (!connection || connection.key !== input.appKey) {
         throw new BadUserInputError('Connection not found')
@@ -61,12 +70,80 @@ const updateStep: MutationResolvers['updateStep'] = async (
           ...(stepName !== undefined ? { stepName } : {}),
         },
       })
-      .withGraphFetched('connection')
+      .withGraphFetched({
+        connection: true,
+        flow: true,
+      })
+
+    /**
+     * NOTE: we need to update flow connections for specific apps:
+     *
+     * Tiles:
+     * 1. add the collaborator to the flow connections table
+     * 2. add the collaborator to the table collaborators table
+     *
+     * Other connections:
+     * 1. add the collaborator to the flow connections table
+     */
+    if (step.role === 'owner') {
+      if (updatedStep.appKey === 'tiles' && updatedStep?.parameters?.tableId) {
+        await FlowConnections.addFlowConnection({
+          flowId: updatedStep.flowId,
+          connectionId: updatedStep.parameters.tableId as string,
+          addedBy: context.currentUser.id,
+          connectionType: 'table',
+        })
+
+        const collaborators = await FlowCollaborator.getCollaborators({
+          flowId: updatedStep.flowId,
+          trx,
+        })
+
+        /**
+         * use Promise.all so that we use the addCollaborator function, which checks
+         * if the collaborator already exists to avoid duplicates
+         */
+        await Promise.all(
+          collaborators.map(async ({ userId, role }) => {
+            await TableCollaborator.addCollaborator({
+              userId,
+              tableId: updatedStep.parameters.tableId as string,
+              role,
+              trx,
+            })
+          }),
+        )
+      } else if (APP_CONNECTION_FIELDS[updatedStep.appKey]) {
+        const { parameterKey } = APP_CONNECTION_FIELDS[updatedStep.appKey]
+
+        const userId = updatedStep?.connection?.userId
+        const connectionId = updatedStep?.connectionId
+
+        if (updatedStep.parameters[parameterKey]) {
+          await FlowConnections.patchFlowConnectionMetadata({
+            flowId: updatedStep.flowId,
+            connectionId,
+            parameterKey,
+            parameterValue: updatedStep.parameters[parameterKey] as string,
+          })
+        } else {
+          await FlowConnections.addFlowConnection({
+            flowId: updatedStep.flowId,
+            connectionId,
+            addedBy: userId,
+            connectionType: 'connection',
+          })
+        }
+      }
+    }
 
     // update the flow's last updated
-    await step.flow.patchLastUpdated({ flowId: step.flowId, trx })
+    const updatedFlow = await step.flow.patchLastUpdated({
+      flowId: step.flowId,
+      trx,
+    })
 
-    return updatedStep
+    return { ...updatedStep, flow: { updatedAt: updatedFlow.updatedAt } }
   })
 
   return step

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,0 +1,93 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { getOrCreateUser } from '@/helpers/auth'
+import { validateAndParseEmail } from '@/helpers/email-validator'
+import logger from '@/helpers/logger'
+import FlowCollaborator from '@/models/flow-collaborators'
+
+import type { MutationResolvers } from '../__generated__/types.generated'
+
+const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
+  async (_parent, params, context) => {
+    const { flowId, email, role } = params.input as {
+      flowId: string
+      email: string
+      role: IFlowCollabRole
+    }
+
+    const validatedEmail = await validateAndParseEmail(email)
+    if (!validatedEmail) {
+      throw new BadUserInputError('Invalid collaborator email')
+    }
+
+    if (context.currentUser.email === validatedEmail) {
+      throw new BadUserInputError('Cannot change own role')
+    }
+
+    try {
+      /**
+       * We check if a flow collaborator has been added before (could have been soft deleted)
+       * and if so, we update the role
+       */
+      await FlowCollaborator.transaction(async (trx) => {
+        /**
+         * this mutation only allows for adding / updating collaborators.
+         * flow transfer is still handled by the updateFlowTransferStatus mutation.
+         * new user will be created if not exists
+         */
+        await FlowCollaborator.hasAccess({
+          userId: context.currentUser.id,
+          flowId,
+          requiredRole: 'editor',
+          trx,
+        })
+
+        const collaboratorUser = await getOrCreateUser(validatedEmail)
+        if (!collaboratorUser) {
+          throw new BadUserInputError('Error creating user')
+        }
+
+        const existingCollaborator = await FlowCollaborator.query(trx)
+          .findOne({
+            flow_id: flowId,
+            user_id: collaboratorUser.id,
+          })
+          .withSoftDeleted()
+
+        if (existingCollaborator) {
+          await existingCollaborator
+            .$query(trx)
+            .patchAndFetch({
+              role,
+              deletedAt: null,
+              updatedBy: context.currentUser.id,
+            })
+            .withSoftDeleted()
+        } else {
+          await FlowCollaborator.query(trx).insert({
+            flowId,
+            userId: collaboratorUser.id,
+            role,
+            updatedBy: context.currentUser.id,
+          })
+        }
+      })
+    } catch (error) {
+      logger.error({
+        message: 'Error upserting flow collaborator',
+        data: {
+          flowId,
+          email,
+          role,
+        },
+        userId: context.currentUser.id,
+        error,
+      })
+      throw new Error(error.message ?? 'Error upserting flow collaborator')
+    }
+
+    return true
+  }
+
+export default upsertFlowCollaborator

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,6 +1,7 @@
 import { IFlowCollabRole } from '@plumber/types'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
+import { addFlowTableConnection } from '@/helpers/add-flow-connection'
 import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
@@ -8,7 +9,6 @@ import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
-import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -71,26 +71,15 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           // add all connections to the flow_connections table
           // first time sharing is always by the owner
           // so we use the flow user_id
-          const connectionInserts = [
-            // Handle regular connections
-            ...Object.entries(connectionDetails.connection).map(
-              ([connectionId, metadata]) => ({
-                flowId,
-                connectionId,
-                addedBy: flow.userId,
-                connectionType: 'connection' as const,
-                metadata,
-              }),
-            ),
-            // Handle table connections (Tiles)
-            ...connectionDetails.table.map((tableId) => ({
-              flowId,
-              connectionId: tableId,
-              addedBy: flow.userId,
-              connectionType: 'table' as const,
-              metadata: {},
-            })),
-          ]
+          const connectionInserts = Object.entries(
+            connectionDetails.connection,
+          ).map(([connectionId, metadata]) => ({
+            flowId,
+            connectionId,
+            addedBy: flow.userId,
+            connectionType: 'connection' as const,
+            metadata,
+          }))
 
           if (connectionInserts.length > 0) {
             await FlowConnections.query(trx)
@@ -131,20 +120,17 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
         }
 
         /**
-         * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
-         * this ensures that the Tile appears in the dropdown when they are working
-         * on the flow
-         *
-         * use Promise.all so that we use the addCollaborator function, which checks
-         * if the collaborator already exists to avoid duplicates
+         * use Promise.all so that we use the addFlowTableConnection function, which checks
+         * if the collaborator already exists to avoid duplicates and adds the tile to
+         * flow_connections at the same time
          */
         if (connectionDetails.table.length > 0) {
           await Promise.all(
             connectionDetails.table.map(async (tableId) => {
-              await TableCollaborator.addCollaborator({
-                userId: collaboratorUser.id,
+              await addFlowTableConnection({
+                flowId,
                 tableId,
-                role,
+                addedBy: context.currentUser.id,
                 trx,
               })
             }),

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -3,8 +3,12 @@ import { IFlowCollabRole } from '@plumber/types'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
+import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
 import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -43,6 +47,59 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           trx,
         })
 
+        /**
+         * NOTE: we only automatically add all connections
+         * in the Pipe to the flow_connections table the first time
+         * the Pipe is shared.
+         *
+         * What is added:
+         * 1. Connections
+         * 2. Connection metadata, i.e. fields that are like connections:
+         *    see helpers/get-shared-connection-details.ts for more details
+         */
+        const hasCollaborators = await Flow.hasCollaborators({
+          flowId,
+          trx,
+        })
+
+        const flow = await Flow.query(trx)
+          .withGraphFetched('steps')
+          .findById(flowId)
+        const connectionDetails = getConnectionDetails(flow?.steps)
+
+        if (!hasCollaborators) {
+          // add all connections to the flow_connections table
+          // first time sharing is always by the owner
+          // so we use the flow user_id
+          const connectionInserts = [
+            // Handle regular connections
+            ...Object.entries(connectionDetails.connection).map(
+              ([connectionId, metadata]) => ({
+                flowId,
+                connectionId,
+                addedBy: flow.userId,
+                connectionType: 'connection' as const,
+                metadata,
+              }),
+            ),
+            // Handle table connections (Tiles)
+            ...connectionDetails.table.map((tableId) => ({
+              flowId,
+              connectionId: tableId,
+              addedBy: flow.userId,
+              connectionType: 'table' as const,
+              metadata: {},
+            })),
+          ]
+
+          if (connectionInserts.length > 0) {
+            await FlowConnections.query(trx)
+              .insert(connectionInserts)
+              .onConflict(['flow_id', 'connection_id'])
+              .ignore()
+          }
+        }
+
         const collaboratorUser = await getOrCreateUser(validatedEmail)
         if (!collaboratorUser) {
           throw new BadUserInputError('Error creating user')
@@ -71,6 +128,27 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
             role,
             updatedBy: context.currentUser.id,
           })
+        }
+
+        /**
+         * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
+         * this ensures that the Tile appears in the dropdown when they are working
+         * on the flow
+         *
+         * use Promise.all so that we use the addCollaborator function, which checks
+         * if the collaborator already exists to avoid duplicates
+         */
+        if (connectionDetails.table.length > 0) {
+          await Promise.all(
+            connectionDetails.table.map(async (tableId) => {
+              await TableCollaborator.addCollaborator({
+                userId: collaboratorUser.id,
+                tableId,
+                role,
+                trx,
+              })
+            }),
+          )
         }
       })
     } catch (error) {

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,10 +1,11 @@
 import { IFlowCollabRole } from '@plumber/types'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { addFlowTableConnection } from '@/helpers/add-flow-connection'
 import { getOrCreateUser } from '@/helpers/auth'
 import { validateAndParseEmail } from '@/helpers/email-validator'
 import { getConnectionDetails } from '@/helpers/get-shared-connection-details'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
@@ -18,6 +19,16 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
       flowId: string
       email: string
       role: IFlowCollabRole
+    }
+
+    // TODO (kevinkim-ogp): remove this once collaborators is released to all
+    const collaboratorsFlag = await getLdFlagValue(
+      'collaborators',
+      context.currentUser.email,
+      false,
+    )
+    if (!collaboratorsFlag) {
+      throw new ForbiddenError(' You are not allowed to add collaborators.')
     }
 
     const validatedEmail = await validateAndParseEmail(email)

--- a/packages/backend/src/graphql/queries/get-app.ts
+++ b/packages/backend/src/graphql/queries/get-app.ts
@@ -21,6 +21,26 @@ const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
   }
 
   if (app.auth?.connectionType === 'user-added') {
+    // NOTE: only have flowId if the user is a collaborator
+    if (params.flowId) {
+      const flowConnections = await context.currentUser
+        .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+        .join('connections', 'connections.id', 'flow_connections.connection_id')
+        .withGraphJoined('connection')
+        .where({
+          'flows.id': params.flowId,
+          'connections.key': params.key,
+          'connections.draft': false,
+        })
+
+      return {
+        ...app,
+        connections: flowConnections.map(
+          (flowConnection) => flowConnection.connection,
+        ),
+      }
+    }
+
     const connections = await context.currentUser
       .$relatedQuery('connections')
       .select('connections.*')

--- a/packages/backend/src/graphql/queries/get-app.ts
+++ b/packages/backend/src/graphql/queries/get-app.ts
@@ -1,4 +1,5 @@
 import App from '@/models/app'
+import Connection from '@/models/connection'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -21,26 +22,44 @@ const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
   }
 
   if (app.auth?.connectionType === 'user-added') {
-    // NOTE: only have flowId if the user is a collaborator
+    let sharedConnections: Connection[] = []
+    /**
+     * NOTE: flow id is only provided in the pipe editor.
+     * it is not provided at the 'My Apps' page, so no need to fetch shared connections
+     */
+
     if (params.flowId) {
+      const flow = await context.currentUser
+        .withAccessibleFlows({ requiredRole: 'viewer' })
+        .findById(params.flowId)
+        .throwIfNotFound({ message: 'Pipe not found' })
+
       const flowConnections = await context.currentUser
         .withAccessibleFlowConnections({ requiredRole: 'viewer' })
         .join('connections', 'connections.id', 'flow_connections.connection_id')
-        .withGraphJoined('connection')
+        .withGraphFetched('connection')
         .where({
           'flows.id': params.flowId,
           'connections.key': params.key,
           'connections.draft': false,
         })
 
-      return {
-        ...app,
-        connections: flowConnections.map(
-          (flowConnection) => flowConnection.connection,
-        ),
+      sharedConnections = flowConnections.map((flowConnection) =>
+        Object.assign(flowConnection.connection, {
+          description: 'This connection can only be used in this pipe.',
+        }),
+      )
+
+      if (flow.role === 'editor') {
+        return {
+          ...app,
+          connections: sharedConnections,
+        }
       }
     }
 
+    // if user is an owner, fetch all the connections
+    // if the user is an owner, fetch all the connections that the user owns
     const connections = await context.currentUser
       .$relatedQuery('connections')
       .select('connections.*')
@@ -53,9 +72,16 @@ const getApp: QueryResolvers['getApp'] = async (_parent, params, context) => {
       .groupBy('connections.id')
       .orderBy('created_at', 'desc')
 
+    const mergedConnections = Object.values(
+      [...sharedConnections, ...connections].reduce((acc, obj) => {
+        acc[obj.id] = obj // last one wins
+        return acc
+      }, {} as Record<string, Connection>),
+    )
+
     return {
       ...app,
-      connections,
+      connections: mergedConnections,
     }
   }
 

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -98,6 +98,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
               APP_CONNECTION_FIELDS[step.appKey].parameterKey
             ]
           })
+          .filter((value) => value !== undefined)
           .flat()
 
         return fetchedData.data.filter((data) =>

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -64,7 +64,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
    * - collaborator should be able to add their own Tiles
    */
   if (
-    step.role !== 'owner' &&
+    step.flow.role !== 'owner' &&
     APP_CONNECTION_FIELDS[step.appKey] &&
     APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
   ) {

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -1,4 +1,5 @@
 import apps from '@/apps'
+import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import globalVariable from '@/helpers/global-variable'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
@@ -48,7 +49,63 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
   }
 
   const fetchedData = await command.run($)
-  // TODO (kevinkim-ogp): should filter out data that is not accessible to the user
+
+  /**
+   * COLLABORATORS
+   * filter out the dynamic data to only show the options that have been shared with the user
+   *
+   * Tiles:
+   * - only show the Tiles that have been shared
+   *
+   * Other connections:
+   * - only show the connections that have been shared
+   *
+   * TODO (kevinkim-ogp): phase 2
+   * - collaborator should be able to add their own Tiles
+   */
+  if (
+    step.role !== 'owner' &&
+    APP_CONNECTION_FIELDS[step.appKey] &&
+    APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === dynamicDataKey
+  ) {
+    switch (step.appKey) {
+      case 'tiles': {
+        const flowConnections = await context.currentUser
+          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+          .where({
+            connection_type: 'table',
+            'flow_connections.flow_id': step.flowId,
+          })
+
+        return fetchedData.data.filter((data) =>
+          flowConnections.some(
+            (flowConnection) => flowConnection.connectionId === data.value,
+          ),
+        )
+      }
+
+      default: {
+        const flowConnections = await context.currentUser
+          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+          .where({
+            connection_id: step.connectionId,
+            'flow_connections.flow_id': step.flowId,
+          })
+
+        const allowedValues = flowConnections
+          .map((flowConnection) => {
+            return flowConnection.metadata[
+              APP_CONNECTION_FIELDS[step.appKey].parameterKey
+            ]
+          })
+          .flat()
+
+        return fetchedData.data.filter((data) =>
+          allowedValues.includes(data.value),
+        )
+      }
+    }
+  }
 
   if (fetchedData.error) {
     throw new Error(JSON.stringify(fetchedData.error))

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -11,7 +11,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
   const { stepId, key: dynamicDataKey, parameters } = params
 
   const step = await context.currentUser
-    .$relatedQuery('steps')
+    .withAccessibleSteps({ requiredRole: 'viewer' })
     .withGraphFetched({
       connection: true,
       flow: {
@@ -37,7 +37,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
     app,
     flow: step.flow,
     step,
-    user: context.currentUser,
+    user: step.flow.user,
   })
 
   const command = app.dynamicData.find((data) => data.key === dynamicDataKey)
@@ -48,6 +48,7 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
   }
 
   const fetchedData = await command.run($)
+  // TODO (kevinkim-ogp): should filter out data that is not accessible to the user
 
   if (fetchedData.error) {
     throw new Error(JSON.stringify(fetchedData.error))

--- a/packages/backend/src/graphql/queries/get-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-execution-steps.ts
@@ -10,7 +10,8 @@ const getExecutionSteps: QueryResolvers['getExecutionSteps'] = async (
   context,
 ) => {
   const execution = await context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
+    .withGraphFetched({ executionSteps: true })
     .withSoftDeleted()
     .findById(params.executionId)
     .throwIfNotFound()

--- a/packages/backend/src/graphql/queries/get-execution.ts
+++ b/packages/backend/src/graphql/queries/get-execution.ts
@@ -6,7 +6,7 @@ const getExecution: QueryResolvers['getExecution'] = async (
   context,
 ) => {
   const execution = await context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
     .withGraphFetched({
       flow: {
         steps: true,

--- a/packages/backend/src/graphql/queries/get-executions.ts
+++ b/packages/backend/src/graphql/queries/get-executions.ts
@@ -11,7 +11,7 @@ const getExecutions: QueryResolvers['getExecutions'] = async (
 ) => {
   const filterBuilder = (builder: ExtendedQueryBuilder<Execution>) => {
     builder.where('test_run', false)
-    builder.where('flow_id', params.flowId)
+    builder.where('executions.flow_id', params.flowId)
 
     // null status means waiting
     if (params.status === null) {
@@ -22,7 +22,7 @@ const getExecutions: QueryResolvers['getExecutions'] = async (
   }
 
   const executionsQuery = context.currentUser
-    .$relatedQuery('executions')
+    .withAccessibleExecutions({ requiredRole: 'viewer' })
     .withGraphFetched({
       executionSteps: true,
     })

--- a/packages/backend/src/graphql/queries/get-flow-transfer-details.ts
+++ b/packages/backend/src/graphql/queries/get-flow-transfer-details.ts
@@ -15,7 +15,7 @@ const getFlowTransferDetails: QueryResolvers['getFlowTransferDetails'] = async (
   const flowTransferDetails: ITransferDetails[] = []
 
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows({ requiredRole: 'viewer' })
     .findById(params.flowId)
     .withGraphFetched({
       steps: {

--- a/packages/backend/src/graphql/queries/get-flow.ts
+++ b/packages/backend/src/graphql/queries/get-flow.ts
@@ -9,7 +9,7 @@ const getFlow: QueryResolvers['getFlow'] = async (_parent, params, context) => {
   }
 
   const flow = await context.currentUser
-    .withAccessibleFlows()
+    .withAccessibleFlows({ requiredRole: 'viewer' })
     .withGraphFetched({
       steps: {
         connection: true,

--- a/packages/backend/src/graphql/queries/get-flow.ts
+++ b/packages/backend/src/graphql/queries/get-flow.ts
@@ -9,16 +9,22 @@ const getFlow: QueryResolvers['getFlow'] = async (_parent, params, context) => {
   }
 
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows()
     .withGraphFetched({
+      steps: {
+        connection: true,
+      },
       pendingTransfer: {
         newOwner: true,
       },
     })
-    .withGraphJoined('[steps.[connection]]')
-    .orderBy('steps.position', 'asc')
     .findOne({ 'flows.id': params.id })
     .throwIfNotFound()
+
+  // Order steps by position (since withGraphJoined doesn't work with our helper)
+  if (flow.steps) {
+    flow.steps.sort((a, b) => a.position - b.position)
+  }
 
   return flow
 }

--- a/packages/backend/src/graphql/queries/get-flows.ts
+++ b/packages/backend/src/graphql/queries/get-flows.ts
@@ -1,5 +1,4 @@
 import paginate from '@/helpers/pagination'
-import Flow from '@/models/flow'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -8,9 +7,15 @@ const getFlows: QueryResolvers['getFlows'] = async (
   params,
   context,
 ) => {
+  // Get the base query with role selection and accessibility filtering
+  const baseQuery = context.currentUser.withAccessibleFlows({
+    requiredRole: 'viewer',
+  })
+
+  // Apply additional filters to the base query
   const filteredFlowIds = (
-    await context.currentUser
-      .$relatedQuery('flows')
+    await baseQuery
+      .clone()
       .distinct('id')
       .where((builder) => {
         if (params.name) {
@@ -29,7 +34,8 @@ const getFlows: QueryResolvers['getFlows'] = async (
     }
   }
 
-  const flowsQuery = Flow.query()
+  const flowsQuery = baseQuery
+    .clone()
     .with('filtered_steps', (builder) => {
       builder
         .distinct('flow_id')
@@ -49,14 +55,13 @@ const getFlows: QueryResolvers['getFlows'] = async (
         .whereIn('flow_id', filteredFlowIds)
         .withSoftDeleted()
     })
-    .innerJoin('filtered_steps', 'id', 'filtered_steps.flow_id')
+    .innerJoin('filtered_steps', 'flows.id', 'filtered_steps.flow_id')
+
+  flowsQuery
     .withGraphFetched({
-      steps: {
-        connection: true,
-      },
-      pendingTransfer: true,
+      steps: true,
     })
-    .groupBy('id')
+    .groupBy('flows.id', 'fc.role')
     .orderBy('active', 'desc')
     .orderBy('updated_at', 'desc')
 

--- a/packages/backend/src/graphql/queries/get-flows.ts
+++ b/packages/backend/src/graphql/queries/get-flows.ts
@@ -56,10 +56,9 @@ const getFlows: QueryResolvers['getFlows'] = async (
         .withSoftDeleted()
     })
     .innerJoin('filtered_steps', 'flows.id', 'filtered_steps.flow_id')
-
-  flowsQuery
     .withGraphFetched({
       steps: true,
+      collaborators: true,
     })
     .groupBy('flows.id', 'fc.role')
     .orderBy('active', 'desc')

--- a/packages/backend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/backend/src/graphql/queries/get-test-execution-steps.ts
@@ -8,9 +8,9 @@ const getTestExecutionSteps: QueryResolvers['getTestExecutionSteps'] = async (
   context,
 ) => {
   const { flowId } = params
-  // For checking if flow belongs to the user
+  // For checking if user is a collaborator
   const flow = await context.currentUser
-    .$relatedQuery('flows')
+    .withAccessibleFlows({ requiredRole: 'viewer' })
     .withGraphFetched({
       steps: true,
     })

--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -1,6 +1,7 @@
 import apps from '@/apps'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
+import User from '@/models/user'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -10,20 +11,30 @@ const testConnection: QueryResolvers['testConnection'] = async (
   context,
 ) => {
   let connection = await context.currentUser
-    .$relatedQuery('connections')
+    .withAccessibleConnections({ requiredRole: 'viewer' })
     .findOne({
-      id: params.connectionId,
+      'connections.id': params.connectionId,
     })
     .throwIfNotFound()
+  const userRole = connection.role
 
   const app = apps[connection.key]
-  let $ = await globalVariable({ connection, app })
+  let $ = await globalVariable({
+    connection,
+    app,
+    user:
+      userRole === 'owner'
+        ? context.currentUser
+        : await User.query().findOne({
+            id: connection.userId,
+          }),
+  })
 
   if (params.flowId) {
     // flowId is supplied when testing within the pipe editor
     // it's used for formsg webhook verification for now
     const flow = await context.currentUser
-      .$relatedQuery('flows')
+      .withAccessibleFlows({ requiredRole: 'viewer' })
       .findById(params.flowId)
       .throwIfNotFound()
 
@@ -57,7 +68,11 @@ const testConnection: QueryResolvers['testConnection'] = async (
   })
 
   // if testing outside of the editor, it does not verify registration (e.g. setting of webhook url)
-  if (!isStillVerified || !params.flowId) {
+  if (
+    !isStillVerified ||
+    !params.flowId ||
+    !params.supportsConnectionRegistration
+  ) {
     return { connectionVerified: isStillVerified, message: errorMessage }
   }
 

--- a/packages/backend/src/graphql/queries/test-connection.ts
+++ b/packages/backend/src/graphql/queries/test-connection.ts
@@ -1,7 +1,9 @@
 import apps from '@/apps'
+import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
 import User from '@/models/user'
+import { getConnection } from '@/services/connection'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
 
@@ -10,13 +12,41 @@ const testConnection: QueryResolvers['testConnection'] = async (
   params,
   context,
 ) => {
-  let connection = await context.currentUser
-    .withAccessibleConnections({ requiredRole: 'viewer' })
-    .findOne({
-      'connections.id': params.connectionId,
+  const { flowId, connectionId, supportsConnectionRegistration } = params
+  let connection
+  let flow
+  let userRole
+
+  if (flowId) {
+    // flowId is only provided when testing connection from the pipe editor
+    // check if user has access to the flow first
+    flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'viewer' })
+      .findById(flowId)
+
+    if (!flow) {
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this pipe',
+      )
+    }
+
+    userRole = flow.role
+
+    connection = await getConnection({
+      context,
+      connectionId: params.connectionId,
+      flowId: params.flowId,
+      includeOwnConnections: userRole === 'owner',
     })
-    .throwIfNotFound()
-  const userRole = connection.role
+  } else {
+    // if flowId is undefined, it is always the owner's connections
+    // as we testing from the My Apps page
+    connection = await context.currentUser
+      .$relatedQuery('connections')
+      .findOne({ id: connectionId })
+      .throwIfNotFound()
+    userRole = 'owner'
+  }
 
   const app = apps[connection.key]
   let $ = await globalVariable({
@@ -30,14 +60,7 @@ const testConnection: QueryResolvers['testConnection'] = async (
           }),
   })
 
-  if (params.flowId) {
-    // flowId is supplied when testing within the pipe editor
-    // it's used for formsg webhook verification for now
-    const flow = await context.currentUser
-      .withAccessibleFlows({ requiredRole: 'viewer' })
-      .findById(params.flowId)
-      .throwIfNotFound()
-
+  if (flowId) {
     $ = await globalVariable({
       connection,
       app,
@@ -54,9 +77,9 @@ const testConnection: QueryResolvers['testConnection'] = async (
   } catch (err) {
     isStillVerified = false
     errorMessage = err.message
-    logger.error(`Error verifying CONNECTION ID: ${params.connectionId}`, {
+    logger.error(`Error verifying CONNECTION ID: ${connectionId}`, {
       event: 'test-connection',
-      flowId: params.flowId,
+      flowId: flowId,
       errMessage: err.message,
       errStack: err.stack,
     })
@@ -68,11 +91,7 @@ const testConnection: QueryResolvers['testConnection'] = async (
   })
 
   // if testing outside of the editor, it does not verify registration (e.g. setting of webhook url)
-  if (
-    !isStillVerified ||
-    !params.flowId ||
-    !params.supportsConnectionRegistration
-  ) {
+  if (!isStillVerified || !flowId || !supportsConnectionRegistration) {
     return { connectionVerified: isStillVerified, message: errorMessage }
   }
 

--- a/packages/backend/src/graphql/schema.gql-to-typescript.ts
+++ b/packages/backend/src/graphql/schema.gql-to-typescript.ts
@@ -3,11 +3,13 @@ import App from '@/models/app'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
+import FlowCollaborator from '@/models/flow-collaborators'
 import FlowTransfer from '@/models/flow-transfers'
 import TableMetadata from '@/models/table-metadata'
 
 export type AppGraphQLType = App
 export type ExecutionStepGraphQLType = ExecutionStep
+export type FlowCollaboratorGraphQLType = FlowCollaborator
 export type TableMetadataGraphQLType = TableMetadata
 export type FlowTransferGraphQLType = FlowTransfer
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -600,6 +600,7 @@ input UpdateStepPositionsInput {
 
 input DeleteStepInput {
   ids: [String!]!
+  flow: StepFlowInput!
 }
 
 input RequestOtpInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -514,6 +514,7 @@ input CreateTemplatedFlowInput {
 input UpdateFlowInput {
   id: String!
   name: String!
+  updatedAt: String!
 }
 
 input UpdateFlowStatusInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -100,6 +100,9 @@ type Mutation {
     input: LoginWithSelectedSgidInput!
   ): LoginWithSelectedSgidResult!
   duplicateFlow(input: DuplicateFlowInput): Flow
+  # Flow collaborators
+  upsertFlowCollaborator(input: FlowCollaboratorInput!): Boolean!
+  deleteFlowCollaborator(input: DeleteFlowCollaboratorInput!): Boolean!
   # S3 operations
   generatePresignedPost(input: GeneratePresignedPostInput): PresignedPostObject
   deleteUploadedFile(id: String!): Boolean
@@ -397,6 +400,17 @@ type Flow {
 
 type FlowCollaborator {
   role: String!
+  email: String!
+}
+
+input FlowCollaboratorInput {
+  flowId: String!
+  email: String!
+  role: String!
+}
+
+input DeleteFlowCollaboratorInput {
+  flowId: String!
   email: String!
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -455,6 +455,7 @@ type Execution {
   status: String
   flow: Flow
   executionSteps: [ExecutionStep]
+  role: String
 }
 
 type BulkRetryExecutionsResult {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -4,7 +4,7 @@ type Query {
     onlyWithTriggers: Boolean
     onlyWithActions: Boolean
   ): [App]
-  getApp(key: String!): App
+  getApp(key: String!, flowId: String): App
   getConnectedApps: [App]
   testConnection(
     connectionId: String!

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -103,6 +103,7 @@ type Mutation {
   loginWithSelectedSgid(
     input: LoginWithSelectedSgidInput!
   ): LoginWithSelectedSgidResult!
+  duplicateBranch(input: DuplicateBranchInput): DuplicateBranchResult
   duplicateFlow(input: DuplicateFlowInput): Flow
   # Flow collaborators
   upsertFlowCollaborator(input: FlowCollaboratorInput!): Boolean!
@@ -550,6 +551,12 @@ input DeleteFlowInput {
   id: String!
 }
 
+input DuplicateBranchInput {
+  flow: StepFlowInput
+  previousStep: PreviousStepInput
+  steps: [CreateStepInput]
+}
+
 input DuplicateFlowInput {
   id: String!
 }
@@ -829,6 +836,11 @@ type PaginatedExecutions {
 type PaginatedExecutionSteps {
   edges: [ExecutionStepEdge]!
   pageInfo: PageInfo!
+}
+
+type DuplicateBranchResult {
+  flow: Flow
+  steps: [Step]
 }
 
 enum DatabaseType {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -704,6 +704,7 @@ enum StepEnumType {
 
 input StepFlowInput {
   id: String
+  updatedAt: String
 }
 
 input StepInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -395,6 +395,11 @@ type Flow {
   template: Template
 }
 
+type FlowCollaborator {
+  role: String!
+  email: String!
+}
+
 # Rate limiting config is omitted here e.g. maxQps
 type FlowConfig {
   errorConfig: FlowErrorConfig

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -6,7 +6,11 @@ type Query {
   ): [App]
   getApp(key: String!): App
   getConnectedApps: [App]
-  testConnection(connectionId: String!, flowId: String): TestConnectionResult
+  testConnection(
+    connectionId: String!
+    flowId: String
+    supportsConnectionRegistration: Boolean
+  ): TestConnectionResult
   getFlow(id: String!): Flow
   getFlows(
     limit: Int!

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -396,6 +396,8 @@ type Flow {
   userId: String
   pendingTransfer: FlowTransfer
   template: Template
+  collaborators: [FlowCollaborator!]
+  role: String
 }
 
 type FlowCollaborator {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -85,7 +85,7 @@ type Mutation {
   deleteFlow(input: DeleteFlowInput): Boolean
   createStep(input: CreateStepInput): Step
   updateStep(input: UpdateStepInput): Step
-  updateStepPositions(input: UpdateStepPositionsInput): [Step]
+  updateStepPositions(input: UpdateStepPositionsInput): Flow
   deleteStep(input: DeleteStepInput): Flow
   requestOtp(input: RequestOtpInput): Boolean
   verifyOtp(input: VerifyOtpInput): Boolean
@@ -597,6 +597,7 @@ input StepPositionInput {
 
 input UpdateStepPositionsInput {
   stepPositions: [StepPositionInput!]!
+  flow: StepFlowInput!
 }
 
 input DeleteStepInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -433,6 +433,7 @@ type FlowConfig {
 
 type FlowErrorConfig {
   notificationFrequency: NotificationFrequency!
+  notificationRecipients: [NotificationRecipients]!
 }
 
 type FlowTemplateConfig {
@@ -526,6 +527,11 @@ enum NotificationFrequency {
   always
 }
 
+enum NotificationRecipients {
+  editor
+  viewer
+}
+
 input FlowAttachmentsConfigInput {
   name: String!
   displayedValue: String!
@@ -537,6 +543,7 @@ input FlowAttachmentsConfigInput {
 input UpdateFlowConfigInput {
   id: String!
   notificationFrequency: NotificationFrequency
+  notificationRecipients: [NotificationRecipients]
   showSurvey: Boolean
   hasLoadedOnce: Boolean
   attachments: [FlowAttachmentsConfigInput]

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -470,6 +470,7 @@ type BulkRetryIterationsResult {
 input CreateConnectionInput {
   key: String!
   formattedData: JSONObject!
+  flowId: String
 }
 
 input GenerateAuthUrlInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -327,6 +327,7 @@ type Connection {
   app: App
   createdAt: String
   flowCount: Int
+  description: String
 }
 
 type ConnectionData {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -514,6 +514,7 @@ input UpdateFlowInput {
 input UpdateFlowStatusInput {
   id: String!
   active: Boolean!
+  updatedAt: String!
 }
 
 enum NotificationFrequency {

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -1,0 +1,356 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { getConnectionDetails } from '../get-shared-connection-details'
+
+describe('getConnectionDetails', () => {
+  const createMockStep = (overrides: Partial<IStep> = {}): IStep => ({
+    id: 'step-1',
+    flowId: 'flow-1',
+    appKey: 'slack',
+    type: 'action',
+    connectionId: null,
+    status: 'completed',
+    position: 1,
+    parameters: {},
+    connection: undefined,
+    flow: {} as any,
+    executionSteps: [],
+    config: {},
+    iconUrl: 'https://example.com/icon.svg',
+    webhookUrl: 'https://example.com/webhook',
+    createdAt: '2023-01-01T00:00:00Z',
+    ...overrides,
+  })
+
+  it('should not include any metadata for apps without connection fields', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'aisay',
+        connectionId: 'aisay-connection-id',
+        parameters: { someParam: 'value' },
+      }),
+      createMockStep({
+        appKey: 'custom-api',
+        connectionId: 'custom-api-connection-id',
+        parameters: { anotherParam: 'value2' },
+      }),
+      createMockStep({
+        appKey: 'formsg',
+        connectionId: 'formsg-connection-id',
+        parameters: { formParam: 'value3' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    // Should return empty object since none of these apps have parameterKey defined
+    expect(result).toEqual({
+      connection: {
+        'aisay-connection-id': {},
+        'custom-api-connection-id': {},
+        'formsg-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  it('should not include metadata for apps without connection fields', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'paysg',
+        connectionId: 'paysg-connection-id',
+        parameters: {
+          fileId: 'file-123',
+          channel: 'general',
+          templateId: 'template-456',
+        },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    // Should return empty object since paysg has empty APP_CONNECTION_FIELDS
+    expect(result).toEqual({
+      connection: {
+        'paysg-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  it('should include metadata for apps with parameterKey defined', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'telegram-bot',
+        connectionId: 'telegram-connection-id',
+        parameters: { chatId: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      connection: {
+        'slack-connection-id': {},
+        'telegram-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  it('should handle multiple connections with different parameter keys', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'm365-excel',
+        connectionId: 'm365-excel-connection-id',
+        parameters: { fileId: 'file-123' },
+      }),
+      createMockStep({
+        appKey: 'lettersg',
+        connectionId: 'lettersg-connection-id',
+        parameters: { templateId: 'template-456' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      connection: {
+        'slack-connection-id': {},
+        'm365-excel-connection-id': {
+          fileId: ['file-123'],
+        },
+        'lettersg-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  it('should not include duplicate parameter values for the same connection', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'general' }, // duplicate
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      connection: {
+        'slack-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  it('should handle steps without connectionId', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'formatter',
+        connectionId: undefined,
+        parameters: { channel: 'general' },
+      }),
+      createMockStep({
+        appKey: 'custom-api',
+        connectionId: null,
+        parameters: { channel: 'random' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      connection: {},
+      table: [],
+    })
+  })
+
+  it('should handle steps with missing parameter values', () => {
+    const steps: IStep[] = [
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: undefined },
+      }),
+      createMockStep({
+        appKey: 'slack',
+        connectionId: 'slack-connection-id',
+        parameters: { channel: '' },
+      }),
+    ]
+
+    const result = getConnectionDetails(steps)
+
+    expect(result).toEqual({
+      connection: {
+        'slack-connection-id': {},
+      },
+      table: [],
+    })
+  })
+
+  describe('special case: Tiles', () => {
+    it('should use tableId for tiles app regardless of connectionId', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-123' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-456' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        connection: {},
+        table: ['table-123', 'table-456'],
+      })
+    })
+
+    it('should handle tiles step with empty parameters', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          parameters: {},
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        connection: {},
+        table: [],
+      })
+    })
+
+    it('should not include duplicate tableIds for tiles', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-123' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-123' }, // duplicate
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: null,
+          parameters: { tableId: 'table-456' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        connection: {},
+        table: ['table-123', 'table-456'],
+      })
+    })
+  })
+
+  describe('mixed scenarios', () => {
+    it('should handle mix of apps with and without parameterKey defined', () => {
+      const steps: IStep[] = [
+        // Apps with empty APP_CONNECTION_FIELDS
+        createMockStep({
+          appKey: 'aisay',
+          connectionId: 'aisay-connection-id',
+          parameters: { someParam: 'value' },
+        }),
+        createMockStep({
+          appKey: 'custom-api',
+          connectionId: 'custom-api-connection-id',
+          parameters: { anotherParam: 'value2' },
+        }),
+        // Apps with parameterKey defined
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'slack-connection-id',
+          parameters: { channel: 'general' },
+        }),
+        createMockStep({
+          appKey: 'm365-excel',
+          connectionId: 'm365-excel-connection-id',
+          parameters: { fileId: 'file-123' },
+        }),
+        // Tiles app
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-123' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        connection: {
+          'aisay-connection-id': {},
+          'custom-api-connection-id': {},
+          'slack-connection-id': {},
+          'm365-excel-connection-id': {
+            fileId: ['file-123'],
+          },
+        },
+        table: ['table-123'],
+      })
+    })
+
+    it('should handle empty steps array', () => {
+      const result = getConnectionDetails([])
+      expect(result).toEqual({
+        connection: {},
+        table: [],
+      })
+    })
+
+    it('should handle steps with unknown appKey', () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'unknown-app' as any,
+          connectionId: 'unknown-app-connection-id',
+          parameters: { someParam: 'value' },
+        }),
+      ]
+
+      const result = getConnectionDetails(steps)
+
+      // Should return empty object since unknown app is not in APP_CONNECTION_FIELDS
+      expect(result).toEqual({
+        connection: {
+          'unknown-app-connection-id': {},
+        },
+        table: [],
+      })
+    })
+  })
+})

--- a/packages/backend/src/helpers/add-authentication-steps.ts
+++ b/packages/backend/src/helpers/add-authentication-steps.ts
@@ -23,6 +23,10 @@ const authenticationStepsWithoutAuthUrl = [
         name: 'formattedData',
         value: '{fields.all}',
       },
+      {
+        name: 'flowId',
+        value: '{flowId}',
+      },
     ],
   },
   {
@@ -49,6 +53,10 @@ const authenticationStepsWithAuthUrl = [
       {
         name: 'formattedData',
         value: '{fields.all}',
+      },
+      {
+        name: 'flowId',
+        value: '{flowId}',
       },
     ],
   },

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -64,6 +64,11 @@ async function addFlowTableConnection({
   addedBy,
   trx,
 }: AddTableFlowConnectionParams): Promise<void> {
+  // COLLABORATORS:
+  // check that the user is already an Owner / Editor of the Tile first
+  // otherwise they should not be allowed to add a new collaborator
+  await TableCollaborator.hasAccess(addedBy, tableId, 'editor')
+
   // first try to add the connection to the flow_connections table
   const addedConnection = await FlowConnections.addFlowConnection({
     flowId,

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -1,0 +1,99 @@
+import { IStep } from '@plumber/types'
+
+import { Transaction } from 'objection'
+
+import FlowCollaborator from '@/models/flow-collaborators'
+import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
+
+import { APP_CONNECTION_FIELDS } from './get-shared-connection-details'
+
+interface AddFlowConnectionParams {
+  step: IStep
+  addedBy: string
+  trx?: Transaction
+}
+
+interface AddTableFlowConnectionParams {
+  flowId: string
+  tableId: string
+  addedBy: string
+  trx?: Transaction
+}
+
+async function addFlowConnection({
+  step,
+  addedBy,
+  trx,
+}: AddFlowConnectionParams): Promise<void> {
+  const appKey = step.appKey
+  const { parameterKey } = APP_CONNECTION_FIELDS?.[appKey] ?? {}
+
+  const flowId = step.flowId
+  const connectionId = step?.connectionId
+
+  // only flow connections with a parameterKey specified need to have
+  // its metadata updated with the parameter value
+  if (step.parameters?.[parameterKey]) {
+    await FlowConnections.patchFlowConnectionMetadata({
+      flowId,
+      connectionId,
+      parameterKey,
+      parameterValue: step.parameters[parameterKey] as string,
+      trx,
+    })
+  } else {
+    await FlowConnections.addFlowConnection({
+      flowId,
+      connectionId,
+      addedBy,
+      connectionType: 'connection',
+      trx,
+    })
+  }
+}
+
+/**
+ * NOTE: we automatically add the collaborator as a collaborator to the Tile(s)
+ * this ensures that the Tile appears in the dropdown when they are working
+ * on the flow
+ */
+async function addFlowTableConnection({
+  flowId,
+  tableId,
+  addedBy,
+  trx,
+}: AddTableFlowConnectionParams): Promise<void> {
+  // first try to add the connection to the flow_connections table
+  const addedConnection = await FlowConnections.addFlowConnection({
+    flowId,
+    connectionId: tableId,
+    addedBy,
+    connectionType: 'table',
+    trx,
+  })
+
+  // only need to proceed if the tile was added to flow_connections
+  if (addedConnection) {
+    // then add the collaborators to the flow_collaborators table
+    const collaborators = await FlowCollaborator.getCollaborators({
+      flowId,
+      trx,
+    })
+
+    // use Promise.all so that we use the addCollaborator function, which checks
+    // if the collaborator already exists to avoid duplicates
+    await Promise.all(
+      collaborators.map(async ({ userId, role }) => {
+        await TableCollaborator.addCollaborator({
+          userId,
+          tableId,
+          role,
+          trx,
+        })
+      }),
+    )
+  }
+}
+
+export { addFlowConnection, addFlowTableConnection }

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -1,0 +1,16 @@
+import type { IFlowCollabRole } from '@plumber/types'
+
+const PERMISSION_LEVELS = ['viewer', 'editor', 'owner']
+
+export const checkUserPermission = (
+  collaboratorRole: IFlowCollabRole,
+  requiredRole: IFlowCollabRole,
+) => {
+  if (
+    PERMISSION_LEVELS.indexOf(collaboratorRole) >=
+    PERMISSION_LEVELS.indexOf(requiredRole)
+  ) {
+    return true
+  }
+  throw new Error('You do not have the required permissions.')
+}

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -1,5 +1,7 @@
 import type { IFlowCollabRole } from '@plumber/types'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
+
 const PERMISSION_LEVELS = ['viewer', 'editor', 'owner']
 
 export const checkUserPermission = (
@@ -12,5 +14,5 @@ export const checkUserPermission = (
   ) {
     return true
   }
-  throw new Error('You do not have the required permissions.')
+  throw new ForbiddenError('You do not have sufficient permissions')
 }

--- a/packages/backend/src/helpers/check-user-permission.ts
+++ b/packages/backend/src/helpers/check-user-permission.ts
@@ -2,7 +2,7 @@ import type { IFlowCollabRole } from '@plumber/types'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 
-const PERMISSION_LEVELS = ['viewer', 'editor', 'owner']
+export const PERMISSION_LEVELS = ['viewer', 'editor', 'owner'] as const
 
 export const checkUserPermission = (
   collaboratorRole: IFlowCollabRole,
@@ -15,4 +15,14 @@ export const checkUserPermission = (
     return true
   }
   throw new ForbiddenError('You do not have sufficient permissions')
+}
+
+export const getAllowedCollaboratorRoles = (
+  requiredRole: IFlowCollabRole,
+): IFlowCollabRole[] => {
+  const requiredIndex = PERMISSION_LEVELS.indexOf(requiredRole)
+  // Collaborators can only be 'viewer' or 'editor'. Owners are handled via flows.user_id.
+  return (['viewer', 'editor'] as IFlowCollabRole[]).filter(
+    (role) => PERMISSION_LEVELS.indexOf(role) >= requiredIndex,
+  )
 }

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -1,3 +1,5 @@
+import { NotificationRecipients } from '@plumber/types'
+
 import { DateTime } from 'luxon'
 
 import appConfig from '@/config/app'
@@ -70,6 +72,25 @@ export async function sendErrorEmail(flow: Flow) {
   const userEmail = flow.user.email
   const errorKey = `error-alert:${flowId}`
   const currDatetime = DateTime.now()
+  const ccList: string[] = []
+
+  // default to notify owner only if no collaborators are specified
+  const notificationRecipients =
+    flow.config?.errorConfig?.notificationRecipients ?? []
+  if (
+    notificationRecipients.length > 0 &&
+    flow.collaborators &&
+    flow.collaborators.length > 0
+  ) {
+    const collaboratorsToCC = flow.collaborators
+      .filter((collaborator) =>
+        notificationRecipients.includes(
+          collaborator.role as NotificationRecipients,
+        ),
+      )
+      .map((collaborator) => collaborator.user.email)
+    ccList.push(...collaboratorsToCC)
+  }
 
   const errorDetails = {
     flowId,
@@ -83,6 +104,7 @@ export async function sendErrorEmail(flow: Flow) {
     body: createBodyErrorMessage(truncatedFlowName, flowId),
     recipient: userEmail,
     replyTo: 'support@plumber.gov.sg',
+    ...(ccList.length > 0 && { cc: ccList }),
   })
 
   await redisClient

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -1,0 +1,95 @@
+import { IStep } from '@plumber/types'
+
+/**
+ * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
+ * we only need to app apps that have fields that behave like connections.
+ * apps that only have connections such as formsg or postman-sms
+ * do not need to be specified here.
+ *
+ * ONLY specify the parameterKey and dynamicDataKey for apps that have fields that need
+ * to be treated like connections, such as M365-Excel files, where we do not want the
+ * collaborator(s) to have access to all the files in the owner's Plumber SharePoint folder.
+ */
+export const APP_CONNECTION_FIELDS: Record<
+  IStep['appKey'],
+  {
+    parameterKey?: string
+    dynamicDataKey?: string
+  }
+> = {
+  'm365-excel': {
+    parameterKey: 'fileId',
+    dynamicDataKey: 'listFiles',
+  },
+  lettersg: {},
+  slack: {},
+  'telegram-bot': {},
+  /**
+   * TILES SPECIAL CASE: tiles is handled differently as the table id is treated as the
+   * connection id in the flow_connections table.
+   */
+  tiles: {
+    parameterKey: 'tableId',
+    dynamicDataKey: 'listTables',
+  },
+}
+
+export function getConnectionDetails(steps: IStep[]): {
+  connection: {
+    [connectionId: string]: {
+      [appKey: string]: string[]
+    }
+  }
+  table: string[]
+} {
+  const connections: {
+    connection: {
+      [connectionId: string]: {
+        [appKey: string]: string[]
+      }
+    }
+    table: string[]
+  } = {
+    connection: {},
+    table: [],
+  }
+
+  steps.map((step) => {
+    if (step.connectionId) {
+      connections.connection[step.connectionId] ??= {}
+
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
+      const paramValue = step.parameters[paramKey] as string
+
+      // only some apps need the metadata, so we only add it if the app has a parameter key
+      if (paramKey) {
+        connections.connection[step.connectionId][paramKey] ??= []
+
+        // push only if not already present
+        if (
+          paramValue &&
+          !connections.connection[step.connectionId][paramKey].includes(
+            paramValue,
+          )
+        ) {
+          connections.connection[step.connectionId][paramKey].push(paramValue)
+        }
+      }
+    }
+
+    /**
+     * SPECIAL CASE: Tiles does not have a connection id
+     * so we use the tableId instead.
+     */
+    if (step.appKey === 'tiles') {
+      const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
+      const paramValue = step.parameters[paramKey] as string
+
+      if (paramValue && !connections.table.includes(paramValue)) {
+        connections.table.push(paramValue)
+      }
+    }
+  })
+
+  return connections
+}

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -132,7 +132,7 @@ const globalVariable = async (
     setActionItem: (actionItem: IActionItem) => {
       $.actionOutput.data = actionItem
     },
-    user: flow?.user ?? user,
+    user: user ?? flow?.user,
     metadata,
   }
 

--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -10,6 +10,7 @@ export interface PostmanEmailRequestBody {
   body: string
   recipient: string
   replyTo?: string
+  cc?: string[]
 }
 
 export async function sendEmail({
@@ -17,6 +18,7 @@ export async function sendEmail({
   body,
   recipient,
   replyTo,
+  cc,
 }: PostmanEmailRequestBody): Promise<void> {
   try {
     await axios.post(
@@ -28,6 +30,7 @@ export async function sendEmail({
         from: `Plumber <${appConfig.postman.fromAddress}>`,
         ...(replyTo && { reply_to: replyTo }),
         disable_tracking: true,
+        ...(cc && { cc }),
       },
       {
         headers: {

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -1,0 +1,112 @@
+import { IFlowCollabRole } from '@plumber/types'
+
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+
+import Flow from '../flow'
+import FlowCollaborator from '../flow-collaborators'
+import User from '../user'
+
+describe('flow collaborators model', () => {
+  let flowId: string
+  const ownerUserId = randomUUID()
+  const editorUserId = randomUUID()
+  const viewerUserId = randomUUID()
+
+  beforeEach(async () => {
+    flowId = randomUUID()
+
+    await User.query().insert([
+      {
+        id: ownerUserId,
+        email: 'owner@example.com',
+      },
+      {
+        id: editorUserId,
+        email: 'editor@example.com',
+      },
+      {
+        id: viewerUserId,
+        email: 'viewer@example.com',
+      },
+    ])
+
+    await Flow.query().insert({
+      id: flowId,
+      name: 'test flow',
+      userId: ownerUserId,
+    })
+    await FlowCollaborator.query().insert([
+      {
+        flowId,
+        userId: editorUserId,
+        role: 'editor',
+        updatedBy: ownerUserId,
+      },
+      {
+        flowId,
+        userId: viewerUserId,
+        role: 'viewer',
+        updatedBy: ownerUserId,
+      },
+    ])
+  })
+
+  it.each([
+    { userId: ownerUserId, requiredRole: 'owner', expectedRole: 'owner' },
+    { userId: ownerUserId, requiredRole: 'editor', expectedRole: 'owner' },
+    { userId: ownerUserId, requiredRole: 'viewer', expectedRole: 'owner' },
+    { userId: editorUserId, requiredRole: 'editor', expectedRole: 'editor' },
+    { userId: editorUserId, requiredRole: 'viewer', expectedRole: 'editor' },
+    { userId: viewerUserId, requiredRole: 'viewer', expectedRole: 'viewer' },
+  ])(
+    'should return the correct access for the user',
+    async ({ userId, requiredRole, expectedRole }) => {
+      const role = await FlowCollaborator.hasAccess({
+        userId,
+        flowId,
+        requiredRole: requiredRole as IFlowCollabRole,
+      })
+      expect(role).toBe(expectedRole)
+    },
+  )
+
+  it.each([
+    { userId: viewerUserId, requiredRole: 'owner' },
+    { userId: viewerUserId, requiredRole: 'editor' },
+    { userId: editorUserId, requiredRole: 'owner' },
+  ])(
+    'should throw error if user does not have enough permissions',
+    async ({ userId, requiredRole }) => {
+      await expect(
+        FlowCollaborator.hasAccess({
+          userId,
+          flowId,
+          requiredRole: requiredRole as IFlowCollabRole,
+        }),
+      ).rejects.toThrow()
+    },
+  )
+
+  it('should throw an error if the user does not have access', async () => {
+    await expect(
+      FlowCollaborator.hasAccess({
+        userId: randomUUID(),
+        flowId,
+        requiredRole: 'editor',
+      }),
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('should throw an error if the flow does not exist', async () => {
+    await expect(
+      FlowCollaborator.hasAccess({
+        userId: ownerUserId,
+        flowId: randomUUID(),
+        requiredRole: 'editor',
+      }),
+    ).rejects.toThrow('Flow not found')
+  })
+})

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -109,4 +109,37 @@ describe('flow collaborators model', () => {
       }),
     ).rejects.toThrow('Flow not found')
   })
+
+  describe('getCollaborators', () => {
+    it('should return all collaborators for a flow', async () => {
+      const collaborators = await FlowCollaborator.getCollaborators({
+        flowId,
+      })
+
+      expect(collaborators).toHaveLength(2)
+      expect(collaborators.map((c) => c.userId)).toContain(editorUserId)
+      expect(collaborators.map((c) => c.userId)).toContain(viewerUserId)
+      expect(collaborators.map((c) => c.role)).toContain('editor')
+      expect(collaborators.map((c) => c.role)).toContain('viewer')
+      expect(collaborators[0].user).toBeDefined()
+      expect(collaborators[0].user.email).toBeDefined()
+      expect(collaborators[1].user).toBeDefined()
+      expect(collaborators[1].user.email).toBeDefined()
+    })
+
+    it('should return empty array when flow has no collaborators', async () => {
+      const newFlowId = randomUUID()
+      await Flow.query().insert({
+        id: newFlowId,
+        name: 'empty flow',
+        userId: ownerUserId,
+      })
+
+      const collaborators = await FlowCollaborator.getCollaborators({
+        flowId: newFlowId,
+      })
+
+      expect(collaborators).toHaveLength(0)
+    })
+  })
 })

--- a/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-collaborators.itest.ts
@@ -142,4 +142,90 @@ describe('flow collaborators model', () => {
       expect(collaborators).toHaveLength(0)
     })
   })
+
+  describe('deleteCollaborator', () => {
+    it('should soft delete the collaborator and exclude from default queries', async () => {
+      const result = await FlowCollaborator.deleteCollaborator({
+        userId: editorUserId,
+        flowId,
+      })
+
+      expect(result).toBeDefined()
+
+      // Not returned by default queries
+      const collaborators = await FlowCollaborator.getCollaborators({ flowId })
+      expect(collaborators.map((c) => c.userId)).not.toContain(editorUserId)
+
+      // But still present when including soft deleted
+      const softDeleted = await FlowCollaborator.query()
+        .withSoftDeleted()
+        .findOne({ user_id: editorUserId, flow_id: flowId })
+      expect(softDeleted).toBeTruthy()
+      expect(softDeleted?.deletedAt).toBeTruthy()
+    })
+
+    it('should throw when deleting a non-existent collaborator', async () => {
+      await expect(
+        FlowCollaborator.deleteCollaborator({
+          userId: randomUUID(),
+          flowId,
+        }),
+      ).rejects.toThrow('No such collaborator found')
+    })
+  })
+
+  describe('upsertCollaborator', () => {
+    it('should create a new collaborator when none exists', async () => {
+      const newUser = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: 'newuser@plumber.gov.sg',
+      })
+
+      const newCollaborator = await FlowCollaborator.upsertCollaborator({
+        userId: newUser.id,
+        flowId,
+        role: 'viewer',
+        updatedBy: ownerUserId,
+      })
+
+      expect(newCollaborator.userId).toBe(newUser.id)
+      expect(newCollaborator.flowId).toBe(flowId)
+      expect(newCollaborator.role).toBe('viewer')
+
+      const collaborators = await FlowCollaborator.getCollaborators({ flowId })
+      expect(collaborators.map((c) => c.userId)).toContain(newUser.id)
+    })
+
+    it('should update role when collaborator exists (and restore if soft-deleted)', async () => {
+      // Soft delete existing viewer collaborator
+      await FlowCollaborator.deleteCollaborator({
+        userId: viewerUserId,
+        flowId,
+      })
+
+      // Ensure not returned by default queries
+      const before = await FlowCollaborator.getCollaborators({ flowId })
+      expect(before.map((c) => c.userId)).not.toContain(viewerUserId)
+
+      // Upsert should restore and update role
+      const updated = await FlowCollaborator.upsertCollaborator({
+        userId: viewerUserId,
+        flowId,
+        role: 'editor',
+        updatedBy: ownerUserId,
+      })
+
+      expect(updated.role).toBe('editor')
+
+      // Verify restored (not soft-deleted) and role changed
+      const withDeleted = await FlowCollaborator.query()
+        .withSoftDeleted()
+        .findOne({ user_id: viewerUserId, flow_id: flowId })
+      expect(withDeleted).toBeTruthy()
+      expect(withDeleted?.role).toBe('editor')
+
+      const after = await FlowCollaborator.getCollaborators({ flowId })
+      expect(after.map((c) => c.userId)).toContain(viewerUserId)
+    })
+  })
 })

--- a/packages/backend/src/models/__tests__/flow-connections.itest.ts
+++ b/packages/backend/src/models/__tests__/flow-connections.itest.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { generateMockContext } from '@/graphql/__tests__/mutations/tiles/table.mock'
+import Context from '@/types/express/context'
+
+import Flow from '../flow'
+import FlowConnections from '../flow-connections'
+
+describe('FlowConnections model', () => {
+  const mockFlowId = randomUUID()
+  const mockConnectionId = randomUUID()
+  const mockUserId = randomUUID()
+
+  let context: Context
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    context = await generateMockContext()
+    await Flow.query().insert({
+      id: mockFlowId,
+      name: 'Test Flow',
+      userId: context.currentUser.id,
+      active: false,
+    })
+  })
+
+  describe('addFlowConnection', () => {
+    it('should not perform the insert if there are no collaborators found', async () => {
+      const hasCollaboratorsSpy = vi
+        .spyOn(Flow, 'hasCollaborators')
+        .mockResolvedValue(false)
+
+      const result = await FlowConnections.addFlowConnection({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        addedBy: mockUserId,
+        connectionType: 'connection',
+      })
+
+      expect(hasCollaboratorsSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+      })
+      expect(result).toBeUndefined()
+    })
+
+    it('should insert if there are collaborators', async () => {
+      const hasCollaboratorsSpy = vi
+        .spyOn(Flow, 'hasCollaborators')
+        .mockResolvedValue(true)
+      const mockConnectionId = randomUUID()
+      const result = await FlowConnections.addFlowConnection({
+        flowId: mockFlowId,
+        connectionId: mockConnectionId,
+        addedBy: context.currentUser.id,
+        connectionType: 'connection',
+      })
+
+      expect(hasCollaboratorsSpy).toHaveBeenCalledWith({
+        flowId: mockFlowId,
+      })
+      expect(result).toBeDefined()
+
+      const flowConnections = await FlowConnections.query().where({
+        flow_id: mockFlowId,
+        connection_id: mockConnectionId,
+      })
+
+      expect(flowConnections).toHaveLength(1)
+      expect(flowConnections[0].connectionId).toBe(mockConnectionId)
+    })
+  })
+})

--- a/packages/backend/src/models/__tests__/flow.test.ts
+++ b/packages/backend/src/models/__tests__/flow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { BadUserInputError } from '@/errors/graphql-errors/bad-user-input'
+import Flow from '@/models/flow'
+
+describe('flow model', () => {
+  describe('assertNotUpdatedSince', () => {
+    it('should not throw when timestamps match', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      const clientUpdatedAt = String(updatedAt.getTime())
+
+      expect(() => flow.assertNotUpdatedSince(clientUpdatedAt)).not.toThrow()
+    })
+
+    it('should throw BadUserInputError when timestamps mismatch', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      const mismatched = String(updatedAt.getTime() + 1)
+
+      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrowError(
+        BadUserInputError,
+      )
+      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    })
+
+    it('should throw BadUserInputError when input is not a number', () => {
+      const flow = new Flow()
+      const updatedAt = new Date('2023-01-01T00:00:00.000Z')
+
+      flow.updatedAt = updatedAt.toISOString()
+
+      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrowError(
+        BadUserInputError,
+      )
+      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrow(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    })
+  })
+})

--- a/packages/backend/src/models/__tests__/flow.test.ts
+++ b/packages/backend/src/models/__tests__/flow.test.ts
@@ -1,9 +1,12 @@
+import { randomUUID } from 'crypto'
 import { describe, expect, it } from 'vitest'
 
 import { BadUserInputError } from '@/errors/graphql-errors/bad-user-input'
 import Flow from '@/models/flow'
 
 describe('flow model', () => {
+  const updatedBy = randomUUID()
+
   describe('assertNotUpdatedSince', () => {
     it('should not throw when timestamps match', () => {
       const flow = new Flow()
@@ -13,7 +16,9 @@ describe('flow model', () => {
 
       const clientUpdatedAt = String(updatedAt.getTime())
 
-      expect(() => flow.assertNotUpdatedSince(clientUpdatedAt)).not.toThrow()
+      expect(() =>
+        flow.assertNotUpdatedSince(clientUpdatedAt, updatedBy),
+      ).not.toThrow()
     })
 
     it('should throw BadUserInputError when timestamps mismatch', () => {
@@ -24,10 +29,10 @@ describe('flow model', () => {
 
       const mismatched = String(updatedAt.getTime() + 1)
 
-      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrowError(
-        BadUserInputError,
-      )
-      expect(() => flow.assertNotUpdatedSince(mismatched)).toThrow(
+      expect(() =>
+        flow.assertNotUpdatedSince(mismatched, updatedBy),
+      ).toThrowError(BadUserInputError)
+      expect(() => flow.assertNotUpdatedSince(mismatched, updatedBy)).toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
     })
@@ -38,10 +43,12 @@ describe('flow model', () => {
 
       flow.updatedAt = updatedAt.toISOString()
 
-      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrowError(
-        BadUserInputError,
-      )
-      expect(() => flow.assertNotUpdatedSince('not-a-number')).toThrow(
+      expect(() =>
+        flow.assertNotUpdatedSince('not-a-number', updatedBy),
+      ).toThrowError(BadUserInputError)
+      expect(() =>
+        flow.assertNotUpdatedSince('not-a-number', updatedBy),
+      ).toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
     })

--- a/packages/backend/src/models/__tests__/step.itest.ts
+++ b/packages/backend/src/models/__tests__/step.itest.ts
@@ -5,6 +5,7 @@ import Step from '@/models/step'
 
 import Execution from '../execution'
 import Flow from '../flow'
+import User from '../user'
 
 const flowId = randomUUID()
 const stepId = randomUUID()
@@ -15,9 +16,14 @@ describe('step model', () => {
   let step: Step
 
   beforeEach(async () => {
+    const user = await User.query().insert({
+      id: randomUUID(),
+      email: 'test@example.com',
+    })
     await Flow.query().insert({
       id: flowId,
       name: 'test flow',
+      userId: user.id,
     })
     step = await Step.query()
       .insert({
@@ -171,8 +177,11 @@ describe('step model', () => {
     it('should patch the flow last updated', async () => {
       const flow = await step.$relatedQuery('flow')
       const originalUpdatedAt = flow.updatedAt
-
-      await flow.patchLastUpdated({ flowId: flow.id })
+      const updatedBy = flow.userId
+      await flow.patchLastUpdated({
+        flowId: flow.id,
+        updatedBy,
+      })
 
       const updatedFlow = await step.$relatedQuery('flow')
 
@@ -180,6 +189,7 @@ describe('step model', () => {
       expect(new Date(updatedFlow.updatedAt).getTime()).toBeGreaterThan(
         new Date(originalUpdatedAt).getTime(),
       )
+      expect(updatedFlow.updatedBy).toBe(updatedBy)
     })
   })
 })

--- a/packages/backend/src/models/__tests__/step.itest.ts
+++ b/packages/backend/src/models/__tests__/step.itest.ts
@@ -167,12 +167,12 @@ describe('step model', () => {
     })
   })
 
-  describe('patchFlowLastUpdated', () => {
+  describe('patchLastUpdated', () => {
     it('should patch the flow last updated', async () => {
       const flow = await step.$relatedQuery('flow')
       const originalUpdatedAt = flow.updatedAt
 
-      await step.patchFlowLastUpdated()
+      await flow.patchLastUpdated({ flowId: flow.id })
 
       const updatedFlow = await step.$relatedQuery('flow')
 

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -1,4 +1,4 @@
-import { IFlowCollabRole, IJSONObject } from '@plumber/types'
+import { IJSONObject } from '@plumber/types'
 
 import { AES, enc } from 'crypto-js'
 import type { RelationMappings, Transaction } from 'objection'
@@ -7,6 +7,7 @@ import { ModelOptions, QueryContext } from 'objection'
 import appConfig from '@/config/app'
 
 import Base from './base'
+import Flow from './flow'
 import Step from './step'
 import User from './user'
 
@@ -20,7 +21,7 @@ class Connection extends Base {
   draft: boolean
   count?: number
   flowCount?: number
-  role?: IFlowCollabRole
+  flow?: Flow
   description?: string
 
   static tableName = 'connections'

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -1,4 +1,4 @@
-import { IJSONObject } from '@plumber/types'
+import { IFlowCollabRole, IJSONObject } from '@plumber/types'
 
 import { AES, enc } from 'crypto-js'
 import type { RelationMappings } from 'objection'
@@ -20,6 +20,7 @@ class Connection extends Base {
   draft: boolean
   count?: number
   flowCount?: number
+  role?: IFlowCollabRole
 
   static tableName = 'connections'
 

--- a/packages/backend/src/models/connection.ts
+++ b/packages/backend/src/models/connection.ts
@@ -1,7 +1,7 @@
 import { IFlowCollabRole, IJSONObject } from '@plumber/types'
 
 import { AES, enc } from 'crypto-js'
-import type { RelationMappings } from 'objection'
+import type { RelationMappings, Transaction } from 'objection'
 import { ModelOptions, QueryContext } from 'objection'
 
 import appConfig from '@/config/app'
@@ -21,6 +21,7 @@ class Connection extends Base {
   count?: number
   flowCount?: number
   role?: IFlowCollabRole
+  description?: string
 
   static tableName = 'connections'
 
@@ -33,7 +34,7 @@ class Connection extends Base {
       key: { type: 'string', minLength: 1, maxLength: 255 },
       data: { type: 'string' },
       formattedData: { type: 'object' },
-      userId: { type: 'string', format: 'uuid' },
+      userId: { type: 'string', format: 'uuid', nullable: true },
       verified: { type: 'boolean', default: false },
       draft: { type: 'boolean' },
     },
@@ -108,6 +109,39 @@ class Connection extends Base {
 
   async $afterFind(): Promise<void> {
     this.decryptData()
+  }
+
+  /**
+   * Duplicates a connection and sets the user id to null
+   * This is used during pipe transfer to ensure that the connection is still valid and
+   * can be used by the new owner even if the old owner is deleted
+   */
+  static duplicate = async (
+    connectionId: string,
+    trx?: Transaction,
+  ): Promise<Connection> => {
+    const connection = await this.query(trx).findOne({ id: connectionId })
+
+    if (!connection) {
+      throw new Error('Connection not found')
+    }
+
+    const {
+      id: _id,
+      createdAt: _createdAt,
+      updatedAt: _updatedAt,
+      userId,
+      ...rest
+    } = connection
+
+    // only need to duplicate if the connection has a user id
+    // it could already be null if the pipe has been transferred before
+    if (userId) {
+      return this.query(trx).insertAndFetch({
+        ...rest,
+        userId: null,
+      })
+    }
   }
 }
 

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -1,5 +1,3 @@
-import { IFlowCollabRole } from '@plumber/types'
-
 import Base from './base'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
@@ -13,7 +11,6 @@ class Execution extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   status: ExecutionStatus
-  role?: IFlowCollabRole
 
   static tableName = 'executions'
 

--- a/packages/backend/src/models/execution.ts
+++ b/packages/backend/src/models/execution.ts
@@ -1,3 +1,5 @@
+import { IFlowCollabRole } from '@plumber/types'
+
 import Base from './base'
 import ExecutionStep from './execution-step'
 import Flow from './flow'
@@ -11,6 +13,7 @@ class Execution extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   status: ExecutionStatus
+  role?: IFlowCollabRole
 
   static tableName = 'executions'
 

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -118,6 +118,18 @@ class FlowCollaborator extends Base {
       return collaborator.role
     }
   }
+
+  static getCollaborators = async ({
+    flowId,
+    trx,
+  }: {
+    flowId: string
+    trx?: Transaction
+  }) => {
+    return await this.query(trx)
+      .where({ flow_id: flowId })
+      .withGraphFetched('user')
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -1,0 +1,123 @@
+import { IFlowCollabRole, IGlobalVariable } from '@plumber/types'
+
+import { Transaction } from 'objection'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import StepError from '@/errors/step'
+import { checkUserPermission } from '@/helpers/check-user-permission'
+
+import Base from './base'
+import Flow from './flow'
+import User from './user'
+
+// Reuse the same role type as tables for consistency
+
+class FlowCollaborator extends Base {
+  userId!: string
+  flowId!: string
+  role!: IFlowCollabRole
+  user!: User
+  flow!: Flow
+  lastAccessedAt?: string
+  updatedBy?: string
+
+  // Virtual field for GraphQL compatibility - populated by custom resolver
+  // Email is guaranteed to be available when user relation is loaded
+  email: string
+
+  static tableName = 'flow_collaborators'
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      userId: { type: 'string', format: 'uuid' },
+      flowId: { type: 'string', format: 'uuid' },
+      role: { type: 'string', enum: ['editor', 'viewer'] },
+      lastAccessedAt: { type: 'string', format: 'date-time' },
+      updatedBy: { type: 'string', format: 'uuid' },
+    },
+  }
+
+  // Acts as a composite primary key
+  static get idColumn() {
+    return ['user_id', 'flow_id']
+  }
+
+  static relationMappings = () => ({
+    user: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: User,
+      join: {
+        from: `${this.tableName}.user_id`,
+        to: `${User.tableName}.id`,
+      },
+    },
+    flow: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Flow,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${Flow.tableName}.id`,
+      },
+    },
+  })
+
+  /**
+   * Checks whether user has the necessary role to access the flow
+   * permission levels: viewer, editor, owner
+   */
+  static hasAccess = async ({
+    userId,
+    flowId,
+    requiredRole,
+    $ = undefined,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    requiredRole: IFlowCollabRole
+    $?: IGlobalVariable
+    trx?: Transaction
+  }): Promise<IFlowCollabRole | never> => {
+    // flow owner is identified by the flow.userId
+
+    const flowOwner = await Flow.query(trx)
+      .findOne({
+        id: flowId,
+      })
+      .throwIfNotFound({ message: 'Flow not found' })
+
+    if (flowOwner?.userId === userId) {
+      return 'owner'
+    }
+
+    // only collaborators need to be checked against flow_collaborators table
+    const collaborator = await this.query(trx).findOne({
+      user_id: userId,
+      flow_id: flowId,
+    })
+
+    if (
+      !collaborator ||
+      !checkUserPermission(collaborator.role, requiredRole)
+    ) {
+      if ($) {
+        throw new StepError(
+          'You do not have sufficient permissions for this pipe',
+          `Please ensure that you are ${
+            requiredRole === 'viewer' ? 'a' : 'an'
+          } ${requiredRole} of this pipe.`,
+          $.step.position,
+          $.app.name,
+        )
+      }
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this pipe',
+      )
+    } else {
+      return collaborator.role
+    }
+  }
+}
+
+export default FlowCollaborator

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -130,6 +130,58 @@ class FlowCollaborator extends Base {
       .where({ flow_id: flowId })
       .withGraphFetched('user')
   }
+
+  static deleteCollaborator = async ({
+    userId,
+    flowId,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    trx?: Transaction
+  }) => {
+    return await this.query(trx)
+      .delete()
+      .where({ user_id: userId, flow_id: flowId })
+      .returning('*')
+      .throwIfNotFound({ message: 'No such collaborator found' })
+  }
+
+  static upsertCollaborator = async ({
+    userId,
+    flowId,
+    role,
+    updatedBy,
+    trx,
+  }: {
+    userId: string
+    flowId: string
+    role: IFlowCollabRole
+    updatedBy: string
+    trx?: Transaction
+  }) => {
+    const collaboratorExists = await this.query(trx)
+      .findOne({ user_id: userId, flow_id: flowId })
+      .withSoftDeleted()
+
+    if (collaboratorExists) {
+      return await collaboratorExists
+        .$query(trx)
+        .patchAndFetch({
+          role,
+          deletedAt: null,
+          updatedBy,
+        })
+        .withSoftDeleted()
+    } else {
+      return await this.query(trx).insert({
+        userId,
+        flowId,
+        role,
+        updatedBy,
+      })
+    }
+  }
 }
 
 export default FlowCollaborator

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,5 +1,3 @@
-import { IFlowCollabRole } from '@plumber/types'
-
 import { Transaction } from 'objection'
 
 import Base from './base'
@@ -21,8 +19,7 @@ class FlowConnections extends Base {
   connection?: Connection
   table?: TableMetadata
   metadata: Record<string, any>
-
-  role?: IFlowCollabRole
+  flow?: Flow
 
   static tableName = 'flow_connections'
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,0 +1,168 @@
+import Base from './base'
+import Connection from './connection'
+import Flow from './flow'
+import FlowCollaborator from './flow-collaborators'
+import TableMetadata from './table-metadata'
+import User from './user'
+
+class FlowConnections extends Base {
+  flowId!: string
+  // NOTE: this connection_id refers to either:
+  // - the connection id of a connection in the connections table; OR
+  // - the id of a Tile
+  connectionId!: string
+  // NOTE: addedBy is the user id of the user who added the connection to the flow
+  addedBy!: string
+  connectionType!: 'connection' | 'table'
+  connection?: Connection
+  table?: TableMetadata
+  metadata: Record<string, any>
+
+  static tableName = 'flow_connections'
+
+  static jsonSchema = {
+    type: 'object',
+    properties: {
+      flowId: { type: 'string', format: 'uuid' },
+      connectionId: { type: 'string', format: 'uuid' },
+      addedBy: { type: 'string', format: 'uuid' },
+      connectionType: { type: 'string', enum: ['connection', 'table'] },
+      metadata: { type: 'object' },
+    },
+  }
+
+  // Acts as a composite primary key
+  static get idColumn() {
+    return ['flow_id', 'connection_id']
+  }
+
+  static relationMappings = () => ({
+    flow: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Flow,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${Flow.tableName}.id`,
+      },
+    },
+    connection: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: Connection,
+      join: {
+        from: `${this.tableName}.connection_id`,
+        to: `${Connection.tableName}.id`,
+      },
+    },
+    // When connection_id refers to a Tile table, this relation can be used
+    table: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: TableMetadata,
+      join: {
+        from: `${this.tableName}.connection_id`,
+        to: `${TableMetadata.tableName}.id`,
+      },
+    },
+    user: {
+      relation: Base.BelongsToOneRelation,
+      modelClass: User,
+      join: {
+        from: `${this.tableName}.added_by`,
+        to: `${User.tableName}.id`,
+      },
+    },
+    collaborators: {
+      relation: Base.HasManyRelation,
+      modelClass: FlowCollaborator,
+      join: {
+        from: `${this.tableName}.flow_id`,
+        to: `${FlowCollaborator.tableName}.flow_id`,
+      },
+    },
+  })
+
+  /**
+   * NOTE: this function only adds the connection to the flow_connections table
+   * if there are collaborators for the flow
+   */
+  static addFlowConnection = async ({
+    flowId,
+    connectionId,
+    addedBy,
+    connectionType,
+  }: {
+    flowId: string
+    connectionId: string
+    addedBy: string
+    connectionType: 'connection' | 'table'
+  }) => {
+    const hasCollaborators = await Flow.hasCollaborators({
+      flowId,
+    })
+
+    if (hasCollaborators) {
+      return await this.query()
+        .insert({
+          flowId,
+          connectionId,
+          addedBy,
+          connectionType,
+        })
+        .onConflict(['flow_id', 'connection_id'])
+        .ignore()
+    }
+  }
+
+  static patchFlowConnectionMetadata = async ({
+    flowId,
+    connectionId,
+    parameterKey,
+    parameterValue,
+  }: {
+    flowId: string
+    connectionId: string
+    parameterKey: string
+    parameterValue: string
+  }) => {
+    return await this.query()
+      .where({
+        flow_id: flowId,
+        connection_id: connectionId,
+      })
+      .patch({
+        // ensure distinct metadata values, we do it in the query to avoid
+        // having additional queries to get the array, de-duplicate and then
+        // update the DB
+        metadata: FlowConnections.raw(
+          `
+            jsonb_set(
+              metadata,
+              ?::text[],
+              (
+                SELECT jsonb_agg(DISTINCT e)
+                FROM jsonb_array_elements_text(
+                COALESCE(metadata->?, '[]'::jsonb) || to_jsonb(ARRAY[?]::text[])
+                ) AS e
+              ),
+              true
+            )
+            `,
+          [`{${parameterKey}}`, parameterKey, parameterValue],
+        ),
+      })
+  }
+
+  /**
+   * Returns the loaded connected resource (either Connection or TableMetadata), if present.
+   */
+  getConnection(): Connection | TableMetadata {
+    if (this.connectionType === 'connection') {
+      return this.connection
+    }
+    if (this.connectionType === 'table') {
+      return this.table
+    }
+    throw new Error('Connection type is not valid')
+  }
+}
+
+export default FlowConnections

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -122,13 +122,15 @@ class FlowConnections extends Base {
     connectionId,
     parameterKey,
     parameterValue,
+    trx,
   }: {
     flowId: string
     connectionId: string
     parameterKey: string
     parameterValue: string
+    trx?: Transaction
   }) => {
-    return await this.query()
+    return await this.query(trx)
       .where({
         flow_id: flowId,
         connection_id: connectionId,

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -109,6 +109,17 @@ class FlowConnections extends Base {
     })
 
     if (hasCollaborators) {
+      // NOTE: somehow .onConflict().ignore() does not return an empty array
+      // on conflict, but actually returns the row its trying to insert
+      const existing = await this.query(trx).findOne({
+        flow_id: flowId,
+        connection_id: connectionId,
+      })
+
+      if (existing) {
+        return null
+      }
+
       return await this.query(trx)
         .insert({
           flowId,

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,3 +1,5 @@
+import { IFlowCollabRole } from '@plumber/types'
+
 import { Transaction } from 'objection'
 
 import Base from './base'
@@ -19,6 +21,8 @@ class FlowConnections extends Base {
   connection?: Connection
   table?: TableMetadata
   metadata: Record<string, any>
+
+  role?: IFlowCollabRole
 
   static tableName = 'flow_connections'
 

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -1,3 +1,5 @@
+import { Transaction } from 'objection'
+
 import Base from './base'
 import Connection from './connection'
 import Flow from './flow'
@@ -89,18 +91,21 @@ class FlowConnections extends Base {
     connectionId,
     addedBy,
     connectionType,
+    trx,
   }: {
     flowId: string
     connectionId: string
     addedBy: string
     connectionType: 'connection' | 'table'
+    trx?: Transaction
   }) => {
     const hasCollaborators = await Flow.hasCollaborators({
       flowId,
+      trx,
     })
 
     if (hasCollaborators) {
-      return await this.query()
+      return await this.query(trx)
         .insert({
           flowId,
           connectionId,

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -3,7 +3,7 @@ import { IFlowCollabRole, IFlowConfig } from '@plumber/types'
 import type { ModelOptions, QueryContext, Transaction } from 'objection'
 import { ValidationError } from 'objection'
 
-import { ForbiddenError } from '@/errors/graphql-errors'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { doesActionProcessFiles } from '@/helpers/actions'
 
 import Base from './base'
@@ -239,6 +239,29 @@ class Flow extends Base {
       .whereNull('deleted_at')
 
     return collaborators.length > 0
+  }
+
+  async patchLastUpdated({
+    flowId,
+    trx,
+  }: {
+    flowId: string
+    trx?: Transaction
+  }) {
+    return await this.$query(trx).patchAndFetchById(flowId, {
+      updatedAt: new Date().toISOString(),
+    })
+  }
+
+  assertNotUpdatedSince(clientUpdatedAt: string) {
+    const inputTimestamp = Number(clientUpdatedAt)
+    const flowTimestamp = new Date(this.updatedAt).getTime()
+
+    if (isNaN(inputTimestamp) || inputTimestamp !== flowTimestamp) {
+      throw new BadUserInputError(
+        'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
+      )
+    }
   }
 }
 

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -27,6 +27,7 @@ class Flow extends Base {
   testExecution?: Execution
   user: User
   collaborators?: FlowCollaborator[]
+  updatedBy?: string
 
   // for typescript support when creating FlowCollaborator row in insertGraph
   role?: IFlowCollabRole

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -50,6 +50,7 @@ class Flow extends Base {
       userId: { type: 'string', format: 'uuid' },
       remoteWebhookId: { type: 'string' },
       active: { type: 'boolean' },
+      updatedBy: { type: 'string', format: 'uuid' },
 
       config: {
         type: 'object',
@@ -251,19 +252,30 @@ class Flow extends Base {
 
   async patchLastUpdated({
     flowId,
+    updatedBy,
     trx,
   }: {
     flowId: string
+    updatedBy: string
     trx?: Transaction
   }) {
     return await this.$query(trx).patchAndFetchById(flowId, {
       updatedAt: new Date().toISOString(),
+      updatedBy,
     })
   }
 
-  assertNotUpdatedSince(clientUpdatedAt: string) {
+  assertNotUpdatedSince(clientUpdatedAt: string, updatedBy: string) {
     const inputTimestamp = Number(clientUpdatedAt)
     const flowTimestamp = new Date(this.updatedAt).getTime()
+    const flowLastUpdatedBy = this.updatedBy
+
+    // return early if the flow was last updated by the same user
+    // avoid potential issues where its a valid update by the same user
+    // but the client timestamp is not updated due to race condition or network issues
+    if (flowLastUpdatedBy === updatedBy) {
+      return true
+    }
 
     if (isNaN(inputTimestamp) || inputTimestamp !== flowTimestamp) {
       throw new BadUserInputError(

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -1,4 +1,4 @@
-import { IFlowConfig } from '@plumber/types'
+import { IFlowCollabRole, IFlowConfig } from '@plumber/types'
 
 import type { ModelOptions, QueryContext, Transaction } from 'objection'
 import { ValidationError } from 'objection'
@@ -26,6 +26,11 @@ class Flow extends Base {
   testExecutionId: string
   testExecution?: Execution
   user: User
+  collaborators?: FlowCollaborator[]
+
+  // for typescript support when creating FlowCollaborator row in insertGraph
+  role?: IFlowCollabRole
+  lastAccessedAt?: string
 
   /**
    * Null means to use default config.
@@ -120,6 +125,9 @@ class Flow extends Base {
       join: {
         from: `${this.tableName}.id`,
         to: `${FlowCollaborator.tableName}.flow_id`,
+      },
+      filter(builder: ExtendedQueryBuilder<FlowCollaborator>) {
+        builder.whereNull('deleted_at')
       },
     },
   })

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -1,6 +1,6 @@
 import { IFlowConfig } from '@plumber/types'
 
-import type { ModelOptions, QueryContext } from 'objection'
+import type { ModelOptions, QueryContext, Transaction } from 'objection'
 import { ValidationError } from 'objection'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
@@ -8,6 +8,7 @@ import { doesActionProcessFiles } from '@/helpers/actions'
 
 import Base from './base'
 import Execution from './execution'
+import FlowCollaborator from './flow-collaborators'
 import FlowTransfer from './flow-transfers'
 import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
@@ -113,6 +114,14 @@ class Flow extends Base {
         to: `${Execution.tableName}.id`,
       },
     },
+    collaborators: {
+      relation: Base.HasManyRelation,
+      modelClass: FlowCollaborator,
+      join: {
+        from: `${this.tableName}.id`,
+        to: `${FlowCollaborator.tableName}.flow_id`,
+      },
+    },
   })
 
   static hasAccess = async (
@@ -206,6 +215,22 @@ class Flow extends Base {
     )
 
     return actionFileFlags.some(Boolean)
+  }
+
+  static hasCollaborators = async ({
+    flowId,
+    trx,
+  }: {
+    flowId: string
+    trx?: Transaction
+  }) => {
+    const collaborators = await FlowCollaborator.query(trx)
+      .where({
+        flow_id: flowId,
+      })
+      .whereNull('deleted_at')
+
+    return collaborators.length > 0
   }
 }
 

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -66,6 +66,13 @@ class Flow extends Base {
               notificationFrequency: {
                 type: 'string',
               },
+              notificationRecipients: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['editor', 'viewer'],
+                },
+              },
             },
           },
         },

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,9 +1,4 @@
-import type {
-  IFlowCollabRole,
-  IJSONObject,
-  IStep,
-  IStepConfig,
-} from '@plumber/types'
+import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
 
 import {
   raw,
@@ -39,7 +34,6 @@ class Step extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   config: IStepConfig
-  role?: IFlowCollabRole
   updatedBy?: string
 
   static tableName = 'steps'

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -40,6 +40,7 @@ class Step extends Base {
   executionSteps: ExecutionStep[]
   config: IStepConfig
   role?: IFlowCollabRole
+  updatedBy?: string
 
   static tableName = 'steps'
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -1,4 +1,9 @@
-import type { IJSONObject, IStep, IStepConfig } from '@plumber/types'
+import type {
+  IFlowCollabRole,
+  IJSONObject,
+  IStep,
+  IStepConfig,
+} from '@plumber/types'
 
 import {
   raw,
@@ -34,6 +39,7 @@ class Step extends Base {
   flow: Flow
   executionSteps: ExecutionStep[]
   config: IStepConfig
+  role?: IFlowCollabRole
 
   static tableName = 'steps'
 

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -4,7 +4,6 @@ import {
   raw,
   RelatedQueryBuilder,
   type StaticHookArguments,
-  Transaction,
   ValidationError,
 } from 'objection'
 import { URL } from 'url'
@@ -191,12 +190,6 @@ class Step extends Base {
     const command = apps[appKey].actions.find((action) => action.key === key)
 
     return command
-  }
-
-  async patchFlowLastUpdated(trx?: Transaction) {
-    await this.$relatedQuery('flow', trx).patch({
-      updatedAt: new Date().toISOString(),
-    })
   }
 
   static async beforeUpdate(args: StaticHookArguments<Step>): Promise<void> {

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -112,6 +112,17 @@ class TableCollaborator extends Base {
       if (existingCollaborator.role === 'owner') {
         throw new BadUserInputError('Cannot change owner role')
       }
+
+      /**
+       * COLLABORATORS:
+       * should not downgrade the role on Tiles when the Pipe collaborator is being
+       * downgraded from an Editor to a Viewer.
+       * Tile Owner / Editor should do that manually.
+       */
+      if (role === 'viewer' && existingCollaborator.role === 'editor') {
+        return
+      }
+
       await existingCollaborator
         .$query(trx)
         .patchAndFetch({

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -1,6 +1,8 @@
 import { IGlobalVariable, ITableCollabRole } from '@plumber/types'
 
-import { ForbiddenError } from '@/errors/graphql-errors'
+import { Transaction } from 'objection'
+
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
 
 import Base from './base'
@@ -82,6 +84,47 @@ class TableCollaborator extends Base {
       throw new ForbiddenError(
         'You do not have sufficient permissions for this tile',
       )
+    }
+  }
+
+  static addCollaborator = async ({
+    userId,
+    tableId,
+    role,
+    trx,
+  }: {
+    userId: string
+    tableId: string
+    role: ITableCollabRole
+    trx?: Transaction
+  }) => {
+    const existingCollaborator = await TableCollaborator.query(trx)
+      .findOne({
+        table_id: tableId,
+        user_id: userId,
+      })
+      .withSoftDeleted()
+
+    /**
+     * Upsert collaborator here
+     */
+    if (existingCollaborator) {
+      if (existingCollaborator.role === 'owner') {
+        throw new BadUserInputError('Cannot change owner role')
+      }
+      await existingCollaborator
+        .$query(trx)
+        .patchAndFetch({
+          role,
+          deletedAt: null,
+        })
+        .withSoftDeleted()
+    } else {
+      await TableCollaborator.query(trx).insert({
+        tableId,
+        userId,
+        role,
+      })
     }
   }
 }

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,4 +1,4 @@
-import { ITableCollabRole } from '@plumber/types'
+import { IFlowCollabRole, ITableCollabRole } from '@plumber/types'
 
 import crypto from 'crypto'
 import {
@@ -7,6 +7,8 @@ import {
   QueryContext,
   Transaction,
 } from 'objection'
+
+import { getAllowedCollaboratorRoles } from '@/helpers/check-user-permission'
 
 import Base from './base'
 import Connection from './connection'
@@ -17,6 +19,13 @@ import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
 import TableCollaborator from './table-collaborators'
 import TableMetadata from './table-metadata'
+
+const ROLE_STMT = `
+  CASE
+    WHEN flows.user_id = ? THEN 'owner'
+    ELSE fc.role
+  END as role
+`
 
 class User extends Base {
   id!: string
@@ -139,31 +148,125 @@ class User extends Base {
     await super.$beforeUpdate(opt, queryContext)
   }
 
+  /**
+   * we use this filter to check for two things:
+   * 1. user is a valid owner or collaborator on this pipe
+   * 2. user has the required permissions to work on this pipe
+   */
+  private applyAccessibilityFilter(
+    query: AnyQueryBuilder,
+    userId: string,
+    requiredRole: IFlowCollabRole,
+  ) {
+    query.leftJoin('flow_collaborators as fc', function () {
+      this.on('fc.flow_id', 'flows.id')
+        .andOnNull('fc.deleted_at')
+        .andOnVal('fc.user_id', userId)
+    })
+
+    if (requiredRole === 'owner') {
+      query.where('flows.user_id', userId)
+      return
+    }
+
+    const allowedRoles = getAllowedCollaboratorRoles(requiredRole)
+
+    query.where(function () {
+      this.where('flows.user_id', userId)
+        .orWhereNotNull('fc.role')
+        .andWhere(function () {
+          this.select('*')
+            .from('flow_collaborators as fc')
+            .whereRaw('fc.flow_id = flows.id')
+            .where('fc.user_id', userId)
+            .whereIn('fc.role', allowedRoles)
+            .whereNull('fc.deleted_at')
+        })
+    })
+  }
+
   withAccessibleFlows({
+    requiredRole,
     queryBuilder,
     trx,
   }: {
+    requiredRole: IFlowCollabRole
     queryBuilder?: ExtendedQueryBuilder<Flow, Flow[]>
     trx?: Transaction
-  } = {}) {
+  }) {
     const userId = this.id
     const baseQuery = queryBuilder || Flow.query(trx)
+    baseQuery.select('flows.*', Flow.raw(ROLE_STMT, [userId]))
+
+    this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
     return baseQuery
-      .select('flows.*')
-      .leftJoin('flow_collaborators as fc', function () {
-        this.on('fc.flow_id', 'flows.id').andOnNull('fc.deleted_at')
-      })
+  }
+
+  withAccessibleSteps({
+    queryBuilder,
+    requiredRole,
+    trx,
+  }: {
+    queryBuilder?: ExtendedQueryBuilder<Step, Step[]>
+    requiredRole: IFlowCollabRole
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || Step.query(trx)
+    baseQuery
+      .select('steps.*', Step.raw(ROLE_STMT, [userId]))
+      .join('flows', 'flows.id', 'steps.flow_id')
+
+    this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    return baseQuery
+  }
+
+  withAccessibleConnections({
+    requiredRole,
+    queryBuilder,
+    trx,
+  }: {
+    requiredRole: IFlowCollabRole
+    queryBuilder?: ExtendedQueryBuilder<Connection, Connection[]>
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || Connection.query(trx)
+    const allowedRoles = getAllowedCollaboratorRoles(requiredRole)
+
+    return baseQuery
       .select(
-        Flow.raw(
-          `CASE
-          WHEN flows.user_id = ? THEN 'owner'
-          ELSE fc.role
-        END as role`,
-          [userId],
+        'connections.*',
+        Connection.raw(
+          `
+          CASE
+            WHEN connections.user_id = ? THEN 'owner'
+            WHEN flows.user_id = ? THEN 'owner'
+            ELSE fc.role
+          END as role
+          `,
+          [userId, userId],
         ),
       )
+      .leftJoin(
+        'flow_connections',
+        'flow_connections.connection_id',
+        'connections.id',
+      )
+      .leftJoin('flows', 'flows.id', 'flow_connections.flow_id')
+      .leftJoin('flow_collaborators as fc', function () {
+        this.on('fc.flow_id', 'flows.id')
+          .andOnNull('fc.deleted_at')
+          .andOnVal('fc.user_id', userId)
+      })
       .where(function () {
-        this.where('flows.user_id', userId).orWhereNotNull('fc.role')
+        // direct ownership OR access through flow_connections
+        this.where('connections.user_id', userId)
+          .orWhere('flows.user_id', userId)
+          .orWhere(function () {
+            // collaborator access
+            this.whereNotNull('fc.role').andWhere('fc.role', 'in', allowedRoles)
+          })
       })
   }
 }

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -14,6 +14,7 @@ import Base from './base'
 import Connection from './connection'
 import Execution from './execution'
 import Flow from './flow'
+import FlowConnections from './flow-connections'
 import FlowTransfer from './flow-transfers'
 import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
@@ -268,6 +269,25 @@ class User extends Base {
             this.whereNotNull('fc.role').andWhere('fc.role', 'in', allowedRoles)
           })
       })
+  }
+
+  withAccessibleFlowConnections({
+    requiredRole,
+    queryBuilder,
+    trx,
+  }: {
+    requiredRole: IFlowCollabRole
+    queryBuilder?: ExtendedQueryBuilder<FlowConnections, FlowConnections[]>
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || FlowConnections.query(trx)
+    baseQuery
+      .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
+      .join('flows', 'flows.id', 'flow_connections.flow_id')
+
+    this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    return baseQuery
   }
 }
 

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -1,13 +1,19 @@
 import { ITableCollabRole } from '@plumber/types'
 
 import crypto from 'crypto'
-import { AnyQueryBuilder, ModelOptions, QueryContext } from 'objection'
+import {
+  AnyQueryBuilder,
+  ModelOptions,
+  QueryContext,
+  Transaction,
+} from 'objection'
 
 import Base from './base'
 import Connection from './connection'
 import Execution from './execution'
 import Flow from './flow'
 import FlowTransfer from './flow-transfers'
+import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
 import TableCollaborator from './table-collaborators'
 import TableMetadata from './table-metadata'
@@ -131,6 +137,34 @@ class User extends Base {
 
   async $beforeUpdate(opt: ModelOptions, queryContext: QueryContext) {
     await super.$beforeUpdate(opt, queryContext)
+  }
+
+  withAccessibleFlows({
+    queryBuilder,
+    trx,
+  }: {
+    queryBuilder?: ExtendedQueryBuilder<Flow, Flow[]>
+    trx?: Transaction
+  } = {}) {
+    const userId = this.id
+    const baseQuery = queryBuilder || Flow.query(trx)
+    return baseQuery
+      .select('flows.*')
+      .leftJoin('flow_collaborators as fc', function () {
+        this.on('fc.flow_id', 'flows.id').andOnNull('fc.deleted_at')
+      })
+      .select(
+        Flow.raw(
+          `CASE
+          WHEN flows.user_id = ? THEN 'owner'
+          ELSE fc.role
+        END as role`,
+          [userId],
+        ),
+      )
+      .where(function () {
+        this.where('flows.user_id', userId).orWhereNotNull('fc.role')
+      })
   }
 }
 

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -286,6 +286,27 @@ class User extends Base {
       .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
       .join('flows', 'flows.id', 'flow_connections.flow_id')
 
+    if (requiredRole) {
+      this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    }
+    return baseQuery
+  }
+
+  withAccessibleExecutions({
+    requiredRole,
+    queryBuilder,
+    trx,
+  }: {
+    requiredRole: IFlowCollabRole
+    queryBuilder?: ExtendedQueryBuilder<Execution, Execution[]>
+    trx?: Transaction
+  }) {
+    const userId = this.id
+    const baseQuery = queryBuilder || Execution.query(trx)
+    baseQuery
+      .select('executions.*', Execution.raw(ROLE_STMT, [userId]))
+      .join('flows', 'flows.id', 'executions.flow_id')
+
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
     return baseQuery
   }

--- a/packages/backend/src/models/user.ts
+++ b/packages/backend/src/models/user.ts
@@ -60,6 +60,11 @@ class User extends Base {
   }
 
   static relationMappings = () => ({
+    /**
+     * NOTE: retain _connections_ and _flows_ relations as they are used to get the owner's
+     * connections and flows.
+     * It is displayed in the My Apps page.
+     */
     connections: {
       relation: Base.HasManyRelation,
       modelClass: Connection,
@@ -74,18 +79,6 @@ class User extends Base {
       join: {
         from: 'users.id',
         to: 'flows.user_id',
-      },
-    },
-    steps: {
-      relation: Base.ManyToManyRelation,
-      modelClass: Step,
-      join: {
-        from: 'users.id',
-        through: {
-          from: 'flows.user_id',
-          to: 'flows.id',
-        },
-        to: 'steps.flow_id',
       },
     },
     executions: {
@@ -147,6 +140,26 @@ class User extends Base {
 
   async $beforeUpdate(opt: ModelOptions, queryContext: QueryContext) {
     await super.$beforeUpdate(opt, queryContext)
+  }
+
+  /**
+   * Generic method to add flow role information to any query that has a flow relation
+   * This can be used with modifyGraph to add role information to flow relations
+   */
+  withFlowRole(query: AnyQueryBuilder): AnyQueryBuilder {
+    const userId = this.id
+    return query
+      .withGraphFetched('flow')
+      .modifyGraph('flow', (flowQuery: any) => {
+        // this.applyFlowRoleSelection(flowQuery, userId)
+        flowQuery
+          .leftJoin('flow_collaborators as fc', function () {
+            this.on('fc.flow_id', 'flows.id')
+              .andOnNull('fc.deleted_at')
+              .andOnVal('fc.user_id', userId)
+          })
+          .select('flows.*', Flow.raw(ROLE_STMT, [userId]))
+      })
   }
 
   /**
@@ -214,11 +227,10 @@ class User extends Base {
   }) {
     const userId = this.id
     const baseQuery = queryBuilder || Step.query(trx)
-    baseQuery
-      .select('steps.*', Step.raw(ROLE_STMT, [userId]))
-      .join('flows', 'flows.id', 'steps.flow_id')
+    baseQuery.select('steps.*').join('flows', 'flows.id', 'steps.flow_id')
 
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 
@@ -235,20 +247,8 @@ class User extends Base {
     const baseQuery = queryBuilder || Connection.query(trx)
     const allowedRoles = getAllowedCollaboratorRoles(requiredRole)
 
-    return baseQuery
-      .select(
-        'connections.*',
-        Connection.raw(
-          `
-          CASE
-            WHEN connections.user_id = ? THEN 'owner'
-            WHEN flows.user_id = ? THEN 'owner'
-            ELSE fc.role
-          END as role
-          `,
-          [userId, userId],
-        ),
-      )
+    baseQuery
+      .select('connections.*')
       .leftJoin(
         'flow_connections',
         'flow_connections.connection_id',
@@ -269,6 +269,10 @@ class User extends Base {
             this.whereNotNull('fc.role').andWhere('fc.role', 'in', allowedRoles)
           })
       })
+
+    // Note: withFlowRole is not called here because Connection model doesn't have a 'flow' relation
+    // The role information is already handled through the joins above
+    return baseQuery
   }
 
   withAccessibleFlowConnections({
@@ -283,12 +287,13 @@ class User extends Base {
     const userId = this.id
     const baseQuery = queryBuilder || FlowConnections.query(trx)
     baseQuery
-      .select('flow_connections.*', FlowConnections.raw(ROLE_STMT, [userId]))
+      .select('flow_connections.*')
       .join('flows', 'flows.id', 'flow_connections.flow_id')
 
     if (requiredRole) {
       this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
     }
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 
@@ -304,10 +309,11 @@ class User extends Base {
     const userId = this.id
     const baseQuery = queryBuilder || Execution.query(trx)
     baseQuery
-      .select('executions.*', Execution.raw(ROLE_STMT, [userId]))
+      .select('executions.*')
       .join('flows', 'flows.id', 'executions.flow_id')
 
     this.applyAccessibilityFilter(baseQuery, userId, requiredRole)
+    this.withFlowRole(baseQuery)
     return baseQuery
   }
 }

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,0 +1,43 @@
+import { Transaction } from 'objection'
+
+import FlowConnections from '@/models/flow-connections'
+import Context from '@/types/express/context'
+
+type GetConnectionParams = {
+  context: Context
+  connectionId: string
+  flowId: string
+  includeOwnConnections?: boolean
+  trx?: Transaction
+}
+
+/**
+ * NOTE: with the introduction of collaborators, we use this helper function to fetch the connection
+ * we do not need to check the user's role again here as the role would have been checked
+ * before this function is called
+ */
+export const getConnection = async (params: GetConnectionParams) => {
+  const { context, connectionId, includeOwnConnections, trx, flowId } = params
+
+  if (includeOwnConnections) {
+    // this means that the user is the owner of the pipe
+    // it could be their own connection or a shared connection
+    // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
+    // will need to include connections from the flow_connections table
+    return await context.currentUser
+      .$relatedQuery('connections', trx)
+      .findOne({ 'connections.id': connectionId })
+      .throwIfNotFound({ message: 'Connection not found' })
+  }
+
+  // NOTE: editor and viewer can only access shared connections from the flow_connections table
+  const flowConnection = await FlowConnections.query(trx)
+    .findOne({
+      connection_id: connectionId,
+      flow_id: flowId,
+    })
+    .withGraphFetched('connection')
+    .throwIfNotFound({ message: 'Connection not found' })
+
+  return flowConnection?.connection
+}

--- a/packages/backend/src/services/connection.ts
+++ b/packages/backend/src/services/connection.ts
@@ -1,5 +1,6 @@
 import { Transaction } from 'objection'
 
+import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 import Context from '@/types/express/context'
 
@@ -20,13 +21,25 @@ export const getConnection = async (params: GetConnectionParams) => {
   const { context, connectionId, includeOwnConnections, trx, flowId } = params
 
   if (includeOwnConnections) {
-    // this means that the user is the owner of the pipe
-    // it could be their own connection or a shared connection
+    // there are 2 types of connections that an owner can access:
+    // 1. the user is the owner of the pipe
+    //    it could be their own connection or a shared connection
+    // 2. the user is the owner of a pipe that has been transferred to them
+    //    it should include connections from the flow_connections table as well
     // TODO (kevinkim-ogp): phase 2 will allow editors to add their own connections, so owner's connections
     // will need to include connections from the flow_connections table
-    return await context.currentUser
-      .$relatedQuery('connections', trx)
-      .findOne({ 'connections.id': connectionId })
+
+    return await Connection.query(trx)
+      .findById(connectionId)
+      .where(function () {
+        // connection is either owned by the user
+        this.where('connections.user_id', context.currentUser.id).orWhereExists(
+          // or accessible via flow_connections table
+          FlowConnections.query(trx)
+            .whereColumn('flow_connections.connection_id', 'connections.id')
+            .where('flow_connections.flow_id', flowId),
+        )
+      })
       .throwIfNotFound({ message: 'Connection not found' })
   }
 

--- a/packages/backend/src/services/test-step.ts
+++ b/packages/backend/src/services/test-step.ts
@@ -9,12 +9,12 @@ import { processAction } from '@/services/action'
 import { processFlow } from '@/services/flow'
 import { processTrigger } from '@/services/trigger'
 
-interface TestStepOptions {
+export interface TestStepOptions {
   stepId: string
   testRunMetadata?: TestRunStepMetadata
 }
 
-interface TestStepResult {
+export interface TestStepResult {
   executionStep: ExecutionStep
   executionId: string
 }

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -123,51 +123,45 @@ describe('Action worker', () => {
       expect(mocks.exponentialBackoffWithJitter).not.toBeCalled()
     })
 
-    it(
-      'retries retriable executions using our custom backoff strategy',
-      {
-        timeout: 20000,
-      },
-      async () => {
-        // Override max attempts to reduce test running time.
-        const maxAttempts = 3
+    it('retries retriable executions using our custom backoff strategy', async () => {
+      // Override max attempts to reduce test running time.
+      const maxAttempts = 3
 
-        mocks.processAction.mockResolvedValue({
-          executionStep: { isFailed: true },
-        })
-        mocks.handleFailedStepAndThrow.mockRejectedValue(
-          new RetriableError({
-            error: 'test retriable error',
-            delayInMs: 10,
-            delayType: 'step',
-          }),
-        )
+      mocks.processAction.mockResolvedValue({
+        executionStep: { isFailed: true },
+      })
+      mocks.handleFailedStepAndThrow.mockRejectedValue(
+        new RetriableError({
+          error: 'test retriable error',
+          delayInMs: 10,
+          delayType: 'step',
+        }),
+      )
 
-        const jobProcessed = new Promise<void>((resolve) => {
-          mainActionWorker.on('failed', async (job) => {
-            if (job.attemptsMade === maxAttempts) {
-              resolve()
-            }
-          })
+      const jobProcessed = new Promise<void>((resolve) => {
+        mainActionWorker.on('failed', async (job) => {
+          if (job.attemptsMade === maxAttempts) {
+            resolve()
+          }
         })
-        await enqueueActionJob({
-          appKey: null,
-          jobName: 'test-job',
-          jobData: {
-            flowId: 'test-flow-id',
-            executionId: 'test-exec-id',
-            stepId: 'test-step-id',
-          },
-          jobOptions: {
-            ...DEFAULT_JOB_OPTIONS,
-            attempts: maxAttempts,
-          },
-        })
-        await jobProcessed
+      })
+      await enqueueActionJob({
+        appKey: null,
+        jobName: 'test-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: {
+          ...DEFAULT_JOB_OPTIONS,
+          attempts: maxAttempts,
+        },
+      })
+      await jobProcessed
 
-        expect(mocks.exponentialBackoffWithJitter).toBeCalled()
-      },
-    )
+      expect(mocks.exponentialBackoffWithJitter).toBeCalled()
+    }, 20000)
 
     it('does not retry non-executable executions', async () => {
       mocks.processAction.mockResolvedValueOnce({

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -271,7 +271,12 @@ export function makeActionWorker(
 
       const flow = await Flow.query()
         .findById(job.data.flowId)
-        .withGraphFetched('user')
+        .withGraphFetched({
+          user: true,
+          collaborators: {
+            user: true,
+          },
+        })
         .throwIfNotFound()
 
       const shouldAlwaysSendEmail =

--- a/packages/frontend/src/components/ApolloProvider/index.tsx
+++ b/packages/frontend/src/components/ApolloProvider/index.tsx
@@ -13,15 +13,21 @@ const ApolloProvider = (props: ApolloProviderProps): React.ReactElement => {
 
   const onError = React.useCallback(
     (message: string) => {
-      toast({
-        title: message,
-        description:
-          'If this error persists, contact us at support@plumber.gov.sg.',
-        status: 'error',
-        duration: 3000,
-        isClosable: true,
-        position: 'top',
-      })
+      // HACKFIX: we use this toast.isActive to prevent duplicate toasts from being shown.
+      // there should be a better way to handle this from the ApolloClient.
+      const id = `graphql-error-${message.slice(0, 15)}`
+      if (!toast.isActive(id)) {
+        toast({
+          id,
+          title: message,
+          description:
+            'If this error persists, contact us at support@plumber.gov.sg.',
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+          position: 'top',
+        })
+      }
     },
     [toast],
   )

--- a/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
@@ -3,7 +3,7 @@ import { IExecutionStep, TDataOutMetadatumType } from '@plumber/types'
 import { useContext, useMemo, useState } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
-import { GetFlowQuery } from '@/graphql/__generated__/graphql'
+import { Flow } from '@/graphql/__generated__/graphql'
 import {
   extractVariables,
   filterVariables,
@@ -15,7 +15,7 @@ import { CheckboxVariable } from '../components/Checkbox'
 import { reformatToCheckboxVariables } from '../utils'
 
 export function useAttachmentOptions(
-  flowData: GetFlowQuery,
+  flowConfig: Flow['config'],
   priorExecutionSteps: IExecutionStep[],
   variableTypes: TDataOutMetadatumType[] | null,
 ) {
@@ -23,10 +23,9 @@ export function useAttachmentOptions(
   const [options, setOptions] = useState<CheckboxVariable[]>([])
 
   const uploadedItems = useMemo(() => {
-    const attachmentsConfig =
-      flowData?.getFlow?.config?.attachments?.filter(Boolean) ?? []
+    const attachmentsConfig = flowConfig?.attachments?.filter(Boolean) ?? []
     return reformatToCheckboxVariables(attachmentsConfig as CheckboxVariable[])
-  }, [flowData])
+  }, [flowConfig])
 
   const suggestions = useMemo(() => {
     const filteredVars = filterVariables(

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -67,7 +67,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   })
 
   const { options, suggestions, uploadedItems } = useAttachmentOptions(
-    flowData,
+    flowData?.getFlow?.config,
     priorExecutionSteps,
     variableTypes,
   )

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -10,6 +10,7 @@ import { EditorContext } from '@/contexts/Editor'
 import { TEST_CONNECTION } from '@/graphql/queries/test-connection'
 import useAuthentication from '@/hooks/useAuthentication'
 
+import { NON_EDITABLE_APP_CONNECTIONS } from '../Editor/constants'
 import {
   type ConnectionDropdownOption,
   optionGenerator,
@@ -51,11 +52,16 @@ function ChooseConnectionSubstep(
 ): React.ReactElement {
   const { step, application, onReconnect } = props
   const { connection } = step
-  const editorContext = useContext(EditorContext)
+  const { readOnly, flow } = useContext(EditorContext)
   const { currentUser } = useAuthentication()
 
   const supportsConnectionRegistration =
     !!application.auth?.connectionRegistrationType
+
+  const isEditConnectionDisabled =
+    readOnly ||
+    (flow.role !== 'owner' &&
+      NON_EDITABLE_APP_CONNECTIONS.includes(application.key))
 
   const { loading: testResultLoading, data: testConnectionData } = useQuery<{
     testConnection: ITestConnectionOutput
@@ -172,7 +178,7 @@ function ChooseConnectionSubstep(
           size="xs"
           leftIcon={connection ? <BiRefresh /> : <BiLink />}
           onClick={onReconnect}
-          isDisabled={editorContext.readOnly}
+          isDisabled={isEditConnectionDisabled}
         >
           {connection ? 'Reconnect' : 'Connect'}
         </Button>

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -62,7 +62,8 @@ function ChooseConnectionSubstep(
   }>(TEST_CONNECTION, {
     variables: {
       connectionId: connection?.id,
-      flowId: supportsConnectionRegistration ? step.flowId : undefined,
+      flowId: step.flowId,
+      supportsConnectionRegistration,
     },
     skip: !connection?.id,
   })

--- a/packages/frontend/src/components/CollaboratorRoleSelect/index.tsx
+++ b/packages/frontend/src/components/CollaboratorRoleSelect/index.tsx
@@ -1,0 +1,48 @@
+import { IFlowCollabRole, ITableCollabRole } from '@plumber/types'
+
+import { BiChevronDown } from 'react-icons/bi'
+import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react'
+import { Button, ButtonProps } from '@opengovsg/design-system-react'
+
+const CollaboratorRoleSelect = ({
+  userRole,
+  value,
+  onChange,
+  isEditable,
+  variant = 'outline',
+  showOwnerOption = true,
+}: {
+  userRole: IFlowCollabRole | ITableCollabRole
+  value: IFlowCollabRole | ITableCollabRole
+  onChange: (val: IFlowCollabRole | ITableCollabRole) => void
+  isEditable: boolean
+  variant?: ButtonProps['variant']
+  showOwnerOption?: boolean
+}) => {
+  return (
+    <Menu gutter={0}>
+      <MenuButton
+        as={Button}
+        pointerEvents={isEditable ? 'auto' : 'none'}
+        colorScheme="secondary"
+        variant={variant}
+        w={32}
+        px={6}
+        textTransform="capitalize"
+        rightIcon={isEditable ? <BiChevronDown /> : undefined}
+        textAlign={variant === 'clear' ? 'left' : 'center'}
+      >
+        {value}
+      </MenuButton>
+      <MenuList w={32}>
+        {userRole === 'owner' && showOwnerOption && (
+          <MenuItem onClick={() => onChange('owner')}>Owner</MenuItem>
+        )}
+        <MenuItem onClick={() => onChange('editor')}>Editor</MenuItem>
+        <MenuItem onClick={() => onChange('viewer')}>Viewer</MenuItem>
+      </MenuList>
+    </Menu>
+  )
+}
+
+export default CollaboratorRoleSelect

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -7,7 +7,10 @@ export const MIN_FLOW_STEP_WIDTH = '320px'
 
 /**
  * NOTE: there are certain fields that behave like connections
- * such as excel files
+ * we use this to manage two things:
+ * 1. which apps do not allow collaborators to edit their connections
+ * 2. which fields behave like connections
+ *
  * we do not allow collaborators to edit these fields
  * we use both the label and key as there are some
  * actions that have the same key but use different labels

--- a/packages/frontend/src/components/Editor/constants.ts
+++ b/packages/frontend/src/components/Editor/constants.ts
@@ -4,3 +4,22 @@ export const EDITOR_MAX_HEIGHT = `calc(100vh - ${EDITOR_MARGIN_TOP})`
 export const EDITOR_RIGHT_DRAWER_WIDTH = '60%'
 
 export const MIN_FLOW_STEP_WIDTH = '320px'
+
+/**
+ * NOTE: there are certain fields that behave like connections
+ * such as excel files
+ * we do not allow collaborators to edit these fields
+ * we use both the label and key as there are some
+ * actions that have the same key but use different labels
+ */
+const NON_EDITABLE_APPS_FIELDS: Record<string, Record<string, string>[]> = {
+  'm365-excel': [],
+}
+
+export const NON_EDITABLE_APP_CONNECTIONS = Object.keys(
+  NON_EDITABLE_APPS_FIELDS,
+)
+
+export const NON_EDITABLE_CONNECTION_FIELDS = Object.values(
+  NON_EDITABLE_APPS_FIELDS,
+).flat()

--- a/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorSnackbar.tsx
@@ -1,5 +1,8 @@
+import { useContext } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
 
 interface EditorSnackbarProps {
   isOpen: boolean
@@ -8,6 +11,7 @@ interface EditorSnackbarProps {
 
 export default function EditorSnackbar(props: EditorSnackbarProps) {
   const { isOpen, handleUnpublish } = props
+  const { hasEditPermission } = useContext(EditorContext)
   const snackbarText = 'To edit this pipe, you need to unpublish it first'
   return (
     <Box
@@ -31,6 +35,7 @@ export default function EditorSnackbar(props: EditorSnackbarProps) {
           colorScheme="inverse"
           onClick={handleUnpublish}
           size={{ sm: 'sm', md: 'md' }}
+          isDisabled={!hasEditPermission}
         >
           Unpublish
         </Button>

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -12,6 +12,7 @@ import {
 
 import * as URLS from '@/config/urls'
 import { EditorContext } from '@/contexts/Editor'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 
 import PublishButton from './PublishButton'
 
@@ -54,12 +55,13 @@ const SettingsItem = ({
   type,
   setLeaveToUrl,
   handleWarnOnLeave,
+  settingsLink,
 }: {
   type: 'icon' | 'button'
   setLeaveToUrl: (url: string) => void
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
+  settingsLink: string
 }) => {
-  const { flowId } = useContext(EditorContext)
   if (type === 'button') {
     return (
       <Button
@@ -67,10 +69,10 @@ const SettingsItem = ({
         aria-label="settings"
         colorScheme="secondary"
         as={Link}
-        to={URLS.FLOW_EDITOR_SHARE(flowId)}
+        to={settingsLink}
         w="100%"
         onClick={(e) => {
-          setLeaveToUrl(URLS.FLOW_EDITOR_SHARE(flowId))
+          setLeaveToUrl(settingsLink)
           handleWarnOnLeave(e)
         }}
       >
@@ -82,7 +84,7 @@ const SettingsItem = ({
     <TouchableTooltip label="Settings" aria-label="settings tooltip">
       <IconButton
         as={Link}
-        to={URLS.FLOW_EDITOR_SHARE(flowId)}
+        to={settingsLink}
         variant="clear"
         aria-label="settings"
         icon={<BiCog />}
@@ -92,7 +94,7 @@ const SettingsItem = ({
           bg: 'interaction.muted.main.hover',
         }}
         onClick={(e) => {
-          setLeaveToUrl(URLS.FLOW_EDITOR_SHARE(flowId))
+          setLeaveToUrl(settingsLink)
           handleWarnOnLeave(e)
         }}
       />
@@ -144,13 +146,21 @@ interface EditorToolbarProps {
 }
 
 export default function EditorToolbar(props: EditorToolbarProps) {
+  const { flowId } = useContext(EditorContext)
+  // TODO: remove this once we open collaborators to all users
+  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
+  const settingsLink =
+    !isFlagsLoading && flags?.collaborators
+      ? URLS.FLOW_EDITOR_SHARE(flowId)
+      : URLS.FLOW_EDITOR_TRANSFERS(flowId)
+
   return (
     <>
       <Show above="md">
         <HStack>
           <ExecutionsItem type="icon" />
           <GuideItem type="icon" />
-          <SettingsItem {...props} type="icon" />
+          <SettingsItem {...props} type="icon" settingsLink={settingsLink} />
           <PublishButton {...props} />
         </HStack>
       </Show>
@@ -172,7 +182,11 @@ export default function EditorToolbar(props: EditorToolbarProps) {
           >
             <ExecutionsItem type="button" />
             <GuideItem type="button" />
-            <SettingsItem {...props} type="button" />
+            <SettingsItem
+              {...props}
+              type="button"
+              settingsLink={settingsLink}
+            />
             <PublishButton {...props} />
           </MenuList>
         </Menu>

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -1,5 +1,4 @@
-import { IFlow } from '@plumber/types'
-
+import { useContext } from 'react'
 import { BiCog, BiHistory, BiInfoCircle } from 'react-icons/bi'
 import { HiOutlineDotsVertical } from 'react-icons/hi'
 import { Link } from 'react-router-dom'
@@ -12,6 +11,7 @@ import {
 } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
+import { EditorContext } from '@/contexts/Editor'
 
 import PublishButton from './PublishButton'
 
@@ -51,16 +51,15 @@ const GuideItem = ({ type }: { type: 'icon' | 'button' }) => {
 }
 
 const SettingsItem = ({
-  flowId,
   type,
   setLeaveToUrl,
   handleWarnOnLeave,
 }: {
-  flowId: string
   type: 'icon' | 'button'
   setLeaveToUrl: (url: string) => void
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
 }) => {
+  const { flowId } = useContext(EditorContext)
   if (type === 'button') {
     return (
       <Button
@@ -101,13 +100,8 @@ const SettingsItem = ({
   )
 }
 
-const ExecutionsItem = ({
-  flowId,
-  type,
-}: {
-  flowId: string
-  type: 'icon' | 'button'
-}) => {
+const ExecutionsItem = ({ type }: { type: 'icon' | 'button' }) => {
+  const { flowId } = useContext(EditorContext)
   if (type === 'button') {
     return (
       <Button
@@ -141,10 +135,6 @@ const ExecutionsItem = ({
 }
 
 interface EditorToolbarProps {
-  flowId: string
-  flow: IFlow
-  isFlowIncomplete: boolean
-  hasFlowTransfer: boolean
   loading: boolean
   shouldWarnOnLeave: boolean
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void
@@ -158,7 +148,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
     <>
       <Show above="md">
         <HStack>
-          <ExecutionsItem {...props} type="icon" />
+          <ExecutionsItem type="icon" />
           <GuideItem type="icon" />
           <SettingsItem {...props} type="icon" />
           <PublishButton {...props} />
@@ -180,7 +170,7 @@ export default function EditorToolbar(props: EditorToolbarProps) {
             gap={2}
             px={2}
           >
-            <ExecutionsItem {...props} type="button" />
+            <ExecutionsItem type="button" />
             <GuideItem type="button" />
             <SettingsItem {...props} type="button" />
             <PublishButton {...props} />

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -148,11 +148,10 @@ interface EditorToolbarProps {
 export default function EditorToolbar(props: EditorToolbarProps) {
   const { flowId } = useContext(EditorContext)
   // TODO: remove this once we open collaborators to all users
-  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
-  const settingsLink =
-    !isFlagsLoading && flags?.collaborators
-      ? URLS.FLOW_EDITOR_SHARE(flowId)
-      : URLS.FLOW_EDITOR_TRANSFERS(flowId)
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const settingsLink = getFlagValue('collaborators', false)
+    ? URLS.FLOW_EDITOR_SHARE(flowId)
+    : URLS.FLOW_EDITOR_TRANSFERS(flowId)
 
   return (
     <>

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -1,18 +1,23 @@
 import { useContext } from 'react'
 import { BiCog, BiHistory, BiInfoCircle } from 'react-icons/bi'
 import { HiOutlineDotsVertical } from 'react-icons/hi'
+import { MdOutlineRemoveRedEye } from 'react-icons/md'
 import { Link } from 'react-router-dom'
 import { Hide, HStack, MenuButton, MenuList, Show } from '@chakra-ui/react'
 import {
   Button,
   IconButton,
   Menu,
+  Tag,
+  TagLabel,
+  TagLeftIcon,
   TouchableTooltip,
 } from '@opengovsg/design-system-react'
 
 import * as URLS from '@/config/urls'
 import { EditorContext } from '@/contexts/Editor'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+import { tagStyles } from '@/pages/Tiles/components/style'
 
 import PublishButton from './PublishButton'
 
@@ -136,6 +141,15 @@ const ExecutionsItem = ({ type }: { type: 'icon' | 'button' }) => {
   )
 }
 
+const ViewOnlyTag = () => {
+  return (
+    <Tag {...tagStyles}>
+      <TagLeftIcon as={MdOutlineRemoveRedEye} />
+      <TagLabel>View only</TagLabel>
+    </Tag>
+  )
+}
+
 interface EditorToolbarProps {
   loading: boolean
   shouldWarnOnLeave: boolean
@@ -146,7 +160,7 @@ interface EditorToolbarProps {
 }
 
 export default function EditorToolbar(props: EditorToolbarProps) {
-  const { flowId } = useContext(EditorContext)
+  const { flow, flowId } = useContext(EditorContext)
   // TODO: remove this once we open collaborators to all users
   const { getFlagValue } = useContext(LaunchDarklyContext)
   const settingsLink = getFlagValue('collaborators', false)
@@ -160,7 +174,11 @@ export default function EditorToolbar(props: EditorToolbarProps) {
           <ExecutionsItem type="icon" />
           <GuideItem type="icon" />
           <SettingsItem {...props} type="icon" settingsLink={settingsLink} />
-          <PublishButton {...props} />
+          {flow?.role === 'viewer' ? (
+            <ViewOnlyTag />
+          ) : (
+            <PublishButton {...props} />
+          )}
         </HStack>
       </Show>
       <Hide above="md">
@@ -186,7 +204,11 @@ export default function EditorToolbar(props: EditorToolbarProps) {
               type="button"
               settingsLink={settingsLink}
             />
-            <PublishButton {...props} />
+            {flow?.role === 'viewer' ? (
+              <ViewOnlyTag />
+            ) : (
+              <PublishButton {...props} />
+            )}
           </MenuList>
         </Menu>
       </Hide>

--- a/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
+++ b/packages/frontend/src/components/EditorLayout/EditorToolbar.tsx
@@ -68,10 +68,10 @@ const SettingsItem = ({
         aria-label="settings"
         colorScheme="secondary"
         as={Link}
-        to={URLS.FLOW_EDITOR_NOTIFICATIONS(flowId)}
+        to={URLS.FLOW_EDITOR_SHARE(flowId)}
         w="100%"
         onClick={(e) => {
-          setLeaveToUrl(URLS.FLOW_EDITOR_NOTIFICATIONS(flowId))
+          setLeaveToUrl(URLS.FLOW_EDITOR_SHARE(flowId))
           handleWarnOnLeave(e)
         }}
       >
@@ -83,7 +83,7 @@ const SettingsItem = ({
     <TouchableTooltip label="Settings" aria-label="settings tooltip">
       <IconButton
         as={Link}
-        to={URLS.FLOW_EDITOR_NOTIFICATIONS(flowId)}
+        to={URLS.FLOW_EDITOR_SHARE(flowId)}
         variant="clear"
         aria-label="settings"
         icon={<BiCog />}
@@ -93,7 +93,7 @@ const SettingsItem = ({
           bg: 'interaction.muted.main.hover',
         }}
         onClick={(e) => {
-          setLeaveToUrl(URLS.FLOW_EDITOR_NOTIFICATIONS(flowId))
+          setLeaveToUrl(URLS.FLOW_EDITOR_SHARE(flowId))
           handleWarnOnLeave(e)
         }}
       />

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -25,7 +25,9 @@ export default function PublishButton({
   return (
     <TouchableTooltip
       label={
-        hasFlowTransfer
+        flow.role === 'viewer'
+          ? 'You do not have permission to edit this pipe'
+          : hasFlowTransfer
           ? 'You cannot publish a pipe with a pending transfer'
           : isFlowIncomplete
           ? 'Set up for all steps must be completed before you can publish your pipe'
@@ -34,7 +36,9 @@ export default function PublishButton({
       wrapperStyles={{ width: '100%' }}
     >
       <Button
-        isDisabled={isFlowIncomplete || hasFlowTransfer}
+        isDisabled={
+          isFlowIncomplete || hasFlowTransfer || flow.role === 'viewer'
+        }
         isLoading={loading}
         spinner={<Spinner fontSize={24} />}
         size="sm"

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -1,27 +1,41 @@
-import { IFlow } from '@plumber/types'
-
+import { useContext, useMemo } from 'react'
 import { Skeleton, Spinner, Text } from '@chakra-ui/react'
 import { Button, TouchableTooltip } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
+import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+
 export default function PublishButton({
-  flow,
-  hasFlowTransfer,
-  isFlowIncomplete,
   loading,
   shouldWarnOnLeave,
   handleWarnOnLeave,
   onFlowStatusUpdate,
   setShouldWarnOnPublish,
 }: {
-  flow: IFlow
-  hasFlowTransfer: boolean
-  isFlowIncomplete: boolean
   loading: boolean
   shouldWarnOnLeave: boolean
   handleWarnOnLeave: (e: React.MouseEvent<HTMLButtonElement>) => void
   onFlowStatusUpdate: (active: boolean) => void
   setShouldWarnOnPublish: (shouldWarnOnPublish: boolean) => void
 }) {
+  const {
+    flow,
+    hasFlowTransfer,
+    isLoading: isEditorContextLoading,
+  } = useContext(EditorContext)
+
+  // disallow user from publishing pipe if any step is incomplete
+  const isFlowIncomplete = useMemo(
+    () =>
+      flow?.steps.length < 2 ||
+      flow?.steps.some((step) => step.status === 'incomplete') ||
+      // NOTE: toolbox apps should have action steps after them
+      // this is relevant in the for-each action where we use the EmptyFlowStepHeader
+      // instead of creating an empty step
+      flow?.steps[flow?.steps.length - 1].appKey === TOOLBOX_APP_KEY,
+    [flow?.steps],
+  )
+
   return (
     <TouchableTooltip
       label={
@@ -39,7 +53,7 @@ export default function PublishButton({
         isDisabled={
           isFlowIncomplete || hasFlowTransfer || flow.role === 'viewer'
         }
-        isLoading={loading}
+        isLoading={loading || isEditorContextLoading}
         spinner={<Spinner fontSize={24} />}
         size="sm"
         minW="120px" // set this to avoid button width changing on publish/unpublish

--- a/packages/frontend/src/components/EditorLayout/PublishButton.tsx
+++ b/packages/frontend/src/components/EditorLayout/PublishButton.tsx
@@ -25,10 +25,10 @@ export default function PublishButton({
   return (
     <TouchableTooltip
       label={
-        isFlowIncomplete
-          ? 'Set up for all steps must be completed before you can publish your pipe'
-          : hasFlowTransfer
+        hasFlowTransfer
           ? 'You cannot publish a pipe with a pending transfer'
+          : isFlowIncomplete
+          ? 'Set up for all steps must be completed before you can publish your pipe'
           : ''
       }
       wrapperStyles={{ width: '100%' }}

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -83,13 +83,7 @@ export default function EditorLayout() {
           input: {
             id: flowId,
             name,
-          },
-        },
-        optimisticResponse: {
-          updateFlow: {
-            __typename: 'Flow',
-            id: flow?.id,
-            name,
+            updatedAt: flow?.updatedAt,
           },
         },
       })

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -1,6 +1,6 @@
 import type { IFlow } from '@plumber/types'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
@@ -16,7 +16,6 @@ import { EditorProvider } from '@/contexts/Editor'
 import { UPDATE_FLOW } from '@/graphql/mutations/update-flow'
 import { UPDATE_FLOW_STATUS } from '@/graphql/mutations/update-flow-status'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { TOOLBOX_APP_KEY } from '@/helpers/toolbox'
 import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
 
 import { EDITOR_MARGIN_TOP } from '../Editor/constants'
@@ -77,10 +76,6 @@ export default function EditorLayout() {
   const shouldOpenAnnouncementModal =
     localLatestTimestamp !== LATEST_ANNOUNCEMENT_MODAL_TIMESTAMP
 
-  // phase 1: add check to prevent user from publishing pipe after submitting request
-  const requestedEmail = flow?.pendingTransfer?.newOwner.email ?? ''
-  const hasFlowTransfer = requestedEmail !== ''
-
   const onFlowNameUpdate = useCallback(
     async (name: string) => {
       await updateFlow({
@@ -109,18 +104,12 @@ export default function EditorLayout() {
           input: {
             id: flowId,
             active,
-          },
-        },
-        optimisticResponse: {
-          updateFlowStatus: {
-            __typename: 'Flow',
-            id: flow?.id,
-            active,
+            updatedAt: flow?.updatedAt,
           },
         },
       })
     },
-    [flow?.id, flowId, updateFlowStatus],
+    [flow?.updatedAt, flowId, updateFlowStatus],
   )
 
   const handleWarningClose = useCallback(() => {
@@ -153,18 +142,6 @@ export default function EditorLayout() {
     shouldWarnOnPublish,
   ])
 
-  // disallow user from publishing pipe if any step is incomplete
-  const isFlowIncomplete = useMemo(
-    () =>
-      flow?.steps.length < 2 ||
-      flow?.steps.some((step) => step.status === 'incomplete') ||
-      // NOTE: toolbox apps should have action steps after them
-      // this is relevant in the for-each action where we use the EmptyFlowStepHeader
-      // instead of creating an empty step
-      flow?.steps[flow?.steps.length - 1].appKey === TOOLBOX_APP_KEY,
-    [flow?.steps],
-  )
-
   // warn user of unsaved changes when they try to close or reload the browser
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
@@ -191,8 +168,6 @@ export default function EditorLayout() {
     return <InvalidEditorPage />
   }
 
-  const isEditorReadOnly =
-    hasFlowTransfer || flow?.active || flow?.role === 'viewer'
   if (!flowId || !flow) {
     return null
   }
@@ -203,7 +178,12 @@ export default function EditorLayout() {
   const shouldOpenDemoModal = showDemo === 'true' && !!demoVideoDetails
 
   return (
-    <>
+    <EditorProvider
+      flow={flow}
+      shouldWarnOnLeave={shouldWarnOnLeave}
+      setShouldWarnOnLeave={setShouldWarnOnLeave}
+      resetFormRef={resetFormRef}
+    >
       <Helmet>
         <title>{flow?.name} | Pipe</title>
       </Helmet>
@@ -247,10 +227,6 @@ export default function EditorLayout() {
             </Flex>
           </Flex>
           <EditorToolbar
-            flowId={flowId}
-            flow={flow}
-            isFlowIncomplete={isFlowIncomplete}
-            hasFlowTransfer={hasFlowTransfer}
             loading={loading}
             shouldWarnOnLeave={shouldWarnOnLeave}
             setShouldWarnOnPublish={setShouldWarnOnPublish}
@@ -267,16 +243,8 @@ export default function EditorLayout() {
           flex={1}
           overflowY="auto"
         >
-          <EditorProvider
-            readOnly={isEditorReadOnly}
-            flow={flow}
-            shouldWarnOnLeave={shouldWarnOnLeave}
-            setShouldWarnOnLeave={setShouldWarnOnLeave}
-            resetFormRef={resetFormRef}
-          >
-            <Editor />
-            {flow.active && flow.config?.showSurvey && <LensSurvey />}
-          </EditorProvider>
+          <Editor />
+          {flow.active && flow.config?.showSurvey && <LensSurvey />}
         </Container>
       </Flex>
 
@@ -306,6 +274,6 @@ export default function EditorLayout() {
         onClose={handleWarningClose}
         onLeave={onDiscardChanges}
       />
-    </>
+    </EditorProvider>
   )
 }

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -36,7 +36,9 @@ export default function EditorLayout() {
   const { flowId } = useParams()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
-  const [updateFlow] = useMutation(UPDATE_FLOW)
+  const [updateFlow] = useMutation(UPDATE_FLOW, {
+    refetchQueries: [GET_FLOW], // need to refetch flow to get the latest updatedAt
+  })
   const [updateFlowStatus] = useMutation(UPDATE_FLOW_STATUS, {
     refetchQueries: [GET_FLOW],
   })

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -222,7 +222,7 @@ export default function EditorLayout() {
               <EditableInput
                 value={flow?.name}
                 onSave={onFlowNameUpdate}
-                readOnly={loading}
+                readOnly={loading || flow?.role === 'viewer'}
               />
             </Flex>
           </Flex>
@@ -244,7 +244,9 @@ export default function EditorLayout() {
           overflowY="auto"
         >
           <Editor />
-          {flow.active && flow.config?.showSurvey && <LensSurvey />}
+          {flow?.active &&
+            flow?.config?.showSurvey &&
+            flow?.role !== 'viewer' && <LensSurvey />}
         </Container>
       </Flex>
 

--- a/packages/frontend/src/components/EditorLayout/index.tsx
+++ b/packages/frontend/src/components/EditorLayout/index.tsx
@@ -182,13 +182,17 @@ export default function EditorLayout() {
   // navigate user to not found page if flow does not belong to the user
   if (
     error instanceof ApolloError &&
-    error?.graphQLErrors?.find((e) => e.message === 'NotFoundError')
+    error?.graphQLErrors?.find(
+      (e) =>
+        e.message === 'NotFoundError' ||
+        e.message === 'You do not have sufficient permissions for this pipe',
+    )
   ) {
     return <InvalidEditorPage />
   }
 
-  const isEditorReadOnly = hasFlowTransfer || flow?.active
-
+  const isEditorReadOnly =
+    hasFlowTransfer || flow?.active || flow?.role === 'viewer'
   if (!flowId || !flow) {
     return null
   }

--- a/packages/frontend/src/components/EditorSettings/EditorDrawer.tsx
+++ b/packages/frontend/src/components/EditorSettings/EditorDrawer.tsx
@@ -11,17 +11,17 @@ import {
 import { IconButton } from '@opengovsg/design-system-react'
 
 import EditorSidebar from './EditorSidebar'
-import { DrawerLink } from '.'
+import { GroupedDrawerLinks } from '.'
 
 interface EditorDrawerProps {
-  links: DrawerLink[]
+  groupedLinks: GroupedDrawerLinks[]
   isDrawerOpen: boolean
   openDrawer: () => void
   closeDrawer: () => void
 }
 
 export default function EditorDrawer(props: EditorDrawerProps) {
-  const { links, isDrawerOpen, openDrawer, closeDrawer } = props
+  const { groupedLinks, isDrawerOpen, openDrawer, closeDrawer } = props
 
   return (
     <>
@@ -48,7 +48,10 @@ export default function EditorDrawer(props: EditorDrawerProps) {
             color="base.content.strong"
           />
           <DrawerBody p={4}>
-            <EditorSidebar links={links} closeDrawer={closeDrawer} />
+            <EditorSidebar
+              groupedLinks={groupedLinks}
+              closeDrawer={closeDrawer}
+            />
           </DrawerBody>
         </DrawerContent>
       </Drawer>

--- a/packages/frontend/src/components/EditorSettings/EditorSidebar.tsx
+++ b/packages/frontend/src/components/EditorSettings/EditorSidebar.tsx
@@ -1,8 +1,9 @@
+import { Fragment } from 'react'
 import { Link, useMatch } from 'react-router-dom'
 import { Text } from '@chakra-ui/react'
 import { SidebarContainer, SidebarItem } from '@opengovsg/design-system-react'
 
-import { DrawerLink } from '.'
+import { DrawerLink, GroupedDrawerLinks } from '.'
 
 interface EditorSidebarItemProps {
   link: DrawerLink
@@ -10,7 +11,7 @@ interface EditorSidebarItemProps {
 }
 
 interface EditorSidebarProps {
-  links: DrawerLink[]
+  groupedLinks: GroupedDrawerLinks[]
   closeDrawer: () => void
 }
 
@@ -48,15 +49,23 @@ function EditorSidebarItem({
 }
 
 export default function EditorSidebar(props: EditorSidebarProps) {
-  const { links, closeDrawer } = props
+  const { groupedLinks, closeDrawer } = props
+
   return (
     <SidebarContainer>
-      {links.map((link, index) => (
-        <EditorSidebarItem
-          key={index}
-          link={link}
-          closeDrawer={closeDrawer}
-        ></EditorSidebarItem>
+      {groupedLinks.map(({ group, links }) => (
+        <Fragment key={group}>
+          <Text p={4} ml={2} textStyle="caption-3">
+            {group}
+          </Text>
+          {links.map((link, index) => (
+            <EditorSidebarItem
+              key={index}
+              link={link}
+              closeDrawer={closeDrawer}
+            />
+          ))}
+        </Fragment>
       ))}
     </SidebarContainer>
   )

--- a/packages/frontend/src/components/EditorSettings/FlowCollaborators.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowCollaborators.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useContext } from 'react'
+import { useMutation } from '@apollo/client'
+import { Divider, Flex, Text, VStack } from '@chakra-ui/react'
+import { useToast } from '@opengovsg/design-system-react'
+
+import { EditorSettingsContext } from '@/contexts/EditorSettings'
+import { UPSERT_FLOW_COLLABORATOR } from '@/graphql/mutations/upsert-flow-collaborator'
+import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
+
+import AddNewCollaborator from './FlowShare/AddNewCollaborator'
+import CollaboratorListRow from './FlowShare/CollaboratorListRow'
+import { editorSettingsStyles as styles } from './styles'
+
+export default function FlowCollaborators() {
+  const { flow, hasEditPermission } = useContext(EditorSettingsContext)
+  const [upsertCollaborator] = useMutation(UPSERT_FLOW_COLLABORATOR)
+
+  const toast = useToast({
+    status: 'success',
+    duration: 3000,
+    isClosable: true,
+  })
+
+  const collaborators = flow?.collaborators || []
+
+  const upsertCollaboratorHandler = useCallback(
+    async (email: string, role: string, update?: boolean) => {
+      await upsertCollaborator({
+        variables: { input: { flowId: flow.id, email, role } },
+        refetchQueries: [GET_FLOW_WITH_COLLABORATORS],
+        awaitRefetchQueries: false,
+        onCompleted: () =>
+          toast({
+            title: `Collaborator ${update ? 'updated' : 'added'}`,
+          }),
+      })
+    },
+    [upsertCollaborator, flow.id, toast],
+  )
+
+  return (
+    <Flex {...styles.editorSettingsWrapper}>
+      <Text textStyle="h3-semibold">Share Pipe</Text>
+      <VStack gap={2} alignItems="flex-start">
+        {hasEditPermission && (
+          <AddNewCollaborator flow={flow} onAdd={upsertCollaboratorHandler} />
+        )}
+        <VStack w="100%" divider={<Divider />}>
+          {collaborators.map((collab) => (
+            <CollaboratorListRow
+              key={collab.email}
+              collaborator={collab}
+              onRoleChange={(newRole) =>
+                upsertCollaboratorHandler(collab.email ?? '', newRole, true)
+              }
+            />
+          ))}
+        </VStack>
+      </VStack>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
@@ -1,0 +1,144 @@
+import { IFlow, IFlowCollabRole } from '@plumber/types'
+
+import { BaseSyntheticEvent, useCallback, useRef, useState } from 'react'
+import { FieldValues, useForm } from 'react-hook-form'
+import {
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { Button, Input } from '@opengovsg/design-system-react'
+import * as yup from 'yup'
+
+import CollaboratorRoleSelect from '@/components/CollaboratorRoleSelect'
+import MenuAlertDialog from '@/components/MenuAlertDialog'
+
+import SharedConnections from './SharedConnections'
+
+const inputSchema = yup
+  .object({
+    email: yup
+      .string()
+      .email('Invalid email address')
+      .required('Email is required'),
+  })
+  .required()
+
+const AddNewCollaborator = ({
+  flow,
+  onAdd,
+}: {
+  flow: IFlow
+  onAdd: (email: string, role: string) => Promise<void>
+}) => {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const [role, setRole] = useState<IFlowCollabRole>('editor')
+  const [isAdding, setIsAdding] = useState(false)
+
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  const {
+    register,
+    formState: { isValid, isSubmitted, errors },
+    handleSubmit,
+    getValues,
+    resetField,
+  } = useForm({
+    resolver: yupResolver(inputSchema),
+  })
+
+  const onSubmit = useCallback(
+    async (data: FieldValues, event?: BaseSyntheticEvent) => {
+      try {
+        event?.preventDefault()
+        const email = getValues('email')
+        if (role === 'editor') {
+          onOpen()
+        } else {
+          setIsAdding(true)
+          await onAdd(email, role)
+          resetField('email')
+          setIsAdding(false)
+        }
+      } catch (error) {
+        console.error(error)
+      }
+    },
+    [onAdd, onOpen, role, getValues, resetField],
+  )
+
+  const onConfirm = useCallback(async () => {
+    setIsAdding(true)
+    const email = getValues('email')
+    await onAdd(email, role)
+    resetField('email')
+    onClose()
+    setIsAdding(false)
+  }, [onAdd, getValues, role, onClose, resetField])
+
+  return (
+    <>
+      <form
+        style={{
+          width: '100%',
+        }}
+        onSubmit={handleSubmit(onSubmit)}
+      >
+        <FormControl isInvalid={isSubmitted && !isValid}>
+          <FormLabel>Add collaborator</FormLabel>
+          <VStack spacing={2} alignItems="flex-start">
+            <Flex alignSelf="stretch" gap={2}>
+              <Input type="email" isRequired {...register('email')} />
+              <CollaboratorRoleSelect
+                userRole={flow.role as IFlowCollabRole}
+                value={role}
+                onChange={setRole}
+                isEditable={true}
+                showOwnerOption={false}
+              />
+            </Flex>
+            {isSubmitted && errors?.email && (
+              <FormErrorMessage>
+                Please enter a valid email address.
+              </FormErrorMessage>
+            )}
+
+            {/* Connections appear if pipe is unpublished */}
+            {role === 'editor' && <SharedConnections />}
+
+            <Button
+              variant={role === 'owner' ? 'solid' : 'outline'}
+              colorScheme="red"
+              type="submit"
+              isLoading={isAdding}
+              isDisabled={!isValid}
+            >
+              Add collaborator
+            </Button>
+          </VStack>
+        </FormControl>
+      </form>
+
+      {/* dialog to warn user that connections will be shared with editors */}
+      <MenuAlertDialog
+        cancelRef={cancelRef}
+        isLoading={isAdding}
+        isDialogOpen={isOpen}
+        onDialogClose={onClose}
+        dialogType="share-connections"
+        dialogHeader="Share connections"
+        onClick={onConfirm}
+        customBody={`You are adding **${getValues('email')?.replace(
+          '@',
+          '@\u200B', // add zero-width space after @ to prevent email address rendering as an external link
+        )}** as an editor. They will have access to your connections and will be able to use them in this Pipe.`}
+      />
+    </>
+  )
+}
+
+export default AddNewCollaborator

--- a/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
@@ -116,11 +116,10 @@ const AddNewCollaborator = ({
             {role === 'editor' && <SharedConnections />}
 
             <Button
-              variant={role === 'owner' ? 'solid' : 'outline'}
-              colorScheme="red"
               type="submit"
               isLoading={isAdding}
               isDisabled={!isValid}
+              alignSelf="flex-end"
             >
               Add collaborator
             </Button>

--- a/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/AddNewCollaborator.tsx
@@ -72,12 +72,17 @@ const AddNewCollaborator = ({
   )
 
   const onConfirm = useCallback(async () => {
-    setIsAdding(true)
-    const email = getValues('email')
-    await onAdd(email, role)
-    resetField('email')
-    onClose()
-    setIsAdding(false)
+    try {
+      setIsAdding(true)
+      const email = getValues('email')
+      await onAdd(email, role)
+      resetField('email')
+    } catch (error) {
+      console.error(error)
+    } finally {
+      onClose()
+      setIsAdding(false)
+    }
   }, [onAdd, getValues, role, onClose, resetField])
 
   return (

--- a/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
@@ -1,0 +1,98 @@
+import { IFlowCollaborator, IFlowCollabRole } from '@plumber/types'
+
+import { useCallback, useContext, useState } from 'react'
+import { BiTrash } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import { Flex, Text } from '@chakra-ui/react'
+import { IconButton, Tag, useToast } from '@opengovsg/design-system-react'
+
+import CollaboratorRoleSelect from '@/components/CollaboratorRoleSelect'
+import { AuthenticationContext } from '@/contexts/Authentication'
+import { EditorSettingsContext } from '@/contexts/EditorSettings'
+import { DELETE_FLOW_COLLABORATOR } from '@/graphql/mutations/delete-flow-collaborator'
+import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
+
+const CollaboratorListRow = ({
+  collaborator,
+  onRoleChange,
+}: {
+  collaborator: IFlowCollaborator
+  onRoleChange: (role: IFlowCollabRole) => void
+}) => {
+  const { currentUser } = useContext(AuthenticationContext)
+  const { flow, hasEditPermission } = useContext(EditorSettingsContext)
+  const { email = '', role } = collaborator
+
+  const toast = useToast({
+    status: 'success',
+    duration: 3000,
+    isClosable: true,
+  })
+
+  const [deleteCollaborator] = useMutation(DELETE_FLOW_COLLABORATOR)
+
+  const [isDeleting, setIsDeleting] = useState(false)
+  const isOwner = role === 'owner'
+  const isSelf = email === currentUser?.email
+  const isEditable = hasEditPermission && !isOwner && !isSelf
+
+  const onDeleteHandler = useCallback(async () => {
+    setIsDeleting(true)
+    try {
+      await deleteCollaborator({
+        variables: {
+          input: { flowId: flow.id, email },
+        },
+        refetchQueries: [GET_FLOW_WITH_COLLABORATORS],
+        awaitRefetchQueries: false,
+        onCompleted: () =>
+          toast({
+            title: 'Collaborator deleted',
+            description: `Access for ${email} has been removed`,
+          }),
+      })
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [deleteCollaborator, email, flow.id, toast])
+
+  if (!flow.role) {
+    return null
+  }
+
+  return (
+    <Flex alignItems="center" w="100%" py={1} px={4}>
+      <Text flex={1}>
+        {collaborator.email}{' '}
+        {isSelf && (
+          <Tag colorScheme="secondary" size="sm" ml={2} pointerEvents="none">
+            You
+          </Tag>
+        )}
+      </Text>
+      <Flex w={44}>
+        <CollaboratorRoleSelect
+          userRole={flow.role as IFlowCollabRole}
+          value={collaborator.role}
+          onChange={onRoleChange}
+          variant="clear"
+          isEditable={isEditable}
+          // changing owner must be done via pipe transfer
+          showOwnerOption={false}
+        />
+        {isEditable && (
+          <IconButton
+            colorScheme="critical"
+            onClick={onDeleteHandler}
+            aria-label={'remove collaborator'}
+            variant="clear"
+            isLoading={isDeleting}
+            icon={<BiTrash />}
+          />
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+export default CollaboratorListRow

--- a/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/CollaboratorListRow.tsx
@@ -61,7 +61,7 @@ const CollaboratorListRow = ({
   }
 
   return (
-    <Flex alignItems="center" w="100%" py={1} px={4}>
+    <Flex alignItems="center" w="100%" py={1}>
       <Text flex={1}>
         {collaborator.email}{' '}
         {isSelf && (

--- a/packages/frontend/src/components/EditorSettings/FlowShare/SharedConnections.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowShare/SharedConnections.tsx
@@ -1,0 +1,88 @@
+import { ITransferDetails } from '@plumber/types'
+
+import { useContext, useState } from 'react'
+import { useQuery } from '@apollo/client'
+import { Box, Center, Flex, Link, Stack, Text } from '@chakra-ui/react'
+import { Badge, Infobox } from '@opengovsg/design-system-react'
+
+import PrimarySpinner from '@/components/PrimarySpinner'
+import { EditorSettingsContext } from '@/contexts/EditorSettings'
+import { GET_FLOW_TRANSFER_DETAILS } from '@/graphql/queries/get-flow-transfer-details'
+
+export default function SharedConnections() {
+  const { flow } = useContext(EditorSettingsContext)
+  const [showConnections, setShowConnections] = useState(false)
+  const { data, loading } = useQuery(GET_FLOW_TRANSFER_DETAILS, {
+    variables: {
+      flowId: flow.id,
+    },
+  })
+  const flowTransferDetails: ITransferDetails[] =
+    data?.getFlowTransferDetails || []
+
+  // NOTE: we group connections by app name to display them in a list
+  // this is different from pipe transfer, where we display each connection individually
+  const groupedConnections = flowTransferDetails?.reduce((acc, curr) => {
+    if (curr.connectionName) {
+      if (!acc[curr.appName]) {
+        acc[curr.appName] = new Set()
+      }
+      acc[curr.appName].add(curr.connectionName)
+    }
+    return acc
+  }, {} as Record<string, Set<string>>)
+
+  if (loading) {
+    return (
+      <Center>
+        <PrimarySpinner margin="auto" fontSize="4xl" />
+      </Center>
+    )
+  }
+
+  // hide infobox if no connections exist
+  if (!loading && flowTransferDetails.length === 0) {
+    return <></>
+  }
+
+  return (
+    <Infobox variant="info" borderRadius="md" w="100%">
+      <Flex flexDir="column" gap={2}>
+        <Text textStyle="subhead-1">
+          Editors will have access to these connections. They will only be able
+          to use them in this pipe.{' '}
+        </Text>
+        <Text
+          textStyle="body-1"
+          color="base.content.default"
+          as={Link}
+          onClick={() => setShowConnections(!showConnections)}
+        >
+          {showConnections ? 'Hide connections' : 'Show connections'}
+        </Text>
+        {showConnections && (
+          <Box>
+            <Stack gap={2}>
+              {Object.entries(groupedConnections).map(
+                ([appName, connections], index) => (
+                  <Flex flexDir="column" gap={2} key={index}>
+                    <Badge colorScheme="info">{appName}</Badge>
+                    {Array.from(connections)?.map((connection) => {
+                      return (
+                        <Flex flexDir="column" gap={2} key={connection}>
+                          <Text textStyle="body-1" color="base.content.default">
+                            {connection}
+                          </Text>
+                        </Flex>
+                      )
+                    })}
+                  </Flex>
+                ),
+              )}
+            </Stack>
+          </Box>
+        )}
+      </Flex>
+    </Infobox>
+  )
+}

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer.tsx
@@ -7,6 +7,7 @@ import {
   FormErrorMessage,
   FormLabel,
   Input,
+  TouchableTooltip,
 } from '@opengovsg/design-system-react'
 import * as yup from 'yup'
 
@@ -16,6 +17,7 @@ import DisallowRequestInfobox from './FlowTransfer/DisallowRequestInfobox'
 import FlowTransferConnections from './FlowTransfer/FlowTransferConnections'
 import PublishedFlowInfobox from './FlowTransfer/PublishedFlowInfobox'
 import TransferFlowModal from './FlowTransfer/TransferFlowModal'
+import { editorSettingsStyles as styles } from './styles'
 
 const inputSchema = yup
   .object({
@@ -56,17 +58,11 @@ export default function FlowTransfer() {
 
   // boolean values to indicate whether infoboxes and button can be enabled
   const hasRequestedEmail = requestedEmail !== ''
-  const shouldDisableInput = flow.active || hasRequestedEmail
+  const shouldDisableInput =
+    flow.active || hasRequestedEmail || flow.role !== 'owner'
 
   return (
-    <Flex
-      py={{ base: '2rem', md: '3rem' }}
-      px={{ base: '1.5rem', md: '5rem' }}
-      flexDir="column"
-      gap={10}
-      maxW={{ base: '100%', xl: '60vw' }}
-      flex={1}
-    >
+    <Flex {...styles.editorSettingsWrapper}>
       <Text textStyle="h3-semibold">Transfer Pipe</Text>
 
       {flow.active && <PublishedFlowInfobox />}
@@ -80,17 +76,25 @@ export default function FlowTransfer() {
         <FormControl isInvalid={!shouldDisableInput && !isValid}>
           <Flex flexDir="column">
             <FormLabel isRequired={true}>Transfer Pipe Ownership</FormLabel>
-            <Input
-              disabled={shouldDisableInput}
-              placeholder={inputDescriptionText}
-              value={newOwnerEmail}
-              autoFocus={true}
-              {...register('email', {
-                onChange: (event) => {
-                  setNewOwnerEmail(event.target.value.toLowerCase())
-                },
-              })}
-            />
+            <TouchableTooltip
+              label={
+                flow.role !== 'owner'
+                  ? 'Only the Pipe owner can transfer ownership'
+                  : ''
+              }
+            >
+              <Input
+                disabled={shouldDisableInput}
+                placeholder={inputDescriptionText}
+                value={newOwnerEmail}
+                autoFocus={true}
+                {...register('email', {
+                  onChange: (event) => {
+                    setNewOwnerEmail(event.target.value.toLowerCase())
+                  },
+                })}
+              />
+            </TouchableTooltip>
 
             {isDirty && !isValid && (
               <FormErrorMessage>

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
@@ -5,7 +5,7 @@ import { Button, Infobox, useToast } from '@opengovsg/design-system-react'
 
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { UPDATE_FLOW_TRANSFER_STATUS } from '@/graphql/mutations/update-flow-transfer-status'
-import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
 
 export default function DisallowRequestInfobox() {
   const { flow } = useContext(EditorSettingsContext)
@@ -23,7 +23,7 @@ export default function DisallowRequestInfobox() {
           status: 'cancelled',
         },
       },
-      refetchQueries: [GET_FLOW],
+      refetchQueries: [GET_FLOW_WITH_COLLABORATORS],
       onCompleted: () => {
         toast({
           title:

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/DisallowRequestInfobox.tsx
@@ -55,6 +55,7 @@ export default function DisallowRequestInfobox() {
           onClick={onFlowTransferStatusUpdate}
           variant="clear"
           colorScheme="secondary"
+          isDisabled={flow.role !== 'owner'}
         >
           Cancel
         </Button>

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
@@ -1,8 +1,8 @@
 import { ITransferDetails } from '@plumber/types'
 
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { useQuery } from '@apollo/client'
-import { Center, Flex, Text } from '@chakra-ui/react'
+import { Box, Center, Flex, Link, Text } from '@chakra-ui/react'
 import { Badge, Infobox } from '@opengovsg/design-system-react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
@@ -11,6 +11,7 @@ import { GET_FLOW_TRANSFER_DETAILS } from '@/graphql/queries/get-flow-transfer-d
 
 function StepConnectionDisplay(props: ITransferDetails) {
   const { appName, position, connectionName, instructions } = props
+
   return (
     <Flex flexDir="column" gap={2}>
       <Badge colorScheme="warning">
@@ -28,6 +29,7 @@ function StepConnectionDisplay(props: ITransferDetails) {
 
 export default function FlowTransferConnections() {
   const { flow } = useContext(EditorSettingsContext)
+  const [showConnections, setShowConnections] = useState(false)
   // phase 1: just retrieve all transfer details to display (without instructions)
   const { data, loading } = useQuery(GET_FLOW_TRANSFER_DETAILS, {
     variables: {
@@ -51,22 +53,33 @@ export default function FlowTransferConnections() {
 
   return (
     <Infobox variant="warning">
-      <Flex flexDir="column" gap={6}>
+      <Flex flexDir="column" gap={2}>
         <Text textStyle="subhead-1">
           You will need to manually add the following connections on the new
           pipe owner&apos;s account for the pipe to continue working.
         </Text>
-
-        {flowTransferDetails.map(
-          ({ appName, position, connectionName, instructions }, index) => (
-            <StepConnectionDisplay
-              key={index}
-              appName={appName}
-              position={position}
-              connectionName={connectionName}
-              instructions={instructions}
-            />
-          ),
+        <Text
+          textStyle="body-1"
+          color="base.content.default"
+          as={Link}
+          onClick={() => setShowConnections(!showConnections)}
+        >
+          {showConnections ? 'Hide connections' : 'Show connections'}
+        </Text>
+        {showConnections && (
+          <Box>
+            {flowTransferDetails.map(
+              ({ appName, position, connectionName, instructions }, index) => (
+                <StepConnectionDisplay
+                  key={index}
+                  appName={appName}
+                  position={position}
+                  connectionName={connectionName}
+                  instructions={instructions}
+                />
+              ),
+            )}
+          </Box>
         )}
       </Flex>
     </Infobox>

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/PublishedFlowInfobox.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/PublishedFlowInfobox.tsx
@@ -17,18 +17,12 @@ export default function PublishedFlowInfobox() {
           input: {
             id: flow.id,
             active,
-          },
-        },
-        optimisticResponse: {
-          updateFlowStatus: {
-            __typename: 'Flow',
-            id: flow.id,
-            active,
+            updatedAt: flow.updatedAt,
           },
         },
       })
     },
-    [flow.id, updateFlowStatus],
+    [flow.id, flow.updatedAt, updateFlowStatus],
   )
 
   return (

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/TransferFlowModal.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/TransferFlowModal.tsx
@@ -14,7 +14,7 @@ import { Button, useToast } from '@opengovsg/design-system-react'
 
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { CREATE_FLOW_TRANSFER } from '@/graphql/mutations/create-flow-transfer'
-import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
 
 interface TransferFlowModalProps {
   onClose: () => void
@@ -36,7 +36,7 @@ export default function TransferFlowModal(props: TransferFlowModalProps) {
           newOwnerEmail,
         },
       },
-      refetchQueries: [GET_FLOW],
+      refetchQueries: [GET_FLOW_WITH_COLLABORATORS],
       onError: () => {
         onClose()
       },

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -1,14 +1,24 @@
-import { useCallback, useContext, useMemo, useState } from 'react'
-import { useMutation } from '@apollo/client'
-import { Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
-import { Menu, useToast } from '@opengovsg/design-system-react'
+import { NotificationRecipients } from '@plumber/types'
 
+import { useCallback, useContext } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { useMutation } from '@apollo/client'
+import { Flex, FormControl, Skeleton, Stack, Text } from '@chakra-ui/react'
+import { Button, Checkbox, useToast } from '@opengovsg/design-system-react'
+
+import Form from '@/components/Form'
+import { SingleSelect } from '@/components/SingleSelect'
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { UPDATE_FLOW_CONFIG } from '@/graphql/mutations/update-flow-config'
 
 enum Frequency {
   Once = 'once_per_day',
   Always = 'always',
+}
+
+enum Recipient {
+  Editor = 'editor',
+  Viewer = 'viewer',
 }
 
 const frequencyOptions = [
@@ -22,24 +32,110 @@ const frequencyOptions = [
   },
 ]
 
+const recipientOptions = [
+  {
+    label: 'editor(s)',
+    value: 'editor',
+  },
+  {
+    label: 'viewer(s)',
+    value: 'viewer',
+  },
+]
+
+const DEFAULT_RECIPIENTS: NotificationRecipients[] = []
+
 const DEFAULT_FREQUENCY = Frequency.Once
+
+function NotificationFormFields() {
+  const { flow } = useContext(EditorSettingsContext)
+  // NOTE: check is for greater than 1 because collaborators includes the owner
+  const hasCollaborators =
+    flow?.collaborators?.length && flow?.collaborators?.length > 1
+  const isReadOnly = flow?.role === 'viewer'
+
+  const {
+    control,
+    register,
+    formState: { isDirty },
+  } = useFormContext()
+
+  return (
+    <Stack gap={2}>
+      <Text textStyle="subhead-1">Frequency</Text>
+      <FormControl key="frequency">
+        <Skeleton isLoaded={!!flow}>
+          <Controller
+            name="frequency"
+            control={control}
+            render={({ field: { onChange, value, name } }) => (
+              <SingleSelect
+                items={frequencyOptions}
+                isSearchable={false}
+                onChange={onChange}
+                value={value}
+                name={name}
+                isClearable={false}
+                colorScheme="secondary"
+                isDisabled={isReadOnly}
+              />
+            )}
+          />
+        </Skeleton>
+      </FormControl>
+      {hasCollaborators && (
+        <Stack gap={0}>
+          <Text textStyle="subhead-1">Collaborators</Text>
+          {recipientOptions.map((recipient) => (
+            <FormControl key={recipient.value}>
+              <Checkbox {...register(recipient.value)} isDisabled={isReadOnly}>
+                Notify {recipient.label}
+              </Checkbox>
+            </FormControl>
+          ))}
+        </Stack>
+      )}
+      <Button
+        size="sm"
+        w="fit-content"
+        type="submit"
+        isDisabled={!isDirty || isReadOnly}
+        alignSelf="flex-end"
+      >
+        {isDirty ? 'Save' : 'Saved'}
+      </Button>
+    </Stack>
+  )
+}
 
 export default function Notifications() {
   const { flow } = useContext(EditorSettingsContext)
 
   const frequency =
     flow?.config?.errorConfig?.notificationFrequency ?? DEFAULT_FREQUENCY
+  const notificationRecipients =
+    flow?.config?.errorConfig?.notificationRecipients ?? DEFAULT_RECIPIENTS
+
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const toast = useToast()
-  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+
+  const defaultValues = {
+    frequency,
+    editor: notificationRecipients.includes(Recipient.Editor),
+    viewer: notificationRecipients.includes(Recipient.Viewer),
+  }
 
   const onFlowConfigUpdate = useCallback(
-    async (frequency: Frequency) => {
+    async (
+      frequency: Frequency,
+      notificationRecipients: NotificationRecipients[],
+    ) => {
       await updateFlowConfig({
         variables: {
           input: {
             id: flow.id,
             notificationFrequency: frequency,
+            notificationRecipients,
           },
         },
         optimisticResponse: {
@@ -49,18 +145,15 @@ export default function Notifications() {
             config: {
               errorConfig: {
                 notificationFrequency: frequency,
+                notificationRecipients,
               },
             },
           },
         },
       })
 
-      const displayLabel = frequencyOptions
-        .find((option) => option.value === frequency)
-        ?.label.toLowerCase()
-
       toast({
-        title: `You will now receive an email notification for ${displayLabel}`,
+        title: `Notifications settings saved!`,
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -68,21 +161,6 @@ export default function Notifications() {
       })
     },
     [flow.id, updateFlowConfig, toast],
-  )
-
-  const handleClick = useCallback(
-    (frequencyOption: Frequency) => {
-      // only update flow config if a different option is selected
-      if (frequencyOption !== frequency) {
-        onFlowConfigUpdate(frequencyOption)
-      }
-    },
-    [onFlowConfigUpdate, frequency],
-  )
-
-  const frequencyLabel = useMemo(
-    () => frequencyOptions.find((option) => option.value === frequency)?.label,
-    [frequency],
   )
 
   return (
@@ -103,42 +181,22 @@ export default function Notifications() {
         </Text>
       </Stack>
       <Stack>
-        <Text textStyle="subhead-1">Frequency</Text>
-        <Menu isStretch>
-          <Menu.Button variant="outline" colorScheme="secondary">
-            <Skeleton isLoaded={!!flow}>
-              <Text
-                textStyle="body-1"
-                color="base.content.default"
-                whiteSpace="nowrap"
-                overflow="hidden"
-                textOverflow="ellipsis"
-              >
-                {frequencyLabel}
-              </Text>
-            </Skeleton>
-          </Menu.Button>
-          <Menu.List>
-            {frequencyOptions.map((option, index) => (
-              <Menu.Item
-                key={index}
-                onClick={() => handleClick(option.value)}
-                onMouseEnter={() => setHoveredIndex(index)}
-                onMouseLeave={() => setHoveredIndex(null)}
-                sx={{
-                  bg:
-                    hoveredIndex === index ||
-                    (hoveredIndex === null && option.label === frequencyLabel)
-                      ? 'interaction.tinted.main.hover'
-                      : 'transparent',
-                  color: 'base.content.default',
-                }}
-              >
-                {option.label}
-              </Menu.Item>
-            ))}
-          </Menu.List>
-        </Menu>
+        <Form
+          defaultValues={defaultValues}
+          onSubmit={(data) => {
+            const newNotificationRecipients = [
+              ...(data.editor ? [Recipient.Editor] : []),
+              ...(data.viewer ? [Recipient.Viewer] : []),
+            ]
+
+            onFlowConfigUpdate(
+              data.frequency as Frequency,
+              newNotificationRecipients,
+            )
+          }}
+        >
+          <NotificationFormFields />
+        </Form>
       </Stack>
     </Flex>
   )

--- a/packages/frontend/src/components/EditorSettings/index.tsx
+++ b/packages/frontend/src/components/EditorSettings/index.tsx
@@ -1,6 +1,6 @@
 import { IFlow } from '@plumber/types'
 
-import { ElementType, ReactNode, useMemo, useState } from 'react'
+import { ElementType, ReactNode, useContext, useMemo, useState } from 'react'
 import { BiMailSend, BiTransfer, BiUserPlus } from 'react-icons/bi'
 import { useParams } from 'react-router-dom'
 import { ApolloError, useQuery } from '@apollo/client'
@@ -16,6 +16,7 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import RedirectToLogin from '@/components/RedirectToLogin'
 import * as URLS from '@/config/urls'
 import { EditorSettingsProvider } from '@/contexts/EditorSettings'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
 import useAuthentication from '@/hooks/useAuthentication'
 import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
@@ -46,6 +47,10 @@ export default function EditorSettingsLayout(
 
   const { currentUser } = useAuthentication()
 
+  // TODO: remove this once we open collaborators to all users
+  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
+  const showCollaborators = !isFlagsLoading && flags?.collaborators
+
   const { flowId } = useParams()
   const { data, loading, error } = useQuery(GET_FLOW_WITH_COLLABORATORS, {
     variables: { id: flowId },
@@ -60,7 +65,7 @@ export default function EditorSettingsLayout(
         {
           group: 'Manage Access',
           links: [
-            {
+            showCollaborators && {
               Icon: BiUserPlus,
               text: 'Collaborators',
               to: URLS.FLOW_EDITOR_SHARE(flowId),
@@ -72,7 +77,7 @@ export default function EditorSettingsLayout(
               to: URLS.FLOW_EDITOR_TRANSFERS(flowId),
               group: 'Manage Access' as const,
             },
-          ],
+          ].filter(Boolean),
         },
         {
           group: 'Notifications',
@@ -89,7 +94,7 @@ export default function EditorSettingsLayout(
       () => setDrawerOpen(true),
       () => setDrawerOpen(false),
     ],
-    [flowId, setDrawerOpen],
+    [flowId, setDrawerOpen, showCollaborators],
   )
 
   const drawerComponent = useBreakpointValue({

--- a/packages/frontend/src/components/EditorSettings/index.tsx
+++ b/packages/frontend/src/components/EditorSettings/index.tsx
@@ -48,8 +48,8 @@ export default function EditorSettingsLayout(
   const { currentUser } = useAuthentication()
 
   // TODO: remove this once we open collaborators to all users
-  const { flags, isLoading: isFlagsLoading } = useContext(LaunchDarklyContext)
-  const showCollaborators = !isFlagsLoading && flags?.collaborators
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const showCollaborators = getFlagValue('collaborators', false)
 
   const { flowId } = useParams()
   const { data, loading, error } = useQuery(GET_FLOW_WITH_COLLABORATORS, {

--- a/packages/frontend/src/components/EditorSettings/index.tsx
+++ b/packages/frontend/src/components/EditorSettings/index.tsx
@@ -1,7 +1,7 @@
 import { IFlow } from '@plumber/types'
 
 import { ElementType, ReactNode, useMemo, useState } from 'react'
-import { BiMailSend, BiTransfer } from 'react-icons/bi'
+import { BiMailSend, BiTransfer, BiUserPlus } from 'react-icons/bi'
 import { useParams } from 'react-router-dom'
 import { ApolloError, useQuery } from '@apollo/client'
 import {
@@ -16,7 +16,7 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import RedirectToLogin from '@/components/RedirectToLogin'
 import * as URLS from '@/config/urls'
 import { EditorSettingsProvider } from '@/contexts/EditorSettings'
-import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { GET_FLOW_WITH_COLLABORATORS } from '@/graphql/queries/get-flow'
 import useAuthentication from '@/hooks/useAuthentication'
 import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
 
@@ -28,6 +28,11 @@ export type DrawerLink = {
   Icon: ElementType
   text: string
   to: string
+}
+
+export type GroupedDrawerLinks = {
+  group: string
+  links: DrawerLink[]
 }
 
 export interface EditorSettingsLayoutProps {
@@ -42,7 +47,7 @@ export default function EditorSettingsLayout(
   const { currentUser } = useAuthentication()
 
   const { flowId } = useParams()
-  const { data, loading, error } = useQuery(GET_FLOW, {
+  const { data, loading, error } = useQuery(GET_FLOW_WITH_COLLABORATORS, {
     variables: { id: flowId },
   })
   const flow: IFlow = data?.getFlow
@@ -53,14 +58,32 @@ export default function EditorSettingsLayout(
     () => [
       [
         {
-          Icon: BiMailSend,
-          text: 'Email notifications',
-          to: URLS.FLOW_EDITOR_NOTIFICATIONS(flowId),
+          group: 'Manage Access',
+          links: [
+            {
+              Icon: BiUserPlus,
+              text: 'Collaborators',
+              to: URLS.FLOW_EDITOR_SHARE(flowId),
+              group: 'Manage Access' as const,
+            },
+            {
+              Icon: BiTransfer,
+              text: 'Transfer Pipe',
+              to: URLS.FLOW_EDITOR_TRANSFERS(flowId),
+              group: 'Manage Access' as const,
+            },
+          ],
         },
         {
-          Icon: BiTransfer,
-          text: 'Transfer Pipe',
-          to: URLS.FLOW_EDITOR_TRANSFERS(flowId),
+          group: 'Notifications',
+          links: [
+            {
+              Icon: BiMailSend,
+              text: 'Email notifications',
+              to: URLS.FLOW_EDITOR_NOTIFICATIONS(flowId),
+              group: 'Notifications' as const,
+            },
+          ],
         },
       ],
       () => setDrawerOpen(true),
@@ -73,7 +96,7 @@ export default function EditorSettingsLayout(
     base: (
       <>
         <EditorDrawer
-          links={drawerLinks}
+          groupedLinks={drawerLinks}
           isDrawerOpen={isDrawerOpen}
           openDrawer={openDrawer}
           closeDrawer={closeDrawer}
@@ -83,7 +106,7 @@ export default function EditorSettingsLayout(
     ),
     md: (
       <>
-        <EditorSidebar links={drawerLinks} closeDrawer={closeDrawer} />
+        <EditorSidebar groupedLinks={drawerLinks} closeDrawer={closeDrawer} />
         <Divider
           orientation="vertical"
           borderColor="base.divider.medium"
@@ -116,7 +139,7 @@ export default function EditorSettingsLayout(
   }
 
   return (
-    <EditorSettingsProvider value={{ flow }}>
+    <EditorSettingsProvider flow={flow}>
       <VStack spacing={0} minH="100vh">
         <Navbar />
         <Flex w="full" flex={1} flexDir={{ base: 'column', md: 'row' }}>

--- a/packages/frontend/src/components/EditorSettings/styles.ts
+++ b/packages/frontend/src/components/EditorSettings/styles.ts
@@ -1,0 +1,12 @@
+import { FlexProps } from '@chakra-ui/react'
+
+export const editorSettingsStyles = {
+  editorSettingsWrapper: {
+    py: { base: '2rem', md: '3rem' },
+    px: { base: '1.5rem', md: '5rem' },
+    flexDir: 'column' as FlexProps['flexDir'],
+    gap: 10,
+    maxW: { base: '100%', xl: '60vw' },
+    flex: 1,
+  },
+}

--- a/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/EmptyFlowStepHeader/index.tsx
@@ -17,7 +17,8 @@ export default function EmptyFlowStepHeader(
   props: EmptyFlowStepHeaderProps,
 ): JSX.Element {
   const { isTrigger, onModalOpen, isNested } = props
-  const { isDrawerOpen, isMobile, isEmptyPipe } = useContext(EditorContext)
+  const { isDrawerOpen, isMobile, isEmptyPipe, readOnly } =
+    useContext(EditorContext)
 
   return (
     <Flex
@@ -30,16 +31,16 @@ export default function EmptyFlowStepHeader(
       h={isNested ? '48px' : '64px'}
       alignItems="center"
       gap={4}
-      onClick={onModalOpen}
+      onClick={() => !readOnly && onModalOpen()}
       _hover={{
         bg: 'interaction.muted.neutral.hover',
-        cursor: 'pointer',
+        cursor: readOnly ? 'not-allowed' : 'pointer',
       }}
       _active={{
         bg: 'interaction.muted.neutral.active',
       }}
       w={getFlowStepHeaderWidth(isDrawerOpen, isMobile, isNested)}
-      sx={isEmptyPipe && isTrigger ? pulsingBoxStyles : {}}
+      sx={isEmptyPipe && isTrigger && !readOnly ? pulsingBoxStyles : {}}
     >
       <Icon
         as={isTrigger ? BiSolidBolt : BiPlus}

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -53,7 +53,7 @@ export function useExecutionStepStatus({
     !isStepSuccessful &&
     !!jobId &&
     hasExecutionFailed &&
-    execution?.role !== 'viewer'
+    execution?.flow?.role !== 'viewer'
 
   const statusIcon = useMemo(() => {
     if (isPartialSuccess) {

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -49,7 +49,11 @@ export function useExecutionStepStatus({
   const isStepSuccessful = status === 'success'
   const hasExecutionFailed = execution?.status === 'failure'
   const isPartialSuccess = status === 'success' && hasError
-  const canRetry = !isStepSuccessful && !!jobId && hasExecutionFailed
+  const canRetry =
+    !isStepSuccessful &&
+    !!jobId &&
+    hasExecutionFailed &&
+    execution?.role !== 'viewer'
 
   const statusIcon = useMemo(() => {
     if (isPartialSuccess) {

--- a/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
+++ b/packages/frontend/src/components/FlowRow/FlowContextMenu.tsx
@@ -111,9 +111,10 @@ export default function FlowContextMenu(props: FlowContextMenuProps) {
           isClosable: true,
           position: 'top',
         })
+        onDialogClose()
       },
     })
-  }, [duplicateFlow, flow.id, toast])
+  }, [duplicateFlow, flow.id, toast, onDialogClose])
 
   const onDuplicateButtonClick = useCallback(
     (event: MouseEvent) => {

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -1,7 +1,7 @@
 import type { IFlow } from '@plumber/types'
 
 import { ReactElement } from 'react'
-import { BiChevronRight, BiSolidGroup } from 'react-icons/bi'
+import { BiChevronRight, BiGroup } from 'react-icons/bi'
 import { Link } from 'react-router-dom'
 import {
   Box,
@@ -53,7 +53,7 @@ function FlowRowTitle({
         >
           {flow?.name}
         </Text>
-        {isShared && <Icon boxSize={5} as={BiSolidGroup} />}
+        {isShared && <Icon boxSize={5} as={BiGroup} />}
       </Flex>
       {showTimestamp && (
         <Text

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -1,7 +1,7 @@
 import type { IFlow } from '@plumber/types'
 
 import { ReactElement } from 'react'
-import { BiChevronRight } from 'react-icons/bi'
+import { BiChevronRight, BiSolidGroup } from 'react-icons/bi'
 import { Link } from 'react-router-dom'
 import {
   Box,
@@ -14,7 +14,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react'
-import { Badge } from '@opengovsg/design-system-react'
+import { Badge, IconButton } from '@opengovsg/design-system-react'
 import { DateTime } from 'luxon'
 
 import FlowAppIcons from '@/components/FlowAppIcons'
@@ -27,12 +27,14 @@ type FlowRowProps = {
   isExecution?: boolean
   showMenu?: boolean
   showTimestamp?: boolean
+  isShared?: boolean
 }
 
 function FlowRowTitle({
   flow,
   showTimestamp,
-}: Pick<FlowRowProps, 'flow' | 'showTimestamp'>) {
+  isShared,
+}: Pick<FlowRowProps, 'flow' | 'showTimestamp' | 'isShared'>) {
   const createdAt = DateTime.fromMillis(parseInt(flow.createdAt, 10))
   const updatedAt = DateTime.fromMillis(parseInt(flow.updatedAt, 10))
   const isUpdated = updatedAt > createdAt
@@ -40,17 +42,19 @@ function FlowRowTitle({
   const relativeUpdatedAt = updatedAt.toRelative()
   return (
     <VStack alignItems="flex-start" justifyContent="center" maxW="100%">
-      <Text
-        whiteSpace="nowrap"
-        overflow="hidden"
-        textOverflow="ellipsis"
-        display="inline-block"
-        w="100%"
-        maxW="100%"
-        textStyle="subhead-1"
-      >
-        {flow?.name}
-      </Text>
+      <Flex alignItems="center" gap={2} w="100%">
+        <Text
+          whiteSpace="nowrap"
+          overflow="hidden"
+          textOverflow="ellipsis"
+          display="inline-block"
+          maxW="100%"
+          textStyle="subhead-1"
+        >
+          {flow?.name}
+        </Text>
+        {isShared && <Icon boxSize={5} as={BiSolidGroup} />}
+      </Flex>
       {showTimestamp && (
         <Text
           display="inline-block"
@@ -74,6 +78,11 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
     isExecution = false,
     showTimestamp = true,
   } = props
+
+  // NOTE: check is for greater than 1 because collaborators includes the owner
+  const isShared = !!(
+    flow?.collaborators?.length && flow?.collaborators?.length > 1
+  )
 
   return (
     <>
@@ -107,31 +116,43 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
             </HStack>
 
             <Box display={{ base: 'none', md: 'inline-flex' }} minWidth="0">
-              <FlowRowTitle flow={flow} showTimestamp={showTimestamp} />
+              <FlowRowTitle
+                flow={flow}
+                showTimestamp={showTimestamp}
+                isShared={isShared}
+              />
             </Box>
 
             <Spacer />
 
             <Flex alignItems="center" gap={1.5} justifyContent="flex-end">
+              {isShared && (
+                <Badge
+                  colorScheme="secondary"
+                  size="sm"
+                  variant="subtle"
+                  textTransform="capitalize"
+                >
+                  {flow.role}
+                </Badge>
+              )}
               <Badge
-                colorScheme={
-                  flow?.active && flow.role !== 'viewer' ? 'success' : 'grey'
-                }
+                colorScheme={flow?.active ? 'success' : 'grey'}
                 variant="subtle"
               >
-                <Text>
-                  {flow.role === 'viewer'
-                    ? 'View Only'
-                    : flow?.active
-                    ? 'Published'
-                    : 'Draft'}
-                </Text>
+                <Text>{flow?.active ? 'Published' : 'Draft'}</Text>
               </Badge>
 
               {showMenu ? (
                 <FlowContextMenu flow={flow} />
               ) : (
-                <Icon boxSize={5} as={BiChevronRight} />
+                <IconButton
+                  aria-label="View Flow"
+                  colorScheme="secondary"
+                  icon={<BiChevronRight />}
+                  variant="clear"
+                  _hover={{}}
+                />
               )}
             </Flex>
           </Flex>

--- a/packages/frontend/src/components/FlowRow/index.tsx
+++ b/packages/frontend/src/components/FlowRow/index.tsx
@@ -114,10 +114,18 @@ export default function FlowRow(props: FlowRowProps): ReactElement {
 
             <Flex alignItems="center" gap={1.5} justifyContent="flex-end">
               <Badge
-                colorScheme={flow?.active ? 'success' : 'grey'}
+                colorScheme={
+                  flow?.active && flow.role !== 'viewer' ? 'success' : 'grey'
+                }
                 variant="subtle"
               >
-                <Text>{flow?.active ? 'Published' : 'Draft'}</Text>
+                <Text>
+                  {flow.role === 'viewer'
+                    ? 'View Only'
+                    : flow?.active
+                    ? 'Published'
+                    : 'Draft'}
+                </Text>
               </Badge>
 
               {showMenu ? (

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -70,7 +70,12 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
     async (e) => {
       e.stopPropagation()
 
-      await deleteStep({ variables: { input: { ids: [step.id] } } })
+      const deletedStep = await deleteStep({
+        variables: {
+          input: { ids: [step.id], flow: { updatedAt: flow.updatedAt } },
+        },
+      })
+      const updatedFlow = deletedStep.data?.deleteStep
       const { previousStep, nextStep } = findAdjacentSteps(
         flow?.steps,
         step.position,
@@ -82,7 +87,10 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
           variables: {
             input: {
               previousStep: { id: previousStep?.id },
-              flow: { id: flow.id },
+              flow: {
+                id: flow.id,
+                updatedAt: updatedFlow?.updatedAt,
+              },
             },
           },
         })

--- a/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DuplicateStepButton.tsx
@@ -74,6 +74,7 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
       },
       flow: {
         id: flow.id,
+        updatedAt: flow.updatedAt,
       },
       appKey: step.appKey,
       key: step.key,
@@ -94,7 +95,7 @@ export default function DuplicateStepButton(props: DuplicateStepButtonProps) {
     const newStep = createdStep.data.createStep
     setCurrentStepId(newStep.id)
     onDrawerOpen()
-  }, [flow.id, step, createStep, setCurrentStepId, onDrawerOpen])
+  }, [flow, step, createStep, setCurrentStepId, onDrawerOpen])
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/AddConnection.tsx
@@ -11,6 +11,7 @@ import {
 
 import InputCreator from '@/components/InputCreator'
 import MarkdownRenderer from '@/components/MarkdownRenderer'
+import { EditorContext } from '@/contexts/Editor'
 import { processStep } from '@/helpers/authenticationSteps'
 import computeAuthStepVariables from '@/helpers/computeAuthStepVariables'
 import { getOpenerOrigin } from '@/helpers/window'
@@ -42,6 +43,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
   const { modalState, patchModalState } = useContext(
     FlowStepConfigurationContext,
   )
+  const { flowId } = useContext(EditorContext)
   const { selectedApp } = modalState
   const { name, authDocUrl, key, auth } = selectedApp || {}
 
@@ -129,6 +131,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
       const response: Response = {
         key,
         fields: data,
+        flowId,
       }
 
       let stepIndex = 0
@@ -157,7 +160,7 @@ export default function AddConnection(props: AddConnectionProps): JSX.Element {
 
       setInProgress(false)
     },
-    [key, steps, handleAddConnection],
+    [steps, key, flowId, handleAddConnection],
   )
 
   const onBack = () => patchModalState({ currentScreen: 'choose-connection' })

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
@@ -1,10 +1,11 @@
 import { type IApp } from '@plumber/types'
 
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 import { FormControl } from '@chakra-ui/react'
 import { FormLabel } from '@opengovsg/design-system-react'
 
 import { SingleSelect } from '@/components/SingleSelect'
+import { EditorContext } from '@/contexts/Editor'
 
 import { DEFAULT_ADD_CONNECTION_LABEL } from '../constants'
 
@@ -27,6 +28,7 @@ function ChooseConnectionDropdown({
   application,
   onAddNewConnection,
 }: ChooseConnectionDropdownProps) {
+  const { flow } = useContext(EditorContext)
   const onSelectionChange = useCallback(
     (value: string) => {
       onChange(value, false)
@@ -35,6 +37,8 @@ function ChooseConnectionDropdown({
   )
 
   const items = [...connectionOptions]
+  const canAddNew =
+    application?.auth?.connectionType === 'user-added' && flow.role === 'owner'
 
   return (
     <>
@@ -50,7 +54,7 @@ function ChooseConnectionDropdown({
           value={value || ''}
           onChange={onSelectionChange}
           addNew={
-            application?.auth?.connectionType === 'user-added'
+            canAddNew
               ? {
                   type: 'modal',
                   label:

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
@@ -36,9 +36,9 @@ function ChooseConnectionDropdown({
     [onChange],
   )
 
-  const items = [...connectionOptions]
   const canAddNew =
     application?.auth?.connectionType === 'user-added' && flow.role === 'owner'
+  const items = [...connectionOptions]
 
   return (
     <>

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -65,6 +65,7 @@ export default function ChooseAndAddConnection(
 ) {
   const { onClose } = props
   const {
+    flow,
     flowId,
     onCreateStep,
     onDrawerOpen,
@@ -82,7 +83,10 @@ export default function ChooseAndAddConnection(
     loading: appConnectionsLoading,
     refetch,
   } = useQuery(GET_APP_CONNECTIONS, {
-    variables: { key: selectedApp?.key },
+    variables: {
+      key: selectedApp?.key,
+      flowId: flow.role !== 'owner' ? flowId : undefined,
+    },
     skip: !selectedApp,
   })
 

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -57,6 +57,7 @@ export const optionGenerator = (
   return {
     label: screenName ?? 'Unnamed',
     value: connection?.id as string,
+    description: connection?.description ?? undefined,
   }
 }
 
@@ -85,7 +86,7 @@ export default function ChooseAndAddConnection(
   } = useQuery(GET_APP_CONNECTIONS, {
     variables: {
       key: selectedApp?.key,
-      flowId: flow.role !== 'owner' ? flowId : undefined,
+      flowId: flow.id,
     },
     skip: !selectedApp,
   })

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useConnectionRegistration.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useConnectionRegistration.ts
@@ -44,7 +44,8 @@ export function useConnectionVerification(
       const { data } = await testConnectionQuery({
         variables: {
           connectionId,
-          flowId: supportsConnectionRegistration ? flowId : undefined,
+          flowId,
+          supportsConnectionRegistration,
         },
       })
       return data?.testConnection

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -66,7 +66,9 @@ export default function Branch(props: BranchProps) {
   const deleteBranch = useCallback(async () => {
     const idsToDelete = branchSteps.map((step) => step.id)
     await deleteStep({
-      variables: { input: { ids: idsToDelete } },
+      variables: {
+        input: { ids: idsToDelete, flow: { updatedAt: flow.updatedAt } },
+      },
     })
 
     setCurrentStepId(null)
@@ -78,6 +80,7 @@ export default function Branch(props: BranchProps) {
     onDrawerClose,
     closeDeleteConfirmation,
     setCurrentStepId,
+    flow.updatedAt,
   ])
 
   const canAddStep = useMemo(() => allowAddStep(branchSteps), [branchSteps])

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
@@ -25,6 +25,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
 
   const { depth } = useContext(BranchContext)
   const {
+    flow,
     flowId,
     readOnly: isEditorReadOnly,
     setCurrentStepId,
@@ -60,6 +61,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           },
           flow: {
             id: flowId,
+            updatedAt: flow.updatedAt,
           },
           parameters: {
             depth,
@@ -79,6 +81,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           },
           flow: {
             id: flowId,
+            updatedAt: branchStep.data.createStep.flow.updatedAt,
           },
         },
       },
@@ -95,6 +98,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
     numBranches,
     onDrawerOpen,
     setCurrentStepId,
+    flow.updatedAt,
   ])
 
   return (

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -5,10 +5,8 @@ import { useMutation } from '@apollo/client'
 import { useDisclosure } from '@chakra-ui/react'
 
 import { EditorContext } from '@/contexts/Editor'
-import client from '@/graphql/client'
-import { CREATE_STEP } from '@/graphql/mutations/create-step'
+import { DUPLICATE_BRANCH } from '@/graphql/mutations/duplicate-branch'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 export default function useDuplicateBranch(branchSteps: IStep[]) {
   const {
@@ -21,7 +19,10 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
   const { flow, isDrawerOpen, onDrawerOpen, setCurrentStepId } =
     useContext(EditorContext)
 
-  const [createStep] = useMutation(CREATE_STEP, { fetchPolicy: 'no-cache' })
+  const [duplicateBranch] = useMutation(DUPLICATE_BRANCH, {
+    fetchPolicy: 'no-cache',
+    refetchQueries: [GET_FLOW],
+  })
 
   const canDuplicateBranch = useMemo(() => {
     return (
@@ -30,7 +31,7 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     )
   }, [branchSteps])
 
-  const duplicateBranch = async () => {
+  const onDuplicateBranch = async () => {
     closeDuplicateConfirmation()
 
     if (branchSteps.length < 2) {
@@ -40,48 +41,37 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     setIsDuplicatingBranch(true)
 
     try {
-      let newConditionId = null
-      let previousStepId = branchSteps[branchSteps.length - 1]?.id
+      const previousStepId = branchSteps[branchSteps.length - 1]?.id
       if (!previousStepId) {
         return
       }
-      // Create steps sequentially to avoid serialization conflicts
-      for (const step of branchSteps) {
-        const { appKey, key, connection, parameters } = step
-        const { branchName, ...restParameters } = parameters
 
-        // use a new branch name
-        const newBranchName = `[COPY] ${branchName}`
-
-        const mutationInput = {
-          previousStep: { id: previousStepId },
-          flow: { id: flow.id },
-          appKey,
-          key,
-          ...(connection && { connection: { id: connection.id } }),
-          parameters: {
-            ...restParameters,
-            ...(branchName && { branchName: newBranchName }),
-          },
-        }
-
-        const createdStep = await createStep({
-          fetchPolicy: 'no-cache',
-          variables: { input: mutationInput },
-        })
-
-        if (key === TOOLBOX_ACTIONS.IfThen) {
-          newConditionId = createdStep.data.createStep.id
-        }
-
-        // use the new step id as the previous step id for the next step
-        previousStepId = createdStep.data.createStep.id
+      const mutationInput = {
+        flow: { id: flow.id, updatedAt: flow.updatedAt },
+        previousStep: { id: previousStepId },
+        steps: branchSteps.map((step) => {
+          const { appKey, key, connection, parameters } = step
+          const { branchName, ...restParameters } = parameters
+          const newBranchName = `[COPY] ${branchName}`
+          return {
+            key,
+            appKey,
+            ...(connection && { connection: { id: connection.id } }),
+            parameters: {
+              ...restParameters,
+              ...(branchName && { branchName: newBranchName }),
+            },
+          }
+        }),
       }
 
-      // Refetch flow data only once after all steps are created
-      await client.refetchQueries({ include: [GET_FLOW] })
+      const duplicatedBranch = await duplicateBranch({
+        variables: { input: mutationInput },
+      })
 
-      setCurrentStepId(newConditionId)
+      const newSteps = duplicatedBranch.data.duplicateBranch.steps
+
+      setCurrentStepId(newSteps[0].id)
       if (!isDrawerOpen) {
         onDrawerOpen()
       }
@@ -101,7 +91,7 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
     duplicateConfirmationIsOpen,
     isDuplicatingBranch,
     closeDuplicateConfirmation,
-    duplicateBranch,
+    duplicateBranch: onDuplicateBranch,
     openDuplicateConfirmation,
   }
 }

--- a/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
+++ b/packages/frontend/src/components/FlowStepGroup/hooks/useDeleteStepConfirmation.ts
@@ -1,9 +1,10 @@
 import { IStep } from '@plumber/types'
 
-import { MouseEventHandler, useCallback, useRef } from 'react'
+import { MouseEventHandler, useCallback, useContext, useRef } from 'react'
 import { useMutation } from '@apollo/client'
 import { useDisclosure } from '@chakra-ui/react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
@@ -13,6 +14,7 @@ const useDeleteStepConfirmation = (
   groupedSteps: IStep[][],
   branchSteps?: IStep[],
 ) => {
+  const { flow } = useContext(EditorContext)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const cancelRef = useRef<HTMLButtonElement>(null)
 
@@ -29,6 +31,7 @@ const useDeleteStepConfirmation = (
   )
 
   const onDelete = useCallback(async () => {
+    const flowInput = { updatedAt: flow.updatedAt }
     if (type === TOOLBOX_ACTIONS.ForEach) {
       /**
        *  deleting the entire for-each deletes the entire for-each loop
@@ -37,16 +40,16 @@ const useDeleteStepConfirmation = (
       const flatSteps = groupedSteps.flat()
       const idsToDelete = flatSteps.map((step) => step.id)
       await deleteStep({
-        variables: { input: { ids: idsToDelete } },
+        variables: { input: { ids: idsToDelete, flow: flowInput } },
       })
     } else if (type === TOOLBOX_ACTIONS.IfThen && branchSteps) {
       const idsToDelete = branchSteps.map((step) => step.id)
       await deleteStep({
-        variables: { input: { ids: idsToDelete } },
+        variables: { input: { ids: idsToDelete, flow: flowInput } },
       })
     }
     onClose()
-  }, [branchSteps, deleteStep, groupedSteps, onClose, type])
+  }, [branchSteps, deleteStep, flow.updatedAt, groupedSteps, onClose, type])
 
   return {
     cancelRef,

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -3,7 +3,6 @@ import type { IAction, IStep, ISubstep, ITrigger } from '@plumber/types'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { Box, Stack, useDisclosure, usePrevious } from '@chakra-ui/react'
-import { useToast } from '@opengovsg/design-system-react'
 
 import FlowStepTestController from '@/components/FlowStepTestController'
 import InputCreator from '@/components/InputCreator'
@@ -39,7 +38,6 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
   } = useDisclosure()
 
   const { arguments: args } = substep
-  const toast = useToast()
   const [isSaving, setIsSaving] = useState(false)
   const [isValid, setIsValid] = useState<boolean>(
     validateSubstep(substep, formContext.getValues() as IStep),
@@ -108,20 +106,10 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      const result = await onUpdateStep(
-        {
-          ...currentStep,
-          status: isSubStepValid ? 'completed' : 'incomplete',
-        },
-        () => {
-          toast({
-            title: 'Step saved successfully!',
-            status: 'success',
-            duration: 2000,
-            isClosable: true,
-          })
-        },
-      )
+      const result = await onUpdateStep({
+        ...currentStep,
+        status: isSubStepValid ? 'completed' : 'incomplete',
+      })
 
       if (!result) {
         throw new Error('Failed to save step')
@@ -132,7 +120,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     } finally {
       setIsSaving(false)
     }
-  }, [formContext, onUpdateStep, substep, toast])
+  }, [formContext, onUpdateStep, substep])
 
   const handleSaveAndTest = useCallback(
     async (testRunMetadata?: Record<string, unknown>) => {

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -108,20 +108,24 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      const result = await onUpdateStep({
-        ...currentStep,
-        status: isSubStepValid ? 'completed' : 'incomplete',
-      })
+      const result = await onUpdateStep(
+        {
+          ...currentStep,
+          status: isSubStepValid ? 'completed' : 'incomplete',
+        },
+        () => {
+          toast({
+            title: 'Step saved successfully!',
+            status: 'success',
+            duration: 2000,
+            isClosable: true,
+          })
+        },
+      )
 
       if (!result) {
         throw new Error('Failed to save step')
       }
-      toast({
-        title: 'Step saved successfully!',
-        status: 'success',
-        duration: 2000,
-        isClosable: true,
-      })
     } catch (error) {
       console.error('Error saving step', error)
       throw error // Re-throw the error so calling functions know saveStep failed

--- a/packages/frontend/src/components/FlowSubstep/index.tsx
+++ b/packages/frontend/src/components/FlowSubstep/index.tsx
@@ -108,9 +108,19 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
       setIsSaving(true)
       const currentStep = formContext.getValues() as IStep
       const isSubStepValid = validateSubstep(substep, currentStep)
-      await onUpdateStep({
+      const result = await onUpdateStep({
         ...currentStep,
         status: isSubStepValid ? 'completed' : 'incomplete',
+      })
+
+      if (!result) {
+        throw new Error('Failed to save step')
+      }
+      toast({
+        title: 'Step saved successfully!',
+        status: 'success',
+        duration: 2000,
+        isClosable: true,
       })
     } catch (error) {
       console.error('Error saving step', error)
@@ -118,17 +128,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
     } finally {
       setIsSaving(false)
     }
-  }, [formContext, onUpdateStep, substep])
-
-  const handleSave = useCallback(async () => {
-    await saveStep()
-    toast({
-      title: 'Step saved successfully!',
-      status: 'success',
-      duration: 2000,
-      isClosable: true,
-    })
-  }, [saveStep, toast])
+  }, [formContext, onUpdateStep, substep, toast])
 
   const handleSaveAndTest = useCallback(
     async (testRunMetadata?: Record<string, unknown>) => {
@@ -164,7 +164,7 @@ function FlowSubstep(props: FlowSubstepProps): JSX.Element {
         isSaving={isSaving}
         isTestResultOpen={isTestResultOpen}
         step={step}
-        handleSave={handleSave}
+        handleSave={saveStep}
         handleSaveAndTest={handleSaveAndTest}
         onTestResultOpen={onTestResultOpen}
         onTestResultClose={onTestResultClose}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -56,10 +56,12 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
    * such as slack channels, telegram chats, and excel files
    */
   const { flow } = useContext(EditorContext)
-  const isNonEditableField = NON_EDITABLE_CONNECTION_FIELDS.some(
-    (item) => item.label === label && item.key === name,
-  )
-  const isReadOnly = readOnly || (flow?.role !== 'owner' && isNonEditableField)
+
+  const canCollaboratorAddNew =
+    !NON_EDITABLE_CONNECTION_FIELDS.find(
+      (item) => item.label === label && item.key === name,
+    ) && flow?.role === 'editor'
+  const isReadOnly = flow?.role !== 'owner' || readOnly
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(
@@ -117,7 +119,10 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
         addNewOption={
-          schema.addNewOption && !isReadOnly ? schema.addNewOption : undefined
+          schema.addNewOption &&
+          (flow.role === 'owner' || canCollaboratorAddNew)
+            ? schema.addNewOption
+            : undefined
         }
         clickableLink={schema.clickableLink}
         label={label}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -61,7 +61,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     !NON_EDITABLE_CONNECTION_FIELDS.find(
       (item) => item.label === label && item.key === name,
     ) && flow?.role === 'editor'
-  const isReadOnly = flow?.role !== 'owner' || readOnly
+  const isReadOnly =
+    // flow is an empty object if it is not in the editor
+    (Object.keys(flow).length > 0 && flow?.role !== 'owner') || readOnly
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -1,5 +1,7 @@
 import type { IField, IFieldDropdownOption } from '@plumber/types'
 
+import { useContext } from 'react'
+
 import AttachmentSuggestions from '@/components/AttachmentSuggestions'
 import ControlledAutocomplete from '@/components/ControlledAutocomplete'
 import DragDropInput from '@/components/DragDropInput'
@@ -7,8 +9,11 @@ import MultiRow from '@/components/MultiRow'
 import MultiSelect from '@/components/MultiSelect'
 import RichTextEditor from '@/components/RichTextEditor'
 import TextField from '@/components/TextField'
+import { EditorContext } from '@/contexts/Editor'
 import { useIsFieldHidden } from '@/helpers/isFieldHidden'
 import useDynamicData from '@/hooks/useDynamicData'
+
+import { NON_EDITABLE_CONNECTION_FIELDS } from '../Editor/constants'
 
 import BooleanRadio from './BooleanRadio'
 
@@ -45,6 +50,16 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     tooltipText,
     noVariablesMessage,
   } = schema
+
+  /**
+   * there are some fields that collaborators cannot edit
+   * such as slack channels, telegram chats, and excel files
+   */
+  const { flow } = useContext(EditorContext)
+  const isNonEditableField = NON_EDITABLE_CONNECTION_FIELDS.some(
+    (item) => item.label === label && item.key === name,
+  )
+  const isReadOnly = readOnly || (flow?.role !== 'owner' && isNonEditableField)
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(
@@ -101,7 +116,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         // if schema source is defined, dynamic data is supported
         onRefresh={schema.source ? () => refetch() : undefined}
         showOptionValue={schema.showOptionValue ?? true}
-        addNewOption={schema.addNewOption}
+        addNewOption={
+          schema.addNewOption && !isReadOnly ? schema.addNewOption : undefined
+        }
         clickableLink={schema.clickableLink}
         label={label}
         placeholder={placeholder}
@@ -151,7 +168,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         defaultValue={value}
         required={required}
         placeholder={placeholder}
-        readOnly={readOnly}
+        readOnly={isReadOnly}
         name={computedName}
         label={label}
         multiline={type === 'multiline'}

--- a/packages/frontend/src/components/MenuAlertDialog/index.tsx
+++ b/packages/frontend/src/components/MenuAlertDialog/index.tsx
@@ -11,7 +11,11 @@ import { Button } from '@opengovsg/design-system-react'
 
 import MarkdownRenderer from '../MarkdownRenderer'
 
-export type AlertDialogType = 'delete' | 'duplicate' | 'duplicate-branch'
+export type AlertDialogType =
+  | 'delete'
+  | 'duplicate'
+  | 'duplicate-branch'
+  | 'share-connections'
 export type AlertHeaderType =
   | 'Connection'
   | 'Pipe'
@@ -19,6 +23,7 @@ export type AlertHeaderType =
   | 'Step'
   | 'File'
   | 'Branch'
+  | 'Share connections'
 
 interface MenuAlertDialogProps {
   isDialogOpen: boolean
@@ -65,6 +70,14 @@ function getAlertDialogContent(
         header: `Duplicate ${dialogHeader}`,
         body: `Every step in this ${dialogHeader} will be duplicated. You will need to check each step again.`,
         buttonText: 'Duplicate',
+      }
+    case 'share-connections':
+      return {
+        header: 'Access to your connections',
+        body:
+          customBody ??
+          `The collaborator will have access to your connections.`,
+        buttonText: 'Yes, add editor',
       }
   }
 }

--- a/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
+++ b/packages/frontend/src/components/NewsDrawer/NewsItemList.ts
@@ -12,6 +12,17 @@ const IF_THEN_EXTERNAL_LINK =
 
 export const NEWS_ITEM_LIST: NewsItemProps[] = [
   {
+    date: '2025-11-21',
+    tag: NEW_FEATURE_TAG,
+    title: 'Collaborators — add editors and viewers to your pipes',
+    details: dedent`
+      With collaborators, you can add editors or viewers to help build or troubleshoot your pipe. Read more about permissions and set up [here](https://guide.plumber.gov.sg/user-guides/pipe-settings#collaborators).
+    `,
+    multimedia: {
+      url: 'https://file.go.gov.sg/plumber-collaborators-whats-new.png',
+    },
+  },
+  {
     date: '2025-09-22',
     tag: NEW_FEATURE_TAG,
     title: `For each item — automate reminders for events, tasks and more!`,

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -58,6 +58,8 @@ export const FLOW_EDITOR = (flowId?: string): string =>
   flowId ? `/editor/${flowId}` : FLOWS
 export const FLOW_EDITOR_NOTIFICATIONS = (flowId?: string): string =>
   flowId ? `/editor/${flowId}/notifications` : FLOWS
+export const FLOW_EDITOR_SHARE = (flowId?: string): string =>
+  flowId ? `/editor/${flowId}/share` : FLOWS
 export const FLOW_EDITOR_TRANSFERS = (flowId?: string): string =>
   flowId ? `/editor/${flowId}/transfer` : FLOWS
 

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -147,7 +147,9 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
     cache.writeQuery({
       query: GET_FLOW,
       variables: { id: flowId },
-      data: { getFlow: { ...flow, steps } },
+      data: {
+        getFlow: { ...flow, updatedAt: createdStep.flow.updatedAt, steps },
+      },
     })
   }
 }
@@ -233,12 +235,22 @@ export const EditorProvider = ({
       eventKey: string,
       connectionId?: string,
     ) => {
+      // NOTE: we read from the cache instead of the prop to get
+      // the updatedAt of the flow, which is updated by the createStep mutation.
+      // this is used to prevent users from updating the pipe when the steps are
+      // outdated.
+      const { getFlow: cachedFlow } = client.readQuery({
+        query: GET_FLOW,
+        variables: { id: flowId },
+      })
+
       const mutationInput = {
         previousStep: {
           id: previousStepId,
         },
         flow: {
           id: flowId,
+          updatedAt: cachedFlow.updatedAt,
         },
         appKey,
         key: eventKey,

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -119,7 +119,6 @@ type EditorProviderProps = {
  * Helper function to update the flow in the cache
  */
 function updateHandlerFactory(
-  flow: IFlow,
   flowId: string,
   previousStepId: string,
   mutationType: 'createStep' | 'updateStep' = 'createStep',
@@ -127,6 +126,15 @@ function updateHandlerFactory(
   return function stepUpdateHandler(cache: any, mutationResult: any) {
     const { data } = mutationResult
     const stepData = data[mutationType]
+
+    // read the flow from the cache to avoid stale data when creating or updating steps
+    // we read from the cache instead of firing a getFlow query on every update
+    // to reduce the UI flicker
+    // TODO (kevinkim-ogp): should just be able to use the flow from the context
+    const { getFlow: flow } = cache.readQuery({
+      query: GET_FLOW,
+      variables: { id: flowId },
+    })
 
     // getFlow requires certain attributes to be returned
     const completeStep = {
@@ -261,12 +269,7 @@ export const EditorProvider = ({
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(
-          flow,
-          flowId,
-          previousStepId,
-          'createStep',
-        ),
+        update: updateHandlerFactory(flowId, previousStepId, 'createStep'),
       })
 
       const newStep = createdStep.data.createStep
@@ -337,7 +340,7 @@ export const EditorProvider = ({
 
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
+        update: updateHandlerFactory(flowId, step.id, 'updateStep'),
         onCompleted: () => onCompleted?.(),
       })
 

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -72,6 +72,8 @@ interface IEditorContextValue {
   allApps: IApp[]
   resetForm: () => void
   resetTimestamp: number
+  isLoading: boolean
+  hasFlowTransfer: boolean
 }
 
 export const EditorContext = createContext<IEditorContextValue>({
@@ -101,11 +103,12 @@ export const EditorContext = createContext<IEditorContextValue>({
   allApps: [],
   resetForm: () => null,
   resetTimestamp: 0,
+  isLoading: true,
+  hasFlowTransfer: false,
 })
 
 type EditorProviderProps = {
   children: ReactNode
-  readOnly: boolean
   flow: IFlow
   shouldWarnOnLeave: boolean
   setShouldWarnOnLeave: (shouldWarnOnLeave: boolean) => void
@@ -158,7 +161,6 @@ function updateHandlerFactory(
 }
 
 export const EditorProvider = ({
-  readOnly,
   flow,
   shouldWarnOnLeave,
   setShouldWarnOnLeave,
@@ -166,6 +168,11 @@ export const EditorProvider = ({
   children,
 }: EditorProviderProps) => {
   const isMobile = useIsMobile()
+
+  // flow transfer phase 1: add check to prevent user from publishing pipe after submitting request
+  const requestedEmail = flow?.pendingTransfer?.newOwner.email ?? ''
+  const hasFlowTransfer = requestedEmail !== ''
+  const readOnly = hasFlowTransfer || flow?.active || flow?.role === 'viewer'
 
   const flowId = flow.id
   const [currentStepId, setCurrentStepId] = useState<string | null>(null)
@@ -185,14 +192,13 @@ export const EditorProvider = ({
     [getAppsData?.getApps],
   )
 
-  const { data } = useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
-    GET_TEST_EXECUTION_STEPS,
-    {
-      variables: {
-        flowId,
-      },
+  const { data, loading: isLoadingTestExecutionSteps } = useQuery<{
+    getTestExecutionSteps: IExecutionStep[]
+  }>(GET_TEST_EXECUTION_STEPS, {
+    variables: {
+      flowId,
     },
-  )
+  })
 
   const testExecutionSteps = useMemo(
     () => data?.getTestExecutionSteps ?? [],
@@ -226,9 +232,11 @@ export const EditorProvider = ({
    * CreateStep mutation
    */
 
-  const [createStep] = useMutation(CREATE_STEP, { refetchQueries: [GET_FLOW] })
+  const [createStep, { loading: isCreatingStep }] = useMutation(CREATE_STEP, {
+    refetchQueries: [GET_FLOW],
+  })
 
-  const [initializeIfThen] = useIfThenInitializer()
+  const [initializeIfThen, isInitializingIfThen] = useIfThenInitializer()
 
   // Add a step to the flow with the given appKey and eventKey
   const onCreateStep = useCallback(
@@ -300,7 +308,7 @@ export const EditorProvider = ({
   /**
    * UpdateStep mutation
    */
-  const [updateStep] = useMutation(UPDATE_STEP)
+  const [updateStep, { loading: isUpdatingStep }] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
     async (step: IStep, onCompleted?: () => void) => {
       const mutationInput: Record<string, unknown> = {
@@ -428,7 +436,7 @@ export const EditorProvider = ({
         flowId,
         currentTestExecutionStep,
         isTestExecuting,
-        readOnly: readOnly || flow.role === 'viewer',
+        readOnly,
         shouldWarnOnLeave,
         stepsWithVars,
         testExecutionSteps,
@@ -442,6 +450,13 @@ export const EditorProvider = ({
         setShouldWarnOnLeave,
         resetForm,
         resetTimestamp,
+        isLoading:
+          isLoadingAllApps ||
+          isLoadingTestExecutionSteps ||
+          isCreatingStep ||
+          isUpdatingStep ||
+          isInitializingIfThen,
+        hasFlowTransfer,
       }}
     >
       {children}

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -40,6 +40,7 @@ interface IEditorContextValue {
   readOnly: boolean
   testExecutionSteps: IExecutionStep[]
   currentStepId: string | null
+  hasEditPermission: boolean
   hasForEach: boolean
   hasIfThen: boolean
   currentTestExecutionStep: IExecutionStep | null
@@ -67,7 +68,7 @@ interface IEditorContextValue {
     eventKey: string,
     connectionId?: string,
   ) => Promise<IStep>
-  onUpdateStep: (step: IStep) => Promise<IStep>
+  onUpdateStep: (step: IStep, onCompleted?: () => void) => Promise<IStep>
   allApps: IApp[]
   resetForm: () => void
   resetTimestamp: number
@@ -77,6 +78,7 @@ export const EditorContext = createContext<IEditorContextValue>({
   flow: {} as IFlow,
   flowId: '',
   currentStepId: null,
+  hasEditPermission: false,
   hasForEach: false,
   hasIfThen: false,
   currentTestExecutionStep: null,
@@ -300,7 +302,7 @@ export const EditorProvider = ({
    */
   const [updateStep] = useMutation(UPDATE_STEP)
   const onUpdateStep = useCallback(
-    async (step: IStep) => {
+    async (step: IStep, onCompleted?: () => void) => {
       const mutationInput: Record<string, unknown> = {
         id: step.id,
         key: step.key,
@@ -328,6 +330,7 @@ export const EditorProvider = ({
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
         update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
+        onCompleted: () => onCompleted?.(),
       })
 
       return updatedStep.data?.updateStep as IStep
@@ -415,6 +418,7 @@ export const EditorProvider = ({
       value={{
         allApps,
         currentStepId,
+        hasEditPermission: flow.role === 'owner' || flow.role === 'editor',
         hasForEach,
         hasIfThen,
         isDrawerOpen,
@@ -424,7 +428,7 @@ export const EditorProvider = ({
         flowId,
         currentTestExecutionStep,
         isTestExecuting,
-        readOnly,
+        readOnly: readOnly || flow.role === 'viewer',
         shouldWarnOnLeave,
         stepsWithVars,
         testExecutionSteps,

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -113,18 +113,19 @@ type EditorProviderProps = {
 /**
  * Helper function to update the flow in the cache
  */
-function updateHandlerFactory(flowId: string, previousStepId: string) {
-  return function createStepUpdateHandler(cache: any, mutationResult: any) {
+function updateHandlerFactory(
+  flow: IFlow,
+  flowId: string,
+  previousStepId: string,
+  mutationType: 'createStep' | 'updateStep' = 'createStep',
+) {
+  return function stepUpdateHandler(cache: any, mutationResult: any) {
     const { data } = mutationResult
-    const { createStep: createdStep } = data
-    const { getFlow: flow } = cache.readQuery({
-      query: GET_FLOW,
-      variables: { id: flowId },
-    })
+    const stepData = data[mutationType]
 
     // getFlow requires certain attributes to be returned
-    const completeCreatedStep = {
-      ...createdStep,
+    const completeStep = {
+      ...stepData,
       iconUrl: null,
       webhookUrl: null,
       config: {
@@ -137,8 +138,8 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
     }
 
     const steps = flow.steps.reduce((steps: any[], currentStep: any) => {
-      if (currentStep.id === previousStepId) {
-        return [...steps, currentStep, completeCreatedStep]
+      if (mutationType === 'createStep' && currentStep.id === previousStepId) {
+        return [...steps, currentStep, completeStep]
       }
 
       return [...steps, currentStep]
@@ -148,7 +149,7 @@ function updateHandlerFactory(flowId: string, previousStepId: string) {
       query: GET_FLOW,
       variables: { id: flowId },
       data: {
-        getFlow: { ...flow, updatedAt: createdStep.flow.updatedAt, steps },
+        getFlow: { ...flow, updatedAt: stepData.flow.updatedAt, steps },
       },
     })
   }
@@ -235,22 +236,13 @@ export const EditorProvider = ({
       eventKey: string,
       connectionId?: string,
     ) => {
-      // NOTE: we read from the cache instead of the prop to get
-      // the updatedAt of the flow, which is updated by the createStep mutation.
-      // this is used to prevent users from updating the pipe when the steps are
-      // outdated.
-      const { getFlow: cachedFlow } = client.readQuery({
-        query: GET_FLOW,
-        variables: { id: flowId },
-      })
-
       const mutationInput = {
         previousStep: {
           id: previousStepId,
         },
         flow: {
           id: flowId,
-          updatedAt: cachedFlow.updatedAt,
+          updatedAt: flow.updatedAt,
         },
         appKey,
         key: eventKey,
@@ -259,7 +251,12 @@ export const EditorProvider = ({
 
       const createdStep = await createStep({
         variables: { input: mutationInput },
-        update: updateHandlerFactory(flowId, previousStepId),
+        update: updateHandlerFactory(
+          flow,
+          flowId,
+          previousStepId,
+          'createStep',
+        ),
       })
 
       const newStep = createdStep.data.createStep
@@ -281,6 +278,9 @@ export const EditorProvider = ({
           const completeStepWithFlow = {
             ...completeStep,
             flowId: flowId,
+            flow: {
+              updatedAt: newStep.flow.updatedAt,
+            },
           }
           if (eventKey === TOOLBOX_ACTIONS.IfThen) {
             return (await initializeIfThen(
@@ -292,7 +292,7 @@ export const EditorProvider = ({
 
       return newStep as IStep
     },
-    [createStep, flowId, initializeIfThen],
+    [createStep, flow, flowId, initializeIfThen],
   )
 
   /**
@@ -310,6 +310,7 @@ export const EditorProvider = ({
         },
         flow: {
           id: flowId,
+          updatedAt: flow.updatedAt,
         },
         config: {
           // NOTE: check for undefined to allow empty string, which defaults to the action/trigger name
@@ -326,11 +327,12 @@ export const EditorProvider = ({
 
       const updatedStep = await updateStep({
         variables: { input: mutationInput },
+        update: updateHandlerFactory(flow, flowId, step.id, 'updateStep'),
       })
 
       return updatedStep.data?.updateStep as IStep
     },
-    [updateStep, flowId],
+    [flow, flowId, updateStep],
   )
 
   /**

--- a/packages/frontend/src/contexts/EditorSettings.tsx
+++ b/packages/frontend/src/contexts/EditorSettings.tsx
@@ -4,23 +4,27 @@ import { createContext, ReactElement } from 'react'
 
 interface IEditorSettingsContext {
   flow: IFlow
+  hasEditPermission: boolean
 }
 
-export const EditorSettingsContext = createContext<IEditorSettingsContext>(
-  {} as IEditorSettingsContext,
-)
+export const EditorSettingsContext = createContext<IEditorSettingsContext>({
+  flow: {} as IFlow,
+  hasEditPermission: false,
+} as IEditorSettingsContext)
 
 type EditorSettingsProviderProps = {
   children: React.ReactNode
-  value: IEditorSettingsContext
+  flow: IFlow
 }
 
 export const EditorSettingsProvider = (
   props: EditorSettingsProviderProps,
 ): ReactElement => {
-  const { children, value } = props
+  const { children, flow } = props
+  const hasEditPermission = flow.role === 'owner' || flow.role === 'editor'
+
   return (
-    <EditorSettingsContext.Provider value={value}>
+    <EditorSettingsContext.Provider value={{ flow, hasEditPermission }}>
       {children}
     </EditorSettingsContext.Provider>
   )

--- a/packages/frontend/src/graphql/mutations/create-step.ts
+++ b/packages/frontend/src/graphql/mutations/create-step.ts
@@ -16,6 +16,9 @@ export const CREATE_STEP = gql`
       config {
         stepName
       }
+      flow {
+        updatedAt
+      }
     }
   }
 `

--- a/packages/frontend/src/graphql/mutations/delete-flow-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/delete-flow-collaborator.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const DELETE_FLOW_COLLABORATOR = graphql(`
+  mutation DeleteFlowCollaborator($input: DeleteFlowCollaboratorInput!) {
+    deleteFlowCollaborator(input: $input)
+  }
+`)

--- a/packages/frontend/src/graphql/mutations/delete-step.ts
+++ b/packages/frontend/src/graphql/mutations/delete-step.ts
@@ -4,6 +4,7 @@ export const DELETE_STEP = graphql(`
   mutation DeleteStep($input: DeleteStepInput) {
     deleteStep(input: $input) {
       id
+      updatedAt
       steps {
         id
       }

--- a/packages/frontend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/frontend/src/graphql/mutations/duplicate-branch.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client'
+
+export const DUPLICATE_BRANCH = gql`
+  mutation DuplicateBranch($input: DuplicateBranchInput) {
+    duplicateBranch(input: $input) {
+      flow {
+        updatedAt
+      }
+      steps {
+        id
+        type
+        key
+        appKey
+        parameters
+        position
+        status
+        connection {
+          id
+        }
+        config {
+          stepName
+        }
+      }
+    }
+  }
+`

--- a/packages/frontend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/frontend/src/graphql/mutations/update-flow-config.ts
@@ -7,6 +7,7 @@ export const UPDATE_FLOW_CONFIG = gql`
       config {
         errorConfig {
           notificationFrequency
+          notificationRecipients
         }
       }
     }

--- a/packages/frontend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/frontend/src/graphql/mutations/update-flow-status.ts
@@ -5,6 +5,7 @@ export const UPDATE_FLOW_STATUS = gql`
     updateFlowStatus(input: $input) {
       id
       active
+      updatedAt
     }
   }
 `

--- a/packages/frontend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/frontend/src/graphql/mutations/update-step-positions.ts
@@ -3,8 +3,11 @@ import { graphql } from '@/graphql/__generated__'
 export const UPDATE_STEP_POSITIONS = graphql(`
   mutation UpdateStepPositions($input: UpdateStepPositionsInput!) {
     updateStepPositions(input: $input) {
-      id
-      position
+      updatedAt
+      steps {
+        id
+        position
+      }
     }
   }
 `)

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -20,6 +20,9 @@ export const UPDATE_STEP = graphql(`
           appEventKey
         }
       }
+      flow {
+        updatedAt
+      }
     }
   }
 `)

--- a/packages/frontend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/frontend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const UPSERT_FLOW_COLLABORATOR = graphql(`
+  mutation UpsertFlowCollaborator($input: FlowCollaboratorInput!) {
+    upsertFlowCollaborator(input: $input)
+  }
+`)

--- a/packages/frontend/src/graphql/queries/get-app-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-app-connections.ts
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const GET_APP_CONNECTIONS = gql`
-  query GetAppConnections($key: String!) {
-    getApp(key: $key) {
+  query GetAppConnections($key: String!, $flowId: String) {
+    getApp(key: $key, flowId: $flowId) {
       key
       connections {
         id

--- a/packages/frontend/src/graphql/queries/get-app-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-app-connections.ts
@@ -13,6 +13,7 @@ export const GET_APP_CONNECTIONS = gql`
           screenName
           env
         }
+        description
         createdAt
       }
     }

--- a/packages/frontend/src/graphql/queries/get-app.ts
+++ b/packages/frontend/src/graphql/queries/get-app.ts
@@ -56,27 +56,6 @@ export const GET_APP = gql`
           }
         }
       }
-      connections {
-        id
-      }
-      triggers {
-        name
-        key
-        type
-        pollInterval
-        description
-        substeps {
-          name
-        }
-      }
-      actions {
-        name
-        key
-        description
-        substeps {
-          name
-        }
-      }
     }
   }
 `

--- a/packages/frontend/src/graphql/queries/get-execution.ts
+++ b/packages/frontend/src/graphql/queries/get-execution.ts
@@ -11,6 +11,7 @@ export const GET_EXECUTION = gql`
         id
         name
         active
+        role
       }
       status
       role

--- a/packages/frontend/src/graphql/queries/get-execution.ts
+++ b/packages/frontend/src/graphql/queries/get-execution.ts
@@ -13,6 +13,7 @@ export const GET_EXECUTION = gql`
         active
       }
       status
+      role
     }
   }
 `

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -1,69 +1,90 @@
 import { gql } from '@apollo/client'
 
-export const GET_FLOW = gql`
-  query GetFlow($id: String!) {
-    getFlow(id: $id) {
+export const FLOW_FIELDS = gql`
+  fragment DefaultFlowFields on Flow {
+    id
+    name
+    active
+    steps {
       id
-      name
-      active
-      steps {
+      type
+      key
+      appKey
+      iconUrl
+      webhookUrl
+      status
+      position
+      createdAt
+      connection {
         id
-        type
-        key
-        appKey
-        iconUrl
-        webhookUrl
-        status
-        position
+        verified
         createdAt
-        connection {
-          id
-          verified
-          createdAt
-          formattedData {
-            screenName
-            env
-          }
-        }
-        parameters
-        config {
-          stepName
-          templateConfig {
-            appEventKey
-          }
+        formattedData {
+          screenName
+          env
         }
       }
+      parameters
       config {
-        errorConfig {
-          notificationFrequency
-        }
+        stepName
         templateConfig {
-          templateId
-          formId
-          tileId
-        }
-        showSurvey
-        attachments {
-          name
-          displayedValue
-          value
-          size
-          updatedAt
-        }
-      }
-      pendingTransfer {
-        id
-        newOwner {
-          id
-          email
-        }
-      }
-      template {
-        demoVideoDetails {
-          url
-          title
+          appEventKey
         }
       }
     }
+    config {
+      errorConfig {
+        notificationFrequency
+      }
+      templateConfig {
+        templateId
+        formId
+        tileId
+      }
+      showSurvey
+      attachments {
+        name
+        displayedValue
+        value
+        size
+        updatedAt
+      }
+    }
+    pendingTransfer {
+      id
+      newOwner {
+        id
+        email
+      }
+    }
+    template {
+      demoVideoDetails {
+        url
+        title
+      }
+    }
+    role
   }
+`
+
+export const GET_FLOW = gql`
+  query GetFlow($id: String!) {
+    getFlow(id: $id) {
+      ...DefaultFlowFields
+    }
+  }
+  ${FLOW_FIELDS}
+`
+
+export const GET_FLOW_WITH_COLLABORATORS = gql`
+  query GetFlowWithCollaborators($id: String!) {
+    getFlow(id: $id) {
+      ...DefaultFlowFields
+      collaborators {
+        email
+        role
+      }
+    }
+  }
+  ${FLOW_FIELDS}
 `

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -36,6 +36,7 @@ export const FLOW_FIELDS = gql`
     config {
       errorConfig {
         notificationFrequency
+        notificationRecipients
       }
       templateConfig {
         templateId

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -5,6 +5,7 @@ export const FLOW_FIELDS = gql`
     id
     name
     active
+    updatedAt
     steps {
       id
       type

--- a/packages/frontend/src/graphql/queries/get-flows.ts
+++ b/packages/frontend/src/graphql/queries/get-flows.ts
@@ -32,6 +32,7 @@ export const GET_FLOWS = gql`
           pendingTransfer {
             id
           }
+          role
         }
       }
     }

--- a/packages/frontend/src/graphql/queries/get-flows.ts
+++ b/packages/frontend/src/graphql/queries/get-flows.ts
@@ -29,6 +29,10 @@ export const GET_FLOWS = gql`
           steps {
             iconUrl
           }
+          collaborators {
+            email
+            role
+          }
           pendingTransfer {
             id
           }

--- a/packages/frontend/src/graphql/queries/test-connection.ts
+++ b/packages/frontend/src/graphql/queries/test-connection.ts
@@ -1,8 +1,16 @@
 import { gql } from '@apollo/client'
 
 export const TEST_CONNECTION = gql`
-  query TestConnection($connectionId: String!, $flowId: String) {
-    testConnection(connectionId: $connectionId, flowId: $flowId) {
+  query TestConnection(
+    $connectionId: String!
+    $flowId: String
+    $supportsConnectionRegistration: Boolean
+  ) {
+    testConnection(
+      connectionId: $connectionId
+      flowId: $flowId
+      supportsConnectionRegistration: $supportsConnectionRegistration
+    ) {
       connectionVerified
       registrationVerified
       message

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -159,6 +159,7 @@ export function useIfThenInitializer(): [
             key: TOOLBOX_ACTIONS.IfThen,
             flow: {
               id: currStep.flowId,
+              updatedAt: currStep.flow.updatedAt,
             },
             parameters: {
               branchName: 'Branch 1',
@@ -170,6 +171,7 @@ export function useIfThenInitializer(): [
           },
         },
       })
+      const updatedFirstBranch = updateFirstBranch?.data?.updateStep
       const createSecondBranch = await createStep({
         variables: {
           input: {
@@ -180,6 +182,7 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: updatedFirstBranch?.flow?.updatedAt,
             },
             parameters: {
               depth,
@@ -188,6 +191,7 @@ export function useIfThenInitializer(): [
           },
         },
       })
+      const createdSecondBranch = createSecondBranch?.data?.createStep
       const [_firstBranch, secondBranch] = await Promise.all([
         updateFirstBranch,
         createSecondBranch,
@@ -199,7 +203,7 @@ export function useIfThenInitializer(): [
       //
       // FIXME (ogp-weeloong): Intentionally serial; need to fix createSteps to
       // enable concurrent updates on same pipe.
-      await createStep({
+      const createFirstStep = await createStep({
         variables: {
           input: {
             previousStep: {
@@ -207,10 +211,12 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: createdSecondBranch.flow.updatedAt,
             },
           },
         },
       })
+      const createdFirstStep = createFirstStep?.data?.createStep
       await createStep({
         variables: {
           input: {
@@ -219,6 +225,7 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
+              updatedAt: createdFirstStep?.flow?.updatedAt,
             },
           },
         },

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -2,7 +2,6 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 import { useMutation } from '@apollo/client'
-import { useToast } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
@@ -16,7 +15,6 @@ interface StepPositionInput {
 }
 
 const useReorderSteps = (flowId: string) => {
-  const toast = useToast()
   const { flow } = useContext(EditorContext)
   const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
@@ -74,21 +72,6 @@ const useReorderSteps = (flowId: string) => {
               },
             })
           }
-        },
-        onError: (error) => {
-          toast({
-            title: 'Failed to reorder steps',
-            description: 'Your changes have been reverted. Please try again.',
-            status: 'error',
-            duration: 5000,
-            isClosable: true,
-            position: 'top',
-          })
-          console.error(
-            'Error updating step positions: ',
-            error,
-            JSON.stringify(stepPositions),
-          )
         },
       })
     } catch (error) {

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -1,8 +1,10 @@
 import { IStep } from '@plumber/types'
 
+import { useContext } from 'react'
 import { useMutation } from '@apollo/client'
 import { useToast } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
@@ -15,18 +17,26 @@ interface StepPositionInput {
 
 const useReorderSteps = (flowId: string) => {
   const toast = useToast()
-  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS)
+  const { flow } = useContext(EditorContext)
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    refetchQueries: [GET_FLOW],
+  })
 
   const handleReorderUpdate = async (stepPositions: StepPositionInput[]) => {
     try {
       await updateStepPositions({
-        variables: { input: { stepPositions } },
+        variables: {
+          input: { stepPositions, flow: { updatedAt: flow.updatedAt } },
+        },
         optimisticResponse: {
-          updateStepPositions: stepPositions.map((sp) => ({
-            id: sp.id,
-            position: sp.position,
-            __typename: 'Step' as const,
-          })),
+          updateStepPositions: {
+            updatedAt: flow.updatedAt,
+            steps: stepPositions.map((sp) => ({
+              id: sp.id,
+              position: sp.position,
+              __typename: 'Step' as const,
+            })),
+          },
         },
         update: (cache: any) => {
           // Update the cache with the new step positions optimistically

--- a/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
+++ b/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
@@ -35,7 +35,10 @@ export default function InvalidEditorPage() {
             textAlign={{ base: 'center', md: 'left' }}
             fontWeight="normal"
           >
-            Pipe not found, you may have transferred it to someone else 🤔
+            Pipe not found.
+            <br />
+            It might have been transferred to someone else, or you may no longer
+            have access. 🤔
           </Text>
           <Link
             textStyle="h6"

--- a/packages/frontend/src/pages/Editor/routes.tsx
+++ b/packages/frontend/src/pages/Editor/routes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Route, Routes } from 'react-router-dom'
 
 import EditorSettingsLayout from '@/components/EditorSettings'
+import FlowCollaborators from '@/components/EditorSettings/FlowCollaborators'
 import FlowTransfer from '@/components/EditorSettings/FlowTransfer'
 import Notifications from '@/components/EditorSettings/Notifications'
 
@@ -17,6 +18,14 @@ export default function EditorRoutes(): React.ReactElement {
         element={
           <EditorSettingsLayout>
             <Notifications />
+          </EditorSettingsLayout>
+        }
+      />
+      <Route
+        path="/:flowId/share"
+        element={
+          <EditorSettingsLayout>
+            <FlowCollaborators />
           </EditorSettingsLayout>
         }
       />

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -66,7 +66,7 @@ function FlowsList({
   return (
     <Box>
       {flows.map((flow) => (
-        <FlowRow key={flow.id} flow={flow} />
+        <FlowRow key={flow.id} flow={flow} showMenu={flow.role !== 'viewer'} />
       ))}
     </Box>
   )

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -66,7 +66,7 @@ function FlowsList({
   return (
     <Box>
       {flows.map((flow) => (
-        <FlowRow key={flow.id} flow={flow} showMenu={flow.role !== 'viewer'} />
+        <FlowRow key={flow.id} flow={flow} showMenu={flow.role === 'owner'} />
       ))}
     </Box>
   )

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -163,6 +163,7 @@ export interface IExecution {
   executionSteps: IExecutionStep[]
   updatedAt: string
   createdAt: string
+  role?: IFlowCollabRole
 }
 
 export interface IStepConfig {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -233,6 +233,7 @@ export type IFlowCollabRole = 'owner' | 'editor' | 'viewer'
 export interface IFlowCollaborator {
   email?: string // Populated by GraphQL resolver
   role: IFlowCollabRole
+  user?: IUser
 }
 
 export interface IFlow {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -211,8 +211,10 @@ export interface IFlowConfig {
   attachments?: IFlowAttachmentsConfig[]
 }
 
+export type NotificationRecipients = 'editor' | 'viewer'
 export interface IFlowErrorConfig {
   notificationFrequency: 'once_per_day' | 'always'
+  notificationRecipients: NotificationRecipients[]
 }
 
 export interface IFlowTemplateConfig {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -164,7 +164,6 @@ export interface IExecution {
   executionSteps: IExecutionStep[]
   updatedAt: string
   createdAt: string
-  role?: IFlowCollabRole
 }
 
 export interface IStepConfig {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -47,6 +47,7 @@ export interface IConnection {
   flowCount?: number
   appData?: IApp
   createdAt: string
+  description?: string
 }
 
 /**

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -248,6 +248,8 @@ export interface IFlow {
   config: IFlowConfig | null
   pendingTransfer?: IFlowTransfer
   template?: ITemplate
+  collaborators?: IFlowCollaborator[]
+  role?: string
 }
 
 export interface IUser {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -228,6 +228,13 @@ export interface IFlowAttachmentsConfig {
   updatedAt: string
 }
 
+export type IFlowCollabRole = 'owner' | 'editor' | 'viewer'
+
+export interface IFlowCollaborator {
+  email?: string // Populated by GraphQL resolver
+  role: IFlowCollabRole
+}
+
 export interface IFlow {
   id: string
   name: string


### PR DESCRIPTION
[COLLAB-1]: Create flow_collaborators table, model, resolvers
[COLLAB-2]: Create flow_connections table, model
[COLLAB-3]: Add mutations to upsert and delete collaborators 
[COLLAB-4]: Automatically add connections when adding collaborator
[COLLAB-5]: Manage collaborators via UI 
[COLLAB-6]: Collaborators can view Pipes 
[COLLAB-7]: Owner creates Step with connection, Editor can create Step
[COLLAB-8]: Owner update Step connection, Editor can save Step 
[COLLAB-9]: Restrict UI based on role
[COLLAB-10]: Editors can edit, save, and check step
[COLLAB-11]: Editors can publish and unpublish
[COLLAB-12]: Editors can delete step 
[COLLAB-13]: Editor can change to shared connections
[COLLAB-14]: Editor add step with shared connection
[COLLAB-14.1]: Editor can duplicate and reorder step
[COLLAB-15]: Collaborators can view executions
[COLLAB-16]: Editor can retry failed execution 
[COLLAB-17]: Add feature flag
[COLLAB-18]: Pipe transfer
[COLLAB-19]: Refactor role to flow model
[COLLAB-20]: fix duplicate branch
[COLLAB-21]: Bug bash fixes
[COLLAB-22]: Error emails for collaborators
[COLLAB-23]: Verify Tiles permissions on role change or pipe transfer
chore: fixes and news item