### PR TITLE
[TILES-PW-6] PLU-672: tiles password settings on frontend

### DIFF
--- a/packages/backend/src/models/table-metadata.ts
+++ b/packages/backend/src/models/table-metadata.ts
@@ -44,6 +44,11 @@ class TableMetadata extends Base {
     },
   }
 
+  // This ensures that the attributes are available in JSON serialization
+  static get virtualAttributes() {
+    return ['isPasswordProtected']
+  }
+
   static relationMappings = () => ({
     collaborators: {
       relation: Base.ManyToManyRelation,
@@ -110,7 +115,7 @@ class TableMetadata extends Base {
   }
 
   get isPasswordProtected() {
-    return this.viewOnlyKey && this.viewOnlyPassword
+    return !!this.viewOnlyKey && !!this.viewOnlyPassword
   }
 }
 

--- a/packages/frontend/src/graphql/mutations/tiles/delete-table-view-password.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/delete-table-view-password.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const DELETE_TABLE_VIEW_PASSWORD = graphql(`
+  mutation DeleteTableViewPassword($tableId: ID!) {
+    deleteTableViewPassword(tableId: $tableId)
+  }
+`)

--- a/packages/frontend/src/graphql/mutations/tiles/set-table-view-password.ts
+++ b/packages/frontend/src/graphql/mutations/tiles/set-table-view-password.ts
@@ -1,0 +1,7 @@
+import { graphql } from '@/graphql/__generated__'
+
+export const SET_TABLE_VIEW_PASSWORD = graphql(`
+  mutation SetTableViewPassword($input: SetTableViewPasswordInput!) {
+    setTableViewPassword(input: $input)
+  }
+`)

--- a/packages/frontend/src/graphql/queries/tiles/get-table.ts
+++ b/packages/frontend/src/graphql/queries/tiles/get-table.ts
@@ -19,6 +19,7 @@ export const GET_TABLE = gql`
         email
         role
       }
+      isPasswordProtected
       role
     }
   }

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareLink.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareLink.tsx
@@ -25,6 +25,8 @@ import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
 
 import { useTableContext } from '../../contexts/TableContext'
 
+import ShareLinkPasswordSection from './ShareLinkPasswordSection'
+
 const ShareLink = () => {
   const { tableId, viewOnlyKey, hasEditPermission } = useTableContext()
   const [isNewLink, setIsNewLink] = useState(false)
@@ -85,6 +87,7 @@ const ShareLink = () => {
       </Button>
     )
   }
+
   return (
     <FormControl>
       <VStack spacing={2} alignItems="flex-start">
@@ -128,6 +131,7 @@ const ShareLink = () => {
             New link generated!
           </FormHelperText>
         )}
+        <ShareLinkPasswordSection />
       </VStack>
       <Divider my={6} />
     </FormControl>

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareLinkPasswordSection.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareLinkPasswordSection.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useState } from 'react'
+import { BiCheck, BiHide, BiPencil, BiShow, BiX } from 'react-icons/bi'
+import { useMutation } from '@apollo/client'
+import {
+  Flex,
+  InputGroup,
+  InputRightElement,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  Checkbox,
+  FormHelperText,
+  IconButton,
+  Input,
+} from '@opengovsg/design-system-react'
+
+import { DELETE_TABLE_VIEW_PASSWORD } from '@/graphql/mutations/tiles/delete-table-view-password'
+import { SET_TABLE_VIEW_PASSWORD } from '@/graphql/mutations/tiles/set-table-view-password'
+import { GET_TABLE } from '@/graphql/queries/tiles/get-table'
+
+import { useTableContext } from '../../contexts/TableContext'
+
+/**
+ * Password protection section for shareable table links.
+ * - isPasswordProtected (from context): server state, true when a password is set.
+ * - isEditing: local state, true when the set/change password form is open.
+ * - Checkbox checked is derived: isPasswordProtected || isEditing.
+ */
+const ShareLinkPasswordSection = () => {
+  const { tableId, viewOnlyKey, isPasswordProtected, hasEditPermission } =
+    useTableContext()
+  const [isEditing, setIsEditing] = useState(false)
+  const [passwordInput, setPasswordInput] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const showSuccess = useCallback((message: string) => {
+    setSuccessMessage(message)
+    setTimeout(() => setSuccessMessage(null), 3000)
+  }, [])
+
+  const [setPassword, { loading: isSettingPassword }] = useMutation(
+    SET_TABLE_VIEW_PASSWORD,
+    {
+      refetchQueries: [GET_TABLE],
+      update(cache, _result, { variables }) {
+        // optimistically update cache to prevent flicker
+        const tableId = variables?.input?.tableId
+        if (!tableId) {
+          return
+        }
+        const existing = cache.readQuery<{
+          getTable: { isPasswordProtected?: boolean; [key: string]: unknown }
+        }>({ query: GET_TABLE, variables: { tableId } })
+        if (!existing?.getTable) {
+          return
+        }
+        cache.writeQuery({
+          query: GET_TABLE,
+          variables: { tableId },
+          data: {
+            getTable: {
+              ...existing.getTable,
+              isPasswordProtected: true,
+            },
+          },
+        })
+      },
+    },
+  )
+
+  const [deletePassword, { loading: isDeletingPassword }] = useMutation(
+    DELETE_TABLE_VIEW_PASSWORD,
+    {
+      variables: { tableId },
+      refetchQueries: [GET_TABLE],
+      // optimistic return success to prevent flicker
+      optimisticResponse: {
+        deleteTableViewPassword: true,
+      },
+    },
+  )
+
+  const onSetPassword = useCallback(async () => {
+    if (!passwordInput) {
+      return
+    }
+    await setPassword({
+      variables: { input: { tableId, password: passwordInput } },
+    })
+    setPasswordInput('')
+    setShowPassword(false)
+    setIsEditing(false)
+    showSuccess(isPasswordProtected ? 'Password updated!' : 'Password set!')
+  }, [passwordInput, setPassword, tableId, isPasswordProtected, showSuccess])
+
+  const onRemovePassword = useCallback(async () => {
+    await deletePassword()
+    showSuccess('Password removed!')
+  }, [deletePassword, showSuccess])
+
+  const onCancelEdit = useCallback(() => {
+    setIsEditing(false)
+    setPasswordInput('')
+    setShowPassword(false)
+  }, [])
+
+  const onCheckboxChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const checked = e.target.checked
+      if (checked) {
+        setIsEditing(true)
+      } else {
+        if (isPasswordProtected) {
+          onRemovePassword()
+        }
+        setIsEditing(false)
+        setPasswordInput('')
+      }
+    },
+    [isPasswordProtected, onRemovePassword],
+  )
+
+  if (!viewOnlyKey || !hasEditPermission) {
+    return null
+  }
+
+  const isCheckboxChecked = isPasswordProtected || isEditing
+
+  return (
+    <VStack
+      spacing={2}
+      alignItems="flex-start"
+      w="full"
+      justifyContent="stretch"
+    >
+      <Flex gap={2} alignItems="center">
+        <Checkbox
+          isChecked={isCheckboxChecked}
+          onChange={onCheckboxChange}
+          isDisabled={isDeletingPassword}
+        >
+          <Text textStyle="subhead-3">Password protection</Text>
+        </Checkbox>
+      </Flex>
+
+      {isCheckboxChecked && (
+        <Flex alignSelf="stretch" gap={2} alignItems="center" pl={10} w="full">
+          {isPasswordProtected && !isEditing ? (
+            <>
+              <Input
+                type="password"
+                value="••••••••••••••••••••"
+                isReadOnly
+                placeholder="Password set"
+              />
+
+              <IconButton
+                icon={<BiPencil />}
+                variant="outline"
+                size="md"
+                aria-label="Change password"
+                onClick={() => setIsEditing(true)}
+              />
+            </>
+          ) : (
+            <>
+              <InputGroup flex={1}>
+                <Input
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder={
+                    isPasswordProtected ? 'New password' : 'Set a password'
+                  }
+                  value={passwordInput}
+                  onChange={(e) => setPasswordInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && passwordInput) {
+                      onSetPassword()
+                    }
+                  }}
+                  autoFocus
+                  pr="10"
+                />
+                <InputRightElement>
+                  <IconButton
+                    icon={showPassword ? <BiHide /> : <BiShow />}
+                    variant="clear"
+                    size="sm"
+                    aria-label={
+                      showPassword ? 'Hide password' : 'Show password'
+                    }
+                    onClick={() => setShowPassword((p) => !p)}
+                  />
+                </InputRightElement>
+              </InputGroup>
+              <IconButton
+                icon={<BiCheck />}
+                variant="solid"
+                aria-label="Save"
+                size="md"
+                isLoading={isSettingPassword}
+                isDisabled={!passwordInput}
+                onClick={onSetPassword}
+              />
+              <IconButton
+                icon={<BiX />}
+                variant="clear"
+                aria-label="Cancel"
+                onClick={onCancelEdit}
+              />
+            </>
+          )}
+        </Flex>
+      )}
+      {successMessage && (
+        <FormHelperText pl={10} variant="success">
+          {successMessage}
+        </FormHelperText>
+      )}
+    </VStack>
+  )
+}
+
+export default ShareLinkPasswordSection

--- a/packages/frontend/src/pages/Tile/components/TilePasswordPrompt.tsx
+++ b/packages/frontend/src/pages/Tile/components/TilePasswordPrompt.tsx
@@ -1,7 +1,15 @@
 import { type FormEvent, useState } from 'react'
+import { BiHide, BiShow } from 'react-icons/bi'
 import { ApolloError, useMutation } from '@apollo/client'
-import { Center, FormControl, Text, VStack } from '@chakra-ui/react'
-import { Button, Input } from '@opengovsg/design-system-react'
+import {
+  Center,
+  FormControl,
+  InputGroup,
+  InputRightElement,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import { Button, IconButton, Input } from '@opengovsg/design-system-react'
 
 import { FORBIDDEN, RATE_LIMITED } from '@/config/errors'
 import { VERIFY_TABLE_VIEW_PASSWORD } from '@/graphql/mutations/tiles/verify-table-view-password'
@@ -21,6 +29,7 @@ export default function TilePasswordPrompt({
   onSuccess,
 }: TilePasswordPromptProps): JSX.Element {
   const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const [verifyPassword, { loading }] = useMutation(
@@ -83,13 +92,27 @@ export default function TilePasswordPrompt({
         <form onSubmit={handleSubmit} style={{ width: '100%' }}>
           <VStack spacing={4} w="full">
             <FormControl isInvalid={!!errorMessage}>
-              <Input
-                type="password"
-                placeholder="Enter password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                autoFocus
-              />
+              <InputGroup>
+                <Input
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="Enter password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  autoFocus
+                  pr="10"
+                />
+                <InputRightElement>
+                  <IconButton
+                    icon={showPassword ? <BiHide /> : <BiShow />}
+                    variant="clear"
+                    size="sm"
+                    aria-label={
+                      showPassword ? 'Hide password' : 'Show password'
+                    }
+                    onClick={() => setShowPassword((p) => !p)}
+                  />
+                </InputRightElement>
+              </InputGroup>
               {errorMessage && (
                 <Text color="red.500" textStyle="body-2" mt={2}>
                   {errorMessage}

--- a/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
+++ b/packages/frontend/src/pages/Tile/contexts/TableContext.tsx
@@ -29,6 +29,7 @@ interface TableContextProps {
   mode: EditMode
   setMode: (mode: EditMode) => void
   hasEditPermission: boolean
+  isPasswordProtected?: boolean
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
   role?: string
@@ -56,6 +57,7 @@ interface TableContextProviderProps {
   tableColumns: ITableColumnMetadata[]
   tableRows: ITableRow[]
   children: React.ReactNode
+  isPasswordProtected?: boolean
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
   // If null, the tile is accessed by a shareable link
@@ -72,6 +74,7 @@ export const TableContextProvider = ({
   tableColumns,
   tableRows,
   children,
+  isPasswordProtected,
   viewOnlyKey,
   collaborators,
   role,
@@ -99,6 +102,7 @@ export const TableContextProvider = ({
         mode,
         setMode,
         hasEditPermission,
+        isPasswordProtected,
         viewOnlyKey,
         collaborators,
         role,

--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -127,8 +127,15 @@ export default function Tile(): JSX.Element | null {
     return null
   }
 
-  const { id, name, columns, viewOnlyKey, collaborators, databaseType } =
-    getTableData.getTable
+  const {
+    id,
+    name,
+    columns,
+    viewOnlyKey,
+    isPasswordProtected,
+    collaborators,
+    databaseType,
+  } = getTableData.getTable
 
   return (
     <TableContextProvider
@@ -138,6 +145,7 @@ export default function Tile(): JSX.Element | null {
       tableColumns={columns}
       tableRows={rows}
       viewOnlyKey={viewOnlyKey}
+      isPasswordProtected={isPasswordProtected}
       collaborators={collaborators}
       role={ownRole}
       isFetching={isFetching}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1025,6 +1025,7 @@ export interface ITableMetadata {
   lastAccessedAt: string
   viewOnlyKey?: string
   collaborators?: ITableCollaborator[]
+  isPasswordProtected: boolean
   role?: ITableCollabRole
 }
 


### PR DESCRIPTION
## Changes

### Backend Changes
- Expose `isPasswordProtected` from backend
- Fix `isPasswordProtected` getter to use boolean coercion for consistent truthy/falsy evaluation

### Frontend Changes
- Add GraphQL mutations for setting and deleting table view passwords
- Create `ShareLinkPasswordSection` component with checkbox toggle, password input, and edit/save functionality
- Add password visibility toggle to both password prompt and settings components


## To test
1. Set password
2. Change password
3. Remove password