### PR TITLE
[AI-BUILDER-28] PLU-682 (fix): error detection and display

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -216,7 +216,20 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
     clearPersistedState,
   ])
 
-  if (error || !steps) {
+  if (isGeneratingSteps) {
+    return (
+      <Center h="100%">
+        <MultiStepLoader
+          loadingStates={LOADING_STATES}
+          loading={isGeneratingSteps}
+          duration={1500}
+          loop={false}
+        />
+      </Center>
+    )
+  }
+
+  if (error || !(output?.trigger && output?.actions?.length) || !steps) {
     return (
       <Center h="80%">
         <Flex
@@ -241,19 +254,6 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
           </Text>
           <Button onClick={retryGenerateAiSteps}>Try again</Button>
         </Flex>
-      </Center>
-    )
-  }
-
-  if (isGeneratingSteps) {
-    return (
-      <Center h="100%">
-        <MultiStepLoader
-          loadingStates={LOADING_STATES}
-          loading={isGeneratingSteps}
-          duration={1500}
-          loop={false}
-        />
       </Center>
     )
   }


### PR DESCRIPTION
### Issues fixed

- Should show loader before seeing error state
- Should see error state if there is error / no output / no steps

### Test

- [ ] Should no longer see any flash of error state before loader
- [ ] Should always see the same error state to 'Modify your prompt or try again' instead of the Step with 'Something went wrong'