### PR TITLE
fix: undefined pipe transfers

### DIFF
--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -24,6 +24,7 @@ const deleteFlow: MutationResolvers['deleteFlow'] = async (
 
   await flow.$relatedQuery('executions').delete()
   await flow.$relatedQuery('steps').delete()
+  await flow.$relatedQuery('pendingTransfer').delete()
 
   // delete attachments from s3
   // Note: specify object keys individually, cannot delete entire folder

--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -1,6 +1,4 @@
 import { COMMON_S3_BUCKET, deleteObjects, parseS3Id } from '@/helpers/s3'
-import Execution from '@/models/execution'
-import ExecutionStep from '@/models/execution-step'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -16,11 +14,15 @@ const deleteFlow: MutationResolvers['deleteFlow'] = async (
     })
     .throwIfNotFound()
 
-  const executionIds = (
-    await flow.$relatedQuery('executions').select('executions.id')
-  ).map((execution: Execution) => execution.id)
+  /**
+   * NOTE: do not delete execution steps similar to delete-step.ts
+   * because this operation is expensive for high volume pipes.
+   */
+  // const executionIds = (
+  //  await flow.$relatedQuery('executions').select('executions.id')
+  //).map((execution: Execution) => execution.id)
 
-  await ExecutionStep.query().delete().whereIn('execution_id', executionIds)
+  // await ExecutionStep.query().delete().whereIn('execution_id', executionIds)
 
   await flow.$relatedQuery('executions').delete()
   await flow.$relatedQuery('steps').delete()

--- a/packages/backend/src/graphql/queries/get-pending-flow-transfers.ts
+++ b/packages/backend/src/graphql/queries/get-pending-flow-transfers.ts
@@ -5,6 +5,7 @@ import type { QueryResolvers } from '../__generated__/types.generated'
 const getPendingFlowTransfers: QueryResolvers['getPendingFlowTransfers'] =
   async (_parent, _params, context) => {
     const flowTransfers = await FlowTransfer.query()
+      .joinRelated('flow') // inner join ensures flow exists
       .where({ new_owner_id: context.currentUser.id, status: 'pending' })
       .withGraphFetched({
         oldOwner: true,


### PR DESCRIPTION
## Problem

Get pending flow transfers query doesn't account for deleted flows: https://plumbersg.zendesk.com/agent/tickets/2680

## Solution

Check for flows that are deleted and not fetch them. Also, deleting flow transfers when a flow is deleted

Also decided to exclude the deletion of execution steps after discussing with Ian since the operation would be costly for high volume pipes

## Tests
For pipe transfer,
1. Create pipe on one account and initiate a transfer to a new account 
2. Check that pipe transfer approval exists on the new account
3. Delete the pipe
4. Check that the pipe transfer approval will not exist on new account anymore

For execution steps,
1. Check that deleted pipes do not delete execution steps associated with the pipe now