### PR TITLE
[PAIR-ACTION-4] feat: default prompt values

### DIFF
--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -5,6 +5,10 @@ import { fromZodError } from 'zod-validation-error'
 
 import StepError, { GenericSolution } from '@/errors/step'
 
+import {
+  DEFAULT_PROMPT_VALUES,
+  DEFAULT_RESPONSE_FIELDS_VALUES,
+} from '../../common/constants'
 import generateObject from '../../common/generate-object'
 import { generateSchemaFromFields } from '../../common/generate-schema'
 
@@ -19,8 +23,6 @@ const action: IRawAction = {
   description:
     'Enter a custom prompt to summarise, categorise or analyse data with Pair',
   arguments: [
-    // TODO (kevinkim-ogp): each option should link to a different
-    // default value for the prompt. update when the default value is provided
     {
       label: 'What would you like to do?',
       key: 'promptType',
@@ -60,11 +62,13 @@ const action: IRawAction = {
         'Undo',
         'Redo',
       ],
-      // TODO (kevinkim-ogp): add the default value for the prompt
+      defaultValue: {
+        fieldKey: 'promptType',
+        options: DEFAULT_PROMPT_VALUES,
+      },
     },
     {
       label: 'How do you want the response?',
-
       key: 'responseFields',
       type: 'multirow-multicol' as const,
       required: true,
@@ -105,7 +109,10 @@ const action: IRawAction = {
           customStyle: { flex: 3 },
         },
       ],
-      // TODO (kevinkim-ogp): add the default value for the response fields
+      defaultValue: {
+        fieldKey: 'promptType',
+        options: DEFAULT_RESPONSE_FIELDS_VALUES,
+      },
     },
   ],
 

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -1,11 +1,99 @@
+import dedent from 'dedent'
+
 export const DEFAULT_PROMPT_VALUES = {
-  analyse: `<p style="margin: 0;font-weight: bold;">Analyse the following content and provide insights on:</p><p></p><p style="margin: 0"><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse" data-label="Replace this with the content to analyse" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse}}</span></p><p style="margin: 0"> </p><p style="margin: 0;font-weight: bold;">Focus on:</p><p>- Key patterns or trends</p><p>- Strengths and weaknesses</p><p>- Implications or recommendations</p><p>- Supporting evidence for your conclusions</p><p></p><p style="margin: 0;font-weight: bold;">Present your analysis in a structured format with clear reasoning.</p>`,
+  analyse: dedent`
+    <p style="margin: 0;font-weight: bold;">
+      Analyse the following content and provide insights on:
+    </p>
+    <p></p>
+    <p style="margin: 0">
+      <span
+        data-type="variable"
+        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse"
+        data-label="Replace this with the content to analyse"
+        data-value
+        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
+        to analyse}}</span
+      >
+    </p>
+    <p style="margin: 0"></p>
+    <p style="margin: 0;font-weight: bold;">Focus on:</p>
+    <p>- Key patterns or trends</p>
+    <p>- Strengths and weaknesses</p>
+    <p>- Implications or recommendations</p>
+    <p>- Supporting evidence for your conclusions</p>
+    <p></p>
+    <p style="margin: 0;font-weight: bold;">
+      Present your analysis in a structured format with clear reasoning.
+    </p>
+  `,
 
-  categorise: `<p>Categorise the following content into relevant groups or themes:</p><p></p><p><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise" data-label="Replace this with the content to categorise" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise}}</span></p><p></p><p>Provide clear category labels and explain your reasoning for each grouping.</p>`,
+  categorise: dedent`
+    <p>Categorise the following content into relevant groups or themes:</p>
+    <p></p>
+    <p>
+      <span
+        data-type="variable"
+        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise"
+        data-label="Replace this with the content to categorise"
+        data-value
+        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
+        to categorise}}</span
+      >
+    </p>
+    <p></p>
+    <p>
+      Provide clear category labels and explain your reasoning for each grouping.
+    </p>
+  `,
 
-  summarise: `<p>Summarise the following content, highlighting the key points and main takeaways:</p><p></p><p><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise" data-label="Replace this with the content to summarise" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise}}</span></p><p></p><p>Focus on the most important information and present it in a clear, concise format.</p>`,
+  summarise: dedent`
+    <p>
+      Summarise the following content, highlighting the key points and main
+      takeaways:
+    </p>
+    <p></p>
+    <p>
+      <span
+        data-type="variable"
+        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise"
+        data-label="Replace this with the content to summarise"
+        data-value
+        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
+        to summarise}}</span
+      >
+    </p>
+    <p></p>
+    <p>
+      Focus on the most important information and present it in a clear, concise
+      format.
+    </p>
+  `,
 
-  write: `<p>Write <span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to write" data-label="Replace this with the content to write" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to write}}</span> based on the following requirements:</p><p></p><p><strong>Topic/Subject</strong>: [Specify topic]</p><p><strong>Purpose</strong>: [Explain the intended use]</p><p><strong>Audience</strong>: [Describe target audience]</p><p><strong>Tone</strong>: [Professional/Formal/Conversational]</p><p><strong>Length</strong>: [Specify word count or length]</p><p><strong>Additional requirements</strong>: [Any specific guidelines or constraints]</p>`,
+  write: dedent`
+    <p>
+      Write
+      <span
+        data-type="variable"
+        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to write"
+        data-label="Replace this with the content to write"
+        data-value
+        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
+        to write}}</span
+      >
+      based on the following requirements:
+    </p>
+    <p></p>
+    <p><strong>Topic/Subject</strong>: [Specify topic]</p>
+    <p><strong>Purpose</strong>: [Explain the intended use]</p>
+    <p><strong>Audience</strong>: [Describe target audience]</p>
+    <p><strong>Tone</strong>: [Professional/Formal/Conversational]</p>
+    <p><strong>Length</strong>: [Specify word count or length]</p>
+    <p>
+      <strong>Additional requirements</strong>: [Any specific guidelines or
+      constraints]
+    </p>
+  `,
 
   custom: `<p>Enter your custom prompt</p>`,
 }
@@ -17,7 +105,11 @@ export const DEFAULT_RESPONSE_FIELDS_VALUES = {
       fieldType: 'text',
     },
     {
-      fieldName: 'strengths_and_weaknesses',
+      fieldName: 'strength',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'weakness',
       fieldType: 'text',
     },
     {
@@ -44,21 +136,12 @@ export const DEFAULT_RESPONSE_FIELDS_VALUES = {
   ],
   write: [
     {
-      fieldName: 'topic_subject',
+      fieldName: 'title',
       fieldType: 'text',
     },
     {
-      fieldName: 'audience',
+      fieldName: 'content',
       fieldType: 'text',
-    },
-    {
-      fieldName: 'tone',
-      fieldType: 'category',
-      fieldCategories: 'Professional, Conversational, Formal',
-    },
-    {
-      fieldName: 'length',
-      fieldType: 'number',
     },
   ],
   custom: [

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -1,0 +1,70 @@
+export const DEFAULT_PROMPT_VALUES = {
+  analyse: `<p style="margin: 0;font-weight: bold;">Analyse the following content and provide insights on:</p><p></p><p style="margin: 0"><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse" data-label="Replace this with the content to analyse" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse}}</span></p><p style="margin: 0"> </p><p style="margin: 0;font-weight: bold;">Focus on:</p><p>- Key patterns or trends</p><p>- Strengths and weaknesses</p><p>- Implications or recommendations</p><p>- Supporting evidence for your conclusions</p><p></p><p style="margin: 0;font-weight: bold;">Present your analysis in a structured format with clear reasoning.</p>`,
+
+  categorise: `<p>Categorise the following content into relevant groups or themes:</p><p></p><p><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise" data-label="Replace this with the content to categorise" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise}}</span></p><p></p><p>Provide clear category labels and explain your reasoning for each grouping.</p>`,
+
+  summarise: `<p>Summarise the following content, highlighting the key points and main takeaways:</p><p></p><p><span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise" data-label="Replace this with the content to summarise" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise}}</span></p><p></p><p>Focus on the most important information and present it in a clear, concise format.</p>`,
+
+  write: `<p>Write <span data-type="variable" data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to write" data-label="Replace this with the content to write" data-value>{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to write}}</span> based on the following requirements:</p><p></p><p><strong>Topic/Subject</strong>: [Specify topic]</p><p><strong>Purpose</strong>: [Explain the intended use]</p><p><strong>Audience</strong>: [Describe target audience]</p><p><strong>Tone</strong>: [Professional/Formal/Conversational]</p><p><strong>Length</strong>: [Specify word count or length]</p><p><strong>Additional requirements</strong>: [Any specific guidelines or constraints]</p>`,
+
+  custom: `<p>Enter your custom prompt</p>`,
+}
+
+export const DEFAULT_RESPONSE_FIELDS_VALUES = {
+  analyse: [
+    {
+      fieldName: 'key_patterns_or_trends',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'strengths_and_weaknesses',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'implications_or_recommendations',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'supporting_evidence_for_your_conclusions',
+      fieldType: 'text',
+    },
+  ],
+  categorise: [
+    {
+      fieldName: 'sentiment',
+      fieldType: 'category',
+      fieldCategories: 'Positive, Negative, Neutral',
+    },
+  ],
+  summarise: [
+    {
+      fieldName: 'summary',
+      fieldType: 'text',
+    },
+  ],
+  write: [
+    {
+      fieldName: 'topic_subject',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'audience',
+      fieldType: 'text',
+    },
+    {
+      fieldName: 'tone',
+      fieldType: 'category',
+      fieldCategories: 'Professional, Conversational, Formal',
+    },
+    {
+      fieldName: 'length',
+      fieldType: 'number',
+    },
+  ],
+  custom: [
+    {
+      fieldName: 'response',
+      fieldType: 'text',
+    },
+  ],
+}

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -277,6 +277,12 @@ type ActionSubstepArgument {
   addRowButtonText: String
   tooltipText: String
   noVariablesMessage: String
+  """
+  Can be either:
+  - A static string value (e.g., "Default text")
+  - A dynamic object with fieldKey and options (e.g., { fieldKey: "promptType", options: { analyse: "Analyse this" } })
+  """
+  defaultValue: JSONObject
 
   # Only for string and multiline
   singleVariableSelection: Boolean

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -1,6 +1,7 @@
 import type { IField, IFieldDropdownOption } from '@plumber/types'
 
 import { useContext } from 'react'
+import { useFormContext } from 'react-hook-form'
 
 import AttachmentSuggestions from '@/components/AttachmentSuggestions'
 import ControlledAutocomplete from '@/components/ControlledAutocomplete'
@@ -10,6 +11,7 @@ import MultiSelect from '@/components/MultiSelect'
 import RichTextEditor from '@/components/RichTextEditor'
 import TextField from '@/components/TextField'
 import { EditorContext } from '@/contexts/Editor'
+import { getDefaultValue } from '@/helpers/editor'
 import { useIsFieldHidden } from '@/helpers/isFieldHidden'
 import useDynamicData from '@/hooks/useDynamicData'
 
@@ -35,6 +37,7 @@ const optionGenerator = (options: RawOption[]): IFieldDropdownOption[] =>
 
 export default function InputCreator(props: InputCreatorProps): JSX.Element {
   const { schema, namePrefix, stepId, parentType, autoFocus } = props
+  const formContext = useFormContext()
 
   const {
     key: name,
@@ -146,6 +149,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         isRich
         noVariablesMessage={noVariablesMessage}
         customRteMenuOptions={schema?.customRteMenuOptions}
+        defaultValue={getDefaultValue(formContext, schema?.defaultValue)}
       />
     )
   }
@@ -222,6 +226,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         type={type}
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
+        defaultValue={getDefaultValue(formContext, schema?.defaultValue)}
       />
     )
   }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,4 +1,4 @@
-import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
+import type { IFieldMultiRowMultiColSubField, IJSONValue } from '@plumber/types'
 
 import React, { useContext } from 'react'
 import { BiTrash } from 'react-icons/bi'
@@ -15,6 +15,7 @@ type MultiColProps = {
   isEditorReadOnly?: boolean
   remove?: (index?: number | number[]) => void
   index?: number
+  defaultValue?: string | IJSONValue
 }
 
 export default function MultiCol(props: MultiColProps) {

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,4 +1,4 @@
-import type { IFieldMultiRowMultiColSubField, IJSONValue } from '@plumber/types'
+import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 import React, { useContext } from 'react'
 import { BiTrash } from 'react-icons/bi'
@@ -15,7 +15,6 @@ type MultiColProps = {
   isEditorReadOnly?: boolean
   remove?: (index?: number | number[]) => void
   index?: number
-  defaultValue?: string | IJSONValue
 }
 
 export default function MultiCol(props: MultiColProps) {

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -1,6 +1,6 @@
-import type { IField } from '@plumber/types'
+import type { IField, IJSONValue } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { BiPlus, BiTrash } from 'react-icons/bi'
 import Markdown from 'react-markdown'
@@ -24,6 +24,7 @@ export type MultiRowProps = {
   showDivider?: boolean
   addRowButtonText?: string
   type?: string
+  defaultValue?: string | IJSONValue
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
 function MultiRow(props: MultiRowProps): JSX.Element {
@@ -36,10 +37,11 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     addRowButtonText,
     showDivider,
     type,
+    defaultValue,
     ...forwardedInputCreatorProps
   } = props
 
-  const { control } = useFormContext()
+  const { control, setValue } = useFormContext()
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
 
   // react-hook-form requires a non-undefined default value for _every_
@@ -61,6 +63,12 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     name,
     rules: { required },
   })
+
+  useEffect(() => {
+    if (defaultValue) {
+      setValue(name, defaultValue)
+    }
+  }, [defaultValue, name, setValue])
 
   const handleAddRow = useCallback(() => {
     // NOTE: only need to use this flag to focus on the rte
@@ -118,6 +126,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                         isEditorReadOnly={isEditorReadOnly}
                         remove={() => remove(index)}
                         index={index}
+                        defaultValue={defaultValue}
                         {...forwardedInputCreatorProps}
                       />
                       {/*

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -126,7 +126,6 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                         isEditorReadOnly={isEditorReadOnly}
                         remove={() => remove(index)}
                         index={index}
-                        defaultValue={defaultValue}
                         {...forwardedInputCreatorProps}
                       />
                       {/*

--- a/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
+++ b/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
@@ -342,6 +342,7 @@ export const MenuBar = ({
           return (
             <button
               key={`${label}${index}`}
+              type="button"
               title={label}
               disabled={!editable}
               style={{

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -1,9 +1,9 @@
 import './RichTextEditor.scss'
 
-import type { TRteMenuOption } from '@plumber/types'
-import { TDataOutMetadatumType } from '@plumber/types'
+import type { TDataOutMetadatumType, TRteMenuOption } from '@plumber/types'
+import { IJSONValue } from '@plumber/types'
 
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useRef } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import {
   Box,
@@ -92,6 +92,7 @@ const RICH_TEXT_EXTENSIONS = [
 interface EditorProps {
   onChange: (...event: any[]) => void
   initialValue: string
+  defaultValue?: string | IJSONValue
   editable: boolean
   placeholder?: string
   variablesEnabled?: boolean
@@ -107,6 +108,7 @@ interface EditorProps {
 const Editor = ({
   onChange,
   initialValue,
+  defaultValue,
   editable,
   placeholder,
   variablesEnabled,
@@ -124,6 +126,10 @@ const Editor = ({
   const { allApps } = useContext(EditorContext)
   const isMobile = useIsMobile()
   const isMulticol = parentType === 'multicol'
+
+  // ref to track the defaultValue
+  // this is to sync the content of the editor with the defaultValue
+  const previousDefaultValueRef = useRef(defaultValue)
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
@@ -221,6 +227,26 @@ const Editor = ({
     // publish and unpublish of pipe
     editor?.setOptions({ editable })
   }, [editable, editor])
+
+  useEffect(() => {
+    // this is to sync the content of the editor with the defaultValue
+    // only do this if the defaultValue has actually changed
+    // for simplicity, we don't check if the initialValue has changed
+    // and just override the content of the editor with the defaultValue
+    const hasDefaultValueChanged =
+      defaultValue !== previousDefaultValueRef.current
+
+    if (editor && defaultValue !== undefined && hasDefaultValueChanged) {
+      editor?.commands.setContent(defaultValue as string)
+      onChange(
+        isRich
+          ? removeProblematicWhitespace(editor.getHTML())
+          : removeProblematicWhitespace(editor.getText()),
+      )
+
+      previousDefaultValueRef.current = defaultValue
+    }
+  }, [defaultValue, editor, isRich, varInfo, onChange, initialValue])
 
   const handleVariableClick = useCallback(
     (variable: Variable) => {
@@ -340,7 +366,7 @@ const Editor = ({
 
 interface RichTextEditorProps {
   required?: boolean
-  defaultValue?: string
+  defaultValue?: string | IJSONValue
   name: string
   label?: string
   description?: string
@@ -411,6 +437,7 @@ const RichTextEditor = ({
           <Editor
             onChange={onChange}
             initialValue={value}
+            defaultValue={defaultValue}
             editable={!readOnly}
             placeholder={placeholder}
             variablesEnabled={variablesEnabled}

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -232,7 +232,10 @@ const Editor = ({
     // this is to sync the content of the editor with the defaultValue
     // only do this if the defaultValue has actually changed
     // for simplicity, we don't check if the initialValue has changed
-    // and just override the content of the editor with the defaultValue
+    // and just overwrite the content of the editor with the defaultValue
+    // this is a trade-off that we make as defaultValues are updated at once
+    // in multiple fields, and a warning may be required to warn the user
+    // that changes have been made and will be overwritten.
     const hasDefaultValueChanged =
       defaultValue !== previousDefaultValueRef.current
 
@@ -246,7 +249,7 @@ const Editor = ({
 
       previousDefaultValueRef.current = defaultValue
     }
-  }, [defaultValue, editor, isRich, varInfo, onChange, initialValue])
+  }, [defaultValue, editor, isRich, onChange])
 
   const handleVariableClick = useCallback(
     (variable: Variable) => {

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -227,6 +227,7 @@ export const GET_APPS = gql`
             }
             singleVariableSelection
             customRteMenuOptions
+            defaultValue
             # Only for multi-row
             subFields {
               label

--- a/packages/frontend/src/helpers/editor.ts
+++ b/packages/frontend/src/helpers/editor.ts
@@ -6,6 +6,7 @@ import {
   ISubstep,
 } from '@plumber/types'
 
+import { FieldValues, UseFormReturn } from 'react-hook-form'
 import { BiQuestionMark } from 'react-icons/bi'
 import { yupResolver } from '@hookform/resolvers/yup'
 import type { BaseSchema } from 'yup'
@@ -162,4 +163,24 @@ export const hasDirtyFields = (fields: Record<string, any>): boolean => {
     }
     return false
   })
+}
+
+export function getDefaultValue(
+  formContext: UseFormReturn<FieldValues, any, FieldValues>,
+  defaultValue?:
+    | string
+    | { fieldKey: string; options: Record<string, string | IJSONValue> }
+    | undefined,
+): string | IJSONValue | undefined {
+  if (!defaultValue) {
+    return undefined
+  }
+
+  if (typeof defaultValue === 'string') {
+    return defaultValue
+  }
+
+  const formValues = formContext.getValues()
+  const fieldValue = formValues.parameters[defaultValue.fieldKey]
+  return defaultValue.options[fieldValue] ?? undefined
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -349,6 +349,34 @@ export interface IBaseField {
 
   // message to show when no variables are available
   noVariablesMessage?: string
+
+  /**
+   * Allows setting a default value for the field.
+   * ---
+   * Can be either:
+   * - A static string value that is always used
+   * - A dynamic object that determines the default based on another field's value
+   * ---
+   * Static example:
+   * defaultValue: 'Default text here'
+   *
+   * Dynamic example:
+   * {
+   *   fieldKey: 'promptType',
+   *   options: {
+   *     analyse: 'Analyse this document',
+   *     categorise: 'Categorise this document',
+   *     summarise: 'Summarise this document',
+   *     write: 'Write this document',
+   *   },
+   * }
+   */
+  defaultValue?:
+    | string
+    | {
+        fieldKey: string
+        options: Record<string, string | IJSONValue>
+      }
 }
 
 export type DropdownAddNewType = 'modal' | 'inline'


### PR DESCRIPTION
### TL;DR

Added default values for Pair app prompt and response fields based on prompt type selection.

### What changed?

- Created a new `constants.ts` file with default prompt templates and response field configurations for different prompt types (analyse, categorise, summarise, write, custom)
- Added support for dynamic default values in form fields through a new `defaultValue` property in the GraphQL schema
- Implemented the `getDefaultValue` helper function to resolve default values based on other field selections
- Enhanced the RichTextEditor component to handle default values and update content when they change
- Updated MultiRow and MultiCol components to support default values
- Applied these default values to the Pair app's send-prompt action

### How to test?

Create a 'Ask Pair' action and select different prompt types (analyse, categorise, summarise, write, custom)

- [ ] Verify that each selection automatically populates the prompt field with the appropriate template
- [ ] Verify that the response fields section also updates with relevant field configurations based on the prompt type

_NOTE_: changing the 'prompt type' will overwrite the prompt content and response fields even if a user has made an edit.