### PR TITLE
[MRF2-1] PLU-520: introduce new worker type for queues

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -12,7 +12,7 @@
     "start:worker": "node dist/worker.js",
     "test:unit": "vitest --config ./vitest.config.ts",
     "test:integration": "vitest --config ./vitest.config.integration.ts",
-    "lint": "eslint . --ignore-path ../../.eslintignore",
+    "lint": "eslint . --ignore-path ../../.eslintignore && tsc --noEmit",
     "db": "DOTENV_CONFIG_PATH=.env knex",
     "readme:db:migration:create": "HOW TO USE: npm run -w backend db:migration:create your_migration_name",
     "db:migration:create": "npm run db -- migrate:make",

--- a/packages/backend/src/apps/aisay/queue/index.ts
+++ b/packages/backend/src/apps/aisay/queue/index.ts
@@ -24,6 +24,7 @@ const queueSettings = {
     concurrency: 1,
   },
   isQueueDelayable: false,
+  workerType: 'action',
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/apps/m365-excel/queue/index.ts
+++ b/packages/backend/src/apps/m365-excel/queue/index.ts
@@ -49,6 +49,7 @@ const queueSettings = {
     max: 1,
     duration: M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
   },
+  workerType: 'action',
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/apps/postman-sms/queue/index.ts
+++ b/packages/backend/src/apps/postman-sms/queue/index.ts
@@ -31,6 +31,7 @@ const queueSettings = {
     },
   },
   isQueueDelayable: false,
+  workerType: 'action',
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/apps/postman/queue/index.ts
+++ b/packages/backend/src/apps/postman/queue/index.ts
@@ -8,6 +8,7 @@ const queueSettings = {
     max: appConfig.postman.rateLimit,
   },
   isQueueDelayable: true,
+  workerType: 'action',
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/apps/tiles/queue/index.ts
+++ b/packages/backend/src/apps/tiles/queue/index.ts
@@ -38,6 +38,7 @@ const queueSettings = {
     concurrency: 1,
   },
   isQueueDelayable: false,
+  workerType: 'action',
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/queues/helpers/get-generic-app-queue.ts
+++ b/packages/backend/src/queues/helpers/get-generic-app-queue.ts
@@ -24,5 +24,6 @@ export function getGenericAppQueue(
       concurrency: concurrency,
     },
     isQueueDelayable: false,
+    workerType: 'action',
   } satisfies IAppQueue
 }

--- a/packages/backend/src/workers/__tests__/action.test.ts
+++ b/packages/backend/src/workers/__tests__/action.test.ts
@@ -27,11 +27,13 @@ vi.mock('@/apps', () => ({
     'app-with-queue-1': {
       queue: {
         stubQueueConfig: 1,
+        workerType: 'action',
       },
     },
     'app-with-queue-2': {
       queue: {
         stubQueueConfig: 2,
+        workerType: 'action',
       },
     },
   },
@@ -49,6 +51,7 @@ describe('action workers', () => {
       redisConnectionPrefix: MAIN_ACTION_QUEUE_REDIS_CONNECTION_PREFIX,
       queueConfig: {
         isQueueDelayable: false,
+        workerType: 'action',
       },
     })
   })
@@ -57,12 +60,12 @@ describe('action workers', () => {
     expect(mocks.makeActionWorker).toHaveBeenCalledWith({
       appKey: 'app-with-queue-1',
       queueName: '{app-actions-app-with-queue-1}',
-      queueConfig: { stubQueueConfig: 1 },
+      queueConfig: { stubQueueConfig: 1, workerType: 'action' },
     })
     expect(mocks.makeActionWorker).toHaveBeenCalledWith({
       appKey: 'app-with-queue-2',
       queueName: '{app-actions-app-with-queue-2}',
-      queueConfig: { stubQueueConfig: 2 },
+      queueConfig: { stubQueueConfig: 2, workerType: 'action' },
     })
   })
 

--- a/packages/backend/src/workers/__tests__/helpers.make-action-worker.test.ts
+++ b/packages/backend/src/workers/__tests__/helpers.make-action-worker.test.ts
@@ -65,7 +65,7 @@ describe('makeActionWorker', () => {
     makeActionWorker({
       appKey: 'test-app',
       queueName: '{test-app-queue}',
-      queueConfig: { isQueueDelayable: false },
+      queueConfig: { isQueueDelayable: false, workerType: 'action' },
     })
     expect(mocks.workerConstructor).toHaveBeenCalledWith(
       '{test-app-queue}',
@@ -82,7 +82,7 @@ describe('makeActionWorker', () => {
       appKey: 'test-app',
       queueName: 'some-queue',
       redisConnectionPrefix: '{test}',
-      queueConfig: { isQueueDelayable: false },
+      queueConfig: { isQueueDelayable: false, workerType: 'action' },
     })
     expect(mocks.workerConstructor).toHaveBeenCalledWith(
       'some-queue',
@@ -102,6 +102,7 @@ describe('makeActionWorker', () => {
           type: 'concurrency' as const,
           concurrency: 2,
         },
+        workerType: 'action' as const,
       },
       expectedWorkerOptions: expect.objectContaining({
         group: {
@@ -120,6 +121,7 @@ describe('makeActionWorker', () => {
             duration: 100,
           },
         },
+        workerType: 'action' as const,
       },
       expectedWorkerOptions: expect.objectContaining({
         group: {
@@ -142,6 +144,7 @@ describe('makeActionWorker', () => {
           max: 1,
           duration: 5000,
         },
+        workerType: 'action' as const,
       },
       expectedWorkerOptions: expect.objectContaining({
         group: {
@@ -160,6 +163,7 @@ describe('makeActionWorker', () => {
           max: 1,
           duration: 5000,
         },
+        workerType: 'action' as const,
       },
       expectedWorkerOptions: expect.objectContaining({
         limiter: {

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -20,6 +20,7 @@ export const mainActionWorker = makeActionWorker({
   redisConnectionPrefix: MAIN_ACTION_QUEUE_REDIS_CONNECTION_PREFIX,
   queueConfig: {
     isQueueDelayable: false,
+    workerType: 'action',
   },
 })
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -564,6 +564,11 @@ export interface IAppQueue {
    * the queueRateLimit.
    */
   isQueueDelayable: boolean
+
+  /**
+   * The type of worker to use for this queue.
+   */
+  workerType: 'action' | 'sub-trigger'
 }
 
 export interface IApp {


### PR DESCRIPTION

Added `workerType` property to app queue configurations to specify the type of worker to use. This also lays groundwork for supporting different worker types (like 'sub-trigger') in a type-safe manner.

### What changed?

- Added a new required `workerType` property to the `IAppQueue` interface in the types package
- Set `workerType: 'action'` in all existing app queue configurations:
  - aisay
  - m365-excel
  - postman-sms
  - postman
  - tiles
  - generic app queue helper
  - main action worker
- Updated tests to include the new property in mock configurations

### What to test?

1. Verify that all existing app queues continue to function correctly
2. Ensure no TypeScript errors are present in the codebase
3. Run the worker tests to confirm they pass with the updated interface
