### PR TITLE
[AI-BUILDER-14] feat: adds AI suggestions for form inputs

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -8,5 +8,6 @@ export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG = 'ai-builder-prompt-config'
  */
 export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK = {
   chatReadinessPrompt: 'chat-readiness-check',
+  refineFormInputPrompt: 'form-input-suggestion',
   version: 'production',
 }

--- a/packages/backend/src/graphql/mutation-resolvers.ts
+++ b/packages/backend/src/graphql/mutation-resolvers.ts
@@ -1,5 +1,6 @@
 import type { MutationResolvers } from './__generated__/types.generated'
 import generateAiSteps from './mutations/ai/generate-ai-steps'
+import refineFormInput from './mutations/ai/refine-form-input'
 import bulkRetryExecutions from './mutations/bulk-retry-executions'
 import bulkRetryIterations from './mutations/bulk-retry-iterations'
 import createConnection from './mutations/create-connection'
@@ -38,7 +39,6 @@ import updateStepPositions from './mutations/update-step-positions'
 import upsertFlowCollaborator from './mutations/upsert-flow-collaborator'
 import verifyConnection from './mutations/verify-connection'
 import verifyOtp from './mutations/verify-otp'
-
 /**
  * Want to create a new mutation or modify an existing mutation?
  * 1. Add/Change your mutation in graphql.schema.
@@ -62,6 +62,7 @@ export default {
   createConnection,
   generateAuthUrl,
   generateAiSteps,
+  refineFormInput,
   updateConnection,
   resetConnection,
   verifyConnection,

--- a/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
+++ b/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
@@ -1,0 +1,103 @@
+import { startActiveObservation } from '@langfuse/tracing'
+import { generateObject } from 'ai'
+import z from 'zod/v3'
+import { fromZodError } from 'zod-validation-error'
+
+import appConfig from '@/config/app'
+import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
+import { getLdFlagValue } from '@/helpers/launch-darkly'
+import { model, MODEL_TYPE } from '@/helpers/pair'
+import { getPrompt } from '@/helpers/pair/get-prompt'
+
+import { MutationResolvers } from '../../__generated__/types.generated'
+
+import { REFINE_FORM_INPUT_SCHEMA } from './schemas/input.zod'
+
+const refineFormInput: MutationResolvers['refineFormInput'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  try {
+    if (!context.currentUser) {
+      throw new ForbiddenError('Not authorised!')
+    }
+
+    const validatedInput = REFINE_FORM_INPUT_SCHEMA.parse(params.input)
+    const { prompt: userPrompt, sessionId } = validatedInput
+
+    const promptConfig = await getLdFlagValue(
+      'ai-builder-prompt-config',
+      context.currentUser.email,
+      {
+        refineFormInputPrompt: 'form-input-suggestion',
+        version: 'production',
+      },
+    )
+    const { refineFormInputPrompt, version } = promptConfig
+    const prompt = await getPrompt(refineFormInputPrompt, version)
+    const { prompt: systemPrompt } = prompt
+
+    const result = await startActiveObservation(
+      'refine-form-input',
+      async (trace) => {
+        trace.updateTrace({
+          userId: context.currentUser.email,
+          environment: appConfig.appEnv,
+          tags: ['ai-builder', 'form', 'refine-form-input'],
+          sessionId: sessionId ?? '',
+        })
+
+        trace.update({
+          input: {
+            prompt: userPrompt,
+          },
+        })
+
+        const generation = trace.startObservation(
+          'refine-form-input',
+          {
+            model: MODEL_TYPE,
+            input: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+          },
+          { asType: 'generation' },
+        )
+
+        generation.update({ prompt })
+
+        const { object } = await generateObject({
+          model,
+          schema: z.object({
+            status: z.boolean(),
+            suggestion: z.string(),
+          }),
+          system: systemPrompt,
+          prompt: userPrompt,
+          experimental_telemetry: {
+            isEnabled: true,
+            functionId: 'is-chat-ready',
+          },
+        })
+
+        trace.update({ output: object })
+
+        generation.update({ output: object }).end()
+
+        return object
+      },
+    )
+
+    return result
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new BadUserInputError(fromZodError(error).details[0].message)
+    }
+
+    throw new Error('Encountered an error, please try again.')
+  }
+}
+
+export default refineFormInput

--- a/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
+++ b/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
@@ -4,6 +4,10 @@ import z from 'zod/v3'
 import { fromZodError } from 'zod-validation-error'
 
 import appConfig from '@/config/app'
+import {
+  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
+  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
+} from '@/config/flags'
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import { model, MODEL_TYPE } from '@/helpers/pair'
@@ -27,12 +31,9 @@ const refineFormInput: MutationResolvers['refineFormInput'] = async (
     const { prompt: userPrompt, sessionId } = validatedInput
 
     const promptConfig = await getLdFlagValue(
-      'ai-builder-prompt-config',
+      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
       context.currentUser.email,
-      {
-        refineFormInputPrompt: 'form-input-suggestion',
-        version: 'production',
-      },
+      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
     )
     const { refineFormInputPrompt, version } = promptConfig
     const prompt = await getPrompt(refineFormInputPrompt, version)

--- a/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
+++ b/packages/backend/src/graphql/mutations/ai/refine-form-input.ts
@@ -22,11 +22,11 @@ const refineFormInput: MutationResolvers['refineFormInput'] = async (
   params,
   context,
 ) => {
-  try {
-    if (!context.currentUser) {
-      throw new ForbiddenError('Not authorised!')
-    }
+  if (!context.currentUser) {
+    throw new ForbiddenError('Not authorised!')
+  }
 
+  try {
     const validatedInput = REFINE_FORM_INPUT_SCHEMA.parse(params.input)
     const { prompt: userPrompt, sessionId } = validatedInput
 
@@ -79,7 +79,7 @@ const refineFormInput: MutationResolvers['refineFormInput'] = async (
           prompt: userPrompt,
           experimental_telemetry: {
             isEnabled: true,
-            functionId: 'is-chat-ready',
+            functionId: 'refine-form-input',
           },
         })
 

--- a/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
@@ -9,3 +9,12 @@ export const INPUT_SCHEMA = z.object({
   isFormMode: z.boolean(),
   sessionId: z.string().nullish(),
 })
+
+export const REFINE_FORM_INPUT_SCHEMA = z.object({
+  prompt: z
+    .string()
+    .trim()
+    .min(15, 'Prompt must be at least 15 characters')
+    .max(3000, 'Prompt must not exceed 3000 characters'),
+  sessionId: z.string().nullish(),
+})

--- a/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
@@ -14,7 +14,7 @@ export const REFINE_FORM_INPUT_SCHEMA = z.object({
   prompt: z
     .string()
     .trim()
-    .min(15, 'Prompt must be at least 15 characters')
+    .min(30, 'Prompt must be at least 30 characters')
     .max(3000, 'Prompt must not exceed 3000 characters'),
   sessionId: z.string().nullish(),
 })

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -133,6 +133,7 @@ type Mutation {
   updateFlowTransferStatus(input: UpdateFlowTransferStatusInput): FlowTransfer!
   # Ai builder mutations
   generateAiSteps(input: GenerateAiStepsInput!): JSONObject
+  refineFormInput(input: RefineFormInputInput!): JSONObject
   # Admin mutations
   admin: AdminMutation!
 }
@@ -140,6 +141,11 @@ type Mutation {
 input GenerateAiStepsInput {
   prompt: String!
   isFormMode: Boolean!
+  sessionId: String
+}
+
+input RefineFormInputInput {
+  prompt: String!
   sessionId: String
 }
 

--- a/packages/frontend/src/graphql/mutations/ai/refine-form-input.ts
+++ b/packages/frontend/src/graphql/mutations/ai/refine-form-input.ts
@@ -1,0 +1,7 @@
+import { gql } from '@apollo/client'
+
+export const REFINE_FORM_INPUT = gql`
+  mutation refineFormInput($input: RefineFormInputInput!) {
+    refineFormInput(input: $input)
+  }
+`

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -178,56 +178,51 @@ export const AIFormModalContent = ({
                 isInvalid={!!errors[field.key]}
                 key={field.key}
               >
-                <Flex gap={2} flexDir="column">
-                  <FormLabel>{field.label}</FormLabel>
-                  <Textarea
-                    {...register(field.key)}
-                    placeholder={field.placeholder}
-                    resize={field.resize}
-                    minH={field.minH}
-                    maxH={field.maxH}
-                    required={field.required}
-                  />
-                  {errors[field.key] && (
-                    <FormErrorMessage>
-                      {errors[field.key]?.message}
-                    </FormErrorMessage>
-                  )}
-                  {field.key === 'actions' && shouldShowSuggestion && (
-                    <Box mt={2} borderRadius="md">
-                      {isRefiningFormInput ? (
-                        <Flex align="center" gap={2}>
-                          <Spinner size="sm" />
-                        </Flex>
-                      ) : showReadyMessage ? (
-                        <Text fontSize="sm" color="green.600">
-                          <Text as="span" fontWeight="semibold">
-                            All good!
-                          </Text>{' '}
-                          Let&apos;s give it a try.
-                        </Text>
-                      ) : (
-                        <Text>
-                          <Text as="span" fontWeight="medium">
-                            Consider addressing:{' '}
-                          </Text>
-                          <Text as="span" fontWeight="regular">
-                            {aiSuggestion}
-                          </Text>
-                        </Text>
-                      )}
-                    </Box>
-                  )}
-
-                  {field.key === 'actions' && shouldShowIdeaButtons && (
-                    <IdeaButtons
-                      ideas={AI_FORM_IDEAS}
-                      onClick={handleIdeaClick}
-                    />
-                  )}
-                </Flex>
+                <FormLabel>{field.label}</FormLabel>
+                <Textarea
+                  {...register(field.key)}
+                  placeholder={field.placeholder}
+                  resize={field.resize}
+                  minH={field.minH}
+                  maxH={field.maxH}
+                  required={field.required}
+                />
+                {errors[field.key] && (
+                  <FormErrorMessage>
+                    {errors[field.key]?.message}
+                  </FormErrorMessage>
+                )}
               </FormControl>
             ))}
+            {shouldShowSuggestion && (
+              <Box borderRadius="md">
+                {isRefiningFormInput ? (
+                  <Flex align="center" gap={2}>
+                    <Spinner size="sm" />
+                  </Flex>
+                ) : showReadyMessage ? (
+                  <Text fontSize="sm" color="green.600">
+                    <Text as="span" fontWeight="semibold">
+                      All good!
+                    </Text>{' '}
+                    Let&apos;s give it a try.
+                  </Text>
+                ) : (
+                  <Text>
+                    <Text as="span" fontWeight="medium">
+                      Consider addressing:{' '}
+                    </Text>
+                    <Text as="span" fontWeight="regular">
+                      {aiSuggestion}
+                    </Text>
+                  </Text>
+                )}
+              </Box>
+            )}
+
+            {shouldShowIdeaButtons && (
+              <IdeaButtons ideas={AI_FORM_IDEAS} onClick={handleIdeaClick} />
+            )}
           </Flex>
         </ModalBody>
         <ModalFooter>

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -98,8 +98,8 @@ export const AIFormModalContent = ({
         return
       }
 
-      // Skip if trigger is empty or too short (minimum 15 characters required by API)
-      if (!prompt || prompt.trim().length < 15) {
+      // Skip if trigger is empty or too short (minimum 30 characters required by API)
+      if (!prompt || prompt.trim().length < 30) {
         setAiSuggestion(null)
         setShowReadyMessage(false)
         return

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -99,7 +99,9 @@ export const AIFormModalContent = ({
   }
 
   useEffect(() => {
-    refineFormInput(triggerValue, actionsValue)
+    if (triggerValue?.trim() && actionsValue?.trim()) {
+      refineFormInput(triggerValue, actionsValue)
+    }
   }, [triggerValue, actionsValue, refineFormInput])
 
   const isCreate = type === 'create'

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -160,6 +160,8 @@ export const AIFormModalContent = ({
   const isCreate = type === 'create'
   const shouldShowIdeaButtons =
     isCreate && !isRefiningFormInput && !aiSuggestion && !showReadyMessage
+  const shouldShowSuggestion =
+    isRefiningFormInput || aiSuggestion || showReadyMessage
 
   return (
     <>
@@ -191,33 +193,32 @@ export const AIFormModalContent = ({
                       {errors[field.key]?.message}
                     </FormErrorMessage>
                   )}
-                  {field.key === 'actions' &&
-                    (isRefiningFormInput ||
-                      aiSuggestion ||
-                      showReadyMessage) && (
-                      <Box mt={2} borderRadius="md">
-                        {isRefiningFormInput ? (
-                          <Flex align="center" gap={2}>
-                            <Spinner size="sm" />
-                            <Text fontSize="sm">Loading suggestion...</Text>
-                          </Flex>
-                        ) : showReadyMessage ? (
-                          <Text fontSize="sm" color="green.600">
-                            <Text as="span" fontWeight="semibold">
-                              All good!
-                            </Text>{' '}
-                            Let&apos;s give it a try.
+                  {field.key === 'actions' && shouldShowSuggestion && (
+                    <Box mt={2} borderRadius="md">
+                      {isRefiningFormInput ? (
+                        <Flex align="center" gap={2}>
+                          <Spinner size="sm" />
+                        </Flex>
+                      ) : showReadyMessage ? (
+                        <Text fontSize="sm" color="green.600">
+                          <Text as="span" fontWeight="semibold">
+                            All good!
+                          </Text>{' '}
+                          Let&apos;s give it a try.
+                        </Text>
+                      ) : (
+                        <Text>
+                          <Text as="span" fontWeight="medium">
+                            Consider addressing:{' '}
                           </Text>
-                        ) : (
-                          <Text fontSize="sm">
-                            <Text as="span" fontWeight="semibold">
-                              Suggestion:
-                            </Text>{' '}
+                          <Text as="span" fontWeight="regular">
                             {aiSuggestion}
                           </Text>
-                        )}
-                      </Box>
-                    )}
+                        </Text>
+                      )}
+                    </Box>
+                  )}
+
                   {field.key === 'actions' && shouldShowIdeaButtons && (
                     <IdeaButtons
                       ideas={AI_FORM_IDEAS}

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { Form } from 'react-router-dom'
-import { useMutation } from '@apollo/client'
 import {
   Box,
   Button,
@@ -18,13 +17,13 @@ import {
 } from '@chakra-ui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormLabel, useIsMobile } from '@opengovsg/design-system-react'
-import { debounce } from 'lodash'
 
 import pairLogo from '@/assets/pair-logo.svg'
 import { ImageBox } from '@/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection'
-import { REFINE_FORM_INPUT } from '@/graphql/mutations/ai/refine-form-input'
 import { AI_FORM_SCHEMA, AiFormData } from '@/pages/AiBuilder/schema'
 import { AI_FORM_IDEAS, AiFormIdea } from '@/pages/Flows/constants'
+
+import { useRefineFormInput } from '../hooks/useRefineFormInput'
 
 import IdeaButtons from './IdeaButtons'
 
@@ -65,9 +64,6 @@ export const AIFormModalContent = ({
   onBack: () => void
   onSubmit: (data: AiFormData) => void
 }) => {
-  const [refineFormInput, { loading: isRefiningFormInput }] =
-    useMutation(REFINE_FORM_INPUT)
-
   const isMobile = useIsMobile()
   const {
     register,
@@ -85,77 +81,26 @@ export const AIFormModalContent = ({
     },
   })
 
+  const triggerValue = watch('trigger')
   const actionsValue = watch('actions')
-  const isFromSuggestionRef = useRef(false)
-  const [aiSuggestion, setAiSuggestion] = useState<string | null>(null)
-  const [showReadyMessage, setShowReadyMessage] = useState(false)
 
-  const callRefineFormInput = useCallback(
-    async (prompt: string) => {
-      // Skip if the value is from a suggestion
-      if (isFromSuggestionRef.current) {
-        isFromSuggestionRef.current = false
-        return
-      }
-
-      // Skip if trigger is empty or too short (minimum 30 characters required by API)
-      if (!prompt || prompt.trim().length < 30) {
-        setAiSuggestion(null)
-        setShowReadyMessage(false)
-        return
-      }
-
-      try {
-        const result = await refineFormInput({
-          variables: {
-            input: {
-              prompt,
-              sessionId: null,
-            },
-          },
-        })
-
-        if (result.data?.refineFormInput) {
-          const { status, suggestion } = result.data.refineFormInput
-          if (status) {
-            // Status is true - show ready message
-            setShowReadyMessage(true)
-            setAiSuggestion(null)
-          } else if (suggestion) {
-            // Status is false and we have a suggestion
-            setAiSuggestion(suggestion)
-            setShowReadyMessage(false)
-          } else {
-            setAiSuggestion(null)
-            setShowReadyMessage(false)
-          }
-        }
-      } catch (error) {
-        console.error('Error refining form input:', error)
-        setAiSuggestion(null)
-        setShowReadyMessage(false)
-      }
-    },
-    [refineFormInput],
-  )
-
-  const debouncedRefineFormInput = useMemo(
-    () => debounce(callRefineFormInput, 2000),
-    [callRefineFormInput],
-  )
+  const {
+    refineFormInput,
+    isRefiningFormInput,
+    aiSuggestion,
+    showReadyMessage,
+    resetSuggestion,
+  } = useRefineFormInput()
 
   const handleIdeaClick = (idea: AiFormIdea) => {
-    isFromSuggestionRef.current = true
-    debouncedRefineFormInput.cancel()
-    setAiSuggestion(null)
-    setShowReadyMessage(false)
+    resetSuggestion()
     setValue('trigger', idea.trigger, { shouldValidate: true })
     setValue('actions', idea.actions, { shouldValidate: true })
   }
 
   useEffect(() => {
-    debouncedRefineFormInput(actionsValue)
-  }, [actionsValue, debouncedRefineFormInput])
+    refineFormInput(triggerValue, actionsValue)
+  }, [triggerValue, actionsValue, refineFormInput])
 
   const isCreate = type === 'create'
   const shouldShowIdeaButtons =

--- a/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AIFormModalContent.tsx
@@ -1,6 +1,9 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Form } from 'react-router-dom'
+import { useMutation } from '@apollo/client'
 import {
+  Box,
   Button,
   Flex,
   FormControl,
@@ -9,14 +12,17 @@ import {
   ModalCloseButton,
   ModalFooter,
   ModalHeader,
+  Spinner,
   Text,
   Textarea,
 } from '@chakra-ui/react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormLabel, useIsMobile } from '@opengovsg/design-system-react'
+import { debounce } from 'lodash'
 
 import pairLogo from '@/assets/pair-logo.svg'
 import { ImageBox } from '@/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureExcelConnection'
+import { REFINE_FORM_INPUT } from '@/graphql/mutations/ai/refine-form-input'
 import { AI_FORM_SCHEMA, AiFormData } from '@/pages/AiBuilder/schema'
 import { AI_FORM_IDEAS, AiFormIdea } from '@/pages/Flows/constants'
 
@@ -59,12 +65,16 @@ export const AIFormModalContent = ({
   onBack: () => void
   onSubmit: (data: AiFormData) => void
 }) => {
+  const [refineFormInput, { loading: isRefiningFormInput }] =
+    useMutation(REFINE_FORM_INPUT)
+
   const isMobile = useIsMobile()
   const {
     register,
     handleSubmit,
     formState: { errors, isValid },
     setValue,
+    watch,
   } = useForm<AiFormData>({
     resolver: zodResolver(AI_FORM_SCHEMA),
     mode: 'onChange',
@@ -75,12 +85,81 @@ export const AIFormModalContent = ({
     },
   })
 
+  const actionsValue = watch('actions')
+  const isFromSuggestionRef = useRef(false)
+  const [aiSuggestion, setAiSuggestion] = useState<string | null>(null)
+  const [showReadyMessage, setShowReadyMessage] = useState(false)
+
+  const callRefineFormInput = useCallback(
+    async (prompt: string) => {
+      // Skip if the value is from a suggestion
+      if (isFromSuggestionRef.current) {
+        isFromSuggestionRef.current = false
+        return
+      }
+
+      // Skip if trigger is empty or too short (minimum 15 characters required by API)
+      if (!prompt || prompt.trim().length < 15) {
+        setAiSuggestion(null)
+        setShowReadyMessage(false)
+        return
+      }
+
+      try {
+        const result = await refineFormInput({
+          variables: {
+            input: {
+              prompt,
+              sessionId: null,
+            },
+          },
+        })
+
+        if (result.data?.refineFormInput) {
+          const { status, suggestion } = result.data.refineFormInput
+          if (status) {
+            // Status is true - show ready message
+            setShowReadyMessage(true)
+            setAiSuggestion(null)
+          } else if (suggestion) {
+            // Status is false and we have a suggestion
+            setAiSuggestion(suggestion)
+            setShowReadyMessage(false)
+          } else {
+            setAiSuggestion(null)
+            setShowReadyMessage(false)
+          }
+        }
+      } catch (error) {
+        console.error('Error refining form input:', error)
+        setAiSuggestion(null)
+        setShowReadyMessage(false)
+      }
+    },
+    [refineFormInput],
+  )
+
+  const debouncedRefineFormInput = useMemo(
+    () => debounce(callRefineFormInput, 2000),
+    [callRefineFormInput],
+  )
+
   const handleIdeaClick = (idea: AiFormIdea) => {
+    isFromSuggestionRef.current = true
+    debouncedRefineFormInput.cancel()
+    setAiSuggestion(null)
+    setShowReadyMessage(false)
     setValue('trigger', idea.trigger, { shouldValidate: true })
     setValue('actions', idea.actions, { shouldValidate: true })
   }
 
+  useEffect(() => {
+    debouncedRefineFormInput(actionsValue)
+  }, [actionsValue, debouncedRefineFormInput])
+
   const isCreate = type === 'create'
+  const shouldShowIdeaButtons =
+    isCreate && !isRefiningFormInput && !aiSuggestion && !showReadyMessage
 
   return (
     <>
@@ -112,7 +191,34 @@ export const AIFormModalContent = ({
                       {errors[field.key]?.message}
                     </FormErrorMessage>
                   )}
-                  {isCreate && field.key === 'actions' && (
+                  {field.key === 'actions' &&
+                    (isRefiningFormInput ||
+                      aiSuggestion ||
+                      showReadyMessage) && (
+                      <Box mt={2} borderRadius="md">
+                        {isRefiningFormInput ? (
+                          <Flex align="center" gap={2}>
+                            <Spinner size="sm" />
+                            <Text fontSize="sm">Loading suggestion...</Text>
+                          </Flex>
+                        ) : showReadyMessage ? (
+                          <Text fontSize="sm" color="green.600">
+                            <Text as="span" fontWeight="semibold">
+                              All good!
+                            </Text>{' '}
+                            Let&apos;s give it a try.
+                          </Text>
+                        ) : (
+                          <Text fontSize="sm">
+                            <Text as="span" fontWeight="semibold">
+                              Suggestion:
+                            </Text>{' '}
+                            {aiSuggestion}
+                          </Text>
+                        )}
+                      </Box>
+                    )}
+                  {field.key === 'actions' && shouldShowIdeaButtons && (
                     <IdeaButtons
                       ideas={AI_FORM_IDEAS}
                       onClick={handleIdeaClick}

--- a/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
+++ b/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { datadogRum } from '@datadog/browser-rum'
 import { debounce } from 'lodash'
@@ -77,6 +77,13 @@ export const useRefineFormInput = () => {
     debouncedRefineFormInput.cancel()
     setAiSuggestion(null)
     setShowReadyMessage(false)
+  }, [debouncedRefineFormInput])
+
+  // Cancel pending debounced calls on unmount to prevent unnecessary API requests
+  useEffect(() => {
+    return () => {
+      debouncedRefineFormInput.cancel()
+    }
   }, [debouncedRefineFormInput])
 
   return {

--- a/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
+++ b/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
@@ -1,13 +1,12 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useMutation } from '@apollo/client'
+import { datadogRum } from '@datadog/browser-rum'
 import { debounce } from 'lodash'
 
 import { REFINE_FORM_INPUT } from '@/graphql/mutations/ai/refine-form-input'
 
-import { useAiBuilderContext } from '../AiBuilderContext'
-
 export const useRefineFormInput = () => {
-  const { ddSessionId } = useAiBuilderContext()
+  const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
   const [refineFormInput, { loading: isRefiningFormInput }] =
     useMutation(REFINE_FORM_INPUT)
 

--- a/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
+++ b/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { useMutation } from '@apollo/client'
+import { debounce } from 'lodash'
+
+import { REFINE_FORM_INPUT } from '@/graphql/mutations/ai/refine-form-input'
+
+import { useAiBuilderContext } from '../AiBuilderContext'
+
+export const useRefineFormInput = () => {
+  const { ddSessionId } = useAiBuilderContext()
+  const [refineFormInput, { loading: isRefiningFormInput }] =
+    useMutation(REFINE_FORM_INPUT)
+
+  const isFromSuggestionRef = useRef(false)
+  const [aiSuggestion, setAiSuggestion] = useState<string | null>(null)
+  const [showReadyMessage, setShowReadyMessage] = useState(false)
+
+  const callRefineFormInput = useCallback(
+    async (triggerPrompt: string, actionsPrompt: string) => {
+      // Skip if the value is from a suggestion
+      if (isFromSuggestionRef.current) {
+        isFromSuggestionRef.current = false
+        return
+      }
+
+      // Combine trigger and actions into a single prompt
+      const combinedPrompt = `${triggerPrompt}\n${actionsPrompt}`.trim()
+
+      // Skip if combined prompt is empty or too short (minimum 30 characters required by API)
+      if (!combinedPrompt || combinedPrompt.length < 30) {
+        setAiSuggestion(null)
+        setShowReadyMessage(false)
+        return
+      }
+
+      try {
+        const result = await refineFormInput({
+          variables: {
+            input: {
+              prompt: combinedPrompt,
+              sessionId: ddSessionId,
+            },
+          },
+        })
+
+        if (result.data?.refineFormInput) {
+          const { status, suggestion } = result.data.refineFormInput
+          if (status) {
+            // Status is true - show ready message
+            setShowReadyMessage(true)
+            setAiSuggestion(null)
+          } else if (suggestion) {
+            // Status is false and we have a suggestion
+            setAiSuggestion(suggestion)
+            setShowReadyMessage(false)
+          } else {
+            setAiSuggestion(null)
+            setShowReadyMessage(false)
+          }
+        }
+      } catch (error) {
+        console.error('Error refining form input:', error)
+        setAiSuggestion(null)
+        setShowReadyMessage(false)
+      }
+    },
+    [refineFormInput, ddSessionId],
+  )
+
+  const debouncedRefineFormInput = useMemo(
+    () => debounce(callRefineFormInput, 2000),
+    [callRefineFormInput],
+  )
+
+  const resetSuggestion = useCallback(() => {
+    isFromSuggestionRef.current = true
+    debouncedRefineFormInput.cancel()
+    setAiSuggestion(null)
+    setShowReadyMessage(false)
+  }, [debouncedRefineFormInput])
+
+  return {
+    refineFormInput: debouncedRefineFormInput,
+    isRefiningFormInput,
+    aiSuggestion,
+    showReadyMessage,
+    resetSuggestion,
+  }
+}

--- a/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
+++ b/packages/frontend/src/pages/AiBuilder/hooks/useRefineFormInput.ts
@@ -23,7 +23,8 @@ export const useRefineFormInput = () => {
       }
 
       // Combine trigger and actions into a single prompt
-      const combinedPrompt = `${triggerPrompt}\n${actionsPrompt}`.trim()
+      const combinedPrompt =
+        `data source:${triggerPrompt}\n workflow description:${actionsPrompt}`.trim()
 
       // Skip if combined prompt is empty or too short (minimum 30 characters required by API)
       if (!combinedPrompt || combinedPrompt.length < 30) {


### PR DESCRIPTION
## TL;DR

This PR adds a new feature that provides real-time feedback and suggestions for form inputs.

## What changed

- Adds a new `refineFormInput` mutation to provide AI-powered suggestions for form inputs
- Create a new hook `useRefineFormInput` to handle form input refinement logic
- Implement debounced API calls to avoid excessive requests
- Add UI components to display loading state, suggestions, and success messages
- Update form validation to require minimum 30 characters for prompts
- Reposition idea buttons and suggestions for better UX

## Tests

Type some inputs into the form

- [ ] Should see suggestions after 2s and suggestions should guide to improve the workflow description
- [ ] Should not trigger the loading state if simply using the suggestions