### PR TITLE
[TILES-PW-5] PLU-672: (frontend) password prompt page

### DIFF
--- a/packages/frontend/src/graphql/mutations/tiles/verify-table-view-password.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/verify-table-view-password.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const VERIFY_TABLE_VIEW_PASSWORD = graphql(`
+  mutation VerifyTableViewPassword($input: VerifyTableViewPasswordInput!) {
+    verifyTableViewPassword(input: $input)
+  }
+`)

--- a/packages/frontend/src/pages/Tile/components/TilePasswordPrompt.tsx
+++ b/packages/frontend/src/pages/Tile/components/TilePasswordPrompt.tsx
@@ -1,0 +1,113 @@
+import { type FormEvent, useState } from 'react'
+import { ApolloError, useMutation } from '@apollo/client'
+import { Center, FormControl, Text, VStack } from '@chakra-ui/react'
+import { Button, Input } from '@opengovsg/design-system-react'
+
+import { FORBIDDEN, RATE_LIMITED } from '@/config/errors'
+import { VERIFY_TABLE_VIEW_PASSWORD } from '@/graphql/mutations/tiles/verify-table-view-password'
+import { parseGraphqlError } from '@/helpers/parseGraphqlError'
+
+interface TilePasswordPromptProps {
+  tableId: string
+  tableName: string
+  viewOnlyKey: string
+  onSuccess: (token: string) => void
+}
+
+export default function TilePasswordPrompt({
+  tableId,
+  tableName,
+  viewOnlyKey,
+  onSuccess,
+}: TilePasswordPromptProps): JSX.Element {
+  const [password, setPassword] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const [verifyPassword, { loading }] = useMutation(
+    VERIFY_TABLE_VIEW_PASSWORD,
+    {
+      context: {
+        headers: { 'x-tiles-view-key': viewOnlyKey },
+        autoSnackbar: false,
+      },
+    },
+  )
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setErrorMessage(null)
+
+    try {
+      const { data } = await verifyPassword({
+        variables: {
+          input: { tableId, password },
+        },
+      })
+
+      if (data?.verifyTableViewPassword) {
+        onSuccess(data.verifyTableViewPassword)
+      }
+    } catch (error) {
+      if (!(error instanceof ApolloError)) {
+        setErrorMessage('Something went wrong. Please try again.')
+        return
+      }
+      const { code } = parseGraphqlError(error)
+      if (code === FORBIDDEN) {
+        setErrorMessage('Incorrect password. Please try again.')
+      }
+      if (code === RATE_LIMITED) {
+        setErrorMessage(
+          'Too many attempts. Please wait a while before trying again.',
+        )
+      }
+    }
+  }
+
+  return (
+    <Center height="100vh" px={8}>
+      <VStack spacing={6} maxW="400px" w="full">
+        <VStack spacing={2}>
+          <Text textStyle="h4" fontWeight="semibold" textAlign="center">
+            {tableName}
+          </Text>
+          <Text
+            textStyle="body-1"
+            color="base.content.medium"
+            textAlign="center"
+          >
+            This tile is password-protected. Enter the password to view.
+          </Text>
+        </VStack>
+
+        <form onSubmit={handleSubmit} style={{ width: '100%' }}>
+          <VStack spacing={4} w="full">
+            <FormControl isInvalid={!!errorMessage}>
+              <Input
+                type="password"
+                placeholder="Enter password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoFocus
+              />
+              {errorMessage && (
+                <Text color="red.500" textStyle="body-2" mt={2}>
+                  {errorMessage}
+                </Text>
+              )}
+            </FormControl>
+
+            <Button
+              type="submit"
+              w="full"
+              isLoading={loading}
+              isDisabled={!password}
+            >
+              Submit
+            </Button>
+          </VStack>
+        </form>
+      </VStack>
+    </Center>
+  )
+}

--- a/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
+++ b/packages/frontend/src/pages/Tile/hooks/useFetchAllRows.tsx
@@ -57,9 +57,11 @@ const processRow = (
 export function useFetchAllRows({
   tableId,
   urlViewOnlyKey,
+  viewToken,
 }: {
   tableId: string
   urlViewOnlyKey?: string
+  viewToken?: string | null
 }) {
   const [rows, setRows] = useState<ITableRow[]>([])
   const [isThroughputError, setIsThroughputError] = useState(false)
@@ -69,11 +71,6 @@ export function useFetchAllRows({
   const startTime = useRef<number>()
 
   const [fetchAllRowsQuery] = useLazyQuery(GET_ALL_ROWS, {
-    context: urlViewOnlyKey
-      ? {
-          headers: { 'x-tiles-view-key': urlViewOnlyKey },
-        }
-      : undefined,
     fetchPolicy: 'cache-and-network',
   })
 
@@ -83,6 +80,12 @@ export function useFetchAllRows({
       setIsFetching(true)
       let rowCount = 0
       let currentCursor = cursor
+      const viewOnlyHeaders = urlViewOnlyKey
+        ? {
+            'x-tiles-view-key': urlViewOnlyKey,
+            ...(viewToken && { 'x-tiles-view-token': viewToken }),
+          }
+        : undefined
       try {
         do {
           const { data, error } = await fetchAllRowsQuery({
@@ -90,6 +93,7 @@ export function useFetchAllRows({
               stringifiedCursor: currentCursor,
               tableId: tableId,
             },
+            context: viewOnlyHeaders ? { headers: viewOnlyHeaders } : undefined,
           })
           if (error) {
             throw error
@@ -126,7 +130,7 @@ export function useFetchAllRows({
         setIsFetching(false)
       }
     },
-    [fetchAllRowsQuery, tableId],
+    [fetchAllRowsQuery, tableId, urlViewOnlyKey, viewToken],
   )
 
   const refetch = useCallback(async () => {

--- a/packages/frontend/src/pages/Tile/hooks/useViewToken.ts
+++ b/packages/frontend/src/pages/Tile/hooks/useViewToken.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from 'react'
+
+function getViewTokenStorageKey(tableId: string): string {
+  return `tile-view-token:${tableId}`
+}
+
+export function useViewToken(tableId: string) {
+  const [viewToken, setViewToken] = useState<string | null>(() =>
+    sessionStorage.getItem(getViewTokenStorageKey(tableId)),
+  )
+
+  const storeViewToken = useCallback(
+    (token: string) => {
+      sessionStorage.setItem(getViewTokenStorageKey(tableId), token)
+      setViewToken(token)
+    },
+    [tableId],
+  )
+
+  return { viewToken, storeViewToken }
+}

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -7,7 +7,11 @@ import { ApolloError, useQuery } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
-import { INVALID_TILE_VIEW_KEY, NOT_FOUND } from '@/config/errors'
+import {
+  INVALID_TILE_VIEW_KEY,
+  INVALID_TILE_VIEW_TOKEN,
+  NOT_FOUND,
+} from '@/config/errors'
 import * as URLS from '@/config/urls'
 import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 import { parseGraphqlError } from '@/helpers/parseGraphqlError'
@@ -16,8 +20,10 @@ import { MissingTile } from '../UnauthorizedTile'
 
 import Table from './components/Table'
 import TableBanner from './components/TableBanner'
+import TilePasswordPrompt from './components/TilePasswordPrompt'
 import { TableContextProvider } from './contexts/TableContext'
 import { useFetchAllRows } from './hooks/useFetchAllRows'
+import { useViewToken } from './hooks/useViewToken'
 
 export default function Tile(): JSX.Element | null {
   const { tileId: tableId, viewOnlyKey: urlViewOnlyKey } = useParams<{
@@ -25,9 +31,19 @@ export default function Tile(): JSX.Element | null {
     viewOnlyKey?: string
   }>()
 
+  const { viewToken, storeViewToken } = useViewToken(tableId as string)
+
+  const viewOnlyHeaders = urlViewOnlyKey
+    ? {
+        'x-tiles-view-key': urlViewOnlyKey,
+        ...(viewToken && { 'x-tiles-view-token': viewToken }),
+      }
+    : undefined
+
   const { rows, isFetching, isThroughputError, refetch } = useFetchAllRows({
     tableId: tableId as string,
     urlViewOnlyKey,
+    viewToken,
   })
 
   const {
@@ -35,25 +51,34 @@ export default function Tile(): JSX.Element | null {
     loading: isTableLoading,
     error: getTableError,
     called: isGetTableCalled,
+    refetch: refetchTable,
   } = useQuery<{
     getTable: ITableMetadata
   }>(GET_TABLE, {
     variables: {
       tableId,
     },
-    context: urlViewOnlyKey
+    context: viewOnlyHeaders
       ? {
-          headers: { 'x-tiles-view-key': urlViewOnlyKey },
+          headers: viewOnlyHeaders,
         }
       : undefined,
   })
   const ownRole = getTableData?.getTable?.role
 
   useEffect(() => {
-    if (isGetTableCalled) {
+    if (isGetTableCalled && getTableData?.getTable) {
+      // load rows after fetching table metadata
       refetch()
     }
-  }, [isGetTableCalled, refetch])
+  }, [isGetTableCalled, getTableError, getTableData, refetch])
+
+  // Refetch table data when view token changes (e.g. after password verification)
+  useEffect(() => {
+    if (viewToken && getTableError) {
+      refetchTable()
+    }
+  }, [viewToken, getTableError, refetchTable])
 
   // On first load, show loading spinner
   if (isTableLoading && !isGetTableCalled) {
@@ -66,7 +91,23 @@ export default function Tile(): JSX.Element | null {
 
   if (getTableError) {
     if (getTableError instanceof ApolloError) {
-      const { code } = parseGraphqlError(getTableError)
+      // Check for password-protected tile error<
+      const { code, data } = parseGraphqlError(getTableError)
+      if (
+        code === INVALID_TILE_VIEW_TOKEN &&
+        urlViewOnlyKey &&
+        data?.tableName
+      ) {
+        return (
+          <TilePasswordPrompt
+            tableId={tableId as string}
+            tableName={data?.tableName as string}
+            viewOnlyKey={urlViewOnlyKey}
+            onSuccess={storeViewToken}
+          />
+        )
+      }
+
       if (code === NOT_FOUND) {
         return (
           <MissingTile title="You do not have access to this Tile, or it does not exist." />


### PR DESCRIPTION
## Changes

- Created `TilePasswordPrompt` component that displays a password input form when accessing password-protected tiles
- Added `VERIFY_TABLE_VIEW_PASSWORD` GraphQL mutation in the frontend
- Implemented `useViewToken` hook to manage view tokens in session storage
- Modified `useFetchAllRows` hook to include view tokens in request headers
- Updated the main Tile component to handle `INVALID_TILE_VIEW_TOKEN` errors by showing the password prompt

### How to test?

1. Create a password-protected tile (via API for now `setTableViewPassword` mutation)
2. Access the tile via its view-only URL
3. Verify the password prompt appears with the table name
4. Test entering incorrect passwords to see error messages
5. Test entering incorrect passwords quickly to see rate limited error
5. Enter the correct password and confirm the tile content loads
6. Refresh the page to verify the session token persists

Scenario 1: Change of password
7. Change the password with `setTableViewPassword` mutation and refresh the page, you should seee the password prompt again

Scenario 2: Removal of password
8. Delete the password with `deleteTableViewPassword` mutation and refresh, there shouldnt be a password prompt anymore
