### PR TITLE
[COLLAB-CON-2]: (frontend) view shared connections

### DIFF
--- a/packages/frontend/src/components/EditorSettings/FlowConnections.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowConnections.tsx
@@ -1,0 +1,13 @@
+import { Flex, Text } from '@chakra-ui/react'
+
+import ConnectionsTable from './FlowConnections/ConnectionsTable'
+import { editorSettingsStyles as styles } from './styles'
+
+export default function FlowConnections() {
+  return (
+    <Flex {...styles.editorSettingsWrapper} maxW="100%">
+      <Text textStyle="h3-semibold">Connections</Text>
+      <ConnectionsTable />
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/EditorSettings/FlowConnections/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowConnections/ConnectionsTable.tsx
@@ -1,0 +1,199 @@
+import { IFlow } from '@plumber/types'
+
+import { useContext } from 'react'
+import { BiTrash } from 'react-icons/bi'
+import { useQuery } from '@apollo/client'
+import {
+  Box,
+  Center,
+  Flex,
+  IconButton,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
+import { Tag } from '@opengovsg/design-system-react'
+
+import AppIcon from '@/components/AppIcon'
+import PrimarySpinner from '@/components/PrimarySpinner'
+import { EditorSettingsContext } from '@/contexts/EditorSettings'
+import { GET_FLOW_CONNECTIONS } from '@/graphql/queries/get-flow-connections'
+
+interface SharedConnection {
+  addedBy: string
+  appName: string
+  appIconUrl: string
+  connectionName: string
+  connectionId: string
+  connectionType: 'connection' | 'table'
+  positions: number[]
+}
+
+interface TableRowProps {
+  connection: SharedConnection
+  flow: IFlow
+  hasEditPermission: boolean
+}
+
+const COLUMNS = ['App', 'Connection name', 'Created by', 'Status', '']
+
+const StatusTag = ({ inUse }: { inUse: boolean }) => {
+  if (inUse) {
+    return <Tag colorScheme="success">In use</Tag>
+  }
+  return (
+    <Tag bg="interaction.sub-subtle.default" color="base.divider.strong">
+      Not in use
+    </Tag>
+  )
+}
+
+const TableHeader = () => {
+  return (
+    <Thead>
+      <Tr bg="interaction.neutral-subtle.default">
+        {COLUMNS.map((column) => (
+          <Th key={column}>{column}</Th>
+        ))}
+      </Tr>
+    </Thead>
+  )
+}
+
+const TableRow = (props: TableRowProps) => {
+  const { connection, hasEditPermission } = props
+  const {
+    connectionId,
+    connectionName,
+    addedBy,
+    positions,
+    appName,
+    appIconUrl,
+  } = connection
+
+  const isInUse = positions.length > 0
+
+  return (
+    <Tr key={connectionId} color={isInUse ? undefined : 'base.divider.strong'}>
+      <Td>
+        <Flex alignItems="center" gap={2}>
+          <AppIcon
+            name={appName}
+            url={appIconUrl}
+            opacity={isInUse ? 1 : 0.5}
+            filter={isInUse ? undefined : 'grayscale(100%)'}
+            height="20px"
+            width="20px"
+          />
+          <Box display={{ base: 'none', md: 'block' }}>{appName}</Box>
+        </Flex>
+      </Td>
+
+      <Td>
+        <Box
+          overflow="hidden"
+          textOverflow="ellipsis"
+          whiteSpace="nowrap"
+          maxW={{ base: '100px', md: '300px' }}
+        >
+          {connectionName}
+        </Box>
+      </Td>
+      <Td>{addedBy}</Td>
+      <Td>
+        <StatusTag inUse={isInUse} />
+      </Td>
+      <Td>
+        {/* TODO: Add the delete functionality */}
+        {hasEditPermission && (
+          <IconButton
+            onClick={(event) => {
+              event.stopPropagation()
+            }}
+            colorScheme="critical"
+            variant="clear"
+            aria-label="Delete flow connection"
+            icon={<BiTrash />}
+          />
+        )}
+      </Td>
+    </Tr>
+  )
+}
+
+export default function ConnectionsTable() {
+  const { flow, hasEditPermission } = useContext(EditorSettingsContext)
+
+  const { data: flowConnectionsData, loading: flowConnectionsLoading } =
+    useQuery(GET_FLOW_CONNECTIONS, {
+      variables: {
+        flowId: flow.id,
+      },
+    })
+
+  const flowConnections: SharedConnection[] =
+    flowConnectionsData?.getFlowConnections || []
+
+  const processedConnections = flowConnections.map((flowConnection) => {
+    const matchingSteps =
+      flow.steps?.filter((step) => {
+        if (flowConnection.connectionType === 'table') {
+          return step?.parameters?.tableId === flowConnection.connectionId
+        }
+        return step?.connection?.id === flowConnection.connectionId
+      }) ?? []
+
+    return {
+      ...flowConnection,
+      positions: matchingSteps.map((step) => step.position),
+    }
+  })
+
+  const sortedConnections = processedConnections.sort((a, b) => {
+    // First, sort by whether connection is in use (in use first, not in use last)
+    const aInUse = a.positions.length > 0 ? 0 : 1
+    const bInUse = b.positions.length > 0 ? 0 : 1
+    if (aInUse !== bInUse) {
+      return aInUse - bInUse
+    }
+
+    // Then sort by app name
+    const appCompare = a.appName.localeCompare(b.appName)
+    if (appCompare !== 0) {
+      return appCompare
+    }
+
+    // Finally sort by connection name
+    return a.connectionName.localeCompare(b.connectionName)
+  })
+
+  if (flowConnectionsLoading) {
+    return (
+      <Center>
+        <PrimarySpinner margin="auto" fontSize="4xl" />
+      </Center>
+    )
+  }
+
+  return (
+    <TableContainer>
+      <Table variant="simple" colorScheme="secondary">
+        <TableHeader />
+        <Tbody>
+          {sortedConnections.map((connection) => (
+            <TableRow
+              key={connection.connectionId}
+              connection={connection}
+              flow={flow}
+              hasEditPermission={hasEditPermission}
+            />
+          ))}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  )
+}

--- a/packages/frontend/src/components/EditorSettings/index.tsx
+++ b/packages/frontend/src/components/EditorSettings/index.tsx
@@ -1,7 +1,7 @@
 import { IFlow } from '@plumber/types'
 
 import { ElementType, ReactNode, useContext, useMemo, useState } from 'react'
-import { BiMailSend, BiTransfer, BiUserPlus } from 'react-icons/bi'
+import { BiLink, BiMailSend, BiTransfer, BiUserPlus } from 'react-icons/bi'
 import { useParams } from 'react-router-dom'
 import { ApolloError, useQuery } from '@apollo/client'
 import {
@@ -56,6 +56,8 @@ export default function EditorSettingsLayout(
     variables: { id: flowId },
   })
   const flow: IFlow = data?.getFlow
+  const hasCollaborators =
+    flow?.collaborators?.length && flow.collaborators.length > 1 // includes owner
 
   const [isDrawerOpen, setDrawerOpen] = useState(false)
 
@@ -79,6 +81,18 @@ export default function EditorSettingsLayout(
             },
           ].filter(Boolean),
         },
+        showCollaborators &&
+          hasCollaborators && {
+            group: 'Manage Pipe',
+            links: [
+              {
+                Icon: BiLink,
+                text: 'Connections',
+                to: URLS.FLOW_EDITOR_CONNECTIONS(flowId),
+                group: 'Manage Pipe' as const,
+              },
+            ],
+          },
         {
           group: 'Notifications',
           links: [
@@ -90,11 +104,11 @@ export default function EditorSettingsLayout(
             },
           ],
         },
-      ],
+      ].filter(Boolean),
       () => setDrawerOpen(true),
       () => setDrawerOpen(false),
     ],
-    [flowId, setDrawerOpen, showCollaborators],
+    [flowId, setDrawerOpen, showCollaborators, hasCollaborators],
   )
 
   const drawerComponent = useBreakpointValue({

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -62,7 +62,8 @@ export const FLOW_EDITOR_SHARE = (flowId?: string): string =>
   flowId ? `/editor/${flowId}/share` : FLOWS
 export const FLOW_EDITOR_TRANSFERS = (flowId?: string): string =>
   flowId ? `/editor/${flowId}/transfer` : FLOWS
-
+export const FLOW_EDITOR_CONNECTIONS = (flowId?: string): string =>
+  flowId ? `/editor/${flowId}/connections` : FLOWS
 export const TRANSFERS = '/transfers'
 
 // Templates routes

--- a/packages/frontend/src/graphql/queries/get-flow-connections.ts
+++ b/packages/frontend/src/graphql/queries/get-flow-connections.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client'
+
+export const GET_FLOW_CONNECTIONS = gql`
+  query GetFlowConnections($flowId: String!) {
+    getFlowConnections(flowId: $flowId) {
+      flowId
+      connectionId
+      connectionType
+      appName
+      appIconUrl
+      addedBy
+      connectionName
+    }
+  }
+`

--- a/packages/frontend/src/pages/Editor/routes.tsx
+++ b/packages/frontend/src/pages/Editor/routes.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 
 import EditorSettingsLayout from '@/components/EditorSettings'
 import FlowCollaborators from '@/components/EditorSettings/FlowCollaborators'
+import FlowConnections from '@/components/EditorSettings/FlowConnections'
 import FlowTransfer from '@/components/EditorSettings/FlowTransfer'
 import Notifications from '@/components/EditorSettings/Notifications'
 
@@ -29,6 +30,14 @@ export default function EditorRoutes(): React.ReactElement {
         element={
           <EditorSettingsLayout>
             <FlowCollaborators />
+          </EditorSettingsLayout>
+        }
+      />
+      <Route
+        path="/:flowId/connections"
+        element={
+          <EditorSettingsLayout>
+            <FlowConnections />
           </EditorSettingsLayout>
         }
       />


### PR DESCRIPTION
### TL;DR
Added a new Connections tab in the Editor Settings to display flow connections.
_NOTE: Delete button does not work now, coming in subsequent PR_

### How to test?

1. Navigate to any flow in the editor
2. Click on the settings icon
3. Should not see "Connections" from the sidebar if Pipe has no collaborators
4. Add collaborator
5. Select "Connections" from the sidebar under "Manage Pipe"
6. Verify that the connections table displays correctly with:
   - Connections sorted by usage status and app name
   - Proper status tags (In use/Not in use)
   - Correct visual styling for used/unused connections

### Screenshot

![Screenshot 2025-11-26 at 11.33.04 AM.png](https://app.graphite.com/user-attachments/assets/fdacdb67-6b80-465e-834a-ced6ea94e717.png)

