### PR TITLE
[MRF2-18] PLU-520: Add LaunchDarkly Flag

### DIFF
--- a/packages/backend/src/apps/formsg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/formsg/auth/verify-credentials.ts
@@ -2,6 +2,8 @@ import { IGlobalVariable } from '@plumber/types'
 
 import get from 'lodash.get'
 
+import { getLdFlagValue } from '@/helpers/launch-darkly'
+
 import { FORM_ID_LENGTH } from '../common/constants'
 import {
   FormEnv,
@@ -32,6 +34,17 @@ export const verifyFormCreds = async (
 
   if (!publicKey) {
     throw new Error('Form is not a storage mode form')
+  }
+
+  if (isMrf) {
+    const canConnectMrf = await getLdFlagValue(
+      'allow-mrf-form',
+      $.user?.email ?? null,
+      false,
+    )
+    if (!canConnectMrf) {
+      throw new Error('MRF forms are not supported yet. Check back soon!')
+    }
   }
 
   const formsgSdk = getSdk(env)


### PR DESCRIPTION
## Changes

Added LD flag to prevent MRF connection. This is to facilitate rollout and detect regression to normal formsg.

### To test
- Use https://app.launchdarkly.com/projects/plumber/flags/allow-mrf-form/targeting?env=production&env=staging&env=test&selected-env=test and toggle between true and false. 
- If false, you should not be able to connect an MRF form.