### PR TITLE
[AI-BUILDER-3] (frontend): preview generated steps

### DIFF
--- a/packages/frontend/src/components/MultiStepLoader/index.tsx
+++ b/packages/frontend/src/components/MultiStepLoader/index.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef, useState } from 'react'
+import { FaCircleCheck } from 'react-icons/fa6'
+import { Box, Flex, Icon, Text } from '@chakra-ui/react'
+import { AnimatePresence, motion } from 'framer-motion'
+
+const LoaderCore = ({
+  loadingStates,
+  value = 0,
+}: {
+  loadingStates: Array<{ text: string }>
+  value?: number
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([])
+
+  useEffect(() => {
+    if (containerRef.current && itemRefs.current[value]) {
+      const container = containerRef.current
+      const currentItem = itemRefs.current[value]
+
+      if (currentItem) {
+        const containerHeight = container.clientHeight
+        const itemTop = currentItem.offsetTop
+        const itemHeight = currentItem.clientHeight
+
+        // Calculate scroll position to center the current item
+        const scrollTop = itemTop - containerHeight / 2 + itemHeight / 2
+
+        container.scrollTo({
+          top: scrollTop,
+          behavior: 'smooth',
+        })
+      }
+    }
+  }, [value])
+
+  return (
+    <Box
+      ref={containerRef}
+      overflow="hidden"
+      position="relative"
+      height="100%"
+      width="fit-content"
+      maxHeight="200px"
+      margin="0 auto"
+    >
+      <Flex
+        flexDirection="column"
+        justifyContent="flex-start"
+        gap={2}
+        position="relative"
+        paddingY="calc(50% - 20px)"
+      >
+        {loadingStates.map((loadingState, index) => {
+          const distance = Math.abs(index - value)
+          const opacity = Math.max(1 - distance * 0.3, 0)
+
+          return (
+            <Box key={index} ref={(el) => (itemRefs.current[index] = el)}>
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: opacity, y: 0 }}
+                transition={{ duration: 0.2 }}
+                style={{ opacity }}
+              >
+                <Flex gap={3} alignItems="center">
+                  <Box
+                    h="16px"
+                    w="16px"
+                    borderRadius="full"
+                    bg={value > index ? 'primary.500' : 'primary.400'}
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    flexShrink={0}
+                    animation={
+                      value === index
+                        ? 'pulse 1.5s ease-in-out infinite'
+                        : undefined
+                    }
+                    sx={{
+                      '@keyframes pulse': {
+                        '0%, 100%': { opacity: 1 },
+                        '50%': { opacity: 0.5 },
+                      },
+                    }}
+                  >
+                    {value > index && (
+                      <Icon
+                        as={FaCircleCheck}
+                        boxSize="14px"
+                        color="white"
+                        strokeWidth={3}
+                      />
+                    )}
+                  </Box>
+                  <Text
+                    color={value > index ? 'gray.400' : 'content.primary'}
+                    textStyle="body-1"
+                  >
+                    {loadingState.text}
+                  </Text>
+                </Flex>
+              </motion.div>
+            </Box>
+          )
+        })}
+      </Flex>
+    </Box>
+  )
+}
+
+export const MultiStepLoader = ({
+  loadingStates,
+  loading,
+  duration = 2000,
+  loop = true,
+}: {
+  loadingStates: Array<{ text: string }>
+  loading?: boolean
+  duration?: number
+  loop?: boolean
+}) => {
+  const [currentState, setCurrentState] = useState(0)
+
+  useEffect(() => {
+    if (!loading) {
+      setCurrentState(0)
+      return
+    }
+    const timeout = setTimeout(() => {
+      setCurrentState((prevState) =>
+        loop
+          ? prevState === loadingStates.length - 1
+            ? 0
+            : prevState + 1
+          : Math.min(prevState + 1, loadingStates.length - 1),
+      )
+    }, duration)
+
+    return () => clearTimeout(timeout)
+  }, [currentState, loading, loop, loadingStates.length, duration])
+
+  return (
+    <AnimatePresence mode="wait">
+      {loading && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100%',
+            height: '100%',
+          }}
+        >
+          <LoaderCore value={currentState} loadingStates={loadingStates} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -1,4 +1,4 @@
-import { type IStep } from '@plumber/types'
+import { IApp, type IStep } from '@plumber/types'
 
 import { useCallback, useContext, useState } from 'react'
 import { useMutation } from '@apollo/client'
@@ -248,4 +248,82 @@ export function useIfThenInitializer(): [
 //
 export function isForEachStep(step: IStep): boolean {
   return step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.ForEach
+}
+
+//
+// General toolbox helpers
+//
+export function getGroupingActions(appsWithActions: IApp[]) {
+  if (!appsWithActions) {
+    return null
+  }
+
+  return new Set(
+    appsWithActions?.flatMap((app) =>
+      app.actions
+        ?.filter((action) => action.groupsLaterSteps)
+        ?.map((action) => `${app.key}-${action.key}`),
+    ) ?? [],
+  )
+}
+
+export function getStepStructure(
+  appsWithActions: IApp[],
+  steps: IStep[],
+): [IStep | null, IStep[], IStep[][]] {
+  const groupingActions = getGroupingActions(appsWithActions)
+
+  if (!groupingActions) {
+    return [null, [], []]
+  }
+
+  const groupStepIdx = steps.findIndex((step, index) => {
+    if (
+      // We ignore the 1st step because it's either a trigger, or a
+      // step-grouping action that is using a nested Editor to edit steps in
+      // its group.
+      index === 0 ||
+      !step.appKey ||
+      !step.key
+    ) {
+      return false
+    }
+    return groupingActions.has(`${step.appKey}-${step.key}`)
+  })
+
+  let branchesWithSteps: IStep[][] = []
+  if (groupStepIdx !== -1) {
+    branchesWithSteps = extractBranchesWithSteps(steps.slice(groupStepIdx), 0)
+  }
+
+  const triggerStep = steps[0]
+
+  return groupStepIdx === -1
+    ? [triggerStep, steps.slice(1), []]
+    : [triggerStep, steps.slice(1, groupStepIdx), branchesWithSteps]
+}
+
+export function getStepGroupTypeAndCaption(groupedSteps: IStep[][]): {
+  stepGroupType: string | null
+  stepGroupCaption: string | null
+} {
+  let stepGroupType: string | null = null
+  let stepGroupCaption: string | null = null
+
+  const groupKey = groupedSteps[0]?.[0]?.key
+  if (!groupKey) {
+    return { stepGroupType: null, stepGroupCaption: null }
+  }
+
+  if (groupKey === TOOLBOX_ACTIONS.IfThen) {
+    stepGroupType = TOOLBOX_ACTIONS.IfThen
+    stepGroupCaption = 'If-then'
+  }
+
+  if (groupKey === TOOLBOX_ACTIONS.ForEach) {
+    stepGroupType = TOOLBOX_ACTIONS.ForEach
+    stepGroupCaption = 'For each'
+  }
+
+  return { stepGroupType, stepGroupCaption }
 }

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -1,0 +1,133 @@
+import { IApp, IStep } from '@plumber/types'
+
+import { createContext, useContext, useMemo } from 'react'
+import { useQuery } from '@apollo/client'
+import { Center } from '@chakra-ui/react'
+import { datadogRum } from '@datadog/browser-rum'
+import { useIsMobile } from '@opengovsg/design-system-react'
+
+import PrimarySpinner from '@/components/PrimarySpinner'
+import { GET_APPS } from '@/graphql/queries/get-apps'
+import { getStepGroupTypeAndCaption, getStepStructure } from '@/helpers/toolbox'
+
+interface AIBuilderContextValue {
+  allApps: IApp[]
+  flowName: string
+  formInput: {
+    trigger: string
+    actions: string
+  }
+  isMobile: boolean
+  isFormMode: boolean
+  output: {
+    trigger: IStep
+    actions: IStep[]
+  }
+  triggerStep: IStep | null
+  steps: IStep[]
+  actionSteps: IStep[]
+  stepsBeforeGroup: IStep[]
+  groupedSteps: IStep[][]
+  stepGroupType: string | null
+  stepGroupCaption: string | null
+  // DataDog RUM Session ID so we can associate the trace with the RUM
+  ddSessionId: string
+}
+
+const AiBuilderContext = createContext<AIBuilderContextValue | undefined>(
+  undefined,
+)
+
+export const useAiBuilderContext = () => {
+  const context = useContext(AiBuilderContext)
+  if (!context) {
+    throw new Error(
+      'useAiBuilderContext must be used within a AiBuilderContextProvider',
+    )
+  }
+  return context
+}
+
+interface AiBuilderContextProviderProps {
+  children: React.ReactNode
+  flowName: string
+  formInput: {
+    trigger: string
+    actions: string
+  }
+  isFormMode: boolean
+  output: {
+    trigger: IStep
+    actions: IStep[]
+  }
+}
+
+export const AiBuilderContextProvider = ({
+  children,
+  flowName = 'Name your Pipe', // default to Name your Pipe if no flow name is provided
+  formInput,
+  isFormMode,
+  output,
+}: AiBuilderContextProviderProps) => {
+  const isMobile = useIsMobile()
+  const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
+
+  const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
+
+  const allApps = useMemo(
+    () => getAppsData?.getApps ?? [],
+    [getAppsData?.getApps],
+  )
+  const appsWithActions: IApp[] = allApps.filter(
+    (app: IApp) => !!app.actions?.length,
+  )
+
+  /**
+   * NOTE: process the steps that have been returned by Pair
+   * as if its in the Editor, but a lot simpler
+   */
+  const steps = useMemo(
+    () => [output?.trigger, ...(output?.actions || [])],
+    [output?.trigger, output?.actions],
+  )
+  const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(
+    () => getStepStructure(appsWithActions, steps),
+    [appsWithActions, steps],
+  )
+
+  const { stepGroupType, stepGroupCaption } = useMemo(
+    () => getStepGroupTypeAndCaption(groupedSteps),
+    [groupedSteps],
+  )
+
+  if (isLoadingAllApps) {
+    return (
+      <Center h="100vh">
+        <PrimarySpinner fontSize="4xl" />
+      </Center>
+    )
+  }
+
+  return (
+    <AiBuilderContext.Provider
+      value={{
+        allApps,
+        flowName,
+        formInput,
+        isFormMode,
+        output,
+        isMobile,
+        steps,
+        triggerStep,
+        actionSteps: output?.actions || [],
+        stepsBeforeGroup,
+        groupedSteps,
+        stepGroupType,
+        stepGroupCaption,
+        ddSessionId,
+      }}
+    >
+      {children}
+    </AiBuilderContext.Provider>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -87,10 +87,14 @@ export const AiBuilderContextProvider = ({
    * as if its in the Editor, but a lot simpler
    */
   const steps = useMemo(
-    () => [
-      ...(output?.trigger ? [output.trigger] : []),
-      ...(output?.actions || []),
-    ],
+    () =>
+      [
+        ...(output?.trigger ? [output.trigger] : []),
+        ...(output?.actions || []),
+      ].map((step, index) => ({
+        ...step,
+        position: index + 1,
+      })),
     [output?.trigger, output?.actions],
   )
   const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -87,7 +87,10 @@ export const AiBuilderContextProvider = ({
    * as if its in the Editor, but a lot simpler
    */
   const steps = useMemo(
-    () => [output?.trigger, ...(output?.actions || [])],
+    () => [
+      ...(output?.trigger ? [output.trigger] : []),
+      ...(output?.actions || []),
+    ],
     [output?.trigger, output?.actions],
   )
   const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/BranchStep.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/BranchStep.tsx
@@ -1,0 +1,38 @@
+import { IStep } from '@plumber/types'
+
+import { Box, Flex, Text } from '@chakra-ui/react'
+
+import { branchStyles } from '@/components/FlowStepGroup/Content/IfThen/styles'
+
+import Step from './Step'
+
+interface BranchStepProps {
+  branchSteps: IStep[]
+  isMobile: boolean
+}
+
+export default function BranchStep(props: BranchStepProps) {
+  const { branchSteps } = props
+
+  const branchName = branchSteps[0].parameters?.branchName as string
+
+  return (
+    <Flex key={String(branchSteps[0].position)} {...branchStyles.container}>
+      <Box w={'100%'} mb={2} h={6} overflow="hidden" role="group">
+        <Text textStyle="subhead-1" color="base.content.default" noOfLines={1}>
+          {branchName}
+        </Text>
+      </Box>
+      <Box w="100%">
+        {branchSteps.map((step, index) => (
+          <Step
+            key={String(step.position)}
+            step={step}
+            isNested={true}
+            isLastStep={index === branchSteps.length - 1}
+          />
+        ))}
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepContainer.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepContainer.tsx
@@ -1,0 +1,38 @@
+import { Flex } from '@chakra-ui/react'
+import { useIsMobile } from '@opengovsg/design-system-react'
+
+import { MIN_FLOW_STEP_WIDTH } from '@/components/Editor/constants'
+import { flowStepGroupStyles } from '@/components/FlowStepGroup/styles'
+
+import GroupedStepHeader from './GroupedStepHeader'
+
+interface GroupedStepContainerProps {
+  children: React.ReactNode
+  isNested: boolean
+  stepGroupType: string
+  stepGroupCaption: string
+}
+
+export default function GroupedStepContainer(props: GroupedStepContainerProps) {
+  const { children, isNested, stepGroupType, stepGroupCaption } = props
+  const isMobile = useIsMobile()
+  return (
+    <Flex justifyContent="center" w="100%">
+      <Flex
+        {...flowStepGroupStyles.container}
+        display={isMobile ? 'block' : 'flex'}
+        w="100%"
+        minW={MIN_FLOW_STEP_WIDTH}
+        pb={4}
+        maxW="600px"
+      >
+        <GroupedStepHeader
+          stepGroupType={stepGroupType}
+          stepGroupCaption={stepGroupCaption}
+          isNested={isNested}
+        />
+        {children}
+      </Flex>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepHeader.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepHeader.tsx
@@ -1,0 +1,45 @@
+import { Box, Flex, Icon, Text } from '@chakra-ui/react'
+
+import { flowStepGroupStyles } from '@/components/FlowStepGroup/styles'
+import { getToolboxIcon } from '@/helpers/editor'
+
+interface GroupedStepHeaderProps {
+  stepGroupType: string
+  stepGroupCaption: string
+  isNested?: boolean
+}
+
+export default function GroupedStepHeader(props: GroupedStepHeaderProps) {
+  const { stepGroupType, stepGroupCaption, isNested } = props
+
+  return (
+    <Box {...flowStepGroupStyles.header} w="100%">
+      <Flex
+        px={4}
+        pt={4}
+        alignItems="center"
+        borderRadius="inherit"
+        w="full"
+        borderLeftWidth={0}
+        borderRightWidth={0}
+        role="group"
+      >
+        <Flex {...flowStepGroupStyles.iconWrapper}>
+          {/* App icon */}
+          <Icon
+            boxSize={isNested ? 6 : 8}
+            as={getToolboxIcon(stepGroupType)}
+            color="primary.500"
+          />
+        </Flex>
+        <Flex direction="column" align="start">
+          <Flex alignItems="center" gap={2}>
+            <Text textStyle="subhead-1" color="base.content.default">
+              {stepGroupCaption}
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/ModifyPromptModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/ModifyPromptModal.tsx
@@ -1,0 +1,43 @@
+import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
+
+import { AiFormData } from '../../schema'
+import { AIFormModalContent } from '../AIFormModalContent'
+
+const ModifyPromptModal = ({
+  isOpen,
+  formInput,
+  onClose,
+  onUpdatePrompt,
+}: {
+  isOpen: boolean
+  formInput: {
+    trigger: string
+    actions: string
+  }
+  onClose: () => void
+  onUpdatePrompt: (formData: AiFormData) => Promise<void>
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      motionPreset="none"
+      closeOnEsc={false}
+      isCentered
+    >
+      <ModalOverlay bg="base.canvas.overlay" />
+
+      <ModalContent>
+        <AIFormModalContent
+          trigger={formInput?.trigger || ''}
+          actions={formInput?.actions || ''}
+          type="update"
+          onBack={onClose}
+          onSubmit={onUpdatePrompt}
+        />
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default ModifyPromptModal

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -56,7 +56,7 @@ export default function Step(props: StepProps) {
           />
           <Box py={isNested ? 2 : 4}>
             <Text textStyle="subhead-2">
-              Something went wrong, delete this step and try again.
+              Something went wrong. Modify your prompt and try again.
             </Text>
             <Text textStyle="caption-1" mt={1}>
               If this issue persists, contact us at{' '}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -1,0 +1,107 @@
+import { IApp, IStep } from '@plumber/types'
+
+import { BiInfoCircle } from 'react-icons/bi'
+import { Box, Divider, Flex, Icon, Text } from '@chakra-ui/react'
+
+import StepAppIcon from '@/components/FlowStep/components/StepAppIcon'
+import StepCaptionAndDemo from '@/components/FlowStep/components/StepCaptionAndDemo'
+import { flowStepStyles } from '@/components/FlowStep/styles'
+import { SUPPORT_FORM_LINK } from '@/config/urls'
+import getStepName from '@/helpers/getStepName'
+import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
+
+interface AiStep extends IStep {
+  description?: string
+}
+
+interface StepProps {
+  step?: AiStep | null
+  isNested?: boolean
+  isLastStep?: boolean
+}
+
+export default function Step(props: StepProps) {
+  const { step, isNested, isLastStep } = props
+  const { allApps } = useAiBuilderContext()
+
+  const app = allApps?.find(
+    (currentApp: IApp) => currentApp.key === step?.appKey,
+  )
+  const { caption } = getStepName(allApps, step as IStep)
+
+  if (!step) {
+    return (
+      <Flex justifyContent="center" w="100%">
+        <Flex
+          h={isNested ? '48px' : '64px'}
+          alignItems="center"
+          bg="interaction.warning-subtle.default"
+          borderColor="interaction.warning.default"
+          borderRadius="lg"
+          borderWidth="1px"
+          gap={4}
+          p={4}
+          w={isNested ? '100%' : '600px'}
+          _hover={{
+            bg: 'interaction.warning-subtle.default',
+            '& .hover-remove-button': {
+              visibility: 'visible',
+            },
+          }}
+        >
+          <Icon
+            as={BiInfoCircle}
+            boxSize={6}
+            color="interaction.warning.hover"
+          />
+          <Box py={isNested ? 2 : 4}>
+            <Text textStyle="subhead-2">
+              Something went wrong, delete this step and try again.
+            </Text>
+            <Text textStyle="caption-1" mt={1}>
+              If this issue persists, contact us at{' '}
+              <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
+                {SUPPORT_FORM_LINK}
+              </a>
+            </Text>
+          </Box>
+        </Flex>
+      </Flex>
+    )
+  }
+
+  return (
+    <Flex flexDir="column" w="100%">
+      <Flex justifyContent="center">
+        <Flex
+          data-test="flow-step"
+          {...flowStepStyles.container}
+          borderTopWidth="1px"
+          borderTopRadius="lg"
+          w={isNested ? '100%' : '600px'}
+          pointerEvents="none"
+        >
+          <Flex {...flowStepStyles.topHeader} py={isNested ? 3 : 4}>
+            <StepAppIcon
+              isCompleted={undefined}
+              isNested={isNested}
+              isTestSuccessful={undefined}
+              shouldTestStepAgain={false}
+              app={app}
+              step={step}
+            />
+            <Box w="100%">
+              <StepCaptionAndDemo app={app} caption={caption} />
+              <Text textStyle="body-2">{step.description}</Text>
+            </Box>
+          </Flex>
+        </Flex>
+      </Flex>
+      {!isLastStep && (
+        <Flex justifyContent="center" h={isNested ? 6 : 12}>
+          <Divider orientation="vertical" borderColor="base.divider.strong" />
+        </Flex>
+      )}
+    </Flex>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -88,14 +88,7 @@ export default function StepsPreview() {
       return
     }
     onGenerateAiSteps()
-  }, [
-    onGenerateAiSteps,
-    formInput,
-    location.pathname,
-    location.state,
-    output,
-    navigate,
-  ])
+  }, [onGenerateAiSteps, output])
 
   /** FOR EACH STEPS COMPUTATION */
   const forEachSteps = groupedSteps[0]

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -1,0 +1,231 @@
+import { Fragment, useCallback, useEffect, useMemo } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { useMutation } from '@apollo/client'
+import {
+  Box,
+  Center,
+  Flex,
+  HStack,
+  Text,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import { Button, useIsMobile } from '@opengovsg/design-system-react'
+
+import Error from '@/components/FlowStepGroup/Content/Error'
+import { MultiStepLoader } from '@/components/MultiStepLoader'
+import PrimarySpinner from '@/components/PrimarySpinner'
+import { GENERATE_AI_STEPS } from '@/graphql/mutations/generate-ai-steps'
+import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
+import { getPromptFromFormInput } from '@/pages/AiBuilder/helpers'
+import { AiFormData } from '@/pages/AiBuilder/schema'
+
+import BranchStep from './BranchStep'
+import GroupedStepContainer from './GroupedStepContainer'
+import ModifyPromptModal from './ModifyPromptModal'
+import Step from './Step'
+
+const LOADING_STATES = [
+  { text: 'Thinking...' },
+  { text: 'Setting up your steps' },
+  { text: 'Writing descriptions for each step' },
+  { text: 'Putting it all together...' },
+]
+
+export default function StepsPreview() {
+  const location = useLocation()
+  const {
+    formInput,
+    output,
+    triggerStep,
+    actionSteps,
+    stepsBeforeGroup,
+    groupedSteps,
+    stepGroupType,
+    stepGroupCaption,
+    isFormMode,
+    ddSessionId,
+  } = useAiBuilderContext()
+
+  const { isOpen, onClose, onOpen } = useDisclosure()
+  const isMobile = useIsMobile()
+  const navigate = useNavigate()
+
+  const [generateAiStepsMutation, { loading: isGeneratingSteps }] =
+    useMutation(GENERATE_AI_STEPS)
+
+  const generateAiSteps = useCallback(
+    async (input: { trigger: string; actions: string }) => {
+      const { data } = await generateAiStepsMutation({
+        variables: {
+          input: {
+            prompt: getPromptFromFormInput(input),
+            isFormMode,
+            sessionId: ddSessionId,
+          },
+        },
+      })
+      return data?.generateAiSteps
+    },
+    [generateAiStepsMutation, isFormMode, ddSessionId],
+  )
+
+  const onGenerateAiSteps = useCallback(async () => {
+    const aiSteps = await generateAiSteps(formInput)
+
+    navigate(location.pathname, {
+      state: {
+        ...location.state,
+        output: aiSteps,
+      },
+      replace: true, // Use replace to avoid adding to history
+    })
+  }, [generateAiSteps, formInput, navigate, location.pathname, location.state])
+
+  useEffect(() => {
+    if (output) {
+      return
+    }
+    onGenerateAiSteps()
+  }, [
+    onGenerateAiSteps,
+    formInput,
+    location.pathname,
+    location.state,
+    output,
+    navigate,
+  ])
+
+  /** FOR EACH STEPS COMPUTATION */
+  const forEachSteps = groupedSteps[0]
+  const ifThenSteps = useMemo(() => {
+    if (groupedSteps.length === 1) {
+      return []
+    }
+    return groupedSteps.slice(1)
+  }, [groupedSteps])
+
+  const onUpdatePrompt = async (formData: AiFormData) => {
+    const aiSteps = await generateAiSteps(formData)
+
+    // Close modal first, then navigate
+    onClose()
+    navigate(location.pathname, {
+      state: {
+        ...location.state,
+        isFormMode: true,
+        formInput: {
+          trigger: formData.trigger,
+          actions: formData.actions,
+        },
+        output: aiSteps,
+      },
+      replace: true,
+    })
+  }
+
+  if (isGeneratingSteps || !output) {
+    return (
+      <Center h="100%">
+        {output && !isGeneratingSteps ? (
+          <PrimarySpinner fontSize="4xl" />
+        ) : (
+          <MultiStepLoader
+            loadingStates={LOADING_STATES}
+            loading={isGeneratingSteps}
+            duration={1500}
+            loop={false}
+          />
+        )}
+      </Center>
+    )
+  }
+
+  return (
+    <>
+      <Box pos="relative" w="100%">
+        <Step step={triggerStep} />
+        {stepsBeforeGroup.map((action) => (
+          <Fragment key={`${action.position}-${action.appKey}`}>
+            <Step
+              key={`${action.position}-${action.appKey}`}
+              step={action}
+              isLastStep={action.position === actionSteps.length + 1}
+            />
+          </Fragment>
+        ))}
+        {groupedSteps.length > 0 && (
+          <GroupedStepContainer
+            stepGroupType={stepGroupType as string}
+            stepGroupCaption={stepGroupCaption as string}
+            isNested={false}
+          >
+            {stepGroupType === TOOLBOX_ACTIONS.IfThen ? (
+              <Flex flexDir="column" w="100%" px={2} gap={4} mt={2}>
+                {groupedSteps.map((branchSteps) => (
+                  <BranchStep
+                    key={String(branchSteps[0].position)}
+                    branchSteps={branchSteps}
+                    isMobile={isMobile}
+                  />
+                ))}
+              </Flex>
+            ) : stepGroupType === TOOLBOX_ACTIONS.ForEach ? (
+              <Box w="100%">
+                <Flex flexDir="column" w="100%" px={4} py={3}>
+                  {forEachSteps.map((step, index) => (
+                    <Step
+                      key={String(step.position)}
+                      step={step}
+                      isNested={true}
+                      isLastStep={
+                        forEachSteps.length - 1 === index &&
+                        ifThenSteps.length === 0
+                      }
+                    />
+                  ))}
+                  {ifThenSteps.length > 0 && (
+                    <GroupedStepContainer
+                      stepGroupType={TOOLBOX_ACTIONS.IfThen}
+                      stepGroupCaption="If-then"
+                      isNested={true}
+                    >
+                      <Flex flexDir="column" w="100%" px={2} gap={4} mt={2}>
+                        {ifThenSteps.map((branchSteps) => (
+                          <BranchStep
+                            key={String(branchSteps[0].position)}
+                            branchSteps={branchSteps}
+                            isMobile={isMobile}
+                          />
+                        ))}
+                      </Flex>
+                    </GroupedStepContainer>
+                  )}
+                </Flex>
+              </Box>
+            ) : (
+              <Error />
+            )}
+          </GroupedStepContainer>
+        )}
+        <VStack mt={10} gap={2}>
+          <Text textStyle="subhead-2">How does this workflow look?</Text>
+          <HStack alignItems="center" justifyContent="center" gap={2}>
+            <Button variant="outline" onClick={onOpen}>
+              Make changes
+            </Button>
+            <Button variant="outline">Create this workflow</Button>
+          </HStack>
+        </VStack>
+      </Box>
+
+      <ModifyPromptModal
+        isOpen={isOpen}
+        onClose={onClose}
+        formInput={formInput}
+        onUpdatePrompt={onUpdatePrompt}
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -1,0 +1,6 @@
+export const getPromptFromFormInput = (formInput: {
+  trigger: string
+  actions: string
+}) => {
+  return `#### Start the workflow\n${formInput.trigger}\n\n#### Actions\n${formInput.actions}`
+}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -1,0 +1,129 @@
+import { Helmet } from 'react-helmet'
+import { BiChevronLeft } from 'react-icons/bi'
+import { Link, useLocation } from 'react-router-dom'
+import { Box, Container, Flex, HStack, Icon, Text } from '@chakra-ui/react'
+import { Tag } from '@opengovsg/design-system-react'
+
+import { EDITOR_MARGIN_TOP } from '@/components/Editor/constants'
+import * as URLS from '@/config/urls'
+import InvalidEditorPage from '@/pages/Editor/components/InvalidEditorPage'
+
+import StepsPreview from './components/StepsPreview'
+import {
+  AiBuilderContextProvider,
+  useAiBuilderContext,
+} from './AiBuilderContext'
+
+function AiBuilderContent() {
+  const { flowName, isFormMode } = useAiBuilderContext()
+
+  return (
+    <>
+      <Helmet>
+        <title>{flowName} | WIP</title>
+      </Helmet>
+      <Flex h="100vh" flexDirection="column">
+        <HStack
+          position="fixed"
+          top={0}
+          left={0}
+          right={0}
+          zIndex={10}
+          bg="white"
+          justifyContent="space-between"
+          alignItems="center"
+          py={2}
+          px={{ base: 4, md: 8 }}
+          borderBottom="1px solid"
+          borderColor="base.divider.medium"
+        >
+          <Flex flex={1} alignItems="center" minWidth={0}>
+            <Box as={Link} to={URLS.FLOWS} mt={1} mr={3} flexShrink={0}>
+              <Icon
+                boxSize={6}
+                color="interaction.support.disabled-content"
+                as={BiChevronLeft}
+              ></Icon>
+            </Box>
+
+            <Flex flex={1} minWidth={0}>
+              <Text>{flowName}</Text>
+            </Flex>
+          </Flex>
+          {/* TODO: Add <AiBuilderToolbar /> */}
+        </HStack>
+        <Container
+          maxW="full"
+          px={0}
+          py={10}
+          mt={EDITOR_MARGIN_TOP}
+          flex={1}
+          overflowY="auto"
+          sx={{
+            backgroundImage: 'radial-gradient(#f5f5f5 2px, transparent 2px)',
+            backgroundSize: '30px 30px',
+          }}
+        >
+          {isFormMode ? (
+            <StepsPreview />
+          ) : (
+            <Flex
+              sx={{
+                backgroundImage:
+                  'radial-gradient(#f5f5f5 2px, transparent 2px)',
+                backgroundSize: '30px 30px',
+              }}
+              h="100%"
+              w="full"
+              flexDir="column"
+              alignItems="center"
+              justifyContent="center"
+              gap={4}
+            >
+              <Tag colorScheme="secondary">Build with AI</Tag>
+              <Text textStyle="h3">What happens in your workflow?</Text>
+              {/* TODO: Add chat interface */}
+            </Flex>
+          )}
+        </Container>
+      </Flex>
+    </>
+  )
+}
+
+export default function AiBuilder() {
+  const { flowName, formInput, isFormMode, output } = useLocation()?.state || {
+    flowName: 'New flow',
+    isFormMode: false,
+    formInput: {
+      trigger: '',
+      actions: '',
+    },
+    output: {
+      trigger: '',
+      actions: '',
+    },
+  }
+
+  /**
+   * NOTE: if isFormMode is true, we validate that the formInput exists.
+   * if it does not exist, we don't bother showing the AiBuilder
+   * since it will waste an API call to Pair
+   */
+  if (isFormMode && (!formInput || !formInput.trigger || !formInput.actions)) {
+    return (
+      <InvalidEditorPage message="Something went wrong. Please try again." />
+    )
+  }
+
+  return (
+    <AiBuilderContextProvider
+      flowName={flowName}
+      formInput={formInput}
+      isFormMode={isFormMode}
+      output={output}
+    >
+      <AiBuilderContent />
+    </AiBuilderContextProvider>
+  )
+}

--- a/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
+++ b/packages/frontend/src/pages/Editor/components/InvalidEditorPage.tsx
@@ -6,7 +6,7 @@ import { PipeIcon } from '@/components/Icons/PipeIcon'
 import * as URLS from '@/config/urls'
 import styles from '@/pages/UnauthorizedTile/UnauthorizedTile.module.css'
 
-export default function InvalidEditorPage() {
+export default function InvalidEditorPage({ message }: { message?: string }) {
   return (
     <>
       <Helmet>
@@ -35,10 +35,14 @@ export default function InvalidEditorPage() {
             textAlign={{ base: 'center', md: 'left' }}
             fontWeight="normal"
           >
-            Pipe not found.
-            <br />
-            It might have been transferred to someone else, or you may no longer
-            have access. 🤔
+            {message || (
+              <>
+                Pipe not found.
+                <br />
+                It might have been transferred to someone else, or you may no
+                longer have access. 🤔
+              </>
+            )}
           </Text>
           <Link
             textStyle="h6"

--- a/packages/frontend/src/pages/Editor/routes.tsx
+++ b/packages/frontend/src/pages/Editor/routes.tsx
@@ -6,11 +6,14 @@ import FlowCollaborators from '@/components/EditorSettings/FlowCollaborators'
 import FlowTransfer from '@/components/EditorSettings/FlowTransfer'
 import Notifications from '@/components/EditorSettings/Notifications'
 
+import AiBuilder from '../AiBuilder'
+
 import EditorPage from './index'
 
 export default function EditorRoutes(): React.ReactElement {
   return (
     <Routes>
+      <Route path="/ai" element={<AiBuilder />} />
       <Route path="/:flowId" element={<EditorPage />} />
 
       <Route


### PR DESCRIPTION
## TL;DR
Adds a new AI Builder page that allows users to preview the AI-generated steps, with a multi-step loader component to display progress during generation.

## What changed?
- Created a new `MultiStepLoader` component that shows animated loading states with progress indicators
- Added a new `AiBuilder` page with context provider to manage state for AI-generated workflows
- Implemented `StepsPreview` to display AI-generated steps with support for nested structures like If-Then and ForEach
- Added toolbox helper functions to handle step grouping and structure
- Created a modal for modifying AI prompts and regenerating workflows
- Added routing for the AI Builder at `/editor/ai`

## How to test?
1. Create a Pipe using 'Build with AI'
1. Enter the workflow description and click on 'Create'
1. Verify redirection to `/editor/ai`
1. Verify that you see the multi-step loader while the steps are being generated
1. Review the generated workflow steps in the preview
1. Test the "Make changes" button to modify the prompt and regenerate the workflow
1. Verify that nested structures (If-Then, ForEach) display correctly
