### PR TITLE
[TILES-PW-5] PLU-672: Error handling refactor

### DIFF
--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -4,6 +4,7 @@ import { allow, and, not, or, rule, shield } from 'graphql-shield'
 
 import { createRedisClient, REDIS_DB_INDEX } from '@/config/redis'
 import { UnauthorisedError } from '@/errors/graphql-errors'
+import { RateLimitedError } from '@/errors/graphql-errors/rate-limited'
 import {
   getAdminTokenUser,
   getLoggedInUser,
@@ -80,6 +81,9 @@ const rateLimitRule = createRateLimitRule({
   // recommended flag: https://github.com/teamplanes/graphql-rate-limit#enablebatchrequestcache
   enableBatchRequestCache: true,
   store: new RedisStore(createRedisClient(REDIS_DB_INDEX.RATE_LIMIT)),
+  createError: (message) => {
+    return new RateLimitedError(message)
+  },
 })
 
 const authentication = shield(

--- a/packages/backend/src/helpers/graphql-instance.ts
+++ b/packages/backend/src/helpers/graphql-instance.ts
@@ -1,3 +1,5 @@
+import { CustomGraphQLFormattedError } from '@plumber/types'
+
 import { ApolloServer, type ApolloServerPlugin } from '@apollo/server'
 import { unwrapResolverError } from '@apollo/server/errors'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
@@ -90,7 +92,7 @@ export const server = new ApolloServer<UnauthenticatedContext>({
   ],
   // We don't want to allow batching within a single HTTP request, this defaults to false
   allowBatchedHttpRequests: false,
-  formatError: (formattedError, error) => {
+  formatError: (formattedError, error): CustomGraphQLFormattedError => {
     logger.error(formattedError)
 
     const unwrappedError = unwrapResolverError(error)
@@ -146,7 +148,7 @@ export const server = new ApolloServer<UnauthenticatedContext>({
     }
     const newError = {
       message: errorMessage,
-      code: formattedError.extensions?.code,
+      code: formattedError.extensions?.code as string,
     }
     return newError
   },

--- a/packages/frontend/src/config/errors.ts
+++ b/packages/frontend/src/config/errors.ts
@@ -4,8 +4,12 @@
  */
 export const NOT_AUTHORISED = 'Not Authorised!'
 
-export const INVALID_TILE_VIEW_KEY = 'Invalid tile view only key'
+export const INVALID_TILE_VIEW_KEY = 'INVALID_TILE_VIEW_KEY'
+
+export const INVALID_TILE_VIEW_TOKEN = 'INVALID_TILE_VIEW_TOKEN'
 
 export const NOT_FOUND = 'NOT_FOUND'
 
 export const RATE_LIMITED = 'RATE_LIMITED'
+
+export const FORBIDDEN = 'FORBIDDEN'

--- a/packages/frontend/src/graphql/link.ts
+++ b/packages/frontend/src/graphql/link.ts
@@ -1,10 +1,15 @@
+import { CustomGraphQLFormattedError } from '@plumber/types'
+
 import type { ApolloLink } from '@apollo/client'
 import { from, HttpLink } from '@apollo/client'
 import { onError } from '@apollo/client/link/error'
 import { removeTypenameFromVariables } from '@apollo/client/link/remove-typename'
 
-import { INVALID_TILE_VIEW_KEY, NOT_AUTHORISED } from '@/config/errors'
-import * as URLS from '@/config/urls'
+import {
+  INVALID_TILE_VIEW_KEY,
+  INVALID_TILE_VIEW_TOKEN,
+  NOT_AUTHORISED,
+} from '@/config/errors'
 
 type CreateLinkOptions = {
   uri: string
@@ -37,19 +42,20 @@ const createErrorLink = (callback: CreateLinkOptions['onError']): ApolloLink =>
     }
 
     if (graphQLErrors) {
-      graphQLErrors.forEach(({ message, locations, path }) => {
-        if (autoSnackbar) {
+      graphQLErrors.forEach((error: unknown) => {
+        const { message, code } = error as CustomGraphQLFormattedError
+        // Password-protected tile errors are handled locally by the Tile page
+        const noSnackbarErrors = [
+          INVALID_TILE_VIEW_KEY,
+          INVALID_TILE_VIEW_TOKEN,
+        ]
+
+        if (autoSnackbar && !noSnackbarErrors.includes(code)) {
           callback?.(message)
         }
 
         // eslint-disable-next-line no-console
-        console.log(
-          `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`,
-        )
-
-        if (message === INVALID_TILE_VIEW_KEY) {
-          window.location.href = URLS.UNAUTHORIZED_TILE
-        }
+        console.log(`[GraphQL error]: Message: ${message}, Code: ${code}`)
       })
     } else if (networkError) {
       if (autoSnackbar) {

--- a/packages/frontend/src/helpers/parseGraphqlError.ts
+++ b/packages/frontend/src/helpers/parseGraphqlError.ts
@@ -1,35 +1,31 @@
+import { CustomGraphQLFormattedError } from '@plumber/types'
+
 import { ApolloError, ServerError } from '@apollo/client'
 
-export function parseGraphqlError(error: ApolloError): {
-  statusCode: number | null
-  message: string | null
-  code: string | null
-} {
+export function parseGraphqlError(
+  error: ApolloError,
+): CustomGraphQLFormattedError {
+  // Handle GraphQL errors (HTTP 200 responses with errors in the body)
+  if (error.graphQLErrors?.length) {
+    const graphqlError = error.graphQLErrors[0] as CustomGraphQLFormattedError
+    return graphqlError
+  }
+
+  // Handle network errors (non-200 HTTP responses, e.g. 403 from ForbiddenError)
   if (error.networkError) {
     const serverError = error.networkError as ServerError
-    const statusCode = serverError.statusCode
     if (serverError.result) {
       const result = serverError.result as {
-        errors: { message: string; code: string }[]
+        errors: CustomGraphQLFormattedError[]
       }
       if (result.errors?.length) {
-        const error = result.errors[0]
-        return {
-          statusCode,
-          message: error?.message,
-          code: error?.code,
-        }
-      }
-      return {
-        statusCode,
-        message: serverError.message,
-        code: null,
+        return result.errors[0]
       }
     }
   }
+
   return {
-    statusCode: null,
     message: error.message,
-    code: null,
+    code: '',
   }
 }

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -7,7 +7,8 @@ import { ApolloError, useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
-import { NOT_FOUND } from '@/config/errors'
+import { INVALID_TILE_VIEW_KEY, NOT_FOUND } from '@/config/errors'
+import * as URLS from '@/config/urls'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 import { parseGraphqlError } from '@/helpers/parseGraphqlError'
 
@@ -70,6 +71,10 @@ export default function Tile(): JSX.Element | null {
         return (
           <MissingTile title="You do not have access to this Tile, or it does not exist." />
         )
+      }
+      if (code === INVALID_TILE_VIEW_KEY) {
+        window.location.href = URLS.UNAUTHORIZED_TILE
+        return null
       }
     }
     return (

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1098,3 +1098,9 @@ export type DemoVideoDetails = {
   url: string
   title: string
 }
+
+export interface CustomGraphQLFormattedError {
+  message: string
+  code: string
+  data?: IJSONObject
+}


### PR DESCRIPTION
## Changes

Improved error handling for GraphQL responses by standardising error format and tightening rate limits for password verification.

### What changed?

- Added `CustomGraphQLFormattedError` interface to standardize error format with `message` and `code` properties
- Updated GraphQL error link to compare error codes instead of messages for conditional logic
- Modified rate limit rule to use custom `RateLimitedError` instead of default error
- Added new error constants: `INVALID_TILE_VIEW_TOKEN` and `FORBIDDEN`
- Updated `parseGraphqlError` helper to return standardized error format
  - handles both 200 and non-200 errors

### How to test?

1. Access invalid tile i.e. http://localhost:3001/tiles/invalid_id.
you should see:

![image.png](https://app.graphite.com/user-attachments/assets/d3d3cb83-6613-4881-9a4d-370fc84e5e3c.png)

2. Access invalid shareable link ie https://localhost:3001/tiles/valid_tile_id/invalid_view_key
you should see:

![image.png](https://app.graphite.com/user-attachments/assets/0fd35b42-70c6-4ff0-b525-8d794f37f249.png)

