### PR TITLE
chore: add individual logs for blacklisted recipients monitor

### DIFF
--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -4,6 +4,7 @@ import HttpError from '@/errors/http'
 import PartialStepError from '@/errors/partial-error'
 import RetriableError from '@/errors/retriable-error'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 
 import { PostmanEmailSendStatus } from './data-out-validator'
 import { createRequestBlacklistFormLink } from './send-blacklist-email'
@@ -102,6 +103,17 @@ export function throwPostmanStepError({
         executionId: $.execution.id,
         blacklistedRecipients,
       })
+
+      // log individual blacklisted recipients
+      blacklistedRecipients.forEach((recipient) => {
+        logger.info('Blacklisted recipient for postman email step', {
+          event: 'postman-step-blacklisted-recipient',
+          blacklistedEmail: recipient,
+          stepId: $.step.id,
+          executionId: $.execution.id,
+        })
+      })
+
       let solution = `The following email addresses have been blacklisted by Postman:
          \n${blacklistedRecipients
            .map((recipient) => `**${recipient}**`)


### PR DESCRIPTION
## Problem

Right now, it is not straightforward to track unique emails in the blacklisted email [monitor](https://ogp.datadoghq.com/monitors/163963033).

## Solution

Add extra logging for every blacklisted recipient.

## Tests
- [ ] Logs show up for every blacklisted recipient
- [ ] Logs will not show up if no blacklisted recipients