### PR TITLE
[MRF2-17] PLU-520: Post-bug bash fixes (UI)

### DIFF
--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
@@ -28,7 +28,9 @@ export function parseWorkflowData(
   for (const step of result.data) {
     populatedFields.push(...step.edit)
     parsedSteps.push({
-      defaultStepName: step.step_name ?? `MRF Step ${parsedSteps.length + 1}`,
+      defaultStepName: step.step_name
+        ? step.step_name.trim()
+        : `MRF Step ${parsedSteps.length + 1}`,
       type: step.workflow_type,
       fields: [...populatedFields],
       formWorkflowStepId: step._id,

--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -7,6 +7,7 @@ import { FlowStep } from '@/exports/components'
 
 import { AddStepButton } from './AddStepButton'
 import { DisabledFlowStep } from './DisabledFlowStep'
+import { SortableItemContext } from '@/components/SortableList/components/SortableItem'
 
 export default function FlowStepWithAddButton({
   step,
@@ -32,6 +33,7 @@ export default function FlowStepWithAddButton({
   }
 }) {
   const { disabledMrfStepToDisplay } = useContext(MrfContext)
+  const { isOverlay, isSorting } = useContext(SortableItemContext)
 
   const shouldShowDisabledMrfStep = isLastStep && disabledMrfStepToDisplay
 
@@ -44,14 +46,18 @@ export default function FlowStepWithAddButton({
         // only allow reordering if there are more than 1 action steps
         allowReorder={allowReorder}
       />
-      <AddStepButton
-        isLastStep={isLastStep}
-        step={step}
-        isHidden={isHidden}
-        isDisabled={isDisabled}
-        showEmptyAction={showEmptyAction}
-      />
-      {shouldShowDisabledMrfStep && (
+      {/* Hide the add step button and dividers for the drag overlay */}
+      {!isOverlay && (
+        <AddStepButton
+          isLastStep={isLastStep}
+          step={step}
+          isHidden={isHidden}
+          isDisabled={isDisabled}
+          showEmptyAction={showEmptyAction}
+        />
+      )}
+      {/* Hide the disabled mrf step for the drag overlay and when sorting is taking place */}
+      {shouldShowDisabledMrfStep && !isOverlay && !isSorting && (
         <DisabledFlowStep
           step={disabledMrfStepToDisplay}
           tooltipText={

--- a/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
+++ b/packages/frontend/src/components/Editor/components/FlowStepWithAddButton.tsx
@@ -2,12 +2,12 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 
+import { SortableItemContext } from '@/components/SortableList/components/SortableItem'
 import { MrfContext } from '@/contexts/MrfContext'
 import { FlowStep } from '@/exports/components'
 
 import { AddStepButton } from './AddStepButton'
 import { DisabledFlowStep } from './DisabledFlowStep'
-import { SortableItemContext } from '@/components/SortableList/components/SortableItem'
 
 export default function FlowStepWithAddButton({
   step,

--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -135,7 +135,7 @@ export function StepsList({ isNested }: StepsListProps) {
         renderItem={(step, isOverlay) => {
           const { id, position } = step
           return (
-            <SortableList.Item id={id}>
+            <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
               <Flex
                 key={`${id}-${position}`}
                 width={isDrawerOpen || isMobile ? '100%' : 'auto'}

--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -32,7 +32,6 @@ export default function StepHeader(props: StepHeaderProps) {
     setCurrentStepId,
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
-
   const { defaultStepName, displayPosition, stepName } = useStepMetadata(step)
 
   const handleClose = () => {

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { Flex, Tab, TabList, TabProps, Tabs } from '@chakra-ui/react'
 
-import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 
 const tabStyle = (primaryColor: string): TabProps => {
@@ -29,7 +28,6 @@ const tabStyle = (primaryColor: string): TabProps => {
 }
 
 export function ApproveReject({ stepId }: { stepId: string }) {
-  const { setCurrentStepId, onDrawerClose } = useContext(EditorContext)
   const { approvalBranches, setApprovalBranch } = useContext(MrfContext)
 
   const isApproveBranch = approvalBranches[stepId] === 'approve'
@@ -37,10 +35,8 @@ export function ApproveReject({ stepId }: { stepId: string }) {
   const onChange = useCallback(
     (index: number) => {
       setApprovalBranch(stepId, index === 0 ? 'approve' : 'reject')
-      setCurrentStepId(null)
-      onDrawerClose()
     },
-    [stepId, setApprovalBranch, setCurrentStepId, onDrawerClose],
+    [stepId, setApprovalBranch],
   )
 
   return (

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -55,7 +55,7 @@ export function ApproveReject({ stepId }: { stepId: string }) {
         onChange={onChange}
         flex={1}
       >
-        <TabList gap={2}>
+        <TabList gap={2} overflow="hidden">
           <Tab {...tabStyle('green.500')}>If approved</Tab>
           <Tab {...tabStyle('red.500')}>If rejected</Tab>
         </TabList>

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -1,7 +1,7 @@
 import './SortableItem.css'
 
 import type { CSSProperties, PropsWithChildren } from 'react'
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext } from 'react'
 import type {
   DraggableSyntheticListeners,
   UniqueIdentifier,
@@ -52,17 +52,7 @@ export function SortableItem({
     transition,
     isSorting,
   } = useSortable({ id })
-  const context = useMemo(
-    () => ({
-      attributes,
-      listeners,
-      ref: setActivatorNodeRef,
-      isDragging,
-      isOverlay,
-      isSorting,
-    }),
-    [attributes, listeners, setActivatorNodeRef, isDragging, isOverlay],
-  )
+
   const style: CSSProperties = {
     opacity: isDragging ? 0.4 : undefined,
     transform: CSS.Translate.toString(transform),
@@ -70,7 +60,17 @@ export function SortableItem({
   }
 
   return (
-    <SortableItemContext.Provider value={context}>
+    <SortableItemContext.Provider
+      value={{
+        attributes,
+        listeners,
+        ref: setActivatorNodeRef,
+        isDragging,
+        isOverlay,
+
+        isSorting,
+      }}
+    >
       <li className="SortableItem" ref={setNodeRef} style={style}>
         {children}
       </li>

--- a/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
+++ b/packages/frontend/src/components/SortableList/components/SortableItem/index.tsx
@@ -20,20 +20,28 @@ interface Context {
   listeners: DraggableSyntheticListeners
   ref(node: HTMLElement | null): void
   isDragging: boolean
+  isOverlay: boolean
+  isSorting: boolean
 }
 
 export const NESTED_DRAG_HANDLE_WIDTH = 16
 
-const SortableItemContext = createContext<Context>({
+export const SortableItemContext = createContext<Context>({
   attributes: {},
   listeners: undefined,
   ref() {
     // Empty implementation for default context
   },
   isDragging: false,
+  isOverlay: false,
+  isSorting: false,
 })
 
-export function SortableItem({ children, id }: PropsWithChildren<Props>) {
+export function SortableItem({
+  children,
+  id,
+  isOverlay = false,
+}: PropsWithChildren<Props & { isOverlay?: boolean }>) {
   const {
     attributes,
     isDragging,
@@ -42,6 +50,7 @@ export function SortableItem({ children, id }: PropsWithChildren<Props>) {
     setActivatorNodeRef,
     transform,
     transition,
+    isSorting,
   } = useSortable({ id })
   const context = useMemo(
     () => ({
@@ -49,8 +58,10 @@ export function SortableItem({ children, id }: PropsWithChildren<Props>) {
       listeners,
       ref: setActivatorNodeRef,
       isDragging,
+      isOverlay,
+      isSorting,
     }),
-    [attributes, listeners, setActivatorNodeRef, isDragging],
+    [attributes, listeners, setActivatorNodeRef, isDragging, isOverlay],
   )
   const style: CSSProperties = {
     opacity: isDragging ? 0.4 : undefined,

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -1,7 +1,7 @@
 import type { IApp, IStep } from '@plumber/types'
 
 import type { ReactNode } from 'react'
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useEffect, useMemo } from 'react'
 
 import { extractBranchesWithSteps } from '@/helpers/toolbox'
 
@@ -33,7 +33,8 @@ interface StepExecutionsProviderProps {
 export function StepsToDisplayProvider({
   children,
 }: StepExecutionsProviderProps): JSX.Element {
-  const { allApps, flow } = useContext(EditorContext)
+  const { allApps, flow, currentStepId, setCurrentStepId, onDrawerClose } =
+    useContext(EditorContext)
   const { approvalBranches } = useContext(MrfContext)
 
   const allSteps = flow.steps
@@ -126,6 +127,16 @@ export function StepsToDisplayProvider({
       ? [triggerStep, stepsToDisplay.slice(1), []]
       : [triggerStep, stepsToDisplay.slice(1, groupStepIdx), branchesWithSteps]
   }, [groupingActions, stepsToDisplay])
+
+  useEffect(() => {
+    if (
+      currentStepId &&
+      !stepsToDisplay.map((step) => step.id).includes(currentStepId)
+    ) {
+      setCurrentStepId(null)
+      onDrawerClose()
+    }
+  }, [stepsToDisplay, currentStepId, onDrawerClose])
 
   return (
     <StepsToDisplayContext.Provider

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -136,7 +136,7 @@ export function StepsToDisplayProvider({
       setCurrentStepId(null)
       onDrawerClose()
     }
-  }, [stepsToDisplay, currentStepId, onDrawerClose])
+  }, [stepsToDisplay, currentStepId, onDrawerClose, setCurrentStepId])
 
   return (
     <StepsToDisplayContext.Provider


### PR DESCRIPTION
## Changes

**fix: approve reject tabs are scrollable**
- Added `overflow="hidden"` to TabList component to prevent tab content from overflowing

**chore: trim mrf step name so markdown bolding works properly**
- Added `.trim()` method to step name processing in workflow data parsing to remove leading/trailing whitespace

**fix: do not close side bar when toggling approval branches unless step disappears**
- Removed automatic drawer closing and step deselection when switching between approve/reject branches
- Added effect to close drawer only when current step is no longer visible in the steps list

**chore: hide disabled mrf step and add new button/divider when dragging**
- Added context tracking for overlay and sorting states in SortableItem
- Conditionally hide AddStepButton and DisabledFlowStep components during drag operations
- Passed isOverlay prop to SortableList.Item component