### PR TITLE
[AI-BUILDER-20] refactor: ai builder feature flag

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -1,12 +1,17 @@
 /**
  * Feature flags
  */
-export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG = 'ai-builder-prompt-config'
+export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
 
 /**
  * Feature flag fallbacks
  */
-export const AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK = {
-  chatReadinessPrompt: 'chat-readiness-check',
-  version: 'production',
+export const AI_BUILDER_FEATURE_FLAG_FALLBACK = {
+  enabled: false,
+  config: {
+    chatPrompt: 'chat',
+    chatReadinessPrompt: 'chat-readiness-check',
+    generateStepsPrompt: 'generate-steps',
+    version: 'production',
+  },
 }

--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -9,9 +9,9 @@ export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
 export const AI_BUILDER_FEATURE_FLAG_FALLBACK = {
   enabled: false,
   config: {
-    chatPrompt: 'chat',
-    chatReadinessPrompt: 'chat-readiness-check',
-    generateStepsPrompt: 'generate-steps',
+    chatPromptName: 'chat',
+    chatReadinessPromptName: 'chat-readiness-check',
+    generateStepsPromptName: 'generate-steps',
     version: 'production',
   },
 }

--- a/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
@@ -85,8 +85,11 @@ describe('generateAiSteps mutation', () => {
 
     mocks.langfusePromptGet.mockResolvedValue({ prompt: 'system prompt' })
     mocks.getLdFlagValue.mockResolvedValue({
-      objectPrompt: 'ai-builder/chat',
-      version: 'production',
+      enabled: true,
+      config: {
+        generateStepsPrompt: 'generate-steps',
+        version: 'production',
+      },
     })
 
     context = {

--- a/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
@@ -87,7 +87,7 @@ describe('generateAiSteps mutation', () => {
     mocks.getLdFlagValue.mockResolvedValue({
       enabled: true,
       config: {
-        generateStepsPrompt: 'generate-steps',
+        generateStepsPromptName: 'generate-steps',
         version: 'production',
       },
     })

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -36,7 +36,7 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
     throw new ForbiddenError('You do not have permissions to use AI Builder!')
   }
 
-  const { generateStepsPrompt: promptName, version } = aiBuilderFlag.config
+  const { generateStepsPromptName: promptName, version } = aiBuilderFlag.config
   let traceId
 
   try {

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -4,6 +4,10 @@ import z from 'zod/v3'
 import { fromZodError } from 'zod-validation-error'
 
 import appConfig from '@/config/app'
+import {
+  AI_BUILDER_FEATURE_FLAG,
+  AI_BUILDER_FEATURE_FLAG_FALLBACK,
+} from '@/config/flags'
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { langfuseClient } from '@/helpers/langfuse'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
@@ -22,15 +26,17 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
   params,
   context,
 ) => {
-  const promptConfig = await getLdFlagValue(
-    'ai-builder-prompt-config',
+  const aiBuilderFlag = await getLdFlagValue(
+    AI_BUILDER_FEATURE_FLAG,
     context.currentUser.email,
-    {
-      objectPrompt: 'ai-builder/form',
-      version: 'production',
-    },
+    AI_BUILDER_FEATURE_FLAG_FALLBACK,
   )
-  const { objectPrompt: promptName, version } = promptConfig
+
+  if (!aiBuilderFlag.enabled) {
+    throw new ForbiddenError('You do not have permissions to use AI Builder!')
+  }
+
+  const { generateStepsPrompt: promptName, version } = aiBuilderFlag.config
   let traceId
 
   try {

--- a/packages/backend/src/graphql/queries/get-chat-readiness.ts
+++ b/packages/backend/src/graphql/queries/get-chat-readiness.ts
@@ -4,8 +4,8 @@ import z from 'zod/v3'
 
 import appConfig from '@/config/app'
 import {
-  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
-  AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
+  AI_BUILDER_FEATURE_FLAG,
+  AI_BUILDER_FEATURE_FLAG_FALLBACK,
 } from '@/config/flags'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
@@ -22,12 +22,12 @@ const getChatReadiness: QueryResolvers['getChatReadiness'] = async (
   try {
     const { message: rawMessage, sessionId } = params
 
-    const promptConfig = await getLdFlagValue(
-      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
+    const aiBuilderFlag = await getLdFlagValue(
+      AI_BUILDER_FEATURE_FLAG,
       context.currentUser.email,
-      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG_FALLBACK,
+      AI_BUILDER_FEATURE_FLAG_FALLBACK,
     )
-    const { chatReadinessPrompt, version } = promptConfig
+    const { chatReadinessPrompt, version } = aiBuilderFlag.config
     const prompt = await getPrompt(chatReadinessPrompt, version)
     const { prompt: systemPrompt } = prompt
 

--- a/packages/backend/src/graphql/queries/get-chat-readiness.ts
+++ b/packages/backend/src/graphql/queries/get-chat-readiness.ts
@@ -27,8 +27,8 @@ const getChatReadiness: QueryResolvers['getChatReadiness'] = async (
       context.currentUser.email,
       AI_BUILDER_FEATURE_FLAG_FALLBACK,
     )
-    const { chatReadinessPrompt, version } = aiBuilderFlag.config
-    const prompt = await getPrompt(chatReadinessPrompt, version)
+    const { chatReadinessPromptName, version } = aiBuilderFlag.config
+    const prompt = await getPrompt(chatReadinessPromptName, version)
     const { prompt: systemPrompt } = prompt
 
     const result = await startActiveObservation(

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -112,7 +112,7 @@ describe('Chat Route Handler', () => {
     it('should process authenticated requests', async () => {
       // Context is set by middleware before reaching handler
       mocks.getLdFlagValue.mockResolvedValueOnce({
-        chatPrompt: 'aids-chat-v0',
+        chatPromptName: 'aids-chat-v0',
         version: 'production',
       })
       mocks.getPrompt.mockResolvedValueOnce({
@@ -161,7 +161,7 @@ describe('Chat Route Handler', () => {
       mocks.getLdFlagValue.mockResolvedValueOnce({
         enabled: true,
         config: {
-          chatPrompt: 'chat-v0',
+          chatPromptName: 'chat-v0',
           version: 'production',
         },
       })
@@ -194,7 +194,7 @@ describe('Chat Route Handler', () => {
       mocks.getLdFlagValue.mockResolvedValueOnce({
         enabled: true,
         config: {
-          chatPrompt: 'chat-v0',
+          chatPromptName: 'chat-v0',
           version: 'production',
         },
       })
@@ -243,7 +243,7 @@ describe('Chat Route Handler', () => {
       mocks.getLdFlagValue.mockResolvedValueOnce({
         enabled: true,
         config: {
-          chatPrompt: 'chat-v0',
+          chatPromptName: 'chat-v0',
           version: 'production',
         },
       })

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -130,7 +130,7 @@ describe('Chat Route Handler', () => {
       await executeChatPostHandler(mockReq, mockRes)
 
       expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'ai-builder-prompt-config',
+        'ai-builder',
         'test@plumber.gov.sg',
         expect.any(Object),
       )
@@ -159,8 +159,11 @@ describe('Chat Route Handler', () => {
       }
 
       mocks.getLdFlagValue.mockResolvedValueOnce({
-        chatPrompt: 'aids-chat-v0',
-        version: 'production',
+        enabled: true,
+        config: {
+          chatPrompt: 'chat-v0',
+          version: 'production',
+        },
       })
       mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
@@ -176,7 +179,7 @@ describe('Chat Route Handler', () => {
       await executeChatPostHandler(mockReq, mockRes)
 
       expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'ai-builder-prompt-config',
+        'ai-builder',
         'feature-test@plumber.gov.sg',
         expect.any(Object),
       )
@@ -189,8 +192,11 @@ describe('Chat Route Handler', () => {
       }
 
       mocks.getLdFlagValue.mockResolvedValueOnce({
-        chatPrompt: 'aids-chat-v0',
-        version: 'production',
+        enabled: true,
+        config: {
+          chatPrompt: 'chat-v0',
+          version: 'production',
+        },
       })
 
       await executeChatPostHandler(mockReq, mockRes)
@@ -203,6 +209,18 @@ describe('Chat Route Handler', () => {
             message: 'Messages array must contain at least one message',
           }),
         ]),
+      })
+    })
+
+    it('should throw error when AI Builder is not enabled', async () => {
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: false,
+      })
+
+      await executeChatPostHandler(mockReq, mockRes)
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: 'You do not have permissions to use AI Builder!',
       })
     })
   })
@@ -223,8 +241,11 @@ describe('Chat Route Handler', () => {
       }
 
       mocks.getLdFlagValue.mockResolvedValueOnce({
-        chatPrompt: 'aids-chat-v0',
-        version: 'production',
+        enabled: true,
+        config: {
+          chatPrompt: 'chat-v0',
+          version: 'production',
+        },
       })
       mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
@@ -240,7 +261,7 @@ describe('Chat Route Handler', () => {
       await executeChatPostHandler(mockReq, mockRes)
 
       expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'ai-builder-prompt-config',
+        'ai-builder',
         'admin@plumber.gov.sg',
         expect.any(Object),
       )

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -38,7 +38,7 @@ const handleChatStream = observe(
       return
     }
 
-    const { chatPrompt, version } = aiBuilderFlag.config
+    const { chatPromptName, version } = aiBuilderFlag.config
 
     try {
       const validationResult = chatRequestSchema.safeParse(req.body)
@@ -59,7 +59,7 @@ const handleChatStream = observe(
       )
 
       // Get the prompt from Langfuse
-      const prompt = await getPrompt(chatPrompt, version)
+      const prompt = await getPrompt(chatPromptName, version)
 
       // Manually capture serializable input for Langfuse
       // joining with new line for readability on Langfuse
@@ -102,7 +102,7 @@ const handleChatStream = observe(
             sessionId: sessionId || 'unknown',
             userId: context.currentUser.email,
             environment: appConfig.appEnv,
-            promptName: chatPrompt,
+            promptName: chatPromptName,
             promptVersion: version,
             langfusePrompt: prompt.toJSON(),
             tags: ['ai-builder', 'chat', 'stream'],

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -10,7 +10,10 @@ import type { Response } from 'express'
 import { Router } from 'express'
 
 import appConfig from '@/config/app'
-import { AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG } from '@/config/flags'
+import {
+  AI_BUILDER_FEATURE_FLAG,
+  AI_BUILDER_FEATURE_FLAG_FALLBACK,
+} from '@/config/flags'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
@@ -22,16 +25,20 @@ import { chatRequestSchema } from './schema'
 const handleChatStream = observe(
   async (req: AuthenticatedRequest, res: Response) => {
     const context = req.context
-    const promptConfig = await getLdFlagValue(
-      AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG,
+    const aiBuilderFlag = await getLdFlagValue(
+      AI_BUILDER_FEATURE_FLAG,
       context.currentUser.email,
-      {
-        chatPrompt: 'ai-builder/chat',
-        version: 'production',
-      },
+      AI_BUILDER_FEATURE_FLAG_FALLBACK,
     )
 
-    const { chatPrompt, version } = promptConfig
+    if (!aiBuilderFlag.enabled) {
+      res
+        .status(403)
+        .json({ error: 'You do not have permissions to use AI Builder!' })
+      return
+    }
+
+    const { chatPrompt, version } = aiBuilderFlag.config
 
     try {
       const validationResult = chatRequestSchema.safeParse(req.body)

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -13,6 +13,7 @@ export const BULK_RETRY_EXECUTIONS_FLAG = 'bulk-retry-failed-executions-v1'
 export const SGID_FEATURE_FLAG = 'sgid-login'
 export const SSO_FEATURE_FLAG = 'ogp-sso-enabled'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
+export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
 
 /**
  * App/events flags

--- a/packages/frontend/src/pages/Flows/contexts/CreateFlowContext.tsx
+++ b/packages/frontend/src/pages/Flows/contexts/CreateFlowContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useContext, useState } from 'react'
 
+import { AI_BUILDER_FEATURE_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 
 interface CreateFlowContextProps {
@@ -35,8 +36,10 @@ export const CreateFlowContextProvider = ({
 }) => {
   // TODO (kevinkim-ogp): remove the flag value once GA
   const { getFlagValue } = useContext(LaunchDarklyContext)
-  const aiBuilderType = getFlagValue('ai-builder-type', 'none')
-  const canUseAiBuilder = aiBuilderType !== 'none'
+  const aiBuilderFlag = getFlagValue(AI_BUILDER_FEATURE_FLAG, {
+    enabled: false,
+  })
+  const canUseAiBuilder = aiBuilderFlag.enabled
 
   const [skipModeSelection, setSkipModeSelection] = useState<boolean>(false)
 


### PR DESCRIPTION
### TL;DR

Consolidated AI Builder feature flags from separate prompt configuration flags into a single unified feature flag with nested configuration structure.

### What changed?

- Renamed `AI_BUILDER_PROMPT_CONFIG_FEATURE_FLAG` to `AI_BUILDER_FEATURE_FLAG`
- Restructured the feature flag fallback to include an `enabled` boolean and nested `config` object containing prompt configurations
- Added feature flag checks to prevent access when AI Builder is disabled, throwing 403 errors in chat routes and GraphQL mutations
- Updated all references across backend GraphQL resolvers, API routes, and frontend components to use the new flag structure
- Modified tests to reflect the new flag structure and added test coverage for disabled AI Builder scenarios

### How to test?

- [ ] Verify AI Builder functionality works when the feature flag `enabled` is set to `true`
- [ ] Test that 403 errors are returned when attempting to use AI Builder features with `enabled` set to `false`
- [ ] Confirm that chat readiness checks, step generation, and chat streaming all respect the new flag structure
- [ ] Validate that the frontend correctly shows/hides AI Builder options based on the `enabled` flag value

### Post-deployment

- [ ] Archive old feature flags: `ai-builder-type` , `ai-builder-prompt-config`