### PR TITLE
[TILES-PW-3] PLU-672: backend mutations

### DIFF
--- a/packages/backend/src/graphql/mutations/tiles/delete-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table-view-password.ts
@@ -3,10 +3,11 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
-const deleteShareableTableLink: MutationResolvers['deleteShareableTableLink'] =
+const deleteTableViewPassword: MutationResolvers['deleteTableViewPassword'] =
   async (_parent, params, context) => {
-    const tableId = params.tableId
+    const { tableId } = params
 
+    // Must be at least editor
     await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 
     const table = await TableMetadata.query()
@@ -14,12 +15,10 @@ const deleteShareableTableLink: MutationResolvers['deleteShareableTableLink'] =
       .throwIfNotFound()
 
     await table.$query().patch({
-      viewOnlyKey: null,
-      // we also remove passwords when shareable link is disabled
       viewOnlyPassword: null,
     })
 
     return true
   }
 
-export default deleteShareableTableLink
+export default deleteTableViewPassword

--- a/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'crypto'
+
+import { BadUserInputError } from '@/errors/graphql-errors'
+import { hashTilePassword } from '@/helpers/auth-tiles'
+import TableCollaborator from '@/models/table-collaborators'
+import TableMetadata from '@/models/table-metadata'
+
+import type { MutationResolvers } from '../../__generated__/types.generated'
+
+const setTableViewPassword: MutationResolvers['setTableViewPassword'] = async (
+  _parent,
+  params,
+  context,
+) => {
+  const { tableId, password } = params.input
+
+  // Must be at least editor
+  await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
+
+  const table = await TableMetadata.query().findById(tableId).throwIfNotFound()
+
+  /**
+   * We check that shareable link is enabled first
+   */
+  if (!table.viewOnlyKey) {
+    throw new BadUserInputError('Shareable link must be enabled first')
+  }
+
+  await table.$query().patch({
+    viewOnlyPassword: {
+      hash: hashTilePassword(password, table.viewOnlyKey),
+      tokenNonce: randomUUID(),
+    },
+  })
+
+  return true
+}
+
+export default setTableViewPassword

--- a/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
@@ -1,0 +1,45 @@
+import { timingSafeEqual } from 'crypto'
+
+import { ForbiddenError } from '@/errors/graphql-errors'
+import { verifyTilePassword } from '@/helpers/auth-tiles'
+import TableMetadata from '@/models/table-metadata'
+
+import type { MutationResolvers } from '../../__generated__/types.generated'
+
+const verifyTableViewPassword: MutationResolvers['verifyTableViewPassword'] =
+  async (_parent, params, context) => {
+    const { tableId, password } = params.input
+
+    const table = await TableMetadata.query()
+      .findById(tableId)
+      .throwIfNotFound()
+
+    /**
+     * We check that shareable link is enabled first
+     */
+    if (!table.viewOnlyKey || !table.viewOnlyPassword) {
+      throw new ForbiddenError("Shareable link or password isn't enabled.")
+    }
+
+    if (
+      // If shareable link view key is not provided
+      !context.tilesViewKey ||
+      // If shareable link view key does not match
+      !timingSafeEqual(
+        Buffer.from(table.viewOnlyKey),
+        Buffer.from(context.tilesViewKey),
+      ) ||
+      // If password is incorrect
+      !verifyTilePassword(
+        password,
+        table.viewOnlyPassword.hash,
+        context.tilesViewKey,
+      )
+    ) {
+      throw new ForbiddenError('Invalid password')
+    }
+
+    return true
+  }
+
+export default verifyTableViewPassword

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -115,6 +115,9 @@ type Mutation {
   createTable(input: CreateTableInput!): TableMetadata!
   createShareableTableLink(tableId: ID!): String!
   deleteShareableTableLink(tableId: ID!): Boolean!
+  setTableViewPassword(input: SetTableViewPasswordInput!): Boolean!
+  deleteTableViewPassword(tableId: ID!): Boolean!
+  verifyTableViewPassword(input: VerifyTableViewPasswordInput!): Boolean!
   updateTable(input: UpdateTableInput!): TableMetadata!
   deleteTable(input: DeleteTableInput!): Boolean!
   # Tiles rows
@@ -936,6 +939,7 @@ type TableMetadata {
   lastAccessedAt: String!
   viewOnlyKey: String
   collaborators: [TableCollaborator!]
+  isPasswordProtected: Boolean!
   role: String
 }
 
@@ -952,6 +956,16 @@ type GetTableRowsResult {
   rows: Any!
   columnIds: [String!]!
   stringifiedCursor: String
+}
+
+input SetTableViewPasswordInput {
+  tableId: ID!
+  password: String!
+}
+
+input VerifyTableViewPasswordInput {
+  tableId: ID!
+  password: String!
 }
 
 # End Tiles types


### PR DESCRIPTION
## Changes

Added new GraphQL mutations to support new feature:
`setTableViewPassword`: computes password hash and nonce to store in db. Will only succeed if Shareable links are enabled

`deleteTableViewPassword`: delete password hash and nonce

`verifyTableViewPassword`: verifies the JWT view token.

`deleteShareableTableLink`: should also delete password hash and nonce

### How to test?
Since there is no frontend, you have to use the Apollo Server API explorer at http://localhost:3001/graphql
Prerequisite, 
1. you should be logged in to localhost:3001
2. Created a tile

### `setTableViewPassword`
```
mutation SetTableViewPassword($input: SetTableViewPasswordInput!) {
  setTableViewPassword(input: $input)
}

variables
{
  "input": {
    "tableId": "<TABLE_ID>",
    "password": "123"
  }
}
```
1. When shareable link is disabled, it should fail
2. When shareable link is enabled, it should succeed

`deleteTableViewPassword`
```
mutation DeleteTableViewPassword($tableId: ID!) {
  deleteTableViewPassword(tableId: $tableId)
}
variables
{
  "tableId": "<TABLE_ID>"
}
```

`deleteShareableLink`
```
mutation DeleteShareableTableLink($tableId: ID!) {
  deleteShareableTableLink(tableId: $tableId)
}
variables
{
  "tableId": "<TABLE_ID>"
}
```

`verifyTableViewPassword`
```
mutation VerifyTableViewPassword($input: VerifyTableViewPasswordInput!) {
  verifyTableViewPassword(input: $input)
}
variables
{
  "input": {
    "tableId": "<TABLE_ID",
    "password": "123"
  }
}
headers:
x-tiles-view-key: <SHAREABLE_LINK_SECOND_PART>
```