### PR TITLE
 mrf fix: correctly reflect submission time for mrf submissions

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/compute-submission-time.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/compute-submission-time.test.ts
@@ -1,0 +1,104 @@
+import { Settings as LuxonSettings } from 'luxon'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { computeSubmissionTime } from '../../auth/helpers/compute-submission-time'
+
+// TZ formatting replicated here (see appConfig) as tests don't load the app
+// config module.
+beforeAll(() => {
+  LuxonSettings.defaultZone = 'Asia/Singapore'
+  LuxonSettings.defaultLocale = 'en-SG'
+})
+
+describe('computeSubmissionTime', () => {
+  describe('SRF (non-MRF) forms', () => {
+    it('returns submission creation time converted to SGT', () => {
+      const result = computeSubmissionTime({
+        created: '2024-01-15T08:30:00.000Z',
+      })
+      // UTC+8 => 16:30 SGT
+      expect(result).toBe('2024-01-15T16:30:00.000+08:00')
+    })
+
+    it('returns creation time when workflowContent is undefined', () => {
+      const result = computeSubmissionTime({
+        created: '2024-06-01T00:00:00.000Z',
+        workflowContent: undefined,
+      })
+      expect(result).toBe('2024-06-01T08:00:00.000+08:00')
+    })
+
+    it('returns creation time when submittedSteps is empty', () => {
+      const result = computeSubmissionTime({
+        created: '2024-01-15T08:30:00.000Z',
+        workflowContent: {
+          workflow: [] as any,
+          workflowStep: 0,
+          submittedSteps: [],
+        },
+      })
+      expect(result).toBe('2024-01-15T16:30:00.000+08:00')
+    })
+  })
+
+  describe('MRF forms', () => {
+    it('returns last submitted step time converted to SGT', () => {
+      const result = computeSubmissionTime({
+        created: '2024-01-15T08:30:00.000Z',
+        workflowContent: {
+          workflow: [] as any,
+          workflowStep: 1,
+          submittedSteps: [
+            {
+              isApproval: false,
+              submittedAt: '2024-01-15T10:00:00.000Z',
+            },
+          ],
+        },
+      })
+      // Uses submittedAt (10:00 UTC => 18:00 SGT), not created
+      expect(result).toBe('2024-01-15T18:00:00.000+08:00')
+    })
+
+    it('returns the last step time when multiple steps exist', () => {
+      const result = computeSubmissionTime({
+        created: '2024-01-15T08:30:00.000Z',
+        workflowContent: {
+          workflow: [] as any,
+          workflowStep: 2,
+          submittedSteps: [
+            {
+              isApproval: false,
+              submittedAt: '2024-01-15T10:00:00.000Z',
+            },
+            {
+              isApproval: true,
+              submittedAt: '2024-01-16T03:45:00.000Z',
+              status: 'APPROVED' as const,
+            },
+          ],
+        },
+      })
+      // Last step: 2024-01-16T03:45 UTC => 2024-01-16T11:45 SGT
+      expect(result).toBe('2024-01-16T11:45:00.000+08:00')
+    })
+
+    it('handles midnight UTC crossing into next day SGT', () => {
+      const result = computeSubmissionTime({
+        created: '2024-01-15T08:30:00.000Z',
+        workflowContent: {
+          workflow: [] as any,
+          workflowStep: 1,
+          submittedSteps: [
+            {
+              isApproval: false,
+              submittedAt: '2024-01-15T23:00:00.000Z',
+            },
+          ],
+        },
+      })
+      // 23:00 UTC => 07:00 next day SGT
+      expect(result).toBe('2024-01-16T07:00:00.000+08:00')
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
@@ -1,0 +1,380 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { processResponsesV3 } from '../../auth/helpers/process-v3-responses'
+
+const mocks = vi.hoisted(() => ({
+  fetchFormSchema: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.loggerError,
+  },
+}))
+
+vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
+  fetchFormSchema: mocks.fetchFormSchema,
+}))
+
+function makeFormSchema(
+  fields: Array<{
+    _id: string
+    title: string
+    fieldType: string
+    columns?: Array<{ title: string; _id: string }>
+  }>,
+) {
+  return {
+    form: {
+      form_fields: fields,
+    },
+  }
+}
+
+describe('processResponsesV3', () => {
+  const $ = {} as IGlobalVariable
+
+  describe('field type mapping', () => {
+    it('maps a simple text field using catch-all', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'field1', title: 'Your name', fieldType: 'textfield' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        field1: { fieldType: 'textfield', answer: 'John' },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'field1',
+          fieldType: 'textfield',
+          question: 'Your name',
+          answer: 'John',
+        },
+      ])
+    })
+
+    it('maps checkbox fields with answerArray from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'cb1', title: 'Hobbies', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        cb1: {
+          fieldType: 'checkbox',
+          answer: { value: ['reading', 'gaming'] },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'cb1',
+          fieldType: 'checkbox',
+          question: 'Hobbies',
+          answerArray: ['reading', 'gaming'],
+        },
+      ])
+    })
+
+    it.each(['radiobutton', 'email', 'mobile'])(
+      'maps %s fields with answer from answer.value',
+      async (fieldType) => {
+        mocks.fetchFormSchema.mockResolvedValueOnce(
+          makeFormSchema([{ _id: 'f1', title: 'Field', fieldType }]),
+        )
+
+        const result = await processResponsesV3($, 'formId', {
+          f1: { fieldType, answer: { value: 'test-value' } },
+        })
+
+        expect(result).toEqual([
+          {
+            _id: 'f1',
+            fieldType,
+            question: 'Field',
+            answer: 'test-value',
+          },
+        ])
+      },
+    )
+
+    it('maps signature fields with answerArray from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'sig1', title: 'Sign here', fieldType: 'signature' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        sig1: {
+          fieldType: 'signature',
+          answer: { type: 'draw', value: [1.1, 1.2] },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'sig1',
+          fieldType: 'signature',
+          question: 'Sign here',
+          answerArray: [1.1, 1.2],
+        },
+      ])
+    })
+
+    it('maps address fields into ordered answerArray', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'addr1', title: 'Address', fieldType: 'address' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        addr1: {
+          fieldType: 'address',
+          answer: {
+            addressSubFields: {
+              blockNumber: '51',
+              streetName: 'Bras Basah Road',
+              buildingName: 'Lazada One',
+              levelNumber: '08',
+              unitNumber: '888',
+              postalCode: '189554',
+            },
+          },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'addr1',
+          fieldType: 'address',
+          question: 'Address',
+          answerArray: [
+            '51',
+            'Bras Basah Road',
+            'Lazada One',
+            '08',
+            '888',
+            '189554',
+          ],
+        },
+      ])
+    })
+
+    it('handles address with missing addressSubFields gracefully', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'addr1', title: 'Address', fieldType: 'address' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        addr1: {
+          fieldType: 'address',
+          answer: {},
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'addr1',
+          fieldType: 'address',
+          question: 'Address',
+          answerArray: [
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+          ],
+        },
+      ])
+    })
+
+    it('maps attachment fields with answer from answer.answer', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'att1', title: 'Upload file', fieldType: 'attachment' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        att1: {
+          fieldType: 'attachment',
+          answer: {
+            hasBeenScanned: true,
+            answer: 'document.pdf',
+            md5Hash: 'abc123',
+          },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'att1',
+          fieldType: 'attachment',
+          question: 'Upload file',
+          answer: 'document.pdf',
+        },
+      ])
+    })
+  })
+
+  describe('table fields', () => {
+    it('maps table rows from objects to arrays using Object.values', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          {
+            _id: 'tbl1',
+            title: 'Items',
+            fieldType: 'table',
+            columns: [
+              { title: 'Name', _id: 'col1' },
+              { title: 'Qty', _id: 'col2' },
+            ],
+          },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        tbl1: {
+          fieldType: 'table',
+          answer: [
+            { col1: 'Apple', col2: '3' },
+            { col1: 'Banana', col2: '5' },
+          ],
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'tbl1',
+          fieldType: 'table',
+          question: 'Items (Name, Qty)',
+          answerArray: [
+            ['Apple', '3'],
+            ['Banana', '5'],
+          ],
+        },
+      ])
+    })
+
+    it('escapes commas in column titles', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          {
+            _id: 'tbl1',
+            title: 'Data',
+            fieldType: 'table',
+            columns: [
+              { title: 'First, Last', _id: 'col1' },
+              { title: 'Age', _id: 'col2' },
+            ],
+          },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        tbl1: {
+          fieldType: 'table',
+          answer: [{ col1: 'John Doe', col2: '30' }],
+        },
+      })
+
+      expect(result[0].question).toBe('Data (First  Last, Age)')
+    })
+
+    it('does not append columns to question if schema has no columns', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'tbl1', title: 'Items', fieldType: 'table' }]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        tbl1: {
+          fieldType: 'table',
+          answer: [{ col1: 'Apple' }],
+        },
+      })
+
+      expect(result[0].question).toBe('Items')
+    })
+  })
+
+  describe('question fallback', () => {
+    it('falls back to "Question N" when form schema has no matching field', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeFormSchema([]))
+
+      const result = await processResponsesV3($, 'formId', {
+        unknown1: { fieldType: 'textfield', answer: 'hello' },
+        unknown2: { fieldType: 'textfield', answer: 'world' },
+      })
+
+      expect(result[0].question).toBe('Question 1')
+      expect(result[1].question).toBe('Question 2')
+    })
+  })
+
+  describe('form schema fetch failure', () => {
+    it('logs error and falls back to question numbers when schema fetch fails', async () => {
+      mocks.fetchFormSchema.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await processResponsesV3($, 'formId', {
+        field1: { fieldType: 'textfield', answer: 'test' },
+      })
+
+      expect(mocks.loggerError).toHaveBeenCalledWith(
+        'Unable to fetch form schema',
+        expect.objectContaining({
+          event: 'formsg-unable-to-fetch-form-schema',
+          formId: 'formId',
+        }),
+      )
+      expect(result).toEqual([
+        {
+          _id: 'field1',
+          fieldType: 'textfield',
+          question: 'Question 1',
+          answer: 'test',
+        },
+      ])
+    })
+  })
+
+  describe('multiple fields', () => {
+    it('processes mixed field types in order', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'f1', title: 'Name', fieldType: 'textfield' },
+          { _id: 'f2', title: 'Email', fieldType: 'email' },
+          { _id: 'f3', title: 'Agree?', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        f1: { fieldType: 'textfield', answer: 'John' },
+        f2: { fieldType: 'email', answer: { value: 'john@example.com' } },
+        f3: { fieldType: 'checkbox', answer: { value: ['Yes'] } },
+      })
+
+      expect(result).toHaveLength(3)
+      expect(result[0]).toMatchObject({ _id: 'f1', answer: 'John' })
+      expect(result[1]).toMatchObject({
+        _id: 'f2',
+        answer: 'john@example.com',
+      })
+      expect(result[2]).toMatchObject({
+        _id: 'f3',
+        answerArray: ['Yes'],
+      })
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -3,22 +3,18 @@ import type { IAuth, IGlobalVariable } from '@plumber/types'
 import {
   DecryptedAttachments,
   DecryptedContent,
-  FormField,
 } from '@opengovsg/formsg-sdk/dist/types'
-import { DateTime } from 'luxon'
 
 import { sha256Hash } from '@/helpers/crypto'
 import logger from '@/helpers/logger'
 
 import { getSdk, parseFormEnv } from '../common/form-env'
 import convertTableAnswerArrayToTableObject from '../common/process-table-field'
-import type {
-  FormSchemaField,
-  FormsgPayloadWorkflowContent,
-} from '../common/types'
-import { fetchFormSchema } from '../triggers/new-submission/fetch-form-schema'
+import type { FormsgPayloadWorkflowContent } from '../common/types'
 import { NricFilter } from '../triggers/new-submission/index'
 
+import { computeSubmissionTime } from './helpers/compute-submission-time'
+import { processResponsesV3 } from './helpers/process-v3-responses'
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
 import {
   decryptFormAttachmentsV3,
@@ -38,135 +34,6 @@ function processLocalAddress(answerArray: string[]): string[] {
   answer.splice(4, 1)
 
   return answer
-}
-
-async function processResponsesV3(
-  $: IGlobalVariable,
-  formId: string,
-  responsesV3: Record<string, any>,
-): Promise<FormField[]> {
-  const formSchemaFields: Record<string, FormSchemaField> = {}
-  try {
-    const formSchema = await fetchFormSchema($, formId)
-    if (formSchema?.form?.form_fields) {
-      for (const field of formSchema.form.form_fields) {
-        formSchemaFields[field._id] = field
-      }
-    }
-  } catch (e) {
-    logger.error('Unable to fetch form schema', {
-      event: 'formsg-unable-to-fetch-form-schema',
-      formId,
-      error: e,
-    })
-  }
-  const mappedResponses: FormField[] = []
-  let questionNumber = 0
-  for (const [key, value] of Object.entries(responsesV3)) {
-    questionNumber++
-    if (value.fieldType === 'table') {
-      let question =
-        formSchemaFields[key]?.title ?? `Question ${questionNumber}`
-      const answerArray = value.answer.map((row: Record<string, string>) => {
-        return Object.values(row)
-      })
-      // we follow the same format as the old table field title schema
-      if (formSchemaFields[key]?.columns) {
-        question += ` (${formSchemaFields[key]?.columns
-          ?.map((column) => column.title.replaceAll(',', ' '))
-          .join(', ')})`
-      }
-      // v3 return table answers in an array of objects (with key as column id )
-      // we need to map it back to a matrix
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question,
-        answerArray,
-      })
-      continue
-    }
-    if (value.fieldType === 'checkbox') {
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        // this is kinda weird, but it's the way formsg returns the answer for checkbox fields
-        answerArray: value.answer.value,
-      })
-      continue
-    }
-    /**
-     * Similary, formv3 responses put these fields in value.answer.value
-     */
-    if (['radiobutton', 'email', 'mobile'].includes(value.fieldType)) {
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        answer: value.answer.value,
-      })
-      continue
-    }
-    if (value.fieldType === 'signature') {
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        // it comes in this form: { type: 'draw', value: [Array] } },
-        answerArray: value.answer.value,
-      })
-      continue
-    }
-    if (value.fieldType === 'address') {
-      //  answer: { addressSubFields: [Object] } },
-      const addressSubFields = value.answer.addressSubFields ?? {}
-      // we need to map to [block number, street name, building name, level number, unit number, postal code]
-      const answerArray = [
-        addressSubFields.blockNumber,
-        addressSubFields.streetName,
-        addressSubFields.buildingName,
-        addressSubFields.levelNumber,
-        addressSubFields.unitNumber,
-        addressSubFields.postalCode,
-      ]
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        answerArray,
-      })
-      continue
-    }
-    if (value.fieldType === 'attachment') {
-      // the answer has the shape { hasBeenScanned: boolean, answer: string, md5Hash: string }
-      // the answer is the filename
-      mappedResponses.push({
-        _id: key,
-        fieldType: value.fieldType,
-        // we fallback to Question # if the question is not found in the form schema
-        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        // we temporarily store the filename in answer, it will subsequently be replaced with the S3 ID from storeAttachmentInS3
-        answer: value.answer.answer,
-      })
-      continue
-    }
-    // catch-all
-    mappedResponses.push({
-      _id: key,
-      fieldType: value.fieldType,
-      // we fallback to Question # if the question is not found in the form schema
-      question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-      answer: value.answer,
-    })
-    continue
-  }
-  return mappedResponses
 }
 
 /**
@@ -388,11 +255,8 @@ export async function decryptFormResponse(
     $.request.body = {
       fields: parsedData,
       submissionId: data.submissionId,
-      // Forms gives us submission time as ISO 8601 UTC TZ, but our users
-      // expect SGT time, so convert it to ISO 8601 SGT TZ (our Luxon is
-      // configured for SGT - so although fromISO -> toISO looks like a no-op,
-      // it internally does a TZ conversion).
-      submissionTime: DateTime.fromISO(data.created).toISO(),
+      // submission time is computed based on whether it's an MRF or SRF form
+      submissionTime: computeSubmissionTime(data),
       formId: data.formId, // this is used to check if a new form is connected to the formsg step
     }
 

--- a/packages/backend/src/apps/formsg/auth/helpers/compute-submission-time.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/compute-submission-time.ts
@@ -1,0 +1,35 @@
+import { DateTime } from 'luxon'
+
+import { FormsgPayloadWorkflowContent } from '../../common/types'
+
+// Forms gives us submission time as ISO 8601 UTC TZ, but our users
+// expect SGT time, so convert it to ISO 8601 SGT TZ (our Luxon is
+// configured for SGT - so although fromISO -> toISO looks like a no-op,
+// it internally does a TZ conversion).
+function convertToSGT(submissionTime: string): string {
+  return DateTime.fromISO(submissionTime).toISO()
+}
+
+interface FormsgPayload {
+  created: string
+  workflowContent?: FormsgPayloadWorkflowContent
+}
+
+/**
+ * This funciton returns the submission time based on whether it's an MRF or SRF form.
+ */
+export function computeSubmissionTime(data: FormsgPayload): string {
+  const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
+
+  // If not MRF, just return submission creation time
+  if (
+    !workflowContent?.submittedSteps ||
+    workflowContent.submittedSteps.length === 0
+  ) {
+    return convertToSGT(data.created)
+  }
+  // if MRF, return the last submitted step's submission time
+  const lastSubmittedStep =
+    workflowContent.submittedSteps[workflowContent.submittedSteps.length - 1]
+  return convertToSGT(lastSubmittedStep.submittedAt)
+}

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -1,0 +1,137 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { FormField } from '@opengovsg/formsg-sdk/dist/types'
+
+import logger from '@/helpers/logger'
+
+import type { FormSchemaField } from '../../common/types'
+import { fetchFormSchema } from '../../triggers/new-submission/fetch-form-schema'
+
+export async function processResponsesV3(
+  $: IGlobalVariable,
+  formId: string,
+  responsesV3: Record<string, any>,
+): Promise<FormField[]> {
+  const formSchemaFields: Record<string, FormSchemaField> = {}
+  try {
+    const formSchema = await fetchFormSchema($, formId)
+    if (formSchema?.form?.form_fields) {
+      for (const field of formSchema.form.form_fields) {
+        formSchemaFields[field._id] = field
+      }
+    }
+  } catch (e) {
+    logger.error('Unable to fetch form schema', {
+      event: 'formsg-unable-to-fetch-form-schema',
+      formId,
+      error: e,
+    })
+  }
+  const mappedResponses: FormField[] = []
+  let questionNumber = 0
+  for (const [key, value] of Object.entries(responsesV3)) {
+    questionNumber++
+    if (value.fieldType === 'table') {
+      let question =
+        formSchemaFields[key]?.title ?? `Question ${questionNumber}`
+      const answerArray = value.answer.map((row: Record<string, string>) => {
+        return Object.values(row)
+      })
+      // we follow the same format as the old table field title schema
+      if (formSchemaFields[key]?.columns) {
+        question += ` (${formSchemaFields[key]?.columns
+          ?.map((column) => column.title.replaceAll(',', ' '))
+          .join(', ')})`
+      }
+      // v3 return table answers in an array of objects (with key as column id )
+      // we need to map it back to a matrix
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'checkbox') {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // this is kinda weird, but it's the way formsg returns the answer for checkbox fields
+        answerArray: value.answer.value,
+      })
+      continue
+    }
+    /**
+     * Similary, formv3 responses put these fields in value.answer.value
+     */
+    if (['radiobutton', 'email', 'mobile'].includes(value.fieldType)) {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answer: value.answer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'signature') {
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // it comes in this form: { type: 'draw', value: [Array] } },
+        answerArray: value.answer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'address') {
+      //  answer: { addressSubFields: [Object] } },
+      const addressSubFields = value.answer.addressSubFields ?? {}
+      // we need to map to [block number, street name, building name, level number, unit number, postal code]
+      const answerArray = [
+        addressSubFields.blockNumber,
+        addressSubFields.streetName,
+        addressSubFields.buildingName,
+        addressSubFields.levelNumber,
+        addressSubFields.unitNumber,
+        addressSubFields.postalCode,
+      ]
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'attachment') {
+      // the answer has the shape { hasBeenScanned: boolean, answer: string, md5Hash: string }
+      // the answer is the filename
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        // we temporarily store the filename in answer, it will subsequently be replaced with the S3 ID from storeAttachmentInS3
+        answer: value.answer.answer,
+      })
+      continue
+    }
+    // catch-all
+    mappedResponses.push({
+      _id: key,
+      fieldType: value.fieldType,
+      // we fallback to Question # if the question is not found in the form schema
+      question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+      answer: value.answer,
+    })
+    continue
+  }
+  return mappedResponses
+}


### PR DESCRIPTION
## Problem
 Currently, all submission times for all subsequent MRF steps follow the first submission time.

## Solution
Use last submission time from `submittedSteps` if it exists

## other changes
- Refactor processing of mrf form fields to separate file
- Unit tests

## To test
- [ ] Create MRF form + pipe
- [ ] Submit the form at various steps, you should see the test data to show the correct submission time.