### PR TITLE
[MRF2-5] PLU-520: refactor worker listeners, introduce new pause-execution command

### DIFF
--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -4,6 +4,8 @@ import type {
   TestRunStepMetadata,
 } from '@plumber/types'
 
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+
 import {
   FOR_EACH_ITERATION_DELAY,
   FOR_EACH_MAX_ITERATIONS,
@@ -170,7 +172,6 @@ export const processAction = async (options: ProcessActionOptions) => {
         : await actionCommand.run($, metadata)
     if (result) {
       runResult = result
-      metadata
     }
   } catch (error) {
     executionError = error
@@ -286,6 +287,17 @@ export const processAction = async (options: ProcessActionOptions) => {
     case 'stop-execution':
       // Nothing to do, nextStep is already null.
       break
+    case 'pause-execution':
+      logger.error({
+        event: 'invalid-action-command',
+        command: 'pause-execution',
+        stepId,
+        flowId,
+        executionId,
+      })
+      throw new UnrecoverableError(
+        'pause-execution command not allowed for actions',
+      )
     default:
       nextStep = await step.getNextStep()
   }

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -11,25 +11,17 @@ import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
 import { handleFailedStepAndThrow } from '@/helpers/actions'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
-import {
-  DEFAULT_JOB_OPTIONS,
-  MAXIMUM_JOB_ATTEMPTS,
-} from '@/helpers/default-job-configuration'
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
-import {
-  isErrorEmailAlreadySent,
-  sendErrorEmail,
-} from '@/helpers/generate-error-email'
-import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
-import Flow from '@/models/flow'
 import Step from '@/models/step'
 import { enqueueActionJob, makeActionJobId } from '@/queues/action'
 import { processAction } from '@/services/action'
 
 import processForEachStatus from './for-each-status-manager'
+import { registerWorkerEventHandlers } from './worker-event-handlers'
 
 function convertParamsToBullMqOptions(
   params: MakeActionWorkerParams,
@@ -217,111 +209,7 @@ export function makeActionWorker(
     workerOptions,
   )
 
-  worker.on('active', (job) => {
-    logger.info(
-      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has started!`,
-      {
-        queueName,
-        job: job.data,
-        workerVersion: appConfig.version,
-      },
-    )
-  })
-
-  worker.on('completed', (job) => {
-    logger.info(
-      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has completed!`,
-      {
-        queueName,
-        job: job.data,
-        workerVersion: appConfig.version,
-      },
-    )
-  })
-
-  worker.on('failed', async (job, err) => {
-    const { flowId, executionId } = job.data
-
-    logger.error(
-      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${flowId} has failed to start with ${err.message}`,
-      {
-        err,
-        queueName,
-        job: job.data,
-        attemptsMade: job.attemptsMade,
-        attemptsStarted: job.attemptsStarted,
-        workerVersion: appConfig.version,
-      },
-    )
-
-    // The job will be retried if:
-    // 1. The error is not an UnrecoverableError, and
-    // 2. We haven't exceeded the maximum number of retry attempts
-    const willRetryJob =
-      !(err instanceof UnrecoverableError) && // Not an unrecoverable error
-      job.attemptsMade < MAXIMUM_JOB_ATTEMPTS // Haven't reached max attempts
-
-    // No further post-processing needed if we're retrying.
-    if (willRetryJob) {
-      return
-    }
-
-    try {
-      await Execution.setStatus(executionId, 'failure')
-
-      const flow = await Flow.query()
-        .findById(job.data.flowId)
-        .withGraphFetched({
-          user: true,
-          collaborators: {
-            user: true,
-          },
-        })
-        .throwIfNotFound()
-
-      const shouldAlwaysSendEmail =
-        flow.config?.errorConfig?.notificationFrequency === 'always'
-
-      // Don't check redis if notification frequency is always
-      if (!shouldAlwaysSendEmail && (await isErrorEmailAlreadySent(flowId))) {
-        return
-      }
-
-      const emailErrorDetails = await sendErrorEmail(flow)
-      logger.info(`Sent error email for execution ID: ${executionId}`, {
-        errorDetails: { ...emailErrorDetails, ...job.data },
-      })
-    } catch (err) {
-      logger.error(
-        `Error while running onFailed callback for execution ID ${executionId}`,
-        {
-          event: 'onfailed-callback-failed',
-          err,
-          jobData: job.data,
-        },
-      )
-    }
-  })
-
-  worker.on('ready', () => {
-    logger.info(`[${queueName}] Worker is ready!`)
-  })
-
-  worker.on('closed', () => {
-    logger.info(`[${queueName}] Worker is closed!`)
-  })
-
-  worker.on('error', (err) => {
-    if (!err) {
-      logger.error(`[${queueName}] Worker had undefined error`)
-      return
-    }
-    // catch-all just in case any errors bubble up and potentially crash the worker task
-    logger.error(`[${queueName}] Worker errored with ${err.message}`, {
-      err: err.stack,
-      queueName,
-    })
-  })
+  registerWorkerEventHandlers(worker, queueName)
 
   return worker
 }

--- a/packages/backend/src/workers/helpers/worker-event-handlers.ts
+++ b/packages/backend/src/workers/helpers/worker-event-handlers.ts
@@ -1,0 +1,128 @@
+import type { IActionJobData } from '@plumber/types'
+
+import { UnrecoverableError, type WorkerPro } from '@taskforcesh/bullmq-pro'
+
+import appConfig from '@/config/app'
+import { MAXIMUM_JOB_ATTEMPTS } from '@/helpers/default-job-configuration'
+import {
+  isErrorEmailAlreadySent,
+  sendErrorEmail,
+} from '@/helpers/generate-error-email'
+import logger from '@/helpers/logger'
+import Execution from '@/models/execution'
+import Flow from '@/models/flow'
+
+/**
+ * Attaches standard event listeners to a worker for logging and error handling.
+ * Used by both action workers and sub-trigger workers.
+ */
+export function registerWorkerEventHandlers(
+  worker: WorkerPro<IActionJobData>,
+  queueName: string,
+): void {
+  worker.on('active', (job) => {
+    logger.info(
+      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has started!`,
+      {
+        queueName,
+        job: job.data,
+        workerVersion: appConfig.version,
+      },
+    )
+  })
+
+  worker.on('completed', (job) => {
+    logger.info(
+      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has completed!`,
+      {
+        queueName,
+        job: job.data,
+        workerVersion: appConfig.version,
+      },
+    )
+  })
+
+  worker.on('failed', async (job, err) => {
+    const { flowId, executionId } = job.data
+
+    logger.error(
+      `[${queueName}] JOB ID: ${job.id} - FLOW ID: ${flowId} has failed to start with ${err.message}`,
+      {
+        err,
+        queueName,
+        job: job.data,
+        attemptsMade: job.attemptsMade,
+        attemptsStarted: job.attemptsStarted,
+        workerVersion: appConfig.version,
+      },
+    )
+
+    // The job will be retried if:
+    // 1. The error is not an UnrecoverableError, and
+    // 2. We haven't exceeded the maximum number of retry attempts
+    const willRetryJob =
+      !(err instanceof UnrecoverableError) && // Not an unrecoverable error
+      job.attemptsMade < MAXIMUM_JOB_ATTEMPTS // Haven't reached max attempts
+
+    // No further post-processing needed if we're retrying.
+    if (willRetryJob) {
+      return
+    }
+
+    try {
+      await Execution.setStatus(executionId, 'failure')
+
+      const flow = await Flow.query()
+        .findById(job.data.flowId)
+        .withGraphFetched({
+          user: true,
+          collaborators: {
+            user: true,
+          },
+        })
+        .throwIfNotFound()
+
+      const shouldAlwaysSendEmail =
+        flow.config?.errorConfig?.notificationFrequency === 'always'
+
+      // Don't check redis if notification frequency is always
+      if (!shouldAlwaysSendEmail && (await isErrorEmailAlreadySent(flowId))) {
+        return
+      }
+
+      const emailErrorDetails = await sendErrorEmail(flow)
+      logger.info(`Sent error email for execution ID: ${executionId}`, {
+        errorDetails: { ...emailErrorDetails, ...job.data },
+      })
+    } catch (err) {
+      logger.error(
+        `Error while running onFailed callback for execution ID ${executionId}`,
+        {
+          event: 'onfailed-callback-failed',
+          err,
+          jobData: job.data,
+        },
+      )
+    }
+  })
+
+  worker.on('ready', () => {
+    logger.info(`[${queueName}] Worker is ready!`)
+  })
+
+  worker.on('closed', () => {
+    logger.info(`[${queueName}] Worker is closed!`)
+  })
+
+  worker.on('error', (err) => {
+    if (!err) {
+      logger.error(`[${queueName}] Worker had undefined error`)
+      return
+    }
+    // catch-all just in case any errors bubble up and potentially crash the worker task
+    logger.error(`[${queueName}] Worker errored with ${err.message}`, {
+      err: err.stack,
+      queueName,
+    })
+  })
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -795,6 +795,10 @@ export interface IActionRunResult {
    */
   nextStep?:
     | { command: 'jump-to-step'; stepId: IStep['id'] }
+    // "stop-execution" works differently from "pause-execution"
+    // for "pause-execution", the execution is paused and the execution status is not patched
+    // for "stop-execution", the execution is ended and the execution status is patched
+    | { command: 'pause-execution' }
     | { command: 'stop-execution' }
     | { command: 'start-for-each'; stepId: IStep['id'] }
   nextStepMetadata?: NextStepMetadata


### PR DESCRIPTION
Added support for the `pause-execution` command in action steps and refactored worker event handlers. Not much changes here.

### What changed?

- Action workers should not receive `pause-execution` command and should throw an `UnrecoverableError`
- Extracted worker event handlers into a separate file (`worker-event-handlers.ts`) to improve code organization and reusability. We will use this later.

### How to test?

1. Verify that the existing action worker should work as per normal. i.e. logging that the job has started/completed etc...