### PR TITLE
[TILES-PW-7] PLU-672: additional security

### DIFF
--- a/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
+++ b/packages/backend/src/graphql/mutations/tiles/set-table-view-password.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto'
+import { z } from 'zod'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
 import { hashTilePassword } from '@/helpers/auth-tiles'
@@ -7,13 +8,21 @@ import TableMetadata from '@/models/table-metadata'
 
 import type { MutationResolvers } from '../../__generated__/types.generated'
 
+const setTableViewPasswordSchema = z.object({
+  tableId: z.string(),
+  password: z.string().min(8).max(100),
+})
+
 const setTableViewPassword: MutationResolvers['setTableViewPassword'] = async (
   _parent,
   params,
   context,
 ) => {
-  const { tableId, password } = params.input
-
+  const result = setTableViewPasswordSchema.safeParse(params.input)
+  if (!result.success) {
+    throw new BadUserInputError('Ensure password is 8-64 characters long')
+  }
+  const { tableId, password } = result.data
   // Must be at least editor
   await TableCollaborator.hasAccess(context.currentUser.id, tableId, 'editor')
 

--- a/packages/backend/src/helpers/morgan.ts
+++ b/packages/backend/src/helpers/morgan.ts
@@ -34,7 +34,12 @@ morgan.token('graphql-query', (req: Request) => {
   }
 })
 
-const SENSITIVE_MUTATIONS = ['createConnection', 'updateConnection']
+const SENSITIVE_MUTATIONS = [
+  'createConnection',
+  'updateConnection',
+  'verifyTableViewPassword',
+  'setTableViewPassword',
+]
 
 morgan.token('graphql-variables', (req: Request) => {
   if (req.body.variables) {

--- a/packages/frontend/src/pages/Tile/components/TableBanner/ShareLinkPasswordSection.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ShareLinkPasswordSection.tsx
@@ -169,9 +169,7 @@ const ShareLinkPasswordSection = () => {
               <InputGroup flex={1}>
                 <Input
                   type={showPassword ? 'text' : 'password'}
-                  placeholder={
-                    isPasswordProtected ? 'New password' : 'Set a password'
-                  }
+                  placeholder={'Enter a new password (min 8 characters)'}
                   value={passwordInput}
                   onChange={(e) => setPasswordInput(e.target.value)}
                   onKeyDown={(e) => {
@@ -200,7 +198,7 @@ const ShareLinkPasswordSection = () => {
                 aria-label="Save"
                 size="md"
                 isLoading={isSettingPassword}
-                isDisabled={!passwordInput}
+                isDisabled={!passwordInput || passwordInput.length < 8}
                 onClick={onSetPassword}
               />
               <IconButton


### PR DESCRIPTION
## Changes

- Added Zod schema validation to the `setTableViewPassword` GraphQL mutation with 8-100 character password length constraints
- Added `verifyTableViewPassword` and `setTableViewPassword` to the list of sensitive mutations that have their variables redacted in logs
