### PR TITLE
PLU-618: GatherSG: Get Case Details action

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -72,6 +72,20 @@ async function getDataOutMetadata(
     }
   }
 
+  const attachmentsMetadata = Object.create(null)
+  const attachmentKeys: string[] = []
+  if (dataOut.attachments) {
+    for (const key of Object.keys(dataOut.attachments)) {
+      attachmentsMetadata[key] = {
+        name: { isHidden: true },
+        mimeType: { isHidden: true },
+        size: { isHidden: true },
+      }
+
+      attachmentKeys.push(key)
+    }
+  }
+
   // handle hex-encoded field names from dataOut
   const fieldsMetadata = Object.create(null)
 
@@ -114,10 +128,26 @@ async function getDataOutMetadata(
           } else {
             // array of primitives (strings, numbers, etc.) - display as comma-separated values
             // allow to use as array
-            fieldsMetadata[hexKey] = {
-              label: decodedLabel,
-              type: 'array',
-              displayedValue: fieldValue.join(', '),
+
+            // HACK: GatherSg returns the attachment field with an array of attachment ids
+            // and a separate attachment object. we hide the array of attachment ids as it is
+            // not useful to the user
+            if (
+              fieldValue.every(
+                (item) =>
+                  typeof item === 'string' && attachmentKeys.includes(item),
+              )
+            ) {
+              fieldsMetadata[hexKey] = {
+                label: decodedLabel,
+                isHidden: true,
+              }
+            } else {
+              fieldsMetadata[hexKey] = {
+                label: decodedLabel,
+                type: 'array',
+                displayedValue: fieldValue.join(', '),
+              }
             }
           }
         } else {
@@ -127,17 +157,6 @@ async function getDataOutMetadata(
       } catch (error) {
         // if decoding fails, use the hex key as-is
         fieldsMetadata[hexKey] = { label: hexKey }
-      }
-    }
-  }
-
-  const attachmentsMetadata = Object.create(null)
-  if (dataOut.attachments) {
-    for (const key of Object.keys(dataOut.attachments)) {
-      attachmentsMetadata[key] = {
-        name: { isHidden: true },
-        mimeType: { isHidden: true },
-        size: { isHidden: true },
       }
     }
   }

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -22,10 +22,7 @@ async function getDataOutMetadata(
       type: {
         name: { label: 'Case type' },
         uuid: { isHidden: true },
-        slaDay: {
-          label: 'Case duration threshold (in days)',
-          isHidden: !dataOut.type.slaDay,
-        },
+        slaDay: { isHidden: true },
       },
       uuid: { label: 'Case UUID' },
       caseRef: { label: 'Case ref' },

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -1,0 +1,116 @@
+import { IDataOutMetadata, IExecutionStep, IJSONArray } from '@plumber/types'
+
+import { dataOutSchema } from './schema'
+
+async function getDataOutMetadata(
+  step: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut: rawDataOut } = step
+  if (!rawDataOut) {
+    return null
+  }
+
+  const parsedDataOut = dataOutSchema.safeParse(rawDataOut)
+  if (!parsedDataOut.success) {
+    return null
+  }
+
+  const { data: dataOut } = parsedDataOut.data
+
+  const metadata = {
+    data: {
+      type: {
+        name: { label: 'Case type' },
+        uuid: { isHidden: true },
+      },
+      uuid: { label: 'Case UUID' },
+      caseRef: { label: 'Case ref' },
+      source: { label: 'Case source' },
+      status: {
+        name: { label: 'Status' },
+        uuid: { isHidden: true },
+        color: { isHidden: true },
+        isFinal: { isHidden: true },
+      },
+      createdAt: { label: 'Created at' },
+      createdBy: {
+        name: { label: 'Created by (name)' },
+        email: { label: 'Created by (email)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
+      },
+      updatedAt: { label: 'Updated at' },
+      updatedBy: {
+        name: { label: 'Updated by (name)' },
+        email: { label: 'Updated by (email)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
+      },
+      durationSec: { isHidden: true },
+      traceId: { label: 'Trace ID' },
+    },
+  }
+
+  // handle hex-encoded field names from dataOut
+  const fieldsMetadata = Object.create(null)
+
+  if (dataOut.fields) {
+    for (const hexKey of Object.keys(dataOut.fields)) {
+      try {
+        // decode hex key to get the original column name
+        const decodedLabel = Buffer.from(hexKey, 'hex').toString('utf-8')
+        const fieldValue = dataOut.fields[hexKey]
+
+        // check if the value is an array
+        if (Array.isArray(fieldValue)) {
+          // check if it's an array of objects or an array of primitives
+          if (
+            fieldValue.length > 0 &&
+            typeof fieldValue[0] === 'object' &&
+            fieldValue[0] !== null
+          ) {
+            // array of objects - create nested object structure for each row
+            const array = fieldValue as IJSONArray
+            const rowsMetadata = Object.create(null)
+
+            for (let i = 0; i < array.length; i++) {
+              const rowObject = array[i]
+              const rowMetadata = Object.create(null)
+
+              if (typeof rowObject === 'object' && rowObject !== null) {
+                for (const nestedKey of Object.keys(rowObject)) {
+                  rowMetadata[nestedKey] = {
+                    type: 'text',
+                    label: `${decodedLabel} Row ${i + 1} ${nestedKey}`,
+                  }
+                }
+              }
+
+              rowsMetadata[i] = rowMetadata
+            }
+
+            fieldsMetadata[hexKey] = rowsMetadata
+          } else {
+            // array of primitives (strings, numbers, etc.) - treat as simple field
+            fieldsMetadata[hexKey] = { label: decodedLabel }
+          }
+        } else {
+          // not an array - treat as simple field
+          fieldsMetadata[hexKey] = { label: decodedLabel }
+        }
+      } catch (error) {
+        // if decoding fails, use the hex key as-is
+        fieldsMetadata[hexKey] = { label: hexKey }
+      }
+    }
+  }
+
+  return {
+    data: {
+      ...metadata.data,
+      fields: fieldsMetadata,
+    },
+  }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -51,6 +51,16 @@ async function getDataOutMetadata(
     },
   }
 
+  // handle tags if any
+  // tags are an array of strings and exist at the top level alongside the
+  // uuid, caseRef, etc
+  const tagsMetadata = Object.create(null)
+  if (dataOut.tags && Array.isArray(dataOut.tags)) {
+    for (let i = 0; i < dataOut.tags.length; i++) {
+      tagsMetadata[i] = { label: `Tag` }
+    }
+  }
+
   // handle hex-encoded field names from dataOut
   const fieldsMetadata = Object.create(null)
 
@@ -108,6 +118,7 @@ async function getDataOutMetadata(
   return {
     data: {
       ...metadata.data,
+      tags: tagsMetadata,
       fields: fieldsMetadata,
     },
   }

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -22,6 +22,10 @@ async function getDataOutMetadata(
       type: {
         name: { label: 'Case type' },
         uuid: { isHidden: true },
+        slaDay: {
+          label: 'Case duration threshold (in days)',
+          isHidden: !dataOut.type.slaDay,
+        },
       },
       uuid: { label: 'Case UUID' },
       caseRef: { label: 'Case ref' },
@@ -47,7 +51,14 @@ async function getDataOutMetadata(
         uuid: { isHidden: true },
       },
       durationSec: { isHidden: true },
-      traceId: { label: 'Trace ID' },
+      durationPaused: { isHidden: true },
+      email: {
+        subject: { label: 'Email subject' },
+        sender: {
+          name: { label: 'Email sender (name)' },
+          address: { label: 'Email sender (email)' },
+        },
+      },
     },
   }
 
@@ -101,8 +112,13 @@ async function getDataOutMetadata(
 
             fieldsMetadata[hexKey] = rowsMetadata
           } else {
-            // array of primitives (strings, numbers, etc.) - treat as simple field
-            fieldsMetadata[hexKey] = { label: decodedLabel }
+            // array of primitives (strings, numbers, etc.) - display as comma-separated values
+            // allow to use as array
+            fieldsMetadata[hexKey] = {
+              label: decodedLabel,
+              type: 'array',
+              displayedValue: fieldValue.join(', '),
+            }
           }
         } else {
           // not an array - treat as simple field
@@ -115,11 +131,23 @@ async function getDataOutMetadata(
     }
   }
 
+  const attachmentsMetadata = Object.create(null)
+  if (dataOut.attachments) {
+    for (const key of Object.keys(dataOut.attachments)) {
+      attachmentsMetadata[key] = {
+        name: { isHidden: true },
+        mimeType: { isHidden: true },
+        size: { isHidden: true },
+      }
+    }
+  }
+
   return {
     data: {
       ...metadata.data,
       tags: tagsMetadata,
       fields: fieldsMetadata,
+      attachments: attachmentsMetadata,
     },
   }
 }

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -8,7 +8,7 @@ import getDataOutMetadata from './get-data-out-metadata'
 const action: IRawAction = {
   name: 'Get case details',
   key: 'getCaseDetails',
-  description: 'Get details of a case based on the case uuid',
+  description: 'Select the case uuid you want to get case details for.',
   arguments: [
     {
       label: 'Case UUID',
@@ -16,6 +16,10 @@ const action: IRawAction = {
       type: 'string' as const,
       required: true,
       variables: true,
+      // we intentionally disable typing for case uuid as it is used in
+      // to get dynamic data for case fields
+      // it can still be pasted via mouse click
+      singleVariableSelection: true,
     },
   ],
 
@@ -47,7 +51,10 @@ const action: IRawAction = {
         },
       })
     } catch (error) {
-      logger.error('Failed to get case details:', error)
+      logger.error(
+        `Failed to get case details for case ${$.step.parameters.caseUuid}:`,
+        error,
+      )
       throw new StepError(
         `An error occurred: '${error.message}'`,
         'Please check that you have configured your step correctly',

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -28,11 +28,33 @@ const action: IRawAction = {
   async run($) {
     try {
       const { caseUuid } = $.step.parameters
-      const { data: rawData } = await $.http.get(`/cases/:caseUuid`, {
-        urlPathParams: { caseUuid },
-      })
 
-      const { fields } = rawData.data
+      let rawData
+      try {
+        const { data } = await $.http.get(`/cases/:caseUuid`, {
+          urlPathParams: { caseUuid },
+        })
+        rawData = data
+      } catch (error) {
+        logger.error(`Failed to get case details for case ${caseUuid}:`, error)
+        throw new StepError(
+          `Invalid case uuid: ${caseUuid}`,
+          'Please check that you have configured your step correctly',
+          $.step.position,
+          $.app.name,
+          error,
+        )
+      }
+
+      const fields = rawData.data?.fields
+      if (!fields) {
+        throw new StepError(
+          `No data found for case ${caseUuid}`,
+          'Please check that you have configured your step correctly',
+          $.step.position,
+          $.app.name,
+        )
+      }
 
       // hex encode the field names
       const hexEncodedFields: Record<string, any> = {}

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -1,0 +1,61 @@
+import { IRawAction } from '@plumber/types'
+
+import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
+
+import getDataOutMetadata from './get-data-out-metadata'
+
+const action: IRawAction = {
+  name: 'Get case details',
+  key: 'getCaseDetails',
+  description: 'Get details of a case based on the case uuid',
+  arguments: [
+    {
+      label: 'Case UUID',
+      key: 'caseUuid',
+      type: 'string' as const,
+      required: true,
+      variables: true,
+    },
+  ],
+
+  getDataOutMetadata,
+
+  async run($) {
+    try {
+      const { caseUuid } = $.step.parameters
+      const { data: rawData } = await $.http.get(`/cases/:caseUuid`, {
+        urlPathParams: { caseUuid },
+      })
+
+      const { fields } = rawData.data
+
+      // hex encode the field names
+      const hexEncodedFields: Record<string, any> = {}
+      for (const [key, value] of Object.entries(fields)) {
+        const hexKey = Buffer.from(key).toString('hex')
+        hexEncodedFields[hexKey] = value
+      }
+
+      $.setActionItem({
+        raw: {
+          ...rawData,
+          data: {
+            ...rawData.data,
+            fields: hexEncodedFields,
+          },
+        },
+      })
+    } catch (error) {
+      logger.error('Failed to get case details:', error)
+      throw new StepError(
+        `An error occurred: '${error.message}'`,
+        'Please check that you have configured your step correctly',
+        $.step.position,
+        $.app.name,
+      )
+    }
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
@@ -22,6 +22,7 @@ export const dataOutSchema = z.object({
           name: z.string().min(1),
         })
         .nullish(),
+      tags: z.array(z.string()).nullish(),
     })
     .nullish(),
 })

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
@@ -3,6 +3,11 @@ import { z } from 'zod'
 export const dataOutSchema = z.object({
   data: z
     .object({
+      type: z.object({
+        name: z.string().min(1),
+        uuid: z.string().min(1),
+        slaDay: z.number().nullish(),
+      }),
       fields: z.record(z.string(), z.any()).nullish(),
       formsg: z
         .object({
@@ -23,6 +28,18 @@ export const dataOutSchema = z.object({
         })
         .nullish(),
       tags: z.array(z.string()).nullish(),
+      attachments: z
+        .record(
+          z.string(),
+          z.object({
+            name: z.string().min(1),
+            mimeType: z.string().min(1),
+            size: z.number(),
+          }),
+        )
+        .nullish(),
+      email: z.record(z.string(), z.any()).nullish(),
     })
     .nullish(),
+  traceId: z.string().min(1),
 })

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+export const dataOutSchema = z.object({
+  data: z
+    .object({
+      fields: z.record(z.string(), z.any()).nullish(),
+      formsg: z
+        .object({
+          formId: z.string().min(1),
+          submissionId: z.string().min(1),
+        })
+        .nullish(),
+      updatedBy: z
+        .object({
+          email: z.string().min(1).nullish(),
+          name: z.string().min(1),
+        })
+        .nullish(),
+      createdBy: z
+        .object({
+          email: z.string().min(1).nullish(),
+          name: z.string().min(1),
+        })
+        .nullish(),
+    })
+    .nullish(),
+})

--- a/packages/backend/src/apps/gathersg/actions/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/index.ts
@@ -1,5 +1,6 @@
 import createCase from './create-case'
+import getCaseDetails from './get-case-details'
 import tagOrUntagCase from './tag-or-untag-case'
 import updateCase from './update-case'
 
-export default [updateCase, tagOrUntagCase, createCase]
+export default [updateCase, tagOrUntagCase, createCase, getCaseDetails]


### PR DESCRIPTION
## TL;DR
This PR introduces an action to retrieve case details from GatherSG using the case uuid.

## How to test?
1. Create cases on GatherSG (can be different case types)
2. Create a Pipe with the GatherSG > Get case details action
3. Verify that the details are being retrieved and displayed correctly for the cases

## Screenshots
<img width="1509" height="802" alt="Screenshot 2025-12-09 at 6 02 04 PM" src="https://github.com/user-attachments/assets/7d211e14-2ed9-483b-8c98-a08e0d197fb0" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GatherSG action to fetch case details by UUID, hex-encode field keys, and expose structured data-out metadata; registers it in the actions list.
> 
> - **Backend – GatherSG Actions**:
>   - **New `get-case-details` action** (`getCaseDetails`):
>     - Fetches case via `GET /cases/:caseUuid` using `caseUuid` argument.
>     - Hex-encodes `data.fields` keys before emitting output.
>     - Provides `getDataOutMetadata`:
>       - Validates output via `schema.ts` (tags, fields, createdBy/updatedBy, formsg).
>       - Labels core case fields (`uuid`, `caseRef`, `status`, etc.).
>       - Generates metadata for `tags` array and hex-named `fields` (handles arrays of objects with nested rows).
>     - Adds logging and `StepError` handling.
>   - **Registration**: Exposes the action in `actions/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a87b663827a8955e4f364956db8e1c86672846. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->