### PR TITLE
fix: cannot create if-then

### DIFF
--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -92,6 +92,7 @@ const createStep: MutationResolvers['createStep'] = async (
 
     return {
       ...step,
+      flowId: flow.id,
       flow: {
         updatedAt: updatedFlow.updatedAt,
       },

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -703,6 +703,7 @@ type Step {
   executionSteps: [ExecutionStep]
   config: StepConfig
   createdAt: String
+  flowId: String
 }
 
 type StepConfig {

--- a/packages/frontend/src/graphql/mutations/create-step.ts
+++ b/packages/frontend/src/graphql/mutations/create-step.ts
@@ -10,6 +10,7 @@ export const CREATE_STEP = gql`
       parameters
       position
       status
+      flowId
       connection {
         id
       }

--- a/packages/frontend/src/graphql/mutations/update-step.ts
+++ b/packages/frontend/src/graphql/mutations/update-step.ts
@@ -11,6 +11,7 @@ export const UPDATE_STEP = graphql(`
       parameters
       status
       position
+      flowId
       connection {
         id
       }

--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -16,6 +16,7 @@ export const FLOW_FIELDS = gql`
       status
       position
       createdAt
+      flowId
       connection {
         id
         verified


### PR DESCRIPTION
## Problem
Frontend bug prevents users from creating If-then.

## Solution
Return `flowId` when creating and updating steps.

## Tests
- [x] Can create if-then at second step
- [x] Can create if-then at third or more step
- [x] Can create if-then inside for-each