### PR TITLE
fix: cannot add collab after adding new connection

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -817,6 +817,61 @@ describe('upsert flow collaborator', () => {
       expect(tableCollaborators2[0].tableId).toBe(tilesTableId1)
       expect(tableCollaborators2[0].role).toBe('editor')
     })
+
+    it('should add subsequent Pipe collaborator as Tile collaborator', async () => {
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: tilesTableId1 },
+        position: 1,
+      })
+
+      // add the editor as a collaborator of the Pipe first
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Check that only one table collaborator was added (duplicates should be handled)
+      const tableCollaborators = await TableCollaborator.query().where({
+        user_id: editor.id,
+      })
+      expect(tableCollaborators).toHaveLength(1)
+      expect(tableCollaborators[0].tableId).toBe(tilesTableId1)
+      expect(tableCollaborators[0].role).toBe('editor')
+
+      // add another collaborator to the Pipe
+      const newCollaborator = await User.query().insert({
+        id: randomUUID(),
+        email: 'new-collaborator@plumber.gov.sg',
+      })
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: {
+            flowId: dummyFlow.id,
+            email: newCollaborator.email,
+            role: 'editor',
+          },
+        },
+        context,
+      )
+
+      // check that the new collaborator was added as a table collaborator
+      const newTableCollaborator = await TableCollaborator.query().where({
+        table_id: tilesTableId1,
+      })
+      expect(newTableCollaborator).toHaveLength(3)
+      expect(
+        newTableCollaborator.find((tc) => tc.userId === newCollaborator.id),
+      ).toBeDefined()
+    })
   })
 
   it('should not allow adding collaborators if collaborators flag is false', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -368,6 +368,81 @@ describe('upsert flow collaborator', () => {
 
       expect(flowConnections).toHaveLength(0)
     })
+
+    it('should ignore duplicate flow_connections when re-sharing after collaborator deletion', async () => {
+      // Step 1: Create step with connection
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'slack',
+        type: 'action',
+        connectionId: connectionId,
+        parameters: { channel: 'general' },
+        position: 1,
+      })
+
+      // Step 2: Add first collaborator
+      await upsertFlowCollaborator(
+        null,
+        {
+          input: { flowId: dummyFlow.id, email: editor.email, role: 'editor' },
+        },
+        context,
+      )
+
+      // Step 3: Verify flow_connections exist
+      const flowConnectionsAfterFirstShare = await FlowConnections.query().where({
+        flow_id: dummyFlow.id,
+      })
+      expect(flowConnectionsAfterFirstShare).toHaveLength(1)
+      expect(flowConnectionsAfterFirstShare[0].connectionId).toBe(connectionId)
+
+      // Step 4: Delete the collaborator
+      await FlowCollaborator.query()
+        .delete()
+        .where({ flow_id: dummyFlow.id, user_id: editor.id })
+
+      // Step 5: Add a new step with a new connection
+      const connectionId2 = randomUUID()
+      await Connection.query().insert({
+        id: connectionId2,
+        key: 'telegram-bot',
+        data: '5678',
+      })
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'sendMessage',
+        appKey: 'telegram-bot',
+        type: 'action',
+        connectionId: connectionId2,
+        parameters: {},
+        position: 2,
+      })
+
+      // Step 6: Add a new collaborator - should not fail on duplicate connection
+      await expect(
+        upsertFlowCollaborator(
+          null,
+          {
+            input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+          },
+          context,
+        ),
+      ).resolves.toBe(true)
+
+      // Verify: both connections exist, no duplicates, no errors
+      const flowConnectionsAfterSecondShare =
+        await FlowConnections.query().where({
+          flow_id: dummyFlow.id,
+        })
+
+      expect(flowConnectionsAfterSecondShare).toHaveLength(2)
+      expect(
+        flowConnectionsAfterSecondShare.map((fc) => fc.connectionId).sort(),
+      ).toEqual([connectionId, connectionId2].sort())
+    })
   })
 
   describe('automatic table collaborator sharing', () => {

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -392,9 +392,10 @@ describe('upsert flow collaborator', () => {
       )
 
       // Step 3: Verify flow_connections exist
-      const flowConnectionsAfterFirstShare = await FlowConnections.query().where({
-        flow_id: dummyFlow.id,
-      })
+      const flowConnectionsAfterFirstShare =
+        await FlowConnections.query().where({
+          flow_id: dummyFlow.id,
+        })
       expect(flowConnectionsAfterFirstShare).toHaveLength(1)
       expect(flowConnectionsAfterFirstShare[0].connectionId).toBe(connectionId)
 
@@ -426,7 +427,11 @@ describe('upsert flow collaborator', () => {
         upsertFlowCollaborator(
           null,
           {
-            input: { flowId: dummyFlow.id, email: viewer.email, role: 'viewer' },
+            input: {
+              flowId: dummyFlow.id,
+              email: viewer.email,
+              role: 'viewer',
+            },
           },
           context,
         ),

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -85,15 +85,16 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
           const connectionInserts = Object.entries(
             connectionDetails.connection,
           ).map(([connectionId, metadata]) => ({
-            flowId,
-            connectionId,
-            addedBy: flow.userId,
-            connectionType: 'connection' as const,
+            flow_id: flowId,
+            connection_id: connectionId,
+            added_by: flow.userId,
+            connection_type: 'connection' as const,
             metadata,
           }))
 
           if (connectionInserts.length > 0) {
-            await FlowConnections.query(trx)
+            await trx
+              .table('flow_connections')
               .insert(connectionInserts)
               .onConflict(['flow_id', 'connection_id'])
               .ignore()

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -9,7 +9,6 @@ import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import FlowCollaborator from '@/models/flow-collaborators'
-import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -71,7 +71,7 @@ async function addFlowTableConnection({
   await TableCollaborator.hasAccess(addedBy, tableId, 'editor')
 
   // first try to add the connection to the flow_connections table
-  const addedConnection = await FlowConnections.addFlowConnection({
+  await FlowConnections.addFlowConnection({
     flowId,
     connectionId: tableId,
     addedBy,
@@ -79,27 +79,24 @@ async function addFlowTableConnection({
     trx,
   })
 
-  // only need to proceed if the tile was added to flow_connections
-  if (addedConnection) {
-    // then add the collaborators to the flow_collaborators table
-    const collaborators = await FlowCollaborator.getCollaborators({
-      flowId,
-      trx,
-    })
+  // then add the collaborators to the flow_collaborators table
+  const collaborators = await FlowCollaborator.getCollaborators({
+    flowId,
+    trx,
+  })
 
-    // use Promise.all so that we use the addCollaborator function, which checks
-    // if the collaborator already exists to avoid duplicates
-    await Promise.all(
-      collaborators.map(async ({ userId, role }) => {
-        await TableCollaborator.addCollaborator({
-          userId,
-          tableId,
-          role,
-          trx,
-        })
-      }),
-    )
-  }
+  // use Promise.all so that we use the addCollaborator function, which checks
+  // if the collaborator already exists to avoid duplicates
+  await Promise.all(
+    collaborators.map(async ({ userId, role }) => {
+      await TableCollaborator.addCollaborator({
+        userId,
+        tableId,
+        role,
+        trx,
+      })
+    }),
+  )
 }
 
 export { addFlowConnection, addFlowTableConnection }


### PR DESCRIPTION
## Problem
Bulk insert into `flow_connections` does not handle insert conflicts properly. During a bulk insert, if a flow_connection already exists, any attempt to insert a new flow_connection will throw `An error has occurred: Cannot read properties of undefined (reading 'metadata')`.

_How to replicate?_
1. Create a Pipe
2. Create 2 steps with connections (e.g., FormSG / Telegram / LetterSG / etc)
3. Add one or more collaborators
4. Delete the collaborators
5. Add a new step with connection
6. Add a new collaborator --> error is thrown here

When collaborators are removed and re-added, Plumber attempts to re-insert `flow_connections` that already exist from the previous collaborator setup, triggering a conflict.

## What caused this issue?
This appears to be a [known Objection.js limitation](https://github.com/Vincit/objection.js/issues/2320). After an INSERT executes, Objection.js tries to take the returned rows and instantiate them as model instances. When ON CONFLICT DO NOTHING skips a row, PostgreSQL doesn't return it in the RETURNING clause, so Objection gets back fewer rows than it inserted. This mismatch causes the error, it expects to build a model for each insert but the data isn't there.

## Solution
Use the raw Knex query instead of Objection.js. Raw Knex returns only the raw result (e.g., row count) without attempting to map rows back to model instances, so ignored conflicts don't cause errors. The query remains parameterised and is still safe.

## Tests
1. Add collaborator to flow with FormSG + M365-Excel connections                                                                                                                         
  - [x] Create a new pipe with FormSG trigger and M365-Excel action                                                                                                                             
  - [x] Configure both steps with valid connections                                                                                                                                             
  - [x] Share the pipe with a collaborator (editor role)                                                                                                                                        
  - [x] **Expected**: Collaborator is added successfully without errors                                                                                                                         
  - [ ] **Verify**: Check `flow_connections` table has entries for both connections with `metadata: {}`                                                                                         
                                                                                                                                                                                                
2. Add collaborator to flow with only FormSG connection                                                                                                                                  
  - [x] Create a new pipe with only FormSG trigger (no action step with connection)                                                                                                             
  - [x] Share the pipe with a collaborator                                                                                                                                                      
  - [x] **Expected**: Collaborator is added successfully                                                                                                                                        
  - [x] **Verify**: `flow_connections` table has entry for FormSG connection                                                                                                                    
                                                                                                                                                                                                
3. Add collaborator to flow with M365-Excel (with fileId metadata)                                                                                                                       
  - [x] Create a pipe with M365-Excel action that has a file selected                                                                                                                           
  - [x] Share the pipe with a collaborator                                                                                                                                                      
  - [x] **Expected**: Collaborator is added successfully                                                                                                                                        
  - [x] **Verify**: `flow_connections` entry has `metadata: { fileId: ['<selected-file-id>'] }`                                                                                                 
                                                                                                                                                                                                
4. Re-share pipe (onConflict ignore works)                                                                                                                                               
  - [x] Use a pipe that was already shared (existing `flow_connections` entries)
  - [x] Delete all collaborators
  - [x] Add a new step with a new connection
  - [x] Add another collaborator to the same pipe
  - [x] **Expected**: No errors, collaborator added successfully
  - [x] **Verify**: No duplicate entries in `flow_connections` table

5. Share pipe with no connections
  - [x] Create a pipe with steps that have no connections (e.g., only trigger with no action)
  - [x] Share the pipe with a collaborator                                                                               
  - [x] **Expected**: Collaborator is added successfully (no connections to insert)

6. Add collaborator to flow with Tiles action                                                                                                                                            
  - [x] Create a pipe with a Tiles action step (e.g., Create Row)
  - [x] Select a table that you own
  - [x] Share the pipe with a collaborator
  - [x] **Expected**: Collaborator is added successfully
  - [x] **Verify**: `flow_connections` table has entry with `connection_type: 'table'` and `connection_id` = table ID
  - [ ] **Verify**: Collaborator is automatically added to `table_collaborators` for that tile