### PR TITLE
fix: editor cannot upload or delete attachment

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
@@ -71,21 +71,24 @@ async function createMockStep(
 
 describe('deleteFromS3', () => {
   let context: Context
+  let mockFlow: Flow
   beforeEach(async () => {
     vi.clearAllMocks()
     context = await generateMockContext()
+    mockFlow = await generateMockFlow(context, mockFlowId)
   })
 
   it('should successfully delete an object when user owns the flow', async () => {
-    await generateMockFlow(context, mockFlowId)
-
     await expect(
-      deleteUploadedFile(null, { id: mockS3Id }, context),
+      deleteUploadedFile(
+        null,
+        { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
+        context,
+      ),
     ).resolves.toBe(true)
   })
 
   it('should successfully delete an object when user is an editor of the flow', async () => {
-    const mockFlow = await generateMockFlow(context, mockFlowId)
     const editor = await generateMockUser('editor')
     await generateMockCollaborator(
       mockFlow.id,
@@ -96,13 +99,16 @@ describe('deleteFromS3', () => {
     context.currentUser = editor
 
     await expect(
-      deleteUploadedFile(null, { id: mockS3Id }, context),
+      deleteUploadedFile(
+        null,
+        { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
+        context,
+      ),
     ).resolves.toBe(true)
   })
 
   it('should delete object from all other steps within a flow', async () => {
     const fileToDelete = createMockS3Id('test_1')
-    await generateMockFlow(context, mockFlowId)
     await createMockStep(context, mockFlowId, 2, {
       body: 'Test body',
       attachments: [fileToDelete],
@@ -112,7 +118,11 @@ describe('deleteFromS3', () => {
       attachments: [fileToDelete, createMockS3Id('test_2')],
     })
 
-    await deleteUploadedFile(null, { id: fileToDelete }, context)
+    await deleteUploadedFile(
+      null,
+      { id: fileToDelete, flowUpdatedAt: mockFlow.updatedAt },
+      context,
+    )
     const postDeleteSteps = await Step.query().where({ flow_id: mockFlowId })
 
     postDeleteSteps.forEach((step) => {
@@ -121,19 +131,19 @@ describe('deleteFromS3', () => {
   })
 
   it('should throw an error if user does not have access to the flow', async () => {
-    vi.fn()
-      .mockRejectedValue(Flow.hasAccess)
-      .mockRejectedValue(
-        new ForbiddenError('You do not have access to this flow'),
-      )
+    const nonCollaborator = await generateMockUser('nonCollaborator')
+    context.currentUser = nonCollaborator
 
     await expect(
-      deleteUploadedFile(null, { id: mockS3Id }, context),
+      deleteUploadedFile(
+        null,
+        { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
+        context,
+      ),
     ).rejects.toThrow(ForbiddenError)
   })
 
   it('should throw an error if the user is not an editor or owner of the flow', async () => {
-    const mockFlow = await generateMockFlow(context, mockFlowId)
     const viewer = await generateMockUser('viewer')
     await generateMockCollaborator(
       mockFlow.id,
@@ -144,7 +154,11 @@ describe('deleteFromS3', () => {
     context.currentUser = viewer
 
     await expect(
-      deleteUploadedFile(null, { id: mockS3Id }, context),
+      deleteUploadedFile(
+        null,
+        { id: mockS3Id, flowUpdatedAt: mockFlow.updatedAt },
+        context,
+      ),
     ).rejects.toThrow(ForbiddenError)
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-uploaded-file.itest.ts
@@ -8,7 +8,12 @@ import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 import { generateMockContext } from './tiles/table.mock'
-import { generateMockFlow, generateMockStep } from './flow.mock'
+import {
+  generateMockCollaborator,
+  generateMockFlow,
+  generateMockStep,
+  generateMockUser,
+} from './flow.mock'
 
 const mockFlowId = '8c2a70d1-e78b-431e-9069-a4d8f97883f6'
 const mockBucket = 'test-bucket'
@@ -79,6 +84,22 @@ describe('deleteFromS3', () => {
     ).resolves.toBe(true)
   })
 
+  it('should successfully delete an object when user is an editor of the flow', async () => {
+    const mockFlow = await generateMockFlow(context, mockFlowId)
+    const editor = await generateMockUser('editor')
+    await generateMockCollaborator(
+      mockFlow.id,
+      editor.id,
+      context.currentUser.id,
+      'editor',
+    )
+    context.currentUser = editor
+
+    await expect(
+      deleteUploadedFile(null, { id: mockS3Id }, context),
+    ).resolves.toBe(true)
+  })
+
   it('should delete object from all other steps within a flow', async () => {
     const fileToDelete = createMockS3Id('test_1')
     await generateMockFlow(context, mockFlowId)
@@ -105,6 +126,22 @@ describe('deleteFromS3', () => {
       .mockRejectedValue(
         new ForbiddenError('You do not have access to this flow'),
       )
+
+    await expect(
+      deleteUploadedFile(null, { id: mockS3Id }, context),
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('should throw an error if the user is not an editor or owner of the flow', async () => {
+    const mockFlow = await generateMockFlow(context, mockFlowId)
+    const viewer = await generateMockUser('viewer')
+    await generateMockCollaborator(
+      mockFlow.id,
+      viewer.id,
+      context.currentUser.id,
+      'viewer',
+    )
+    context.currentUser = viewer
 
     await expect(
       deleteUploadedFile(null, { id: mockS3Id }, context),

--- a/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
@@ -6,12 +6,21 @@ import generatePresignedPost from '@/graphql/mutations/generate-presigned-post'
 import Flow from '@/models/flow'
 import Context from '@/types/express/context'
 
+import {
+  generateMockCollaborator,
+  generateMockFlow,
+  generateMockUser,
+} from './flow.mock'
+
 const VALID_PARAMS = {
-  flowId: '193040de-c818-4a0c-90f9-1dcfb1963f53',
   filename: 'test.txt',
   fileType: 'text/plain',
   size: 100,
   updatedAt: new Date().toISOString(),
+  flow: {
+    id: '193040de-c818-4a0c-90f9-1dcfb1963f53',
+    updatedAt: new Date().toISOString(),
+  },
 }
 
 // Mock the s3 helpers module
@@ -44,27 +53,61 @@ describe('generatePresignedPost', () => {
   })
 
   it('should generate a presigned url', async () => {
-    await Flow.query().insert({
-      id: VALID_PARAMS.flowId,
-      name: 'Test Flow',
-      userId: context.currentUser.id,
-    })
+    const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
 
-    await generatePresignedPost(null, { input: VALID_PARAMS }, context)
+    await generatePresignedPost(
+      null,
+      {
+        input: {
+          ...VALID_PARAMS,
+          flow: {
+            id: mockFlow.id,
+            updatedAt: mockFlow.updatedAt,
+          },
+        },
+      },
+      context,
+    )
     expect(getPresignedPost).toHaveBeenCalledWith(
       COMMON_S3_BUCKET,
       expect.stringMatching(
         new RegExp(
-          `^${VALID_PARAMS.flowId}/[a-f0-9-]+/${VALID_PARAMS.filename}$`,
+          `^${VALID_PARAMS.flow.id}/[a-f0-9-]+/${VALID_PARAMS.filename}$`,
         ),
       ),
       VALID_PARAMS.fileType,
       {
-        flowId: VALID_PARAMS.flowId,
+        flowId: VALID_PARAMS.flow.id,
         filename: VALID_PARAMS.filename,
         size: VALID_PARAMS.size.toString(),
         updatedAt: VALID_PARAMS.updatedAt,
       },
+    )
+  })
+
+  it('should generate a presigned url when user is an editor of the flow', async () => {
+    const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
+    const editor = await generateMockUser('editor')
+    await generateMockCollaborator(
+      mockFlow.id,
+      editor.id,
+      context.currentUser.id,
+      'editor',
+    )
+    context.currentUser = editor
+
+    await generatePresignedPost(
+      null,
+      {
+        input: {
+          ...VALID_PARAMS,
+          flow: {
+            id: VALID_PARAMS.flow.id,
+            updatedAt: mockFlow.updatedAt,
+          },
+        },
+      },
+      context,
     )
   })
 
@@ -74,7 +117,23 @@ describe('generatePresignedPost', () => {
       .patch({
         userId: otherUserContext.currentUser.id,
       })
-      .where('id', VALID_PARAMS.flowId)
+      .where('id', VALID_PARAMS.flow.id)
+
+    await expect(
+      generatePresignedPost(null, { input: VALID_PARAMS }, context),
+    ).rejects.toThrow(ForbiddenError)
+  })
+
+  it('should throw an error if the user is a viewer of the flow', async () => {
+    const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
+    const viewer = await generateMockUser('viewer')
+    await generateMockCollaborator(
+      mockFlow.id,
+      viewer.id,
+      context.currentUser.id,
+      'viewer',
+    )
+    context.currentUser = viewer
 
     await expect(
       generatePresignedPost(null, { input: VALID_PARAMS }, context),
@@ -83,7 +142,7 @@ describe('generatePresignedPost', () => {
 
   it('should throw an error if the file size is too large', async () => {
     await Flow.query().insert({
-      id: VALID_PARAMS.flowId,
+      id: VALID_PARAMS.flow.id,
       name: 'Test Flow',
       userId: context.currentUser.id,
     })
@@ -103,7 +162,7 @@ describe('generatePresignedPost', () => {
     'should throw an error if the file type is not supported: %s',
     async (fileType) => {
       await Flow.query().insert({
-        id: VALID_PARAMS.flowId,
+        id: VALID_PARAMS.flow.id,
         name: 'Test Flow',
         userId: context.currentUser.id,
       })

--- a/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
+++ b/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
@@ -14,7 +14,7 @@ const deleteUploadedFile: MutationResolvers['deleteUploadedFile'] = async (
   params,
   context,
 ) => {
-  const { id } = params
+  const { id, flowUpdatedAt } = params
   if (!validateManualUploadId(id)) {
     throw new Error('Invalid id')
   }
@@ -32,6 +32,8 @@ const deleteUploadedFile: MutationResolvers['deleteUploadedFile'] = async (
       'You do not have sufficient permissions for this pipe',
     )
   }
+
+  flow.assertNotUpdatedSince(flowUpdatedAt, context.currentUser.id)
 
   // only postman has attachments
   // Get all postman steps and update attachments in a single transaction

--- a/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
+++ b/packages/backend/src/graphql/mutations/delete-uploaded-file.ts
@@ -1,10 +1,10 @@
+import { ForbiddenError } from '@/errors/graphql-errors'
 import {
   COMMON_S3_BUCKET,
   deleteObjects,
   parseS3Id,
   validateManualUploadId,
 } from '@/helpers/s3'
-import Flow from '@/models/flow'
 import Step from '@/models/step'
 
 import { MutationResolvers } from '../__generated__/types.generated'
@@ -21,9 +21,17 @@ const deleteUploadedFile: MutationResolvers['deleteUploadedFile'] = async (
 
   const { objectKey } = parseS3Id(id)
 
-  // check if flow belongs to user
+  // check if user is an editor of the flow
   const flowId = objectKey.split('/')[0]
-  await Flow.hasAccess(context.currentUser.id, flowId)
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findOne({ id: flowId })
+
+  if (!flow) {
+    throw new ForbiddenError(
+      'You do not have sufficient permissions for this pipe',
+    )
+  }
 
   // only postman has attachments
   // Get all postman steps and update attachments in a single transaction

--- a/packages/backend/src/graphql/mutations/generate-presigned-post.ts
+++ b/packages/backend/src/graphql/mutations/generate-presigned-post.ts
@@ -1,6 +1,7 @@
 import { PresignedPost } from '@aws-sdk/s3-presigned-post'
 import { randomUUID } from 'crypto'
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import {
   ACCEPTED_FILE_TYPES,
   COMMON_S3_BUCKET,
@@ -8,13 +9,18 @@ import {
   MAX_FILE_SIZE,
   validateObjectKey,
 } from '@/helpers/s3'
-import Flow from '@/models/flow'
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
 const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
   async (_parent, params, context) => {
-    const { flowId, filename, fileType, size, updatedAt } = params.input
+    const {
+      flow: flowInput,
+      filename,
+      fileType,
+      size,
+      updatedAt,
+    } = params.input
 
     if (size > MAX_FILE_SIZE) {
       throw new Error('Size of attachment exceeds 10MB')
@@ -24,19 +30,29 @@ const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
     }
 
     const uuid = randomUUID()
-    const objectKey = `${flowId}/${uuid}/${filename}`
+    const objectKey = `${flowInput.id}/${uuid}/${filename}`
     if (!validateObjectKey(objectKey)) {
       throw new Error('File path cannot be longer than 1024 bytes')
     }
 
-    await Flow.hasAccess(context.currentUser.id, flowId)
+    const flow = await context.currentUser
+      .withAccessibleFlows({ requiredRole: 'editor' })
+      .findOne({ id: flowInput.id })
+
+    if (!flow) {
+      throw new ForbiddenError(
+        'You do not have sufficient permissions for this pipe',
+      )
+    }
+
+    flow.assertNotUpdatedSince(flowInput.updatedAt, context.currentUser.id)
 
     const presignedPost = await getPresignedPost(
       COMMON_S3_BUCKET,
       objectKey,
       fileType,
       {
-        flowId,
+        flowId: flowInput.id,
         filename,
         size: size.toString(),
         updatedAt,

--- a/packages/backend/src/graphql/mutations/update-flow-config.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-config.ts
@@ -57,6 +57,8 @@ const updateFlowConfig = async (
 
   return await flow.$query().patchAndFetch({
     config: newConfig,
+    updatedAt: new Date().toISOString(),
+    updatedBy: context.currentUser.id,
   })
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -570,11 +570,11 @@ input DuplicateFlowInput {
 }
 
 input GeneratePresignedPostInput {
-  flowId: String!
   filename: String!
   fileType: String!
   size: Int!
   updatedAt: String!
+  flow: StepFlowInput!
 }
 
 input CreateStepInput {

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -110,7 +110,7 @@ type Mutation {
   deleteFlowCollaborator(input: DeleteFlowCollaboratorInput!): Boolean!
   # S3 operations
   generatePresignedPost(input: GeneratePresignedPostInput): PresignedPostObject
-  deleteUploadedFile(id: String!): Boolean
+  deleteUploadedFile(id: String!, flowUpdatedAt: String!): Boolean
   # Tiles
   createTable(input: CreateTableInput!): TableMetadata!
   createShareableTableLink(tableId: ID!): String!

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -44,7 +44,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const [currentTab, setCurrentTab] = useState<number>(0)
   const [selectedFile, setSelectedFile] = useState<Variable | null>(null)
 
-  const flowId = getValues('flowId')
+  const flow = getValues('flow')
 
   const {
     isOpen: isDialogOpen,
@@ -63,7 +63,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     loading,
     refetch: refetchFlow,
   } = useQuery(GET_FLOW, {
-    variables: { id: flowId },
+    variables: { id: flow.id },
   })
 
   const { options, suggestions, uploadedItems } = useAttachmentOptions(
@@ -148,10 +148,10 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
       if (!isValid) {
         setError(name, { type: 'invalidFile', message: error })
       } else {
-        await uploadToS3(file, flowId)
+        await uploadToS3(file, flow.id, flow.updatedAt)
       }
     },
-    [flowId, getValues, name, options, setError, uploadToS3],
+    [flow.id, flow.updatedAt, getValues, name, options, setError, uploadToS3],
   )
 
   return (

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -107,6 +107,7 @@ export function createUpdateStep(
     },
     flow: {
       id: flow.id,
+      updatedAt: flow.updatedAt,
     },
   }
 

--- a/packages/frontend/src/graphql/mutations/delete-uploaded-file.ts
+++ b/packages/frontend/src/graphql/mutations/delete-uploaded-file.ts
@@ -1,7 +1,7 @@
 import { graphql } from '@/graphql/__generated__'
 
 export const DELETE_UPLOADED_FILE = graphql(`
-  mutation DeleteUploadedFile($id: String!) {
-    deleteUploadedFile(id: $id)
+  mutation DeleteUploadedFile($id: String!, $flowUpdatedAt: String!) {
+    deleteUploadedFile(id: $id, flowUpdatedAt: $flowUpdatedAt)
   }
 `)

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -60,7 +60,8 @@ export const useS3Operations = (
   const deleteUploadedFile = async (file: any) => {
     try {
       const { name: filename, value, displayedValue } = file
-      const flowId = getValues('flowId')
+      const flow = getValues('flow')
+      const { id: flowId, updatedAt: flowUpdatedAt } = flow
       setIsDeleting(true)
 
       // NOTE: this is to ensure all changes are saved before deleting a file
@@ -71,7 +72,9 @@ export const useS3Operations = (
       const mutationInput = createUpdateStep(getValues(), currentAttachments)
       await updateStep({ variables: { input: mutationInput } })
 
-      await deleteFile({ variables: { id: value } })
+      await deleteFile({
+        variables: { id: value, flowUpdatedAt },
+      })
 
       await updateFlowConfig(
         getConfigInput(flowId, [

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -92,10 +92,10 @@ export const useS3Operations = (
       return true
     } catch (error) {
       console.error('Error deleting file:', error)
-      triggerToast(`Failed to delete ${file.name}`, 'error')
+      triggerToast(`Failed to delete file`, 'error')
       setIsDeleting(false)
       const errorMessage = error instanceof Error ? error.message : ''
-      options.onError?.(file.name, 'deleteError', errorMessage)
+      options.onError?.('file', 'deleteError', errorMessage)
       return false
     }
   }

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -17,6 +17,7 @@ import { DELETE_UPLOADED_FILE } from '@/graphql/mutations/delete-uploaded-file'
 import { GENERATE_PRESIGNED_POST } from '@/graphql/mutations/generate-presigned-post'
 import { UPDATE_FLOW_CONFIG } from '@/graphql/mutations/update-flow-config'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
 
 interface UseS3UploadOptions {
   onError?: (filename: string, type: string, errorMessage: string) => void
@@ -36,7 +37,9 @@ export const useS3Operations = (
   const [isDeleting, setIsDeleting] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [deleteFile] = useMutation(DELETE_UPLOADED_FILE)
-  const [generatePresignedPost] = useMutation(GENERATE_PRESIGNED_POST)
+  const [generatePresignedPost] = useMutation(GENERATE_PRESIGNED_POST, {
+    refetchQueries: [GET_FLOW],
+  })
   const [updateFlowConfig] = useMutation(UPDATE_FLOW_CONFIG)
   const [updateStep] = useMutation(UPDATE_STEP)
 
@@ -94,7 +97,11 @@ export const useS3Operations = (
     }
   }
 
-  const uploadToS3 = async (file: File, flowId: string) => {
+  const uploadToS3 = async (
+    file: File,
+    flowId: string,
+    flowUpdatedAt: string,
+  ) => {
     try {
       setIsUploading(true)
       const { name: filename, size, type } = file
@@ -103,11 +110,14 @@ export const useS3Operations = (
       const res = await generatePresignedPost({
         variables: {
           input: {
-            flowId,
             filename,
             fileType: type,
             size,
             updatedAt,
+            flow: {
+              id: flowId,
+              updatedAt: flowUpdatedAt,
+            },
           },
         },
       })


### PR DESCRIPTION
## Problem
When releasing collaborators, there was a missed update to the functionality to upload/delete attachments.

- Editor(s) cannot upload or delete attachments at the Postman step.
- Error message is also incorrect when Owner attempts to upload new attachment(s) in a Pipe that has been edited by another user. The file actually gets uploaded, but we are unable to update the step parameters that this attachment is 'selected'.

## Solution
- Fixed the mutation to check that the current user is a collaborator of the Pipe
- Fixed the mutation to `assertNotUpdatedSince` when uploading or deleting files

## Tests
In a Pipe without collaborators:
- [ ] Can upload file
- [ ] Can delete file

In a Pipe WITH collaborators:
- [ ] Owner can upload file
- [ ] Owner can delete file
- [ ] Editor can upload file
- [ ] Editor can delete file
- [ ] Error is thrown when Owner / Editor is attempting to upload / delete file that another user has worked on