### PR TITLE
[AI-BUILDER-24] refactor: improve layout and options

### DIFF
--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
@@ -1,24 +1,24 @@
 import { FormEvent } from 'react'
-import { BiBulb, BiPlus, BiSolidMagicWand } from 'react-icons/bi'
-import { Form } from 'react-router-dom'
 import {
+  BiBookOpen,
+  BiPlus,
+  BiRightArrowAlt,
+  BiSolidMagicWand,
+} from 'react-icons/bi'
+import { Form, useNavigate } from 'react-router-dom'
+import {
+  Box,
   Flex,
   FormControl,
+  Icon,
   ModalBody,
   ModalFooter,
   ModalHeader,
   Text,
 } from '@chakra-ui/react'
-import {
-  Button,
-  FormLabel,
-  Infobox,
-  Input,
-  Tile,
-} from '@opengovsg/design-system-react'
+import { Button, FormLabel, Input, Tile } from '@opengovsg/design-system-react'
 
-import MarkdownRenderer from '@/components/MarkdownRenderer'
-import { infoboxMdComponents } from '@/components/MarkdownRenderer/CustomMarkdownComponents'
+import NewBadge from '@/components/FlowStepConfigurationModal/ChooseAppAndEvent/NewBadge'
 import * as URLS from '@/config/urls'
 import { useCreateFlowContext } from '@/pages/Flows/contexts/CreateFlowContext'
 
@@ -39,70 +39,89 @@ export default function FlowNameAndModeContent({
 }) {
   const { canUseAiBuilder, createMode, skipModeSelection, setCreateMode } =
     useCreateFlowContext()
+  const navigate = useNavigate()
 
   return (
     <Form onSubmit={handleSubmit}>
       <ModalHeader p="2.5rem 2rem 1.5rem">
-        <Text textStyle="h4">Create Pipe</Text>
+        <Text textStyle="h4">How do you want to create your workflow?</Text>
       </ModalHeader>
       <ModalBody>
         <Flex flexDir="column" rowGap={4}>
-          {/* Specific form items */}
-          <Flex flexDir="column">
-            <FormControl isRequired>
-              <FormLabel textStyle="subhead-1">Name your pipe</FormLabel>
-              <Input
-                ref={inputRef}
-                placeholder="For e.g. track event feedback, send customised replies"
-                onChange={handleInputChange}
-                value={flowName}
-                required
-              />
-            </FormControl>
-          </Flex>
+          {canUseAiBuilder && !skipModeSelection && (
+            <Tile
+              icon={() => (
+                <Box py={2}>
+                  <BiSolidMagicWand fontSize="2rem" />
+                </Box>
+              )}
+              flex={1}
+              onClick={() => setCreateMode('ai')}
+              isSelected={createMode === 'ai'}
+              badge={<NewBadge />}
+            >
+              <Text textStyle="subhead-1">Build with AI</Text>
+              <Text textStyle="body-2">
+                Describe your workflow and we&apos;ll create the steps for you
+              </Text>
+            </Tile>
+          )}
 
-          {canUseAiBuilder && !skipModeSelection ? (
-            <FormControl>
-              <FormLabel isRequired>How do you want to start?</FormLabel>
-              <Flex gap={4} direction={{ base: 'column', sm: 'row' }}>
-                <Tile
-                  icon={BiSolidMagicWand}
-                  flex={1}
-                  onClick={() => setCreateMode('ai')}
-                  isSelected={createMode === 'ai'}
-                >
-                  <Text textStyle="h5">Build with AI</Text>
-                  <Text textStyle="body-2">
-                    Describe your workflow and we&apos;ll create the steps for
-                    you
-                  </Text>
-                </Tile>
-                <Tile
-                  icon={BiPlus}
-                  flex={1}
-                  onClick={() => setCreateMode('new')}
-                  isSelected={createMode === 'new'}
-                >
-                  <Text textStyle="h5">Start from scratch</Text>
-                  <Text textStyle="body-2">
-                    Great option if you already know what you want to do!
-                  </Text>
-                </Tile>
-              </Flex>
-            </FormControl>
-          ) : (
-            <Infobox icon={<BiBulb />} variant="primary">
-              <MarkdownRenderer
-                source={`Need suggestions on what to automate? [See use cases](${URLS.TEMPLATES})`}
-                components={infoboxMdComponents}
-              />
-            </Infobox>
+          <FormControl>
+            <Flex gap={4} direction={{ base: 'column', sm: 'row' }}>
+              <Tile
+                icon={() => (
+                  <Box py={2}>
+                    <BiBookOpen fontSize="2rem" />
+                  </Box>
+                )}
+                flex={1}
+                onClick={() => navigate(URLS.TEMPLATES)}
+                isSelected={createMode === 'template'}
+              >
+                <Text textStyle="subhead-1">Use a template</Text>
+                <Text textStyle="body-2">
+                  Choose from a pre-built workflow to customise
+                </Text>
+              </Tile>
+              <Tile
+                icon={() => (
+                  <Box py={2}>
+                    <BiPlus fontSize="2rem" />
+                  </Box>
+                )}
+                flex={1}
+                onClick={() => setCreateMode('new')}
+                isSelected={createMode === 'new'}
+              >
+                <Text textStyle="subhead-1">Start from scratch</Text>
+                <Text textStyle="body-2">
+                  Use our builder to create your own workflow
+                </Text>
+              </Tile>
+            </Flex>
+          </FormControl>
+
+          {/* Specific form items */}
+          {(createMode === 'ai' || createMode === 'new') && (
+            <Flex flexDir="column">
+              <FormControl isRequired>
+                <FormLabel textStyle="subhead-1">Name your pipe</FormLabel>
+                <Input
+                  ref={inputRef}
+                  placeholder="For e.g. track event feedback, send customised replies"
+                  onChange={handleInputChange}
+                  value={flowName}
+                  required
+                />
+              </FormControl>
+            </Flex>
           )}
         </Flex>
       </ModalBody>
       <ModalFooter>
         <Button type="submit" isDisabled={isButtonDisabled} isLoading={loading}>
-          {createMode === 'ai' ? 'Next' : 'Create'}
+          Next <Icon boxSize={6} as={BiRightArrowAlt} />
         </Button>
       </ModalFooter>
     </Form>


### PR DESCRIPTION
### What changed?

- Changed modal header from "Create Pipe" to "How do you want to create your workflow?"
- Reordered UI to show creation method selection first (AI builder, templates, start from scratch)
- Added "Use a template" option that navigates directly to the templates page
- Moved pipe naming input to appear only after selecting AI or scratch creation modes
- Added NewBadge component to the AI builder option
- Replaced info box with direct template navigation
- Updated button text to consistently show "Next" with arrow icon for all creation modes
- Modified icon imports and layout components for the new design

### Tests

- [ ] 'Build with AI' shows the input to enter Pipe name
- [ ] 'Start from scratch' shows the input to enter Pipe name
- [ ] 'Next' button is only enabled after typing in the Pipe name
- [ ] 'Use a template' automatically redirects to the templates page

### Screenshots

![Screenshot 2026-03-09 at 10.14.51 AM.png](https://app.graphite.com/user-attachments/assets/55c1ae71-3b09-4b17-b5bb-7b47b7da0ff6.png)![Screenshot 2026-03-09 at 10.13.38 AM.png](https://app.graphite.com/user-attachments/assets/a0bcfc6e-ca69-4bb2-a8b4-7b17026b993a.png)![Screenshot 2026-03-09 at 10.14.43 AM.png](https://app.graphite.com/user-attachments/assets/b70037f1-7899-411a-b007-3338dd35b98a.png)

