### PR TITLE
[PAIR-ACTION-2] feat(backend): add schema, dataOut metadata, and call Pair

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
@@ -1,0 +1,392 @@
+import { assert, describe, expect, it } from 'vitest'
+
+import { schema } from '@/apps/pair/actions/send-prompt/schema'
+
+describe('call-pair schema', () => {
+  describe('promptType validation', () => {
+    it('should accept valid prompt types', () => {
+      const validTypes = [
+        'analyse',
+        'categorise',
+        'summarise',
+        'write',
+        'custom',
+      ]
+
+      validTypes.forEach((promptType) => {
+        const result = schema.safeParse({
+          promptType,
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'summary',
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.promptType === promptType)
+      })
+    })
+
+    it('should reject invalid prompt types', () => {
+      const result = schema.safeParse({
+        promptType: 'invalid',
+        prompt: 'test prompt',
+      })
+      assert(result.success === false)
+    })
+
+    it('should require promptType', () => {
+      const result = schema.safeParse({
+        prompt: 'test prompt',
+      })
+      assert(result.success === false)
+    })
+  })
+
+  describe('prompt validation', () => {
+    it('should accept valid non-empty prompts', () => {
+      const result = schema.safeParse({
+        promptType: 'analyse',
+        prompt: 'Analyze this document',
+        responseFields: [
+          {
+            fieldName: 'summary',
+            fieldType: 'text',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.prompt === 'Analyze this document')
+    })
+
+    it('should reject empty prompts', () => {
+      const result = schema.safeParse({
+        promptType: 'analyse',
+        prompt: '',
+      })
+      assert(result.success === false)
+    })
+
+    it('should require prompt field', () => {
+      const result = schema.safeParse({
+        promptType: 'analyse',
+      })
+      assert(result.success === false)
+    })
+  })
+
+  describe('responseFields validation', () => {
+    describe('fieldName validation', () => {
+      it.each([
+        'field1',
+        'field_name',
+        'field-name',
+        'Field123',
+        'field_123-test',
+        'ABC123_test-name',
+      ])(
+        'should accept valid field names with letters, numbers, underscores, and hyphens: %s',
+        (fieldName) => {
+          const result = schema.safeParse({
+            promptType: 'analyse',
+            prompt: 'test prompt',
+            responseFields: [
+              {
+                fieldName,
+                fieldType: 'text',
+              },
+            ],
+          })
+          assert(result.success === true)
+          assert(result.data.responseFields[0].fieldName === fieldName)
+        },
+      )
+
+      it.each([
+        'field name',
+        'field@name',
+        'field.name',
+        'field#name',
+        'field!name',
+        'field$name',
+      ])(
+        'should reject field names with invalid characters: %s',
+        (fieldName) => {
+          const result = schema.safeParse({
+            promptType: 'analyse',
+            prompt: 'test prompt',
+            responseFields: [{ fieldName, fieldType: 'text' }],
+          })
+          assert(result.success === false)
+        },
+      )
+
+      it('should reject empty field names', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: '',
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should reject field names longer than 64 characters', () => {
+        const longName = 'a'.repeat(65)
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: longName,
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should accept field names exactly 64 characters long', () => {
+        const maxName = 'a'.repeat(64)
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: maxName,
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === true)
+      })
+    })
+
+    describe('fieldType validation', () => {
+      it('should accept text field type', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields[0].fieldType === 'text')
+      })
+
+      it('should accept number field type', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'number',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields[0].fieldType === 'number')
+      })
+
+      it('should accept category field type with valid categories', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'category',
+              fieldCategories: 'option1, option2, option3',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields[0].fieldType === 'category')
+      })
+
+      it('should reject invalid field types', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'invalid',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+    })
+
+    describe('fieldCategories validation', () => {
+      it('should require fieldCategories when fieldType is category', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'category',
+            },
+          ],
+        })
+        assert(result.success === false)
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            'Categories are required when field type is category. Enter comma-separated values',
+          )
+        }
+      })
+
+      it('should accept valid comma-separated categories', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'category',
+              fieldCategories: 'red, blue, green',
+            },
+          ],
+        })
+        assert(result.success === true)
+      })
+
+      it('should accept categories without spaces', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'category',
+              fieldCategories: 'red,blue,green',
+            },
+          ],
+        })
+        assert(result.success === true)
+      })
+
+      it('should reject empty categories when fieldType is category', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'category',
+              fieldCategories: '',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it.each([
+        ',',
+        'red,,blue',
+        'red, ,blue',
+        ',red,blue',
+        'red,blue,',
+        '  ,  ,  ',
+      ])(
+        'should reject categories with empty items after trimming: %s',
+        (fieldCategories) => {
+          const result = schema.safeParse({
+            promptType: 'analyse',
+            prompt: 'test prompt',
+            responseFields: [
+              {
+                fieldName: 'field1',
+                fieldType: 'category',
+                fieldCategories,
+              },
+            ],
+          })
+          assert(result.success === false)
+        },
+      )
+
+      it('should allow fieldCategories to be optional when fieldType is not category', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'text',
+            },
+          ],
+        })
+        assert(result.success === true)
+        expect(result.data.responseFields[0].fieldCategories).toBeUndefined()
+      })
+    })
+
+    describe('multiple fields validation', () => {
+      it('should accept multiple valid response fields', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'field1',
+              fieldType: 'text',
+            },
+            {
+              fieldName: 'field2',
+              fieldType: 'number',
+            },
+            {
+              fieldName: 'field3',
+              fieldType: 'category',
+              fieldCategories: 'A, B, C',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields.length === 3)
+      })
+    })
+  })
+
+  describe('complete schema validation', () => {
+    it('should validate a complete configuration', () => {
+      const result = schema.safeParse({
+        promptType: 'analyse',
+        prompt: 'Analyze the sentiment and extract key information',
+        responseFields: [
+          {
+            fieldName: 'sentiment',
+            fieldType: 'category',
+            fieldCategories: 'positive, neutral, negative',
+          },
+          {
+            fieldName: 'summary',
+            fieldType: 'text',
+          },
+          {
+            fieldName: 'confidence_score',
+            fieldType: 'number',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.promptType === 'analyse')
+      assert(result.data.responseFields.length === 3)
+    })
+  })
+})

--- a/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
@@ -228,6 +228,23 @@ describe('call-pair schema', () => {
         })
         assert(result.success === false)
       })
+
+      it('should reject empty response fields', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [],
+        })
+        assert(result.success === false)
+      })
+
+      it('should reject non-existent response fields', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+        })
+        assert(result.success === false)
+      })
     })
 
     describe('fieldCategories validation', () => {

--- a/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
@@ -166,6 +166,33 @@ describe('call-pair schema', () => {
         })
         assert(result.success === true)
       })
+
+      it('should not accept duplicate field names (case-insensitive)', () => {
+        const result = schema.safeParse({
+          promptType: 'analyse',
+          prompt: 'test prompt',
+          responseFields: [
+            {
+              fieldName: 'Field1',
+              fieldType: 'text',
+            },
+            {
+              fieldName: 'field1',
+              fieldType: 'text',
+            },
+            {
+              fieldName: 'field2',
+              fieldType: 'number',
+            },
+            {
+              fieldName: 'field3',
+              fieldType: 'category',
+              fieldCategories: 'A, B, C',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
     })
 
     describe('fieldType validation', () => {
@@ -262,7 +289,7 @@ describe('call-pair schema', () => {
         assert(result.success === false)
         if (!result.success) {
           expect(result.error.issues[0].message).toBe(
-            'Categories are required when field type is category. Enter comma-separated values',
+            'Enter categories as comma-separated values with no empty or duplicate entries.',
           )
         }
       })
@@ -334,6 +361,36 @@ describe('call-pair schema', () => {
             ],
           })
           assert(result.success === false)
+        },
+      )
+
+      it.each([
+        'red,blue,red',
+        'red, blue, red',
+        'red,blue,Red',
+        'Red, Blue, red',
+        'apple, banana, APPLE',
+        'A,B,C,a',
+      ])(
+        'should reject categories with duplicates (case-insensitive): %s',
+        (fieldCategories) => {
+          const result = schema.safeParse({
+            promptType: 'analyse',
+            prompt: 'test prompt',
+            responseFields: [
+              {
+                fieldName: 'field1',
+                fieldType: 'category',
+                fieldCategories,
+              },
+            ],
+          })
+          assert(result.success === false)
+          if (!result.success) {
+            expect(result.error.issues[0].message).toBe(
+              'Enter categories as comma-separated values with no empty or duplicate entries.',
+            )
+          }
         },
       )
 

--- a/packages/backend/src/apps/pair/__tests__/common/generate-schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/common/generate-schema.test.ts
@@ -1,0 +1,448 @@
+import { assert, describe, expect, it } from 'vitest'
+import z from 'zod/v3'
+
+import { generateSchemaFromFields } from '../../common/generate-schema'
+
+describe('generateSchemaFromFields', () => {
+  describe('text field type', () => {
+    it('should generate a string schema for text field', () => {
+      const fields = [
+        {
+          fieldName: 'description',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ description: 'test text' })
+
+      assert(result.success === true)
+      expect(result.data.description).toBe('test text')
+    })
+
+    it('should reject non-string values for text field', () => {
+      const fields = [
+        {
+          fieldName: 'description',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ description: 123 })
+
+      assert(result.success === false)
+    })
+
+    it('should include field description for text field', () => {
+      const fields = [
+        {
+          fieldName: 'summary',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const schemaShape = schema._def.shape()
+
+      expect(schemaShape.summary.description).toBe('Text field: summary')
+    })
+  })
+
+  describe('number field type', () => {
+    it('should generate a number schema for number field', () => {
+      const fields = [
+        {
+          fieldName: 'count',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ count: 42 })
+
+      assert(result.success === true)
+      expect(result.data.count).toBe(42)
+    })
+
+    it('should accept decimal numbers', () => {
+      const fields = [
+        {
+          fieldName: 'score',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ score: 98.5 })
+
+      assert(result.success === true)
+      expect(result.data.score).toBe(98.5)
+    })
+
+    it('should reject non-number values for number field', () => {
+      const fields = [
+        {
+          fieldName: 'count',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ count: 'not a number' })
+
+      assert(result.success === false)
+    })
+
+    it('should include field description for number field', () => {
+      const fields = [
+        {
+          fieldName: 'amount',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const schemaShape = schema._def.shape()
+
+      expect(schemaShape.amount.description).toBe('Number field: amount')
+    })
+  })
+
+  describe('category field type', () => {
+    it('should generate an enum schema for category field with valid categories', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: 'pending, approved, rejected',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'approved' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('approved')
+    })
+
+    it('should accept all valid category values', () => {
+      const fields = [
+        {
+          fieldName: 'priority',
+          fieldType: 'category' as const,
+          fieldCategories: 'low, medium, high',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+
+      const lowResult = schema.safeParse({ priority: 'low' })
+      assert(lowResult.success === true)
+
+      const mediumResult = schema.safeParse({ priority: 'medium' })
+      assert(mediumResult.success === true)
+
+      const highResult = schema.safeParse({ priority: 'high' })
+      assert(highResult.success === true)
+    })
+
+    it('should reject invalid category values', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: 'pending, approved, rejected',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'invalid' })
+
+      assert(result.success === false)
+    })
+
+    it('should handle categories without spaces after commas', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: 'active,inactive,archived',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'active' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('active')
+    })
+
+    it('should trim whitespace from category values', () => {
+      const fields = [
+        {
+          fieldName: 'type',
+          fieldType: 'category' as const,
+          fieldCategories: '  option1  ,  option2  ,  option3  ',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ type: 'option1' })
+
+      assert(result.success === true)
+      expect(result.data.type).toBe('option1')
+    })
+
+    it('should filter out empty category values after trimming', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: 'valid1, , valid2,  , valid3',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+
+      const valid1Result = schema.safeParse({ status: 'valid1' })
+      const valid2Result = schema.safeParse({ status: 'valid2' })
+      const valid3Result = schema.safeParse({ status: 'valid3' })
+
+      assert(valid1Result.success === true)
+      assert(valid2Result.success === true)
+      assert(valid3Result.success === true)
+    })
+
+    it('should include category values in field description', () => {
+      const fields = [
+        {
+          fieldName: 'color',
+          fieldType: 'category' as const,
+          fieldCategories: 'red, blue, green',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const schemaShape = schema._def.shape()
+
+      expect(schemaShape.color.description).toBe(
+        'Category field: color. Must be one of: red, blue, green',
+      )
+    })
+
+    it('should fall back to string schema when fieldCategories is missing', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'any string' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('any string')
+    })
+
+    it('should fall back to string schema when fieldCategories is empty', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: '',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'any string' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('any string')
+    })
+
+    it('should fall back to string schema when all categories are empty after filtering', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: '  ,  ,  ',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'any string' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('any string')
+    })
+  })
+
+  describe('field name handling', () => {
+    it('should handle field names with special characters allowed by schema', () => {
+      const fields = [
+        {
+          fieldName: 'field_name-123',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ 'field_name-123': 'test' })
+
+      assert(result.success === true)
+      expect(result.data['field_name-123']).toBe('test')
+    })
+  })
+
+  describe('multiple fields', () => {
+    it('should generate schema for multiple fields of different types', () => {
+      const fields = [
+        {
+          fieldName: 'title',
+          fieldType: 'text' as const,
+        },
+        {
+          fieldName: 'count',
+          fieldType: 'number' as const,
+        },
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: 'active, inactive',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({
+        title: 'Test Title',
+        count: 42,
+        status: 'active',
+      })
+
+      assert(result.success === true)
+      expect(result.data.title).toBe('Test Title')
+      expect(result.data.count).toBe(42)
+      expect(result.data.status).toBe('active')
+    })
+
+    it('should reject when any field has invalid value', () => {
+      const fields = [
+        {
+          fieldName: 'name',
+          fieldType: 'text' as const,
+        },
+        {
+          fieldName: 'age',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({
+        name: 'John',
+        age: 'not a number',
+      })
+
+      assert(result.success === false)
+    })
+
+    it('should require all defined fields', () => {
+      const fields = [
+        {
+          fieldName: 'required1',
+          fieldType: 'text' as const,
+        },
+        {
+          fieldName: 'required2',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({
+        required1: 'value',
+        // missing required2
+      })
+
+      assert(result.success === false)
+    })
+  })
+
+  describe('empty fields array', () => {
+    it('should generate empty object schema for empty fields array', () => {
+      const fields: Array<{
+        fieldName?: string
+        fieldType?: 'text' | 'number' | 'category'
+        fieldCategories?: string
+      }> = []
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({})
+
+      assert(result.success === true)
+      expect(result.data).toEqual({})
+    })
+
+    it('should reject non-empty object when schema is empty', () => {
+      const fields: Array<{
+        fieldName?: string
+        fieldType?: 'text' | 'number' | 'category'
+        fieldCategories?: string
+      }> = []
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ extraField: 'value' })
+
+      assert(result.success === false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle single category value', () => {
+      const fields = [
+        {
+          fieldName: 'single',
+          fieldType: 'category' as const,
+          fieldCategories: 'only_option',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ single: 'only_option' })
+
+      assert(result.success === true)
+      expect(result.data.single).toBe('only_option')
+    })
+
+    it('should handle categories with leading/trailing commas', () => {
+      const fields = [
+        {
+          fieldName: 'status',
+          fieldType: 'category' as const,
+          fieldCategories: ',option1,option2,',
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({ status: 'option1' })
+
+      assert(result.success === true)
+      expect(result.data.status).toBe('option1')
+    })
+
+    it('should maintain zod object structure', () => {
+      const fields = [
+        {
+          fieldName: 'test',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+
+      expect(schema).toBeInstanceOf(z.ZodObject)
+    })
+  })
+})

--- a/packages/backend/src/apps/pair/actions/send-prompt/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/get-data-out-metadata.ts
@@ -1,0 +1,26 @@
+import {
+  IDataOutMetadata,
+  IDataOutMetadatum,
+  IExecutionStep,
+} from '@plumber/types'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut) {
+    return null
+  }
+
+  const metadata = Object.keys(dataOut).reduce((acc, key) => {
+    acc[key] = {
+      label: key,
+      type: 'ai_response',
+    }
+    return acc
+  }, {} as Record<string, IDataOutMetadatum>)
+
+  return metadata
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -1,5 +1,15 @@
 import { IRawAction } from '@plumber/types'
 
+import { fromZodError } from 'zod-validation-error'
+
+import StepError, { GenericSolution } from '@/errors/step'
+
+import generateObject from '../../common/generate-object'
+import { generateSchemaFromFields } from '../../common/generate-schema'
+
+import getDataOutMetadata from './get-data-out-metadata'
+import { schema } from './schema'
+
 const action: IRawAction = {
   name: 'Ask Pair',
   key: 'sendPrompt',
@@ -96,17 +106,35 @@ const action: IRawAction = {
     },
   ],
 
-  // TODO (kevinkim-ogp): add the data out metadata
+  getDataOutMetadata,
 
   async run($) {
-    // TODO (kevinkim-ogp): add the validation for the parameters
+    const validatedParameters = schema.safeParse($.step.parameters)
 
-    // TODO (kevinkim-ogp): add the dynamic schema for the response fields
+    if (!validatedParameters.success) {
+      const firstError = fromZodError(validatedParameters.error).details[0]
+      throw new StepError(
+        firstError.message,
+        GenericSolution.ReconfigureInvalidField,
+        $.step.position,
+        $.app.name,
+      )
+    }
 
-    // TODO (kevinkim-ogp): add the generate object
+    const { prompt, responseFields } = validatedParameters.data
+
+    const dynamicSchema = generateSchemaFromFields(responseFields)
+
+    const response = await generateObject(prompt, dynamicSchema, {
+      userId: $.user.email,
+      flowId: $.flow.id,
+      stepId: $.step.id,
+      executionId: $.execution.id,
+      tags: ['pair', 'action', 'generate-text'],
+    })
 
     $.setActionItem({
-      raw: { data: $.step.parameters },
+      raw: { ...response },
     })
   },
 }

--- a/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
@@ -28,22 +28,46 @@ export const schema = z.object({
               if (!data.fieldCategories) {
                 return false
               }
-              // Validate comma-separated values
-              // each value (after trimming) must not be empty
-              const items = data.fieldCategories
-                .split(',')
-                .map((item: string) => item.trim())
-              return items.every((item: string) => item.length > 0)
+              // Validate comma-separated values in a single pass
+              const items = data.fieldCategories.split(',')
+              const seen = new Set<string>()
+
+              for (const item of items) {
+                const trimmed = item.trim()
+
+                // Check if empty
+                if (trimmed.length === 0) {
+                  return false
+                }
+
+                // Check for duplicate (case-insensitive)
+                const lower = trimmed.toLowerCase()
+                if (seen.has(lower)) {
+                  return false
+                }
+                seen.add(lower)
+              }
+
+              return true
             }
             return true
           },
           {
             message:
-              'Categories are required when field type is category. Enter comma-separated values',
+              'Enter categories as comma-separated values with no empty or duplicate entries.',
           },
         ),
     )
     .min(1, {
       message: 'Enter at least one response field',
-    }),
+    })
+    .refine(
+      (fields) => {
+        const names = fields.map((f) => f.fieldName.toLowerCase())
+        return new Set(names).size === names.length
+      },
+      {
+        message: 'Field names must be unique (case-insensitive)',
+      },
+    ),
 })

--- a/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
@@ -1,71 +1,49 @@
 import z from 'zod/v3'
 
-export const schema = z
-  .object({
-    promptType: z.enum([
-      'analyse',
-      'categorise',
-      'summarise',
-      'write',
-      'custom',
-    ]),
-    prompt: z.string().min(1),
-    responseFields: z
-      .array(
-        z
-          .object({
-            fieldName: z
-              .string()
-              .min(1)
-              .max(64)
-              .regex(
-                /^[a-zA-Z0-9_-]+$/,
-                'Field name cannot contain spaces. Use only letters, numbers, underscores (_), and hyphens (-)',
-              ),
-            fieldType: z.enum(['text', 'number', 'category']),
-            fieldCategories: z.string().optional(),
-          })
-          .refine(
-            (data: {
-              fieldName?: string
-              fieldType?: string
-              fieldCategories?: string
-            }) => {
-              if (data.fieldType === 'category') {
-                if (!data.fieldCategories) {
-                  return false
-                }
-                // Validate comma-separated values
-                // each value (after trimming) must not be empty
-                const items = data.fieldCategories
-                  .split(',')
-                  .map((item: string) => item.trim())
-                return items.every((item: string) => item.length > 0)
+export const schema = z.object({
+  promptType: z.enum(['analyse', 'categorise', 'summarise', 'write', 'custom']),
+  prompt: z.string().min(1),
+  responseFields: z
+    .array(
+      z
+        .object({
+          fieldName: z
+            .string()
+            .min(1)
+            .max(64)
+            .regex(
+              /^[a-zA-Z0-9_-]+$/,
+              'Field name cannot contain spaces. Use only letters, numbers, underscores (_), and hyphens (-)',
+            ),
+          fieldType: z.enum(['text', 'number', 'category']),
+          fieldCategories: z.string().optional(),
+        })
+        .refine(
+          (data: {
+            fieldName?: string
+            fieldType?: string
+            fieldCategories?: string
+          }) => {
+            if (data.fieldType === 'category') {
+              if (!data.fieldCategories) {
+                return false
               }
-              return true
-            },
-            {
-              message:
-                'Categories are required when field type is category. Enter comma-separated values',
-            },
-          ),
-      )
-      .optional()
-      .default([]),
-  })
-  .refine(
-    (data: {
-      responseFields: {
-        fieldName?: string
-        fieldType?: 'number' | 'text' | 'category'
-        fieldCategories?: string
-      }[]
-    }) => {
-      return data.responseFields && data.responseFields.length > 0
-    },
-    {
-      message:
-        'Response fields must contain at least one field when response format is multiple fields',
-      path: ['responseFields'],
-    },
-  )
+              // Validate comma-separated values
+              // each value (after trimming) must not be empty
+              const items = data.fieldCategories
+                .split(',')
+                .map((item: string) => item.trim())
+              return items.every((item: string) => item.length > 0)
+            }
+            return true
+          },
+          {
+            message:
+              'Categories are required when field type is category. Enter comma-separated values',
+          },
+        ),
+    )
+    .min(1, {
+      message: 'Enter at least one response field',
+    }),
+})

--- a/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
@@ -1,0 +1,71 @@
+import z from 'zod/v3'
+
+export const schema = z
+  .object({
+    promptType: z.enum([
+      'analyse',
+      'categorise',
+      'summarise',
+      'write',
+      'custom',
+    ]),
+    prompt: z.string().min(1),
+    responseFields: z
+      .array(
+        z
+          .object({
+            fieldName: z
+              .string()
+              .min(1)
+              .max(64)
+              .regex(
+                /^[a-zA-Z0-9_-]+$/,
+                'Field name cannot contain spaces. Use only letters, numbers, underscores (_), and hyphens (-)',
+              ),
+            fieldType: z.enum(['text', 'number', 'category']),
+            fieldCategories: z.string().optional(),
+          })
+          .refine(
+            (data: {
+              fieldName?: string
+              fieldType?: string
+              fieldCategories?: string
+            }) => {
+              if (data.fieldType === 'category') {
+                if (!data.fieldCategories) {
+                  return false
+                }
+                // Validate comma-separated values
+                // each value (after trimming) must not be empty
+                const items = data.fieldCategories
+                  .split(',')
+                  .map((item: string) => item.trim())
+                return items.every((item: string) => item.length > 0)
+              }
+              return true
+            },
+            {
+              message:
+                'Categories are required when field type is category. Enter comma-separated values',
+            },
+          ),
+      )
+      .optional()
+      .default([]),
+  })
+  .refine(
+    (data: {
+      responseFields: {
+        fieldName?: string
+        fieldType?: 'number' | 'text' | 'category'
+        fieldCategories?: string
+      }[]
+    }) => {
+      return data.responseFields && data.responseFields.length > 0
+    },
+    {
+      message:
+        'Response fields must contain at least one field when response format is multiple fields',
+      path: ['responseFields'],
+    },
+  )

--- a/packages/backend/src/apps/pair/common/generate-object.ts
+++ b/packages/backend/src/apps/pair/common/generate-object.ts
@@ -1,0 +1,37 @@
+import { AttributeValue } from '@opentelemetry/api'
+import { generateObject as AiSdkGenerateObject } from 'ai'
+import z from 'zod/v3'
+
+import logger from '@/helpers/logger'
+import { model } from '@/helpers/pair'
+
+async function generateObject(
+  prompt: string,
+  schema: z.ZodObject<any>,
+  metadata: Record<string, AttributeValue>,
+): Promise<any> {
+  try {
+    const { object } = await AiSdkGenerateObject({
+      model,
+      schema,
+      system:
+        "Based on the user's prompt, generate an object that adheres to the provided schema.",
+      prompt,
+      experimental_telemetry: {
+        isEnabled: true,
+        functionId: 'pair-action-generate-object',
+        metadata,
+      },
+    })
+
+    return object
+  } catch (error) {
+    logger.error('Failed to generate object', {
+      error: error,
+      ...metadata,
+    })
+    throw error
+  }
+}
+
+export default generateObject

--- a/packages/backend/src/apps/pair/common/generate-object.ts
+++ b/packages/backend/src/apps/pair/common/generate-object.ts
@@ -27,7 +27,7 @@ async function generateObject(
     return object
   } catch (error) {
     logger.error('Failed to generate object', {
-      error: error,
+      error,
       ...metadata,
     })
     throw error

--- a/packages/backend/src/apps/pair/common/generate-schema.ts
+++ b/packages/backend/src/apps/pair/common/generate-schema.ts
@@ -1,0 +1,64 @@
+import z from 'zod/v3'
+
+type ResponseField = {
+  fieldName?: string
+  fieldType?: 'text' | 'number' | 'category'
+  fieldCategories?: string
+}
+
+export function generateSchemaFromFields(fields: ResponseField[]) {
+  const schemaShape: Record<string, z.ZodTypeAny> = {}
+
+  for (const field of fields) {
+    const { fieldName, fieldType, fieldCategories } = field
+
+    if (!fieldName) {
+      continue
+    }
+
+    switch (fieldType) {
+      case 'text':
+        schemaShape[fieldName] = z.string().describe(`Text field: ${fieldName}`)
+        break
+      case 'number':
+        schemaShape[fieldName] = z
+          .number()
+          .describe(`Number field: ${fieldName}`)
+        break
+      case 'category':
+        if (fieldCategories) {
+          const categoryValues = fieldCategories
+            .split(',')
+            .map((cat) => cat.trim())
+            .filter((cat) => cat.length > 0)
+
+          if (categoryValues.length > 0) {
+            // Create enum from categories
+            schemaShape[fieldName] = z
+              .enum([categoryValues[0], ...categoryValues.slice(1)] as [
+                string,
+                ...string[],
+              ])
+              .describe(
+                `Category field: ${fieldName}. Must be one of: ${categoryValues.join(
+                  ', ',
+                )}`,
+              )
+          } else {
+            schemaShape[fieldName] = z
+              .string()
+              .describe(`Category field: ${fieldName}`)
+          }
+        } else {
+          schemaShape[fieldName] = z
+            .string()
+            .describe(`Category field: ${fieldName}`)
+        }
+        break
+    }
+  }
+
+  // NOTE: we set strict to ensure that the schema rejects any object
+  // with fields that are not explicitly defined in the schema
+  return z.object(schemaShape).strict()
+}


### PR DESCRIPTION
### TL;DR

Implemented the "Ask Pair" action functionality with schema validation and dynamic response field generation.

### What changed?

- Added schema validation for the "Ask Pair" action parameters
- Implemented `generateSchemaFromFields` to dynamically create Zod schemas based on user-defined response fields
- Created `generateObject` function that uses the `generateObject` from `ai-sdk` to get the response for the prompt
- Added `getDataOutMetadata` to properly display generated fields in the frontend

### How to test?
- Create an "Ask Pair" action in a Pipe
- Define response fields with different types (text, number, category)
- For category fields, provide comma-separated values

- [ ] 'Check step' and verify that the AI generates responses according to the defined schema
- [ ] Check that validation errors are properly displayed when invalid configurations are provided