### PR TITLE
fix: dont use lodash.get since its not installed

### DIFF
--- a/packages/frontend/src/components/VariablesList/schema.ts
+++ b/packages/frontend/src/components/VariablesList/schema.ts
@@ -1,6 +1,6 @@
 import { IJSONObject } from '@plumber/types'
 
-import get from 'lodash.get'
+import get from 'lodash/get'
 import { z } from 'zod'
 
 const RowDataSchema = z.object({


### PR DESCRIPTION
### TL;DR

Plumber Admin build on GH actions erroring out

### What changed?

Changed the import statement for the `get` function from `lodash.get` to `lodash/get` in the VariablesList schema file. This modifies the import to use the path-based syntax rather than the package-based syntax.
