### PR TITLE
[AI-BUILDER-27] PLU-674 (chore): improve mobile responsiveness

### DIFF
--- a/packages/frontend/src/graphql/queries/get-flow.ts
+++ b/packages/frontend/src/graphql/queries/get-flow.ts
@@ -31,6 +31,7 @@ export const FLOW_FIELDS = gql`
         stepName
         templateConfig {
           appEventKey
+          customTemplate
         }
         approval {
           branch

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -18,6 +18,13 @@ export interface Message {
   text: string
   traceId?: string // only assistant messages have this
   isUser: boolean
+  /**
+   * used to track the latest message with isChatReady: true.
+   * this is used to determine where we should show the preview button
+   * on mobile mode.
+   * only assistant messages should have this.
+   */
+  isChatReady: boolean
 }
 
 // Custom message type with metadata
@@ -44,9 +51,11 @@ export function useChatStream(options: UseChatStreamOptions) {
   const { ddSessionId } = useAiBuilderContext()
 
   // Track step readiness from data-isChatReady annotation
-  // Defaults to false, becomes true when API returns isReady: true
-  // Resets to false when a new message is sent
-  const [isReady, setIsReady] = useState(false)
+  // Initialize based on whether initialMessages contains a ready message
+  const initialIsReady = !!options?.initialMessages?.findLast(
+    (msg) => msg.isChatReady,
+  )
+  const [isReady, setIsReady] = useState(initialIsReady)
 
   // Use ref to always access the latest location state in callbacks
   // This ensures onFinish sees updates made by other components (e.g., StepsPreview)
@@ -157,10 +166,23 @@ export function useChatStream(options: UseChatStreamOptions) {
     }
 
     const transformedMessages = transformMessages(messagesToTransform)
-    const allMessages = deduplicateMessages([
+    const combined = deduplicateMessages([
       ...initialMsgs,
       ...transformedMessages,
     ])
+
+    // Ensure only the last message with isChatReady: true keeps the flag
+    let lastReadyIndex = -1
+    const allMessages = combined.map((msg, index) => {
+      if (msg.isChatReady) {
+        lastReadyIndex = index
+      }
+      return { ...msg, isChatReady: false }
+    })
+
+    if (lastReadyIndex !== -1) {
+      allMessages[lastReadyIndex].isChatReady = true
+    }
 
     return allMessages
   }, [aiMessages, options?.initialMessages, status])

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -1,6 +1,6 @@
 import { IApp, IStep } from '@plumber/types'
 
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { Center } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
@@ -39,6 +39,8 @@ interface AIBuilderContextValue extends AIBuilderSharedProps {
   stepGroupCaption: string | null
   // DataDog RUM Session ID so we can associate the trace with the RUM
   ddSessionId: string
+  isDrawerOpen: boolean
+  setIsDrawerOpen: (open: boolean) => void
 }
 
 const AiBuilderContext = createContext<AIBuilderContextValue | undefined>(
@@ -70,6 +72,21 @@ export const AiBuilderContextProvider = ({
 }: AiBuilderContextProviderProps) => {
   const isMobile = useIsMobile()
   const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  // Update drawer state when isMobile or output changes (handles async isMobile hook)
+  useEffect(() => {
+    const shouldOpen =
+      !isMobile && Boolean(output?.trigger || output?.actions?.length)
+
+    if (shouldOpen !== isDrawerOpen) {
+      setIsDrawerOpen(shouldOpen)
+    }
+
+    // NOTE: re-trigger based on changes to isMobile
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile])
 
   const { data: getAppsData, loading: isLoadingAllApps } = useQuery(GET_APPS)
 
@@ -132,6 +149,8 @@ export const AiBuilderContextProvider = ({
         stepGroupCaption,
         ddSessionId,
         clearPersistedState,
+        isDrawerOpen,
+        setIsDrawerOpen,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -77,7 +77,7 @@ export default function PromptInput({
         w="full"
         minH={showIdeas ? '120px' : '50px'}
         height="auto"
-        mb={isMobile ? 0 : 6}
+        mb={isMobile ? (shouldShowIdeas ? 6 : 0) : 6}
       >
         <Textarea
           ref={textareaRef}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/SideDrawer.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/SideDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@chakra-ui/react'
+import { Box, CloseButton, Flex } from '@chakra-ui/react'
 import { useIsMobile } from '@opengovsg/design-system-react'
 
 import StepsPreview from '../StepsPreview'
@@ -6,11 +6,13 @@ import StepsPreview from '../StepsPreview'
 interface SideDrawerProps {
   isOpen: boolean
   isReadyForPreview: boolean
+  onClose: () => void
 }
 
 export default function SideDrawer({
   isOpen,
   isReadyForPreview,
+  onClose,
 }: SideDrawerProps) {
   const isMobile = useIsMobile()
 
@@ -30,9 +32,20 @@ export default function SideDrawer({
       pointerEvents={isOpen ? 'auto' : 'none'}
       visibility={isOpen ? 'visible' : 'hidden'}
     >
-      <Flex h="100%" flexDir="column" w="full">
+      <Flex h="100%" flexDir="column" w="full" py={isMobile ? 0 : 4}>
+        {isMobile && (
+          <Flex
+            px={4}
+            borderBottom="1px solid"
+            borderColor="base.divider.medium"
+            py={2}
+          >
+            <CloseButton size="sm" onClick={onClose} />
+          </Flex>
+        )}
+
         {/* Content */}
-        <Box flex={1} overflowY="auto" py={6}>
+        <Box flex={1} overflowY="auto" py={2} px={isMobile ? 4 : 0}>
           {isOpen && <StepsPreview isReadyForPreview={isReadyForPreview} />}
         </Box>
       </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { Box, Flex, Text } from '@chakra-ui/react'
-import { useIsMobile } from '@opengovsg/design-system-react'
 import { StickToBottom } from 'use-stick-to-bottom'
 
 import pairLogo from '@/assets/pair-logo.svg'
@@ -36,12 +35,8 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   } = props
   const navigate = useNavigate()
   const location = useLocation()
-  const isMobile = useIsMobile()
-  const { flowName, chatInput, output } = useAiBuilderContext()
-
-  const [isDrawerOpen, setIsDrawerOpen] = useState(
-    Boolean(output?.trigger || output?.actions?.length),
-  )
+  const { flowName, chatInput, isMobile, isDrawerOpen, setIsDrawerOpen } =
+    useAiBuilderContext()
 
   const hasMessages = messages.length > 0 || isStreaming
 
@@ -57,8 +52,19 @@ export default function ChatInterface(props: ChatInterfaceProps) {
         replace: true,
       })
     }
-    setIsDrawerOpen(true)
-  }, [chatInput, messages, location.state, flowName, navigate])
+
+    if (!isMobile) {
+      setIsDrawerOpen(true)
+    }
+  }, [
+    chatInput,
+    messages,
+    setIsDrawerOpen,
+    navigate,
+    location.state,
+    flowName,
+    isMobile,
+  ])
 
   // Auto-open preview when streaming completes and result is ready
   useEffect(() => {
@@ -130,7 +136,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             flexShrink={0}
             position="relative"
           >
-            <Box maxW="4xl" mx="auto" px={4} py={4} pb={8}>
+            <Box maxW="4xl" mx="auto" px={4} py={4} pb={isMobile ? 4 : 8}>
               <ScrollButton />
               <PromptInput
                 sendMessage={sendMessage}
@@ -156,7 +162,12 @@ export default function ChatInterface(props: ChatInterfaceProps) {
           <ImageBox imageUrl={pairLogo} boxSize={6} />
         </Flex>
       )}
-      <SideDrawer isOpen={isDrawerOpen} isReadyForPreview={isReadyForPreview} />
+
+      <SideDrawer
+        isOpen={isDrawerOpen}
+        isReadyForPreview={isReadyForPreview}
+        onClose={() => setIsDrawerOpen(false)}
+      />
     </Flex>
   )
 }

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -8,16 +8,20 @@ import ChatMessageToolbar from './ChatMessageToolbar'
 
 interface ChatMessageProps {
   message: Message
+  shouldShowPreview?: boolean
 }
 
-const AiMessage = memo(({ message }: ChatMessageProps) => {
+const AiMessage = memo(({ message, shouldShowPreview }: ChatMessageProps) => {
   return (
     <Flex gap={3} w="full" align="start">
       <Box flex={1} px={2} color="gray.900">
         <ChakraStreamdown isAnimating={false}>
           {message.text || ''}
         </ChakraStreamdown>
-        <ChatMessageToolbar traceId={message.traceId || ''} />
+        <ChatMessageToolbar
+          traceId={message.traceId || ''}
+          shouldShowPreviewButton={shouldShowPreview}
+        />
       </Box>
     </Flex>
   )
@@ -46,12 +50,20 @@ const UserMessage = memo(({ message }: ChatMessageProps) => {
 
 UserMessage.displayName = 'UserMessage'
 
-const ChatMessage = memo(({ message }: { message: Message }) => {
-  if (message.isUser) {
-    return <UserMessage message={message} />
-  }
-  return <AiMessage message={message} />
-})
+const ChatMessage = memo(
+  ({
+    message,
+    shouldShowPreview,
+  }: {
+    message: Message
+    shouldShowPreview: boolean
+  }) => {
+    if (message.isUser) {
+      return <UserMessage message={message} />
+    }
+    return <AiMessage message={message} shouldShowPreview={shouldShowPreview} />
+  },
+)
 
 ChatMessage.displayName = 'ChatMessage'
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessageToolbar/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessageToolbar/index.tsx
@@ -1,18 +1,33 @@
-import { Flex } from '@chakra-ui/react'
+import { Button, Flex } from '@chakra-ui/react'
+
+import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 
 import { FeedbackButton } from './FeedbackButton'
 
 interface ChatMessageToolbarProps {
   traceId: string
+  shouldShowPreviewButton?: boolean
 }
 
 export default function ChatMessageToolbar({
   traceId,
+  shouldShowPreviewButton,
 }: ChatMessageToolbarProps) {
+  const { setIsDrawerOpen } = useAiBuilderContext()
+
   return (
-    <Flex gap={1} mt={2}>
-      <FeedbackButton feedbackType="positive" traceId={traceId} />
-      <FeedbackButton feedbackType="negative" traceId={traceId} />
-    </Flex>
+    <>
+      {shouldShowPreviewButton && (
+        <Flex gap={1} alignItems="center" bottom={4} right={4} zIndex={5}>
+          <Button size="md" width="full" onClick={() => setIsDrawerOpen(true)}>
+            Preview workflow
+          </Button>
+        </Flex>
+      )}
+      <Flex gap={1} mt={2}>
+        <FeedbackButton feedbackType="positive" traceId={traceId} />
+        <FeedbackButton feedbackType="negative" traceId={traceId} />
+      </Flex>
+    </>
   )
 }

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/index.tsx
@@ -1,4 +1,5 @@
 import { Box, VStack } from '@chakra-ui/react'
+import { useIsMobile } from '@opengovsg/design-system-react'
 import { StickToBottom } from 'use-stick-to-bottom'
 
 import { Message } from '@/hooks/useChatStream'
@@ -17,6 +18,8 @@ export default function ChatMessages({
   currentResponse,
   isStreaming,
 }: ChatMessagesProps) {
+  const isMobile = useIsMobile()
+
   return (
     <StickToBottom.Content
       style={{
@@ -27,9 +30,16 @@ export default function ChatMessages({
     >
       <Box w="full" maxW="4xl" mx="auto" px={4} py={6}>
         <VStack align="stretch" spacing={4}>
-          {messages.map((message) => (
-            <ChatMessage key={message.id} message={message} />
-          ))}
+          {messages.map((message) => {
+            const shouldShowPreview = isMobile && message.isChatReady
+            return (
+              <ChatMessage
+                key={message.id}
+                message={message}
+                shouldShowPreview={shouldShowPreview}
+              />
+            )
+          })}
 
           {/* Streaming response */}
           {isStreaming && (

--- a/packages/frontend/src/pages/AiBuilder/components/IdeaButtons.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/IdeaButtons.tsx
@@ -12,7 +12,7 @@ export default function IdeaButtons({ ideas, onClick }: IdeaButtonsProps) {
   return (
     <Flex flexDir="row" alignItems="center" w="full">
       <Flex
-        flexDir="row"
+        flexDir={{ base: 'column', md: 'row' }}
         gap={3}
         justifyContent="space-evenly"
         flexWrap="wrap"
@@ -31,9 +31,10 @@ export default function IdeaButtons({ ideas, onClick }: IdeaButtonsProps) {
             onClick={() => onClick(idea)}
             px={3}
             minH={4}
-            flex="1"
-            minW="150px"
-            maxW="250px"
+            flex={{ base: 'none', md: '1' }}
+            w={{ base: 'full', md: 'auto' }}
+            minW={{ base: 'auto', md: '150px' }}
+            maxW={{ base: 'none', md: '250px' }}
             whiteSpace="normal"
             height="auto"
           >

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -1,6 +1,10 @@
 import { TextPart } from 'ai'
 
-import { CustomUIMessage, Message } from '@/hooks/useChatStream'
+import {
+  CustomUIMessage,
+  IsChatReadyPart,
+  Message,
+} from '@/hooks/useChatStream'
 
 // deduplicate messages by id
 // there may be duplicates when the messages are combined
@@ -24,10 +28,30 @@ export const extractTextContent = (msg: CustomUIMessage): string => {
 }
 
 export const transformMessages = (messages: CustomUIMessage[]) => {
-  return messages.map((msg) => ({
-    id: msg.id,
-    text: extractTextContent(msg),
-    isUser: msg.role === 'user',
-    traceId: msg.metadata?.traceId,
-  }))
+  let lastReadyIndex = -1
+
+  const transformed = messages.map((msg, index) => {
+    const isChatReady = msg.parts.find(
+      (part): part is IsChatReadyPart => part.type === 'data-isChatReady',
+    )?.data.isChatReady
+
+    if (isChatReady) {
+      lastReadyIndex = index
+    }
+
+    return {
+      id: msg.id,
+      text: extractTextContent(msg),
+      isUser: msg.role === 'user',
+      traceId: msg.metadata?.traceId,
+      isChatReady: false, // default to false
+    }
+  })
+
+  // Only set the last ready message to true
+  if (lastReadyIndex !== -1) {
+    transformed[lastReadyIndex].isChatReady = true
+  }
+
+  return transformed
 }

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -17,7 +17,13 @@ import {
 
 function AiBuilderContent() {
   const navigate = useNavigate()
-  const { flowName, chatMessages, clearPersistedState } = useAiBuilderContext()
+  const {
+    flowName,
+    chatMessages,
+    clearPersistedState,
+    isMobile,
+    isDrawerOpen,
+  } = useAiBuilderContext()
 
   const {
     messages,
@@ -61,31 +67,33 @@ function AiBuilderContent() {
         <title>{flowName} | WIP</title>
       </Helmet>
       <Flex h="100vh" flexDirection="column">
-        <HStack
-          position="fixed"
-          top={0}
-          left={0}
-          right={0}
-          zIndex={10}
-          bg="white"
-          justifyContent="space-between"
-          alignItems="center"
-          py={2}
-          px={{ base: 4, md: 8 }}
-          borderBottom="1px solid"
-          borderColor="base.divider.medium"
-        >
-          <Flex flex={1} alignItems="center" minWidth={0} gap={2}>
-            <CloseButton size="sm" onClick={handleClose} />
+        {!(isMobile && isDrawerOpen) && (
+          <HStack
+            position="fixed"
+            top={0}
+            left={0}
+            right={0}
+            zIndex={10}
+            bg="white"
+            justifyContent="space-between"
+            alignItems="center"
+            py={2}
+            px={{ base: 4, md: 8 }}
+            borderBottom="1px solid"
+            borderColor="base.divider.medium"
+          >
+            <Flex flex={1} alignItems="center" minWidth={0} gap={2}>
+              <CloseButton size="sm" onClick={handleClose} />
 
-            <Text>{flowName}</Text>
-          </Flex>
-        </HStack>
+              <Text>{flowName}</Text>
+            </Flex>
+          </HStack>
+        )}
         <Container
           maxW="full"
           px={0}
           py={0}
-          mt="51.5px"
+          mt={isMobile && isDrawerOpen ? 0 : '51.5px'}
           flex={1}
           overflowY="auto"
           sx={{


### PR DESCRIPTION
### TL;DR

Added mobile-responsive drawer functionality.

### What changed?

- Added `isChatReady` boolean field to the `Message` interface to track which assistant messages should display preview functionality
- Moved drawer state (`isDrawerOpen`, `setIsDrawerOpen`) to `AiBuilderContext` with automatic initialisation based on mobile state and output presence
- Added close button and mobile-specific styling to `SideDrawer` component
- Implemented "Preview workflow" button that appears on mobile for messages marked as chat-ready
- Updated idea buttons to stack vertically on mobile devices instead of horizontally
- Modified header visibility to hide when drawer is open on mobile
- Adjusted spacing and padding throughout the interface for better mobile experience
- Enhanced message transformation logic to ensure only the latest ready message maintains the `isChatReady` flag

### Tests

- [x] Desktop version of the AI Builder should still work as per normal
    - [x] Steps are auto-generated
    - [x] Side drawer is automatically opened on browser refresh if it was open before
- [x] Mobile version
    - [x] Suggestions are stacked
    - [x] Messages are still streamed properly
    - [x] `Preview workflow` button only appears for messages when its ready to generate steps (ie, normal chat responses should not have this)
    - [x] Side drawer should NOT automatically open
    - [x] Side drawer only opens when you click `Preview workflow`
    - [x] Side drawer closes when you click the 'X' button
    - [x] Sie drawer is reopened when you click `Preview workflow`

### Screenshots

![Screenshot 2026-03-11 at 3.51.50 PM.png](https://app.graphite.com/user-attachments/assets/8fbc19c8-b8c5-4782-b005-8f2969af6572.png)![Screenshot 2026-03-11 at 3.51.55 PM.png](https://app.graphite.com/user-attachments/assets/19a15d02-7eea-4f54-bb15-419cd0616592.png)