### PR TITLE
PLU-620: reduce Slack scopes

### DIFF
--- a/packages/backend/src/apps/slack/auth/generate-auth-url.ts
+++ b/packages/backend/src/apps/slack/auth/generate-auth-url.ts
@@ -6,46 +6,8 @@ import type {
 
 import qs from 'qs'
 
-const scopes = [
-  'channels:manage',
-  'channels:read',
-  'channels:join',
-  'chat:write',
-  'chat:write.customize',
-  'chat:write.public',
-  'files:write',
-  'im:write',
-  'mpim:write',
-  'team:read',
-  'users.profile:read',
-  'users:read',
-  'workflow.steps:execute',
-  'users:read.email',
-  'commands',
-]
-const userScopes = [
-  'channels:history',
-  'channels:read',
-  'channels:write',
-  'chat:write',
-  'emoji:read',
-  'files:read',
-  'files:write',
-  'groups:history',
-  'groups:read',
-  'groups:write',
-  'im:write',
-  'mpim:write',
-  'reactions:read',
-  'reminders:write',
-  'search:read',
-  'stars:read',
-  'team:read',
-  'users.profile:read',
-  'users.profile:write',
-  'users:read',
-  'users:read.email',
-]
+const scopes = ['chat:write', 'chat:write.customize', 'chat:write.public']
+const userScopes = ['channels:read', 'chat:write', 'search:read', 'users:read']
 
 export default async function generateAuthUrl($: IGlobalVariable) {
   // Our own auth, so safe to cast $.app.auth

--- a/packages/backend/src/apps/slack/auth/index.ts
+++ b/packages/backend/src/apps/slack/auth/index.ts
@@ -22,7 +22,7 @@ const auth: IUserAddedConnectionAuth = {
     },
     {
       key: 'consumerKey',
-      label: 'API Key',
+      label: 'Client ID',
       type: 'string' as const,
       required: true,
       readOnly: false,
@@ -33,7 +33,7 @@ const auth: IUserAddedConnectionAuth = {
     },
     {
       key: 'consumerSecret',
-      label: 'API Secret',
+      label: 'Client Secret',
       type: 'string' as const,
       required: true,
       readOnly: false,


### PR DESCRIPTION
## Problem
Slack integration requests for a lot of scopes when adding the app to a workplace.

## Solution
Use the least permissive access required.

## Other changes
Renamed auth fields to `Client ID` and `Client Secret` to match the names on Slack.

## Tests
- [ ] Can still add app to Plumber
- [ ] Can send message to public channel as user
- [ ] Can send message to public channel as bot
  - [ ] Can set bot name
  - [ ] Can set bot icon
- [ ] Can send message to private channel as user
- [ ] Can search for messages


## Before & After Screenshots
<img width="601" height="430" alt="Screenshot 2025-12-02 at 10 56 35 AM" src="https://github.com/user-attachments/assets/a525fe87-0540-42f8-a303-70dbce672f9c" />
<img width="598" height="414" alt="Screenshot 2025-12-02 at 10 56 41 AM" src="https://github.com/user-attachments/assets/427c7e9a-dd7b-4601-8ef0-b2548d2299da" />
<img width="593" height="409" alt="Screenshot 2025-12-02 at 10 56 47 AM" src="https://github.com/user-attachments/assets/22412234-5e7f-4947-8597-a1360ab59c35" />


<img width="615" height="687" alt="Screenshot 2025-12-02 at 11 06 48 AM" src="https://github.com/user-attachments/assets/9624a71e-8b70-4e05-954d-41ddc79c73dd" />
