### PR TITLE
fix: for each delete visible in published pipe

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/index.tsx
@@ -26,7 +26,8 @@ interface FlowStepGroupProps {
 
 export default function FlowStepGroup(props: FlowStepGroupProps) {
   const { groupedSteps, stepsBeforeGroup } = props
-  const { isDrawerOpen, isMobile, onDrawerClose } = useContext(EditorContext)
+  const { isDrawerOpen, isMobile, onDrawerClose, readOnly } =
+    useContext(EditorContext)
 
   const { stepGroupType, stepGroupCaption } = useMemo(() => {
     let stepGroupType: string | null = null
@@ -112,7 +113,7 @@ export default function FlowStepGroup(props: FlowStepGroupProps) {
                 </Text>
               </Flex>
             </Flex>
-            {stepGroupType === TOOLBOX_ACTIONS.ForEach && (
+            {stepGroupType === TOOLBOX_ACTIONS.ForEach && !readOnly && (
               <Flex ml="auto" opacity={0} _groupHover={{ opacity: 1 }}>
                 <IconButton
                   boxSize={8}


### PR DESCRIPTION
## Problem
Delete button is visible for the for-each group even when the Pipe is published.

## Tests
- [ ] Delete button no longer visible at for-each for published pipe
- [ ] Delete button works for for-each when pipe is not published