### PR TITLE
PLU-456: part 1 - add simple ui for allowing past dates during test step

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import StepError from '@/errors/step'
 
-import delayUntilAction from '../actions/delay-until'
+import delayUntilAction, {
+  PAST_TIMESTAMP_WARNING_MESSAGE,
+} from '../actions/delay-until'
 import delayApp from '../index'
 
 const PAST_DATE = '2023-11-08'
@@ -44,6 +46,14 @@ describe('Delay until action', () => {
       },
       execution: {
         testRun: false,
+      },
+      actionOutput: {
+        data: {
+          raw: null,
+          meta: {
+            warningMessage: PAST_TIMESTAMP_WARNING_MESSAGE,
+          },
+        },
       },
       setActionItem: mocks.setActionItem,
       getLastExecutionStep: mocks.getLastExecutionStep,
@@ -144,7 +154,7 @@ describe('Delay until action', () => {
   })
 
   describe('retry logic', () => {
-    it('prevents retries during test runs', async () => {
+    it('no need for retries during test runs', async () => {
       $.step.parameters = {
         delayUntil: PAST_DATE,
         delayUntilTime: DEFAULT_TIME,
@@ -153,15 +163,19 @@ describe('Delay until action', () => {
       // Set testRun to true to simulate test environment
       $.execution.testRun = true
 
-      // Mock last execution step to indicate a retry for past timestamp
-      mocks.getLastExecutionStep.mockResolvedValue({
-        errorDetails: {
-          name: 'Delay until timestamp entered is in the past',
+      const result = await delayUntilAction.run($)
+      expect(result).toBeFalsy()
+
+      // shows warning message in metadata for test runs
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: {
+          delayUntil: PAST_DATE,
+          delayUntilTime: DEFAULT_TIME,
+        },
+        meta: {
+          warningMessage: PAST_TIMESTAMP_WARNING_MESSAGE,
         },
       })
-
-      // Should throw error even with valid retry conditions due to testRun
-      await expect(delayUntilAction.run($)).rejects.toThrowError(StepError)
     })
 
     it('allows past timestamp when retrying after past timestamp error', async () => {

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -6,6 +6,9 @@ import StepError from '@/errors/step'
 
 import generateTimestamp from '../../helpers/generate-timestamp'
 
+export const PAST_TIMESTAMP_WARNING_MESSAGE =
+  'The delay until timestamp entered is in the past. Do note that your pipe will fail to run if this was your actual live data.'
+
 async function isValidRetry($: IGlobalVariable): Promise<boolean> {
   // do not allow retries in test runs
   if ($.execution.testRun) {
@@ -95,8 +98,10 @@ const action: IRawAction = {
      * - delay until timestamp entered is in the past
      */
     const isRetry = await isValidRetry($)
+    const isPastTimestamp = delayTimestamp < DateTime.now().toMillis()
 
-    if (delayTimestamp < DateTime.now().toMillis()) {
+    // Allow test step to always succeed but show warning in the frontend
+    if (!$.execution.testRun && isPastTimestamp) {
       if (isRetry) {
         const dateTimeNow = DateTime.now()
         dataItem = {
@@ -113,7 +118,16 @@ const action: IRawAction = {
       }
     }
 
-    $.setActionItem({ raw: dataItem })
+    // Only show warning message for test executions
+    $.setActionItem({
+      raw: dataItem,
+      ...(isPastTimestamp &&
+        $.execution.testRun && {
+          meta: {
+            warningMessage: PAST_TIMESTAMP_WARNING_MESSAGE,
+          },
+        }),
+    })
   },
 }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -363,6 +363,7 @@ type ExecutionStepMetadata {
   iterationStatus: JSONObject
   isLastIteration: Boolean
   isLastStep: Boolean
+  warningMessage: String
 }
 
 type Field {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -195,6 +195,11 @@ export const processAction = async (options: ProcessActionOptions) => {
     })
   }
 
+  // update metadata with warning message
+  if ($.actionOutput.data?.meta?.warningMessage) {
+    metadata.warningMessage = $.actionOutput.data.meta.warningMessage
+  }
+
   const executionStep = await execution
     .$relatedQuery('executionSteps')
     .insertAndFetch({

--- a/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/TestResult.tsx
@@ -50,6 +50,7 @@ interface TestResultsProps {
   isOpen: boolean
   isIfThenStep?: boolean
   onModalOpen?: () => void
+  warningMessage?: string
 }
 
 export default function TestResult(props: TestResultsProps): JSX.Element {
@@ -60,11 +61,11 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
     isOpen,
     isIfThenStep,
     step,
+    warningMessage,
   } = props
 
   const { testExecutionSteps } = useContext(EditorContext)
   const isForEachStep = step.key === TOOLBOX_ACTIONS.ForEach
-
   const Content = () => {
     // No data only happens if user hasn't executed yet, or step returned null.
     if (!variables?.length) {
@@ -93,6 +94,15 @@ export default function TestResult(props: TestResultsProps): JSX.Element {
             </Text>
           </Infobox>
         )}
+
+        {warningMessage && (
+          <Infobox variant="warning" width="full">
+            <Box>
+              <Text fontWeight="600">{warningMessage}</Text>
+            </Box>
+          </Infobox>
+        )}
+
         <VariablesList variables={variables} customStyles={{ py: 0, px: 2 }} />
       </Box>
     )

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -350,6 +350,9 @@ export default function FlowStepTestController(
               isMock={currentTestExecutionStep?.metadata?.isMock}
               isOpen={isTestResultOpen}
               isIfThenStep={isIfThenStep}
+              warningMessage={
+                currentTestExecutionStep?.metadata?.warningMessage ?? ''
+              }
             />
           </VStack>
         ) : (

--- a/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
+++ b/packages/frontend/src/graphql/queries/get-test-execution-steps.ts
@@ -36,6 +36,7 @@ export const GET_TEST_EXECUTION_STEPS = gql`
         isMock
         lastTestSubmissionDate
         iteration
+        warningMessage
       }
     }
   }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -153,6 +153,7 @@ export interface IExecutionStepMetadata {
   >
   isLastIteration?: boolean
   isLastStep?: boolean
+  warningMessage?: string
 }
 
 export interface IExecution {
@@ -783,8 +784,13 @@ export interface IActionOutput {
   error?: IJSONObject
 }
 
+// This is useful for actions that need to display a warning message to the user
+// and still succeed e.g. delay until step
 export interface IActionItem {
   raw: IJSONObject
+  meta?: {
+    warningMessage?: string
+  }
 }
 
 export interface IBaseAction {


### PR DESCRIPTION
### TL;DR

Added warning message for past timestamps in the Delay Until action while allowing test runs to succeed.

### What changed?

- Added a warning message when a user enters a timestamp in the past for the Delay Until action
- Modified the behavior to allow test runs to succeed even with past timestamps, but display a warning
- Created a new warning message display in the test results UI
- Extended the GraphQL schema and types to support warning messages in execution step metadata
- Added support for passing warning messages from actions to the frontend

### Screenshots
When testing step,
<img width="1440" height="652" alt="Screenshot 2025-12-26 at 10 34 25 AM" src="https://github.com/user-attachments/assets/0e850843-7fe5-4b87-a996-c8fb1fbc1590" />

When coming back to this step,
<img width="1437" height="653" alt="Screenshot 2025-12-26 at 10 34 12 AM" src="https://github.com/user-attachments/assets/3198c0db-c16a-4205-a6a1-bd947f8edcd0" />


### How to test?

1. Create a flow with a Delay Until action
2. Set the timestamp to a past date/time
3. Run a test on the step
4. Verify that the test succeeds but displays a warning message
5. Verify that in a real execution (not a test), the step would still fail with a past timestamp

### Why make this change?

This improves the user experience by providing clearer feedback when testing the Delay Until action with past timestamps. Previously, tests would fail with past timestamps, which was confusing for users who were just testing their flow configuration. Now, tests will succeed but show a warning message, making it clear that the configuration would fail in a real execution while still allowing users to continue building their flow.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared action execution plumbing and GraphQL/types to persist and display new metadata; risk is mainly schema/client compatibility and ensuring warnings don’t affect non-test executions.
> 
> **Overview**
> Test executions of the `Delay until` action no longer fail when the configured timestamp is in the past; instead they succeed and emit a warning message.
> 
> This threads a new `warningMessage` through the stack by adding `meta.warningMessage` to `IActionItem`, persisting it onto `ExecutionStepMetadata` in `processAction`, exposing it via GraphQL, and rendering it in `FlowStepTestController` test results. Unit tests for `delay-until` were updated to assert the new test-run behavior and metadata output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f97830a2894c0b37de374022cff2bb8fffbbbce1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->