### PR TITLE
chore: remove old code for sept keyword bug

### DIFF
--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,8 +1,4 @@
-import type {
-  IActionRunResult,
-  IJSONValue,
-  TestRunStepMetadata,
-} from '@plumber/types'
+import type { IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -26,20 +22,6 @@ import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 
 import getForEachMetadata from './helpers/get-for-each-metadata'
-
-// TODO on Oct: remove this once the logging is not needed anymore
-const SEPT_KEYWORD_REGEX = /Sept /
-
-function containsSeptKeyword(obj: IJSONValue): boolean {
-  if (typeof obj === 'string') {
-    return SEPT_KEYWORD_REGEX.test(obj)
-  }
-  if (typeof obj === 'object' && obj !== null) {
-    return SEPT_KEYWORD_REGEX.test(JSON.stringify(obj))
-  }
-
-  return false
-}
 
 type ProcessActionOptions = {
   flowId: string
@@ -226,17 +208,6 @@ export const processAction = async (options: ProcessActionOptions) => {
       key: step.key,
       metadata,
     })
-
-  // TODO on Oct: remove this once the logging is not needed anymore
-  if (!testRun && containsSeptKeyword($.step.parameters ?? {})) {
-    logger.info('Execution contains Sept keyword', {
-      event: 'execution-contains-sept-keyword',
-      stepId,
-      flowId,
-      executionId,
-      executionStepId: executionStep.id,
-    })
-  }
 
   let nextStep = null
   switch (runResult.nextStep?.command) {


### PR DESCRIPTION
## Details
Added this logging in Sept to track which pipes were using the "Sept" keyword, but now just doing a cleanup and removing the code that is unnecessary now.

Refer to this [PR](https://github.com/opengovsg/plumber/pull/1185) if necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes temporary logging previously used to detect "Sept" keyword usage to reduce noise and dead code.
> 
> - Deletes `SEPT_KEYWORD_REGEX` and `containsSeptKeyword` helper and the conditional logging block in `processAction`
> - Drops unused `IJSONValue` import from `@plumber/types`
> - No changes to execution flow or for-each handling beyond logging removal
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5599f443c6efb6a2c4a506df2fa506beb7565e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->