### PR TITLE
PLU-629 (frontend): cannot click RTE in Safari when popover open

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -8,8 +8,8 @@ import {
   Box,
   FormControl,
   Popover,
+  PopoverAnchor,
   PopoverContent,
-  PopoverTrigger,
   Portal,
   useDisclosure,
 } from '@chakra-ui/react'
@@ -264,28 +264,29 @@ const Editor = ({
       onClose={closeSuggestions}
       isOpen={isSuggestionsOpen && variablesEnabled}
       placement={getPopoverPlacement(editor)}
+      closeOnBlur={false}
     >
-      <div
-        className="editor"
-        onClick={(e) => {
-          e.stopPropagation()
-          openSuggestions()
-        }}
-        onBlur={(e) => {
-          // Focus might shift to menu bar or other children, where we do _not_
-          // want to close our popper.
-          const editorContainer =
-            e.currentTarget.closest('.single-line-editor') || e.currentTarget
-          if (
-            editorContainer.contains(e.relatedTarget) ||
-            e.relatedTarget?.closest('.chakra-popover__content')
-          ) {
-            return
-          }
-          closeSuggestions()
-        }}
-      >
-        <PopoverTrigger>
+      <PopoverAnchor>
+        <div
+          className="editor"
+          onClick={(e) => {
+            e.stopPropagation()
+            openSuggestions()
+          }}
+          onBlur={(e) => {
+            // Focus might shift to menu bar or other children, where we do _not_
+            // want to close our popper.
+            const editorContainer =
+              e.currentTarget.closest('.single-line-editor') || e.currentTarget
+            if (
+              editorContainer.contains(e.relatedTarget) ||
+              e.relatedTarget?.closest('.chakra-popover__content')
+            ) {
+              return
+            }
+            closeSuggestions()
+          }}
+        >
           <Box className={isMulticol ? 'single-line-editor' : undefined}>
             {isRich && (
               <MenuBar
@@ -303,31 +304,31 @@ const Editor = ({
                 }
               }}
             />
-            <Portal>
-              <PopoverContent
-                w={isMobile ? '100%' : isMulticol ? '55vw' : '100%'}
-                motionProps={POPOVER_MOTION_PROPS}
-                onFocus={(e) => {
-                  // Go back to previous focus when clicking on suggestions to resume typing
-                  if (e.relatedTarget instanceof HTMLElement) {
-                    e.relatedTarget?.focus()
-                  }
-                }}
-                _focus={{
-                  boxShadow: 'none',
-                  borderColor: 'inherit',
-                }}
-              >
-                <Suggestions
-                  data={stepsWithVariables}
-                  onSuggestionClick={(v) => editable && handleVariableClick(v)}
-                  noVariablesMessage={noVariablesMessage}
-                />
-              </PopoverContent>
-            </Portal>
           </Box>
-        </PopoverTrigger>
-      </div>
+        </div>
+      </PopoverAnchor>
+      <Portal>
+        <PopoverContent
+          w={isMobile ? '100%' : isMulticol ? '55vw' : '100%'}
+          motionProps={POPOVER_MOTION_PROPS}
+          onFocus={(e) => {
+            // Go back to previous focus when clicking on suggestions to resume typing
+            if (e.relatedTarget instanceof HTMLElement) {
+              e.relatedTarget?.focus()
+            }
+          }}
+          _focus={{
+            boxShadow: 'none',
+            borderColor: 'inherit',
+          }}
+        >
+          <Suggestions
+            data={stepsWithVariables}
+            onSuggestionClick={(v) => editable && handleVariableClick(v)}
+            noVariablesMessage={noVariablesMessage}
+          />
+        </PopoverContent>
+      </Portal>
     </Popover>
   )
 }


### PR DESCRIPTION
## Problem
Safari issue.
When editing in a rich text field, users cannot click to other parts of the text or input when the suggestions popover is open.

Can still use the keyboard to move the cursor, but not an ideal experience

## Solution
Use the `PopoverAnchor` for the Tiptap Editor instead of using `PopoverTrigger`.

## Tests
Make sure that the Editor works the same as intended across Chrome / Edge / Safari
- [ ] Can select variables from different steps and suggestions popover does not close
- [ ] Can click on variable, then click on Tiptap Editor to move cursor AND can highlight text in Tiptap Editor
- [ ] Can use the menu bar to modify the text and the suggestions popover should not close
- [ ] Popover closes when you click outside
- [ ] Popover closes when you hit 'tab'

## Pre-deploy
Run e2e tests on staging to be safe (ran on local no issues)