### PR TITLE
chore: enable automatic retry for TIMEDOUT m365 calls

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -36,6 +36,12 @@ function mockAxiosAdapterToThrowOnce(
   })
 }
 
+function mockAxiosAdapterToThrowNetworkErrorOnce(code: string): void {
+  mocks.axiosAdapter.mockImplementationOnce((config) => {
+    throw new AxiosError('Network error', code, config, null, undefined)
+  })
+}
+
 const mocks = vi.hoisted(() => ({
   axiosAdapter: vi.fn(
     async (config: InternalAxiosRequestConfig): AxiosPromise => ({
@@ -203,6 +209,11 @@ describe('M365 request error handlers', () => {
       expect.stringContaining('HTTP 509'),
       expect.objectContaining({ event: 'm365-http-509' }),
     )
+  })
+
+  it('throws a RetriableError with default step delay on ETIMEDOUT', async () => {
+    mockAxiosAdapterToThrowNetworkErrorOnce('ETIMEDOUT')
+    await expect(http.get('/test-url')).rejects.toThrow(RetriableError)
   })
 
   it('throws HTTP error on other non-successful codes', async () => {

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -11,6 +11,19 @@ type ThrowingHandler = (
   ...args: Parameters<IApp['requestErrorHandler']>
 ) => never
 
+type MaybeThrowingHandler = (
+  ...args: Parameters<IApp['requestErrorHandler']>
+) => never | void
+
+const handleIntermittentError: MaybeThrowingHandler = ($, error) => {
+  if (error.code === 'ETIMEDOUT') {
+    throw new RetriableError({
+      error: `Retrying ETIMEDOUT ${error.message} from M365 Excel`,
+      delayType: 'step',
+      delayInMs: 'default',
+    })
+  }
+}
 //
 // Handle MS rate limiting us
 //
@@ -120,6 +133,9 @@ const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
       return handle500and502and503($, error)
     case 509: // Bandwidth limit reached
       return handle509($, error)
+    default:
+      handleIntermittentError($, error)
+      throw error
   }
 }
 


### PR DESCRIPTION
## Problem

Excel actions were not automatically retried during intermittent Excel/Azure downtime.

## Changes
This PR improves error handling for network timeouts in the M365 Excel backend by introducing logic to treat `ETIMEDOUT` errors as retriable and updating the corresponding tests to verify this behavior.
