### PR TITLE
[MRF2-9] PLU-520: Add support for FormSG v3 response processing with schema lookup

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -12,7 +12,11 @@ import logger from '@/helpers/logger'
 
 import { getSdk, parseFormEnv } from '../common/form-env'
 import convertTableAnswerArrayToTableObject from '../common/process-table-field'
-import type { FormsgPayloadWorkflowContent } from '../common/types'
+import type {
+  FormSchemaField,
+  FormsgPayloadWorkflowContent,
+} from '../common/types'
+import { fetchFormSchema } from '../triggers/new-submission/fetch-form-schema'
 import { NricFilter } from '../triggers/new-submission/index'
 
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
@@ -30,6 +34,126 @@ function processLocalAddress(answerArray: string[]): string[] {
   answer.splice(4, 1)
 
   return answer
+}
+
+async function processResponsesV3(
+  $: IGlobalVariable,
+  formId: string,
+  responsesV3: Record<string, any>,
+): Promise<FormField[]> {
+  const formSchemaFields: Record<string, FormSchemaField> = {}
+  try {
+    const formSchema = await fetchFormSchema($, formId)
+    if (formSchema?.form?.form_fields) {
+      for (const field of formSchema.form.form_fields) {
+        formSchemaFields[field._id] = field
+      }
+    }
+  } catch (e) {
+    logger.error('Unable to fetch form schema', {
+      event: 'formsg-unable-to-fetch-form-schema',
+      formId,
+      error: e,
+    })
+  }
+  const mappedResponses: FormField[] = []
+  let questionNumber = 0
+  for (const [key, value] of Object.entries(responsesV3)) {
+    questionNumber++
+    if (value.fieldType === 'table') {
+      let question =
+        formSchemaFields[key]?.title ?? `Question ${questionNumber}`
+      const answerArray = value.answer.map((row: Record<string, string>) => {
+        return Object.values(row)
+      })
+      // we follow the same format as the old table field title schema
+      if (formSchemaFields[key]?.columns) {
+        question += ` (${formSchemaFields[key]?.columns
+          ?.map((column) => column.title.replaceAll(',', ' '))
+          .join(', ')})`
+      }
+      // v3 return table answers in an array of objects (with key as column id )
+      // we need to map it back to a matrix
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'checkbox') {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // this is kinda weird, but it's the way formsg returns the answer for checkbox fields
+        answerArray: value.answer.value,
+      })
+      continue
+    }
+    /**
+     * Similary, formv3 responses put these fields in value.answer.value
+     */
+    if (['radio', 'email', 'mobile'].includes(value.fieldType)) {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answer: value.answer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'signature') {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // it comes in this form: { type: 'draw', value: [Array] } },
+        answerArray: value.answer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'address') {
+      //  answer: { addressSubFields: [Object] } },
+      const addressSubFields = value.answer.addressSubFields ?? {}
+      // we need to map to [block number, street name, building name, level number, unit number, postal code]
+      const answerArray = [
+        addressSubFields.blockNumber,
+        addressSubFields.streetName,
+        addressSubFields.buildingName,
+        addressSubFields.levelNumber,
+        addressSubFields.unitNumber,
+        addressSubFields.postalCode,
+      ]
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'attachment') {
+      // we dont extract attachment fields
+      continue
+    }
+    // catch-all
+    mappedResponses.push({
+      _id: key,
+      fieldType: value.fieldType,
+      // we fallback to Question # if the question is not found in the form schema
+      question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+      answer: value.answer,
+    })
+    continue
+  }
+  return mappedResponses
 }
 
 /**
@@ -104,28 +228,11 @@ export async function decryptFormResponse(
   if (version >= 3) {
     const decryptedSubmission = formSgSdk.cryptoV3.decrypt(formSecretKey, data)
     const responsesV3 = decryptedSubmission?.responses
-    const mappedResponses: FormField[] = []
-    let questionNumber = 1
-    for (const [key, value] of Object.entries(responsesV3)) {
-      if (typeof value.answer === 'string') {
-        mappedResponses.push({
-          _id: key,
-          fieldType: value.fieldType,
-          // this is temporary since formsg isnt returning us the question yet
-          question: `Question ${questionNumber}`,
-          answer: value.answer,
-        })
-      } else if (Array.isArray(value.answer)) {
-        mappedResponses.push({
-          _id: key,
-          fieldType: value.fieldType,
-          // this is temporary since formsg isnt returning us the question yet
-          question: `Question ${questionNumber}`,
-          answerArray: value.answer,
-        })
-      }
-      questionNumber++
-    }
+    const mappedResponses = await processResponsesV3(
+      $,
+      data.formId,
+      responsesV3,
+    )
     submission = {
       responses: mappedResponses,
       verified: decryptedSubmission?.verified,
@@ -148,7 +255,7 @@ export async function decryptFormResponse(
     for (const [index, formField] of submission.responses.entries()) {
       const { _id, ...rest } = formField
       // perform null character sanitisation for all answer fields so that it can be inserted into the DB
-      if (rest.answer) {
+      if (rest.answer && typeof rest.answer === 'string') {
         rest.answer = rest.answer.replaceAll('\u0000', '')
       }
 

--- a/packages/backend/src/apps/formsg/common/types.ts
+++ b/packages/backend/src/apps/formsg/common/types.ts
@@ -12,6 +12,19 @@ export const mrfWorkflowDataSchema = z.array(
 
 type IMrfWorkflow = z.infer<typeof mrfWorkflowDataSchema>
 
+export interface FormSchemaField {
+  _id: string
+  fieldType: string
+  title: string
+  // for table fields
+  columns?: Array<{
+    title: string
+    _id: string
+  }>
+  minimumRows?: number
+  maximumRows?: number
+}
+
 export interface FormSchema {
   form: {
     workflow?: IMrfWorkflow
@@ -20,7 +33,7 @@ export interface FormSchema {
     _id: string
     title: string
     status: string
-    form_fields: Array<Record<string, any>>
+    form_fields: Array<FormSchemaField>
     authType: string
     isSubmitterIdCollectionEnabled: boolean
     payments_field?: {

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -112,7 +112,11 @@ const trigger: IRawTrigger = {
 
     const formSchema = await fetchFormSchema($, formId)
 
-    if (formSchema.form.responseMode === 'multirespondent') {
+    if (
+      formSchema.form.responseMode === 'multirespondent' &&
+      // if the workflow is not set up, we treat it as a single respondent form
+      formSchema.form.workflow?.length > 0
+    ) {
       // Create MRF steps for multirespondent forms
       const mrfWorkflowData = await parseWorkflowData($, formSchema)
       try {


### PR DESCRIPTION
## Changes

### Fetch question title from schema

`decrypt-form-response.ts` now supports fetching form schema to get questions since it's no longer returned in the payload.

### Field Support - responses v3

Unless otherwise stated, the shape should be in 

```jsx
{ 
   "fieldType": "textField",
   "answer": "hello123"
}
```

| Field | Special shape | Supported? |
| --- | --- | --- |
| Short Answer |  | ✅ |
| Long Answer |  | ✅ |
| Radio | { answer: { value: …}} | ✅ |
| Checkbox | { answer: { value: [..,..] } } | ✅ |
| Dropdown |  | ✅ |
| Rating |  | ✅ |
| Yes/No |  | ✅ |
| Heading |  | ✅ |
| Paragraph |  | ✅ |
| Image |  | ✅ |
| Number |  | ✅ |
| Decimal |  | ✅ |
| Date |  | ✅ |
| Email | { answer: { value: …}} | ✅ |
| Mobile Number | { answer: { value: …}} | ✅ |
| Home Number |  | ✅ |
| Local Address | { answer: { blockNumber: … , streetName: ..}} | ✅ |
| NRIC/FIN |  | ✅ |
| UEN |  | ✅ |
| Country / Region |  | ✅ |
| Signature |  | ✅ |
| Table | { answer: [ { “col1_id”: value, “col2_id”: “value}, …} | ✅ |
| Attachment | {  answer: { hasBeenScanned: true, answer: 'all mrf fields.txt', md5Hash: '...'   } |  |