### PR TITLE
PLU-456: part 2 - add checkbox to allow past timestamp

### DIFF
--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -44,16 +44,15 @@ const action: IRawAction = {
       key: 'delayUntilTime',
       type: 'string' as const,
       required: false,
+      placeholder: '00:00',
       description: 'Delay until the time (24h). E.g. 08:00, 23:00',
       variables: true,
     },
     {
-      label: 'Always allow past timestamp?',
-      key: 'alwaysAllowPastTimestamp',
+      label: 'Stop if the scheduled time has already passed',
+      key: 'stopIfPastTimestamp',
       type: 'checkbox' as const,
       required: false,
-      description:
-        'Always allow the pipe to continue running even if the delay until timestamp is in the past.',
       value: false,
     },
   ],
@@ -61,7 +60,7 @@ const action: IRawAction = {
   async run($) {
     const defaultTime = '00:00'
     // trim the date and time for user
-    const { delayUntil, delayUntilTime, alwaysAllowPastTimestamp } =
+    const { delayUntil, delayUntilTime, stopIfPastTimestamp } =
       $.step.parameters
     const delayUntilString = new String(delayUntil).trim()
     // catch empty string (user input), null, undefined (backwards compat)
@@ -113,7 +112,7 @@ const action: IRawAction = {
     // Allow test step to always succeed but show warning in the frontend
     // Note: Allow users to still retry for past timestamp live executions so we don't have to debug and fix the issue for them. They have the control over this.
     if (!$.execution.testRun && isPastTimestamp) {
-      if (isRetry || alwaysAllowPastTimestamp) {
+      if (isRetry || !stopIfPastTimestamp) {
         const dateTimeNow = DateTime.now()
         dataItem = {
           delayUntil: dateTimeNow.toPlumberFormat('dd MMM yyyy'),
@@ -134,7 +133,7 @@ const action: IRawAction = {
       raw: dataItem,
       ...(isPastTimestamp &&
         $.execution.testRun &&
-        !alwaysAllowPastTimestamp && {
+        stopIfPastTimestamp && {
           meta: {
             warningMessage: PAST_TIMESTAMP_WARNING_MESSAGE,
           },

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -47,12 +47,22 @@ const action: IRawAction = {
       description: 'Delay until the time (24h). E.g. 08:00, 23:00',
       variables: true,
     },
+    {
+      label: 'Always allow past timestamp?',
+      key: 'alwaysAllowPastTimestamp',
+      type: 'checkbox' as const,
+      required: false,
+      description:
+        'Always allow the pipe to continue running even if the delay until timestamp is in the past.',
+      value: false,
+    },
   ],
 
   async run($) {
     const defaultTime = '00:00'
     // trim the date and time for user
-    const { delayUntil, delayUntilTime } = $.step.parameters
+    const { delayUntil, delayUntilTime, alwaysAllowPastTimestamp } =
+      $.step.parameters
     const delayUntilString = new String(delayUntil).trim()
     // catch empty string (user input), null, undefined (backwards compat)
     const delayUntilTimeString = delayUntilTime
@@ -95,14 +105,15 @@ const action: IRawAction = {
 
     /**
      * RETRY: we check and only allow manual retries for failures due to:
-     * - delay until timestamp entered is in the past
+     * - delay until timestamp entered is in the past and allowPastTimestamp is false by default
      */
     const isRetry = await isValidRetry($)
     const isPastTimestamp = delayTimestamp < DateTime.now().toMillis()
 
     // Allow test step to always succeed but show warning in the frontend
+    // Note: Allow users to still retry for past timestamp live executions so we don't have to debug and fix the issue for them. They have the control over this.
     if (!$.execution.testRun && isPastTimestamp) {
-      if (isRetry) {
+      if (isRetry || alwaysAllowPastTimestamp) {
         const dateTimeNow = DateTime.now()
         dataItem = {
           delayUntil: dateTimeNow.toPlumberFormat('dd MMM yyyy'),
@@ -118,11 +129,12 @@ const action: IRawAction = {
       }
     }
 
-    // Only show warning message for test executions
+    // Only show warning message for test executions and if alwaysAllowPastTimestamp is false
     $.setActionItem({
       raw: dataItem,
       ...(isPastTimestamp &&
-        $.execution.testRun && {
+        $.execution.testRun &&
+        !alwaysAllowPastTimestamp && {
           meta: {
             warningMessage: PAST_TIMESTAMP_WARNING_MESSAGE,
           },

--- a/packages/frontend/src/components/InputCreator/Checkbox.tsx
+++ b/packages/frontend/src/components/InputCreator/Checkbox.tsx
@@ -1,11 +1,9 @@
 import { useContext } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
-import Markdown from 'react-markdown'
-import { FormControl } from '@chakra-ui/react'
+import { FormControl, Text } from '@chakra-ui/react'
 import {
   Checkbox as ChakraCheckbox,
   FormErrorMessage,
-  FormLabel,
 } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
@@ -44,8 +42,6 @@ export default function Checkbox(props: CheckboxProps) {
 
         return (
           <FormControl isInvalid={isError}>
-            {label && <FormLabel isRequired={required}>{label}</FormLabel>}
-
             <ChakraCheckbox
               isChecked={isChecked}
               onChange={(e) => {
@@ -55,9 +51,16 @@ export default function Checkbox(props: CheckboxProps) {
               }}
               isDisabled={readOnly}
               colorScheme="secondary"
+              pl={2.5}
+              _hover={{ bg: 'interaction.muted.neutral.hover' }}
+              _focusWithin={{ outline: 'none', boxShadow: 'none' }}
             >
+              {label && <Text textStyle="subhead-1">{label}</Text>}
+
               {description && (
-                <Markdown linkTarget="_blank">{description}</Markdown>
+                <Text textStyle="body-2" color="base.content.medium">
+                  {description}
+                </Text>
               )}
             </ChakraCheckbox>
 

--- a/packages/frontend/src/components/InputCreator/Checkbox.tsx
+++ b/packages/frontend/src/components/InputCreator/Checkbox.tsx
@@ -1,0 +1,70 @@
+import { useContext } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import Markdown from 'react-markdown'
+import { FormControl } from '@chakra-ui/react'
+import {
+  Checkbox as ChakraCheckbox,
+  FormErrorMessage,
+  FormLabel,
+} from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
+
+interface CheckboxProps {
+  name: string
+  label?: string
+  description?: string
+  required?: boolean
+  defaultValue?: boolean
+}
+
+export default function Checkbox(props: CheckboxProps) {
+  const {
+    name,
+    label,
+    required = false,
+    defaultValue = false,
+    description,
+  } = props
+  const { control } = useFormContext()
+  const { readOnly } = useContext(EditorContext)
+
+  return (
+    <Controller
+      name={name}
+      rules={{ required }}
+      control={control}
+      defaultValue={defaultValue}
+      render={({
+        field: { onChange, value },
+        fieldState: { isTouched, error },
+      }) => {
+        const isError = Boolean(isTouched && !!error)
+        const isChecked = value === true || value === 'true'
+
+        return (
+          <FormControl isInvalid={isError}>
+            {label && <FormLabel isRequired={required}>{label}</FormLabel>}
+
+            <ChakraCheckbox
+              isChecked={isChecked}
+              onChange={(e) => {
+                if (!readOnly) {
+                  onChange(e.target.checked)
+                }
+              }}
+              isDisabled={readOnly}
+              colorScheme="secondary"
+            >
+              {description && (
+                <Markdown linkTarget="_blank">{description}</Markdown>
+              )}
+            </ChakraCheckbox>
+
+            {isError && <FormErrorMessage>{error?.message}</FormErrorMessage>}
+          </FormControl>
+        )
+      }}
+    />
+  )
+}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -16,6 +16,7 @@ import useDynamicData from '@/hooks/useDynamicData'
 import { COLLABORATOR_RESTRICTED_FIELDS } from '../Editor/constants'
 
 import BooleanRadio from './BooleanRadio'
+import Checkbox from './Checkbox'
 
 export type InputCreatorProps = {
   schema: IField
@@ -88,6 +89,18 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         required={required}
         defaultValue={value as boolean}
         options={schema?.options}
+      />
+    )
+  }
+
+  if (type === 'checkbox') {
+    return (
+      <Checkbox
+        name={computedName}
+        label={label}
+        description={description}
+        required={required}
+        defaultValue={value as boolean}
       />
     )
   }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -475,6 +475,11 @@ export interface IFieldBooleanRadioOption {
   value: boolean
 }
 
+export interface IFieldCheckbox extends IBaseField {
+  type: 'checkbox'
+  value: boolean // have to default to the more preferred value
+}
+
 export type IField =
   | IFieldDropdown
   | IFieldText
@@ -485,6 +490,7 @@ export type IField =
   | IFieldMultiRow
   | IFieldRichText
   | IFieldBooleanRadio
+  | IFieldCheckbox
   | IFieldDragDrop
 
 export interface IAuthenticationStepField {


### PR DESCRIPTION
### TL;DR
Added a new "Stop if past timestamp" checkbox option to the Delay Until action, allowing users to either bypass or get blocked at the past timestamp validation.
Default is that the pipe will continue running even with a past timestamp since the checkbox is unchecked.

### TODOs
- [ ] Send email to all recipients with delay until step configured. Warn them that their pipes will continue to run if the configuration is not done

### What changed?

- Added a new checkbox parameter `stopIfPastTimestamp` to the Delay Until action
- Created a new `Checkbox` component in the frontend to support checkbox inputs (label and description is placed together now because checkbox should look like that)
- Updated the action logic to allow execution to continue when a past timestamp is detected if the checkbox is enabled
- Modified the warning message display logic to only show warnings for test executions when the checkbox is disabled
- Added the `IFieldCheckbox` interface to the types definition

### Screenshots
<img width="885" height="496" alt="Screenshot 2025-12-26 at 12 36 08 PM" src="https://github.com/user-attachments/assets/41bff75f-bed4-45cc-98a2-6156e0c1c2a7" />

**New changes after discussing with Vedant**
<img width="1774" height="900" alt="image" src="https://github.com/user-attachments/assets/dae92d17-4f88-4e31-baae-eda174170fc8" />


### How to test?
Important note:
Existing workflows will now have their pipes "going through" after the delay step if the checkbox is unchecked and not configured.
For existing pipes:
- Workflow 1: It has a failed execution with past delay timestamp --> retry should still work.
- Workflow 2: Future executions with past delay timestamp will not get an error.
- Workflow 3: Future executions with valid past delay timestamp should continue to wait as intended.

For new pipes:
- Workflow 1: Past delay timestamp will not produce an error in test step and actual live execution when checkbox is left untouched
- Workflow 2: Past delay timestamp will show a warning message in test step and actual live execution will throw a step error when checkbox is selected
- Workflow 3: Valid delay timestamp should continue to work and wait as intended.

### Why make this change?

This change gives users more control over the Delay Until action's behavior. Previously, when a timestamp in the past was detected, users had to manually retry the execution. With this new option, users can configure the action to automatically continue execution even with past timestamps, reducing the need for manual intervention and making the action more flexible for various use cases.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes execution control flow for the delay step on past timestamps and introduces a new form field type; misconfiguration or edge cases could cause runs to skip delays or fail unexpectedly.
> 
> **Overview**
> Updates the `Delay until` action to include a new `stopIfPastTimestamp` checkbox parameter and adjusts past-timestamp handling so live runs either **fail** (when checked) or **auto-skip the delay** and proceed (when unchecked or when manually retrying a past-timestamp failure).
> 
> Adds frontend support for `type: 'checkbox'` fields via a new `InputCreator/Checkbox` component and extends shared types with `IFieldCheckbox`, allowing actions to define and render checkbox inputs (used here for the new Delay setting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc4c1c547208cc3d8a32b1275cbd8d6cfb897685. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->