### PR TITLE
fix: cannot update for each step name if no variable

### DIFF
--- a/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/schema.ts
@@ -147,5 +147,7 @@ export const parameterSchema = z.object({
     })
     .refine((v) => VARIABLE_REGEX.test(v), {
       message: PARAMETER_ERROR_MESSAGE,
-    }),
+    })
+    // could be null when user is updating the step name before selecting a variable
+    .nullish(),
 })


### PR DESCRIPTION
## Problem
Cannot update step name if there is no variable selected at the for each step.
<img width="1506" height="804" alt="Screenshot 2025-11-27 at 5 36 03 PM" src="https://github.com/user-attachments/assets/a50cb3b1-4074-4c42-bf77-dc9ebc5e5368" />


## Solution
Update schema with `.nullish()` to allow step name to be updated before any for each variable is selected

## Test
- [ ] Can update step name before a variable is selected in the or each input
- [ ] Validation that input must be a variable still works

