### PR TITLE
[MRF2-13] PLU-520: added attachment support

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3.test.ts
@@ -1,0 +1,175 @@
+import { IGlobalVariable, IRequest } from '@plumber/types'
+
+import { FormField } from '@opengovsg/formsg-sdk/dist/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  decryptFormAttachmentsV3,
+  decryptSubmissionSecretKey,
+} from '../../auth/decrypt-form-attachments-v3'
+import { getSdk } from '../../common/form-env'
+
+const mocks = vi.hoisted(() => {
+  return {
+    consoleError: vi.fn(),
+    consoleWarn: vi.fn(),
+    axiosGet: vi.fn(async () => ({
+      data: {
+        encryptedFile: {
+          submissionPublicKey: 'Xva5B9ruxzidbHpucRGizb6iRnWLnoypkOdBn3scWDY=',
+          nonce: '0hOPZZ8gpM+beUk/X/PjbFTThYyOffyv',
+          binary:
+            'I50wqO1h6fc2zQszCys7/nFmHUKvxEXtTAB7Wrc3XmjkTOWUc854EaEZzSS2gzuIG6h3YSz48cGtX4t9u1IVjs5G3zJZqjXex0N538WME52oIAIk7J8c9Q==',
+        },
+      },
+    })),
+  }
+})
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.consoleError,
+    warn: mocks.consoleWarn,
+  },
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: mocks.axiosGet,
+  },
+}))
+
+const formSgSdk = getSdk('prod')
+
+// test form secret key - OK to commit
+const FORM_SECRET_KEY = 'Lrw8HdnQwiCE5umnmrIkhff60WKmMGXrCgtLXgdZtzs='
+const FORM_FIELDS: FormField[] = [
+  {
+    _id: '68f7ac5bd9b9803e70a2db61',
+    fieldType: 'attachment',
+    question: 'Attachment 1',
+    answer: 'randomFile.txt',
+  },
+  {
+    _id: '674321674321674321674321',
+    fieldType: 'textfield',
+    question: 'Name',
+    answer: 'John Doe',
+  },
+  {
+    _id: '69958687d939fdde2fec5e49',
+    fieldType: 'attachment',
+    question: 'Attachment 2',
+    answer: 'randomFile2.txt',
+  },
+]
+
+describe('decrypt form attachments v3', () => {
+  let $: IGlobalVariable
+  let decryptedSubmissionSecretKey: string | null
+  beforeEach(() => {
+    $ = {
+      request: {
+        body: {
+          data: {
+            formId: '6878bfa1f4c0afec0b00d66c',
+            submissionId: '699586d9ea08d91cf723aec2',
+            encryptedContent:
+              'LgJWBkp6MVo432cAMvAcRlPnhtggPJerpXiY3oteQGQ=;YpmLWI3Rv5GWLofAHm0UlrXu6MdckhXh:r+8dQYY6r8f/UUy6mDrzS/Ou5jVAWtnprn0quwbBdeMbG66r3/SOZI+cjoZS9J5XTVcQJyIUFpVhXvgURWeEV7Am8WBUREu9ssETGtjQHgqtscgL/KYydWYXoyPvgtyf/jU6x3TxUYYGfzRGmDAKfzojQkje12bY3vsfuKe1mFpZbSnF+tHBZYRTJM9PTJcRjXOYYNQ5q5nMDd6OahATt/rn9GGdw+aOpAS8HJkOiLAHV2gS0LE/4UB0RXmXbA6fOv/GGrRDFYPMpd8xdNX4TMLp4mrS6vG+lK5P6a769qIOadRL9AREY+yNXjGEbhRi8bquUewnRmpVUBVB/bYzA15c80Ve+lOrwKSmqeQoiH7L7kf1Q6p6ND5Rh7jQ4STs2oAF2HYQAiAW7MHPodQFh3tFj7lxYZqS5tkkeWdbZydkCdT9Y8GwNvlOsyl5UuXmqc9RntTGTuBvBsxu52+iyCg=',
+            encryptedSubmissionSecretKey:
+              'EC9w/sRlgNbc2RyiYS2yYJdrk5HLWwFHO/XUBgoHvQI=;/ydnXQTWCaMhfM0pBWy/33YwFb6dw1Xa:R4x79/GvAg0Gx7xs8dqv/McEErHH+peP43UJru+m+e3UUfqNKG2OpxBnOC14Pq4P',
+            version: 3,
+            created: '2026-02-18T09:31:05.563Z',
+            attachmentDownloadUrls: {
+              '68f7ac5bd9b9803e70a2db61':
+                'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/6878bfa1f4c0afec0b00d66c/3717b2ffb126e8d78c78acd3c0742939f03ea0e3/123',
+              '69958687d939fdde2fec5e49':
+                'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/6878bfa1f4c0afec0b00d66c/60cc89ff7553e293f02daea73243208fa9fba137/345',
+            },
+          },
+        },
+      } as IRequest,
+    } as IGlobalVariable
+    decryptedSubmissionSecretKey = decryptSubmissionSecretKey(
+      FORM_SECRET_KEY,
+      $.request.body.data.encryptedSubmissionSecretKey,
+    )
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('decrypt submission secret key', () => {
+    it('should return null when encrypted submission secret key is invalid', () => {
+      const result = decryptSubmissionSecretKey(FORM_SECRET_KEY, 'invalid')
+      expect(result).toBeNull()
+    })
+    it('should return the decrypted submission secret key', () => {
+      const result = decryptSubmissionSecretKey(
+        FORM_SECRET_KEY,
+        $.request.body.data.encryptedSubmissionSecretKey,
+      )
+      expect(result).toBe('UEHWr01L6Fura3bGYxCH22w9kocYhxOcfUuznnCL21I=')
+    })
+  })
+
+  describe('decrypt attachments v3', () => {
+    it('should return decrypted attachments when attachmentDownloadUrls is present', async () => {
+      const result = await decryptFormAttachmentsV3(
+        formSgSdk,
+        decryptedSubmissionSecretKey,
+        $.request.body.data.attachmentDownloadUrls,
+        FORM_FIELDS,
+      )
+      expect(Object.keys(result)).toHaveLength(2)
+      expect(result['68f7ac5bd9b9803e70a2db61']).toHaveProperty('filename')
+      expect(result['68f7ac5bd9b9803e70a2db61']).toHaveProperty('content')
+      expect(result['69958687d939fdde2fec5e49']).toHaveProperty('filename')
+      expect(result['69958687d939fdde2fec5e49']).toHaveProperty('content')
+    })
+
+    it('should return empty object when attachmentDownloadUrls is empty', async () => {
+      const result = await decryptFormAttachmentsV3(
+        formSgSdk,
+        decryptedSubmissionSecretKey,
+        {},
+        FORM_FIELDS,
+      )
+      expect(result).toBeDefined()
+    })
+
+    it('should return all attachments even if form fields are not present', async () => {
+      const result = await decryptFormAttachmentsV3(
+        formSgSdk,
+        decryptedSubmissionSecretKey,
+        $.request.body.data.attachmentDownloadUrls,
+        [],
+      )
+      expect(Object.keys(result)).toHaveLength(2)
+    })
+
+    it('should throw an error if decryption fails', async () => {
+      await expect(
+        decryptFormAttachmentsV3(
+          formSgSdk,
+          'Lrw9HdnQwiCE5umnmrIkhff60WKmMGXrCgtLXgdZtzs=', // invalid
+          $.request.body.data.attachmentDownloadUrls,
+          FORM_FIELDS,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should throw an error if downloading fails', async () => {
+      mocks.axiosGet.mockRejectedValueOnce(new Error('Download failed'))
+      await expect(
+        decryptFormAttachmentsV3(
+          formSgSdk,
+          decryptedSubmissionSecretKey,
+          $.request.body.data.attachmentDownloadUrls,
+          FORM_FIELDS,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -1,0 +1,387 @@
+import { IGlobalVariable, IRequest } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import apps from '@/apps'
+
+import { decryptFormResponse } from '../../auth/decrypt-form-response'
+import type { FormsgPayloadWorkflowContent } from '../../common/types'
+
+// mocks hoisted here so that they can be used in import mocks
+const mocks = vi.hoisted(() => {
+  const webhooksAuthenticate = vi.fn()
+  const cryptoV3Decrypt = vi.fn()
+  const mockSdk = {
+    webhooks: {
+      authenticate: webhooksAuthenticate,
+    },
+    cryptoV3: {
+      decrypt: cryptoV3Decrypt,
+    },
+  }
+
+  return {
+    webhooksAuthenticate,
+    cryptoV3Decrypt,
+    consoleError: vi.fn(),
+    consoleWarn: vi.fn(),
+    getSdk: vi.fn(() => mockSdk),
+    parseFormEnv: vi.fn(),
+    storeAttachmentInS3: vi.fn(() => 'mock-s3-id'),
+    fetchFormSchema: vi.fn(() => null),
+    decryptSubmissionSecretKey: vi.fn(() => 'mock-secret-key'),
+    decryptFormAttachmentsV3: vi.fn(() => ({})),
+  }
+})
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.consoleError,
+    warn: mocks.consoleWarn,
+  },
+}))
+
+vi.mock('../../common/form-env', () => ({
+  getSdk: mocks.getSdk,
+  parseFormEnv: mocks.parseFormEnv,
+}))
+
+vi.mock('../../auth/helpers/store-attachment-in-s3', () => ({
+  default: mocks.storeAttachmentInS3,
+}))
+
+vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
+  fetchFormSchema: mocks.fetchFormSchema,
+}))
+
+vi.mock('../../auth/decrypt-form-attachments-v3', () => ({
+  decryptSubmissionSecretKey: mocks.decryptSubmissionSecretKey,
+  decryptFormAttachmentsV3: mocks.decryptFormAttachmentsV3,
+}))
+
+const MOCK_WORKFLOW: FormsgPayloadWorkflowContent['workflow'] = [
+  {
+    _id: 'step-0-id',
+    edit: ['field1'],
+    step_name: 'Step 1',
+    workflow_type: 'static',
+  },
+  {
+    _id: 'step-1-id',
+    edit: ['field2'],
+    step_name: 'Step 2',
+    workflow_type: 'static',
+  },
+  {
+    _id: 'step-2-id',
+    edit: ['field3'],
+    step_name: 'Step 3',
+    workflow_type: 'static',
+  },
+]
+
+function makeWorkflowContent(
+  workflowStep: number,
+): FormsgPayloadWorkflowContent {
+  return {
+    workflow: MOCK_WORKFLOW,
+    workflowStep,
+    submittedSteps: [
+      {
+        isApproval: false,
+        submittedAt: '2023-07-06T10:26:27.505Z',
+      },
+    ],
+  }
+}
+
+describe('decrypt form response - MRF specific', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      request: {
+        query: {
+          formId: 'something',
+        } as Record<string, string>,
+        headers: {
+          'x-formsg-signature': 'signature',
+        } as Record<string, string>,
+        body: {
+          data: {
+            submissionId: 'submissionId',
+            formId: 'formId123',
+            created: '2023-07-06T10:26:27.505Z',
+            version: 3,
+          },
+        },
+      } as IRequest,
+      auth: {
+        set: vi.fn(),
+        data: {
+          formId: 'something',
+          privateKey: 'secretkey',
+        },
+      },
+      step: {
+        id: '123',
+        appKey: apps.formsg.key,
+        position: 0,
+        parameters: {
+          nricFilter: undefined,
+        },
+      },
+      flow: {
+        id: 'flowid',
+        userId: 'userid',
+        hasFileProcessingActions: false,
+        name: 'test flow',
+      },
+      user: {
+        id: 'userid',
+        email: 'test-email@open.gov.sg',
+        createdAt: `${new Date().getTime()}`,
+        updatedAt: `${new Date().getTime()}`,
+      },
+      app: apps.formsg,
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('v3 decryption path', () => {
+    it('should call cryptoV3.decrypt and processResponsesV3 for v3 submissions', async () => {
+      const v3Responses = {
+        field1: {
+          fieldType: 'textfield',
+          answer: 'hello',
+        },
+      }
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: v3Responses,
+        verified: undefined,
+      })
+      const bodyData = $.request.body.data
+      await decryptFormResponse($)
+
+      expect(mocks.cryptoV3Decrypt).toHaveBeenCalledWith('secretkey', bodyData)
+      // processResponsesV3 calls fetchFormSchema internally
+      expect(mocks.fetchFormSchema).toHaveBeenCalledWith($, 'formId123')
+    })
+
+    it('should call decryptSubmissionSecretKey and decryptFormAttachmentsV3 for v3 attachments', async () => {
+      $.flow.hasFileProcessingActions = true
+      $.request.body.data.attachmentDownloadUrls = {
+        attachField1:
+          'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
+      }
+      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          attachField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+        attachField1: {
+          filename: 'myfile.pdf',
+          content: Buffer.from('file content'),
+        },
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.decryptSubmissionSecretKey).toHaveBeenCalledWith(
+        'secretkey',
+        'encrypted-key',
+      )
+      expect(mocks.decryptFormAttachmentsV3).toHaveBeenCalledWith(
+        mocks.getSdk(),
+        'mock-secret-key',
+        {
+          attachField1:
+            'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
+        },
+        expect.any(Array),
+      )
+    })
+
+    it('should not call v3 attachment decryption when no attachmentDownloadUrls', async () => {
+      $.flow.hasFileProcessingActions = true
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          field1: { fieldType: 'textfield', answer: 'hello' },
+        },
+        verified: undefined,
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.decryptSubmissionSecretKey).not.toHaveBeenCalled()
+      expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
+    })
+
+    it('should not call v3 attachment decryption when hasFileProcessingActions is false', async () => {
+      $.flow.hasFileProcessingActions = false
+      $.request.body.data.attachmentDownloadUrls = {
+        attachField1: 'https://example.com/download/1',
+      }
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          field1: { fieldType: 'textfield', answer: 'hello' },
+        },
+        verified: undefined,
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.decryptSubmissionSecretKey).not.toHaveBeenCalled()
+      expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('return value and request body for MRF submissions', () => {
+    it('should return isSubtrigger: false and set workflowContent when workflowStep is 0', async () => {
+      const workflowContent = makeWorkflowContent(0)
+      $.request.body.data.workflowContent = workflowContent
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {},
+        verified: undefined,
+      })
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({
+        verified: true,
+        internalId: 'submissionId',
+        isSubtrigger: false,
+        subtriggerData: {
+          type: 'mrf',
+          mrfStepId: 'step-0-id',
+        },
+      })
+      expect($.request.body.workflowContent).toEqual(workflowContent)
+    })
+
+    it('should return isSubtrigger: true and set workflowContent when workflowStep is 1', async () => {
+      const workflowContent = makeWorkflowContent(1)
+      $.request.body.data.workflowContent = workflowContent
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {},
+        verified: undefined,
+      })
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({
+        verified: true,
+        internalId: 'submissionId',
+        isSubtrigger: true,
+        subtriggerData: {
+          type: 'mrf',
+          mrfStepId: 'step-1-id',
+        },
+      })
+      expect($.request.body.workflowContent).toEqual(workflowContent)
+    })
+
+    it('should return correct mrfStepId from workflow array for workflowStep 2', async () => {
+      const workflowContent = makeWorkflowContent(2)
+      $.request.body.data.workflowContent = workflowContent
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {},
+        verified: undefined,
+      })
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          isSubtrigger: true,
+          subtriggerData: {
+            type: 'mrf',
+            mrfStepId: 'step-2-id',
+          },
+        }),
+      )
+    })
+  })
+
+  describe('attachment storage ID suffix for MRF', () => {
+    it('should suffix storageId with workflowStep for MRF attachments', async () => {
+      $.flow.hasFileProcessingActions = true
+      const workflowContent = makeWorkflowContent(2)
+      $.request.body.data.workflowContent = workflowContent
+      $.request.body.data.attachmentDownloadUrls = {
+        attachmentField1: 'https://example.com/download/1',
+      }
+      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          attachmentField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+        attachmentField1: {
+          filename: 'myfile.pdf',
+          content: Buffer.from('file content'),
+        },
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
+        $,
+        'submissionId-2',
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+
+    it('should not suffix storageId for non-MRF attachments', async () => {
+      $.flow.hasFileProcessingActions = true
+      $.request.body.data.attachmentDownloadUrls = {
+        attachmentField1: 'https://example.com/download/1',
+      }
+      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
+
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          attachmentField1: {
+            fieldType: 'attachment',
+            answer: { answer: 'myfile.pdf' },
+          },
+        },
+        verified: undefined,
+      })
+      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+        attachmentField1: {
+          filename: 'myfile.pdf',
+          content: Buffer.from('file content'),
+        },
+      })
+
+      await decryptFormResponse($)
+
+      expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
+        $,
+        'submissionId',
+        expect.anything(),
+        expect.anything(),
+      )
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3.ts
@@ -1,0 +1,91 @@
+import {
+  DecryptedAttachments,
+  FormField,
+} from '@opengovsg/formsg-sdk/dist/types'
+import {
+  convertEncryptedAttachmentToFileContent,
+  decryptContent,
+} from '@opengovsg/formsg-sdk/dist/util/crypto'
+import axios from 'axios'
+
+import logger from '@/helpers/logger'
+
+import { getSdk } from '../common/form-env'
+
+export function decryptSubmissionSecretKey(
+  formSecretKey: string,
+  encryptedSubmissionSecretKey: string,
+): string | null {
+  const decrypted = decryptContent(formSecretKey, encryptedSubmissionSecretKey)
+  if (!decrypted) {
+    return null
+  }
+  return Buffer.from(decrypted).toString('base64')
+}
+
+/**
+ * Decrypts V3 form attachments from presigned S3 download URLs.
+ *
+ * @param formSgSdk - The FormSG SDK instance
+ * @param submissionSecretKey - The decrypted submission secret key (base64)
+ * @param attachmentDownloadUrls - Map of field ID to presigned S3 download URL
+ * @param formFields - All decrypted form fields - it will be filtered to attachment fields only later
+ */
+export async function decryptFormAttachmentsV3(
+  formSgSdk: ReturnType<typeof getSdk>,
+  submissionSecretKey: string,
+  attachmentDownloadUrls: Record<string, string>,
+  formFields: FormField[],
+): Promise<DecryptedAttachments> {
+  if (Object.keys(attachmentDownloadUrls).length === 0) {
+    return {}
+  }
+
+  const decryptedAttachments: DecryptedAttachments = {}
+
+  const filenames = formFields.reduce((acc, field) => {
+    if (field.fieldType === 'attachment') {
+      acc[field._id] = field.answer
+    }
+    return acc
+  }, {} as Record<string, string>)
+
+  await Promise.all(
+    Object.entries(attachmentDownloadUrls).map(async ([fieldId, url]) => {
+      try {
+        const { data: downloadResponse } = await axios.get(url, {
+          responseType: 'json',
+        })
+
+        const encryptedFile =
+          convertEncryptedAttachmentToFileContent(downloadResponse)
+        const decryptedBinary = await formSgSdk.cryptoV3.decryptFile(
+          submissionSecretKey,
+          encryptedFile,
+        )
+
+        if (!decryptedBinary) {
+          logger.error({
+            event: 'formsg-v3-attachment-decrypt-binary-failed',
+            fieldId,
+          })
+          throw new Error('Failed to decrypt V3 attachment binary')
+        }
+
+        decryptedAttachments[fieldId] = {
+          filename: filenames[fieldId] ?? fieldId,
+          content: decryptedBinary,
+        }
+      } catch (err) {
+        logger.error({
+          event: 'formsg-v3-attachment-error',
+          fieldId,
+          error: err,
+        })
+        throw 'Error downloading or decrypting V3 attachment'
+      }
+    }),
+  )
+
+  return decryptedAttachments
+}

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -20,6 +20,10 @@ import { fetchFormSchema } from '../triggers/new-submission/fetch-form-schema'
 import { NricFilter } from '../triggers/new-submission/index'
 
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
+import {
+  decryptFormAttachmentsV3,
+  decryptSubmissionSecretKey,
+} from './decrypt-form-attachments-v3'
 
 const NRIC_VERIFIED_FIELDS = new Set(['sgidUinFin', 'uinFin'])
 
@@ -140,7 +144,16 @@ async function processResponsesV3(
       continue
     }
     if (value.fieldType === 'attachment') {
-      // we dont extract attachment fields
+      // the answer has the shape { hasBeenScanned: boolean, answer: string, md5Hash: string }
+      // the answer is the filename
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // we temporarily store the filename in answer, it will subsequently be replaced with the S3 ID from storeAttachmentInS3
+        answer: value.answer.answer,
+      })
       continue
     }
     // catch-all
@@ -233,23 +246,43 @@ export async function decryptFormResponse(
       data.formId,
       responsesV3,
     )
+
     submission = {
       responses: mappedResponses,
       verified: decryptedSubmission?.verified,
     }
-  } else if (shouldStoreAttachments) {
-    const decryptedResponse = await formSgSdk.crypto.decryptWithAttachments(
-      formSecretKey,
-      data,
-    )
-    submission = decryptedResponse?.content
-    attachments = decryptedResponse?.attachments
+
+    // shouldStoreAttachments should only consider steps after the mrf step instead of the whole pipe
+    // but leaving it as such for now to avoid complexity
+    if (shouldStoreAttachments && data.attachmentDownloadUrls) {
+      const submissionSecretKey = decryptSubmissionSecretKey(
+        formSecretKey,
+        data.encryptedSubmissionSecretKey,
+      )
+      attachments = await decryptFormAttachmentsV3(
+        formSgSdk,
+        submissionSecretKey,
+        data.attachmentDownloadUrls,
+        mappedResponses,
+      )
+    }
   } else {
-    submission = formSgSdk.crypto.decrypt(formSecretKey, data)
+    if (shouldStoreAttachments) {
+      const decryptedResponse = await formSgSdk.crypto.decryptWithAttachments(
+        formSecretKey,
+        data,
+      )
+      submission = decryptedResponse?.content
+      attachments = decryptedResponse?.attachments
+    } else {
+      submission = formSgSdk.crypto.decrypt(formSecretKey, data)
+    }
   }
 
   // If the decryption failed, submission will be `null`.
   if (submission) {
+    const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
+
     const parsedData: Record<string, any> = {}
 
     for (const [index, formField] of submission.responses.entries()) {
@@ -294,9 +327,15 @@ export async function decryptFormResponse(
       }
 
       if (rest.fieldType === 'attachment' && shouldStoreAttachments) {
+        let s3FolderId = data.submissionId
+        if (data.workflowContent) {
+          // we add a suffix if it's an mrf step to prevent
+          // overwriting attachments from previous steps
+          s3FolderId += `-${workflowContent.workflowStep}`
+        }
         rest.answer = await storeAttachmentInS3(
           $,
-          data.submissionId,
+          s3FolderId,
           formField,
           attachments,
         )
@@ -375,13 +414,11 @@ export async function decryptFormResponse(
     /**
      * This means it's the first mrf step and is a new submission
      */
-    if (!data.workflowContent) {
+    if (!workflowContent) {
       return { verified: true, internalId }
     }
 
-    $.request.body.workflowContent = data.workflowContent
-
-    const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
+    $.request.body.workflowContent = workflowContent
 
     return {
       verified: true,


### PR DESCRIPTION
## Changes
Added support for MRF attachments since this is not supported in the SDK currently.

### What changed?

- Created a new module `decrypt-form-attachments-v3.ts` to handle FormSG v3 attachment decryption
- Added functionality to decrypt submission secret keys and download encrypted attachments from S3
- Updated the form response decryption process to handle v3 attachments
- Appending workflow step numbers to S3 folder IDs to prevent overwriting attachments
- Added unit tests

### How to test?

1. Create an MRF form with attachment fields
2. Set up MRF workflow to allow editing of these fields in one or more steps
3. Submit form at different steps while sending attachments via postman after each mrf step
4. Verify attachments received are correct.