### PR TITLE
[AI-BUILDER-10] (backend): add chat readiness check

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -2,3 +2,11 @@
  * Feature flags
  */
 export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG = 'ai-builder-prompt-config'
+
+/**
+ * Feature flag fallbacks
+ */
+export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK = {
+  chatReadinessPrompt: 'chat-readiness-check',
+  version: 'production',
+}

--- a/packages/backend/src/graphql/queries/get-chat-readiness.ts
+++ b/packages/backend/src/graphql/queries/get-chat-readiness.ts
@@ -3,6 +3,10 @@ import { generateObject } from 'ai'
 import z from 'zod/v3'
 
 import appConfig from '@/config/app'
+import {
+  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
+  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
+} from '@/config/flags'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
@@ -19,12 +23,9 @@ const getChatReadiness: QueryResolvers['getChatReadiness'] = async (
     const { message: rawMessage, sessionId } = params
 
     const promptConfig = await getLdFlagValue(
-      'ai-builder-prompt-config',
+      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
       context.currentUser.email,
-      {
-        chatReadinessPrompt: 'chat-readiness-check',
-        version: 'production',
-      },
+      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
     )
     const { chatReadinessPrompt, version } = promptConfig
     const prompt = await getPrompt(chatReadinessPrompt, version)

--- a/packages/backend/src/graphql/queries/get-chat-readiness.ts
+++ b/packages/backend/src/graphql/queries/get-chat-readiness.ts
@@ -1,7 +1,5 @@
 import { startActiveObservation } from '@langfuse/tracing'
 import { generateObject } from 'ai'
-import type { Request, Response } from 'express'
-import { Router } from 'express'
 import z from 'zod/v3'
 
 import appConfig from '@/config/app'
@@ -10,21 +8,15 @@ import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import { getPrompt } from '@/helpers/pair/get-prompt'
 
-import { getAuthenticatedContext } from '../middleware/authentication'
+import type { QueryResolvers } from '../__generated__/types.generated'
 
-interface ChatReadinessRequest {
-  message: string
-  sessionId: string
-}
-
-const handleChatReadiness = async (
-  req: Request,
-  res: Response,
-): Promise<void> => {
-  const context = getAuthenticatedContext(req)
-
+const getChatReadiness: QueryResolvers['getChatReadiness'] = async (
+  _parent,
+  params,
+  context,
+) => {
   try {
-    const { message: rawMessage } = req.body as ChatReadinessRequest
+    const { message: rawMessage, sessionId } = params
 
     const promptConfig = await getLdFlagValue(
       'ai-builder-prompt-config',
@@ -45,6 +37,7 @@ const handleChatReadiness = async (
           userId: context.currentUser.email,
           environment: appConfig.appEnv,
           tags: ['ai-builder', 'is-chat-ready'],
+          sessionId,
         })
 
         trace.update({
@@ -88,15 +81,11 @@ const handleChatReadiness = async (
       },
     )
 
-    res.json({ isReady: result.isReady })
+    return { isReady: result.isReady }
   } catch (error) {
-    logger.error('Error in chat readiness', { error })
-    res.status(500).json({ error: 'Internal server error' })
+    logger.error('Error in getChatReadiness', { error })
+    throw new Error('Error encountered. Please try again.')
   }
 }
 
-const router = Router()
-
-router.post('/', handleChatReadiness)
-
-export default router
+export default getChatReadiness

--- a/packages/backend/src/graphql/query-resolvers.ts
+++ b/packages/backend/src/graphql/query-resolvers.ts
@@ -1,6 +1,7 @@
 import type { QueryResolvers } from './__generated__/types.generated'
 import getApp from './queries/get-app'
 import getApps from './queries/get-apps'
+import getChatReadiness from './queries/get-chat-readiness'
 import getConnectedApps from './queries/get-connected-apps'
 import getCurrentUser from './queries/get-current-user'
 import getDynamicData from './queries/get-dynamic-data'
@@ -45,6 +46,7 @@ export default {
   getPendingFlowTransfers,
   getFlowTransferDetails,
   getTemplates,
+  getChatReadiness,
   ...tilesQueryResolvers,
 
   // This is a special stub that enables us to group all our admin-related

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -57,6 +57,8 @@ type Query {
   admin: AdminQuery!
   # Templates (including demo templates)
   getTemplates(tag: TemplateTagType): [Template!]!
+  # AI
+  getChatReadiness(message: String!, sessionId: String!): ChatReadinessResult!
 }
 
 type AdminQuery {
@@ -150,6 +152,10 @@ input CreateFlowWithStepsInput {
   flowName: String!
   steps: [StepInput!]!
   aiBuilderConfig: FlowAiBuilderConfigInput!
+}
+
+type ChatReadinessResult {
+  isReady: Boolean!
 }
 
 type AdminMutation {

--- a/packages/backend/src/helpers/pair/get-prompt.ts
+++ b/packages/backend/src/helpers/pair/get-prompt.ts
@@ -1,0 +1,9 @@
+import { langfuseClient } from '@/helpers/langfuse'
+
+export const getPrompt = async (promptName: string, version?: string) => {
+  const prompt = await langfuseClient.prompt.get(
+    promptName,
+    version ? { label: version } : undefined,
+  )
+  return prompt
+}

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -5,11 +5,13 @@ import { Router } from 'express'
 
 import appConfig from '@/config/app'
 import { AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG } from '@/config/flags'
-import { langfuseClient } from '@/helpers/langfuse'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
+import { getPrompt } from '@/helpers/pair/get-prompt'
 import { AuthenticatedRequest } from '@/types/express/context'
+
+import chatReadinessRouter from './readiness'
 
 interface ChatRequest {
   messages: Array<{
@@ -57,9 +59,7 @@ async function handleChatStream(req: AuthenticatedRequest, res: Response) {
       .pop()
 
     // Get the prompt from Langfuse
-    const prompt = await langfuseClient.prompt.get(chatPrompt, {
-      label: version,
-    })
+    const prompt = await getPrompt(chatPrompt, version)
 
     let traceId = ''
 
@@ -109,7 +109,6 @@ async function handleChatStream(req: AuthenticatedRequest, res: Response) {
 
             trace.update({
               output: { result: event.text },
-              level: 'DEFAULT',
             })
 
             generation
@@ -176,5 +175,6 @@ async function handleChatStream(req: AuthenticatedRequest, res: Response) {
 const router = Router()
 
 router.post('/', handleChatStream)
+router.use('/readiness', chatReadinessRouter)
 
 export default router

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -11,8 +11,6 @@ import { model, MODEL_TYPE } from '@/helpers/pair'
 import { getPrompt } from '@/helpers/pair/get-prompt'
 import { AuthenticatedRequest } from '@/types/express/context'
 
-import chatReadinessRouter from './readiness'
-
 interface ChatRequest {
   messages: Array<{
     role: 'user' | 'assistant' | 'system'
@@ -175,6 +173,5 @@ async function handleChatStream(req: AuthenticatedRequest, res: Response) {
 const router = Router()
 
 router.post('/', handleChatStream)
-router.use('/readiness', chatReadinessRouter)
 
 export default router

--- a/packages/backend/src/routes/api/chat/readiness.ts
+++ b/packages/backend/src/routes/api/chat/readiness.ts
@@ -5,6 +5,7 @@ import { Router } from 'express'
 import z from 'zod/v3'
 
 import appConfig from '@/config/app'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import { getPrompt } from '@/helpers/pair/get-prompt'
@@ -25,8 +26,16 @@ const handleChatReadiness = async (
   try {
     const { message: rawMessage } = req.body as ChatReadinessRequest
 
-    // Get the prompt from Langfuse
-    const prompt = await getPrompt('ai-builder/chat-to-form-check')
+    const promptConfig = await getLdFlagValue(
+      'ai-builder-prompt-config',
+      context.currentUser.email,
+      {
+        chatReadinessPrompt: 'chat-readiness-check',
+        version: 'production',
+      },
+    )
+    const { chatReadinessPrompt, version } = promptConfig
+    const prompt = await getPrompt(chatReadinessPrompt, version)
     const { prompt: systemPrompt } = prompt
 
     const result = await startActiveObservation(

--- a/packages/backend/src/routes/api/chat/readiness.ts
+++ b/packages/backend/src/routes/api/chat/readiness.ts
@@ -1,0 +1,93 @@
+import { startActiveObservation } from '@langfuse/tracing'
+import { generateObject } from 'ai'
+import type { Request, Response } from 'express'
+import { Router } from 'express'
+import z from 'zod/v3'
+
+import appConfig from '@/config/app'
+import logger from '@/helpers/logger'
+import { model, MODEL_TYPE } from '@/helpers/pair'
+import { getPrompt } from '@/helpers/pair/get-prompt'
+
+import { getAuthenticatedContext } from '../middleware/authentication'
+
+interface ChatReadinessRequest {
+  message: string
+  sessionId: string
+}
+
+const handleChatReadiness = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  const context = getAuthenticatedContext(req)
+
+  try {
+    const { message: rawMessage } = req.body as ChatReadinessRequest
+
+    // Get the prompt from Langfuse
+    const prompt = await getPrompt('ai-builder/chat-to-form-check')
+    const { prompt: systemPrompt } = prompt
+
+    const result = await startActiveObservation(
+      'chat-readiness',
+      async (trace) => {
+        trace.updateTrace({
+          userId: context.currentUser.email,
+          environment: appConfig.appEnv,
+          tags: ['ai-builder', 'is-chat-ready'],
+        })
+
+        trace.update({
+          input: {
+            message: rawMessage,
+          },
+        })
+
+        const generation = trace.startObservation(
+          'is-chat-ready',
+          {
+            model: MODEL_TYPE,
+            input: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: rawMessage },
+            ],
+          },
+          { asType: 'generation' },
+        )
+
+        generation.update({ prompt })
+
+        const { object } = await generateObject({
+          model,
+          schema: z.object({
+            isReady: z.boolean(),
+          }),
+          system: systemPrompt,
+          prompt: rawMessage,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId: 'is-chat-ready',
+          },
+        })
+
+        trace.update({ output: object })
+
+        generation.update({ output: object }).end()
+
+        return object
+      },
+    )
+
+    res.json({ isReady: result.isReady })
+  } catch (error) {
+    logger.error('Error in chat readiness', { error })
+    res.status(500).json({ error: 'Internal server error' })
+  }
+}
+
+const router = Router()
+
+router.post('/', handleChatReadiness)
+
+export default router


### PR DESCRIPTION
## TL;DR
This PR adds a new GraphQL query `getChatReadiness` that determines if a user message is ready for chat processing.

## What changed
- Creates a new GraphQL query resolver for checking chat readiness
- Adds the necessary schema definitions for the query and response type
- Extracts a reusable `getPrompt` helper function to fetch prompts from Langfuse
- Configures the prompt via Launch Darkly flags
- Implements tracing for monitoring and debugging
- Restructures the chat API folder organization

## How to test?
- [ ] Make a direct call to the query and receive either `true` or `false` depending on whether the workflow description makes sense and is sufficient to generate the steps for the Pipe.