### PR TITLE
Release v1.56.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30815,7 +30815,7 @@
       }
     },
     "packages/backend": {
-      "version": "1.56.4",
+      "version": "1.56.5",
       "dependencies": {
         "@apollo/server": "5.0.0",
         "@as-integrations/express4": "1.1.2",
@@ -30902,7 +30902,7 @@
       }
     },
     "packages/frontend": {
-      "version": "1.56.4",
+      "version": "1.56.5",
       "hasInstallScript": true,
       "dependencies": {
         "@datadog/browser-rum": "^5.2.0",
@@ -30990,7 +30990,7 @@
     },
     "packages/types": {
       "name": "@plumber/types",
-      "version": "1.56.4"
+      "version": "1.56.5"
     }
   }
 }

--- a/packages/backend/docker-compose.dev.yml
+++ b/packages/backend/docker-compose.dev.yml
@@ -42,7 +42,7 @@ services:
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TOKEN}
   minio:
-    image: 'bitnami/minio:2025.7.23'
+    image: 'minio/minio:RELEASE.2025-09-07T16-13-09Z'
     user: '0:0'
     ports:
       - '9000:9000'
@@ -59,7 +59,7 @@ services:
       interval: 1s
       retries: 5
   create-minio-buckets:
-    image: bitnami/minio-client:2025.7.21
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     volumes:
       - ../frontend/src/assets/plumber-logo.jpg:/assets/plumber-logo.jpg
     depends_on:

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -111,5 +111,5 @@
     "tsconfig-paths": "^4.2.0",
     "type-fest": "4.10.3"
   },
-  "version": "1.56.4"
+  "version": "1.56.5"
 }

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -22,6 +22,7 @@ const action: IRawAction = {
       description: 'Enter the case uuid you want to tag or untag',
       required: true,
       variables: true,
+      singleVariableSelection: true,
     },
     {
       label: 'Tag or untag',

--- a/packages/backend/src/apps/gathersg/common/fetch-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/common/fetch-case-fields.ts
@@ -25,7 +25,7 @@ export const fetchCaseFields = async ({
   caseTypeUuid: string
 }) => {
   const { data } = await $.http.get<GatherSGCaseFields>(
-    `/admin/caseTypes/:caseTypeUuid`,
+    `/caseTypes/:caseTypeUuid`,
     {
       urlPathParams: { caseTypeUuid },
     },

--- a/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
+++ b/packages/backend/src/apps/gathersg/dynamic-data/get-case-fields.ts
@@ -83,66 +83,40 @@ const dynamicData: IDynamicData = {
 
         return processCaseFields(filteredFields)
       } else if (caseUuid) {
+        // account that case uuid can be pasted in the frontend
+        // and may not always be a variable
+        let computedCaseUuid = caseUuid as string
+
         if (
           typeof caseUuid === 'string' &&
           caseUuid.match(`^${VARIABLE_REGEX.source}$`)
         ) {
           // if the case uuid is a variable, we need to compute the value
-          const computedCaseUuid = await getCaseUuidFromVariable($, caseUuid)
-
-          // use the case uuid to fetch the case data to derive the case type uuid
-          const { data: caseData } = await $.http.get<{ data: GatherSGCase }>(
-            `/cases/:caseUuid`,
-            {
-              urlPathParams: { caseUuid: computedCaseUuid as string },
-            },
-          )
-
-          const { filteredFields } = await fetchCaseFields({
+          computedCaseUuid = (await getCaseUuidFromVariable(
             $,
-            caseTypeUuid: caseData.data.type.uuid,
-          })
-          return processCaseFields(filteredFields)
+            caseUuid,
+          )) as string
         }
 
-        return {
-          data: [],
-        }
+        // use the case uuid to fetch the case data to derive the case type uuid
+        const { data: caseData } = await $.http.get<{ data: GatherSGCase }>(
+          `/cases/:caseUuid`,
+          {
+            urlPathParams: { caseUuid: computedCaseUuid },
+          },
+        )
+
+        const { filteredFields } = await fetchCaseFields({
+          $,
+          caseTypeUuid: caseData.data.type.uuid,
+        })
+        return processCaseFields(filteredFields)
       }
 
-      // BACKWARD COMPATIBILITY: this gets the case fields from the latest case in gathersg
-      const { data: searchResult } = await $.http.post<{
-        traceId: string
-        total: number
-        data: GatherSGCase[]
-      }>('/cases/search', {
-        page: 1,
-        size: 1,
-        sort: 'createdAt',
-        order: 'desc',
-      })
-
-      /**
-       * No cases found
-       */
-      if (searchResult.data.length === 0) {
-        return {
-          data: [],
-        }
-      }
-
-      const caseFields: object = searchResult.data[0].fields
-      const updatedCaseFields: { name: string; value: string }[] = []
-      for (const [field, value] of Object.entries(caseFields)) {
-        // Right now, we cannot support adding of array of objects as a value so just going to exclude to not cause errors unnecessarily
-        if (Array.isArray(value)) {
-          continue
-        }
-        updatedCaseFields.push({ name: field, value: field })
-      }
-
+      // fallback to return empty array
+      // user can still manually input the case field
       return {
-        data: updatedCaseFields,
+        data: [],
       }
     } catch (error) {
       if (error instanceof HttpError) {

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -4,6 +4,7 @@ import HttpError from '@/errors/http'
 import PartialStepError from '@/errors/partial-error'
 import RetriableError from '@/errors/retriable-error'
 import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
 
 import { PostmanEmailSendStatus } from './data-out-validator'
 import { createRequestBlacklistFormLink } from './send-blacklist-email'
@@ -102,6 +103,17 @@ export function throwPostmanStepError({
         executionId: $.execution.id,
         blacklistedRecipients,
       })
+
+      // log individual blacklisted recipients
+      blacklistedRecipients.forEach((recipient) => {
+        logger.info('Blacklisted recipient for postman email step', {
+          event: 'postman-step-blacklisted-recipient',
+          blacklistedEmail: recipient,
+          stepId: $.step.id,
+          executionId: $.execution.id,
+        })
+      })
+
       let solution = `The following email addresses have been blacklisted by Postman:
          \n${blacklistedRecipients
            .map((recipient) => `**${recipient}**`)

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,8 +1,4 @@
-import type {
-  IActionRunResult,
-  IJSONValue,
-  TestRunStepMetadata,
-} from '@plumber/types'
+import type { IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -26,20 +22,6 @@ import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 
 import getForEachMetadata from './helpers/get-for-each-metadata'
-
-// TODO on Oct: remove this once the logging is not needed anymore
-const SEPT_KEYWORD_REGEX = /Sept /
-
-function containsSeptKeyword(obj: IJSONValue): boolean {
-  if (typeof obj === 'string') {
-    return SEPT_KEYWORD_REGEX.test(obj)
-  }
-  if (typeof obj === 'object' && obj !== null) {
-    return SEPT_KEYWORD_REGEX.test(JSON.stringify(obj))
-  }
-
-  return false
-}
 
 type ProcessActionOptions = {
   flowId: string
@@ -226,17 +208,6 @@ export const processAction = async (options: ProcessActionOptions) => {
       key: step.key,
       metadata,
     })
-
-  // TODO on Oct: remove this once the logging is not needed anymore
-  if (!testRun && containsSeptKeyword($.step.parameters ?? {})) {
-    logger.info('Execution contains Sept keyword', {
-      event: 'execution-contains-sept-keyword',
-      stepId,
-      flowId,
-      executionId,
-      executionStepId: executionStep.id,
-    })
-  }
 
   let nextStep = null
   switch (runResult.nextStep?.command) {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.56.4",
+  "version": "1.56.5",
   "type": "module",
   "scripts": {
     "dev": "wait-on tcp:3000 && vite --host --force",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,5 +2,5 @@
   "name": "@plumber/types",
   "description": "Shared types for plumber",
   "types": "./index.d.ts",
-  "version": "1.56.4"
+  "version": "1.56.5"
 }


### PR DESCRIPTION
## Chores
- GatherSG API update and refactor
- Add logging for recognising unique blacklisted emails
- Modify minio and minio-client versions for dockerfile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **GatherSG updates**: Change endpoint to `GET /caseTypes/:caseTypeUuid` and improve `get-case-fields` to handle pasted `caseUuid` (compute if variable, fetch case to derive type, then fetch fields). Adds `singleVariableSelection: true` for `tagOrUntagCase` `caseUuid` argument.
> - **Postman logging**: Log each blacklisted recipient in `throw-errors.ts` for clearer auditability.
> - **Infra**: Switch dev `docker-compose` MinIO images to `minio/minio` and `minio/mc` releases.
> - **Backend cleanup**: Remove temporary "Sept" keyword logging and unused types in `services/action.ts`.
> - **Versioning**: Bump `backend`, `frontend`, and `@plumber/types` to `1.56.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93c6701b26b6f476b1ac8d08d4895b1c688a036d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->