### PR TITLE
fix: flaky pipe transfer test

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -138,7 +138,10 @@ describe('updateFlowTransferStatus', () => {
       await Connection.query().insert({
         id: connectionId,
         key: 'slack',
-        data: 'secret',
+        data: AES.encrypt(
+          JSON.stringify({ token: 'secret' }),
+          appConfig.encryptionKey,
+        ).toString(),
         userId: owner.id,
       })
 


### PR DESCRIPTION
## Problem
Pipe transfer test fails from time to time due to:

1. In the test: A connection is created with data: 'secret' - this is unencrypted plain text
2. During `Connection.duplicate()`: The connection is queried from the database
3. After query hook: $afterFind() is called, which invokes `decryptData()`
4. Decryption fails: When AES.decrypt() tries to decrypt the plain text string 'secret', it returns an empty string or garbled data
5. JSON.parse() fails: When the decrypted result is empty or invalid, JSON.parse(decrypted) throws an error

## Solution
The test should insert encrypted data, not plain text.
```
data: AES.encrypt(
  JSON.stringify({ accessToken: 'test-token' }),
  appConfig.encryptionKey,
).toString(),
```

## Tests
- [ ] Test still works
