### PR TITLE
[VULN-3] chore: bump axios to 1.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10375,14 +10375,30 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -25647,7 +25663,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25890,7 +25906,7 @@
         "@taskforcesh/bullmq-pro": "7.7.1",
         "ajv-formats": "^2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.12.1",
+        "axios": "1.13.5",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.7",
         "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "overrides": {
-    "axios": "1.12.1",
+    "axios": "1.13.5",
     "graphql-rate-limit": {
       "@graphql-tools/utils": {
         "graphql": "16.11.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@taskforcesh/bullmq-pro": "7.7.1",
     "ajv-formats": "^2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.12.1",
+    "axios": "1.13.5",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.7",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
### TL;DR

Upgraded axios from version `1.12.1` to `1.13.5`

### Tests

1. Run `npm install` to update dependencies
2. Verify that the application functions correctly with network requests
3. Test any features that rely on axios for HTTP requests
4. Ensure no regressions in API calls or data fetching

### Why make this change?

- https://github.com/opengovsg/plumber/security/dependabot/133
- https://github.com/opengovsg/plumber/security/dependabot/134