### PR TITLE
[AI-BUILDER-23] refactor: optimise chat messages

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -133,12 +133,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     },
   })
 
-  // Cache the last stable messages to avoid recalculating during streaming
-  const cachedMessagesRef = useRef<Message[]>([])
-  const lastMessageCountRef = useRef(0)
-
   // Transform AI SDK messages to our Message format
-  // Optimized to avoid recalculating historical messages during streaming
   const messages = useMemo<Message[]>(() => {
     const isActivelyStreaming = status === 'streaming' || status === 'submitted'
     const initialMsgs = options?.initialMessages || []
@@ -156,22 +151,11 @@ export function useChatStream(options: UseChatStreamOptions) {
       }
     }
 
-    // During streaming, if the message count hasn't changed, return cached messages
-    // This prevents expensive recalculation when only the streaming content changes
-    const messageCount = initialMsgs.length + messagesToTransform.length
-    if (isActivelyStreaming && messageCount === lastMessageCountRef.current) {
-      return cachedMessagesRef.current
-    }
-
     const transformedMessages = transformMessages(messagesToTransform)
     const allMessages = deduplicateMessages([
       ...initialMsgs,
       ...transformedMessages,
     ])
-
-    // Update cache
-    cachedMessagesRef.current = allMessages
-    lastMessageCountRef.current = messageCount
 
     return allMessages
   }, [aiMessages, options?.initialMessages, status])

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -133,11 +133,14 @@ export function useChatStream(options: UseChatStreamOptions) {
     },
   })
 
+  // Cache the last stable messages to avoid recalculating during streaming
+  const cachedMessagesRef = useRef<Message[]>([])
+  const lastMessageCountRef = useRef(0)
+
   // Transform AI SDK messages to our Message format
+  // Optimized to avoid recalculating historical messages during streaming
   const messages = useMemo<Message[]>(() => {
     const isActivelyStreaming = status === 'streaming' || status === 'submitted'
-
-    // Start with initial messages if provided
     const initialMsgs = options?.initialMessages || []
 
     // Filter user and assistant messages from AI SDK
@@ -153,11 +156,23 @@ export function useChatStream(options: UseChatStreamOptions) {
       }
     }
 
+    // During streaming, if the message count hasn't changed, return cached messages
+    // This prevents expensive recalculation when only the streaming content changes
+    const messageCount = initialMsgs.length + messagesToTransform.length
+    if (isActivelyStreaming && messageCount === lastMessageCountRef.current) {
+      return cachedMessagesRef.current
+    }
+
     const transformedMessages = transformMessages(messagesToTransform)
     const allMessages = deduplicateMessages([
       ...initialMsgs,
       ...transformedMessages,
     ])
+
+    // Update cache
+    cachedMessagesRef.current = allMessages
+    lastMessageCountRef.current = messageCount
+
     return allMessages
   }, [aiMessages, options?.initialMessages, status])
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
@@ -10,7 +11,7 @@ interface ChatMessageProps {
   message: Message
 }
 
-const AiMessage = ({ message }: ChatMessageProps) => {
+const AiMessage = memo(({ message }: ChatMessageProps) => {
   return (
     <Flex gap={3} w="full" align="start">
       <PlumberAvatar mt={3} />
@@ -22,9 +23,11 @@ const AiMessage = ({ message }: ChatMessageProps) => {
       </Box>
     </Flex>
   )
-}
+})
 
-const UserMessage = ({ message }: ChatMessageProps) => {
+AiMessage.displayName = 'AiMessage'
+
+const UserMessage = memo(({ message }: ChatMessageProps) => {
   return (
     <Flex justify="flex-end">
       <Box
@@ -41,13 +44,17 @@ const UserMessage = ({ message }: ChatMessageProps) => {
       </Box>
     </Flex>
   )
-}
+})
 
-const ChatMessage = ({ message }: { message: Message }) => {
+UserMessage.displayName = 'UserMessage'
+
+const ChatMessage = memo(({ message }: { message: Message }) => {
   if (message.isUser) {
     return <UserMessage message={message} />
   }
   return <AiMessage message={message} />
-}
+})
+
+ChatMessage.displayName = 'ChatMessage'
 
 export default ChatMessage

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react'
 import { Box, Flex } from '@chakra-ui/react'
 
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
@@ -10,7 +9,7 @@ interface StreamingMessageProps {
   currentResponse: string
 }
 
-const StreamingMessage = memo(({ currentResponse }: StreamingMessageProps) => {
+const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
   if (currentResponse) {
     return (
       <Flex gap={3} w="full" align="start">
@@ -30,8 +29,6 @@ const StreamingMessage = memo(({ currentResponse }: StreamingMessageProps) => {
       <Loader />
     </Flex>
   )
-})
-
-StreamingMessage.displayName = 'StreamingMessage'
+}
 
 export default StreamingMessage

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { Box, Flex } from '@chakra-ui/react'
 
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
@@ -9,7 +10,7 @@ interface StreamingMessageProps {
   currentResponse: string
 }
 
-const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
+const StreamingMessage = memo(({ currentResponse }: StreamingMessageProps) => {
   if (currentResponse) {
     return (
       <Flex gap={3} w="full" align="start">
@@ -29,6 +30,8 @@ const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
       <Loader />
     </Flex>
   )
-}
+})
+
+StreamingMessage.displayName = 'StreamingMessage'
 
 export default StreamingMessage

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -27,8 +27,8 @@ export default function ChatMessages({
     >
       <Box w="full" maxW="4xl" mx="auto" px={4} py={6}>
         <VStack align="stretch" spacing={4}>
-          {messages.map((message, index) => (
-            <ChatMessage key={index} message={message} />
+          {messages.map((message) => (
+            <ChatMessage key={message.id} message={message} />
           ))}
 
           {/* Streaming response */}

--- a/packages/frontend/src/theme/components/Streamdown.tsx
+++ b/packages/frontend/src/theme/components/Streamdown.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Code, Link, List, ListItem, Text } from '@chakra-ui/react'
 import { Streamdown } from 'streamdown'
 
@@ -10,26 +11,49 @@ export function ChakraStreamdown({
   children,
   isAnimating = false,
 }: ChakraStreamdownProps) {
+  // Memoize components to prevent unnecessary re-renders during streaming
+  const components = useMemo(
+    () => ({
+      h1: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h1" {...props} />
+      ),
+      h2: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h2" mb={2} {...props} />
+      ),
+      h3: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h3" mt={2} mb={2} {...props} />
+      ),
+      h4: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h4" mt={2} mb={2} {...props} />
+      ),
+      h5: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h5" mt={2} mb={2} {...props} />
+      ),
+      h6: (props: React.ComponentProps<typeof Text>) => (
+        <Text textStyle="h6" mt={2} mb={2} {...props} />
+      ),
+      p: (props: React.ComponentProps<typeof Text>) => <Text {...props} />,
+      code: (props: React.ComponentProps<typeof Code>) => (
+        <Code colorScheme="gray" {...props} />
+      ),
+      a: (props: React.ComponentProps<typeof Link>) => (
+        <Link color="blue.500" {...props} />
+      ),
+      ul: (props: React.ComponentProps<typeof List>) => (
+        <List styleType="disc" spacing={2} pl={4} {...props} />
+      ),
+      ol: (props: React.ComponentProps<typeof List>) => (
+        <List as="ol" styleType="decimal" spacing={2} pl={4} {...props} />
+      ),
+      li: (props: React.ComponentProps<typeof ListItem>) => (
+        <ListItem {...props} />
+      ),
+    }),
+    [],
+  )
+
   return (
-    <Streamdown
-      isAnimating={isAnimating}
-      components={{
-        h1: (props) => <Text textStyle="h1" {...props} />,
-        h2: (props) => <Text textStyle="h2" mb={2} {...props} />,
-        h3: (props) => <Text textStyle="h3" mt={2} mb={2} {...props} />,
-        h4: (props) => <Text textStyle="h4" mt={2} mb={2} {...props} />,
-        h5: (props) => <Text textStyle="h5" mt={2} mb={2} {...props} />,
-        h6: (props) => <Text textStyle="h6" mt={2} mb={2} {...props} />,
-        p: (props) => <Text {...props} />,
-        code: (props) => <Code colorScheme="gray" {...props} />,
-        a: (props) => <Link color="blue.500" {...props} />,
-        ul: (props) => <List styleType="disc" spacing={2} pl={4} {...props} />,
-        ol: (props) => (
-          <List as="ol" styleType="decimal" spacing={2} pl={4} {...props} />
-        ),
-        li: (props) => <ListItem {...props} />,
-      }}
-    >
+    <Streamdown isAnimating={isAnimating} components={components}>
       {children}
     </Streamdown>
   )


### PR DESCRIPTION
### TL;DR

Optimized chat streaming performance by implementing message caching and React memoization to prevent unnecessary re-renders during streaming.

### What changed?

- Added message caching in `useChatStream` hook using `useRef` to avoid recalculating historical messages during active streaming
- Wrapped `ChatMessage`, `AiMessage`, `UserMessage`, and `StreamingMessage` components with `React.memo` to prevent unnecessary re-renders
- Memoized Streamdown components in `ChakraStreamdown` to reduce component recreation during streaming
- Changed message keys from array index to `message.id` for better React reconciliation

### Test

- [ ] Messages stream smoothly when starting a new conversation
- [ ] Messages still stream smoothly when there are many messages (try back-and-forth many times)
- [ ] Messages still stream smoothly even after refreshing the chat window