### PR TITLE
[MRF2-10] PLU-520:  use display position instead of db position

### DIFF
--- a/packages/frontend/src/components/Editor/components/DisabledFlowStep.tsx
+++ b/packages/frontend/src/components/Editor/components/DisabledFlowStep.tsx
@@ -5,7 +5,7 @@ import { Flex } from '@chakra-ui/react'
 import { TouchableTooltip } from '@opengovsg/design-system-react'
 
 import StepAppIcon from '@/components/FlowStep/components/StepAppIcon'
-import StepCaptionAndDemo from '@/components/FlowStep/components/StepCaptionAndDemo'
+import StepNameAndDemo from '@/components/FlowStep/components/StepNameAndDemo'
 import { flowStepStyles } from '@/components/FlowStep/styles'
 import { EditorContext } from '@/contexts/Editor'
 import { getFlowStepHeaderWidth } from '@/helpers/editor'
@@ -21,7 +21,7 @@ export function DisabledFlowStep(props: DisabledFlowStepProps) {
 
   const { isMobile, isDrawerOpen } = useContext(EditorContext)
 
-  const { app, caption } = useStepMetadata(step)
+  const { app, stepName } = useStepMetadata(step)
   const headerWidth = getFlowStepHeaderWidth(isDrawerOpen, isMobile, false)
 
   return (
@@ -45,7 +45,7 @@ export function DisabledFlowStep(props: DisabledFlowStepProps) {
             pointerEvents="none"
           >
             <StepAppIcon app={app} step={step} />
-            <StepCaptionAndDemo app={app} caption={caption} />
+            <StepNameAndDemo stepName={stepName} />
           </Flex>
         </Flex>
       </TouchableTooltip>

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -33,11 +33,7 @@ export default function StepHeader(props: StepHeaderProps) {
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
 
-  const {
-    defaultCaption,
-    position,
-    stepName: initialStepName,
-  } = useStepMetadata(step)
+  const { defaultStepName, displayPosition, stepName } = useStepMetadata(step)
 
   const handleClose = () => {
     if (shouldWarnOnLeave) {
@@ -70,13 +66,15 @@ export default function StepHeader(props: StepHeaderProps) {
   return (
     <Flex {...styles.stepHeader}>
       <Flex alignItems="center" maxW="100%">
-        {position && <Text whiteSpace="pre-wrap">{position}.&nbsp;</Text>}
+        {displayPosition && (
+          <Text whiteSpace="pre-wrap">{displayPosition}.&nbsp;</Text>
+        )}
         <EditableInput
           key={step.id}
-          value={initialStepName}
+          value={stepName}
           onSave={onSave}
           readOnly={isReadOnlyEditor}
-          placeholder={defaultCaption}
+          placeholder={defaultStepName}
           allowEmpty={true}
         />
       </Flex>

--- a/packages/frontend/src/components/ErrorFlowStepHeader/index.tsx
+++ b/packages/frontend/src/components/ErrorFlowStepHeader/index.tsx
@@ -52,7 +52,7 @@ export default function ErrorFlowStepHeader(props: ErrorFlowStepHeaderProps) {
       <DeleteStepButton
         isNested={isNested}
         step={step}
-        caption="this error step"
+        stepName="this error step"
       />
     </Flex>
   )

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -22,14 +22,15 @@ interface DeleteStepButtonProps {
   isNested?: boolean
   isDeletingStep?: boolean
   step: IStep
-  caption?: string
+  stepName: string
+  displayPosition: number
 }
 
 export default function DeleteStepButton(props: DeleteStepButtonProps) {
-  const { isNested, step, caption } = props
+  const { isNested, step, stepName, displayPosition } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
-  const customBody = caption
-    ? `Are you sure you want to delete step **${caption}**? You can't undo this action afterwards.`
+  const customBody = stepName
+    ? `Are you sure you want to delete step **${displayPosition}. ${stepName}**? You can't undo this action afterwards.`
     : undefined
   const {
     isOpen: isDialogOpen,

--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -23,14 +23,16 @@ interface DeleteStepButtonProps {
   isDeletingStep?: boolean
   step: IStep
   stepName: string
-  displayPosition: number
+  displayPosition?: number
 }
 
 export default function DeleteStepButton(props: DeleteStepButtonProps) {
   const { isNested, step, stepName, displayPosition } = props
   const cancelRef = useRef<HTMLButtonElement>(null)
   const customBody = stepName
-    ? `Are you sure you want to delete step **${displayPosition}. ${stepName}**? You can't undo this action afterwards.`
+    ? `Are you sure you want to delete step **${
+        displayPosition ? `${displayPosition}. ` : ''
+      }${stepName}**? You can't undo this action afterwards.`
     : undefined
   const {
     isOpen: isDialogOpen,

--- a/packages/frontend/src/components/FlowStep/components/StepNameAndDemo.tsx
+++ b/packages/frontend/src/components/FlowStep/components/StepNameAndDemo.tsx
@@ -1,14 +1,12 @@
-import { IApp } from '@plumber/types'
-
 import { Flex, Text } from '@chakra-ui/react'
 
-interface StepCaptionProps {
-  app?: IApp
-  caption: string
+interface StepNameAndDemoProps {
+  displayPosition?: number
+  stepName: string
 }
 
-export default function StepCaptionAndDemo(props: StepCaptionProps) {
-  const { caption } = props
+export default function StepNameAndDemo(props: StepNameAndDemoProps) {
+  const { stepName, displayPosition } = props
   return (
     <>
       <Flex direction="column" align="start" flex={1} flexShrink={1} minW={0}>
@@ -21,7 +19,8 @@ export default function StepCaptionAndDemo(props: StepCaptionProps) {
             textOverflow="ellipsis"
             maxW="100%"
           >
-            {caption}
+            {displayPosition ? `${displayPosition}. ` : ''}
+            {stepName}
           </Text>
         </Flex>
       </Flex>

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -23,7 +23,7 @@ import { DragHandle } from '../SortableList/components'
 import DeleteStepButton from './components/DeleteStepButton'
 import DuplicateStepButton from './components/DuplicateStepButton'
 import StepAppIcon from './components/StepAppIcon'
-import StepCaptionAndDemo from './components/StepCaptionAndDemo'
+import StepNameAndDemo from './components/StepNameAndDemo'
 import TestAgainInfobox from './components/TestAgainInfobox'
 import FlowStepWrapper from './FlowStepWrapper'
 import { flowStepStyles } from './styles'
@@ -70,7 +70,8 @@ export default function FlowStep(
   } = useContext(EditorContext)
   const {
     app,
-    caption,
+    stepName,
+    displayPosition,
     isCompleted,
     isTrigger,
     selectedActionOrTrigger,
@@ -242,7 +243,10 @@ export default function FlowStep(
                   app={app}
                   step={step}
                 />
-                <StepCaptionAndDemo app={app} caption={caption} />
+                <StepNameAndDemo
+                  displayPosition={displayPosition}
+                  stepName={stepName}
+                />
                 {isDeletable && (
                   <Flex gap={1} ml="auto">
                     {!isTrigger && (
@@ -251,7 +255,8 @@ export default function FlowStep(
                     <DeleteStepButton
                       isNested={isNested}
                       step={step}
-                      caption={caption}
+                      displayPosition={displayPosition}
+                      stepName={stepName}
                     />
                   </Flex>
                 )}

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -14,6 +14,7 @@ export type StepToDisplayContextValue = {
   groupedSteps: IStep[][]
   appsWithActions: IApp[]
   groupingActions: Set<string> | null
+  stepIdToOrder: Record<string, number>
 }
 
 export const StepsToDisplayContext = createContext<StepToDisplayContextValue>({
@@ -22,6 +23,7 @@ export const StepsToDisplayContext = createContext<StepToDisplayContextValue>({
   groupedSteps: [],
   appsWithActions: [],
   groupingActions: null,
+  stepIdToOrder: {},
 })
 
 interface StepExecutionsProviderProps {
@@ -83,6 +85,14 @@ export function StepsToDisplayProvider({
     ) as Set<string>
   }, [appsWithActions])
 
+  const stepIdToOrder = useMemo(() => {
+    const map: Record<string, number> = {}
+    stepsToDisplay.forEach((step, index) => {
+      map[step.id] = index + 1
+    })
+    return map
+  }, [stepsToDisplay])
+
   const [triggerStep, actionStepsBeforeGroup, groupedSteps] = useMemo(() => {
     if (!groupingActions) {
       return [null, [], []]
@@ -125,6 +135,7 @@ export function StepsToDisplayProvider({
         groupedSteps,
         appsWithActions,
         groupingActions,
+        stepIdToOrder,
       }}
     >
       {children}

--- a/packages/frontend/src/helpers/__tests__/getStepName.test.ts
+++ b/packages/frontend/src/helpers/__tests__/getStepName.test.ts
@@ -1,0 +1,175 @@
+import { IApp, IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import getStepName from '@/helpers/getStepName'
+
+function createMockStep(overrides: Partial<IStep> = {}): IStep {
+  return {
+    id: 'step-1',
+    flowId: 'flow-1',
+    iconUrl: '',
+    webhookUrl: '',
+    type: 'action',
+    status: 'incomplete',
+    position: 1,
+    parameters: {},
+    executionSteps: [],
+    config: {},
+    createdAt: '',
+    ...overrides,
+  } as IStep
+}
+
+function createMockApp(overrides: Partial<IApp> = {}): IApp {
+  return {
+    key: 'testApp',
+    name: 'Test App',
+    iconUrl: '',
+    primaryColor: '',
+    authDocUrl: '',
+    actions: [{ key: 'testAction', name: 'Test Action' }],
+    triggers: [{ key: 'testTrigger', name: 'Test Trigger' }],
+    ...overrides,
+  } as IApp
+}
+
+describe('getStepName', () => {
+  it('returns empty strings for undefined step', () => {
+    const result = getStepName([], undefined)
+    expect(result).toEqual({ stepName: '', defaultStepName: '' })
+  })
+
+  describe('IfThen steps', () => {
+    const ifThenStep = createMockStep({
+      appKey: 'toolbox',
+      key: 'ifThen',
+    })
+
+    it('returns custom name when config.stepName is set', () => {
+      const step = createMockStep({
+        ...ifThenStep,
+        config: { stepName: 'My Condition' },
+      })
+      const result = getStepName([], step)
+      expect(result).toEqual({
+        stepName: 'My Condition',
+        defaultStepName: 'Condition',
+      })
+    })
+
+    it('returns "Condition" when no custom name', () => {
+      const result = getStepName([], ifThenStep)
+      expect(result).toEqual({
+        stepName: 'Condition',
+        defaultStepName: 'Condition',
+      })
+    })
+  })
+
+  describe('ForEach steps', () => {
+    const forEachStep = createMockStep({
+      appKey: 'toolbox',
+      key: 'forEach',
+    })
+
+    it('returns custom name when config.stepName is set', () => {
+      const step = createMockStep({
+        ...forEachStep,
+        config: { stepName: 'Loop Items' },
+      })
+      const result = getStepName([], step)
+      expect(result).toEqual({
+        stepName: 'Loop Items',
+        defaultStepName: 'For each item',
+      })
+    })
+
+    it('returns "For each item" when no custom name', () => {
+      const result = getStepName([], forEachStep)
+      expect(result).toEqual({
+        stepName: 'For each item',
+        defaultStepName: 'For each item',
+      })
+    })
+  })
+
+  describe('regular action steps', () => {
+    const app = createMockApp()
+
+    it('returns custom stepName from config when set', () => {
+      const step = createMockStep({
+        appKey: 'testApp',
+        key: 'testAction',
+        config: { stepName: 'Send notification' },
+      })
+      const result = getStepName([app], step)
+      expect(result.stepName).toBe('Send notification')
+      expect(result.defaultStepName).toBe('Test Action')
+    })
+
+    it('returns action name as both stepName and defaultStepName when no custom name', () => {
+      const step = createMockStep({
+        appKey: 'testApp',
+        key: 'testAction',
+      })
+      const result = getStepName([app], step)
+      expect(result.stepName).toBe('Test Action')
+      expect(result.defaultStepName).toBe('Test Action')
+    })
+
+    it('falls back to app name when no matching action', () => {
+      const step = createMockStep({
+        appKey: 'testApp',
+        key: 'unknownAction',
+      })
+      const result = getStepName([app], step)
+      expect(result.stepName).toBe('Test App')
+      expect(result.defaultStepName).toBeUndefined()
+    })
+  })
+
+  describe('trigger steps', () => {
+    it('returns trigger name when matched', () => {
+      const app = createMockApp()
+      const step = createMockStep({
+        type: 'trigger',
+        appKey: 'testApp',
+        key: 'testTrigger',
+      })
+      const result = getStepName([app], step)
+      expect(result.stepName).toBe('Test Trigger')
+      expect(result.defaultStepName).toBe('Test Trigger')
+    })
+
+    it('returns fallback message when no app/action match', () => {
+      const step = createMockStep({
+        type: 'trigger',
+        appKey: 'unknownApp',
+        key: 'unknownTrigger',
+      })
+      const result = getStepName([], step)
+      expect(result.stepName).toBe('This step starts your pipe')
+    })
+  })
+
+  describe('fallbacks', () => {
+    it('capitalizes appKey when no other name is available', () => {
+      const step = createMockStep({
+        appKey: 'myapp',
+        key: 'unknownAction',
+      })
+      const result = getStepName([], step)
+      expect(result.stepName).toBe('Myapp')
+    })
+
+    it('returns empty string when no appKey and no matches', () => {
+      const step = createMockStep({
+        appKey: undefined,
+        key: undefined,
+      })
+      const result = getStepName([], step)
+      expect(result.stepName).toBe('')
+    })
+  })
+})

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -8,16 +8,15 @@ import {
 export default function getStepName(allApps: IApp[], step: IStep | undefined) {
   if (!step) {
     return {
-      caption: '',
-      defaultCaption: '',
+      stepName: '',
+      defaultStepName: '',
     }
   }
 
   const {
     appKey,
     key,
-    config: { stepName = undefined } = {},
-    position,
+    config: { stepName: customStepName = undefined } = {},
     type,
   } = step
 
@@ -37,44 +36,40 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
     (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === key,
   )
 
-  let caption = ''
-  let defaultCaption = selectedActionOrTrigger?.name
+  let stepName = ''
+  let defaultStepName = selectedActionOrTrigger?.name
 
   if (isIfThen) {
-    defaultCaption = 'Condition'
-    caption = stepName ? `${position}. ${stepName}` : `${position}. Condition`
+    defaultStepName = 'Condition'
+    stepName = customStepName ?? 'Condition'
     return {
-      caption,
-      defaultCaption,
+      stepName,
+      defaultStepName,
     }
   }
 
   if (isForEach) {
-    caption = stepName
-      ? `${position}. ${stepName}`
-      : `${position}. For each item`
+    stepName = customStepName ?? 'For each item'
     return {
-      caption,
-      defaultCaption,
+      stepName,
+      defaultStepName,
     }
   }
 
-  if (stepName) {
-    caption = `${position}. ${stepName}`
-  } else if (defaultCaption) {
-    caption = `${position ? `${position}. ` : ''}${defaultCaption}`
+  if (customStepName) {
+    stepName = customStepName
+  } else if (defaultStepName) {
+    stepName = defaultStepName
   } else if (app?.name) {
-    caption = `${position ? `${position}. ` : ''}${app.name}`
+    stepName = app.name
   } else if (isTrigger) {
-    caption = 'This step starts your pipe'
+    stepName = 'This step starts your pipe'
   }
 
   return {
-    caption:
-      caption ||
-      (appKey
-        ? `${position}. ${appKey.charAt(0).toUpperCase() + appKey.slice(1)}`
-        : ''),
-    defaultCaption,
+    stepName:
+      stepName ||
+      (appKey ? appKey.charAt(0).toUpperCase() + appKey.slice(1) : ''),
+    defaultStepName,
   }
 }

--- a/packages/frontend/src/helpers/getStepName.ts
+++ b/packages/frontend/src/helpers/getStepName.ts
@@ -13,16 +13,24 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
     }
   }
 
-  const {
-    appKey,
-    key,
-    config: { stepName: customStepName = undefined } = {},
-    type,
-  } = step
+  const { appKey, key, config: { stepName: customStepName } = {}, type } = step
+
+  // IfThen and ForEach are toolbox steps that don't need app lookup
+  if (checkIfThenStep(step)) {
+    return {
+      stepName: customStepName ?? 'Condition',
+      defaultStepName: 'Condition',
+    }
+  }
+
+  if (checkForEachStep(step)) {
+    return {
+      stepName: customStepName ?? 'For each item',
+      defaultStepName: 'For each item',
+    }
+  }
 
   const isTrigger = type === 'trigger'
-  const isIfThen = checkIfThenStep(step)
-  const isForEach = checkForEachStep(step)
 
   const apps: IApp[] = allApps?.filter((app: IApp) =>
     isTrigger ? !!app.triggers?.length : !!app.actions?.length,
@@ -36,40 +44,17 @@ export default function getStepName(allApps: IApp[], step: IStep | undefined) {
     (actionOrTrigger: IAction | ITrigger) => actionOrTrigger.key === key,
   )
 
-  let stepName = ''
-  let defaultStepName = selectedActionOrTrigger?.name
+  const defaultStepName = selectedActionOrTrigger?.name
 
-  if (isIfThen) {
-    defaultStepName = 'Condition'
-    stepName = customStepName ?? 'Condition'
-    return {
-      stepName,
-      defaultStepName,
-    }
-  }
-
-  if (isForEach) {
-    stepName = customStepName ?? 'For each item'
-    return {
-      stepName,
-      defaultStepName,
-    }
-  }
-
-  if (customStepName) {
-    stepName = customStepName
-  } else if (defaultStepName) {
-    stepName = defaultStepName
-  } else if (app?.name) {
-    stepName = app.name
-  } else if (isTrigger) {
-    stepName = 'This step starts your pipe'
-  }
+  const stepName =
+    customStepName ||
+    defaultStepName ||
+    app?.name ||
+    (isTrigger ? 'This step starts your pipe' : undefined) ||
+    (appKey ? appKey.charAt(0).toUpperCase() + appKey.slice(1) : '')
 
   return {
-    stepName:
-      stepName ||
-      (appKey ? appKey.charAt(0).toUpperCase() + appKey.slice(1) : ''),
+    stepName,
     defaultStepName,
   }
 }

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -208,7 +208,7 @@ export function extractVariables(
       })
       // sort by step position since the order of steps by createdAt is no longer preserved in single-step testing
       .sort((a, b) => a.step.position - b.step.position)
-      .map((executionStep: IExecutionStep) => {
+      .map((executionStep: IExecutionStep, index: number) => {
         const metadata = executionStep.dataOutMetadata ?? {}
         const variables = process(
           executionStep.stepId,
@@ -222,8 +222,8 @@ export function extractVariables(
         sortVariables(variables)
         return {
           id: executionStep.stepId,
-          // Need to add position here
-          name: stepName,
+
+          name: `${index + 1}. ${stepName}`,
           output: variables,
         }
       })

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -217,15 +217,13 @@ export function extractVariables(
           '',
         )
 
-        const { caption: name } = getStepName(
-          allApps || [],
-          executionStep?.step,
-        )
+        const { stepName } = getStepName(allApps || [], executionStep?.step)
         // sort variable by order key in-place
         sortVariables(variables)
         return {
           id: executionStep.stepId,
-          name,
+          // Need to add position here
+          name: stepName,
           output: variables,
         }
       })

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -11,6 +11,7 @@ import { useContext, useMemo } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import getStepName from '@/helpers/getStepName'
 import {
   isIfThenStep as checkIfThenStep,
@@ -20,14 +21,14 @@ import {
 interface UseStepMetadataResult {
   app: IApp | undefined
   selectedActionOrTrigger: IAction | ITrigger | undefined
-  caption: string
-  defaultCaption?: string
+  stepName: string
+  defaultStepName?: string
   hasConnection: boolean
   isCompleted: boolean
   isIfThenStep: boolean
   isTrigger: boolean
   position: number
-  stepName: string
+  displayPosition: number
   substeps: ISubstep[]
   shouldShowDragHandle?: boolean
   isDeletable: boolean
@@ -43,6 +44,7 @@ export function useStepMetadata(
   const { readOnly, isMobile, isDrawerOpen, allApps } =
     useContext(EditorContext)
   const { mrfSteps, approvalBranches } = useContext(MrfContext)
+  const { stepIdToOrder } = useContext(StepsToDisplayContext)
 
   const isCompleted = step?.status === 'completed'
   const isTrigger = step?.type === 'trigger'
@@ -67,7 +69,7 @@ export function useStepMetadata(
     [actionsOrTriggers, step?.key],
   )
 
-  const { caption, defaultCaption } = getStepName(allApps, step)
+  const { stepName, defaultStepName } = getStepName(allApps, step)
 
   const substeps = selectedActionOrTrigger?.substeps || []
   const hasConnection = substeps?.some(
@@ -165,19 +167,19 @@ export function useStepMetadata(
     isMrfStep,
   ])
 
+  const displayPosition = stepIdToOrder[step?.id ?? ''] ?? step?.position ?? 0
+
   return {
     app,
     selectedActionOrTrigger,
-    caption,
-    defaultCaption,
+    stepName,
+    defaultStepName,
     hasConnection,
     isCompleted,
     isIfThenStep,
     isTrigger,
     position: step?.position ?? 0,
-    stepName: step?.config?.stepName
-      ? step.config.stepName
-      : defaultCaption ?? '',
+    displayPosition,
     substeps,
     shouldShowDragHandle,
     isDeletable,


### PR DESCRIPTION
## Summary
- Separate step name from position number so they can be managed independently — `getStepName` no longer embeds position (e.g., `"3. Send email"`) and instead returns the raw stepName and `defaultStepName`
- Add `stepIdToOrder` mapping in `StepsToDisplayContext` that computes 1-based display order from the filtered visible steps, so position numbers are sequential even when MRF approval branches hide steps
- `useStepMetadata` exposes `displayPosition` (from the mapping) alongside the raw `position` (database value), letting components compose them as needed
- Rename `caption`/`defaultCaption` to `stepName`/`defaultStepName` across components for clarity
- Remove `StepCaptionAndDemo` in favor of `StepNameAndDemo` which receives `displayPosition` and `stepName` as separate props

## How to test
- [ ]  Verify step numbers display sequentially in the editor (no gaps when approval branches filter steps)
- [ ]  Verify step name editing in StepHeader works correctly (editable name separate from position number)
- [ ]  Verify delete confirmation dialog shows the correct step number and name
- [ ]  Verify nested steps (IfThen/ForEach branches) still display correctly