### PR TITLE
[MRF2-16] PLU-520: Post-bug bash fixes (logic)

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
@@ -79,7 +79,7 @@ describe('getBranchStepIdToSkipTo', () => {
     }
 
     const result = await getBranchStepIdToSkipTo($ as any)
-    expect(result).toBeUndefined()
+    expect(result).toBeNull()
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 
@@ -289,7 +289,7 @@ describe('getBranchStepIdToSkipTo', () => {
     }
 
     const result = await getBranchStepIdToSkipTo($ as any)
-    expect(result).toBeUndefined()
+    expect(result).toBeNull()
     expect(consoleErrorSpy).not.toHaveBeenCalled()
   })
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
@@ -407,4 +407,93 @@ describe('getBranchStepIdToSkipTo', () => {
       expect(result).toBe('step5')
     })
   })
+
+  describe('MRF approval flows', () => {
+    const makeSteps = (step2Config: object, step4Config: object) => [
+      {
+        id: 'step1',
+        appKey: 'formsg',
+        key: 'newSubmission',
+        parameters: {},
+        config: {},
+        position: 1,
+      },
+      {
+        id: 'step2',
+        appKey: 'toolbox',
+        key: 'ifThen',
+        parameters: { depth: '1' },
+        config: step2Config,
+        position: 2,
+      },
+      {
+        id: 'step3',
+        appKey: 'postman',
+        key: 'sendTransactionalEmail',
+        config: {},
+        position: 3,
+      },
+      {
+        id: 'step4',
+        appKey: 'toolbox',
+        key: 'ifThen',
+        parameters: { depth: '1' },
+        config: step4Config,
+        position: 4,
+      },
+      {
+        id: 'step5',
+        appKey: 'postman',
+        key: 'sendTransactionalEmail',
+        config: {},
+        position: 5,
+      },
+    ]
+
+    const $ = { flow: { id: 'flow-mrf' }, step: { id: 'step2', position: 2 } }
+
+    it('approval-branch if-then skips to next approval-branch if-then', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce(makeSteps({}, {}))
+      const result = await getBranchStepIdToSkipTo($ as any)
+      expect(result).toBe('step4')
+    })
+
+    it('approval-branch if-then does not skip to rejection-branch if-then', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        makeSteps({}, { approval: { branch: 'reject', stepId: 'mrf1' } }),
+      )
+      const result = await getBranchStepIdToSkipTo($ as any)
+      expect(result).toBeNull()
+    })
+
+    it('rejection-branch if-then skips to next rejection-branch if-then with same stepId', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        makeSteps(
+          { approval: { branch: 'reject', stepId: 'mrf1' } },
+          { approval: { branch: 'reject', stepId: 'mrf1' } },
+        ),
+      )
+      const result = await getBranchStepIdToSkipTo($ as any)
+      expect(result).toBe('step4')
+    })
+
+    it('rejection-branch if-then does not skip to rejection-branch if-then with different stepId', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        makeSteps(
+          { approval: { branch: 'reject', stepId: 'mrf1' } },
+          { approval: { branch: 'reject', stepId: 'mrf2' } },
+        ),
+      )
+      const result = await getBranchStepIdToSkipTo($ as any)
+      expect(result).toBeNull()
+    })
+
+    it('rejection-branch if-then does not skip to approval-branch if-then', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        makeSteps({ approval: { branch: 'reject', stepId: 'mrf1' } }, {}),
+      )
+      const result = await getBranchStepIdToSkipTo($ as any)
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
+++ b/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
@@ -74,8 +74,8 @@ export async function getBranchStepIdToSkipTo(
 
   // To account for MRF flows: don't skip across approval/rejection branch boundaries,
   // or into a rejection branch belonging to a different MRF approval step.
-  const currApproval = currBranchStep.config.approval
-  const nextApproval = nextBranchStep.config.approval
+  const currApproval = currBranchStep.config?.approval
+  const nextApproval = nextBranchStep.config?.approval
   const isSameBranch =
     currApproval?.branch === 'reject' && nextApproval?.branch === 'reject'
       ? currApproval.stepId === nextApproval.stepId

--- a/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
+++ b/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
@@ -67,5 +67,19 @@ export async function getBranchStepIdToSkipTo(
 
       return nextBranchDepth <= currDepth
     })
-  return nextBranchStep?.id
+
+  if (!nextBranchStep) {
+    return null
+  }
+
+  // To account for MRF flows: don't skip across approval/rejection branch boundaries,
+  // or into a rejection branch belonging to a different MRF approval step.
+  const currApproval = currBranchStep.config.approval
+  const nextApproval = nextBranchStep.config.approval
+  const isSameBranch =
+    currApproval?.branch === 'reject' && nextApproval?.branch === 'reject'
+      ? currApproval.stepId === nextApproval.stepId
+      : currApproval?.branch !== 'reject' && nextApproval?.branch !== 'reject'
+
+  return isSameBranch ? nextBranchStep.id : null
 }

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -127,12 +127,22 @@ describe('updateFlowStatus', () => {
     )
   })
 
-  it('throws an error when activating a flow with more than one for-each step', async () => {
+  it('throws an error when publishing a flow with more than one for-each step', async () => {
     fakeFlow.active = false
     fakeFlow.steps = [
       { position: 1 },
-      { position: 2, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
-      { position: 3, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.FOR_EACH },
+      {
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: {},
+      },
+      {
+        position: 3,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: {},
+      },
     ]
 
     await expect(
@@ -140,6 +150,54 @@ describe('updateFlowStatus', () => {
     ).rejects.toThrow(
       'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
     )
+  })
+
+  it('throws an error when publishing a flow with 2 for-each step in the same branch', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { position: 1 },
+      {
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+      },
+      {
+        position: 3,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+      },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).rejects.toThrow(
+      'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',
+    )
+  })
+
+  it('should not throw an error when publishing a flow with 2 for-each step in different branches', async () => {
+    fakeFlow.active = false
+    fakeFlow.steps = [
+      { position: 1 },
+      {
+        position: 2,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: {},
+      },
+      {
+        position: 3,
+        appKey: TOOLBOX_APP_KEY,
+        key: TOOLBOX_ACTIONS.FOR_EACH,
+        config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+      },
+    ]
+
+    await expect(
+      updateFlowStatus({}, { input: defaultInput }, context),
+    ).resolves.not.toThrow()
   })
 
   it('activates the flow and enqueues a job for non-webhook triggers', async () => {

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -20,12 +20,16 @@ const validateFlowSteps = (steps: Step[]) => {
     )
   }
 
+  const forEachSteps = steps.filter(
+    (step) =>
+      step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH,
+  )
+
   if (
-    steps.filter(
-      (step) =>
-        step.appKey === TOOLBOX_APP_KEY &&
-        step.key === TOOLBOX_ACTIONS.FOR_EACH,
-    ).length > 1
+    forEachSteps.length > 2 ||
+    (forEachSteps.length === 2 &&
+      forEachSteps[0].config.approval?.branch ===
+        forEachSteps[1].config.approval?.branch)
   ) {
     throw new Error(
       'Flow must have exactly one for-each step. Please contact support@plumber.gov.sg for help.',

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -264,24 +264,28 @@ const mockFlow = {
       position: 1,
       appKey: 'test-app',
       key: 'test-action',
+      config: {},
     },
     {
       id: randomForEachStepId,
       position: 2,
       appKey: TOOLBOX_APP_KEY,
       key: TOOLBOX_ACTIONS.FOR_EACH,
+      config: {},
     },
     {
       id: randomAction1StepId,
       position: 3,
       appKey: 'test-app',
       key: 'test-action-after-foreach',
+      config: {},
     },
     {
       id: randomAction2StepId,
       position: 4,
       appKey: 'test-app',
       key: 'test-action-after-foreach',
+      config: {},
     },
   ],
 } as unknown as Flow
@@ -295,6 +299,7 @@ describe('getStepContext', () => {
           position: 1,
           appKey: 'test-app',
           key: 'test-action',
+          config: {},
         },
       ],
     } as unknown as Flow
@@ -361,6 +366,103 @@ describe('getStepContext', () => {
       [mockFlow.steps[1].id]: 2,
       [mockFlow.steps[2].id]: 3,
       [mockFlow.steps[3].id]: 4,
+    })
+  })
+
+  describe('MRF approval flows', () => {
+    const mrfStepId = randomUUID()
+    const approveStep1Id = randomUUID()
+    const approveStep2Id = randomUUID()
+    const rejectForEachStepId = randomUUID()
+    const rejectStep1Id = randomUUID()
+    const rejectStep2Id = randomUUID()
+
+    // Flow: approve for-each(1) → approve(2) → approve(3) → reject for-each(4) → reject(5) → reject(6)
+    const mockMrfFlow = {
+      steps: [
+        {
+          id: mrfStepId,
+          position: 1,
+          appKey: TOOLBOX_APP_KEY,
+          key: TOOLBOX_ACTIONS.FOR_EACH,
+          config: {},
+        },
+        {
+          id: approveStep1Id,
+          position: 2,
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          config: {},
+        },
+        {
+          id: approveStep2Id,
+          position: 3,
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          config: {},
+        },
+        {
+          id: rejectForEachStepId,
+          position: 4,
+          appKey: TOOLBOX_APP_KEY,
+          key: TOOLBOX_ACTIONS.FOR_EACH,
+          config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+        },
+        {
+          id: rejectStep1Id,
+          position: 5,
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+        },
+        {
+          id: rejectStep2Id,
+          position: 6,
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          config: { approval: { branch: 'reject', stepId: 'mrf1' } },
+        },
+      ],
+    } as unknown as Flow
+
+    it('last approval-branch step is isLastStep, not the rejection-branch steps that follow', () => {
+      const approveStep2 = mockMrfFlow.steps[2]
+      const context = getStepContext(mockMrfFlow, approveStep2)
+      expect(context.isLastStep).toBe(true)
+    })
+
+    it('last rejection-branch step is isLastStep, not the approval-branch steps', () => {
+      const rejectStep2 = mockMrfFlow.steps[5]
+      const context = getStepContext(mockMrfFlow, rejectStep2)
+      expect(context.isLastStep).toBe(true)
+    })
+
+    it('non-last approval-branch step is not isLastStep', () => {
+      const approveStep1 = mockMrfFlow.steps[1]
+      const context = getStepContext(mockMrfFlow, approveStep1)
+      expect(context.isLastStep).toBe(false)
+    })
+
+    it('approval-branch step finds approval-branch for-each', () => {
+      const approveStep1 = mockMrfFlow.steps[1]
+      const context = getStepContext(mockMrfFlow, approveStep1)
+      expect(context.forEachStepPosition).toBe(1)
+    })
+
+    it('rejection-branch step finds rejection-branch for-each', () => {
+      const rejectStep1 = mockMrfFlow.steps[4]
+      const context = getStepContext(mockMrfFlow, rejectStep1)
+      expect(context.forEachStepPosition).toBe(4)
+    })
+
+    it('rejection-branch step returns forEachStepPosition -1 when no rejection for-each exists', () => {
+      const flowWithOnlyApproveForEach = {
+        steps: mockMrfFlow.steps.filter((s) => s.id !== rejectForEachStepId),
+      } as unknown as Flow
+      const rejectStep1 = mockMrfFlow.steps[4]
+      const context = getStepContext(flowWithOnlyApproveForEach, rejectStep1)
+      expect(context.forEachStepPosition).toBe(-1)
+      expect(context.isLastStep).toBe(false)
     })
   })
 

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -41,9 +41,14 @@ export function getStepContext(
 } {
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
+
+  const stepApprovalConfig = step.config.approval
   const forEachSteps = flow.steps.filter(
-    (step) =>
-      step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH,
+    (currStep) =>
+      currStep.appKey === TOOLBOX_APP_KEY &&
+      currStep.key === TOOLBOX_ACTIONS.FOR_EACH &&
+      currStep.config.approval?.branch === stepApprovalConfig?.branch &&
+      currStep.config.approval?.stepId === stepApprovalConfig?.stepId,
   )
   // NOTE: do not allow multiple for-each steps in a flow
   if (forEachSteps.length !== 1) {
@@ -65,11 +70,15 @@ export function getStepContext(
    *   used in for each to terminate an iteration within the loop
    */
   const { stepPositions, lastStepId } = flow.steps.reduce(
-    (acc, step) => {
-      acc.stepPositions[step.id] = step.position
-      if (step.position > acc.maxPosition) {
-        acc.maxPosition = step.position
-        acc.lastStepId = step.id
+    (acc, currStep) => {
+      acc.stepPositions[currStep.id] = currStep.position
+      // to account for MRF flows: only track the last step within the same branch
+      if (
+        currStep.config.approval?.branch === stepApprovalConfig?.branch &&
+        currStep.position > acc.maxPosition
+      ) {
+        acc.maxPosition = currStep.position
+        acc.lastStepId = currStep.id
       }
       return acc
     },
@@ -127,6 +136,8 @@ export function computeForEachParameters({
 
   // SPECIAL CASE: this returns the iteration number of the specific iteration.
   // metadata.iteration is not available for test runs
+  console.log('forEachKeyPath', forEachKeyPath)
+  console.log('metadata', metadata)
   if (forEachKeyPath === FOR_EACH_ITERATION_KEY) {
     return metadata?.iteration ? metadata.iteration : 1
   }

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -75,6 +75,7 @@ export function getStepContext(
       // to account for MRF flows: only track the last step within the same branch
       if (
         currStep.config.approval?.branch === stepApprovalConfig?.branch &&
+        currStep.config.approval?.stepId === stepApprovalConfig?.stepId &&
         currStep.position > acc.maxPosition
       ) {
         acc.maxPosition = currStep.position
@@ -136,8 +137,6 @@ export function computeForEachParameters({
 
   // SPECIAL CASE: this returns the iteration number of the specific iteration.
   // metadata.iteration is not available for test runs
-  console.log('forEachKeyPath', forEachKeyPath)
-  console.log('metadata', metadata)
   if (forEachKeyPath === FOR_EACH_ITERATION_KEY) {
     return metadata?.iteration ? metadata.iteration : 1
   }


### PR DESCRIPTION
## Bug bash fixes

### Fix: if-then skipping from approval to rejection branch

Prevents if-then steps from incorrectly skipping across approval/rejection branch boundaries in MRF flows. Approval-branch if-then steps now only skip to other approval-branch steps, while rejection-branch if-then steps only skip to rejection-branch steps with the same stepId.
 
#### To test:
- [x] Setup If-then on both approval and reject branch
- [x] Ensure that it doesnt skip from approval to reject branch

### Fix: for-each allowed in both branches, correctly computes iteration status

- Allows up to 2 for-each steps in a flow (one for approval branch, one for rejection branch) and ensures proper context computation for MRF approval flows.
- Steps now correctly identify their corresponding for-each step and last step within their respective branches.
#### To test:
- [x] Allow publish of pipe with 2 for-each steps
- [x] Running each of them in each branches should correctly compute status