### PR TITLE
chore: add minor changes to templates

### DIFF
--- a/packages/backend/src/db/storage/archived_templates/schedule-reminders.ts
+++ b/packages/backend/src/db/storage/archived_templates/schedule-reminders.ts
@@ -1,6 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
-import { USER_EMAIL_PLACEHOLDER } from './constants'
+import { USER_EMAIL_PLACEHOLDER } from '../constants'
 
 const SCHEDULE_REMINDERS_ID = '65e90f41-b605-4e83-bcd7-e4d2e349299d'
 

--- a/packages/backend/src/db/storage/for-each-reminder.ts
+++ b/packages/backend/src/db/storage/for-each-reminder.ts
@@ -4,7 +4,6 @@ import {
   CREATE_TEMPLATE_STEP_VARIABLE,
   TILE_COL_DATA_PLACEHOLDER,
   TILE_ID_PLACEHOLDER,
-  USER_EMAIL_PLACEHOLDER,
 } from './constants'
 
 const FOR_EACH_REMINDER_ID = 'b8dd6c22-3578-460d-89e2-e2062b3601f2'
@@ -58,10 +57,14 @@ export const FOR_EACH_REMINDER_TEMPLATE: ITemplate = {
       appKey: 'postman',
       eventKey: 'sendTransactionalEmail',
       parameters: {
-        body: '<p style="margin: 0">This is a gentle reminder for the upcoming event! </p>',
+        body: `<p style="margin: 0">Hi ${CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace with name from step 3',
+        )},\n This is a gentle reminder for the upcoming event! </p>`,
         subject: 'Event reminder',
         senderName: 'Event reminder',
-        destinationEmail: USER_EMAIL_PLACEHOLDER,
+        destinationEmail: CREATE_TEMPLATE_STEP_VARIABLE(
+          'Replace with email from step 3',
+        ),
       },
     },
     {
@@ -70,7 +73,7 @@ export const FOR_EACH_REMINDER_TEMPLATE: ITemplate = {
       eventKey: 'updateSingleRow',
       parameters: {
         tableId: TILE_ID_PLACEHOLDER,
-        rowId: CREATE_TEMPLATE_STEP_VARIABLE('Replace with Row ID from Step 3'),
+        rowId: CREATE_TEMPLATE_STEP_VARIABLE('Replace with Row ID from step 3'),
         rowData: [
           {
             columnId: TILE_COL_DATA_PLACEHOLDER('Reminder sent'),


### PR DESCRIPTION
## Details
- Was preparing for demo for scdf sharing, made some minor edits to the for-each template
- Archive the `schedule-reminders` template

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adjusts stored template definitions (placeholders/import paths and email text) with no changes to runtime logic or security-sensitive code.
> 
> **Overview**
> Moves the archived `schedule-reminders` template to import `USER_EMAIL_PLACEHOLDER` from the shared `../constants` module (fixing the import path after archiving).
> 
> Updates the `for-each-reminder` template’s email step to be personalized and data-driven: replaces the static body with a templated greeting using step-3 variables, replaces `destinationEmail` from `USER_EMAIL_PLACEHOLDER` to a step-3 email variable, and makes a minor copy tweak in the row-id placeholder label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 567f327749f644e632b01d3fb187af6d6e08efe5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->