### PR TITLE
fix: filter excel steps to nullify

### DIFF
--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -103,7 +103,9 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
       // nullify connections for M365-excel
       // excel connections cannot be shared; the new owner should use their own connection
       const excelStepIds = flow.steps
-        .filter((step) => step.appKey === 'm365-excel')
+        .filter(
+          (step) => step.appKey === 'm365-excel' && step.connectionId != null,
+        )
         .map((step) => step.id)
       const numExcelNullified = await Step.query(trx)
         .patch({ connection: null, connectionId: null, status: 'incomplete' })


### PR DESCRIPTION
## Problem
Cannot transfer Pipe that contains Excel steps without connections.
Caused by inconsistent check for number of Excel steps to nullify.

**How to replicate?**
Create a Pipe with Excel step.
Transfer to user A (this works).
Don't do anything.
Transfer to user B (this will fail).

## Solution
Only filter out Excel steps with connections.

## Tests
1. Create a Pipe with Excel step.
2. Transfer to user A: this works
3. Don't do anything.
4. Transfer to user B: this should also work