### PR TITLE
PLU-636: Postman incorrect max number of attachments

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/components/Checkbox.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, memo } from 'react'
+import { memo } from 'react'
 import { BiTrash } from 'react-icons/bi'
 import { BsDot } from 'react-icons/bs'
 import {
@@ -54,16 +54,12 @@ function Checkbox(props: CheckboxProps) {
     )
   }
 
-  // Note: removes the outline around the checkbox that is last focused
-  const handleBlur = (e: ChangeEvent<HTMLInputElement>) => e.target.blur()
-
   return (
     <ChakraCheckbox
       key={value as string}
       isChecked={isChecked}
       onChange={(e) => {
         onClick?.(variable, e.target.checked)
-        handleBlur(e)
       }}
       _hover={{
         backgroundColor: 'primary.100',

--- a/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext, useLayoutEffect, useMemo, useRef } from 'react'
 import {
   Box,
   Collapse,
@@ -55,6 +55,20 @@ export default function Suggestions(props: SuggestionsProps) {
   } = props
 
   const { readOnly } = useContext(EditorContext)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const scrollPositionRef = useRef<number>(0)
+
+  // Preserve scroll position across re-renders
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current
+    if (container && scrollPositionRef.current > 0) {
+      container.scrollTop = scrollPositionRef.current
+    }
+  })
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    scrollPositionRef.current = e.currentTarget.scrollTop
+  }
 
   const SuggestionsRightPanel = ({ values }: { values: any }) => {
     if (suggestions.length === 0) {
@@ -62,7 +76,12 @@ export default function Suggestions(props: SuggestionsProps) {
     }
 
     return (
-      <>
+      <Box
+        ref={scrollContainerRef}
+        maxH={64}
+        overflowY="auto"
+        onScroll={handleScroll}
+      >
         {suggestions.map((option: StepWithVariables, index: number) => {
           const { addNew, output } = option
           return (
@@ -81,7 +100,7 @@ export default function Suggestions(props: SuggestionsProps) {
                     processFile={processFile}
                   />
                 )}
-                <Box data-test="attachment-group" maxH={64} overflowY="auto">
+                <Box data-test="attachment-group">
                   {output?.map((variable) => {
                     const { name } = variable
                     return (
@@ -108,7 +127,7 @@ export default function Suggestions(props: SuggestionsProps) {
             )
           )
         })}
-      </>
+      </Box>
     )
   }
 

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -18,7 +18,7 @@ import MenuAlertDialog from '../MenuAlertDialog'
 import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
-import { validateFiles } from './utils'
+import { validateFiles, validateFileSize } from './utils'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -144,14 +144,19 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
 
   const processFile = useCallback(
     async (file: File) => {
-      const { isValid, error } = validateFiles(file, options, getValues(name))
+      /**
+       * when uploading the file, we only need to validate the file size.
+       * the total number of files and total size of files are validated when users make
+       * their selection via the suggestions component.
+       */
+      const { isValid, error } = validateFileSize(file)
       if (!isValid) {
         setError(name, { type: 'invalidFile', message: error })
       } else {
         await uploadToS3(file, flow.id, flow.updatedAt)
       }
     },
-    [flow.id, flow.updatedAt, getValues, name, options, setError, uploadToS3],
+    [flow.id, flow.updatedAt, name, setError, uploadToS3],
   )
 
   return (

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -180,7 +180,7 @@ export function validateFiles(
     0,
   )
   const totalSize = currentTotalSize + fileSize
-  const currentFileCount = selectedOptions.length + 1
+  const currentFileCount = currentSelection.length + 1
 
   if (currentFileCount > MAX_NUM_FILES) {
     return {
@@ -188,14 +188,28 @@ export function validateFiles(
       error: 'Total number of files cannot exceed 10',
     }
   }
-  if (fileSize > MAX_FILE_SIZE) {
-    return { isValid: false, error: 'Size of attachment exceeds 2MB' }
+
+  const { isValid: isValidFileSize, error: fileSizeError } =
+    validateFileSize(file)
+  if (!isValidFileSize) {
+    return { isValid: false, error: fileSizeError }
   }
+
   if (totalSize > MAX_TOTAL_FILE_SIZE) {
     return {
       isValid: false,
       error: 'Total size of attachments exceeds 10MB',
     }
+  }
+  return { isValid: true }
+}
+
+export function validateFileSize(
+  file: File | CheckboxVariable,
+): FileSizeValidationResult {
+  const fileSize = file.size ?? 0
+  if (fileSize > MAX_FILE_SIZE) {
+    return { isValid: false, error: 'Size of attachment exceeds 10MB' }
   }
   return { isValid: true }
 }

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -11,6 +11,7 @@ import { type CheckboxVariable } from '@/components/AttachmentSuggestions/compon
 import {
   AttachmentConfigInput,
   createUpdateStep,
+  MAX_NUM_FILES,
   reformatToAttachmentConfig,
 } from '@/components/AttachmentSuggestions/utils'
 import { EditorContext } from '@/contexts/Editor'
@@ -167,10 +168,25 @@ export const useS3Operations = (
         )
 
         const currentAttachments = getValues(name) || []
-        const mutationInput = createUpdateStep(flow, getValues(), [
-          ...currentAttachments,
-          s3Id,
-        ])
+
+        /**
+         * we update the attachments in the step parameters based on the maxNumFiles
+         * if maxNumFiles is 1, we replace the existing attachments with the new one
+         * if the number of attachments is equal to maxNumFiles, we keep the existing selection
+         * else, we add the new attachment to the existing attachments
+         */
+        const updatedAttachments = []
+        if (currentAttachments.length >= MAX_NUM_FILES) {
+          updatedAttachments.push(...currentAttachments)
+        } else {
+          updatedAttachments.push(...currentAttachments, s3Id)
+        }
+
+        const mutationInput = createUpdateStep(
+          flow,
+          getValues(),
+          updatedAttachments,
+        )
 
         await updateStep({
           variables: { input: mutationInput },


### PR DESCRIPTION
## Problem
1. The maximum number of attachments limit is currently applied per suggestions tab, rather than across all attachments. 
    For example, when the limit is set to 10 attachments, it only counts the attachments in the “Uploaded attachments” tab and ignores attachments selected from FormSG or LetterSG.
1. Cannot upload new attachments if the limit is hit.
1. Suggestions popper will auto-scroll to the top after selecting an option

## Solution
1. Fix the count by counting attachments applied across all tabs
1. Allow the manual upload, but do not automatically select the new attachment. User needs to manually remove other attachments before selecting the new one.
1. Remove the `handleBlur` and add `useLayoutEffect` to preserve the scroll position

## Tests
- [ ] Can select up to 10 attachments for Postman
- [ ] Can still upload new attachment(s) if 10 were selected. 
  - [ ] Verify that new upload is unchecked
- [ ] Scroll position is preserved in suggestions popover when an attachment is selected / unselected


## Deploy Notes
- [ ] Verify that `e2e` tests run successfully
