### PR TITLE
[MRF2-3] PLU-520: handle mrf subtrigger webhooks in processSubtrigger

### DIFF
--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -1,4 +1,4 @@
-import { IRequest, ITriggerItem } from '@plumber/types'
+import { IRequest, ITriggerItem, SubtriggerData } from '@plumber/types'
 
 import { randomUUID } from 'crypto'
 import { Response } from 'express'
@@ -13,6 +13,7 @@ import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 import Flow from '@/models/flow'
 import { enqueueActionJob } from '@/queues/action'
+import { processSubTrigger } from '@/services/sub-trigger'
 import { type CustomWebhookResponse, processTrigger } from '@/services/trigger'
 
 const DEFAULT_MAX_QPS = 10
@@ -110,6 +111,12 @@ export default async (request: IRequest, response: Response) => {
     return response.sendStatus(404)
   }
 
+  let isSubtrigger = false
+  /**
+   * This is the workflow data which is currently mrf workflow content only
+   */
+  let subtriggerData: SubtriggerData | undefined
+
   if (triggerApp.auth?.verifyWebhook) {
     const $ = await globalVariable({
       flow,
@@ -119,13 +126,14 @@ export default async (request: IRequest, response: Response) => {
       request,
     })
 
-    const { verified, internalId: newInternalId } =
-      await triggerApp.auth.verifyWebhook($)
+    const verifyResult = await triggerApp.auth.verifyWebhook($)
 
-    if (!verified) {
+    if (!verifyResult.verified) {
       return response.sendStatus(401)
     }
-    internalId = newInternalId
+    internalId = verifyResult.internalId
+    isSubtrigger = verifyResult.isSubtrigger ?? false
+    subtriggerData = verifyResult.subtriggerData
   }
 
   // in case trigger type is 'webhook'
@@ -144,6 +152,54 @@ export default async (request: IRequest, response: Response) => {
     meta: {
       internalId,
     },
+  }
+
+  // Handle MRF sub-trigger (subsequent workflow step submissions)
+  if (!testRun && isSubtrigger && subtriggerData !== undefined) {
+    const subTriggerResult = await processSubTrigger({
+      flowId,
+      triggerItem,
+      subtriggerData,
+    })
+
+    span?.addTags({
+      flowId,
+      executionId: subTriggerResult?.executionId,
+      appKey: triggerApp.key,
+      testRun,
+      isSubTrigger: true,
+    })
+
+    // No existing execution found or MRF step not found - return 200 but skip processing
+    if (!subTriggerResult) {
+      return response.sendStatus(200)
+    }
+
+    const { executionId, nextStep } = subTriggerResult
+
+    // For test runs, don't enqueue the next step
+    if (testRun) {
+      return response.sendStatus(200)
+    }
+
+    // Enqueue the next step after the MRF action step
+    if (nextStep) {
+      const jobName = `${executionId}-${nextStep.id}`
+      const jobData = {
+        flowId,
+        executionId,
+        stepId: nextStep.id,
+      }
+
+      await enqueueActionJob({
+        appKey: nextStep.appKey,
+        jobName,
+        jobData,
+        jobOptions: DEFAULT_JOB_OPTIONS,
+      })
+    }
+
+    return response.sendStatus(200)
   }
 
   /**

--- a/packages/backend/src/services/sub-trigger.ts
+++ b/packages/backend/src/services/sub-trigger.ts
@@ -1,0 +1,126 @@
+import type { ITriggerItem, SubtriggerData } from '@plumber/types'
+
+import get from 'lodash.get'
+
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Step from '@/models/step'
+
+export type ProcessSubTriggerOptions = {
+  flowId: string
+  triggerItem: ITriggerItem
+  subtriggerData: SubtriggerData
+}
+
+type ProcessSubTriggerResult = {
+  executionId: string
+  executionStep: ExecutionStep
+  /**
+   * The next step to execute after the MRF action step
+   */
+  nextStep: Step | null
+  shouldExecute: boolean
+}
+
+/**
+ * Processes a sub-trigger for MRF (multi-respondent form) subsequent submissions.
+ * Instead of creating a new execution, it finds the existing execution by submissionId
+ * and creates an execution step for the corresponding MRF action step.
+ */
+export const processSubTrigger = async (
+  options: ProcessSubTriggerOptions,
+): Promise<ProcessSubTriggerResult | null> => {
+  const { flowId, triggerItem, subtriggerData } = options
+  const internalId = triggerItem.meta.internalId
+
+  if (subtriggerData.type !== 'mrf') {
+    logger.error(
+      `Sub-trigger: Subtrigger data type is not MRF for internalId: ${internalId}, flowId: ${flowId}`,
+      {
+        event: 'sub-trigger-subtrigger-data-type-not-mrf',
+        flowId,
+        internalId,
+      },
+    )
+    return null
+  }
+
+  if (!internalId) {
+    logger.error(`Sub-trigger: No internalId found for flowId: ${flowId}`, {
+      event: 'sub-trigger-no-internal-id',
+      flowId,
+    })
+  }
+  // Find the execution to attach to
+  const execution = await Execution.query()
+    .where({
+      flow_id: flowId,
+      test_run: false,
+      internal_id: internalId,
+    })
+    .first()
+
+  if (!execution) {
+    // No existing execution found - skip processing per requirements
+    logger.warn(
+      `Sub-trigger: No existing execution found for internalId: ${internalId}, flowId: ${flowId}`,
+      {
+        event: 'sub-trigger-no-execution',
+        flowId,
+        internalId,
+        mrfStepId: subtriggerData.mrfStepId,
+      },
+    )
+    return null
+  }
+
+  // Find all MRF action steps for this flow, ordered by position
+  const mrfSteps = await Step.query()
+    .where({
+      flow_id: flowId,
+      type: 'action',
+      app_key: 'formsg',
+      key: 'mrfSubmission',
+    })
+    .orderBy('position', 'asc')
+
+  // workflowStep is 1-indexed from FormSG, so the Nth MRF step corresponds to workflowStep N
+  // (workflowStep 1 = first MRF action step, workflowStep 2 = second MRF action step, etc.)
+  const mrfStep = mrfSteps.find(
+    (step) =>
+      get(step.parameters, 'mrf.formWorkflowStepId', null) ===
+      subtriggerData.mrfStepId,
+  )
+
+  if (!mrfStep) {
+    logger.error(
+      `Sub-trigger: MRF step not found for workflowStep: ${subtriggerData.mrfStepId}, flowId: ${flowId}`,
+      {
+        event: 'sub-trigger-mrf-step-not-found',
+        flowId,
+        internalId,
+        mrfStepId: subtriggerData.mrfStepId,
+      },
+    )
+    return null
+  }
+
+  // Create the execution step for the MRF action step
+  const executionStep = await execution
+    .$relatedQuery('executionSteps')
+    .insertAndFetch({
+      stepId: mrfStep.id,
+      dataIn: mrfStep.parameters,
+      dataOut: triggerItem.raw,
+      appKey: mrfStep.appKey,
+      key: mrfStep.key,
+    })
+
+  return {
+    executionId: execution.id,
+    executionStep,
+    nextStep: mrfStep ?? null,
+    shouldExecute: true,
+  }
+}


### PR DESCRIPTION
Added a new service `processSubtrigger` to handle webhook payloads from MRF (2nd step onwards). Instead of creating a new execution for each submission, it now looks for the corresponding execution and creates a new execution step under the same execution. This is a partial feature implementation so it can't be tested.

### What changed?

- Added a new `processSubTrigger` service to handle MRF sub-trigger submissions
- Modified webhook handler to identify and process mrf sub-triggers
- Implemented logic to find existing executions **by submission ID (aka internalId)** and create execution steps for corresponding MRF action steps
- Enqueues the next step after an MRF action step

### How to test?

N/A

