### PR TITLE
[AI-BUILDER-12] (frontend): chat readiness check for steps preview

### DIFF
--- a/packages/frontend/src/graphql/queries/get-chat-readiness.ts
+++ b/packages/frontend/src/graphql/queries/get-chat-readiness.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client'
+
+export const GET_CHAT_READINESS = gql`
+  query GetChatReadiness($message: String!, $sessionId: String!) {
+    getChatReadiness(message: $message, sessionId: $sessionId) {
+      isReady
+    }
+  }
+`

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -56,6 +56,13 @@ export default function ChatMessages({
     checkReadiness()
   }, [isStreaming, messages])
 
+  // Scroll to bottom when PreviewStepsButton appears
+  useEffect(() => {
+    if (isReadyForPreview) {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [isReadyForPreview, messagesEndRef])
+
   return (
     <Flex
       ref={messagesContainerRef}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from 'react'
+import { useLazyQuery } from '@apollo/client'
 import { Box, Flex, VStack } from '@chakra-ui/react'
 
+import { GET_CHAT_READINESS } from '@/graphql/queries/get-chat-readiness'
 import { Message } from '@/hooks/useChatStream'
+
+import { useAiBuilderContext } from '../../AiBuilderContext'
 
 import ChatMessage from './ChatMessage'
 import PreviewStepsButton from './PreviewStepsButton'
@@ -26,7 +30,10 @@ export default function ChatMessages({
   hasMessages,
   onOpenDrawer,
 }: ChatMessagesProps) {
+  const { ddSessionId } = useAiBuilderContext()
   const [isReadyForPreview, setIsReadyForPreview] = useState(false)
+
+  const [getChatReadiness] = useLazyQuery(GET_CHAT_READINESS)
 
   useEffect(() => {
     const checkReadiness = async () => {
@@ -38,23 +45,17 @@ export default function ChatMessages({
       const lastMessage = messages[messages.length - 1]
 
       try {
-        const response = await fetch('/api/chat/readiness', {
-          method: 'POST',
-          body: JSON.stringify({ message: lastMessage.text }),
-          headers: {
-            'Content-Type': 'application/json',
-          },
+        const { data } = await getChatReadiness({
+          variables: { message: lastMessage.text, sessionId: ddSessionId },
         })
-
-        const result = await response.json()
-        setIsReadyForPreview(result.isReady)
+        setIsReadyForPreview(data?.getChatReadiness?.isReady)
       } catch {
         setIsReadyForPreview(false)
       }
     }
 
     checkReadiness()
-  }, [isStreaming, messages])
+  }, [ddSessionId, getChatReadiness, isStreaming, messages])
 
   // Scroll to bottom when PreviewStepsButton appears
   useEffect(() => {

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { Box, Flex, VStack } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
@@ -23,8 +24,38 @@ export default function ChatMessages({
   messagesEndRef,
   messagesContainerRef,
   hasMessages,
-  onOpenDrawer: onOpenDrawer,
+  onOpenDrawer,
 }: ChatMessagesProps) {
+  const [isReadyForPreview, setIsReadyForPreview] = useState(false)
+
+  useEffect(() => {
+    const checkReadiness = async () => {
+      if (isStreaming || messages.length === 0) {
+        setIsReadyForPreview(false)
+        return
+      }
+
+      const lastMessage = messages[messages.length - 1]
+
+      try {
+        const response = await fetch('/api/chat/readiness', {
+          method: 'POST',
+          body: JSON.stringify({ message: lastMessage.text }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        })
+
+        const result = await response.json()
+        setIsReadyForPreview(result.isReady)
+      } catch {
+        setIsReadyForPreview(false)
+      }
+    }
+
+    checkReadiness()
+  }, [isStreaming, messages])
+
   return (
     <Flex
       ref={messagesContainerRef}
@@ -39,7 +70,7 @@ export default function ChatMessages({
             <ChatMessage key={index} message={message} />
           ))}
 
-          {hasMessages && !isStreaming && (
+          {hasMessages && !isStreaming && isReadyForPreview && (
             <PreviewStepsButton
               messages={messages}
               onOpenDrawer={onOpenDrawer}


### PR DESCRIPTION
## TL;DR

Adds the readiness check to the frontend and only show the 'Preview steps' button if the chat message is deemed to be sufficient for the LLM to generate steps for the Pipe.

## How to test?

- [ ] Should see the Preview steps button when the chat interface has reasonable information to generate steps
- [ ] Should not see the Preview steps button if the user input gibberish and the LLM is request for more information or does not have enough information to generate steps for a Pipe