### PR TITLE
[TILES-PW-4] PLU-672: auth for mutations

### DIFF
--- a/packages/backend/src/errors/invalid-tile-view-key.ts
+++ b/packages/backend/src/errors/invalid-tile-view-key.ts
@@ -1,8 +1,10 @@
 export default class InvalidTileViewKeyError extends Error {
   tableId: string
   viewOnlyKey: string
+  code: string
   constructor(tableId: string, viewOnlyKey: string) {
     super('Invalid tile view only key')
+    this.code = 'INVALID_TILE_VIEW_KEY'
     this.tableId = tableId
     this.viewOnlyKey = viewOnlyKey
   }

--- a/packages/backend/src/errors/invalid-tile-view-password.ts
+++ b/packages/backend/src/errors/invalid-tile-view-password.ts
@@ -1,0 +1,11 @@
+export default class InvalidTileViewTokenError extends Error {
+  tableId: string
+  tableName: string
+  code: string
+  constructor(tableId: string, tableName: string) {
+    super('Tile is password-protected')
+    this.code = 'INVALID_TILE_VIEW_TOKEN'
+    this.tableId = tableId
+    this.tableName = tableName
+  }
+}

--- a/packages/backend/src/graphql/mutations/tiles/index.ts
+++ b/packages/backend/src/graphql/mutations/tiles/index.ts
@@ -8,9 +8,12 @@ import deleteRows from './delete-rows'
 import deleteTable from './delete-table'
 import deleteTableCollaborator from './delete-table-collaborator'
 import deleteShareableTableLink from './delete-table-shareable-link'
+import deleteTableViewPassword from './delete-table-view-password'
+import setTableViewPassword from './set-table-view-password'
 import updateRow from './update-row'
 import updateTable from './update-table'
 import upsertTableCollaborator from './upsert-table-collaborator'
+import verifyTableViewPassword from './verify-table-view-password'
 
 export default {
   createTable,
@@ -24,4 +27,7 @@ export default {
   deleteShareableTableLink,
   deleteTableCollaborator,
   upsertTableCollaborator,
+  setTableViewPassword,
+  deleteTableViewPassword,
+  verifyTableViewPassword,
 } satisfies MutationResolvers

--- a/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/verify-table-view-password.ts
@@ -1,7 +1,7 @@
 import { timingSafeEqual } from 'crypto'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
-import { verifyTilePassword } from '@/helpers/auth-tiles'
+import { generateViewToken, verifyTilePassword } from '@/helpers/auth-tiles'
 import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
@@ -38,8 +38,12 @@ const verifyTableViewPassword: MutationResolvers['verifyTableViewPassword'] =
     ) {
       throw new ForbiddenError('Invalid password')
     }
-
-    return true
+    const token = generateViewToken(
+      table.id,
+      table.viewOnlyKey,
+      table.viewOnlyPassword.tokenNonce,
+    )
+    return token
   }
 
 export default verifyTableViewPassword

--- a/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-all-rows.ts
@@ -7,12 +7,15 @@ import {
 import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import { RateLimitedError } from '@/errors/graphql-errors/rate-limited'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
+import InvalidTileViewTokenError from '@/errors/invalid-tile-view-password'
 import logger from '@/helpers/logger'
 import TableMetadata from '@/models/table-metadata'
 import { DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE } from '@/models/tiles/dynamodb/helpers'
 import { getTableOperations } from '@/models/tiles/factory'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
+
+import { fetchTableWithViewOnlyCheck } from './view-only.helper'
 
 const getAllRows: QueryResolvers['getAllRows'] = async (
   _parent,
@@ -22,19 +25,22 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
   const { tableId, stringifiedCursor } = params
 
   try {
-    const table = context.tilesViewKey
-      ? await TableMetadata.query()
-          .withGraphFetched('columns')
-          .findOne({
-            id: tableId,
-            view_only_key: context.tilesViewKey,
-          })
-          .throwIfNotFound()
-      : await context.currentUser
-          .$relatedQuery('tables')
-          .withGraphFetched('columns')
-          .findById(tableId)
-          .throwIfNotFound()
+    let table: TableMetadata | undefined
+    if (context.tilesViewKey) {
+      const { table: fetchedTable } = await fetchTableWithViewOnlyCheck({
+        tableId,
+        context,
+        withColumns: true,
+      })
+
+      table = fetchedTable
+    } else {
+      table = await context.currentUser
+        .$relatedQuery('tables')
+        .withGraphFetched('columns')
+        .findById(tableId)
+        .throwIfNotFound()
+    }
 
     // update last accessed at for collaborator/table
     if (!context.tilesViewKey && !context.isAdminOperation) {
@@ -76,15 +82,18 @@ const getAllRows: QueryResolvers['getAllRows'] = async (
   } catch (e) {
     logger.error(e)
     if (e instanceof ObjectionNotFoundError) {
-      if (context.tilesViewKey) {
-        throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
-      }
       throw new NotFoundError('Table does not exist or you do not have access.')
     }
     if (e.message.includes(DYNAMODB_THROUGHPUT_EXCEEDED_ERROR_MESSAGE)) {
       throw new RateLimitedError(
         'Unable to fetch rows at the moment. Please retry in a bit.',
       )
+    }
+    if (
+      e instanceof InvalidTileViewKeyError ||
+      e instanceof InvalidTileViewTokenError
+    ) {
+      throw e
     }
     throw new Error('Error fetching rows')
   }

--- a/packages/backend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/backend/src/graphql/queries/tiles/get-table.ts
@@ -2,10 +2,12 @@ import { NotFoundError as ObjectionNotFoundError } from 'objection'
 
 import { NotFoundError } from '@/errors/graphql-errors/not-found'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
+import InvalidTileViewTokenError from '@/errors/invalid-tile-view-password'
 import logger from '@/helpers/logger'
-import TableMetadata from '@/models/table-metadata'
 
 import type { QueryResolvers } from '../../__generated__/types.generated'
+
+import { fetchTableWithViewOnlyCheck } from './view-only.helper'
 
 const getTable: QueryResolvers['getTable'] = async (
   _parent,
@@ -13,28 +15,34 @@ const getTable: QueryResolvers['getTable'] = async (
   context,
 ) => {
   const { tableId } = params
-
   try {
-    const table = context.tilesViewKey
-      ? await TableMetadata.query()
-          .findOne({
-            id: tableId,
-            view_only_key: context.tilesViewKey,
-          })
-          .throwIfNotFound()
-      : await context.currentUser
-          .$relatedQuery('tables')
-          .findById(tableId)
-          .throwIfNotFound()
+    if (context.tilesViewKey) {
+      const { table } = await fetchTableWithViewOnlyCheck({
+        tableId,
+        context,
+        // columns are fetched later in the custom resolver
+        withColumns: false,
+      })
 
+      return table
+    }
+
+    // Normal authenticated user flow
+    const table = await context.currentUser
+      .$relatedQuery('tables')
+      .findById(tableId)
+      .throwIfNotFound()
     return table
   } catch (e) {
     logger.error(e)
     if (e instanceof ObjectionNotFoundError) {
-      if (context.tilesViewKey) {
-        throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
-      }
       throw new NotFoundError('Table does not exist or you do not have access.')
+    }
+    if (
+      e instanceof InvalidTileViewTokenError ||
+      e instanceof InvalidTileViewKeyError
+    ) {
+      throw e
     }
     throw new Error('Error fetching table')
   }

--- a/packages/backend/src/graphql/queries/tiles/view-only.helper.ts
+++ b/packages/backend/src/graphql/queries/tiles/view-only.helper.ts
@@ -1,0 +1,52 @@
+import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
+import InvalidTileViewTokenError from '@/errors/invalid-tile-view-password'
+import { verifyViewToken } from '@/helpers/auth-tiles'
+import TableMetadata from '@/models/table-metadata'
+import type { UnauthenticatedContext } from '@/types/express/context'
+
+interface ViewOnlyCheckResult {
+  table: TableMetadata
+}
+
+interface ViewOnlyCheckOptions {
+  tableId: string
+  context: UnauthenticatedContext
+  withColumns?: boolean
+}
+
+export async function fetchTableWithViewOnlyCheck({
+  tableId,
+  context,
+  withColumns,
+}: ViewOnlyCheckOptions): Promise<ViewOnlyCheckResult> {
+  let query = TableMetadata.query().findOne({
+    id: tableId,
+    view_only_key: context.tilesViewKey,
+  })
+
+  if (withColumns) {
+    query = query.withGraphFetched('columns')
+  }
+
+  const table = await query
+
+  if (!table) {
+    throw new InvalidTileViewKeyError(tableId, context.tilesViewKey)
+  }
+
+  const isPasswordBlocked =
+    !!table.viewOnlyPassword &&
+    (!context.tilesViewToken ||
+      !verifyViewToken(
+        context.tilesViewToken,
+        table.id,
+        context.tilesViewKey,
+        table.viewOnlyPassword.tokenNonce,
+      ))
+
+  if (isPasswordBlocked) {
+    throw new InvalidTileViewTokenError(tableId, table.name)
+  }
+
+  return { table }
+}

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -117,7 +117,7 @@ type Mutation {
   deleteShareableTableLink(tableId: ID!): Boolean!
   setTableViewPassword(input: SetTableViewPasswordInput!): Boolean!
   deleteTableViewPassword(tableId: ID!): Boolean!
-  verifyTableViewPassword(input: VerifyTableViewPasswordInput!): Boolean!
+  verifyTableViewPassword(input: VerifyTableViewPasswordInput!): String!
   updateTable(input: UpdateTableInput!): TableMetadata!
   deleteTable(input: DeleteTableInput!): Boolean!
   # Tiles rows

--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -25,8 +25,11 @@ export const setCurrentUserContext = async ({
     isAdminOperation: false,
   }
 
-  // Get tiles view key from headers
+  // Get tiles view key and token from headers
   context.tilesViewKey = req.headers['x-tiles-view-key'] as string | undefined
+  context.tilesViewToken = req.headers['x-tiles-view-token'] as
+    | string
+    | undefined
 
   if (typeof req.headers['x-plumber-admin-token'] === 'string') {
     const adminToken = parseAdminToken(req.headers['x-plumber-admin-token'])
@@ -108,6 +111,10 @@ const authentication = shield(
       loginWithSgid: rateLimitRule({ window: '1s', max: 5 }),
       loginWithSelectedSgid: rateLimitRule({ window: '1s', max: 5 }),
       loginWithSso: rateLimitRule({ window: '1s', max: 5 }),
+      verifyTableViewPassword: and(
+        isViewKey,
+        rateLimitRule({ window: '1s', max: 5 }),
+      ),
       admin: isAdminOperation,
     },
     AdminMutation: isAdminOperation,

--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -12,6 +12,7 @@ import { DBError } from 'objection'
 import appConfig from '@/config/app'
 import { BadUserInputError, UnauthorisedError } from '@/errors/graphql-errors'
 import InvalidTileViewKeyError from '@/errors/invalid-tile-view-key'
+import InvalidTileViewTokenError from '@/errors/invalid-tile-view-password'
 import { typeDefs } from '@/graphql/__generated__/typeDefs.generated'
 import resolvers from '@/graphql/resolvers'
 import authentication, { setCurrentUserContext } from '@/helpers/authentication'
@@ -92,20 +93,30 @@ export const server = new ApolloServer<UnauthenticatedContext>({
   formatError: (formattedError, error) => {
     logger.error(formattedError)
 
+    const unwrappedError = unwrapResolverError(error)
     // NOTE: objection throws all error with DBError class
     // so we handle them here
-    if (unwrapResolverError(error) instanceof DBError) {
+    if (unwrappedError instanceof DBError) {
       return { message: 'Internal server error', code: 'INTERNAL_SERVER_ERROR' }
     }
 
-    if (unwrapResolverError(error) instanceof UnauthorisedError) {
+    if (unwrappedError instanceof UnauthorisedError) {
       return { message: 'Not Authorised!', code: 'NOT_AUTHORISED' }
     }
 
-    if (unwrapResolverError(error) instanceof InvalidTileViewKeyError) {
+    if (unwrappedError instanceof InvalidTileViewKeyError) {
       return {
-        message: 'Invalid tile view only key',
-        code: 'INVALID_TILE_VIEW_KEY',
+        message: unwrappedError.message,
+        code: unwrappedError.code,
+      }
+    }
+    if (unwrappedError instanceof InvalidTileViewTokenError) {
+      return {
+        message: unwrappedError.message,
+        code: unwrappedError.code,
+        data: {
+          tableName: unwrappedError.tableName,
+        },
       }
     }
 

--- a/packages/backend/src/types/express/context.ts
+++ b/packages/backend/src/types/express/context.ts
@@ -8,6 +8,7 @@ export interface UnauthenticatedContext {
   currentUser: User | null
   isAdminOperation: boolean
   tilesViewKey?: string
+  tilesViewToken?: string
 }
 
 interface Context extends UnauthenticatedContext {


### PR DESCRIPTION
## Changes

1. Expose `setTableViewPassword`, `deleteTableViewPassword` and `verifyTableViewPassword` mutations
2. Updated `verifyTableViewPassword` mutation to graphql shield to allow access when `x-table-view-key` is present + set rate limit
3. Updated `getAllRows` and `getTable` queries to check password requirements before granting access. It should through new Error `InvalidTileViewPasswordError` if not allowed.


### How to test?
Have to use the apollo explorer for this as well
Pre-reqs:
1. Create a table with view-only access enabled
2. Use incognito

`GetTable`
Dont set a password first
1. Call getTable with correct `x-tiles-view-key` header, should see correct response
1. Attempt to call getTable without wrong `x-tiles-view-key` header. Expect to see 
```
{
  "errors": [
    {
      "message": "Invalid tile view only key",
      "code": "INVALID_TILE_VIEW_KEY"
    }
  ],
  "data": null
}
```

Set password
1. Attempt to access the table via view-only mode without the password header - should receive 
```
{
  "errors": [
    {
      "message": "Tile is password-protected",
      "code": "INVALID_TILE_VIEW_TOKEN"
    }
  ],
  "data": {
        "tableName": "<TILE_NAME>"
  }
}
```
2. Exchange password for view token
```
mutation VerifyTableViewPassword($input: VerifyTableViewPasswordInput!) {
  verifyTableViewPassword(input: $input)
}

variables
{
  "input": {
    "tableId": "<TABLE_ID>",
    "password": "123"
  }
}
```
3. Copy the view JWT token
4. Set header `x-tiles-view-token`:  <JWT_TOKEN>
5. Call getTable
```
query getTable($tableId: String!) {
  getTable(tableId: $tableId) {
    id
  }
}
or
query GetAllRows($tableId: String!) {
  getAllRows(tableId: $tableId) {
    columnIds
    rows
  }
}
variables
{
  "tableId": "<TABLE_ID>"
}
```
6. You should see a successful response
7. Put an invalid `x-tiles-view-token` and you should see the same error
```
{
  "errors": [
    {
      "message": "Tile is password-protected",
      "code": "INVALID_TILE_VIEW_TOKEN"
    }
  ],
  "data": {
        "tableName": "<TILE_NAME>"
  }
}
```

