### PR TITLE
[TO-CLOSE] chore: adjust mock data date to work with delay until action

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -177,6 +177,13 @@ async function getMockData($: IGlobalVariable) {
           data.responses[formFields[i]._id].answer = ''
         }
 
+        // mock date to be current date in dd MMM yyyy format + 1 day for delay until step
+        if (fieldType === 'date') {
+          data.responses[formFields[i]._id].answer = DateTime.now()
+            .plus({ days: 1 })
+            .toPlumberFormat('dd MMM yyyy')
+        }
+
         data.responses[formFields[i]._id].order = i + 1
         data.responses[formFields[i]._id].id = undefined
       }


### PR DESCRIPTION
## Problem

Mock data date is randomised so user cannot be guaranteed to get a valid date (after current date) to be used for the delay until step. Thanks @jacksonOGP 

## Solution
Just set the date to be +1 day after current day because current day would take the midnight time as default so it won't work also...

## Tests
- [x] Works with new pipe setup
Note that users have to re-test their formsg step for current existing pipes but new pipes will work fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set mock `date` field answers to next day formatted as `dd MMM yyyy` to ensure valid dates for delay-until steps.
> 
> - **Backend**:
>   - **FormSG mock data generator** (`packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts`):
>     - For `date` fields, set `answer` to current date + 1 day, formatted as `dd MMM yyyy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 837990ee93066e86902417a5bec08e210f799303. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->