### PR TITLE
[COLLAB-CON-4]: (frontend) delete flow connection

### DIFF
--- a/packages/backend/src/models/flow-connections.ts
+++ b/packages/backend/src/models/flow-connections.ts
@@ -109,15 +109,29 @@ class FlowConnections extends Base {
     if (hasCollaborators) {
       // NOTE: somehow .onConflict().ignore() does not return an empty array
       // on conflict, but actually returns the row its trying to insert
-      const existing = await this.query(trx).findOne({
-        flow_id: flowId,
-        connection_id: connectionId,
-      })
+
+      // check if the connection existed before and was deleted
+      const existing = await this.query(trx)
+        .findOne({
+          flow_id: flowId,
+          connection_id: connectionId,
+        })
+        .withSoftDeleted()
 
       if (existing) {
-        return null
+        // if it existed before and was deleted, restore it
+        return await this.query(trx)
+          .where({
+            flow_id: flowId,
+            connection_id: connectionId,
+          })
+          .patch({
+            deletedAt: null,
+          })
+          .withSoftDeleted()
       }
 
+      // if it did not exist before, add it
       return await this.query(trx)
         .insert({
           flowId,

--- a/packages/frontend/src/components/EditorSettings/FlowConnections/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowConnections/ConnectionsTable.tsx
@@ -1,13 +1,11 @@
 import { IFlow } from '@plumber/types'
 
 import { useContext } from 'react'
-import { BiTrash } from 'react-icons/bi'
 import { useQuery } from '@apollo/client'
 import {
   Box,
   Center,
   Flex,
-  IconButton,
   Table,
   TableContainer,
   Tbody,
@@ -23,7 +21,9 @@ import PrimarySpinner from '@/components/PrimarySpinner'
 import { EditorSettingsContext } from '@/contexts/EditorSettings'
 import { GET_FLOW_CONNECTIONS } from '@/graphql/queries/get-flow-connections'
 
-interface SharedConnection {
+import DeleteFlowConnectionButton from './DeleteFlowConnectionButton'
+
+export interface SharedConnection {
   addedBy: string
   appName: string
   appIconUrl: string
@@ -43,10 +43,19 @@ const COLUMNS = ['App', 'Connection name', 'Created by', 'Status', '']
 
 const StatusTag = ({ inUse }: { inUse: boolean }) => {
   if (inUse) {
-    return <Tag colorScheme="success">In use</Tag>
+    return (
+      <Tag colorScheme="success" _active={{}} _hover={{}}>
+        In use
+      </Tag>
+    )
   }
   return (
-    <Tag bg="interaction.sub-subtle.default" color="base.divider.strong">
+    <Tag
+      bg="interaction.sub-subtle.default"
+      color="base.divider.strong"
+      _active={{}}
+      _hover={{}}
+    >
       Not in use
     </Tag>
   )
@@ -65,7 +74,7 @@ const TableHeader = () => {
 }
 
 const TableRow = (props: TableRowProps) => {
-  const { connection, hasEditPermission } = props
+  const { connection, flow, hasEditPermission } = props
   const {
     connectionId,
     connectionName,
@@ -108,16 +117,11 @@ const TableRow = (props: TableRowProps) => {
         <StatusTag inUse={isInUse} />
       </Td>
       <Td>
-        {/* TODO: Add the delete functionality */}
         {hasEditPermission && (
-          <IconButton
-            onClick={(event) => {
-              event.stopPropagation()
-            }}
-            colorScheme="critical"
-            variant="clear"
-            aria-label="Delete flow connection"
-            icon={<BiTrash />}
+          <DeleteFlowConnectionButton
+            flow={flow}
+            connection={connection}
+            isInUse={isInUse}
           />
         )}
       </Td>

--- a/packages/frontend/src/components/EditorSettings/FlowConnections/DeleteFlowConnectionButton.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowConnections/DeleteFlowConnectionButton.tsx
@@ -1,0 +1,82 @@
+import { IFlow } from '@plumber/types'
+
+import { useCallback, useRef } from 'react'
+import { BiTrash } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import { useDisclosure } from '@chakra-ui/react'
+import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
+
+import MenuAlertDialog from '@/components/MenuAlertDialog'
+import { DELETE_FLOW_CONNECTION } from '@/graphql/mutations/delete-flow-connection'
+import { GET_FLOW_CONNECTIONS } from '@/graphql/queries/get-flow-connections'
+
+import { SharedConnection } from './ConnectionsTable'
+
+interface DeleteFlowConnectionButtonProps {
+  flow: IFlow
+  connection: SharedConnection
+  isInUse?: boolean
+}
+
+export default function DeleteFlowConnectionButton(
+  props: DeleteFlowConnectionButtonProps,
+) {
+  const { flow, connection, isInUse } = props
+  const { connectionId, connectionName, connectionType } = connection
+  const isActive = flow.active
+  const isDisabled = isActive || isInUse
+
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const {
+    isOpen: isDialogOpen,
+    onOpen: onDialogOpen,
+    onClose: onDialogClose,
+  } = useDisclosure()
+
+  const [deleteConnection, { loading: isDeletingConnection }] = useMutation(
+    DELETE_FLOW_CONNECTION,
+    { refetchQueries: [GET_FLOW_CONNECTIONS] },
+  )
+
+  const onDeleteConnection = useCallback(async () => {
+    await deleteConnection({
+      variables: {
+        input: { flowId: flow.id, connectionId, connectionType },
+      },
+      onCompleted: () => onDialogClose(),
+    })
+  }, [deleteConnection, flow.id, connectionId, connectionType, onDialogClose])
+  return (
+    <TouchableTooltip
+      label={
+        isActive
+          ? 'You cannot delete a connection when the Pipe is published'
+          : isInUse
+          ? 'This connection is in use and cannot be deleted.'
+          : ''
+      }
+    >
+      <IconButton
+        onClick={(event) => {
+          event.stopPropagation()
+          onDialogOpen()
+        }}
+        colorScheme="critical"
+        variant="clear"
+        aria-label="Delete flow connection"
+        icon={<BiTrash />}
+        isDisabled={isDisabled}
+      />
+      <MenuAlertDialog
+        cancelRef={cancelRef}
+        isLoading={isDeletingConnection}
+        isDialogOpen={isDialogOpen}
+        onDialogClose={onDialogClose}
+        dialogType="delete"
+        dialogHeader={connectionName}
+        onClick={onDeleteConnection}
+        customBody="Are you sure you want to delete this shared connection? You will need to reconfigure the connection for all steps using this connection."
+      />
+    </TouchableTooltip>
+  )
+}

--- a/packages/frontend/src/components/MenuAlertDialog/index.tsx
+++ b/packages/frontend/src/components/MenuAlertDialog/index.tsx
@@ -30,7 +30,7 @@ interface MenuAlertDialogProps {
   cancelRef: React.RefObject<HTMLButtonElement>
   onDialogClose: () => void
   dialogType: AlertDialogType
-  dialogHeader: AlertHeaderType
+  dialogHeader: AlertHeaderType | string
   onClick: (() => void) | MouseEventHandler
   isLoading: boolean
   customBody?: string
@@ -44,7 +44,7 @@ interface AlertDialogContent {
 }
 
 function getAlertDialogContent(
-  dialogHeader: AlertHeaderType,
+  dialogHeader: AlertHeaderType | string,
   dialogType: AlertDialogType,
   customBody?: string,
 ): AlertDialogContent {

--- a/packages/frontend/src/graphql/mutations/delete-flow-connection.ts
+++ b/packages/frontend/src/graphql/mutations/delete-flow-connection.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const DELETE_FLOW_CONNECTION = graphql(`
+  mutation DeleteFlowConnection($input: DeleteFlowConnectionInput!) {
+    deleteFlowConnection(input: $input)
+  }
+`)


### PR DESCRIPTION
## TL;DR

- Adds the ability to delete shared connections from a flow in the UI.
- Checks if the shared connection existed in `flow_connections` and was deleted, and restores it rather than attempt to create a new entry

## How to test?

- [x] Cannot delete flow connection when Pipe is published

Delete a flow connection

- [x] Removed from UI
- [x] Removed from Step(s) that use the flow connection

## Screenshots

![Screenshot 2025-11-26 at 11.50.09 AM.png](https://app.graphite.com/user-attachments/assets/267b48ca-9d33-4f1b-9143-75a90a5b823e.png)

![Screenshot 2025-11-26 at 11.56.27 AM.png](https://app.graphite.com/user-attachments/assets/9938fd7c-4d32-4de2-b7e2-46ac63fdd10d.png)