### PR TITLE
chore(robots): noindex for tiles

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -19,6 +19,7 @@ import csp from '@/helpers/csp'
 import errorHandler from '@/helpers/error-handler'
 import injectBullBoardHandler from '@/helpers/inject-bull-board-handler'
 import morgan from '@/helpers/morgan'
+import robotsHeaderMiddleware from '@/helpers/robots-header'
 import webUIHandler from '@/helpers/web-ui-handler'
 import router from '@/routes'
 
@@ -50,7 +51,7 @@ app.use(
   }),
 )
 app.use(cors(corsOptions))
-
+app.use(robotsHeaderMiddleware)
 injectBullBoardHandler(app, serverAdapter)
 
 appAssetsHandler(app)

--- a/packages/backend/src/helpers/robots-header.ts
+++ b/packages/backend/src/helpers/robots-header.ts
@@ -1,0 +1,15 @@
+import { NextFunction, Request, Response } from 'express'
+
+const robotsHeaderMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  // Add X-Robots-Tag header for all /tiles/* routes
+  if (req.path.startsWith('/tiles/')) {
+    res.setHeader('X-Robots-Tag', 'noindex, nofollow')
+  }
+  next()
+}
+
+export default robotsHeaderMiddleware

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -99,6 +99,7 @@ export default function Tile(): JSX.Element | null {
       refetch={refetch}
     >
       <Helmet>
+        <meta name="robots" content="noindex,nofollow" />
         <title>{name} | Tile</title>
       </Helmet>
       <Flex

--- a/packages/frontend/src/pages/UnauthorizedTile/InvalidTileLink.tsx
+++ b/packages/frontend/src/pages/UnauthorizedTile/InvalidTileLink.tsx
@@ -1,3 +1,4 @@
+import { Helmet } from 'react-helmet'
 import { Image, Stack, Text, VStack } from '@chakra-ui/react'
 
 import spreadsheetImg from '@/assets/spreadsheet.png'
@@ -6,48 +7,54 @@ import styles from './UnauthorizedTile.module.css'
 
 export function InvalidTileLink(): JSX.Element {
   return (
-    <Stack
-      direction={{ base: 'column', md: 'row' }}
-      maxW="1000px"
-      margin="auto"
-      gap={8}
-      px={8}
-      alignItems="center"
-      justifyContent="center"
-    >
-      <Image
-        className={styles.flicker}
-        src={spreadsheetImg}
-        alt="Spreadsheet"
-        w="400px"
-        maxW="50%"
-      />
-      <VStack alignItems={{ base: 'center', md: 'start' }} gap={2}>
-        <Text
-          textStyle="h4"
-          textAlign={{ base: 'center', md: 'left' }}
-          fontWeight="normal"
-        >
-          Your{' '}
+    <>
+      <Helmet>
+        <meta name="robots" content="noindex,nofollow" />
+        <title>you seem lost...</title>
+      </Helmet>
+      <Stack
+        direction={{ base: 'column', md: 'row' }}
+        maxW="1000px"
+        margin="auto"
+        gap={8}
+        px={8}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Image
+          className={styles.flicker}
+          src={spreadsheetImg}
+          alt="Spreadsheet"
+          w="400px"
+          maxW="50%"
+        />
+        <VStack alignItems={{ base: 'center', md: 'start' }} gap={2}>
           <Text
-            bgGradient="linear(to-r, primary.400, primary.500)"
-            backgroundClip="text"
-            as="span"
-            className={styles.flicker}
-            fontWeight="bold"
+            textStyle="h4"
+            textAlign={{ base: 'center', md: 'left' }}
+            fontWeight="normal"
           >
-            Tile
-          </Text>{' '}
-          link is invalid or has expired.
-        </Text>
-        <Text
-          textStyle="h6"
-          textAlign={{ base: 'center', md: 'left' }}
-          fontWeight="normal"
-        >
-          Please request a new link from the tile owner.
-        </Text>
-      </VStack>
-    </Stack>
+            Your{' '}
+            <Text
+              bgGradient="linear(to-r, primary.400, primary.500)"
+              backgroundClip="text"
+              as="span"
+              className={styles.flicker}
+              fontWeight="bold"
+            >
+              Tile
+            </Text>{' '}
+            link is invalid or has expired.
+          </Text>
+          <Text
+            textStyle="h6"
+            textAlign={{ base: 'center', md: 'left' }}
+            fontWeight="normal"
+          >
+            Please request a new link from the tile owner.
+          </Text>
+        </VStack>
+      </Stack>
+    </>
   )
 }

--- a/packages/frontend/src/pages/UnauthorizedTile/MissingTile.tsx
+++ b/packages/frontend/src/pages/UnauthorizedTile/MissingTile.tsx
@@ -15,6 +15,7 @@ export function MissingTile({ title }: MissingTileProps): JSX.Element {
   return (
     <>
       <Helmet>
+        <meta name="robots" content="noindex,nofollow" />
         <title>you seem lost...</title>
       </Helmet>
       <Stack


### PR DESCRIPTION
## Problem
We have a rule setup on Cloudflare to prevent robots from indexing Tiles links. 
To reduce the reliance on Cloudflare we want to move the rule dependency to our app.

## Solution
This is a fallback in case we need to turn off orange cloud in the event of a Cloudflare outage.

**Frontend:**
Added `<meta name="robots" content="noindex,nofollow" />` to:
* Main tile viewer page
* Invalid/expired tile links
* Missing tile error page

**Backend:**
 Created `robots-header.ts` - Express middleware that sets `X-Robots-Tag: noindex, nofollow` header for all `/tiles/*` routes

Note: the meta tag should be present even if the route is invalid so that all routes to `tiles/*` are not indexed.

## Tests
- [x]  Build and run locally: npm run build && npm start
- [ ]  Verify header on tiles routes: curl -I http://localhost:8080/tiles/123 shows X-Robots-Tag: noindex, nofollow
- [ ]  Verify no header on non-tiles routes: curl -I http://localhost:8080/flows has no X-Robots-Tag

## Screenshots
**Tile**
<img width="1920" height="970" alt="Screenshot 2025-11-28 at 3 51 56 PM" src="https://github.com/user-attachments/assets/636c406d-9b18-4b7a-aa8a-f397e365c5f3" />

**Invalid Tile link**
<img width="1920" height="1013" alt="Screenshot 2025-11-28 at 3 52 27 PM" src="https://github.com/user-attachments/assets/f81f9446-8bca-4d45-ba28-91299efee06e" />

**View only link**
<img width="1920" height="968" alt="Screenshot 2025-11-28 at 3 54 50 PM" src="https://github.com/user-attachments/assets/a995384e-529c-498e-b891-2ca6d8e4566d" />


**Revoked view only link**

<img width="1920" height="965" alt="Screenshot 2025-11-28 at 3 56 45 PM" src="https://github.com/user-attachments/assets/07acea2f-5e2e-4f74-9615-4de9da488089" />
