### PR TITLE
[MRF2-4] PLU-520: modify getNextStep to respect mrf branches

### DIFF
--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -167,9 +167,53 @@ class Step extends Base {
   async getNextStep() {
     const flow = await this.$relatedQuery('flow')
 
-    return await flow
+    const nextImmediateStep = await flow
       .$relatedQuery('steps')
       .findOne({ position: this.position + 1 })
+
+    if (!nextImmediateStep) {
+      return undefined
+    }
+
+    const isCurrentStepInMrfRejectionBranch =
+      this.config.approval?.branch === 'reject'
+    const isNextStepInMrfRejectionBranch =
+      nextImmediateStep.config.approval?.branch === 'reject'
+    if (isCurrentStepInMrfRejectionBranch) {
+      /**
+       * If the current step is in the rejection branch, return the next step in the rejection branch
+       */
+      if (
+        isNextStepInMrfRejectionBranch &&
+        this.config.approval?.stepId ===
+          nextImmediateStep.config.approval?.stepId
+      ) {
+        return nextImmediateStep
+      }
+      /**
+       * If the next step is not in the rejection branch, return undefined
+       */
+      return undefined
+    } else {
+      /**
+       * If the current step and next step are not in the rejection branch, return the next step
+       */
+      if (!isNextStepInMrfRejectionBranch) {
+        return nextImmediateStep
+      }
+
+      /**
+       * If the next step is in a rejection branch, skip to the next mrf action step
+       */
+      const nextMrfStep = await Step.query()
+        .where('flow_id', flow.id)
+        .andWhere('type', 'action')
+        .andWhere('key', 'mrfSubmission')
+        .andWhere('position', '>', nextImmediateStep.position)
+        .orderBy('position', 'asc')
+        .first()
+      return nextMrfStep
+    }
   }
 
   async getTriggerCommand() {


### PR DESCRIPTION
Enhanced the `getNextStep` method to properly handle MRF branches in workflow steps. As this is a partial implementation, you can't test it properly yet.

### What changed?
Added logic to determine if the current step or next step is in a rejection branch
- If the current step is in a rejection branch, it will only return the next step if it's also in the same rejection branch
- If the current step is not in a rejection branch but the next step is, it will skip to the next MRF action step
- If the current step and next step are not in a rejection branch, proceed to queue as per normal.

### How to test?
 N/A
