### PR TITLE
[COLLAB-CON-1]: getFlowConnections query

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/get-flow-connections.test.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-flow-connections.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import getFlowConnections from '@/graphql/queries/get-flow-connections'
+import type Context from '@/types/express/context'
+
+vi.mock('@/models/app', () => ({
+  default: {
+    findAll: vi.fn(() => [
+      { key: 'slack', name: 'Slack', iconUrl: 'https://example.com/slack.png' },
+      {
+        key: 'telegram-bot',
+        name: 'Telegram',
+        iconUrl: 'https://example.com/telegram.png',
+      },
+      {
+        key: 'tiles',
+        name: 'Tables',
+        iconUrl: 'https://example.com/tiles.png',
+      },
+    ]),
+  },
+}))
+
+const mockFlowConnectionsQuery = vi.fn()
+
+vi.mock('@/models/flow-connections', () => ({
+  default: {
+    query: () => mockFlowConnectionsQuery(),
+  },
+}))
+
+const mockFlow = {
+  id: 'flow-123',
+  role: 'editor',
+}
+
+const context = {
+  currentUser: {
+    withAccessibleFlows: vi.fn().mockReturnValue({
+      findById: vi.fn().mockReturnValue(mockFlow),
+    }),
+  },
+} as unknown as Context
+
+describe('getFlowConnections', () => {
+  it('should use connection screenName and app key for regular connections', async () => {
+    mockFlowConnectionsQuery.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      withGraphFetched: vi.fn().mockResolvedValue([
+        {
+          flowId: 'flow-123',
+          connectionId: 'conn-456',
+          connectionType: 'connection',
+          connection: {
+            key: 'slack',
+            formattedData: {
+              screenName: 'My Slack Workspace',
+            },
+          },
+          user: { email: 'owner@open.gov.sg' },
+        },
+      ]),
+    })
+
+    const result = await getFlowConnections({}, { flowId: 'flow-123' }, context)
+
+    expect(result).toEqual([
+      {
+        flowId: 'flow-123',
+        connectionId: 'conn-456',
+        connectionType: 'connection',
+        addedBy: 'owner@open.gov.sg',
+        appName: 'Slack',
+        appIconUrl: 'https://example.com/slack.png',
+        connectionName: 'My Slack Workspace',
+      },
+    ])
+  })
+
+  it('should use table name and "tiles" as appKey for table connections', async () => {
+    mockFlowConnectionsQuery.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      withGraphFetched: vi.fn().mockResolvedValue([
+        {
+          flowId: 'flow-123',
+          connectionId: 'table-789',
+          connectionType: 'table',
+          table: {
+            name: 'My Customer Table',
+          },
+          user: { email: 'owner@open.gov.sg' },
+        },
+      ]),
+    })
+
+    const result = await getFlowConnections({}, { flowId: 'flow-123' }, context)
+
+    expect(result).toEqual([
+      {
+        flowId: 'flow-123',
+        connectionId: 'table-789',
+        connectionType: 'table',
+        addedBy: 'owner@open.gov.sg',
+        appName: 'Tables',
+        appIconUrl: 'https://example.com/tiles.png',
+        connectionName: 'My Customer Table',
+      },
+    ])
+  })
+
+  it('should handle mixed connection types correctly', async () => {
+    mockFlowConnectionsQuery.mockReturnValue({
+      where: vi.fn().mockReturnThis(),
+      withGraphFetched: vi.fn().mockResolvedValue([
+        {
+          flowId: 'flow-123',
+          connectionId: 'conn-456',
+          connectionType: 'connection',
+          connection: {
+            key: 'telegram-bot',
+            formattedData: {
+              screenName: 'My Telegram Bot',
+            },
+          },
+          user: {
+            email: 'owner@open.gov.sg',
+          },
+        },
+        {
+          flowId: 'flow-123',
+          connectionId: 'table-789',
+          connectionType: 'table',
+          table: {
+            name: 'Sales Data',
+          },
+          user: {
+            email: 'owner@open.gov.sg',
+          },
+        },
+      ]),
+    })
+
+    const result = await getFlowConnections({}, { flowId: 'flow-123' }, context)
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({
+      connectionType: 'connection',
+      appName: 'Telegram',
+      connectionName: 'My Telegram Bot',
+    })
+    expect(result[1]).toMatchObject({
+      connectionType: 'table',
+      appName: 'Tables',
+      connectionName: 'Sales Data',
+    })
+  })
+
+  it('should throw a ForbiddenError if the user does not have access to the flow', async () => {
+    context.currentUser.withAccessibleFlows = vi.fn().mockReturnValue({
+      findById: vi.fn().mockReturnValue(null),
+    })
+
+    await expect(
+      getFlowConnections({}, { flowId: 'flow-123' }, context),
+    ).rejects.toThrow(ForbiddenError)
+  })
+})

--- a/packages/backend/src/graphql/queries/get-flow-connections.ts
+++ b/packages/backend/src/graphql/queries/get-flow-connections.ts
@@ -1,0 +1,77 @@
+import { IApp } from '@/../../types'
+import { ForbiddenError } from '@/errors/graphql-errors'
+import App from '@/models/app'
+import FlowConnections from '@/models/flow-connections'
+
+import { QueryResolvers } from '../__generated__/types.generated'
+
+const getFlowConnections: QueryResolvers['getFlowConnections'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const apps = await App.findAll()
+
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findById(params.flowId)
+
+  if (!flow) {
+    throw new ForbiddenError(
+      'You do not have sufficient permissions for this pipe',
+    )
+  }
+
+  const rawFlowConnections = await FlowConnections.query()
+    .where({
+      flow_id: params.flowId,
+    })
+    .withGraphFetched({
+      connection: true,
+      user: true,
+      table: true,
+    })
+
+  const filteredFlowConnections = rawFlowConnections.filter(
+    (flowConnection) => {
+      if (flowConnection.connectionType === 'table') {
+        return !!flowConnection.table
+      }
+      return !!flowConnection.connection
+    },
+  )
+
+  const flowConnections = await Promise.all(
+    filteredFlowConnections.map(async (flowConnection) => {
+      let connectionName = flowConnection?.connection?.formattedData?.screenName
+      if (flowConnection.connectionType === 'table' && flowConnection.table) {
+        connectionName = flowConnection.table?.name
+      }
+
+      const appKey = flowConnection.connection?.key
+      const app = apps.find(
+        (app: IApp) =>
+          app.key ===
+          (flowConnection.connectionType === 'table' ? 'tiles' : appKey),
+      )
+
+      if (!app) {
+        throw new Error(`App not found for key: ${appKey}`)
+      }
+
+      return {
+        flowId: flowConnection.flowId,
+        connectionId: flowConnection.connectionId,
+        connectionType: flowConnection.connectionType,
+        addedBy: flowConnection?.user?.email || '',
+        appName: app.name,
+        appIconUrl: app.iconUrl,
+        connectionName: connectionName as string,
+      }
+    }),
+  )
+
+  return flowConnections
+}
+
+export default getFlowConnections

--- a/packages/backend/src/graphql/query-resolvers.ts
+++ b/packages/backend/src/graphql/query-resolvers.ts
@@ -7,6 +7,7 @@ import getExecution from './queries/get-execution'
 import getExecutionSteps from './queries/get-execution-steps'
 import getExecutions from './queries/get-executions'
 import getFlow from './queries/get-flow'
+import getFlowConnections from './queries/get-flow-connections'
 import getFlowTransferDetails from './queries/get-flow-transfer-details'
 import getFlows from './queries/get-flows'
 import getPendingFlowTransfers from './queries/get-pending-flow-transfers'
@@ -41,6 +42,7 @@ export default {
   getCurrentUser,
   healthcheck,
   getPendingFlowTransfers,
+  getFlowConnections,
   getFlowTransferDetails,
   getTemplates,
   ...tilesQueryResolvers,

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -36,6 +36,7 @@ type Query {
     key: String!
     parameters: JSONObject
   ): [JSONObject]
+  getFlowConnections(flowId: String!): [SharedFlowConnection!]!
   # Tiles
   getTable(tableId: String!): TableMetadata!
   getTableConnections(tableIds: [String!]!): JSONObject
@@ -506,6 +507,16 @@ type FlowAttachmentConfig {
   value: String!
   size: Int!
   updatedAt: String!
+}
+
+type SharedFlowConnection {
+  flowId: String!
+  connectionId: String!
+  connectionType: String!
+  appName: String!
+  appIconUrl: String!
+  addedBy: String!
+  connectionName: String!
 }
 
 type Execution {

--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -18,6 +18,7 @@ class FlowConnections extends Base {
   connectionType!: 'connection' | 'table'
   connection?: Connection
   table?: TableMetadata
+  user?: User
   metadata: Record<string, any>
   flow?: Flow
 


### PR DESCRIPTION
### TL;DR

Added a new `getFlowConnections` query to fetch shared connection.

### What changed?

- Created a new GraphQL query resolver `getFlowConnections` that returns connections associated with a specific flow
- Added a new GraphQL type `SharedFlowConnection` to represent flow connections in the schema
- Implemented handling for both regular connections and table connections
- Added comprehensive tests to verify the functionality works correctly for different connection types
- Updated the query resolvers to include the new resolver

### How to test?

1. Query the GraphQL endpoint with:
   ```graphql
   query {
     getFlowConnections(flowId: "your-flow-id") {
       flowId
       connectionId
       connectionType
       appName
       appIconUrl
       addedBy
       connectionName
     }
   }
   ```
2. Verify that regular connections (like Slack, Telegram) returned with the correct information
3. Verify that Tile connections are returned with the correct Tile name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `getFlowConnections` to return a flow’s shared connections (apps and tables) with app metadata and contributor info, updating schema/resolvers and adding tests.
> 
> - **GraphQL**:
>   - **New Query**: `getFlowConnections(flowId: String!)` returning `[SharedFlowConnection!]!`.
>   - **New Type**: `SharedFlowConnection` with `flowId`, `connectionId`, `connectionType`, `appName`, `appIconUrl`, `addedBy`, `connectionName`.
>   - **Resolver**: Implements `queries/get-flow-connections.ts`:
>     - Authorizes via `currentUser.withAccessibleFlows(requiredRole: 'editor')`.
>     - Fetches from `FlowConnections` with `connection`, `table`, and `user` relations.
>     - Maps app metadata from `App.findAll()`; uses `tiles` for table connections.
>     - Filters out entries without a loaded `connection` or `table`.
>   - **Wiring**: Adds resolver to `query-resolvers.ts` and schema.
> - **Model**:
>   - Adds optional `user?: User` property to `FlowConnections`.
> - **Tests**:
>   - Adds unit tests for regular connections, table connections, and mixed results in `__tests__/queries/get-flow-connections.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc3338df34be08ad86e11534e1348a600bbff041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->