### PR TITLE
[AI-BUILDER-17] refactor: create pipe opens to chat only

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -7,7 +7,6 @@ import { datadogRum } from '@datadog/browser-rum'
 import { useIsMobile } from '@opengovsg/design-system-react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
-import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { GET_APPS } from '@/graphql/queries/get-apps'
 import { getStepGroupTypeAndCaption, getStepStructure } from '@/helpers/toolbox'
 import { Message } from '@/hooks/useChatStream'
@@ -44,8 +43,6 @@ interface AIBuilderContextValue extends AIBuilderSharedProps {
   stepGroupCaption: string | null
   // DataDog RUM Session ID so we can associate the trace with the RUM
   ddSessionId: string
-  // TODO(kevinkim-ogp): remove this once A/B test is complete
-  aiBuilderType: string
 }
 
 const AiBuilderContext = createContext<AIBuilderContextValue | undefined>(
@@ -77,9 +74,6 @@ export const AiBuilderContextProvider = ({
 }: AiBuilderContextProviderProps) => {
   const isMobile = useIsMobile()
   const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
-  // TODO(kevinkim-ogp): remove this once A/B test is complete
-  const { getFlagValue } = useContext(LaunchDarklyContext)
-  const aiBuilderType = getFlagValue('ai-builder-type', 'none')
 
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
 
@@ -143,8 +137,6 @@ export const AiBuilderContextProvider = ({
         stepGroupType,
         stepGroupCaption,
         ddSessionId,
-        // TODO(kevinkim-ogp): remove this once A/B test is complete
-        aiBuilderType,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -14,13 +14,7 @@ import {
 } from './AiBuilderContext'
 
 function AiBuilderContent() {
-  const { aiBuilderType, flowName, isFormMode, chatInput, chatMessages } =
-    useAiBuilderContext()
-
-  // TODO(kevinkim-ogp): remove this once A/B test is complete
-  if (aiBuilderType === 'ai-form' && !chatInput && chatMessages?.length === 0) {
-    return <InvalidEditorPage message="You do not have access to this." />
-  }
+  const { flowName, isFormMode } = useAiBuilderContext()
 
   return (
     <>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
@@ -68,8 +68,8 @@ export default function FlowNameAndModeContent({
                 <Tile
                   icon={BiSolidMagicWand}
                   flex={1}
-                  onClick={() => setCreateMode('ai-form')}
-                  isSelected={createMode === 'ai-form'}
+                  onClick={() => setCreateMode('ai')}
+                  isSelected={createMode === 'ai'}
                 >
                   <Text textStyle="h5">Build with AI</Text>
                   <Text textStyle="body-2">
@@ -102,7 +102,7 @@ export default function FlowNameAndModeContent({
       </ModalBody>
       <ModalFooter>
         <Button type="submit" isDisabled={isButtonDisabled} isLoading={loading}>
-          {createMode === 'ai-form' ? 'Next' : 'Create'}
+          {createMode === 'ai' ? 'Next' : 'Create'}
         </Button>
       </ModalFooter>
     </Form>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
@@ -22,7 +22,7 @@ interface CreateFlowModalProps {
 
 export default function CreateFlowModal(props: CreateFlowModalProps) {
   const { onClose } = props
-  const { createMode, aiBuilderType } = useCreateFlowContext()
+  const { createMode } = useCreateFlowContext()
 
   const navigate = useNavigate()
   const [createFlow, { loading }] = useMutation(CREATE_FLOW)
@@ -69,18 +69,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
       return
     }
 
-    // TODO(kevinkim-ogp): remove aiBuilderType once A/B test is complete
-    if (
-      createMode === 'ai-form' &&
-      (aiBuilderType === 'ai-form' || aiBuilderType === 'all')
-    ) {
-      // Store the flow name before switching to AI modal content
-      setFlowName(trimmedFlowName)
-      setShowAiModalContent(true)
-      return
-    }
-
-    if (createMode === 'ai-chat' && aiBuilderType === 'ai-chat') {
+    if (createMode === 'ai') {
       event.preventDefault()
       onClose()
       navigate(`${URLS.EDITOR}/ai`, {

--- a/packages/frontend/src/pages/Flows/components/EmptyFlows.tsx
+++ b/packages/frontend/src/pages/Flows/components/EmptyFlows.tsx
@@ -9,12 +9,8 @@ import CreatePipeTile, { TileProps } from './CreatePipeTile'
 
 export default function EmptyFlows({ onCreate }: { onCreate: () => void }) {
   const navigate = useNavigate()
-  const {
-    aiBuilderType,
-    canUseAiBuilder,
-    setCreateMode,
-    setSkipModeSelection,
-  } = useCreateFlowContext()
+  const { canUseAiBuilder, setCreateMode, setSkipModeSelection } =
+    useCreateFlowContext()
 
   const TILES = [
     canUseAiBuilder && {
@@ -22,15 +18,7 @@ export default function EmptyFlows({ onCreate }: { onCreate: () => void }) {
       description:
         'Describe your workflow and we&apos;ll create the steps for you',
       iconName: 'BiSolidMagicWand',
-      onClick: () => {
-        if (aiBuilderType === 'ai-form' || aiBuilderType === 'all') {
-          setCreateMode('ai-form')
-          setSkipModeSelection(true)
-          onCreate()
-        } else {
-          navigate(`${URLS.EDITOR}/ai`)
-        }
-      },
+      onClick: () => navigate(`${URLS.EDITOR}/ai`),
     },
     {
       header: 'Use a template',

--- a/packages/frontend/src/pages/Flows/contexts/CreateFlowContext.tsx
+++ b/packages/frontend/src/pages/Flows/contexts/CreateFlowContext.tsx
@@ -4,14 +4,13 @@ import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 
 interface CreateFlowContextProps {
   canUseAiBuilder: boolean
-  aiBuilderType: string
   createMode: FLOW_CREATE_MODE | null
   setCreateMode: (mode: FLOW_CREATE_MODE) => void
   skipModeSelection: boolean
   setSkipModeSelection: (skip: boolean) => void
 }
 
-export type FLOW_CREATE_MODE = 'ai-chat' | 'ai-form' | 'new' | 'template'
+export type FLOW_CREATE_MODE = 'ai' | 'new' | 'template'
 
 const CreateFlowContext = createContext<CreateFlowContextProps | null>(null)
 
@@ -44,7 +43,6 @@ export const CreateFlowContextProvider = ({
   return (
     <CreateFlowContext.Provider
       value={{
-        aiBuilderType,
         canUseAiBuilder,
         createMode,
         setCreateMode,


### PR DESCRIPTION
### TL;DR

Removed testing logic for AI builder types and consolidated AI builder modes into a single "ai" mode.

### What changed?

- Removed `aiBuilderType` from `AiBuilderContext` and related LaunchDarkly feature flag logic
- Consolidated `ai-form` and `ai-chat` modes into a single `ai` mode in the flow creation modal
- Updated `FLOW_CREATE_MODE` type to use `'ai'` instead of separate `'ai-chat'` and `'ai-form'` options
- AI builder navigation always route to the AI editor page
- Removed conditional logic that handled different AI builder variants

### Test

Navigate to the flows page and click "Create Pipe"

- [ ] Verify the "Build with AI" option works and routes to the AI builder

Test creating flows in an Empty Flows page

- [ ] Verify the "Build with AI" option works and routes to the AI builder