### PR TITLE
chore(refactor): add control for num files and file types at action

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -31,11 +31,18 @@ const action: IRawAction = {
   arguments: [
     {
       label: 'Image',
+      description: 'Supported file types: JPEG, JPG, PDF, PNG, WebP',
       key: 'image',
       type: 'attachment' as const,
       required: true,
       variableTypes: ['file'],
-      // TODO(kevinkim-ogp): restrict the supported file types
+      acceptedFileTypes: [
+        'application/pdf', // .pdf
+        'image/jpeg', // .jpg, .jpeg
+        'image/png', // .png
+        'image/webp', // .webp
+      ],
+      maxNumFiles: 1,
     },
     {
       label: 'Response field(s)',

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -257,6 +257,10 @@ type ActionSubstepArgument {
 
   # Only for rich text
   customRteMenuOptions: [String]
+
+  # Only for attachment
+  acceptedFileTypes: [String]
+  maxNumFiles: Int
 }
 
 type DropdownClickableLink {

--- a/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
@@ -16,12 +16,13 @@ import { StepWithVariables, Variable } from '@/helpers/variables'
 import { POPOVER_MOTION_PROPS } from '@/theme/constants'
 
 import { boxStyles, divWrapperStyles, noVariablesTextStyles } from '../style'
-import { ACCEPTED_FILE_TYPES, AttachmentConfigInput } from '../utils'
+import { AttachmentConfigInput, DEFAULT_FILE_TYPES } from '../utils'
 
 import Checkbox, { type CheckboxVariable } from './Checkbox'
 import TagList from './TagList'
 
 interface SuggestionsProps {
+  acceptedFileTypes: string[]
   allOptions: (CheckboxVariable | AttachmentConfigInput)[]
   currentTab: number
   isSuggestionsOpen: boolean
@@ -39,6 +40,7 @@ interface SuggestionsProps {
 
 export default function Suggestions(props: SuggestionsProps) {
   const {
+    acceptedFileTypes,
     allOptions,
     currentTab,
     isSuggestionsOpen,
@@ -55,6 +57,9 @@ export default function Suggestions(props: SuggestionsProps) {
   } = props
 
   const { readOnly } = useContext(EditorContext)
+  const fileTypes = useMemo(() => {
+    return acceptedFileTypes?.join(',') ?? DEFAULT_FILE_TYPES.join(',')
+  }, [acceptedFileTypes])
 
   const SuggestionsRightPanel = ({ values }: { values: any }) => {
     if (suggestions.length === 0) {
@@ -74,7 +79,7 @@ export default function Suggestions(props: SuggestionsProps) {
               >
                 {addNew && (
                   <FileUpload
-                    accept={ACCEPTED_FILE_TYPES.join(',')}
+                    accept={fileTypes}
                     buttonType="textButton"
                     disabled={isUploading || readOnly}
                     loading={isUploading}

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -17,7 +17,7 @@ import MenuAlertDialog from '../MenuAlertDialog'
 import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
-import { validateFiles } from './utils'
+import { DEFAULT_MAX_NUM_FILES, validateFiles } from './utils'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -26,6 +26,8 @@ interface AttachmentSuggestionsProps {
   description?: string
   required?: boolean
   variableTypes?: TDataOutMetadatumType[]
+  acceptedFileTypes?: string[]
+  maxNumFiles?: number
 }
 
 function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
@@ -36,6 +38,8 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     label,
     variableTypes = null,
     defaultValue = [],
+    acceptedFileTypes = [],
+    maxNumFiles = DEFAULT_MAX_NUM_FILES,
   } = props
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const cancelRef = useRef<HTMLButtonElement>(null)
@@ -99,6 +103,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
           variable,
           options,
           getValues(name),
+          maxNumFiles,
         )
         if (!isValid) {
           setError(name, { type: 'invalidFile', message: error })
@@ -107,7 +112,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
         }
       }
     },
-    [getValues, name, setError, options],
+    [getValues, name, setError, options, maxNumFiles],
   )
 
   useOutsideClick({
@@ -144,14 +149,19 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
 
   const processFile = useCallback(
     async (file: File) => {
-      const { isValid, error } = validateFiles(file, options, getValues(name))
+      const { isValid, error } = validateFiles(
+        file,
+        options,
+        getValues(name),
+        maxNumFiles,
+      )
       if (!isValid) {
         setError(name, { type: 'invalidFile', message: error })
       } else {
         await uploadToS3(file, flowId)
       }
     },
-    [flowId, getValues, name, options, setError, uploadToS3],
+    [flowId, getValues, name, options, setError, uploadToS3, maxNumFiles],
   )
 
   return (
@@ -195,6 +205,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
               openSuggestions={openSuggestions}
               processFile={processFile}
               setCurrentTab={setCurrentTab}
+              acceptedFileTypes={acceptedFileTypes}
             />
             <MenuAlertDialog
               cancelRef={cancelRef}

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -17,7 +17,7 @@ import MenuAlertDialog from '../MenuAlertDialog'
 import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
-import { DEFAULT_MAX_NUM_FILES, validateFiles } from './utils'
+import { DEFAULT_MAX_NUM_FILES, validateFiles, validateFileSize } from './utils'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -125,7 +125,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   })
 
   const { deleteUploadedFile, isDeleting, uploadToS3, isUploading } =
-    useS3Operations(name, getValues, refetchFlow, uploadedItems, {
+    useS3Operations(name, getValues, refetchFlow, uploadedItems, maxNumFiles, {
       onError: (filename: string, type: string, errorMessage: string) => {
         setError(name, {
           type: type,
@@ -149,19 +149,19 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
 
   const processFile = useCallback(
     async (file: File) => {
-      const { isValid, error } = validateFiles(
-        file,
-        options,
-        getValues(name),
-        maxNumFiles,
-      )
+      /**
+       * when uploading the file, we only need to validate the file size.
+       * the total number of files and total size of files are validated when users make
+       * their selection via the suggestions component.
+       */
+      const { isValid, error } = validateFileSize(file)
       if (!isValid) {
         setError(name, { type: 'invalidFile', message: error })
       } else {
         await uploadToS3(file, flowId)
       }
     },
-    [flowId, getValues, name, options, setError, uploadToS3, maxNumFiles],
+    [flowId, name, setError, uploadToS3],
   )
 
   return (

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -6,11 +6,11 @@ import { type CheckboxVariable } from './components/Checkbox'
 
 const KB = 1024
 const MB = KB * KB
-export const MAX_NUM_FILES = 10
+export const DEFAULT_MAX_NUM_FILES = 10
 const MAX_FILE_SIZE = 10 * MB // 10MB
 const MAX_TOTAL_FILE_SIZE = 10 * MB // 10MB
 
-export const ACCEPTED_FILE_TYPES = [
+export const DEFAULT_FILE_TYPES = [
   'text/plain', // .txt, .asc
   'video/x-msvideo', // .avi
   'image/bmp', // .bmp
@@ -168,6 +168,7 @@ export function validateFiles(
   file: File | CheckboxVariable,
   options: CheckboxVariable[],
   currentSelection: string[],
+  maxNumFiles: number,
 ): FileSizeValidationResult {
   const fileSize = file.size ?? 0
   const selectedOptions = options.filter((o) =>
@@ -180,10 +181,13 @@ export function validateFiles(
   const totalSize = currentTotalSize + fileSize
   const currentFileCount = selectedOptions.length + 1
 
-  if (currentFileCount > MAX_NUM_FILES) {
+  const maxAllowedFiles = maxNumFiles ?? DEFAULT_MAX_NUM_FILES
+  if (currentFileCount > maxAllowedFiles) {
     return {
       isValid: false,
-      error: 'Total number of files cannot exceed 10',
+      error: `Maximum of ${maxAllowedFiles} file${
+        maxAllowedFiles === 1 ? '' : 's'
+      } allowed`,
     }
   }
   if (fileSize > MAX_FILE_SIZE) {

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -1,9 +1,9 @@
 import { TDataOutMetadatumType } from '@plumber/types'
 
 import { FieldValues } from 'react-hook-form'
+import set from 'lodash/set'
 
 import { type CheckboxVariable } from './components/Checkbox'
-import set from 'lodash/set'
 
 const KB = 1024
 const MB = KB * KB
@@ -194,14 +194,27 @@ export function validateFiles(
       } allowed`,
     }
   }
-  if (fileSize > MAX_FILE_SIZE) {
-    return { isValid: false, error: 'Size of attachment exceeds 2MB' }
+
+  const { isValid: isValidFileSize, error: fileSizeError } =
+    validateFileSize(file)
+  if (!isValidFileSize) {
+    return { isValid: false, error: fileSizeError }
   }
   if (totalSize > MAX_TOTAL_FILE_SIZE) {
     return {
       isValid: false,
       error: 'Total size of attachments exceeds 10MB',
     }
+  }
+  return { isValid: true }
+}
+
+export function validateFileSize(
+  file: File | CheckboxVariable,
+): FileSizeValidationResult {
+  const fileSize = file.size ?? 0
+  if (fileSize > MAX_FILE_SIZE) {
+    return { isValid: false, error: 'Size of attachment exceeds 10MB' }
   }
   return { isValid: true }
 }

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -3,6 +3,7 @@ import { TDataOutMetadatumType } from '@plumber/types'
 import { FieldValues } from 'react-hook-form'
 
 import { type CheckboxVariable } from './components/Checkbox'
+import set from 'lodash/set'
 
 const KB = 1024
 const MB = KB * KB
@@ -91,6 +92,7 @@ export function createUpdateFlowConfigInput(
 }
 
 export function createUpdateStep(
+  parameterName: string,
   formValues: FieldValues,
   updatedAttachments: string[],
 ) {
@@ -100,7 +102,6 @@ export function createUpdateStep(
     key,
     parameters: {
       ...parameters,
-      attachments: updatedAttachments,
     },
     connection: {
       id: connection?.id,
@@ -109,6 +110,9 @@ export function createUpdateStep(
       id: flow.id,
     },
   }
+
+  // we use lodash.set as the parameterName is in this format: parameters.attachments / parameters.image
+  set(mutationInput, parameterName, updatedAttachments)
 
   if (appKey) {
     mutationInput.appKey = appKey

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -197,6 +197,9 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         label={label}
         description={description}
         variableTypes={schema.variableTypes}
+        required={required}
+        acceptedFileTypes={schema.acceptedFileTypes}
+        maxNumFiles={schema.maxNumFiles}
       />
     )
   }

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -198,6 +198,8 @@ export const GET_APPS = gql`
             tooltipText
             value
             noVariablesMessage
+            acceptedFileTypes
+            maxNumFiles
             options {
               label
               description

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -65,7 +65,11 @@ export const useS3Operations = (
       // before clicking "Continue," the file would be deleted, but other
       // inputs remain visible in the UI without being saved.
       const currentAttachments = getValues(name) || []
-      const mutationInput = createUpdateStep(getValues(), currentAttachments)
+      const mutationInput = createUpdateStep(
+        name,
+        getValues(),
+        currentAttachments,
+      )
       await updateStep({ variables: { input: mutationInput } })
 
       await deleteFile({ variables: { id: value } })
@@ -149,7 +153,7 @@ export const useS3Operations = (
         )
 
         const currentAttachments = getValues(name) || []
-        const mutationInput = createUpdateStep(getValues(), [
+        const mutationInput = createUpdateStep(name, getValues(), [
           ...currentAttachments,
           s3Id,
         ])

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -30,6 +30,7 @@ export const useS3Operations = (
     variables?: Partial<OperationVariables> | undefined,
   ) => Promise<ApolloQueryResult<any>>,
   uploadedFiles: CheckboxVariable[],
+  maxNumFiles: number,
   options: UseS3UploadOptions = {},
 ) => {
   const toast = useToast()
@@ -153,10 +154,26 @@ export const useS3Operations = (
         )
 
         const currentAttachments = getValues(name) || []
-        const mutationInput = createUpdateStep(name, getValues(), [
-          ...currentAttachments,
-          s3Id,
-        ])
+        /**
+         * we update the attachments in the step parameters based on the maxNumFiles
+         * if maxNumFiles is 1, we replace the existing attachments with the new one
+         * if the number of attachments is equal to maxNumFiles, we keep the existing selection
+         * else, we add the new attachment to the existing attachments
+         */
+        const updatedAttachments = []
+        if (maxNumFiles === 1) {
+          updatedAttachments.push(s3Id)
+        } else if (currentAttachments.length >= maxNumFiles) {
+          updatedAttachments.push(...currentAttachments)
+        } else {
+          updatedAttachments.push(...currentAttachments, s3Id)
+        }
+
+        const mutationInput = createUpdateStep(
+          name,
+          getValues(),
+          updatedAttachments,
+        )
 
         await updateStep({
           variables: { input: mutationInput },

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -440,6 +440,16 @@ export interface IFieldAttachment extends IBaseField {
   type: 'attachment'
   value?: string
   variableTypes?: TDataOutMetadatumType[]
+  /**
+   * acceptedFileTypes
+   * the allowed MIME type, e.g., application/pdf, image/jpeg, image/png, image/webp
+   */
+  acceptedFileTypes?: string[]
+  /**
+   * maxNumFiles
+   * the maximum number of files allowed
+   */
+  maxNumFiles?: number
 }
 
 export interface IFieldMultiline extends IBaseField {


### PR DESCRIPTION
## TL;DR

Added file type restrictions and maximum file count for attachment fields.

## What changed?
- Added file type restrictions to the image processing action, limiting uploads to PDF, JPEG, PNG, and WebP formats
- Limited the maximum number of files to 1 for the image processing action
- Modified the frontend components to respect these new restrictions

## How to test?
Create a Pair > Process image action
- [ ] Verify that only PDF, JPEG, PNG, and WebP files can be uploaded
- [ ] Try uploading multiple files and confirm that an error message appears limiting to 1 file

Verify that other attachment fields work i.e., Postman
- [ ] Verify that all other accepted file types can be uploaded
- [ ] Verify that multiple files can be selected, up to the limit of 10

