### PR TITLE
fix(gathersg): only encode field names with invalid chars

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -1,5 +1,7 @@
 import { IDataOutMetadata, IExecutionStep, IJSONArray } from '@plumber/types'
 
+import { decodeFieldName } from '../../common/utils'
+
 import { dataOutSchema } from './schema'
 
 async function getDataOutMetadata(
@@ -90,7 +92,7 @@ async function getDataOutMetadata(
     for (const hexKey of Object.keys(dataOut.fields)) {
       try {
         // decode hex key to get the original column name
-        const decodedLabel = Buffer.from(hexKey, 'hex').toString('utf-8')
+        const decodedLabel = decodeFieldName(hexKey)
         const fieldValue = dataOut.fields[hexKey]
 
         // check if the value is an array

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -3,6 +3,8 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 
+import { processFields } from '../../common/utils'
+
 import getDataOutMetadata from './get-data-out-metadata'
 
 const action: IRawAction = {
@@ -57,18 +59,14 @@ const action: IRawAction = {
       }
 
       // hex encode the field names
-      const hexEncodedFields: Record<string, any> = {}
-      for (const [key, value] of Object.entries(fields)) {
-        const hexKey = Buffer.from(key).toString('hex')
-        hexEncodedFields[hexKey] = value
-      }
+      const processedFields = processFields(fields)
 
       $.setActionItem({
         raw: {
           ...rawData,
           data: {
             ...rawData.data,
-            fields: hexEncodedFields,
+            fields: processedFields,
           },
         },
       })

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -14,3 +14,5 @@ export const UNSUPPORTED_FIELDS = [
 
 // Prefix for hex encoding field names that contain special characters
 export const HEX_ENCODED_FIELD_PREFIX = '__HEX_ENCODED__'
+// Regex to match invalid characters in field names that need to be hex encoded
+export const INVALID_CHAR_REGEX = /[^a-zA-Z0-9-_ ]/

--- a/packages/backend/src/apps/gathersg/common/utils.ts
+++ b/packages/backend/src/apps/gathersg/common/utils.ts
@@ -1,0 +1,31 @@
+import { HEX_ENCODED_FIELD_PREFIX, INVALID_CHAR_REGEX } from './constants'
+
+export function processFields(fields: Record<string, any>) {
+  const processedFields: Record<string, any> = {}
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (INVALID_CHAR_REGEX.test(key)) {
+      const hexKey = `${HEX_ENCODED_FIELD_PREFIX}${Buffer.from(key).toString(
+        'hex',
+      )}`
+      processedFields[hexKey] = value
+    } else {
+      processedFields[key] = value
+    }
+  }
+  return processedFields
+}
+
+export function decodeFieldName(key: string): string {
+  // decode hex encoded field name to get the original field name
+  let decodedLabel: string
+  if (key.startsWith(HEX_ENCODED_FIELD_PREFIX)) {
+    decodedLabel = Buffer.from(
+      key.replace(HEX_ENCODED_FIELD_PREFIX, ''),
+      'hex',
+    ).toString('utf-8')
+  } else {
+    decodedLabel = key
+  }
+  return decodedLabel
+}


### PR DESCRIPTION
## Refactor
* Existing `newInstantWorkflow` trigger only hex encodes fields that contain invalid characters.
* New `getCaseDetails` action should follow the same behaviour

## Why?
* Post this PR, there will be another PR to refactor to use common utility functions to process the fields and the data out metadata.

## How to test?
- [ ] Fields from GatherSG are still displayed correctly
- [ ] Fields with special characters are displayed with the correct labels and can be used in subsequent steps