### PR TITLE
[MRF2-15] PLU-520: Pre-bug bash fixes

### DIFF
--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -101,7 +101,7 @@ async function processResponsesV3(
     /**
      * Similary, formv3 responses put these fields in value.answer.value
      */
-    if (['radio', 'email', 'mobile'].includes(value.fieldType)) {
+    if (['radiobutton', 'email', 'mobile'].includes(value.fieldType)) {
       mappedResponses.push({
         _id: key,
         fieldType: value.fieldType,

--- a/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
@@ -185,8 +185,12 @@ export async function createMrfSteps(
       await Step.query(trx)
         .where('flow_id', $.flow.id)
         .where('position', '>=', newMrfSteps[0].position)
-        .andWhereNot('key', MRF_KEY)
-        .andWhereNot('app_key', MRF_APP_KEY)
+        .where((builder) => {
+          builder.whereNot('key', MRF_KEY).orWhereNull('key')
+        })
+        .where((builder) => {
+          builder.whereNot('app_key', MRF_APP_KEY).orWhereNull('app_key')
+        })
         .increment('position', newMrfSteps.length)
 
       // Get all the step ids in the reject branch

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -18,6 +18,7 @@ import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
 import { validateFiles } from './utils'
+import { EditorContext } from '@/contexts/Editor'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -40,11 +41,12 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const cancelRef = useRef<HTMLButtonElement>(null)
   const wrapperRef = useRef(null)
+  const { flow } = useContext(EditorContext)
   const { control, setError, getValues } = useFormContext()
   const [currentTab, setCurrentTab] = useState<number>(0)
   const [selectedFile, setSelectedFile] = useState<Variable | null>(null)
 
-  const flow = getValues('flow')
+
 
   const {
     isOpen: isDialogOpen,

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -7,6 +7,7 @@ import { useQuery } from '@apollo/client'
 import { FormControl, useDisclosure, useOutsideClick } from '@chakra-ui/react'
 import { FormErrorMessage, FormLabel } from '@opengovsg/design-system-react'
 
+import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { type Variable } from '@/helpers/variables'
@@ -18,7 +19,6 @@ import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
 import { validateFiles } from './utils'
-import { EditorContext } from '@/contexts/Editor'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -45,8 +45,6 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const { control, setError, getValues } = useFormContext()
   const [currentTab, setCurrentTab] = useState<number>(0)
   const [selectedFile, setSelectedFile] = useState<Variable | null>(null)
-
-
 
   const {
     isOpen: isDialogOpen,

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -1,4 +1,4 @@
-import { TDataOutMetadatumType } from '@plumber/types'
+import { IFlow, TDataOutMetadatumType } from '@plumber/types'
 
 import { FieldValues } from 'react-hook-form'
 
@@ -91,10 +91,11 @@ export function createUpdateFlowConfigInput(
 }
 
 export function createUpdateStep(
+  flow: IFlow,
   formValues: FieldValues,
   updatedAttachments: string[],
 ) {
-  const { appKey, id, key, parameters, connection, flow } = formValues
+  const { appKey, id, key, parameters, connection } = formValues
   const mutationInput: Record<string, unknown> = {
     id,
     key,

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -235,7 +235,7 @@ export default function FlowStep(
                 shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
               }
               borderTopRadius={hasInfoBox ? 'none' : 'lg'}
-              h={isNested ? '48px' : isApprovalStep ? '124px' : '64px'}
+              h={isNested ? '56px' : isApprovalStep ? '124px' : '64px'}
               w={headerWidth}
               onClick={handleClick}
             >

--- a/packages/frontend/src/contexts/MrfContext.tsx
+++ b/packages/frontend/src/contexts/MrfContext.tsx
@@ -78,7 +78,18 @@ export const MrfContextProvider = ({ children }: MrfContextProviderProps) => {
       return
     }
     setApprovalBranches(generateDefaultApprovalBranches(mrfApprovalSteps))
+    setDisabledMrfStepToDisplay(null)
   }, [approvalBranches, mrfApprovalSteps])
+
+  // Dont show disabled mrf step if it's deleted.
+  useEffect(() => {
+    if (
+      disabledMrfStepToDisplay &&
+      !mrfSteps.map((step) => step.id).includes(disabledMrfStepToDisplay.id)
+    ) {
+      setDisabledMrfStepToDisplay(null)
+    }
+  }, [mrfSteps, disabledMrfStepToDisplay])
 
   const setApprovalBranch = (stepId: string, branch: IStepApprovalBranch) => {
     setApprovalBranches((prev) => ({

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { FieldValues, UseFormGetValues } from 'react-hook-form'
 import {
   ApolloQueryResult,
@@ -18,6 +18,7 @@ import { GENERATE_PRESIGNED_POST } from '@/graphql/mutations/generate-presigned-
 import { UPDATE_FLOW_CONFIG } from '@/graphql/mutations/update-flow-config'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
+import { EditorContext } from '@/contexts/Editor'
 
 interface UseS3UploadOptions {
   onError?: (filename: string, type: string, errorMessage: string) => void
@@ -34,6 +35,7 @@ export const useS3Operations = (
   options: UseS3UploadOptions = {},
 ) => {
   const toast = useToast()
+  const { flow } = useContext(EditorContext)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [deleteFile] = useMutation(DELETE_UPLOADED_FILE)
@@ -60,7 +62,6 @@ export const useS3Operations = (
   const deleteUploadedFile = async (file: any) => {
     try {
       const { name: filename, value, displayedValue } = file
-      const flow = getValues('flow')
       const { id: flowId, updatedAt: flowUpdatedAt } = flow
       setIsDeleting(true)
 
@@ -69,7 +70,7 @@ export const useS3Operations = (
       // before clicking "Continue," the file would be deleted, but other
       // inputs remain visible in the UI without being saved.
       const currentAttachments = getValues(name) || []
-      const mutationInput = createUpdateStep(getValues(), currentAttachments)
+      const mutationInput = createUpdateStep(flow, getValues(), currentAttachments)
       await updateStep({ variables: { input: mutationInput } })
 
       await deleteFile({
@@ -162,7 +163,7 @@ export const useS3Operations = (
         )
 
         const currentAttachments = getValues(name) || []
-        const mutationInput = createUpdateStep(getValues(), [
+        const mutationInput = createUpdateStep(flow, getValues(), [
           ...currentAttachments,
           s3Id,
         ])

--- a/packages/frontend/src/hooks/useS3Operations.ts
+++ b/packages/frontend/src/hooks/useS3Operations.ts
@@ -13,12 +13,12 @@ import {
   createUpdateStep,
   reformatToAttachmentConfig,
 } from '@/components/AttachmentSuggestions/utils'
+import { EditorContext } from '@/contexts/Editor'
 import { DELETE_UPLOADED_FILE } from '@/graphql/mutations/delete-uploaded-file'
 import { GENERATE_PRESIGNED_POST } from '@/graphql/mutations/generate-presigned-post'
 import { UPDATE_FLOW_CONFIG } from '@/graphql/mutations/update-flow-config'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
-import { EditorContext } from '@/contexts/Editor'
 
 interface UseS3UploadOptions {
   onError?: (filename: string, type: string, errorMessage: string) => void
@@ -70,7 +70,11 @@ export const useS3Operations = (
       // before clicking "Continue," the file would be deleted, but other
       // inputs remain visible in the UI without being saved.
       const currentAttachments = getValues(name) || []
-      const mutationInput = createUpdateStep(flow, getValues(), currentAttachments)
+      const mutationInput = createUpdateStep(
+        flow,
+        getValues(),
+        currentAttachments,
+      )
       await updateStep({ variables: { input: mutationInput } })
 
       await deleteFile({


### PR DESCRIPTION
## Summary

These were fixes that were discovered and fixed before bug bash


## Fixes
**fix: radio field not parsed properly**
- was handling 'radio' instead of 'radiobutton'
#### to test: 
- [x] ensure that radio button shows up in mock data and submissions properly

**fix: if-then step position not incrementing properly**
ref: packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
- bug where SQL query to increment steps was using app_key <> MRF_APP_KEY which is false for null
- added orWhereNull('app_key') to fix this
#### to test: 
- [x] When adding MRF step before if-then step, ensure that that the if-then steps still appear properly


**fix: postman email step editor error**
- think this was a regression where the flowId was taken from step.flow.id in AttachmentSuggestion. there was a refactor earlier in this stack where flow was removed from step since its duplicating info returned. 
- fixed but retrieving flowId from EditorContext instead (please verify !)
#### to test: 
- [x] Email attachments still work

fix: nested step height incorrect
- CSS issue: grouped/nest steps were being squashed
- fixed by increasing height
#### to test: 
- [x] Grouped/nested steps dont appear squashed

fix: disabled step still appears after deleted
- Set disabled step to null on delete
#### to test: 
- [x] Go to reject branch and see disabled MRF step, delete the trigger, the disabled MRF step should be gone
