### PR TITLE
[MRF2-7] PLU-520: implement actual mrf run command

### DIFF
--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -1,6 +1,7 @@
 import type { IGlobalVariable, IRawAction } from '@plumber/types'
 
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
 
@@ -9,6 +10,7 @@ import {
   FormsgPayloadWorkflowContent,
   type ParsedMrfWorkflowStep,
   parsedMrfWorkflowStepSchema,
+  submittedStepsSchema,
 } from '../../common/types'
 
 function validateMrfStep($: IGlobalVariable): ParsedMrfWorkflowStep {
@@ -108,6 +110,146 @@ const action: IRawAction = {
       raw: triggerExecutionStep.dataOut,
       meta: triggerExecutionStep.metadata,
     })
+  },
+
+  async run($: IGlobalVariable) {
+    validateMrfStep($)
+    /*
+     * Find the previous executable trigger/action step in the workflow
+     * that should be already executed in order for this current step to proceed
+     */
+    const previousExecutableStep = await Step.query()
+      .where('flow_id', $.flow.id)
+      .andWhere('position', '<', $.step.position)
+      .andWhereRaw(`config -> 'approval' IS NULL`) // exclude steps in reject branch
+      .orderBy('position', 'desc')
+      .first()
+    if (!previousExecutableStep) {
+      throw new StepError(
+        'Previous executable step not found',
+        'The previous executable step was not found. This should not happen.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    const previousExecutableExecutionStep = await ExecutionStep.query()
+      .where('step_id', previousExecutableStep.id)
+      .andWhere('execution_id', $.execution.id)
+      .orderBy('created_at', 'desc')
+      .first()
+
+    if (
+      !previousExecutableExecutionStep ||
+      previousExecutableExecutionStep.isFailed
+    ) {
+      // end and do nothing
+      logger.info({
+        event:
+          'mrf-submission - previous executable execution step not found or failed',
+        executionId: $.execution.id,
+      })
+      return {
+        nextStep: {
+          command: 'pause-execution',
+        },
+      }
+    }
+
+    const currentExecutionStep = await $.getLastExecutionStep({
+      sameExecution: true,
+    })
+
+    if (!currentExecutionStep) {
+      logger.info({
+        event: 'mrf-submission - no webhook yet',
+        executionId: $.execution.id,
+      })
+      return {
+        nextStep: {
+          command: 'pause-execution',
+        },
+      }
+    }
+
+    // Extract the workflowContent (current workflow state and metadata) and fields (form responses) from the last execution step's output.
+    const { workflowContent } = currentExecutionStep.dataOut as unknown as {
+      workflowContent: FormsgPayloadWorkflowContent
+    }
+
+    const submittedStepsResult = submittedStepsSchema.safeParse(
+      workflowContent.submittedSteps,
+    )
+    // Ensure workflowContent exists and workflowStep index is a valid number.
+    if (submittedStepsResult.success === false) {
+      // If these are missing, something has gone wrong in the form submission or wiring.
+      throw new StepError(
+        'Invalid MRF data: submitted steps are not valid',
+        'Click check step to sync your MRF form and try again.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    // Find the last submitted step which is the current step
+    const submittedStep =
+      submittedStepsResult.data[submittedStepsResult.data.length - 1]
+    if (!submittedStep) {
+      // Should never happen unless the workflow schema did not sync or was changed.
+      throw new StepError(
+        'Invalid MRF data: unable to find submitted step',
+        'Click check step to sync your MRF form and try again.',
+        $.step.position,
+        $.app.name,
+      )
+    }
+
+    // If this workflow step does not require approval (no approval_field), we can immediately enqueue the next step.
+    if (!submittedStep.isApproval) {
+      // No approval field means no gating required -- move forward.
+      return
+    }
+
+    const isApproved = submittedStep.status === 'APPROVED'
+
+    // Check the value of the approval field and handle the response accordingly.
+    if (isApproved) {
+      // If approved ("Yes"), continue with normal workflow and enqueue the next step.
+      logger.info({
+        event: 'mrf-submission - approved',
+        executionId: $.execution.id,
+      })
+      return
+    } else {
+      // If rejected ("No"), skip to the rejection branch. (Logic to skip is elsewhere.)
+      // Find the next step in the rejection branch based on current step id
+      const nextStep = await Step.query()
+        .where('flow_id', $.flow.id)
+        .andWhere('position', '>', $.step.position)
+        .orderBy('position', 'asc')
+        .andWhereRaw(`steps.config->'approval'->>'branch' = ?`, ['reject'])
+        .andWhereRaw(`steps.config->'approval'->>'stepId' = ?`, [$.step.id])
+        .first()
+
+      logger.info({
+        event: 'mrf-submission - rejection branch',
+        executionId: $.execution.id,
+        nextStepId: nextStep?.id,
+      })
+      if (!nextStep) {
+        return {
+          nextStep: {
+            command: 'stop-execution',
+          },
+        }
+      }
+      return {
+        nextStep: {
+          command: 'jump-to-step',
+          stepId: nextStep.id,
+        },
+      }
+    }
   },
 }
 


### PR DESCRIPTION
### TL;DR

Added the actual `run` function to the MRF submission action to handle workflow execution based on approval status.

### What changed?

Implemented the acution `run` function for the MRF submission action that:
- Validates the MRF step parameters with zod
- Checks for 2 conditions before continuing
  If either conditions are not satisifed, return `pause-execution` command, which does nothing and end the job.
  - Checks that the previous executable step is completed
  - Checks that the execution step is created (i.e. webhook has arrived)
- Handles approval logic:
  - Continues normal workflow execution if approved (i.e. leave it to subTrigger worker to enqueue next step)
  - Jumps to rejection branch if rejected (using `skip-to-step` command, or `stop-execution` if no step in rejection branch)

### How to test?
Test full MRF flow
1. Create a workflow with an MRF submission step that includes approval fields
2. Submit a form with both approval and rejection scenarios
3. Verify that the workflow correctly follows the main path when approved
4. Verify that the workflow jumps to the rejection branch when rejected
5. Check executions page to confirm proper execution flow

Test worker logic
1. MRF steps cannot have more than 1 execution step
2. Check that `subtrigger` worker is picking up the job not `action` worker


## What's left
### Phase 4 (Edge cases)

- [ ]  In executions page, dont show error icon when status is undefined (waiting) for execution step
- [ ]  Handle errors (set status to failure and allow retry?)
- [ ]  On frontend pipe, show the proper number of steps instead of relying on positions
- [ ]  To discuss: What happens if an MRF step is added/modified/deleted on forms but not synced to Plumber

### Phase 5 (MRF Payload)

- [ ]  Get questions labels from webhook payload
- [ ]  Get attachments from webhook payload