### PR TITLE
fix: modify minio and minio-client versions

### DIFF
--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -42,7 +42,7 @@ services:
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN}
   minio:
-    image: 'bitnami/minio:2025.7.23'
+    image: 'minio/minio:RELEASE.2025-09-07T16-13-09Z'
     user: '0:0'
     ports:
       - '9000:9000'
@@ -59,7 +59,7 @@ services:
       interval: 1s
       retries: 5
   create-minio-buckets:
-    image: bitnami/minio-client:2025.7.21
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     volumes:
       - ../frontend/src/assets/plumber-logo.jpg:/assets/plumber-logo.jpg
     depends_on:


### PR DESCRIPTION
## Details
- Cannot pull the minion and minio-client versions when running `npm run setup`, have to update to the specific release versions for it to work, thks @pregnantboy 

More details: https://hub.docker.com/r/minio/mc/tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches MinIO and MinIO Client in `packages/backend/docker-compose.dev.yml` to official images with specific release tags.
> 
> - **Dev environment (`packages/backend/docker-compose.dev.yml`)**:
>   - **Images**:
>     - Update `minio` service from `bitnami/minio` to `minio/minio:RELEASE.2025-09-07T16-13-09Z`.
>     - Update `create-minio-buckets` from `bitnami/minio-client` to `minio/mc:RELEASE.2025-08-13T08-35-41Z`.
>   - **Volumes**:
>     - Ensure `plumber-tiles-postgres` volume remains declared.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b898b36a21865ea145e12f774214217e839afaf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->