### PR TITLE
PLU-670 fix: add Tile owner for transfer before collab

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-transfer-status.itest.ts
@@ -316,7 +316,7 @@ describe('updateFlowTransferStatus', () => {
         .mockResolvedValue(undefined)
 
       const addCollaboratorSpy = vi
-        .spyOn(TableCollaborator, 'addCollaborator')
+        .spyOn(TableCollaborator, 'upgradeOrInsertCollaborator')
         .mockResolvedValue(undefined)
 
       // Approve the transfer as new owner

--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -648,7 +648,7 @@ describe('updateStep mutation', () => {
       // mock the check that the user has access to the tile
       vi.spyOn(TableCollaborator, 'hasAccess').mockResolvedValue(undefined)
       const addCollaboratorSpy = vi
-        .spyOn(TableCollaborator, 'addCollaborator')
+        .spyOn(TableCollaborator, 'upgradeOrInsertCollaborator')
         .mockResolvedValue(undefined)
       const patchSpy = vi.spyOn(FlowConnections, 'patchFlowConnectionMetadata')
       const addSpy = vi

--- a/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/upsert-flow-collaborator.itest.ts
@@ -872,6 +872,158 @@ describe('upsert flow collaborator', () => {
         newTableCollaborator.find((tc) => tc.userId === newCollaborator.id),
       ).toBeDefined()
     })
+
+    /**
+     * This tests the fix for the issue where:
+     * 1. A Pipe with a Tiles connection was transferred before Collaborators was released
+     * 2. The new owner is only an editor of the Tile
+     * 3. The old owner remains the owner of the Tile
+     * 4. The new owner attempts to add the old owner as a Pipe collaborator
+     *
+     * Previously this would throw 'Cannot change owner role' error because
+     * the code tried to add the Tile owner as a table collaborator.
+     */
+    it('should succeed when adding Tile owner as Pipe collaborator (transferred pipe scenario)', async () => {
+      // Simulate: "old owner" owns the tile
+      const oldOwner = await User.query().insert({
+        id: randomUUID(),
+        email: 'old-owner@plumber.gov.sg',
+      })
+
+      // Create a new tile where oldOwner is the owner
+      const transferredTileId = randomUUID()
+      await TableMetadata.query().insert({
+        id: transferredTileId,
+        name: 'transferred tile',
+        db: 'pg',
+      })
+
+      await TableCollaborator.query().insert({
+        tableId: transferredTileId,
+        userId: oldOwner.id,
+        role: 'owner',
+      })
+
+      // context.currentUser (new owner of Pipe) is only an editor of the Tile
+      await TableCollaborator.query().insert({
+        tableId: transferredTileId,
+        userId: context.currentUser.id,
+        role: 'editor',
+      })
+
+      // Add a Tile step using the transferred tile
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: transferredTileId },
+        position: 1,
+      })
+
+      // New owner tries to add old owner as a Pipe collaborator
+      // This should succeed - the old owner is already the Tile owner,
+      // so the error should be silently ignored
+      await expect(
+        upsertFlowCollaborator(
+          null,
+          {
+            input: {
+              flowId: dummyFlow.id,
+              email: oldOwner.email,
+              role: 'editor',
+            },
+          },
+          context,
+        ),
+      ).resolves.toBe(true)
+
+      // Verify the flow collaborator was added
+      const flowCollaborators = await FlowCollaborator.query().where({
+        flow_id: dummyFlow.id,
+        user_id: oldOwner.id,
+      })
+      expect(flowCollaborators).toHaveLength(1)
+      expect(flowCollaborators[0].role).toBe('editor')
+
+      // Verify the old owner's Tile ownership was NOT changed
+      const tileCollaborator = await TableCollaborator.query().findOne({
+        table_id: transferredTileId,
+        user_id: oldOwner.id,
+      })
+      expect(tileCollaborator).toBeDefined()
+      expect(tileCollaborator.role).toBe('owner')
+    })
+
+    it('should succeed when adding Tile owner as viewer (flow was transferred, owner became viewer)', async () => {
+      // Scenario: Pipe was transferred, old owner (Tile owner) is being added back as viewer
+      const oldOwner = await User.query().insert({
+        id: randomUUID(),
+        email: 'old-pipe-owner@plumber.gov.sg',
+      })
+
+      const sharedTileId = randomUUID()
+      await TableMetadata.query().insert({
+        id: sharedTileId,
+        name: 'transferred tile 2',
+        db: 'pg',
+      })
+
+      // Old owner is the Tile owner
+      await TableCollaborator.query().insert({
+        tableId: sharedTileId,
+        userId: oldOwner.id,
+        role: 'owner',
+      })
+
+      // Current user (new pipe owner) is editor of the Tile
+      await TableCollaborator.query().insert({
+        tableId: sharedTileId,
+        userId: context.currentUser.id,
+        role: 'editor',
+      })
+
+      await Step.query().insert({
+        id: randomUUID(),
+        flowId: dummyFlow.id,
+        key: 'createTileRow',
+        appKey: 'tiles',
+        type: 'action',
+        parameters: { tableId: sharedTileId },
+        position: 1,
+      })
+
+      // Add old owner as viewer (even though they're Tile owner)
+      await expect(
+        upsertFlowCollaborator(
+          null,
+          {
+            input: {
+              flowId: dummyFlow.id,
+              email: oldOwner.email,
+              role: 'viewer',
+            },
+          },
+          context,
+        ),
+      ).resolves.toBe(true)
+
+      // Verify flow collaborator was added as viewer
+      const flowCollab = await FlowCollaborator.query().findOne({
+        flow_id: dummyFlow.id,
+        user_id: oldOwner.id,
+      })
+      expect(flowCollab).toBeDefined()
+      expect(flowCollab.role).toBe('viewer')
+
+      // Verify Tile ownership was NOT changed
+      const tileCollab = await TableCollaborator.query().findOne({
+        table_id: sharedTileId,
+        user_id: oldOwner.id,
+      })
+      expect(tileCollab.role).toBe('owner')
+    })
   })
 
   it('should not allow adding collaborators if collaborators flag is false', async () => {

--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -212,7 +212,7 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
 
               // there may be instances where the new pipe owner is already the owner of the table
               // we catch the error but do nothing`
-              await TableCollaborator.addCollaborator({
+              await TableCollaborator.upgradeOrInsertCollaborator({
                 userId: context.currentUser.id, // the new owner
                 tableId,
                 role: 'editor',

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -2,7 +2,6 @@ import { IStep } from '@plumber/types'
 
 import { Transaction } from 'objection'
 
-import { BadUserInputError } from '@/errors/graphql-errors'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
 import TableCollaborator from '@/models/table-collaborators'
@@ -90,22 +89,12 @@ async function addFlowTableConnection({
   // if the collaborator already exists to avoid duplicates
   await Promise.all(
     collaborators.map(async ({ userId, role }) => {
-      try {
-        await TableCollaborator.addCollaborator({
-          userId,
-          tableId,
-          role,
-          trx,
-        })
-      } catch (e) {
-        // do nothing if the new collaborator is already the owner of the tile
-        const isOwnerRoleError =
-          e instanceof BadUserInputError &&
-          e.message === 'Cannot change owner role'
-        if (!isOwnerRoleError) {
-          throw e
-        }
-      }
+      await TableCollaborator.upgradeOrInsertCollaborator({
+        userId,
+        tableId,
+        role,
+        trx,
+      })
     }),
   )
 }

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -2,6 +2,7 @@ import { IStep } from '@plumber/types'
 
 import { Transaction } from 'objection'
 
+import { BadUserInputError } from '@/errors/graphql-errors'
 import FlowCollaborator from '@/models/flow-collaborators'
 import FlowConnections from '@/models/flow-connections'
 import TableCollaborator from '@/models/table-collaborators'
@@ -89,12 +90,22 @@ async function addFlowTableConnection({
   // if the collaborator already exists to avoid duplicates
   await Promise.all(
     collaborators.map(async ({ userId, role }) => {
-      await TableCollaborator.addCollaborator({
-        userId,
-        tableId,
-        role,
-        trx,
-      })
+      try {
+        await TableCollaborator.addCollaborator({
+          userId,
+          tableId,
+          role,
+          trx,
+        })
+      } catch (e) {
+        // do nothing if the new collaborator is already the owner of the tile
+        const isOwnerRoleError =
+          e instanceof BadUserInputError &&
+          e.message === 'Cannot change owner role'
+        if (!isOwnerRoleError) {
+          throw e
+        }
+      }
     }),
   )
 }

--- a/packages/backend/src/models/__tests__/table-collaborators.itest.ts
+++ b/packages/backend/src/models/__tests__/table-collaborators.itest.ts
@@ -1,0 +1,265 @@
+import { ITableCollabRole } from '@plumber/types'
+
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+
+import TableCollaborator from '../table-collaborators'
+import TableMetadata from '../table-metadata'
+import User from '../user'
+
+describe('table collaborators model', () => {
+  let tableId: string
+  let owner: User
+  let editor: User
+  let viewer: User
+
+  beforeEach(async () => {
+    owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: 'owner@plumber.gov.sg',
+    })
+    editor = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: 'editor@plumber.gov.sg',
+    })
+    viewer = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: 'viewer@plumber.gov.sg',
+    })
+
+    const table = await TableMetadata.query().insertAndFetch({
+      name: 'Test Table',
+      db: 'pg',
+    })
+    tableId = table.id
+
+    await TableCollaborator.query().insert([
+      {
+        tableId,
+        userId: owner.id,
+        role: 'owner',
+      },
+      {
+        tableId,
+        userId: editor.id,
+        role: 'editor',
+      },
+      {
+        tableId,
+        userId: viewer.id,
+        role: 'viewer',
+      },
+    ])
+  })
+
+  describe('hasAccess', () => {
+    it.each([
+      { userRole: 'owner', requiredRole: 'owner' },
+      { userRole: 'owner', requiredRole: 'editor' },
+      { userRole: 'owner', requiredRole: 'viewer' },
+      { userRole: 'editor', requiredRole: 'editor' },
+      { userRole: 'editor', requiredRole: 'viewer' },
+      { userRole: 'viewer', requiredRole: 'viewer' },
+    ] as { userRole: ITableCollabRole; requiredRole: ITableCollabRole }[])(
+      'should not throw when $userRole accesses with $requiredRole requirement',
+      async ({ userRole, requiredRole }) => {
+        const user =
+          userRole === 'owner' ? owner : userRole === 'editor' ? editor : viewer
+
+        await expect(
+          TableCollaborator.hasAccess(user.id, tableId, requiredRole),
+        ).resolves.not.toThrow()
+      },
+    )
+
+    it.each([
+      { userRole: 'editor', requiredRole: 'owner' },
+      { userRole: 'viewer', requiredRole: 'owner' },
+      { userRole: 'viewer', requiredRole: 'editor' },
+    ] as { userRole: ITableCollabRole; requiredRole: ITableCollabRole }[])(
+      'should throw when $userRole accesses with $requiredRole requirement',
+      async ({ userRole, requiredRole }) => {
+        const user = userRole === 'editor' ? editor : viewer
+
+        await expect(
+          TableCollaborator.hasAccess(user.id, tableId, requiredRole),
+        ).rejects.toThrow(ForbiddenError)
+      },
+    )
+
+    it('should throw when user is not a collaborator', async () => {
+      const nonCollaborator = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: 'stranger@plumber.gov.sg',
+      })
+
+      await expect(
+        TableCollaborator.hasAccess(nonCollaborator.id, tableId, 'viewer'),
+      ).rejects.toThrow(ForbiddenError)
+    })
+
+    it('should throw when table does not exist', async () => {
+      await expect(
+        TableCollaborator.hasAccess(owner.id, randomUUID(), 'viewer'),
+      ).rejects.toThrow(ForbiddenError)
+    })
+  })
+
+  describe('upgradeOrInsertCollaborator', () => {
+    it('should insert a new collaborator when none exists', async () => {
+      const newUser = await User.query().insertAndFetch({
+        id: randomUUID(),
+        email: 'new_user@plumber.gov.sg',
+      })
+
+      await TableCollaborator.upgradeOrInsertCollaborator({
+        userId: newUser.id,
+        tableId,
+        role: 'editor',
+      })
+
+      const collaborator = await TableCollaborator.query().findOne({
+        user_id: newUser.id,
+        table_id: tableId,
+      })
+      expect(collaborator).toBeDefined()
+      expect(collaborator?.role).toBe('editor')
+    })
+
+    it('should upgrade viewer to editor', async () => {
+      await TableCollaborator.upgradeOrInsertCollaborator({
+        userId: viewer.id,
+        tableId,
+        role: 'editor',
+      })
+
+      const collaborator = await TableCollaborator.query().findOne({
+        user_id: viewer.id,
+        table_id: tableId,
+      })
+      expect(collaborator?.role).toBe('editor')
+    })
+
+    it.each([
+      { currentRole: 'owner', newRole: 'owner' },
+      { currentRole: 'owner', newRole: 'editor' },
+      { currentRole: 'owner', newRole: 'viewer' },
+      { currentRole: 'editor', newRole: 'editor' },
+      { currentRole: 'editor', newRole: 'viewer' },
+      { currentRole: 'viewer', newRole: 'viewer' },
+    ] as { currentRole: ITableCollabRole; newRole: ITableCollabRole }[])(
+      'should no-op when changing $currentRole to $newRole (same or less permissive)',
+      async ({ currentRole, newRole }) => {
+        const testUser = await User.query().insertAndFetch({
+          id: randomUUID(),
+          email: 'test_user@plumber.gov.sg',
+        })
+
+        await TableCollaborator.query().insert({
+          tableId,
+          userId: testUser.id,
+          role: currentRole,
+        })
+
+        await TableCollaborator.upgradeOrInsertCollaborator({
+          userId: testUser.id,
+          tableId,
+          role: newRole,
+        })
+
+        const collaborator = await TableCollaborator.query().findOne({
+          user_id: testUser.id,
+          table_id: tableId,
+        })
+        expect(collaborator?.role).toBe(currentRole)
+      },
+    )
+
+    describe('soft-deleted collaborators', () => {
+      it('should restore soft-deleted collaborator with the new role', async () => {
+        // Soft delete the editor
+        await TableCollaborator.query()
+          .patch({ deletedAt: new Date().toISOString() })
+          .where({ user_id: editor.id, table_id: tableId })
+
+        // Verify soft deleted
+        const beforeRestore = await TableCollaborator.query().findOne({
+          user_id: editor.id,
+          table_id: tableId,
+        })
+        expect(beforeRestore).toBeUndefined()
+
+        // Try to add back as viewer (less permissive than original editor role)
+        await TableCollaborator.upgradeOrInsertCollaborator({
+          userId: editor.id,
+          tableId,
+          role: 'viewer',
+        })
+
+        // Should be restored with the new role
+        const afterRestore = await TableCollaborator.query().findOne({
+          user_id: editor.id,
+          table_id: tableId,
+        })
+        expect(afterRestore).toBeDefined()
+        expect(afterRestore?.role).toBe('viewer')
+        expect(afterRestore?.deletedAt).toBeNull()
+      })
+
+      it('should restore soft-deleted collaborator with same role', async () => {
+        // Soft delete the viewer
+        await TableCollaborator.query()
+          .patch({ deletedAt: new Date().toISOString() })
+          .where({ user_id: viewer.id, table_id: tableId })
+
+        // Try to add back as viewer (same role)
+        await TableCollaborator.upgradeOrInsertCollaborator({
+          userId: viewer.id,
+          tableId,
+          role: 'viewer',
+        })
+
+        // Should be restored
+        const afterRestore = await TableCollaborator.query().findOne({
+          user_id: viewer.id,
+          table_id: tableId,
+        })
+        expect(afterRestore).toBeDefined()
+        expect(afterRestore?.role).toBe('viewer')
+        expect(afterRestore?.deletedAt).toBeNull()
+      })
+
+      it('should restore soft-deleted collaborator with upgraded role', async () => {
+        // Soft delete the viewer
+        await TableCollaborator.query()
+          .patch({ deletedAt: new Date().toISOString() })
+          .where({ user_id: viewer.id, table_id: tableId })
+
+        // Verify soft deleted
+        const beforeRestore = await TableCollaborator.query().findOne({
+          user_id: viewer.id,
+          table_id: tableId,
+        })
+        expect(beforeRestore).toBeUndefined()
+
+        // Try to add back as editor (more permissive)
+        await TableCollaborator.upgradeOrInsertCollaborator({
+          userId: viewer.id,
+          tableId,
+          role: 'editor',
+        })
+
+        // Should be restored with upgraded role
+        const afterRestore = await TableCollaborator.query().findOne({
+          user_id: viewer.id,
+          table_id: tableId,
+        })
+        expect(afterRestore).toBeDefined()
+        expect(afterRestore?.role).toBe('editor')
+        expect(afterRestore?.deletedAt).toBeNull()
+      })
+    })
+  })
+})

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -2,12 +2,14 @@ import { IGlobalVariable, ITableCollabRole } from '@plumber/types'
 
 import { Transaction } from 'objection'
 
-import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
+import { ForbiddenError } from '@/errors/graphql-errors'
 import StepError from '@/errors/step'
 
 import Base from './base'
 import TableMetadata from './table-metadata'
 import User from './user'
+
+const TILE_COLLAB_ROLES = ['owner', 'editor', 'viewer']
 
 class TableCollaborator extends Base {
   userId!: string
@@ -25,7 +27,7 @@ class TableCollaborator extends Base {
       userId: { type: 'string', format: 'uuid' },
       tableId: { type: 'string', format: 'uuid' },
       name: { type: 'string', format: 'uuid' },
-      role: { type: 'string', enum: ['owner', 'editor', 'viewer'] },
+      role: { type: 'string', enum: TILE_COLLAB_ROLES },
       lastAccessedAt: { type: 'string', format: 'date-time' },
     },
   }
@@ -61,15 +63,14 @@ class TableCollaborator extends Base {
     role: ITableCollabRole,
     $?: IGlobalVariable,
   ): Promise<void | never> => {
-    const permissionLevels = ['viewer', 'editor', 'owner']
     const collaborator = await this.query().findOne({
       user_id: userId,
       table_id: tableId,
     })
     if (
       !collaborator ||
-      permissionLevels.indexOf(collaborator.role) <
-        permissionLevels.indexOf(role)
+      TILE_COLLAB_ROLES.indexOf(collaborator.role) >
+        TILE_COLLAB_ROLES.indexOf(role)
     ) {
       if ($) {
         throw new StepError(
@@ -87,7 +88,7 @@ class TableCollaborator extends Base {
     }
   }
 
-  static addCollaborator = async ({
+  static upgradeOrInsertCollaborator = async ({
     userId,
     tableId,
     role,
@@ -106,20 +107,21 @@ class TableCollaborator extends Base {
       .withSoftDeleted()
 
     /**
-     * Upsert collaborator here
+     * Upgrade or insert collaborator here
      */
     if (existingCollaborator) {
-      if (existingCollaborator.role === 'owner') {
-        throw new BadUserInputError('Cannot change owner role')
-      }
+      const currentRoleIndex = TILE_COLLAB_ROLES.indexOf(
+        existingCollaborator.role,
+      )
+      const newRoleIndex = TILE_COLLAB_ROLES.indexOf(role)
 
       /**
-       * COLLABORATORS:
-       * should not downgrade the role on Tiles when the Pipe collaborator is being
-       * downgraded from an Editor to a Viewer.
-       * Tile Owner / Editor should do that manually.
+       * No-op if new role is less or equally permissive to current role.
+       * - Owner role cannot be changed
+       * - Tile collaborators should not be downgraded when Pipe collaborator is downgraded
+       * Only applies to active collaborators; soft-deleted ones should be restored with the new role.
        */
-      if (role === 'viewer' && existingCollaborator.role === 'editor') {
+      if (!existingCollaborator.deletedAt && newRoleIndex >= currentRoleIndex) {
         return
       }
 


### PR DESCRIPTION
### TL;DR

Fixed an error when adding Tile owners as Pipe collaborators in scenarios where Pipes were transferred before the Collaborators feature was released. This issue occurs when:

- A Pipe with a Tiles connection was transferred **before** Collaborators was released
- The **new owner** is only an _editor_ of the Tile
- The **old owner** remains the _owner_ of the Tile
- The new owner attempts to add the old owner as a Pipe collaborator
- Result: **Error**

### Solution

- Align with existing Pipe transfer logic
- Not an error if the Tile owner is not added as a collaborator

### Tests

- [x] Should succeed when adding Tile owner as Pipe collaborator (pipe transferred before collab release)
- [ ] New Pipe transfer automatically changes the Tile owner (and Pipe owner) to Pipe editor
- [x] Modifying a Pipe role does not affect Tile role

_Note: if you do not have a Pipe that was transferred prior to Collaborators and need to replicate in local dev:_

1. _Transfer a Pipe with Tiles_
2. _Delete the new rows introduced from the Pipe transfer in the DB_
3. _Delete the new shared connections in_ `flow_connections`
4. _Delete the new collaborator in_ `flow_collaborators`