### PR TITLE
[MRF-9] PLU-520: MRF context and refactor

### DIFF
--- a/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
@@ -11,6 +11,7 @@ export default function FlowStepWithAddButton({
   step,
   isLastStep,
   isNested,
+  allowReorder,
   addButtonProps: {
     isHidden = false,
     isDisabled = false,
@@ -22,6 +23,7 @@ export default function FlowStepWithAddButton({
   isNested?: boolean
   stepsBeforeGroup: IStep[]
   groupedSteps: IStep[][]
+  allowReorder: boolean
   addButtonProps: {
     isHidden: boolean
     isDisabled: boolean
@@ -37,7 +39,7 @@ export default function FlowStepWithAddButton({
         isLastStep={isLastStep}
         isNested={isNested}
         // only allow reordering if there are more than 1 action steps
-        allowReorder={true}
+        allowReorder={allowReorder}
       />
       {isApprovalStep && <ApproveReject />}
       <AddStepButton

--- a/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
@@ -1,10 +1,9 @@
 import { IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import { ApproveReject } from '../FlowStep/components/ApproveReject'
@@ -15,50 +14,26 @@ export default function FlowStepWithAddButton({
   step,
   isLastStep,
   isNested,
-  stepsBeforeGroup,
-  groupedSteps,
-  showAddButton = true,
+  addButtonProps: {
+    isHidden = false,
+    isDisabled = false,
+    showEmptyAction = false,
+  },
 }: {
   step: IStep
   isLastStep: boolean
   isNested?: boolean
   stepsBeforeGroup: IStep[]
   groupedSteps: IStep[][]
-  showAddButton?: boolean
+  addButtonProps: {
+    isHidden: boolean
+    isDisabled: boolean
+    showEmptyAction: boolean
+  }
 }) {
-  const { readOnly, allApps } = useContext(EditorContext)
+  const { allApps } = useContext(EditorContext)
 
   const { isApprovalStep } = useStepMetadata(allApps, step)
-
-  const nonIfThenActionSteps = stepsBeforeGroup.filter(
-    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.IfThen,
-  )
-
-  // Disables last add step and hide in-between add step buttons
-  const hasExactlyOneEmptyActionStep =
-    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
-
-  // Disables last add step button but show empty action instead
-  const hasNoActionSteps = nonIfThenActionSteps.length === 0
-
-  const getAddStepButtonProps = useMemo(() => {
-    const shouldShowEmptyAction = hasNoActionSteps && !groupedSteps.length
-    const shouldDisableButton =
-      (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !groupedSteps.length
-
-    return (isLastStep: boolean, stepId: string) => ({
-      isHidden: readOnly,
-      showEmptyAction: shouldShowEmptyAction,
-      isDisabled: shouldDisableButton,
-      isLastStep,
-      stepId,
-    })
-  }, [
-    readOnly,
-    hasNoActionSteps,
-    groupedSteps.length,
-    hasExactlyOneEmptyActionStep,
-  ])
 
   return (
     <>
@@ -67,13 +42,16 @@ export default function FlowStepWithAddButton({
         isLastStep={isLastStep}
         isNested={isNested}
         // only allow reordering if there are more than 1 action steps
-        allowReorder={nonIfThenActionSteps.length > 1}
+        allowReorder={true}
       />
       {isApprovalStep && <ApproveReject />}
-
-      {showAddButton && (
-        <AddStepButton {...getAddStepButtonProps(isLastStep, step.id)} />
-      )}
+      <AddStepButton
+        isLastStep={isLastStep}
+        stepId={step.id}
+        isHidden={isHidden}
+        isDisabled={isDisabled}
+        showEmptyAction={showEmptyAction}
+      />
     </>
   )
 }

--- a/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/FlowStepWithAddButton.tsx
@@ -1,8 +1,5 @@
 import { IStep } from '@plumber/types'
 
-import { useContext } from 'react'
-
-import { EditorContext } from '@/contexts/Editor'
 import { FlowStep } from '@/exports/components'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
@@ -31,9 +28,7 @@ export default function FlowStepWithAddButton({
     showEmptyAction: boolean
   }
 }) {
-  const { allApps } = useContext(EditorContext)
-
-  const { isApprovalStep } = useStepMetadata(allApps, step)
+  const { isApprovalStep } = useStepMetadata(step)
 
   return (
     <>

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -26,7 +26,7 @@ type EditorProps = {
 export default function Editor(props: EditorProps): React.ReactElement {
   const { isNested } = props
 
-  const { allApps, isDrawerOpen, isMobile, flow, readOnly } =
+  const { allApps, isDrawerOpen, isMobile, flow, readOnly, currentStepId } =
     useContext(EditorContext)
 
   const { handleReorderUpdate } = useReorderSteps(flow.id)
@@ -43,6 +43,10 @@ export default function Editor(props: EditorProps): React.ReactElement {
       })),
     [flow, rawSteps],
   )
+
+  const currentStep = useMemo(() => {
+    return steps.find((step) => step.id === currentStepId)
+  }, [currentStepId, steps])
 
   const appsWithActions: IApp[] = allApps.filter(
     (app: IApp) => !!app.actions?.length,
@@ -92,14 +96,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
       ? [triggerStep, steps.slice(1), []]
       : [triggerStep, steps.slice(1, groupStepIdx), branchesWithSteps]
   }, [groupingActions, steps])
-
-  const flowStepGroupIconUrl = useMemo(() => {
-    if (groupedSteps.length === 0) {
-      return undefined
-    }
-    return appsWithActions.find((app) => app.key === groupedSteps[0][0].appKey)
-      ?.iconUrl
-  }, [appsWithActions, groupedSteps])
 
   const handleReorderSteps = async (reorderedSteps: IStep[]) => {
     const stepPositions = reorderedSteps.map((step, index) => ({
@@ -242,10 +238,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
             opacity={isDrawerOpen ? 1 : 0}
             transform={rightDrawerTransform}
           >
-            <EditorRightDrawer
-              flowStepGroupIconUrl={flowStepGroupIconUrl}
-              steps={steps}
-            />
+            <EditorRightDrawer step={currentStep} />
           </Flex>
         </StepExecutionsToIncludeProvider>
       </MrfContextProvider>

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -180,6 +180,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
                 isNested={isNested}
                 stepsBeforeGroup={[]} // no reason to pass in for this
                 groupedSteps={groupedSteps}
+                allowReorder={false}
                 addButtonProps={{
                   isHidden: readOnly,
                   isDisabled: shouldDisableAddButton,
@@ -207,6 +208,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
                         isNested={isNested}
                         stepsBeforeGroup={actionStepsBeforeGroup}
                         groupedSteps={groupedSteps}
+                        allowReorder={nonIfThenActionSteps.length > 1}
                         addButtonProps={{
                           isHidden: readOnly || !!isOverlay,
                           isDisabled: shouldDisableAddButton,

--- a/packages/frontend/src/components/Editor/index.tsx
+++ b/packages/frontend/src/components/Editor/index.tsx
@@ -7,6 +7,7 @@ import EditorRightDrawer from '@/components/EditorRightDrawer'
 import FlowStepGroup from '@/components/FlowStepGroup'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
+import { MrfContextProvider } from '@/contexts/MrfContext'
 import { StepExecutionsToIncludeProvider } from '@/contexts/StepExecutionsToInclude'
 import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { extractBranchesWithSteps, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
@@ -25,7 +26,7 @@ type EditorProps = {
 export default function Editor(props: EditorProps): React.ReactElement {
   const { isNested } = props
 
-  const { allApps, isDrawerOpen, isMobile, currentStepId, flow } =
+  const { allApps, isDrawerOpen, isMobile, flow, readOnly } =
     useContext(EditorContext)
 
   const { handleReorderUpdate } = useReorderSteps(flow.id)
@@ -61,7 +62,7 @@ export default function Editor(props: EditorProps): React.ReactElement {
     )
   }, [appsWithActions])
 
-  const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(() => {
+  const [triggerStep, actionStepsBeforeGroup, groupedSteps] = useMemo(() => {
     if (!groupingActions) {
       return [null, [], []]
     }
@@ -100,34 +101,6 @@ export default function Editor(props: EditorProps): React.ReactElement {
       ?.iconUrl
   }, [appsWithActions, groupedSteps])
 
-  //
-  // Compute which steps are eligible for variable extraction.
-  // Mainly for if-then branches where we do not want to include steps
-  // from other branches.
-  //
-  // Note:
-  // - we include some grouped steps as there is no longer a nested editor
-  // - we identify the group by checking if the current step id is in the group
-  // - for-each steps are always included
-  const groupStepsToInclude = useMemo(() => {
-    return groupedSteps.flatMap((group) =>
-      group.some((step) => step.id === currentStepId) ||
-      group.some((step) => step.key === TOOLBOX_ACTIONS.ForEach)
-        ? group
-        : [],
-    )
-  }, [currentStepId, groupedSteps])
-
-  const stepExecutionsToInclude = useMemo(
-    () =>
-      new Set([
-        ...(triggerStep?.id ? [triggerStep.id] : []),
-        ...stepsBeforeGroup.map((step) => step.id),
-        ...groupStepsToInclude.map((s) => s.id),
-      ]),
-    [triggerStep, stepsBeforeGroup, groupStepsToInclude],
-  )
-
   const handleReorderSteps = async (reorderedSteps: IStep[]) => {
     const stepPositions = reorderedSteps.map((step, index) => ({
       id: step.id,
@@ -145,6 +118,21 @@ export default function Editor(props: EditorProps): React.ReactElement {
       )
     }
   }
+
+  const nonIfThenActionSteps = actionStepsBeforeGroup.filter(
+    (step) => step.key !== TOOLBOX_ACTIONS.IfThen,
+  )
+
+  // Disables last add step and hide in-between add step buttons
+  const hasExactlyOneEmptyActionStep =
+    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
+
+  // Disables last add step button but show empty action instead
+  const hasNoActionSteps = nonIfThenActionSteps.length === 0
+  const shouldShowEmptyAction = hasNoActionSteps && !groupedSteps.length
+  // for backwards compatibility where empty step is created
+  const shouldDisableAddButton =
+    (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !groupedSteps.length
 
   if (!appsWithActions || !groupingActions) {
     return (
@@ -172,80 +160,95 @@ export default function Editor(props: EditorProps): React.ReactElement {
         backgroundSize: '30px 30px',
       }}
     >
-      <StepExecutionsToIncludeProvider value={stepExecutionsToInclude}>
-        <Flex
-          {...editorStyles.stepHeaderContainer}
-          flex={isDrawerOpen ? (isMobile ? 0 : 1) : undefined}
-          px={leftStepPadding}
-          maxWidth={`calc(100% - ${
-            isDrawerOpen ? EDITOR_RIGHT_DRAWER_WIDTH : '0px'
-          })`}
+      <MrfContextProvider steps={steps}>
+        <StepExecutionsToIncludeProvider
+          groupedSteps={groupedSteps}
+          triggerStep={triggerStep}
+          actionStepsBeforeGroup={actionStepsBeforeGroup}
         >
-          {triggerStep && (
-            <FlowStepWithAddButton
-              step={triggerStep}
-              isLastStep={
-                stepsBeforeGroup.length === 0 && groupedSteps.length === 0
-              }
-              isNested={isNested}
-              stepsBeforeGroup={stepsBeforeGroup}
-              groupedSteps={groupedSteps}
-              showAddButton={true}
-            />
-          )}
+          <Flex
+            {...editorStyles.stepHeaderContainer}
+            flex={isDrawerOpen ? (isMobile ? 0 : 1) : undefined}
+            px={leftStepPadding}
+            maxWidth={`calc(100% - ${
+              isDrawerOpen ? EDITOR_RIGHT_DRAWER_WIDTH : '0px'
+            })`}
+          >
+            {triggerStep && (
+              <FlowStepWithAddButton
+                step={triggerStep}
+                isLastStep={
+                  actionStepsBeforeGroup.length === 0 &&
+                  groupedSteps.length === 0
+                }
+                isNested={isNested}
+                stepsBeforeGroup={[]} // no reason to pass in for this
+                groupedSteps={groupedSteps}
+                addButtonProps={{
+                  isHidden: readOnly,
+                  isDisabled: shouldDisableAddButton,
+                  showEmptyAction: shouldShowEmptyAction,
+                }}
+              />
+            )}
 
-          <SortableList
-            items={stepsBeforeGroup}
-            onChange={handleReorderSteps}
-            renderItem={(step, isOverlay) => {
-              const { id, position } = step
-              return (
-                <SortableList.Item id={id}>
-                  <Flex
-                    key={`${id}-${position}`}
-                    width={isDrawerOpen || isMobile ? '100%' : 'auto'}
-                    flexDir="column"
-                    position="relative"
-                  >
-                    <FlowStepWithAddButton
-                      step={step}
-                      isLastStep={position === steps.length}
-                      isNested={isNested}
-                      stepsBeforeGroup={stepsBeforeGroup}
-                      groupedSteps={groupedSteps}
-                      showAddButton={!isOverlay}
-                    />
-                  </Flex>
-                </SortableList.Item>
-              )
-            }}
-          />
-          {groupedSteps.length > 0 && (
-            <FlowStepGroup
-              stepsBeforeGroup={stepsBeforeGroup}
-              groupedSteps={groupedSteps}
+            <SortableList
+              items={actionStepsBeforeGroup}
+              onChange={handleReorderSteps}
+              renderItem={(step, isOverlay) => {
+                const { id, position } = step
+                return (
+                  <SortableList.Item id={id}>
+                    <Flex
+                      key={`${id}-${position}`}
+                      width={isDrawerOpen || isMobile ? '100%' : 'auto'}
+                      flexDir="column"
+                      position="relative"
+                    >
+                      <FlowStepWithAddButton
+                        step={step}
+                        isLastStep={position === steps.length}
+                        isNested={isNested}
+                        stepsBeforeGroup={actionStepsBeforeGroup}
+                        groupedSteps={groupedSteps}
+                        addButtonProps={{
+                          isHidden: readOnly || !!isOverlay,
+                          isDisabled: shouldDisableAddButton,
+                          showEmptyAction: shouldShowEmptyAction,
+                        }}
+                      />
+                    </Flex>
+                  </SortableList.Item>
+                )
+              }}
             />
-          )}
-        </Flex>
-        {/** HACKFIX (kevinkim-ogp): to ensure that the transitions are smooth */}
-        <Flex
-          {...editorStyles.dummyRightContainer}
-          w={rightDrawerWidth}
-          transform={rightDrawerTransform}
-        />
-        <Flex
-          {...editorStyles.rightDrawerContainer}
-          w={rightDrawerWidth}
-          visibility={isDrawerOpen ? 'visible' : 'hidden'}
-          opacity={isDrawerOpen ? 1 : 0}
-          transform={rightDrawerTransform}
-        >
-          <EditorRightDrawer
-            flowStepGroupIconUrl={flowStepGroupIconUrl}
-            steps={steps}
+            {groupedSteps.length > 0 && (
+              <FlowStepGroup
+                stepsBeforeGroup={actionStepsBeforeGroup}
+                groupedSteps={groupedSteps}
+              />
+            )}
+          </Flex>
+          {/** HACKFIX (kevinkim-ogp): to ensure that the transitions are smooth */}
+          <Flex
+            {...editorStyles.dummyRightContainer}
+            w={rightDrawerWidth}
+            transform={rightDrawerTransform}
           />
-        </Flex>
-      </StepExecutionsToIncludeProvider>
+          <Flex
+            {...editorStyles.rightDrawerContainer}
+            w={rightDrawerWidth}
+            visibility={isDrawerOpen ? 'visible' : 'hidden'}
+            opacity={isDrawerOpen ? 1 : 0}
+            transform={rightDrawerTransform}
+          >
+            <EditorRightDrawer
+              flowStepGroupIconUrl={flowStepGroupIconUrl}
+              steps={steps}
+            />
+          </Flex>
+        </StepExecutionsToIncludeProvider>
+      </MrfContextProvider>
     </Flex>
   )
 }

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -8,7 +8,6 @@ import FlowSubstep from '@/components/FlowSubstep'
 import Form from '@/components/Form'
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsProvider } from '@/contexts/StepExecutions'
-import { StepExecutionsToIncludeContext } from '@/contexts/StepExecutionsToInclude'
 import { generateValidationSchema } from '@/helpers/editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
@@ -30,20 +29,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
     onClose: onModalClose,
   } = useDisclosure()
 
-  const { allApps, onUpdateStep, testExecutionSteps, resetTimestamp } =
-    useContext(EditorContext)
-
-  // This includes all steps that run even after the current step, but within the same branch.
-  const stepExecutionsToInclude = useContext(StepExecutionsToIncludeContext)
-  const priorExecutionSteps = useMemo(
-    () =>
-      testExecutionSteps.filter(
-        (stepExecution) =>
-          stepExecutionsToInclude?.has(stepExecution.stepId) &&
-          stepExecution.step.position < step.position,
-      ),
-    [step.position, stepExecutionsToInclude, testExecutionSteps],
-  )
+  const { allApps, onUpdateStep, resetTimestamp } = useContext(EditorContext)
 
   const { app, hasConnection, isTrigger, selectedActionOrTrigger, substeps } =
     useStepMetadata(allApps, step)
@@ -67,7 +53,7 @@ export default function Step(props: StepProps): React.ReactElement | null {
   return (
     <>
       <Flex w="100%" flexDir="column">
-        <StepExecutionsProvider priorExecutionSteps={priorExecutionSteps}>
+        <StepExecutionsProvider currentStep={step}>
           <Form
             key={`${step.id}-${resetTimestamp}`}
             defaultValues={step}

--- a/packages/frontend/src/components/EditorRightDrawer/Step.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/Step.tsx
@@ -1,7 +1,7 @@
 import type { IStep } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
-import { CircularProgress, Flex, useDisclosure } from '@chakra-ui/react'
+import { Fragment, useCallback, useContext, useMemo } from 'react'
+import { Flex, useDisclosure } from '@chakra-ui/react'
 
 import ChooseConnectionSubstep from '@/components/ChooseConnectionSubstep'
 import FlowSubstep from '@/components/FlowSubstep'
@@ -17,11 +17,10 @@ import LearnFromGuideInfobox from './LearnFromGuideInfobox'
 
 type StepProps = {
   step: IStep
-  isLastStep: boolean
 }
 
 export default function Step(props: StepProps): React.ReactElement | null {
-  const { step, isLastStep } = props
+  const { step } = props
 
   const {
     isOpen: isModalOpen,
@@ -29,10 +28,10 @@ export default function Step(props: StepProps): React.ReactElement | null {
     onClose: onModalClose,
   } = useDisclosure()
 
-  const { allApps, onUpdateStep, resetTimestamp } = useContext(EditorContext)
+  const { onUpdateStep, resetTimestamp } = useContext(EditorContext)
 
   const { app, hasConnection, isTrigger, selectedActionOrTrigger, substeps } =
-    useStepMetadata(allApps, step)
+    useStepMetadata(step)
 
   const handleSubmit = useCallback(
     (val: any) => {
@@ -45,10 +44,6 @@ export default function Step(props: StepProps): React.ReactElement | null {
     () => generateValidationSchema(substeps),
     [substeps],
   )
-
-  if (!allApps) {
-    return <CircularProgress isIndeterminate my={2} />
-  }
 
   return (
     <>
@@ -96,7 +91,8 @@ export default function Step(props: StepProps): React.ReactElement | null {
         <FlowStepConfigurationModal
           onClose={onModalClose}
           isTrigger={isTrigger}
-          isLastStep={isLastStep}
+          // this shouldnt matter here since it's just for reconnecting
+          isLastStep={false}
           step={step}
           app={app}
           event={selectedActionOrTrigger}

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -25,7 +25,6 @@ export default function StepHeader(props: StepHeaderProps) {
   } = useDisclosure()
 
   const {
-    allApps,
     readOnly: isReadOnlyEditor,
     shouldWarnOnLeave,
     onDrawerClose,
@@ -38,7 +37,7 @@ export default function StepHeader(props: StepHeaderProps) {
     defaultCaption,
     position,
     stepName: initialStepName,
-  } = useStepMetadata(allApps, step)
+  } = useStepMetadata(step)
 
   const handleClose = () => {
     if (shouldWarnOnLeave) {

--- a/packages/frontend/src/components/EditorRightDrawer/index.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/index.tsx
@@ -1,9 +1,7 @@
 import { IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
 import { Flex } from '@chakra-ui/react'
 
-import { EditorContext } from '@/contexts/Editor'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
 import Step from './Step'
@@ -11,21 +9,15 @@ import StepHeader from './StepHeader'
 import { editorRightDrawerStyles as styles } from './styles'
 
 interface EditorRightDrawerProps {
-  flowStepGroupIconUrl?: string
-  steps: IStep[]
+  step?: IStep
 }
 
 export default function EditorRightDrawer(props: EditorRightDrawerProps) {
-  const { steps } = props
+  const { step } = props
 
-  const { allApps, currentStepId } = useContext(EditorContext)
+  const { hasConnection } = useStepMetadata(step)
 
-  const step = useMemo(() => {
-    return steps.find((step) => step.id === currentStepId)
-  }, [currentStepId, steps])
-  const { hasConnection } = useStepMetadata(allApps, step)
-
-  if (!currentStepId || !step) {
+  if (!step) {
     return null
   }
 
@@ -40,7 +32,7 @@ export default function EditorRightDrawer(props: EditorRightDrawerProps) {
     >
       <StepHeader step={step} />
       <Flex {...styles.stepContentsWrapper} pt={hasConnection ? 0 : 4}>
-        <Step step={step} isLastStep={step.position === steps.length} />
+        <Step step={step} />
       </Flex>
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -77,14 +77,7 @@ export default function FlowStep(
     substeps,
     shouldShowDragHandle,
     isDeletable,
-  } = useStepMetadata(
-    allApps,
-    step,
-    readOnly,
-    allowReorder,
-    isMobile,
-    isDrawerOpen,
-  )
+  } = useStepMetadata(allApps, step, true)
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -77,7 +77,7 @@ export default function FlowStep(
     substeps,
     shouldShowDragHandle,
     isDeletable,
-  } = useStepMetadata(step, true)
+  } = useStepMetadata(step, allowReorder)
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -77,7 +77,7 @@ export default function FlowStep(
     substeps,
     shouldShowDragHandle,
     isDeletable,
-  } = useStepMetadata(allApps, step, true)
+  } = useStepMetadata(step, true)
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -40,16 +40,8 @@ export function HoverAddStepButton(
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
 
-  const { allApps, readOnly, isMobile, isDrawerOpen } =
-    useContext(EditorContext)
-  const { shouldShowDragHandle } = useStepMetadata(
-    allApps,
-    step,
-    readOnly,
-    allowReorder,
-    isMobile,
-    isDrawerOpen,
-  )
+  const { allApps, readOnly, isDrawerOpen } = useContext(EditorContext)
+  const { shouldShowDragHandle } = useStepMetadata(allApps, step, allowReorder)
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/HoverAddStepButton.tsx
@@ -40,8 +40,8 @@ export function HoverAddStepButton(
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isHovered, setIsHovered] = useState(false)
 
-  const { allApps, readOnly, isDrawerOpen } = useContext(EditorContext)
-  const { shouldShowDragHandle } = useStepMetadata(allApps, step, allowReorder)
+  const { readOnly, isDrawerOpen } = useContext(EditorContext)
+  const { shouldShowDragHandle } = useStepMetadata(step, allowReorder)
 
   const {
     cancelRef,

--- a/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/components/GroupStepWithAddButton.tsx
@@ -26,7 +26,6 @@ export default function GroupStepWithAddButton(
     isLastStep,
     isOverlay,
     allowReorder,
-
     showEmptyAction,
     canChildStepsReorder,
   } = props

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -114,7 +114,7 @@ export default function FlowStepTestController(
     isMrfStep,
     selectedActionOrTrigger,
     substeps,
-  } = useStepMetadata(allApps, step)
+  } = useStepMetadata(step)
 
   const {
     isTestSuccessful,

--- a/packages/frontend/src/contexts/MrfContext.tsx
+++ b/packages/frontend/src/contexts/MrfContext.tsx
@@ -1,0 +1,67 @@
+import { IStep } from '@plumber/types'
+
+import { createContext, useContext, useState } from 'react'
+
+import { FORMSG_APP_KEY, MRF_ACTION_KEY } from '@/helpers/formsg'
+
+type ApprovalBranch = 'approve' | 'reject'
+
+interface MrfContextReturnValue {
+  mrfSteps: IStep[]
+  approvalBranches: {
+    [stepId: string]: ApprovalBranch
+  }
+  setApprovalBranch: (stepId: string, branch: ApprovalBranch) => void
+}
+
+const MrfContext = createContext<MrfContextReturnValue | undefined>(undefined)
+
+export const useMrfContext = () => {
+  const context = useContext(MrfContext)
+  if (!context) {
+    throw new Error('useMrfContext must be used within a MrfContextProvider')
+  }
+  return context
+}
+
+interface MrfContextProviderProps {
+  children: React.ReactNode
+  steps: IStep[]
+}
+
+export const MrfContextProvider = ({
+  children,
+  steps,
+}: MrfContextProviderProps) => {
+  const mrfSteps = steps.filter(
+    (step) => step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY,
+  )
+
+  const [approvalBranches, setApprovalBranches] = useState<
+    Record<string, ApprovalBranch>
+  >({
+    ...mrfSteps.reduce((acc, step) => {
+      acc[step.id] = 'approve'
+      return acc
+    }, {} as Record<string, ApprovalBranch>),
+  })
+
+  const setApprovalBranch = (stepId: string, branch: ApprovalBranch) => {
+    setApprovalBranches((prev) => ({
+      ...prev,
+      [stepId]: branch,
+    }))
+  }
+
+  return (
+    <MrfContext.Provider
+      value={{
+        mrfSteps,
+        approvalBranches,
+        setApprovalBranch,
+      }}
+    >
+      {children}
+    </MrfContext.Provider>
+  )
+}

--- a/packages/frontend/src/contexts/StepExecutions.tsx
+++ b/packages/frontend/src/contexts/StepExecutions.tsx
@@ -1,20 +1,73 @@
-import type { IExecutionStep } from '@plumber/types'
+import type { IExecutionStep, IStep } from '@plumber/types'
 
-import * as React from 'react'
+import { createContext, useContext, useMemo } from 'react'
 
-export const StepExecutionsContext = React.createContext<{
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+
+import { EditorContext } from './Editor'
+import { StepExecutionsToIncludeContext } from './StepExecutionsToInclude'
+
+export const StepExecutionsContext = createContext<{
   priorExecutionSteps: IExecutionStep[]
 }>({ priorExecutionSteps: [] })
 
 type StepExecutionsProviderProps = {
   children: React.ReactNode
-  priorExecutionSteps: IExecutionStep[]
+  currentStep: IStep
 }
 
-export const StepExecutionsProvider = (
-  props: StepExecutionsProviderProps,
-): React.ReactElement => {
-  const { children, priorExecutionSteps } = props
+export const StepExecutionsProvider = ({
+  currentStep,
+  children,
+}: StepExecutionsProviderProps): React.ReactElement => {
+  const { testExecutionSteps } = useContext(EditorContext)
+
+  const {
+    triggerStep,
+    actionStepsBeforeGroup: stepsBeforeGroup,
+    groupedSteps,
+  } = useContext(StepExecutionsToIncludeContext)
+
+  //
+  // Compute which steps are eligible for variable extraction.
+  // Mainly for if-then branches where we do not want to include steps
+  // from other branches.
+  //
+  // Note:
+  // - we include some grouped steps as there is no longer a nested editor
+  // - we identify the group by checking if the current step id is in the group
+  // - for-each steps are always included
+  const groupStepsToInclude = useMemo(() => {
+    return groupedSteps.flatMap((group) =>
+      group.some(
+        (step) =>
+          step.key === TOOLBOX_ACTIONS.ForEach || step.id === currentStep.id,
+      )
+        ? group
+        : [],
+    )
+  }, [currentStep?.id, groupedSteps])
+
+  const stepExecutionsToInclude = useMemo(
+    () =>
+      new Set([
+        ...(triggerStep?.id ? [triggerStep.id] : []),
+        ...stepsBeforeGroup.map((step) => step.id),
+        ...groupStepsToInclude.map((s) => s.id),
+      ]),
+    [triggerStep, stepsBeforeGroup, groupStepsToInclude],
+  )
+
+  const priorExecutionSteps = useMemo(
+    () =>
+      testExecutionSteps.filter(
+        (stepExecution) =>
+          stepExecutionsToInclude?.has(stepExecution.stepId) &&
+          stepExecution.step.position < currentStep.position,
+      ),
+    [currentStep.position, stepExecutionsToInclude, testExecutionSteps],
+  )
+
   return (
     <StepExecutionsContext.Provider value={{ priorExecutionSteps }}>
       {children}

--- a/packages/frontend/src/contexts/StepExecutionsToInclude.tsx
+++ b/packages/frontend/src/contexts/StepExecutionsToInclude.tsx
@@ -3,22 +3,40 @@ import type { IStep } from '@plumber/types'
 import type { ReactNode } from 'react'
 import { createContext } from 'react'
 
-export type StepExecutionsToIncludeContextData = ReadonlySet<IStep['id']>
-
-export const StepExecutionsToIncludeContext =
-  createContext<StepExecutionsToIncludeContextData>(new Set())
-
-type StepExecutionsProviderProps = {
-  children: ReactNode
-  value: StepExecutionsToIncludeContextData
+export type StepExecutionsToIncludeContextData = {
+  triggerStep: IStep | null
+  actionStepsBeforeGroup: IStep[]
+  groupedSteps: IStep[][]
 }
 
-export function StepExecutionsToIncludeProvider(
-  props: StepExecutionsProviderProps,
-): JSX.Element {
-  const { children, value } = props
+export const StepExecutionsToIncludeContext =
+  createContext<StepExecutionsToIncludeContextData>({
+    triggerStep: null,
+    actionStepsBeforeGroup: [],
+    groupedSteps: [],
+  })
+
+interface StepExecutionsProviderProps {
+  children: ReactNode
+  triggerStep: IStep | null
+  actionStepsBeforeGroup: IStep[]
+  groupedSteps: IStep[][]
+}
+
+export function StepExecutionsToIncludeProvider({
+  children,
+  triggerStep,
+  actionStepsBeforeGroup,
+  groupedSteps,
+}: StepExecutionsProviderProps): JSX.Element {
   return (
-    <StepExecutionsToIncludeContext.Provider value={value}>
+    <StepExecutionsToIncludeContext.Provider
+      value={{
+        triggerStep,
+        actionStepsBeforeGroup,
+        groupedSteps,
+      }}
+    >
       {children}
     </StepExecutionsToIncludeContext.Provider>
   )

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -30,11 +30,11 @@ interface UseStepMetadataResult {
 }
 
 export function useStepMetadata(
-  allApps: IApp[],
   step: IStep | undefined,
   allowReorder?: boolean,
 ): UseStepMetadataResult {
-  const { readOnly, isMobile, isDrawerOpen } = useContext(EditorContext)
+  const { readOnly, isMobile, isDrawerOpen, allApps } =
+    useContext(EditorContext)
 
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -1,8 +1,9 @@
 import { IAction, IApp, IStep, ISubstep, ITrigger } from '@plumber/types'
 
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import get from 'lodash/get'
 
+import { EditorContext } from '@/contexts/Editor'
 import { FORMSG_APP_KEY, MRF_ACTION_KEY } from '@/helpers/formsg'
 import getStepName from '@/helpers/getStepName'
 import {
@@ -31,11 +32,10 @@ interface UseStepMetadataResult {
 export function useStepMetadata(
   allApps: IApp[],
   step: IStep | undefined,
-  readOnly?: boolean,
   allowReorder?: boolean,
-  isMobile?: boolean,
-  isDrawerOpen?: boolean,
 ): UseStepMetadataResult {
+  const { readOnly, isMobile, isDrawerOpen } = useContext(EditorContext)
+
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'
   const isIfThenStep = step ? checkIfThenStep(step) : false

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -99,9 +99,18 @@ export function useStepMetadata(
       !isMobile &&
       !isIfThenStep &&
       allowReorder &&
-      !isDrawerOpen
+      !isDrawerOpen &&
+      !isMrfStep
     )
-  }, [readOnly, isTrigger, isMobile, isIfThenStep, allowReorder, isDrawerOpen])
+  }, [
+    readOnly,
+    isTrigger,
+    isMobile,
+    isIfThenStep,
+    allowReorder,
+    isDrawerOpen,
+    isMrfStep,
+  ])
 
   return {
     app,


### PR DESCRIPTION
## Changes

1. Added a new MrfContextProvider to manage form approval branches
2. Refactoring the useStepMetadata hook to read context values directly from EditorContext
3. Simplifying the StepExecutionsToIncludeProvider to use a more structured context object
4. Improving the way steps are passed to EditorRightDrawer

These changes make the code more maintainable and prepare for future form approval functionality.