### PR TITLE
[VULN-4]: chore: bump testcontainers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5233,18 +5233,44 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
         "node": ">=12.10.0"
       }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.15",
@@ -7769,13 +7795,13 @@
       }
     },
     "node_modules/@testcontainers/postgresql": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-11.5.1.tgz",
-      "integrity": "sha512-6P1QYIKRkktSVwTuwU0Pke5WbXTkvpLleyQcgknJPbZwhaIsCrhnbZlVzj2g/e+Nf9Lmdy1F2OAai+vUrBq0AQ==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/postgresql/-/postgresql-11.11.0.tgz",
+      "integrity": "sha512-Og64I/h5LKLVvUTkAcLeTXfFcMhh3dCHCypN3Uzd+tQMd70SpCfQ0LCP9v/U+MS7JBRzU9EmqhUFkTOm4hyZWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "testcontainers": "^11.5.1"
+        "testcontainers": "^11.11.0"
       }
     },
     "node_modules/@theguild/federation-composition": {
@@ -8485,9 +8511,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.43",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.43.tgz",
-      "integrity": "sha512-YCi0aKKpKeC9dhKTbuglvsWDnAyuIITd6CCJSTKiAdbDzPH4RWu0P9IK2XkJHdyplH6mzYtDYO+gB06JlzcPxg==",
+      "version": "3.3.47",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
+      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8900,9 +8926,9 @@
       }
     },
     "node_modules/@types/ssh2-streams": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.12.tgz",
-      "integrity": "sha512-Sy8tpEmCce4Tq0oSOYdfqaBpA3hDM8SoxoFh5vzFsu2oL+znzGz8oVWW7xb4K920yYMUY+PIG31qZnFMfPWNCg==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8910,9 +8936,9 @@
       }
     },
     "node_modules/@types/ssh2/node_modules/@types/node": {
-      "version": "18.19.123",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.123.tgz",
-      "integrity": "sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9962,9 +9988,10 @@
       }
     },
     "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10401,13 +10428,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -10469,24 +10489,33 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
     },
     "node_modules/bare-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.2.tgz",
-      "integrity": "sha512-5vn+bdnlCYMwETIm1FqQXDP6TYPbxr2uJd88ve40kr4oPbiTZJVrTNzqA3/4sfWZeWKuQR/RkboBt7qEEDtfMA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+      "integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -10543,6 +10572,17 @@
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base16": {
@@ -10938,9 +10978,9 @@
       "license": "MIT"
     },
     "node_modules/buildcheck": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
-      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -12810,9 +12850,9 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.0.tgz",
-      "integrity": "sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.1.tgz",
+      "integrity": "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12839,9 +12879,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.7.tgz",
-      "integrity": "sha512-R+rgrSRTRdU5mH14PZTCPZtW/zw3HDWNTS/1ZAQpL/5Upe/ye5K9WQkIysu4wBoiMwKynsz0a8qWuGsHgEvSAA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
+      "integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12850,7 +12890,7 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.6",
         "protobufjs": "^7.3.2",
-        "tar-fs": "~2.1.2",
+        "tar-fs": "^2.1.4",
         "uuid": "^10.0.0"
       },
       "engines": {
@@ -12895,9 +12935,9 @@
       }
     },
     "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14115,6 +14155,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/expect-type": {
@@ -19384,9 +19434,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -23184,17 +23234,15 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -23534,9 +23582,9 @@
       "peer": true
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23558,6 +23606,21 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/tarn": {
@@ -23632,27 +23695,45 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.5.1.tgz",
-      "integrity": "sha512-YSSP4lSJB8498zTeu4HYTZYgSky54ozBmIDdC8PFU5inj+vBo5hPpilhcYTgmsqsYjrXOJGV7jl0MWByS7GwuA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.11.0.tgz",
+      "integrity": "sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.42",
+        "@types/dockerode": "^3.3.47",
         "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
-        "debug": "^4.4.1",
-        "docker-compose": "^1.2.0",
-        "dockerode": "^4.0.7",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.3.0",
+        "dockerode": "^4.0.9",
         "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
         "properties-reader": "^2.3.0",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.1.0",
-        "tmp": "^0.2.4",
-        "undici": "^7.13.0"
+        "tar-fs": "^3.1.1",
+        "tmp": "^0.2.5",
+        "undici": "^7.16.0"
+      }
+    },
+    "node_modules/testcontainers/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-decoder": {
@@ -23663,6 +23744,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
+      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/text-hex": {
@@ -24421,9 +24517,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.15.0.tgz",
-      "integrity": "sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
+      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -25953,7 +26049,7 @@
       },
       "devDependencies": {
         "@swc/core": "^1.13.5",
-        "@testcontainers/postgresql": "^11.0.3",
+        "@testcontainers/postgresql": "^11.10.0",
         "@types/bcrypt": "^5.0.0",
         "@types/big.js": "6.2.2",
         "@types/bull": "^3.15.8",
@@ -25969,7 +26065,7 @@
         "@types/multer": "1.4.12",
         "@types/pg": "^8.6.1",
         "nodemon": "^3.1.10",
-        "testcontainers": "^11.0.3",
+        "testcontainers": "^11.10.0",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "type-fest": "4.10.3"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@swc/core": "^1.13.5",
-    "@testcontainers/postgresql": "^11.0.3",
+    "@testcontainers/postgresql": "^11.10.0",
     "@types/bcrypt": "^5.0.0",
     "@types/big.js": "6.2.2",
     "@types/bull": "^3.15.8",
@@ -106,7 +106,7 @@
     "@types/multer": "1.4.12",
     "@types/pg": "^8.6.1",
     "nodemon": "^3.1.10",
-    "testcontainers": "^11.0.3",
+    "testcontainers": "^11.10.0",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "type-fest": "4.10.3"


### PR DESCRIPTION
### TL;DR

Updated testcontainers and related dependencies to newer versions.

### What changed?

- Updated `@testcontainers/postgresql` from 11.5.1 to 11.11.0
- Updated `testcontainers` from 11.5.1 to 11.11.0

### How to test?

1. Run the test suite to ensure all tests using testcontainers still pass
2. Verify that PostgreSQL container tests initialize and run correctly
3. Check that any Docker-related functionality works as expected