### PR TITLE
PLU-456: add alert tab for paused workflow executions

### DIFF
--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -125,6 +125,7 @@ const action: IRawAction = {
           delayUntilTime: dateTimeNow.toPlumberFormat('HH:mm'),
         }
       } else {
+        // Update in `useExecutionStepStatus.ts` if the error name changes
         throw new StepError(
           'Delay until timestamp entered is in the past',
           'This action was scheduled to run at a time that has already passed. Click "Retry" to skip the delay and continue the Pipe now.',

--- a/packages/frontend/src/components/ErrorResult/ErrorDetailsCollapse.tsx
+++ b/packages/frontend/src/components/ErrorResult/ErrorDetailsCollapse.tsx
@@ -1,0 +1,41 @@
+import { IJSONObject } from '@plumber/types'
+
+import { useCallback, useState } from 'react'
+import { Box, Collapse } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import JSONViewer from '@/components/JSONViewer'
+
+interface ErrorDetailsCollapseProps {
+  details: IJSONObject
+  buttonText?: string
+}
+
+export default function ErrorDetailsCollapse(props: ErrorDetailsCollapseProps) {
+  const { details, buttonText = 'View error details below.' } = props
+  const [isOpen, setIsOpen] = useState(false)
+
+  const toggleDropdown = useCallback(() => {
+    setIsOpen((value) => !value)
+  }, [])
+
+  return (
+    <>
+      <Button
+        onClick={toggleDropdown}
+        variant="link"
+        size="sm"
+        sx={{ textDecoration: 'underline' }}
+        mt={2}
+      >
+        {buttonText}
+      </Button>
+
+      <Box>
+        <Collapse in={isOpen}>
+          <JSONViewer data={details} />
+        </Collapse>
+      </Box>
+    </>
+  )
+}

--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -39,9 +39,9 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
             opacity={0.8}
             w="full"
           >
-            If this error still persists, contact us at{' '}
+            If this error still persists, contact{' '}
             <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              {SUPPORT_FORM_LINK}
+              Plumber support
             </a>
             .
           </Box>

--- a/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/GenericErrorResult.tsx
@@ -1,11 +1,10 @@
 import { IJSONObject } from '@plumber/types'
 
-import { useCallback, useState } from 'react'
-import { Box, Collapse, Text } from '@chakra-ui/react'
-import { Button, Infobox } from '@opengovsg/design-system-react'
+import { Box, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
 
-import JSONViewer from '@/components/JSONViewer'
-import { SUPPORT_FORM_LINK } from '@/config/urls'
+import ErrorDetailsCollapse from './ErrorDetailsCollapse'
+import SupportContactMessage from './SupportContactMessage'
 
 interface GenericErrorResultProps {
   errorDetails: IJSONObject
@@ -14,10 +13,6 @@ interface GenericErrorResultProps {
 
 export default function GenericErrorResult(props: GenericErrorResultProps) {
   const { errorDetails, isTestRun } = props
-  const [isOpen, setIsOpen] = useState(false)
-  const toggleDropdown = useCallback(() => {
-    setIsOpen((value) => !value)
-  }, [])
 
   return (
     <Infobox variant="error" borderRadius="lg">
@@ -27,39 +22,12 @@ export default function GenericErrorResult(props: GenericErrorResultProps) {
         </Text>
 
         <Text textStyle="body-1">
-          <Text textStyle="body-1">
-            {`Check if you have configured ${
-              isTestRun ? 'the steps above' : 'this step'
-            } correctly and retest.`}
-          </Text>
-          <Box
-            marginTop={4}
-            borderTop="1px solid #E0E0E0"
-            fontSize="0.8rem"
-            opacity={0.8}
-            w="full"
-          >
-            If this error still persists, contact{' '}
-            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              Plumber support
-            </a>
-            .
-          </Box>
-          <Button
-            onClick={toggleDropdown}
-            variant="link"
-            size="sm"
-            sx={{ textDecoration: 'underline' }}
-            mt={2}
-          >
-            View error details below.
-          </Button>
+          {`Check if you have configured ${
+            isTestRun ? 'the steps above' : 'this step'
+          } correctly and retest.`}
 
-          <Box>
-            <Collapse in={isOpen}>
-              <JSONViewer data={errorDetails}></JSONViewer>
-            </Collapse>
-          </Box>
+          <SupportContactMessage />
+          <ErrorDetailsCollapse details={errorDetails} />
         </Text>
       </Box>
     </Infobox>

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -1,9 +1,8 @@
 import { IStepError } from '@plumber/types'
 
-import { useCallback, useState } from 'react'
 import Markdown from 'react-markdown'
 import { useMutation } from '@apollo/client'
-import { Box, Collapse, Text } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 import {
   Badge,
   Button,
@@ -11,12 +10,13 @@ import {
   useToast,
 } from '@opengovsg/design-system-react'
 
-import JSONViewer from '@/components/JSONViewer'
-import { SUPPORT_FORM_LINK } from '@/config/urls'
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
 import { infoboxMdComponents } from '../MarkdownRenderer/CustomMarkdownComponents'
+
+import ErrorDetailsCollapse from './ErrorDetailsCollapse'
+import SupportContactMessage from './SupportContactMessage'
 
 interface SpecificErrorResultProps {
   errorDetails: IStepError
@@ -28,10 +28,6 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props
   const { name, solution, position, appName, details, partialRetry } =
     errorDetails
-  const [isOpen, setIsOpen] = useState(false)
-  const toggleDropdown = useCallback(() => {
-    setIsOpen((value) => !value)
-  }, [])
 
   const toast = useToast()
 
@@ -75,37 +71,14 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
           <Markdown linkTarget="_blank" components={infoboxMdComponents}>
             {solution}
           </Markdown>
-          <Box
-            marginTop={4}
-            borderTop="1px solid #E0E0E0"
-            fontSize="0.8rem"
-            opacity={0.8}
-            w="full"
-          >
-            If this error still persists, contact{' '}
-            <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              Plumber support
-            </a>
-            .
-          </Box>
-          {details && (
-            <>
-              <Button
-                onClick={toggleDropdown}
-                variant="link"
-                size="sm"
-                sx={{ textDecoration: 'underline' }}
-                mt={2}
-              >
-                View http error details below.
-              </Button>
 
-              <Box>
-                <Collapse in={isOpen}>
-                  <JSONViewer data={details}></JSONViewer>
-                </Collapse>
-              </Box>
-            </>
+          <SupportContactMessage />
+
+          {details && (
+            <ErrorDetailsCollapse
+              details={details}
+              buttonText="View http error details below."
+            />
           )}
 
           {!isTestRun && partialRetry && executionStepId && (

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -82,9 +82,9 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
             opacity={0.8}
             w="full"
           >
-            If this error still persists, contact us at{' '}
+            If this error still persists, contact{' '}
             <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
-              {SUPPORT_FORM_LINK}
+              Plumber support
             </a>
             .
           </Box>

--- a/packages/frontend/src/components/ErrorResult/SupportContactMessage.tsx
+++ b/packages/frontend/src/components/ErrorResult/SupportContactMessage.tsx
@@ -1,0 +1,21 @@
+import { Box } from '@chakra-ui/react'
+
+import { SUPPORT_FORM_LINK } from '@/config/urls'
+
+export default function SupportContactMessage() {
+  return (
+    <Box
+      marginTop={4}
+      borderTop="1px solid #E0E0E0"
+      fontSize="0.8rem"
+      opacity={0.8}
+      w="full"
+    >
+      If this error still persists, contact{' '}
+      <a href={SUPPORT_FORM_LINK} target="_blank" rel="noreferrer">
+        Plumber support
+      </a>
+      .
+    </Box>
+  )
+}

--- a/packages/frontend/src/components/ExecutionStep/components/DelayPausedAlert.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/DelayPausedAlert.tsx
@@ -1,0 +1,56 @@
+import type { IExecution } from '@plumber/types'
+
+import { Link } from 'react-router-dom'
+import { Divider, Flex, Text } from '@chakra-ui/react'
+import { Infobox } from '@opengovsg/design-system-react'
+
+import { FLOW_EDITOR } from '@/config/urls'
+
+interface DelayPausedAlertProps {
+  execution: IExecution
+}
+
+/**
+ * TODO: Change this component name if there are more use cases that involve "pausing" the pipe
+ */
+export default function DelayPausedAlert({
+  execution,
+}: DelayPausedAlertProps): React.ReactElement {
+  const flowId = execution.flow?.id
+  const flowName = execution.flow?.name
+
+  return (
+    <Flex direction="column" align="stretch" gap={4}>
+      <Infobox variant="info" borderRadius="lg">
+        <Flex flexDir="column" gap={4}>
+          <Flex flexDir="column" gap={2}>
+            <Text textStyle="subhead-1">This execution was paused</Text>
+            <Text textStyle="body-1">
+              The scheduled date had already passed when this workflow ran. This
+              happened because you chose to pause executions in this situation.
+            </Text>
+          </Flex>
+
+          <Divider />
+          {flowId && (
+            <Flex textStyle="body-1" gap={1}>
+              <Text>Workflow:</Text>
+              <Link
+                to={FLOW_EDITOR(flowId)}
+                target="_blank"
+                color="primary.500"
+              >
+                <Flex align="center" gap={1} color="primary.500">
+                  <Text>{flowName}</Text>
+                  <Text mb="-1" fontSize="1rem">
+                    ↗
+                  </Text>
+                </Flex>
+              </Link>
+            </Flex>
+          )}
+        </Flex>
+      </Infobox>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
@@ -4,7 +4,9 @@ import { useMutation } from '@apollo/client'
 import { HStack, Icon, Text } from '@chakra-ui/react'
 import { Button, useToast } from '@opengovsg/design-system-react'
 
+import client from '@/graphql/client'
 import { RETRY_EXECUTION_STEP } from '@/graphql/mutations/retry-execution-step'
+import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
 interface RetryButtonProps {
   executionStepId: string
@@ -39,6 +41,13 @@ const RetryButton = ({
         position: 'bottom-right',
       })
       setIsRetrySuccessful(true)
+
+      // reload page after short delay because the job is retrying
+      setTimeout(() => {
+        client.refetchQueries({
+          include: [GET_EXECUTION_STEPS],
+        })
+      }, 3000)
     },
     onError: () => {
       setIsRetrySuccessful(false)

--- a/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
@@ -28,6 +28,7 @@ const partialIcon = (
 
 const waitingIcon = <Image src={executionWaitingIcon} h={6} />
 
+// Only used for delay until past timestamp paused errors
 const delayPausedIcon = (
   <Icon boxSize={6} as={BiSolidErrorCircle} color="blue.500" />
 )

--- a/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/StatusIcons.tsx
@@ -28,4 +28,8 @@ const partialIcon = (
 
 const waitingIcon = <Image src={executionWaitingIcon} h={6} />
 
-export { failureIcon, partialIcon, successIcon, waitingIcon }
+const delayPausedIcon = (
+  <Icon boxSize={6} as={BiSolidErrorCircle} color="blue.500" />
+)
+
+export { delayPausedIcon, failureIcon, partialIcon, successIcon, waitingIcon }

--- a/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
+++ b/packages/frontend/src/components/ExecutionStep/hooks/useExecutionStepStatus.ts
@@ -7,11 +7,15 @@ import { GroupStatusType } from '@/components/ExecutionGroup/GroupStatusFilter'
 import { GET_APP } from '@/graphql/queries/get-app'
 
 import {
+  delayPausedIcon,
   failureIcon,
   partialIcon,
   successIcon,
   waitingIcon,
 } from '../components/StatusIcons'
+
+// This is frontend hardcoded, remember to change if error name changes
+const ERROR_NAME_DELAY_PAUSED = 'Delay until timestamp entered is in the past'
 
 export interface UseExecutionStepStatusProps {
   appKey: string
@@ -28,6 +32,7 @@ export interface UseExecutionStepStatusReturn {
   isStepSuccessful: boolean
   hasError: boolean
   isPartialSuccess: boolean
+  isDelayPaused: boolean
   canRetry: boolean
   loading: boolean
   customRetryButtonText?: string
@@ -49,6 +54,7 @@ export function useExecutionStepStatus({
   const isStepSuccessful = status === 'success'
   const hasExecutionFailed = execution?.status === 'failure'
   const isPartialSuccess = status === 'success' && hasError
+  const isDelayPaused = errorDetails?.name === ERROR_NAME_DELAY_PAUSED
   const canRetry =
     !isStepSuccessful &&
     !!jobId &&
@@ -56,6 +62,9 @@ export function useExecutionStepStatus({
     execution?.flow?.role !== 'viewer'
 
   const statusIcon = useMemo(() => {
+    if (isDelayPaused) {
+      return delayPausedIcon
+    }
     if (isPartialSuccess) {
       return partialIcon
     }
@@ -66,7 +75,7 @@ export function useExecutionStepStatus({
       return waitingIcon
     }
     return failureIcon
-  }, [isPartialSuccess, isStepSuccessful, status])
+  }, [isPartialSuccess, isStepSuccessful, status, isDelayPaused])
 
   const customRetryButtonText = useMemo(() => {
     // specific to email by postman where we want to allow users to retry without attachments
@@ -89,6 +98,7 @@ export function useExecutionStepStatus({
     isStepSuccessful,
     hasError,
     isPartialSuccess,
+    isDelayPaused,
     canRetry,
     loading,
     customRetryButtonText,

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -17,6 +17,7 @@ import JSONViewer from '@/components/JSONViewer'
 import { EXECUTION_STEP_PER_PAGE } from '@/pages/Execution'
 
 import AppIconWithStatus from './components/AppIconWithStatus'
+import DelayPausedAlert from './components/DelayPausedAlert'
 import { RetryAllButton } from './components/RetryAllButton'
 import RetryButton from './components/RetryButton'
 import { useExecutionStepStatus } from './hooks/useExecutionStepStatus'
@@ -48,6 +49,7 @@ export default function ExecutionStep({
     statusIcon,
     hasError,
     isPartialSuccess,
+    isDelayPaused,
     canRetry,
     customRetryButtonText,
   } = useExecutionStepStatus({
@@ -57,6 +59,9 @@ export default function ExecutionStep({
     execution,
     jobId,
   })
+
+  const showAlertTab = isDelayPaused
+  const showErrorTab = hasError && !isDelayPaused
 
   if (!app) {
     return null
@@ -86,7 +91,9 @@ export default function ExecutionStep({
                 <RetryAllButton execution={execution} />
                 <RetryButton
                   executionStepId={executionStep.id}
-                  customButtonText={customRetryButtonText}
+                  customButtonText={
+                    isDelayPaused ? 'Resume' : customRetryButtonText
+                  }
                 />
               </>
             )}
@@ -95,7 +102,7 @@ export default function ExecutionStep({
 
         {/* bottom half: data in, data out and error */}
         <Box borderTop="1px solid" borderTopColor="base.divider.strong" p={4}>
-          <Tabs defaultIndex={hasError ? 2 : 0}>
+          <Tabs defaultIndex={showAlertTab || hasError ? 2 : 0}>
             <TabList
               borderBottom="1px solid"
               borderBottomColor="base.divider.medium"
@@ -103,7 +110,9 @@ export default function ExecutionStep({
             >
               <Tab>Data In</Tab>
               <Tab>Data Out</Tab>
-              {hasError && (
+              {/* Only for paused delay until pipes for now */}
+              {showAlertTab && <Tab>Alert</Tab>}
+              {showErrorTab && (
                 <Tab position="relative">
                   Error
                   {isPartialSuccess && (
@@ -126,7 +135,12 @@ export default function ExecutionStep({
               <TabPanel>
                 <JSONViewer data={executionStep.dataOut} />
               </TabPanel>
-              {hasError && (
+              {showAlertTab && (
+                <TabPanel>
+                  <DelayPausedAlert execution={execution} />
+                </TabPanel>
+              )}
+              {showErrorTab && (
                 <TabPanel>
                   <ErrorResult
                     executionStepId={executionStep.id}


### PR DESCRIPTION
### TL;DR

Added special handling for delay-paused executions with improved UI messaging and support link text updates.

### What changed?

- **Error result components**: Changed support contact text from "contact us at {SUPPORT_FORM_LINK}" to "contact Plumber support" with cleaner link display
- **Delay paused handling**: Added `DelayPausedAlert` component to show informational message when scheduled delays are paused due to past timestamps
- **Status icons**: Added blue `delayPausedIcon` for delay-paused execution steps
- **Execution step UI**: Added "Alert" tab for delay-paused steps, changed retry button text to "Resume" for paused delays
- **Retry functionality**: Added automatic page refresh 3 seconds after successful retry to show updated execution status

### How to test?

1. Create a workflow with a delay step scheduled for a past timestamp with pause-on-past-date enabled
2. Run the workflow and verify the execution step shows a blue icon and "Alert" tab with the pause message
3. Click "Resume" button and verify the page refreshes after 3 seconds
4. Trigger any error condition and verify the support link displays "Plumber support" instead of the raw URL

Basically, error messages will still show as:
<img width="1199" height="333" alt="Screenshot 2026-03-11 at 11 04 56 AM" src="https://github.com/user-attachments/assets/4536c74a-3455-473f-a97f-1a5b43ada893" />

But only for delay until errors that have a past delayed timestamp: `paused execution`:
<img width="1201" height="352" alt="Screenshot 2026-03-11 at 11 04 33 AM" src="https://github.com/user-attachments/assets/cbbbb18a-b355-4412-b5c3-aec02ccde72a" />


### Why make this change?

Improves user experience by providing clearer messaging for delay-paused executions and cleaner support contact information. The automatic refresh ensures users see updated execution status without manual page reload.