### PR TITLE
hotfix: old pipes dont have notificationRecipients

### DIFF
--- a/packages/backend/src/graphql/custom-resolvers/flow.ts
+++ b/packages/backend/src/graphql/custom-resolvers/flow.ts
@@ -3,7 +3,10 @@ import sortBy from 'lodash/sortBy'
 import { TEMPLATES } from '@/db/storage'
 import FlowCollaborator from '@/models/flow-collaborators'
 
-import type { Resolvers } from '../__generated__/types.generated'
+import type {
+  FlowErrorConfigResolvers,
+  Resolvers,
+} from '../__generated__/types.generated'
 
 type FlowResolver = Resolvers['Flow']
 
@@ -44,6 +47,20 @@ const collaborators: FlowResolver['collaborators'] = async (parent) => {
 const role: FlowResolver['role'] = async (parent) => {
   // Return the computed role from the query
   return (parent as any)?.role || 'viewer'
+}
+
+// in collaborators, we introduced the concept of notificationRecipients,
+// which is an array that may contain 'editor' and/or 'viewer'.
+// however, there may be existing flows that already have errorConfig.notificationFrequency
+// and when returning, may not contain this `notificationRecipients` field
+// to avoid gql errors, we force it to return an empty array
+const notificationRecipients: FlowErrorConfigResolvers['notificationRecipients'] =
+  (parent) => {
+    return parent?.notificationRecipients ?? []
+  }
+
+export const FlowErrorConfig: FlowErrorConfigResolvers = {
+  notificationRecipients,
 }
 
 export default {

--- a/packages/backend/src/graphql/custom-resolvers/index.ts
+++ b/packages/backend/src/graphql/custom-resolvers/index.ts
@@ -1,5 +1,5 @@
 import ExecutionStep from './execution-step'
-import Flow from './flow'
+import Flow, { FlowErrorConfig } from './flow'
 import FlowCollaborator from './flow-collaborator'
 import TableMetadata from './table-metadata'
 
@@ -14,4 +14,10 @@ import TableMetadata from './table-metadata'
  * schema.gql-to-typescript.ts.
  */
 
-export default { ExecutionStep, TableMetadata, Flow, FlowCollaborator }
+export default {
+  ExecutionStep,
+  TableMetadata,
+  Flow,
+  FlowCollaborator,
+  FlowErrorConfig,
+}

--- a/packages/frontend/src/components/EditorSettings/Notifications.tsx
+++ b/packages/frontend/src/components/EditorSettings/Notifications.tsx
@@ -1,6 +1,6 @@
 import { NotificationRecipients } from '@plumber/types'
 
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { useMutation } from '@apollo/client'
 import { Flex, FormControl, Skeleton, Stack, Text } from '@chakra-ui/react'
@@ -119,11 +119,14 @@ export default function Notifications() {
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const toast = useToast()
 
-  const defaultValues = {
-    frequency,
-    editor: notificationRecipients.includes(Recipient.Editor),
-    viewer: notificationRecipients.includes(Recipient.Viewer),
-  }
+  const defaultValues = useMemo(
+    () => ({
+      frequency,
+      editor: notificationRecipients.includes(Recipient.Editor),
+      viewer: notificationRecipients.includes(Recipient.Viewer),
+    }),
+    [frequency, notificationRecipients],
+  )
 
   const onFlowConfigUpdate = useCallback(
     async (


### PR DESCRIPTION
## Problem
In collaborators, added the `notificationRecipients` to store whether to send editors/viewers error notifications.
Error is thrown for old pipes that contain `notificationFrequency` configured, and they do not have `notificationRecipients`, since the GraphQL expects both to be not null when an `errorConfig` is present.


## Solution
Add a custom resolver to add an empty array if it is not present in `errorConfig`

## How to test?
1. Find a pipe that already has the notification frequency changed, it should open properly.
2. Otherwise, set the `errorConfig.notificationFrequency` directly in the DB, should expect no error.