### PR TITLE
chore: bump react-router-dom to v6.30.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9472,13 +9472,13 @@
       "peer": true
     },
     "node_modules/@remix-run/router": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
-      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -26605,33 +26605,33 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
-      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.6.2"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
-      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.6.2",
-        "react-router": "6.11.2"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -30984,7 +30984,7 @@
         "launchdarkly-react-client-sdk": "3.0.8",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-router-dom": "6.11.2",
+        "react-router-dom": "6.30.3",
         "zod": "3.22.4"
       }
     },

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -92,7 +92,7 @@
     "launchdarkly-react-client-sdk": "3.0.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-router-dom": "6.11.2",
+    "react-router-dom": "6.30.3",
     "zod": "3.22.4"
   },
   "browserslist": {


### PR DESCRIPTION
## Problem
https://github.com/remix-run/react-router/security/advisories/GHSA-9jcx-v3wj-wh4m
https://github.com/opengovsg/plumber/security/dependabot/116

Plumber does not seem to be affected as we only navigate/redirect to specified and trusted URLs, but bumping nontheless.

## Solution
Bump `react-router-dom` from `v6.11.2` to `v6.30.3`

## Tests
- [ ] Verify that navigation still works within Plumber
- [ ] Verify that navigation to external URLs still work