### PR TITLE
PLU-456: add radio button changes and copy changes for delay until

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -144,26 +144,6 @@ describe('Delay until action', () => {
   })
 
   describe('retry logic', () => {
-    it('prevents retries during test runs', async () => {
-      $.step.parameters = {
-        delayUntil: PAST_DATE,
-        delayUntilTime: DEFAULT_TIME,
-      }
-
-      // Set testRun to true to simulate test environment
-      $.execution.testRun = true
-
-      // Mock last execution step to indicate a retry for past timestamp
-      mocks.getLastExecutionStep.mockResolvedValue({
-        errorDetails: {
-          name: 'Delay until timestamp entered is in the past',
-        },
-      })
-
-      // Should throw error even with valid retry conditions due to testRun
-      await expect(delayUntilAction.run($)).rejects.toThrowError(StepError)
-    })
-
     it('allows past timestamp when retrying after past timestamp error', async () => {
       $.step.parameters = {
         delayUntil: PAST_DATE,

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -44,12 +44,32 @@ const action: IRawAction = {
       description: 'Delay until the time (24h). E.g. 08:00, 23:00',
       variables: true,
     },
+    {
+      label: 'How should we handle dates in the past?',
+      key: 'allowPastDate',
+      type: 'boolean-radio' as const,
+      required: false,
+      value: true,
+      options: [
+        {
+          label: 'Continue the workflow',
+          description: `If the scheduled date has passed when the workflow runs, the next action will execute immediately and the delay won't apply.`,
+          value: true,
+        },
+        {
+          label: 'Pause the workflow',
+          description:
+            'You can resume it on the Executions page. You will receive an email notification if any executions were paused based on your pipe settings.',
+          value: false,
+        },
+      ],
+    },
   ],
 
   async run($) {
     const defaultTime = '00:00'
     // trim the date and time for user
-    const { delayUntil, delayUntilTime } = $.step.parameters
+    const { delayUntil, delayUntilTime, allowPastDate } = $.step.parameters
     const delayUntilString = new String(delayUntil).trim()
     // catch empty string (user input), null, undefined (backwards compat)
     const delayUntilTimeString = delayUntilTime
@@ -83,8 +103,9 @@ const action: IRawAction = {
 
     if (isNaN(delayTimestamp)) {
       throw new StepError(
-        'Invalid timestamp entered',
-        'Check that the date or time entered is of a valid format.',
+        'Incorrect date or time format',
+        `* Date must be in DD MMM YYYY and time in HH:MM format. 
+         \n* If you're using a variable, make sure it returns values in these formats.`,
         $.step.position,
         $.app.name,
       )
@@ -92,12 +113,13 @@ const action: IRawAction = {
 
     /**
      * RETRY: we check and only allow manual retries for failures due to:
-     * - delay until timestamp entered is in the past
+     * - delay until timestamp entered is in the past and allowPastDate is false
      */
     const isRetry = await isValidRetry($)
+    const isPastTimestamp = delayTimestamp < DateTime.now().toMillis()
 
-    if (delayTimestamp < DateTime.now().toMillis()) {
-      if (isRetry) {
+    if (!$.execution.testRun && isPastTimestamp) {
+      if (isRetry || allowPastDate) {
         const dateTimeNow = DateTime.now()
         dataItem = {
           delayUntil: dateTimeNow.toPlumberFormat('dd MMM yyyy'),

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -125,6 +125,7 @@ const action: IRawAction = {
           delayUntilTime: dateTimeNow.toPlumberFormat('HH:mm'),
         }
       } else {
+        // Update in `useExecutionStepStatus.ts` if the error name changes
         throw new StepError(
           'Delay until timestamp entered is in the past',
           'This action was scheduled to run at a time that has already passed. Click "Retry" to skip the delay and continue the Pipe now.',

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -48,7 +48,7 @@ const action: IRawAction = {
       label: 'How should we handle dates in the past?',
       key: 'allowPastDate',
       type: 'boolean-radio' as const,
-      required: false,
+      required: true,
       value: true,
       options: [
         {
@@ -104,8 +104,7 @@ const action: IRawAction = {
     if (isNaN(delayTimestamp)) {
       throw new StepError(
         'Incorrect date or time format',
-        `* Date must be in DD MMM YYYY and time in HH:MM format. 
-         \n* If you're using a variable, make sure it returns values in these formats.`,
+        `* Date must be in DD MMM YYYY and time in HH:MM format.\n* If you're using a variable, make sure it returns values in these formats.`,
         $.step.position,
         $.app.name,
       )

--- a/packages/frontend/src/components/ErrorResult/ErrorDetailsCollapse.tsx
+++ b/packages/frontend/src/components/ErrorResult/ErrorDetailsCollapse.tsx
@@ -1,0 +1,41 @@
+import { IJSONObject } from '@plumber/types'
+
+import { useCallback, useState } from 'react'
+import { Box, Collapse } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import JSONViewer from '@/components/JSONViewer'
+
+interface ErrorDetailsCollapseProps {
+  details: IJSONObject
+  buttonText?: string
+}
+
+export default function ErrorDetailsCollapse(props: ErrorDetailsCollapseProps) {
+  const { details, buttonText = 'View error details below.' } = props
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleDropdown = useCallback(() => {
+    setIsOpen((value) => !value)
+  }, [])
+
+  return (
+    <>
+      <Button
+        onClick={toggleDropdown}
+        variant="link"
+        size="sm"
+        sx={{ textDecoration: 'underline' }}
+        mt={2}
+      >
+        {buttonText}
+      </Button>
+
+      <Box>
+        <Collapse in={isOpen}>
+          <JSONViewer data={details} />
+        </Collapse>
+      </Box>
+    </>
+  )
+}

--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -1,11 +1,10 @@
 import { IJSONObject } from '@plumber/types'
 
-import { useCallback, useState } from 'react'
-import { Box, Collapse, Text } from '@chakra-ui/react'
-import { Button, Infobox } from '@opengovsg/design-system-react'
+import { Box, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
 
-import JSONViewer from '@/components/JSONViewer'
-import { SUPPORT_FORM_LINK } from '@/config/urls'
+import ErrorDetailsCollapse from './ErrorDetailsCollapse'
+import SupportContactMessage from './SupportContactMessage'
 
 interface GenericErrorResultProps {
   errorDetails: IJSONObject
@@ -14,10 +13,6 @@ interface GenericErrorResultProps {
 
 export default function GenericErrorResult(props: GenericErrorResultProps) {
   const { errorDetails, isTestRun } = props
-  const [isOpen, setIsOpen] = useState(false)
-  const toggleDropdown = useCallback(() => {
-    setIsOpen((value) => !value)
-  }, [])
 
   return (
     <Infobox variant="error" borderRadius="lg">
@@ -27,39 +22,12 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
         </Text>
 
         <Text textStyle="body-1">
-          <Text textStyle="body-1">
-            {`Check if you have configured ${
-              isTestRun ? 'the steps above' : 'this step'
-            } correctly and retest.`}
-          </Text>
-          <Box
-            marginTop={4}
-            borderTop="1px solid #E0E0E0"
-            fontSize="0.8rem"
-            opacity={0.8}
-            w="full"
-          >
-            If this error still persists, contact us at{' '}
-            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              {SUPPORT_FORM_LINK}
-            </a>
-            .
-          </Box>
-          <Button
-            onClick={toggleDropdown}
-            variant="link"
-            size="sm"
-            sx={{ textDecoration: 'underline' }}
-            mt={2}
-          >
-            View error details below.
-          </Button>
+          {`Check if you have configured ${
+            isTestRun ? 'the steps above' : 'this step'
+          } correctly and retest.`}
 
-          <Box>
-            <Collapse in={isOpen}>
-              <JSONViewer data={errorDetails}></JSONViewer>
-            </Collapse>
-          </Box>
+          <SupportContactMessage />
+          <ErrorDetailsCollapse details={errorDetails} />
         </Text>
       </Box>
     </Infobox>

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -1,9 +1,8 @@
 import { IStepError } from '@plumber/types'
 
-import { useCallback, useState } from 'react'
 import Markdown from 'react-markdown'
 import { useMutation } from '@apollo/client'
-import { Box, Collapse, Text } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 import {
   Badge,
   Button,
@@ -11,12 +10,13 @@ import {
   useToast,
 } from '@opengovsg/design-system-react'
 
-import JSONViewer from '@/components/JSONViewer'
-import { SUPPORT_FORM_LINK } from '@/config/urls'
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
+
+import ErrorDetailsCollapse from './ErrorDetailsCollapse'
+import SupportContactMessage from './SupportContactMessage'
 
 interface SpecificErrorResultProps {
   errorDetails: IStepError
@@ -28,10 +28,6 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props
   const { name, solution, position, appName, details, partialRetry } =
     errorDetails
-  const [isOpen, setIsOpen] = useState(false)
-  const toggleDropdown = useCallback(() => {
-    setIsOpen((value) => !value)
-  }, [])
 
   const toast = useToast()
 
@@ -75,37 +71,14 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
           <Markdown linkTarget="_blank" components={infoboxMdComponents}>
             {solution}
           </Markdown>
-          <Box
-            marginTop={4}
-            borderTop="1px solid #E0E0E0"
-            fontSize="0.8rem"
-            opacity={0.8}
-            w="full"
-          >
-            If this error still persists, contact us at{' '}
-            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              {SUPPORT_FORM_LINK}
-            </a>
-            .
-          </Box>
-          {details && (
-            <>
-              <Button
-                onClick={toggleDropdown}
-                variant="link"
-                size="sm"
-                sx={{ textDecoration: 'underline' }}
-                mt={2}
-              >
-                View http error details below.
-              </Button>
 
-              <Box>
-                <Collapse in={isOpen}>
-                  <JSONViewer data={details}></JSONViewer>
-                </Collapse>
-              </Box>
-            </>
+          <SupportContactMessage />
+
+          {details && (
+            <ErrorDetailsCollapse
+              details={details}
+              buttonText="View http error details below."
+            />
           )}
 
           {!isTestRun && partialRetry && executionStepId && (

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -16,6 +16,8 @@ import { SUPPORT_FORM_LINK } from '@/config/urls'
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
+import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
+
 interface SpecificErrorResultProps {
   errorDetails: IStepError
   isTestRun: boolean
@@ -70,7 +72,9 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
         </Text>
 
         <Text textStyle="body-1">
-          <Markdown linkTarget="_blank">{solution}</Markdown>
+          <Markdown linkTarget="_blank" components={infoboxMdComponents}>
+            {solution}
+          </Markdown>
           <Box
             marginTop={4}
             borderTop="1px solid #E0E0E0"

--- a/packages/frontend/src/components/ErrorResult/SupportContactMessage.tsx
+++ b/packages/frontend/src/components/ErrorResult/SupportContactMessage.tsx
@@ -1,0 +1,21 @@
+import { Box } from '@chakra-ui/react'
+
+import { SUPPORT_FORM_LINK } from '@/config/urls'
+
+export default function SupportContactMessage() {
+  return (
+    <Box
+      marginTop={4}
+      borderTop="1px solid #E0E0E0"
+      fontSize="0.8rem"
+      opacity={0.8}
+      w="full"
+    >
+      If this error still persists, contact{' '}
+      <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
+        Plumber support
+      </a>
+      .
+    </Box>
+  )
+}

--- a/packages/frontend/src/components/ExecutionStep/components/DelayPausedAlert.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/DelayPausedAlert.tsx
@@ -1,0 +1,56 @@
+import type { IExecution } from '@plumber/types'
+
+import { Link } from 'react-router-dom'
+import { Divider, Flex, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
+
+import { FLOW_EDITOR } from '@/config/urls'
+
+interface DelayPausedAlertProps {
+  execution: IExecution
+}
+
+/**
+ * TODO: Change this component name if there are more use cases that involve "pausing" the pipe
+ */
+export default function DelayPausedAlert({
+  execution,
+}: DelayPausedAlertProps): React.ReactElement {
+  const flowId = execution.flow?.id
+  const flowName = execution.flow?.name
+
+  return (
+    <Flex direction="column" align="stretch" gap={4}>
+      <Infobox variant="info" borderRadius="lg">
+        <Flex flexDir="column" gap={4}>
+          <Flex flexDir="column" gap={2}>
+            <Text textStyle="subhead-1">This execution was paused</Text>
+            <Text textStyle="body-1">
+              The scheduled date had already passed when this workflow ran. This
+              happened because you chose to pause executions in this situation.
+            </Text>
+          </Flex>
+
+          <Divider />
+          {flowId && (
+            <Flex textStyle="body-1" gap={1}>
+              <Text>Workflow:</Text>
+              <Link
+                to={FLOW_EDITOR(flowId)}
+                target="_blank"
+                color="primary.500"
+              >
+                <Flex align="center" gap={1} color="primary.500">
+                  <Text>{flowName}</Text>
+                  <Text mb="-1" fontSize="1rem">
+                    ↗
+                  </Text>
+                </Flex>
+              </Link>
+            </Flex>
+          )}
+        </Flex>
+      </Infobox>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
@@ -4,7 +4,9 @@ import { useMutation } from '@apollo/client'
 import { HStack, Icon, Text } from '@chakra-ui/react'
 import { Button, useToast } from '@opengovsg/design-system-react'
 
+import client from '@/graphql/client'
 import { RETRY_EXECUTION_STEP } from '@/graphql/mutations/retry-execution-step'
+import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
 interface RetryButtonProps {
   executionStepId: string
@@ -39,6 +41,13 @@ const RetryButton = ({
         position: 'bottom-right',
       })
       setIsRetrySuccessful(true)
+
+      // reload page after short delay because the job is retrying
+      setTimeout(() => {
+        client.refetchQueries({
+          include: [GET_EXECUTION_STEPS],
+        })
+      }, 3000)
     },
     onError: () => {
       setIsRetrySuccessful(false)

--- a/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
@@ -28,4 +28,9 @@ const partialIcon = (
 
 const waitingIcon = <Image src={executionWaitingIcon} h={6} />
 
-export { failureIcon, partialIcon, successIcon, waitingIcon }
+// Only used for delay until past timestamp paused errors
+const delayPausedIcon = (
+  <Icon boxSize={6} as={BiSolidErrorCircle} color="blue.500" />
+)
+
+export { delayPausedIcon, failureIcon, partialIcon, successIcon, waitingIcon }

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -7,11 +7,15 @@ import { GroupStatusType } from '@/components/ExecutionGroup/GroupStatusFilter'
 import { GET_APP } from '@/graphql/queries/get-app'
 
 import {
+  delayPausedIcon,
   failureIcon,
   partialIcon,
   successIcon,
   waitingIcon,
 } from '../components/StatusIcons'
+
+// This is frontend hardcoded, remember to change if error name changes
+const ERROR_NAME_DELAY_PAUSED = 'Delay until timestamp entered is in the past'
 
 export interface UseExecutionStepStatusProps {
   appKey: string
@@ -28,6 +32,7 @@ export interface UseExecutionStepStatusReturn {
   isStepSuccessful: boolean
   hasError: boolean
   isPartialSuccess: boolean
+  isDelayPaused: boolean
   canRetry: boolean
   loading: boolean
   customRetryButtonText?: string
@@ -49,6 +54,7 @@ export function useExecutionStepStatus({
   const isStepSuccessful = status === 'success'
   const hasExecutionFailed = execution?.status === 'failure'
   const isPartialSuccess = status === 'success' && hasError
+  const isDelayPaused = errorDetails?.name === ERROR_NAME_DELAY_PAUSED
   const canRetry =
     !isStepSuccessful &&
     !!jobId &&
@@ -56,6 +62,9 @@ export function useExecutionStepStatus({
     execution?.flow?.role !== 'viewer'
 
   const statusIcon = useMemo(() => {
+    if (isDelayPaused) {
+      return delayPausedIcon
+    }
     if (isPartialSuccess) {
       return partialIcon
     }
@@ -66,7 +75,7 @@ export function useExecutionStepStatus({
       return waitingIcon
     }
     return failureIcon
-  }, [isPartialSuccess, isStepSuccessful, status])
+  }, [isPartialSuccess, isStepSuccessful, status, isDelayPaused])
 
   const customRetryButtonText = useMemo(() => {
     // specific to email by postman where we want to allow users to retry without attachments
@@ -89,6 +98,7 @@ export function useExecutionStepStatus({
     isStepSuccessful,
     hasError,
     isPartialSuccess,
+    isDelayPaused,
     canRetry,
     loading,
     customRetryButtonText,

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -17,6 +17,7 @@ import JSONViewer from '@/components/JSONViewer'
 import { EXECUTION_STEP_PER_PAGE } from '@/pages/Execution'
 
 import AppIconWithStatus from './components/AppIconWithStatus'
+import DelayPausedAlert from './components/DelayPausedAlert'
 import { RetryAllButton } from './components/RetryAllButton'
 import RetryButton from './components/RetryButton'
 import { useExecutionStepStatus } from './hooks/useExecutionStepStatus'
@@ -48,6 +49,7 @@ export default function ExecutionStep({
     statusIcon,
     hasError,
     isPartialSuccess,
+    isDelayPaused,
     canRetry,
     customRetryButtonText,
   } = useExecutionStepStatus({
@@ -57,6 +59,9 @@ export default function ExecutionStep({
     execution,
     jobId,
   })
+
+  const showAlertTab = isDelayPaused
+  const showErrorTab = hasError && !isDelayPaused
 
   if (!app) {
     return null
@@ -86,7 +91,9 @@ export default function ExecutionStep({
                 <RetryAllButton execution={execution} />
                 <RetryButton
                   executionStepId={executionStep.id}
-                  customButtonText={customRetryButtonText}
+                  customButtonText={
+                    isDelayPaused ? 'Resume' : customRetryButtonText
+                  }
                 />
               </>
             )}
@@ -95,7 +102,7 @@ export default function ExecutionStep({
 
         {/* bottom half: data in, data out and error */}
         <Box borderTop="1px solid" borderTopColor="base.divider.strong" p={4}>
-          <Tabs defaultIndex={hasError ? 2 : 0}>
+          <Tabs defaultIndex={showAlertTab || hasError ? 2 : 0}>
             <TabList
               borderBottom="1px solid"
               borderBottomColor="base.divider.medium"
@@ -103,7 +110,9 @@ export default function ExecutionStep({
             >
               <Tab>Data In</Tab>
               <Tab>Data Out</Tab>
-              {hasError && (
+              {/* Only for paused delay until pipes for now */}
+              {showAlertTab && <Tab>Alert</Tab>}
+              {showErrorTab && (
                 <Tab position="relative">
                   Error
                   {isPartialSuccess && (
@@ -126,7 +135,12 @@ export default function ExecutionStep({
               <TabPanel>
                 <JSONViewer data={executionStep.dataOut} />
               </TabPanel>
-              {hasError && (
+              {showAlertTab && (
+                <TabPanel>
+                  <DelayPausedAlert execution={execution} />
+                </TabPanel>
+              )}
+              {showErrorTab && (
                 <TabPanel>
                   <ErrorResult
                     executionStepId={executionStep.id}

--- a/packages/frontend/src/components/InputCreator/BooleanRadio.tsx
+++ b/packages/frontend/src/components/InputCreator/BooleanRadio.tsx
@@ -3,7 +3,7 @@ import type { IFieldBooleanRadioOptions } from '@plumber/types'
 import { useContext } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import Markdown from 'react-markdown'
-import { FormControl, RadioGroup, Stack } from '@chakra-ui/react'
+import { FormControl, RadioGroup, Stack, Text } from '@chakra-ui/react'
 import {
   FormErrorMessage,
   FormLabel,
@@ -102,12 +102,22 @@ export default function BooleanRadio(props: BooleanRadioProps) {
                   value={convertBooleanToString(firstOption.value)}
                 >
                   {firstOption.label}
+                  {firstOption.description && (
+                    <Text textStyle="body-2" textColor="base.content.default">
+                      {firstOption.description}
+                    </Text>
+                  )}
                 </Radio>
                 <Radio
                   allowDeselect={!required}
                   value={convertBooleanToString(secondOption.value)}
                 >
                   {secondOption.label}
+                  {secondOption.description && (
+                    <Text textStyle="body-2" textColor="base.content.default">
+                      {secondOption.description}
+                    </Text>
+                  )}
                 </Radio>
               </Stack>
             </RadioGroup>

--- a/packages/frontend/src/components/MarkdownRenderer/CustomMarkdownComponents.tsx
+++ b/packages/frontend/src/components/MarkdownRenderer/CustomMarkdownComponents.tsx
@@ -15,4 +15,7 @@ export const infoboxMdComponents: Components = {
   // react-markdown wraps everything in a <Text> by default,
   // which mucks up styling for infoboxes with variants.
   p: ({ ...props }) => <chakra.p {...props} />,
+  li: ({ ...props }) => (
+    <chakra.li {...props} sx={{ marginInlineStart: '1.25em' }} />
+  ),
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -480,6 +480,7 @@ export type IFieldBooleanRadioOptions = [
 
 export interface IFieldBooleanRadioOption {
   label: string
+  description?: string
   value: boolean
 }
 


### PR DESCRIPTION
### TODOs

- [ ] Need to run SQL query to update every `delay-until` step with `allowPastDate`: `false`

### TL;DR

Added a new configuration option to the delay-until action that allows users to choose whether workflows should continue immediately or pause when the scheduled date is in the past.

### What changed?

- Added an `allowPastDate` boolean radio parameter to the delay-until action with two options:
  - "Continue the workflow" (default): executes immediately if the date has passed
  - "Pause the workflow": pauses execution and sends email notifications
- Enhanced the BooleanRadio component to display option descriptions below radio button labels
- Improved error messaging for invalid date/time formats with clearer formatting requirements
- Updated markdown rendering in error messages to properly display list items with indentation

### How to test?
Existing workflows will still work as previously intended
For existing pipes (no configuration set):
- Workflow 1: It has a failed execution with past delay timestamp --> retry should still work.
- Workflow 2: Future executions with past delay timestamp will get no error.
- Workflow 3: Future executions with valid past delay timestamp should continue to wait as intended.

For new pipes:
- Workflow 1: Past delay timestamp will not produce an error in test step and actual live execution when `Continue the Workflow` is selected
- Workflow 2: Past delay timestamp will not produce an error in test step but show an error for actual live execution when `Pause the Workflow` is selected
- Workflow 3: Valid delay timestamp should continue to work and wait as intended.

Other tests:
1. Test invalid date formats to confirm the improved error messages display correctly
2. Verify that radio button descriptions appear properly in the UI

### Why make this change?

This change provides users with more control over how their workflows handle scheduling edge cases. Previously, workflows would always fail when encountering past dates, requiring manual intervention. Now users can choose the behavior that best fits their use case - either continuing immediately for time-sensitive workflows or pausing for workflows that require specific timing.