### PR TITLE
[MRF2-8] PLU-520: resolve PR comments

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -265,6 +265,9 @@ export async function decryptFormResponse(
 
     const internalId = data.submissionId
 
+    /**
+     * This means it's the first mrf step and is a new submission
+     */
     if (!data.workflowContent) {
       return { verified: true, internalId }
     }
@@ -273,17 +276,10 @@ export async function decryptFormResponse(
 
     const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
 
-    /**
-     * This means it's the first mrf step and is a new submission
-     */
-    if (!workflowContent) {
-      return { verified: true, internalId }
-    }
-
     return {
       verified: true,
       internalId,
-      isSubtrigger: workflowContent.workflowStep > 0 ? true : false,
+      isSubtrigger: workflowContent.workflowStep > 0,
       subtriggerData: {
         type: 'mrf',
         mrfStepId: workflowContent.workflow[workflowContent.workflowStep]?._id,

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -177,11 +177,6 @@ export default async (request: IRequest, response: Response) => {
 
     const { executionId, nextStep } = subTriggerResult
 
-    // For test runs, don't enqueue the next step
-    if (testRun) {
-      return response.sendStatus(200)
-    }
-
     // Enqueue the next step after the MRF action step
     if (nextStep) {
       const jobName = `${executionId}-${nextStep.id}`

--- a/packages/backend/src/graphql/mutations/request-otp.ts
+++ b/packages/backend/src/graphql/mutations/request-otp.ts
@@ -43,8 +43,11 @@ const requestOtp: MutationResolvers['requestOtp'] = async (_parent, params) => {
   })
 
   if (appConfig.isDev) {
-    // eslint-disable-next-line no-console
-    console.log(`OTP for ${email}: \x1b[45m${otp}\x1b[0m`)
+    // adding a delay so that the otp is printed after the dd trace log
+    setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.log(`OTP for ${email}: \x1b[45m${otp}\x1b[0m`)
+    }, 100)
   } else {
     // Send otp
     await sendEmail({

--- a/packages/backend/src/services/sub-trigger.ts
+++ b/packages/backend/src/services/sub-trigger.ts
@@ -51,6 +51,7 @@ export const processSubTrigger = async (
       event: 'sub-trigger-no-internal-id',
       flowId,
     })
+    return null
   }
   // Find the execution to attach to
   const execution = await Execution.query()
@@ -106,20 +107,41 @@ export const processSubTrigger = async (
     return null
   }
 
-  // Create the execution step for the MRF action step
-  const executionStep = await execution
-    .$relatedQuery('executionSteps')
-    .insertAndFetch({
+  const executionStep = await ExecutionStep.transaction(async (trx) => {
+    // Check if the execution step already exists
+    const existing = await ExecutionStep.query(trx)
+      .findOne({
+        execution_id: execution.id,
+        step_id: mrfStep.id,
+      })
+      .forUpdate() // Prevents race conditions
+
+    // if the execution step already exists, do not process again
+    if (existing) {
+      logger.warn({
+        event: 'sub-trigger-execution-step-already-exists',
+        executionId: execution.id,
+        stepId: mrfStep.id,
+      })
+      // we don't throw an error so formsg does not retry the webhook
+      return null
+    }
+    // Create the execution step for the MRF action step
+    return await ExecutionStep.query(trx).insertAndFetch({
       stepId: mrfStep.id,
+      executionId: execution.id,
       dataIn: mrfStep.parameters,
       dataOut: triggerItem.raw,
       appKey: mrfStep.appKey,
       key: mrfStep.key,
     })
+  })
 
   return {
     executionId: execution.id,
     executionStep,
+    // we enqueue the mrfStep itself, since the above logic does not actually process the mrfStep
+    // we need the mrf action to run to determine which is the actual next step to enqueue
     nextStep: mrfStep ?? null,
     shouldExecute: true,
   }

--- a/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
+++ b/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
@@ -88,7 +88,7 @@ export function makeSubTriggerWorker(
         app: await step.getApp(),
         step,
         connection: await step.$relatedQuery('connection'),
-        execution: execution,
+        execution,
         testRun: false,
         metadata: jobData.metadata ?? {},
       })

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -16,6 +16,7 @@ export const VISIBLE_VARIABLE_TYPES: TDataOutMetadatumType[] = [
   'text',
   'array',
   'tile_row_id',
+  'approval',
 ]
 
 export interface StepWithVariables {


### PR DESCRIPTION
| Comment | Link | Status |
| --- | --- | --- |
| Unreachable code, duplicate check | https://github.com/opengovsg/plumber/pull/1383#discussion_r2649190739 | ✅ |
| The ternary operator is unnecessary here | https://github.com/opengovsg/plumber/pull/1383#discussion_r2649190741 | ✅ |
| Approval variable not usable in subsequent steps | https://github.com/opengovsg/plumber/pull/1383#pullrequestreview-3629876865 | ✅ |
| [clarification] will the arrays/table field be automatically fixed once formsg returns the question? | https://github.com/opengovsg/plumber/pull/1383#pullrequestreview-3629876865 Status: mock data *should* show the table questions properly, but real submission will not | ❌ |
| Missing early return after logging the error when `internalId` is not found. | https://github.com/opengovsg/plumber/pull/1384#discussion_r2649190807 | ✅ |
| Duplicate check for `testRun` | https://github.com/opengovsg/plumber/pull/1384#discussion_r2649190816 | ✅ |
| [question]: do we have a way to prevent the same MRF step from executing again in the event of a duplicate webhook call from FormSG? | https://github.com/opengovsg/plumber/pull/1384#pullrequestreview-3630124909 Resolved by checking that execution step with step_id and execution_id does not already exists | ✅ |
| execution steps are 'out of order' when there is a delay, but the steps are executed correctly (edge case and its been slated for the next phase) | https://github.com/opengovsg/plumber/pull/1388#pullrequestreview-3633949500 |⏳  |
| do we want to show a different error icon for an MRF approval step that has been 'rejected'? (its not wrong per se since the step was 'rejected' and the execution is marked correctly as a 'success') | https://github.com/opengovsg/plumber/pull/1388#pullrequestreview-3633949500 |⏳ |