### PR TITLE
chore: send blacklist notification to collab

### DIFF
--- a/packages/backend/src/apps/postman/common/send-blacklist-email.ts
+++ b/packages/backend/src/apps/postman/common/send-blacklist-email.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { redisClient as pipeErrorRedisClient } from '@/helpers/generate-error-email'
+import { getNotificationCcRecipients } from '@/helpers/get-notification-cc-recipients'
 import { escapeHtml, safeHtml, trustedHtml } from '@/helpers/html-utils'
 import { sendEmail } from '@/helpers/send-email'
 
@@ -134,6 +135,9 @@ export async function sendBlacklistEmail({
     return
   }
 
+  // COLLABORATORS: retrieve list of collaborators to CC if any
+  const ccList = await getNotificationCcRecipients(flowId)
+
   await sendEmail({
     subject: `Plumber: Blacklisted email detected on ${truncatedFlowName}`,
     body: createBodyErrorMessage({
@@ -143,6 +147,7 @@ export async function sendBlacklistEmail({
       blacklistedRecipients: filteredBlacklist,
     }),
     recipient: userEmail,
+    cc: ccList,
     replyTo: 'support@plumber.gov.sg',
   })
 

--- a/packages/backend/src/helpers/generate-error-email.ts
+++ b/packages/backend/src/helpers/generate-error-email.ts
@@ -1,5 +1,3 @@
-import { NotificationRecipients } from '@plumber/types'
-
 import { DateTime } from 'luxon'
 
 import appConfig from '@/config/app'
@@ -7,6 +5,7 @@ import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import { sendEmail } from '@/helpers/send-email'
 import Flow from '@/models/flow'
 
+import { getNotificationCcRecipients } from './get-notification-cc-recipients'
 import { safeHtml } from './html-utils'
 
 const MAX_LENGTH = 80
@@ -72,25 +71,9 @@ export async function sendErrorEmail(flow: Flow) {
   const userEmail = flow.user.email
   const errorKey = `error-alert:${flowId}`
   const currDatetime = DateTime.now()
-  const ccList: string[] = []
 
-  // default to notify owner only if no collaborators are specified
-  const notificationRecipients =
-    flow.config?.errorConfig?.notificationRecipients ?? []
-  if (
-    notificationRecipients.length > 0 &&
-    flow.collaborators &&
-    flow.collaborators.length > 0
-  ) {
-    const collaboratorsToCC = flow.collaborators
-      .filter((collaborator) =>
-        notificationRecipients.includes(
-          collaborator.role as NotificationRecipients,
-        ),
-      )
-      .map((collaborator) => collaborator.user.email)
-    ccList.push(...collaboratorsToCC)
-  }
+  // COLLABORATORS: retrieve list of collaborators to CC if any
+  const ccList = await getNotificationCcRecipients(flowId, flow)
 
   const errorDetails = {
     flowId,

--- a/packages/backend/src/helpers/get-notification-cc-recipients.ts
+++ b/packages/backend/src/helpers/get-notification-cc-recipients.ts
@@ -1,0 +1,47 @@
+import { NotificationRecipients } from '@plumber/types'
+
+import Flow from '@/models/flow'
+
+export async function getNotificationCcRecipients(
+  flowId: string,
+  flow?: Flow,
+): Promise<string[]> {
+  const ccList: string[] = []
+  let erroredFlow = flow ?? null
+
+  if (!erroredFlow) {
+    erroredFlow = await Flow.query()
+      .findOne({
+        id: flowId,
+      })
+      .withGraphFetched({
+        collaborators: {
+          user: true,
+        },
+      })
+      .throwIfNotFound({
+        message: 'Flow not found',
+      })
+  }
+
+  // default to notify owner only if no collaborators are specified
+  const notificationRecipients =
+    erroredFlow.config?.errorConfig?.notificationRecipients ?? []
+
+  if (
+    notificationRecipients.length > 0 &&
+    erroredFlow.collaborators &&
+    erroredFlow.collaborators.length > 0
+  ) {
+    const collaboratorsToCC = erroredFlow.collaborators
+      .filter((collaborator) =>
+        notificationRecipients.includes(
+          collaborator.role as NotificationRecipients,
+        ),
+      )
+      .map((collaborator) => collaborator.user.email)
+    ccList.push(...collaboratorsToCC)
+  }
+
+  return ccList
+}


### PR DESCRIPTION
## Problem
Currently, collaborators only receive notifications on Pipe errors, but do not receive notifications for blacklisted emails.

## Solution
Also send notifications for blacklisted emails to collaborators.

## What changed?
* Refactored the logic for retrieving collaborators into a shared helper function
* Reuse logic for notifying collaborators for blacklisted emails

## Tests
- [ ] Error emails should still be sent correctly based on the error configuration
  - [ ] First error per day
    - [ ] Owner only
    - [ ] Owner + Editors
    - [ ] Owner + Editors + Viewers
  - [ ] All errors
    - [ ] Owner only
    - [ ] Owner + Editors
    - [ ] Owner + Editors + Viewers
- [ ] Blacklist notification emails should be sent correctly based on the error configuration
  - [ ] Owner only
  - [ ] Owner + Editors
  - [ ] Owners + Editors + Viewers


