### PR TITLE
[MRF2-2] PLU-520: handle test submission for mrf

### DIFF
--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -6,9 +6,25 @@ import Step from '@/models/step'
 
 import getDataOutMetadata from '../../common/get-data-out-metadata'
 import {
+  FormsgPayloadWorkflowContent,
   type ParsedMrfWorkflowStep,
   parsedMrfWorkflowStepSchema,
 } from '../../common/types'
+
+function validateMrfStep($: IGlobalVariable): ParsedMrfWorkflowStep {
+  const { mrf } = $.step.parameters as unknown as {
+    mrf: ParsedMrfWorkflowStep
+  }
+  if (!mrf || parsedMrfWorkflowStepSchema.safeParse(mrf).success === false) {
+    throw new StepError(
+      'Misconfigured MRF step',
+      'Reconnect your MRF form and try again.',
+      $.step.position,
+      $.app.name,
+    )
+  }
+  return mrf
+}
 
 const action: IRawAction = {
   name: 'New form response',
@@ -20,18 +36,7 @@ const action: IRawAction = {
 
   async testRun($: IGlobalVariable) {
     // Gets the execution step of the trigger
-    const { mrf } = $.step.parameters as unknown as {
-      mrf: ParsedMrfWorkflowStep
-    }
-
-    if (!mrf || parsedMrfWorkflowStepSchema.safeParse(mrf).success === false) {
-      throw new StepError(
-        'Misconfigured MRF step',
-        'Reconnect your MRF form and try again.',
-        $.step.position,
-        $.app.name,
-      )
-    }
+    const mrf = validateMrfStep($)
 
     const triggerStep = await Step.query()
       .findOne({
@@ -41,12 +46,58 @@ const action: IRawAction = {
         app_key: 'formsg',
       })
       .throwIfNotFound()
-    const triggerExecutionStep = await ExecutionStep.query()
-      .where('step_id', triggerStep.id)
-      .andWhere('execution_id', $.execution.id)
-      .first()
+    const triggerExecutionStep = await ExecutionStep.query().findOne({
+      step_id: triggerStep.id,
+      execution_id: $.execution.id,
+    })
 
     if (!triggerExecutionStep) {
+      $.setActionItem({
+        raw: null,
+      })
+      return
+    }
+
+    const workflowContent = triggerExecutionStep.dataOut
+      .workflowContent as unknown as FormsgPayloadWorkflowContent
+
+    /**
+     * Dont bother checking fields if it's a mock submission
+     */
+    if (triggerExecutionStep.metadata?.isMock) {
+      $.setActionItem({
+        raw: triggerExecutionStep.dataOut,
+        meta: triggerExecutionStep.metadata, // this contains isMock and lastTestSubmissionDate
+      })
+      return
+    }
+
+    /**
+     * If it's not a mock submission, and the workflow content is not available, show no test data
+     * It means it's not a valid mrf submission
+     */
+    if (!workflowContent) {
+      $.setActionItem({
+        raw: null,
+      })
+      return
+    }
+
+    /**
+     * The current trigger data could have not completed this step of the MRF yet.
+     * If the submitted steps do not include the current MRF step, show no test data
+     */
+    const completedWorkflowSteps = workflowContent.workflow.slice(
+      0,
+      workflowContent.workflowStep + 1,
+    )
+
+    if (
+      !completedWorkflowSteps ||
+      !completedWorkflowSteps
+        .map((step) => step._id)
+        .includes(mrf.formWorkflowStepId)
+    ) {
       $.setActionItem({
         raw: null,
       })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -1,8 +1,9 @@
-import { IGlobalVariable } from '@plumber/types'
+import type { IAuth, IGlobalVariable } from '@plumber/types'
 
 import {
   DecryptedAttachments,
   DecryptedContent,
+  FormField,
 } from '@opengovsg/formsg-sdk/dist/types'
 import { DateTime } from 'luxon'
 
@@ -11,6 +12,7 @@ import logger from '@/helpers/logger'
 
 import { getSdk, parseFormEnv } from '../common/form-env'
 import convertTableAnswerArrayToTableObject from '../common/process-table-field'
+import type { FormsgPayloadWorkflowContent } from '../common/types'
 import { NricFilter } from '../triggers/new-submission/index'
 
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
@@ -58,7 +60,7 @@ export function filterNric($: IGlobalVariable, value: string): string | null {
 
 export async function decryptFormResponse(
   $: IGlobalVariable,
-): Promise<{ verified: boolean; internalId: string | null }> {
+): ReturnType<IAuth['verifyWebhook']> {
   if (!$.request) {
     logger.error('No trigger item provided')
     return { verified: false, internalId: null }
@@ -93,12 +95,42 @@ export async function decryptFormResponse(
   }
 
   const formSecretKey = $.auth.data.privateKey as string
+  const version = data.version
 
   const shouldStoreAttachments = $.flow.hasFileProcessingActions
   let submission: DecryptedContent | null = null
   let attachments: DecryptedAttachments | null = null
 
-  if (shouldStoreAttachments) {
+  if (version >= 3) {
+    const decryptedSubmission = formSgSdk.cryptoV3.decrypt(formSecretKey, data)
+    const responsesV3 = decryptedSubmission?.responses
+    const mappedResponses: FormField[] = []
+    let questionNumber = 1
+    for (const [key, value] of Object.entries(responsesV3)) {
+      if (typeof value.answer === 'string') {
+        mappedResponses.push({
+          _id: key,
+          fieldType: value.fieldType,
+          // this is temporary since formsg isnt returning us the question yet
+          question: `Question ${questionNumber}`,
+          answer: value.answer,
+        })
+      } else if (Array.isArray(value.answer)) {
+        mappedResponses.push({
+          _id: key,
+          fieldType: value.fieldType,
+          // this is temporary since formsg isnt returning us the question yet
+          question: `Question ${questionNumber}`,
+          answerArray: value.answer,
+        })
+      }
+      questionNumber++
+    }
+    submission = {
+      responses: mappedResponses,
+      verified: decryptedSubmission?.verified,
+    }
+  } else if (shouldStoreAttachments) {
     const decryptedResponse = await formSgSdk.crypto.decryptWithAttachments(
       formSecretKey,
       data,
@@ -231,7 +263,32 @@ export async function decryptFormResponse(
     delete $.request.headers
     delete $.request.query
 
-    return { verified: true, internalId: data.submissionId }
+    const internalId = data.submissionId
+
+    if (!data.workflowContent) {
+      return { verified: true, internalId }
+    }
+
+    $.request.body.workflowContent = data.workflowContent
+
+    const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
+
+    /**
+     * This means it's the first mrf step and is a new submission
+     */
+    if (!workflowContent) {
+      return { verified: true, internalId }
+    }
+
+    return {
+      verified: true,
+      internalId,
+      isSubtrigger: workflowContent.workflowStep > 0 ? true : false,
+      subtriggerData: {
+        type: 'mrf',
+        mrfStepId: workflowContent.workflow[workflowContent.workflowStep]?._id,
+      },
+    }
   } else {
     // Could not decrypt the submission
     logger.error('Unable to decrypt formsg response')

--- a/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
@@ -431,6 +431,9 @@ async function getDataOutMetadata(
       type: 'text',
       label: 'Submission Time',
     },
+    workflowContent: {
+      isHidden: true,
+    },
   }
   if (verifiedSubmitterInfo) {
     result.verifiedSubmitterInfo = verifiedSubmitterInfo

--- a/packages/backend/src/apps/formsg/common/types.ts
+++ b/packages/backend/src/apps/formsg/common/types.ts
@@ -10,9 +10,11 @@ export const mrfWorkflowDataSchema = z.array(
   }),
 )
 
+type IMrfWorkflow = z.infer<typeof mrfWorkflowDataSchema>
+
 export interface FormSchema {
   form: {
-    workflow?: z.infer<typeof mrfWorkflowDataSchema>
+    workflow?: IMrfWorkflow
     publicKey: string
     responseMode: string
     _id: string
@@ -55,3 +57,22 @@ export const stepApprovalConfigSchema = z.object({
   branch: z.literal('reject'),
   stepId: z.string().uuid(),
 })
+
+export const submittedStepsSchema = z.array(
+  z.object({
+    isApproval: z.boolean(),
+    submittedAt: z.string(),
+    nextStepRecipientEmails: z.array(z.string()).optional(),
+    status: z.enum(['APPROVED', 'REJECTED']).optional(),
+    stepNumber: z.number().optional(),
+  }),
+)
+
+/*
+ * type for workflowContent in formsg mrf payload
+ */
+export interface FormsgPayloadWorkflowContent {
+  workflow: IMrfWorkflow
+  workflowStep: number
+  submittedSteps: z.infer<typeof submittedStepsSchema>
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -654,6 +654,11 @@ type IConnectionModalLabel = {
   addConnectionLabel?: string
 }
 
+export interface SubtriggerData {
+  type: 'mrf'
+  mrfStepId: string
+}
+
 interface IBaseAuth {
   connectionType: AuthConnectionType
 
@@ -661,9 +666,12 @@ interface IBaseAuth {
   verifyCredentials?($: IGlobalVariable): Promise<void>
   isStillVerified?($: IGlobalVariable): Promise<boolean>
   refreshToken?($: IGlobalVariable): Promise<void>
-  verifyWebhook?(
-    $: IGlobalVariable,
-  ): Promise<{ verified: boolean; internalId: string | null }>
+  verifyWebhook?($: IGlobalVariable): Promise<{
+    verified: boolean
+    internalId: string | null
+    isSubtrigger?: boolean
+    subtriggerData?: SubtriggerData
+  }>
   isRefreshTokenRequested?: boolean
   authenticationSteps?: IAuthenticationStep[]
   reconnectionSteps?: IAuthenticationStep[]


### PR DESCRIPTION
Added check step with last submission support for MRF. Basically what it does is use the latest submission data from the trigger and copy to the current steps' execution step data if the workflow steps covers it.

### What changed?

- Created a `validateMrfStep` function to extract and validate MRF step parameters
- Enhanced `decryptFormResponse` to handle FormSG v3 API responses and MRF workflow content (temporary implementation since the current payload is incompatible)
- Added logic to determine if a submission is part of a multi-step workflow
- Improved test run functionality to check if the current trigger data has completed the MRF step
- Added types for MRF workflow content and submitted steps
- Updated the `IAuth` interface to support subtrigger data for MRF steps

### How to test?

1. Create an MRF form with multiple steps
2. Connect the form to Plumber
3. For each stage of the MRF, submit and check step with the latest submission data. Always click approve or else the MRF just terminates there.
4. Check that the test data shown is correct. For those steps that have not been submitted, it should not show any data. 

