### PR TITLE
[TILES-PW-1] PLU-672: DB schema

### DIFF
--- a/packages/backend/src/db/migrations/20260305084905_add_tiles_password.ts
+++ b/packages/backend/src/db/migrations/20260305084905_add_tiles_password.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.table('table_metadata', (table) => {
+    table.jsonb('view_only_password').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.table('table_metadata', (table) => {
+    table.dropColumn('view_only_password')
+  })
+}

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -6,12 +6,18 @@ import TableCollaborator from './table-collaborators'
 import TableColumnMetadata from './table-column-metadata'
 import User from './user'
 
+interface ViewOnlyPassword {
+  hash: string
+  tokenNonce: string
+}
+
 class TableMetadata extends Base {
   id!: string
   name: string
   collaborators!: User[]
   columns: TableColumnMetadata[]
   viewOnlyKey?: string | null
+  viewOnlyPassword?: ViewOnlyPassword | null
 
   /**
    * for typescript support when creating TableCollaborator row in insertGraph
@@ -28,6 +34,13 @@ class TableMetadata extends Base {
       id: { type: 'string', format: 'uuid' },
       name: { type: 'string' },
       viewOnlyKey: { type: ['string', 'null'] },
+      viewOnlyPassword: {
+        type: ['object', 'null'],
+        properties: {
+          hash: { type: 'string' },
+          tokenNonce: { type: 'string' },
+        },
+      },
     },
   }
 

--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -108,6 +108,10 @@ class TableMetadata extends Base {
     }
     return mappedData
   }
+
+  get isPasswordProtected() {
+    return this.viewOnlyKey && this.viewOnlyPassword
+  }
 }
 
 export default TableMetadata


### PR DESCRIPTION
## Changes

### Db schema change
Added `view_only_password` JSONB column to the `table_metadata` table to store password hash and token nonce for view-only access protection.

### Objection model change

Added `isPasswordProtected` getter method to `TableMetadata` model that returns true when both `viewOnlyKey` and `viewOnlyPassword` are present.