### PR TITLE
[AI-BUILDER-16] refactor: chat request handling and validation

### DIFF
--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -3,12 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getLdFlagValue: vi.fn(),
-  langfuseClient: {
-    prompt: {
-      get: vi.fn(),
-    },
-  },
-  startActiveObservation: vi.fn(),
+  getPrompt: vi.fn(),
+  getActiveTraceId: vi.fn(),
+  updateActiveObservation: vi.fn(),
+  updateActiveTrace: vi.fn(),
+  observe: vi.fn((fn) => fn),
   streamText: vi.fn(),
 }))
 
@@ -16,12 +15,15 @@ vi.mock('@/helpers/launch-darkly', () => ({
   getLdFlagValue: mocks.getLdFlagValue,
 }))
 
-vi.mock('@/helpers/langfuse', () => ({
-  langfuseClient: mocks.langfuseClient,
+vi.mock('@/helpers/pair/get-prompt', () => ({
+  getPrompt: mocks.getPrompt,
 }))
 
 vi.mock('@langfuse/tracing', () => ({
-  startActiveObservation: mocks.startActiveObservation,
+  observe: mocks.observe,
+  getActiveTraceId: mocks.getActiveTraceId,
+  updateActiveObservation: mocks.updateActiveObservation,
+  updateActiveTrace: mocks.updateActiveTrace,
 }))
 
 vi.mock('ai', () => ({
@@ -113,28 +115,17 @@ describe('Chat Route Handler', () => {
         chatPrompt: 'aids-chat-v0',
         version: 'production',
       })
-      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+      mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
+        toJSON: vi.fn(),
       })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
 
       // Mock streamText to return a mock result
       const mockResult = {
         pipeUIMessageStreamToResponse: vi.fn(),
       }
-      mocks.startActiveObservation.mockImplementationOnce(
-        async (name, callback) => {
-          const mockTrace = {
-            updateTrace: vi.fn(),
-            startObservation: vi.fn(() => ({
-              update: vi.fn(),
-            })),
-            update: vi.fn(),
-            traceId: 'test-trace-id',
-          }
-          return await callback(mockTrace)
-        },
-      )
-      mocks.streamText.mockResolvedValueOnce(mockResult)
+      mocks.streamText.mockReturnValueOnce(mockResult)
 
       await executeChatPostHandler(mockReq, mockRes)
 
@@ -171,27 +162,16 @@ describe('Chat Route Handler', () => {
         chatPrompt: 'aids-chat-v0',
         version: 'production',
       })
-      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+      mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
+        toJSON: vi.fn(),
       })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
 
       const mockResult = {
         pipeUIMessageStreamToResponse: vi.fn(),
       }
-      mocks.startActiveObservation.mockImplementationOnce(
-        async (name, callback) => {
-          const mockTrace = {
-            updateTrace: vi.fn(),
-            startObservation: vi.fn(() => ({
-              update: vi.fn(),
-            })),
-            update: vi.fn(),
-            traceId: 'test-trace-id',
-          }
-          return await callback(mockTrace)
-        },
-      )
-      mocks.streamText.mockResolvedValueOnce(mockResult)
+      mocks.streamText.mockReturnValueOnce(mockResult)
 
       await executeChatPostHandler(mockReq, mockRes)
 
@@ -217,7 +197,12 @@ describe('Chat Route Handler', () => {
 
       expect(mockRes.status).toHaveBeenCalledWith(400)
       expect(mockRes.json).toHaveBeenCalledWith({
-        error: 'Messages array is required',
+        error: 'Invalid request body',
+        details: expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Messages array must contain at least one message',
+          }),
+        ]),
       })
     })
   })
@@ -241,27 +226,16 @@ describe('Chat Route Handler', () => {
         chatPrompt: 'aids-chat-v0',
         version: 'production',
       })
-      mocks.langfuseClient.prompt.get.mockResolvedValueOnce({
+      mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
+        toJSON: vi.fn(),
       })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
 
       const mockResult = {
         pipeUIMessageStreamToResponse: vi.fn(),
       }
-      mocks.startActiveObservation.mockImplementationOnce(
-        async (name, callback) => {
-          const mockTrace = {
-            updateTrace: vi.fn(),
-            startObservation: vi.fn(() => ({
-              update: vi.fn(),
-            })),
-            update: vi.fn(),
-            traceId: 'test-trace-id',
-          }
-          return await callback(mockTrace)
-        },
-      )
-      mocks.streamText.mockResolvedValueOnce(mockResult)
+      mocks.streamText.mockReturnValueOnce(mockResult)
 
       await executeChatPostHandler(mockReq, mockRes)
 

--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -181,5 +181,13 @@ describe('chatRequestSchema', () => {
       })
       expect(result.success).toBe(true)
     })
+
+    it('should accept empty sessionId', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+        sessionId: '',
+      })
+      expect(result.success).toBe(true)
+    })
   })
 })

--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+
+import { chatRequestSchema } from '../../chat/schema'
+
+describe('chatRequestSchema', () => {
+  const validMessage = {
+    role: 'user' as const,
+    parts: [{ type: 'text' as const, text: 'Hello' }],
+  }
+
+  describe('valid requests', () => {
+    it('should accept a valid request with one message', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept a valid request with sessionId', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+        sessionId: '550e8400-e29b-41d4-a716-446655440000',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept assistant role', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [
+          { role: 'assistant', parts: [{ type: 'text', text: 'Hi' }] },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept step-start part type', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              { type: 'text', text: 'Working...' },
+            ],
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('messages validation', () => {
+    it('should reject empty messages array', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Messages array must contain at least one message',
+      )
+    })
+
+    it('should reject more than 50 messages', () => {
+      const messages = Array(51).fill(validMessage)
+      const result = chatRequestSchema.safeParse({ messages })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Cannot send more than 50 messages',
+      )
+    })
+  })
+
+  describe('role validation', () => {
+    it('should reject system role', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [
+          { role: 'system', parts: [{ type: 'text', text: 'You are...' }] },
+        ],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject invalid role', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'admin', parts: [{ type: 'text', text: 'Hello' }] }],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('parts validation', () => {
+    it('should reject empty parts array', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts: [] }],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Message must have at least one part',
+      )
+    })
+
+    it('should reject more than 10 parts', () => {
+      const parts = Array(11).fill({ type: 'text', text: 'part' })
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts }],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Message cannot have more than 10 parts',
+      )
+    })
+  })
+
+  describe('text validation', () => {
+    it('should reject empty text', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts: [{ type: 'text', text: '' }] }],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Text cannot be empty')
+    })
+
+    it('should reject whitespace-only text', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts: [{ type: 'text', text: '   ' }] }],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe('Text cannot be empty')
+    })
+
+    it('should reject text exceeding 10000 characters', () => {
+      const longText = 'a'.repeat(10001)
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts: [{ type: 'text', text: longText }] }],
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Text cannot exceed 10000 characters',
+      )
+    })
+
+    it('should accept text at exactly 10000 characters', () => {
+      const maxText = 'a'.repeat(10000)
+      const result = chatRequestSchema.safeParse({
+        messages: [{ role: 'user', parts: [{ type: 'text', text: maxText }] }],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should trim text before validation', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [
+          { role: 'user', parts: [{ type: 'text', text: '  hello  ' }] },
+        ],
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.messages[0].parts[0]).toEqual({
+          type: 'text',
+          text: 'hello',
+        })
+      }
+    })
+  })
+
+  describe('sessionId validation', () => {
+    it('should reject invalid UUID format', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+        sessionId: 'not-a-uuid',
+      })
+      expect(result.success).toBe(false)
+      expect(result.error?.issues[0].message).toBe(
+        'Session ID must be a valid UUID',
+      )
+    })
+
+    it('should accept missing sessionId', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+})

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -121,6 +121,12 @@ const handleChatStream = observe(
             traceId,
             error: errorMessage,
           })
+
+          updateActiveObservation({ output: errorMessage })
+          updateActiveTrace({ output: errorMessage })
+
+          // Manually end the span since we're streaming
+          trace.getActiveSpan()?.end()
         },
       })
 

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -1,4 +1,10 @@
-import { startActiveObservation } from '@langfuse/tracing'
+import {
+  getActiveTraceId,
+  observe,
+  updateActiveObservation,
+  updateActiveTrace,
+} from '@langfuse/tracing'
+import { trace } from '@opentelemetry/api'
 import { convertToModelMessages, smoothStream, streamText } from 'ai'
 import type { Response } from 'express'
 import { Router } from 'express'
@@ -11,164 +17,153 @@ import { model, MODEL_TYPE } from '@/helpers/pair'
 import { getPrompt } from '@/helpers/pair/get-prompt'
 import { AuthenticatedRequest } from '@/types/express/context'
 
-interface ChatRequest {
-  messages: Array<{
-    role: 'user' | 'assistant' | 'system'
-    parts: Array<{ type: 'text'; text: string }>
-  }>
-  /**
-   * sessionId: Datadog RUM session ID
-   */
-  sessionId?: string
-}
+import { chatRequestSchema } from './schema'
 
-async function handleChatStream(req: AuthenticatedRequest, res: Response) {
-  const context = req.context
-  const promptConfig = await getLdFlagValue(
-    AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
-    context.currentUser.email,
-    {
-      chatPrompt: 'ai-builder/chat',
-      version: 'production',
-    },
-  )
-
-  const { chatPrompt, version } = promptConfig
-
-  try {
-    const { messages: rawMessages, sessionId } = req.body as ChatRequest
-
-    if (
-      !rawMessages ||
-      !Array.isArray(rawMessages) ||
-      rawMessages.length === 0
-    ) {
-      res.status(400).json({ error: 'Messages array is required' })
-      return
-    }
-
-    // Convert UIMessages to ModelMessages
-    const messages = convertToModelMessages(rawMessages)
-
-    // Extract last user message text for tracking (simple text-only format)
-    const lastUserMessage = rawMessages
-      .filter((m) => m.role === 'user')
-      .map((m) => m.parts.find((p) => p.type === 'text')?.text || '')
-      .pop()
-
-    // Get the prompt from Langfuse
-    const prompt = await getPrompt(chatPrompt, version)
-
-    let traceId = ''
-
-    // Setup observation and stream using AI SDK
-    const result = await startActiveObservation(
-      'ai-chat-stream',
-      async (trace) => {
-        trace.updateTrace({
-          name: 'ai-chat-stream',
-          sessionId: sessionId || 'unknown',
-          userId: context.currentUser.email || 'anonymous',
-          input: { messages, prompt: lastUserMessage },
-          tags: ['ai-builder', 'chat', 'stream'],
-          environment: appConfig.appEnv,
-        })
-
-        const generation = trace.startObservation(
-          'ai-stream-generation',
-          {
-            model: MODEL_TYPE,
-            input: [{ role: 'system', content: prompt.prompt }, ...messages],
-          },
-          { asType: 'generation' },
-        )
-
-        generation.update({
-          prompt,
-        })
-
-        // Capture IDs for client
-        traceId = trace.traceId
-
-        return streamText({
-          model,
-          messages: [{ role: 'system', content: prompt.prompt }, ...messages],
-          experimental_transform: smoothStream({
-            chunking: 'word', // Stream word-by-word for typing effect
-          }),
-          experimental_telemetry: {
-            isEnabled: true,
-          },
-          onFinish: (event) => {
-            logger.info('Stream finished', {
-              traceId,
-              textLength: event.text.length,
-            })
-
-            trace.update({
-              output: { result: event.text },
-            })
-
-            generation
-              .update({
-                output: event.text,
-                usageDetails: {
-                  input: event.usage.inputTokens,
-                  output: event.usage.outputTokens,
-                  total: event.usage.totalTokens,
-                },
-              })
-              .end()
-          },
-          onError: (error) => {
-            const errorMessage =
-              error instanceof Error ? error.message : String(error)
-
-            logger.error('Error generating chat response', {
-              traceId,
-              error: errorMessage,
-            })
-
-            trace.update({
-              output: { error: errorMessage },
-              level: 'ERROR',
-            })
-
-            generation
-              .update({
-                output: errorMessage,
-                level: 'ERROR',
-              })
-              .end()
-          },
-        })
+const handleChatStream = observe(
+  async (req: AuthenticatedRequest, res: Response) => {
+    const context = req.context
+    const promptConfig = await getLdFlagValue(
+      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
+      context.currentUser.email,
+      {
+        chatPrompt: 'ai-builder/chat',
+        version: 'production',
       },
     )
 
-    // Pipe the UI message stream to Express response
-    // This uses the data stream protocol that DefaultChatTransport expects
-    result.pipeUIMessageStreamToResponse(res, {
-      messageMetadata: () => {
-        return {
-          traceId,
-          model: MODEL_TYPE,
-        }
-      },
-    })
-  } catch (error) {
-    logger.error('Error in chat stream', { error })
+    const { chatPrompt, version } = promptConfig
 
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error occurred'
+    try {
+      const validationResult = chatRequestSchema.safeParse(req.body)
 
-    // If headers haven't been sent yet, send error response
-    if (!res.headersSent) {
-      res.status(500).json({ error: errorMessage })
-    } else {
-      res.end()
+      if (!validationResult.success) {
+        res.status(400).json({
+          error: 'Invalid request body',
+          details: validationResult.error.errors,
+        })
+        return
+      }
+
+      const { messages: rawMessages, sessionId } = validationResult.data
+
+      // Convert UIMessages to ModelMessages
+      const messages = convertToModelMessages(
+        rawMessages as Parameters<typeof convertToModelMessages>[0],
+      )
+
+      // Get the prompt from Langfuse
+      const prompt = await getPrompt(chatPrompt, version)
+
+      // Manually capture serializable input for Langfuse
+      // joining with new line for readability on Langfuse
+      updateActiveObservation({
+        input: {
+          messages: rawMessages.map((m) => ({
+            role: m.role,
+            content: m.parts
+              .map((p) => {
+                if (p.type === 'text') {
+                  return p.text
+                }
+                return ''
+              })
+              .join('\n'),
+          })),
+        },
+      })
+
+      // Get the active trace ID from Langfuse context
+      const traceId = getActiveTraceId() || ''
+
+      logger.info('Starting AI chat stream', {
+        traceId,
+        sessionId,
+        userId: context.currentUser.email,
+        model: MODEL_TYPE,
+      })
+
+      const result = streamText({
+        model,
+        messages: [{ role: 'system', content: prompt.prompt }, ...messages],
+        experimental_transform: smoothStream({
+          chunking: 'word', // Stream word-by-word for typing effect
+        }),
+        experimental_telemetry: {
+          isEnabled: true,
+          metadata: {
+            name: 'ai-chat-stream',
+            sessionId: sessionId || 'unknown',
+            userId: context.currentUser.email,
+            environment: appConfig.appEnv,
+            promptName: chatPrompt,
+            promptVersion: version,
+            langfusePrompt: prompt.toJSON(),
+            tags: ['ai-builder', 'chat', 'stream'],
+          },
+        },
+        onFinish: (event) => {
+          logger.info('Stream finished', {
+            traceId,
+            textLength: event.text.length,
+          })
+
+          updateActiveObservation({ output: event })
+          updateActiveTrace({ output: event })
+
+          // Manually end the span since we're streaming
+          trace.getActiveSpan()?.end()
+        },
+        onError: (error) => {
+          const errorMessage =
+            error instanceof Error ? error.message : String(error)
+
+          logger.error('Error generating chat response', {
+            traceId,
+            error: errorMessage,
+          })
+        },
+      })
+
+      // Pipe the UI message stream to Express response
+      // This uses the data stream protocol that DefaultChatTransport expects
+      result.pipeUIMessageStreamToResponse(res, {
+        messageMetadata: () => {
+          return {
+            traceId,
+            model: MODEL_TYPE,
+          }
+        },
+      })
+    } catch (error) {
+      logger.error('Error in chat stream', { error })
+
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+
+      // If headers haven't been sent yet, send error response
+      if (!res.headersSent) {
+        res.status(500).json({ error: errorMessage })
+      } else {
+        res.end()
+      }
     }
-  }
-}
+  },
+  {
+    name: 'ai-chat-stream',
+    asType: 'generation',
+    /**
+     * do not capture the input and output automatically as they will
+     * throw an error about serializing the input and output
+     */
+    captureInput: false,
+    captureOutput: false,
+    /**
+     * do not automatically end so that we can update the trace and observation
+     * in the onFinish callback
+     */
+    endOnExit: false,
+  },
+)
 
 const router = Router()
 

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 // Limits to protect API and LLM costs
 const MAX_MESSAGES = 50
 const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
@@ -44,9 +47,15 @@ export const chatRequestSchema = z.object({
     .min(1, 'Messages array must contain at least one message')
     .max(MAX_MESSAGES, `Cannot send more than ${MAX_MESSAGES} messages`),
   /**
-   * Datadog RUM session IDs are always UUIDs
+   * Datadog RUM session UUID for debugging. Optional and allows empty string
+   * (e.g., in dev) to avoid failing the API since we already have the user's email.
    */
-  sessionId: z.string().uuid('Session ID must be a valid UUID').optional(),
+  sessionId: z
+    .string()
+    .refine((val) => val === '' || UUID_REGEX.test(val), {
+      message: 'Session ID must be a valid UUID',
+    })
+    .optional(),
 })
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+
+// Limits to protect API and LLM costs
+const MAX_MESSAGES = 50
+const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
+const MAX_PARTS_PER_MESSAGE = 10
+
+const messagePartSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    text: z
+      .string()
+      .trim()
+      .min(1, 'Text cannot be empty')
+      .max(MAX_TEXT_LENGTH, `Text cannot exceed ${MAX_TEXT_LENGTH} characters`),
+  }),
+  z.object({
+    type: z.literal('step-start'),
+  }),
+])
+
+const messageSchema = z.object({
+  /**
+   * NOTE: we do not accept a 'system' role as this is handled by the system prompt.
+   * It also serves as a basic form of protection against malicious input.
+   */
+  role: z.enum(['user', 'assistant']),
+  /**
+   * The parts of the message can be either text or a step start.
+   * If the type is a 'step-start', there will not be any other key.
+   */
+  parts: z
+    .array(messagePartSchema)
+    .min(1, 'Message must have at least one part')
+    .max(
+      MAX_PARTS_PER_MESSAGE,
+      `Message cannot have more than ${MAX_PARTS_PER_MESSAGE} parts`,
+    ),
+})
+
+export const chatRequestSchema = z.object({
+  messages: z
+    .array(messageSchema)
+    .min(1, 'Messages array must contain at least one message')
+    .max(MAX_MESSAGES, `Cannot send more than ${MAX_MESSAGES} messages`),
+  /**
+   * Datadog RUM session IDs are always UUIDs
+   */
+  sessionId: z.string().uuid('Session ID must be a valid UUID').optional(),
+})
+
+export type ChatRequest = z.infer<typeof chatRequestSchema>


### PR DESCRIPTION
### TL;DR

Refactored chat API endpoint with improved validation, error handling, and Langfuse tracing.

### What changed?

- Added proper request validation using Zod schema with detailed error messages
- Created a dedicated schema file (`schema.ts`) with validation rules for chat requests
- Implemented limits for messages, text length, and parts per message
- Improved Langfuse tracing by using the newer `observe` pattern instead of `startActiveObservation`
    - This allows us to get the Langfuse trace ID via `getTraceId`, while eliminating the need to manually create and update the generation.
- Simplified error handling and logging
- Updated tests to match the new implementation
- Added schema validation tests

### How to test?

1. Send valid chat requests to the API endpoint and verify successful responses
2. Test with invalid inputs (empty messages, too many messages, invalid text) and verify appropriate error responses
3. Check Langfuse traces to ensure proper telemetry is being captured

### Why make this change?

This refactoring improves the robustness of the chat API by:

- Preventing malformed requests from reaching the LLM
- Providing clearer error messages to clients
- Limiting resource usage to prevent abuse
- Improving observability through better tracing
- Making the code more maintainable with a cleaner structure

The changes also align with modern Langfuse tracing patterns and provide better protection against potential misuse of the API.