### PR TITLE
chore: bump multer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18820,6 +18820,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -19041,21 +19042,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -19065,18 +19067,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/multer/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/multer/node_modules/type-is": {
@@ -25544,7 +25534,7 @@
         "lottie-web": "5.12.2",
         "luxon": "2.5.2",
         "morgan": "^1.10.0",
-        "multer": "2.0.2",
+        "multer": "2.1.0",
         "nanoid": "3.3.8",
         "objection": "^3.0.0",
         "openid-client": "5.4.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -70,7 +70,7 @@
     "lottie-web": "5.12.2",
     "luxon": "2.5.2",
     "morgan": "^1.10.0",
-    "multer": "2.0.2",
+    "multer": "2.1.0",
     "nanoid": "3.3.8",
     "objection": "^3.0.0",
     "openid-client": "5.4.0",


### PR DESCRIPTION
## TL;DR
- Upgraded the `multer` dependency from version 2.0.2 to 2.1.0 in `packages/backend/package.json`.

## Tests
- [ ] Can send email with attachments from FormSG, LetterSG, etc
- [ ] Webhook rejects attachments