### PR TITLE
[TILES-PW-2] PLU-672: crypto-related helpers

### DIFF
--- a/packages/backend/src/helpers/__tests__/auth-tiles.test.ts
+++ b/packages/backend/src/helpers/__tests__/auth-tiles.test.ts
@@ -1,0 +1,109 @@
+import jwt from 'jsonwebtoken'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config/app', () => ({
+  default: {
+    sessionSecretKey: 'test-secret-key',
+  },
+}))
+
+import {
+  generateViewToken,
+  hashTilePassword,
+  verifyTilePassword,
+  verifyViewToken,
+} from '../auth-tiles'
+
+describe('auth-tiles', () => {
+  describe('verifyTilePassword', () => {
+    it('returns true for the correct password', () => {
+      const viewOnlyKey = 'view-only-key'
+      const hash = hashTilePassword('password123', viewOnlyKey)
+      expect(verifyTilePassword('password123', hash, viewOnlyKey)).toBe(true)
+    })
+
+    it('returns false for an incorrect password', () => {
+      const viewOnlyKey = 'view-only-key'
+      const hash = hashTilePassword('password123', viewOnlyKey)
+      expect(verifyTilePassword('wrong-password', hash, viewOnlyKey)).toBe(
+        false,
+      )
+    })
+
+    it('returns false when viewOnlyKey does not match', () => {
+      const hash = hashTilePassword('password123', 'key-1')
+      expect(verifyTilePassword('password123', hash, 'key-2')).toBe(false)
+    })
+  })
+
+  describe('verifyViewToken', () => {
+    const tileId = 'tile-1'
+    const viewOnlyKey = 'vok-1'
+    const tokenNonce = 'nonce-1'
+
+    it('returns true for a valid token with matching params', () => {
+      const token = generateViewToken(tileId, viewOnlyKey, tokenNonce)
+      expect(verifyViewToken(token, tileId, viewOnlyKey, tokenNonce)).toBe(true)
+    })
+
+    it('returns false when tileId does not match', () => {
+      const token = generateViewToken(tileId, viewOnlyKey, tokenNonce)
+      expect(
+        verifyViewToken(token, 'wrong-tile', viewOnlyKey, tokenNonce),
+      ).toBe(false)
+    })
+
+    it('returns false when viewOnlyKey does not match', () => {
+      const token = generateViewToken(tileId, viewOnlyKey, tokenNonce)
+      expect(verifyViewToken(token, tileId, 'wrong-key', tokenNonce)).toBe(
+        false,
+      )
+    })
+
+    it('returns false when tokenNonce does not match', () => {
+      const token = generateViewToken(tileId, viewOnlyKey, tokenNonce)
+      expect(verifyViewToken(token, tileId, viewOnlyKey, 'wrong-nonce')).toBe(
+        false,
+      )
+    })
+
+    it('returns false for a malformed token', () => {
+      expect(
+        verifyViewToken('not-a-jwt', tileId, viewOnlyKey, tokenNonce),
+      ).toBe(false)
+    })
+
+    it('returns false for a token signed with a different secret', () => {
+      const badToken = jwt.sign(
+        { tileId, viewOnlyKey, tokenNonce },
+        'different-secret',
+      )
+      expect(verifyViewToken(badToken, tileId, viewOnlyKey, tokenNonce)).toBe(
+        false,
+      )
+    })
+
+    it('returns false for an expired token', () => {
+      const expiredToken = jwt.sign(
+        { tileId, viewOnlyKey, tokenNonce },
+        'test-secret-key',
+        {
+          expiresIn: '-1s',
+        },
+      ) as unknown as string // sorry for force casting, im not sure why it's not typed properly
+      expect(
+        verifyViewToken(expiredToken, tileId, viewOnlyKey, tokenNonce),
+      ).toBe(false)
+    })
+
+    it('re-throws non-JWT errors', () => {
+      vi.spyOn(jwt, 'verify').mockImplementation(() => {
+        throw new Error('unexpected error')
+      })
+      expect(() =>
+        verifyViewToken('token', tileId, viewOnlyKey, tokenNonce),
+      ).toThrow('unexpected error')
+      vi.restoreAllMocks()
+    })
+  })
+})

--- a/packages/backend/src/helpers/auth-tiles.ts
+++ b/packages/backend/src/helpers/auth-tiles.ts
@@ -1,0 +1,77 @@
+import { randomBytes, scryptSync, timingSafeEqual } from 'crypto'
+import jwt, { JsonWebTokenError } from 'jsonwebtoken'
+
+import appConfig from '@/config/app'
+
+const { sessionSecretKey } = appConfig
+
+const SCRYPT_KEY_LENGTH = 64
+
+interface TileViewTokenPayload {
+  tileId: string
+  viewOnlyKey: string
+  tokenNonce: string
+}
+
+const VIEW_TOKEN_EXPIRES_IN_SEC = 24 * 60 * 60 // 24 hours
+
+// Uses viewOnlyKey as salt - no separate salt column needed
+// When viewOnlyKey is changed, the password hash will be invalidated
+export function hashTilePassword(
+  password: string,
+  viewOnlyKey: string,
+): string {
+  return scryptSync(password, viewOnlyKey, SCRYPT_KEY_LENGTH).toString('base64')
+}
+
+export function verifyTilePassword(
+  password: string,
+  storedHash: string,
+  viewOnlyKey: string,
+): boolean {
+  const inputHash = scryptSync(password, viewOnlyKey, SCRYPT_KEY_LENGTH)
+  const storedHashBuffer = Buffer.from(storedHash, 'base64')
+  return timingSafeEqual(inputHash, storedHashBuffer)
+}
+
+export function generateTokenNonce(): string {
+  return randomBytes(32).toString('base64')
+}
+
+/**
+ * This will be stored in session storage
+ */
+
+export function generateViewToken(
+  tileId: string,
+  viewOnlyKey: string,
+  tokenNonce: string,
+): string {
+  /**
+   * The token is invalidated when viewOnlyKey or tokenNonce (correlated with password) is changed
+   */
+  return jwt.sign({ tileId, viewOnlyKey, tokenNonce }, sessionSecretKey, {
+    expiresIn: VIEW_TOKEN_EXPIRES_IN_SEC,
+  })
+}
+
+export function verifyViewToken(
+  token: string,
+  tileId: string,
+  viewOnlyKey: string,
+  tokenNonce: string,
+): boolean {
+  try {
+    const payload = jwt.verify(token, sessionSecretKey) as TileViewTokenPayload
+    return (
+      payload.tileId === tileId &&
+      payload.viewOnlyKey === viewOnlyKey &&
+      payload.tokenNonce === tokenNonce
+    )
+  } catch (err) {
+    if (err instanceof JsonWebTokenError) {
+      return false // expired, malformed, or invalid signature
+    }
+    throw err
+  }
+}


### PR DESCRIPTION
## Changes

Added authentication utilities for tile password hashing and view token management with JWT-based session tokens.

### What changed?

Created `auth-tiles.ts` helper module with functions for:
- Password hashing using scrypt with tiles viewOnlyKey as salt (`hashTilePassword`, `verifyTilePassword`)
- Random token nonce generation (`generateTokenNonce`)
- JWT view token creation and verification (`generateViewToken`, `verifyViewToken`)

The view tokens include tileId, viewOnlyKey, and tokenNonce in the payload and expire after 24 hours. Password hashes are automatically invalidated when the viewOnlyKey or passwordNonce changes since it's used as the salt.

### How to test?

Covered by unit tests
- Correct and incorrect password verification
- Valid and invalid view token scenarios (wrong parameters, malformed tokens, expired tokens, wrong signing secret)
- Edge cases like non-JWT errors
