### PR TITLE
PLU-688: Add parsing of single padded dates

### DIFF
--- a/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/delay-until.test.ts
@@ -119,6 +119,60 @@ describe('Delay until action', () => {
     })
   })
 
+  describe('single-padded to double-padded formatting', () => {
+    it('converts single-padded day to double-padded in date output', async () => {
+      $.step.parameters = {
+        delayUntil: '5 Dec 2026', // single-padded day
+        delayUntilTime: VALID_TIME,
+      }
+
+      const result = await delayUntilAction.run($)
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { delayUntil: '05 Dec 2026', delayUntilTime: VALID_TIME },
+      })
+    })
+
+    it('converts single-padded hour to double-padded in time output', async () => {
+      $.step.parameters = {
+        delayUntil: VALID_DATE,
+        delayUntilTime: '9:30', // single-padded hour
+      }
+
+      const result = await delayUntilAction.run($)
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { delayUntil: VALID_DATE, delayUntilTime: '09:30' },
+      })
+    })
+
+    it('converts both single-padded date and time to double-padded', async () => {
+      $.step.parameters = {
+        delayUntil: '1 Jan 2027', // single-padded day
+        delayUntilTime: '8:05', // single-padded hour
+      }
+
+      const result = await delayUntilAction.run($)
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { delayUntil: '01 Jan 2027', delayUntilTime: '08:05' },
+      })
+    })
+
+    it('keeps double-padded date and time unchanged', async () => {
+      $.step.parameters = {
+        delayUntil: '05 Dec 2026', // already double-padded
+        delayUntilTime: '09:30', // already double-padded
+      }
+
+      const result = await delayUntilAction.run($)
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { delayUntil: '05 Dec 2026', delayUntilTime: '09:30' },
+      })
+    })
+  })
+
   it('throws step error if delay until has a past timestamp', async () => {
     $.step.parameters = {
       delayUntil: PAST_DATE,

--- a/packages/backend/src/apps/delay/__tests__/generate-timestamp.test.ts
+++ b/packages/backend/src/apps/delay/__tests__/generate-timestamp.test.ts
@@ -27,6 +27,12 @@ describe('delay until date and time handler', () => {
       expect(generateTimestamp(date, time)).toBeTruthy()
     })
 
+    it('[Valid] ISO Complete Date format (single-padded)', () => {
+      const date = '2023-9-5'
+      const time = DEFAULT_TIME
+      expect(generateTimestamp(date, time)).toBeTruthy()
+    })
+
     it('[Invalid] ISO DateTime format', () => {
       const date = '2023-09-05T12:00:00.000Z'
       const time = DEFAULT_TIME
@@ -68,6 +74,12 @@ describe('delay until date and time handler', () => {
     it('[Valid]: Short date format (with time)', () => {
       const date = '05/09/2023'
       const time = VALID_TIME
+      expect(generateTimestamp(date, time)).toBeTruthy()
+    })
+
+    it('[Valid]: Single-padded day and month', () => {
+      const date = '5/9/2023'
+      const time = DEFAULT_TIME
       expect(generateTimestamp(date, time)).toBeTruthy()
     })
 
@@ -115,10 +127,10 @@ describe('delay until date and time handler', () => {
       expect(generateTimestamp(date, time)).toBeFalsy()
     })
 
-    it('[Invalid]: Wrong day padding', () => {
+    it('[Valid]: Single-padded day format', () => {
       const date = '5 Oct 2023'
       const time = DEFAULT_TIME
-      expect(generateTimestamp(date, time)).toBeFalsy()
+      expect(generateTimestamp(date, time)).toBeTruthy()
     })
 
     it('[Invalid]: Wrong time format', () => {

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -62,23 +62,32 @@ const action: IRawAction = {
     )
 
     // check if delayUntilString is of dd MMM yyyy format, if so, force en-US to maintain consistency with FormSG
+    // Use 'd MMM yyyy' for lenient parsing (accepts both single and double-padded day)
     let delayUntilFormatted = delayUntilString
     // Try parsing with en-SG first (for "Sept"), then en-US (for "Sep"), this is for the test case to work because it is not aware of the en-US locale
-    let dateTime = DateTime.fromFormat(delayUntilString, 'dd MMM yyyy', {
+    let dateTime = DateTime.fromFormat(delayUntilString, 'd MMM yyyy', {
       locale: 'en-SG',
     })
     if (!dateTime.isValid) {
-      dateTime = DateTime.fromFormat(delayUntilString, 'dd MMM yyyy', {
+      dateTime = DateTime.fromFormat(delayUntilString, 'd MMM yyyy', {
         locale: 'en-US',
       })
     }
     if (dateTime.isValid) {
+      // Always output double-padded format
       delayUntilFormatted = dateTime.toPlumberFormat('dd MMM yyyy')
+    }
+
+    // Format time to ensure double-padded output (e.g., '9:30' -> '09:30')
+    let delayUntilTimeFormatted = delayUntilTimeString
+    const parsedTime = DateTime.fromFormat(delayUntilTimeString, 'H:mm')
+    if (parsedTime.isValid) {
+      delayUntilTimeFormatted = parsedTime.toPlumberFormat('HH:mm')
     }
 
     let dataItem = {
       delayUntil: delayUntilFormatted,
-      delayUntilTime: delayUntilTimeString,
+      delayUntilTime: delayUntilTimeFormatted,
     }
 
     if (isNaN(delayTimestamp)) {

--- a/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
+++ b/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
@@ -1,9 +1,9 @@
 import { generateTimestampFromFormats } from '@/helpers/generate-timestamp-from-formats'
 
 const VALID_DATETIME_FORMATS = [
-  'yyyy-L-d h:mm',
-  'd LLL yyyy h:mm',
-  'd/L/yyyy h:mm',
+  'yyyy-L-d H:mm',
+  'd LLL yyyy H:mm',
+  'd/L/yyyy H:mm',
 ]
 
 export default function generateTimestamp(date: string, time: string): number {

--- a/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
+++ b/packages/backend/src/apps/delay/helpers/generate-timestamp.ts
@@ -1,9 +1,9 @@
 import { generateTimestampFromFormats } from '@/helpers/generate-timestamp-from-formats'
 
 const VALID_DATETIME_FORMATS = [
-  'yyyy-MM-dd HH:mm',
-  'dd MMM yyyy HH:mm',
-  'dd/MM/yyyy HH:mm',
+  'yyyy-L-d h:mm',
+  'd LLL yyyy h:mm',
+  'd/L/yyyy h:mm',
 ]
 
 export default function generateTimestamp(date: string, time: string): number {

--- a/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
@@ -52,6 +52,11 @@ describe('common date-time formatter functions', () => {
       expect(dateTime.toUnixInteger()).toEqual(1711555200)
     })
 
+    it('supports parsing single-padded day input', () => {
+      const dateTime = parseDateTime('formsgDateField', '5 Apr 2024')
+      expect(dateTime.toUnixInteger()).toEqual(1712246400)
+    })
+
     it('supports converting to FormSG date field, with time omitted', () => {
       const dateTime = DateTime.fromSeconds(1711986308)
       expect(dateTimeToString('formsgDateField', dateTime)).toEqual(

--- a/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.format.test.ts
@@ -141,6 +141,86 @@ describe('convert date time', () => {
     })
   })
 
+  // Test that formats accept both single-padded and double-padded input
+  it.each([
+    // dd/LL/yy accepts both padded and non-padded
+    {
+      inputFormat: 'dd/LL/yy',
+      inputValue: '01/04/24',
+      toFormat: 'dd/LL/yyyy',
+      expectedResult: '01/04/2024',
+    },
+    {
+      inputFormat: 'dd/LL/yy',
+      inputValue: '1/4/24',
+      toFormat: 'dd/LL/yyyy',
+      expectedResult: '01/04/2024',
+    },
+    // dd/LL/yyyy accepts both padded and non-padded
+    {
+      inputFormat: 'dd/LL/yyyy',
+      inputValue: '05/12/2025',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '05 Dec 2025',
+    },
+    {
+      inputFormat: 'dd/LL/yyyy',
+      inputValue: '5/12/2025',
+      toFormat: 'dd LLL yyyy',
+      expectedResult: '05 Dec 2025',
+    },
+    // yyyy/LL/dd accepts both padded and non-padded
+    {
+      inputFormat: 'yyyy/LL/dd',
+      inputValue: '2024/04/01',
+      toFormat: 'dd/LL/yy',
+      expectedResult: '01/04/24',
+    },
+    {
+      inputFormat: 'yyyy/LL/dd',
+      inputValue: '2024/4/1',
+      toFormat: 'dd/LL/yy',
+      expectedResult: '01/04/24',
+    },
+    // hh:mm a accepts both padded and non-padded hour
+    {
+      inputFormat: 'hh:mm a',
+      inputValue: '09:30 am',
+      toFormat: 'hh:mm:ss a',
+      expectedResult: '09:30:00 am',
+    },
+    {
+      inputFormat: 'hh:mm a',
+      inputValue: '9:30 am',
+      toFormat: 'hh:mm:ss a',
+      expectedResult: '09:30:00 am',
+    },
+    // dd LLL yyyy hh:mm a accepts both padded and non-padded
+    {
+      inputFormat: 'dd LLL yyyy hh:mm a',
+      inputValue: '05 Apr 2024 09:30 am',
+      toFormat: 'dd/LL/yyyy',
+      expectedResult: '05/04/2024',
+    },
+    {
+      inputFormat: 'dd LLL yyyy hh:mm a',
+      inputValue: '5 Apr 2024 9:30 am',
+      toFormat: 'dd/LL/yyyy',
+      expectedResult: '05/04/2024',
+    },
+  ])('accepts both single-padded and double-padded input', (testParams) => {
+    const { inputFormat, inputValue, toFormat, expectedResult } = testParams
+    $.step.parameters = {
+      dateTimeFormat: inputFormat,
+      formatDateTimeToFormat: toFormat,
+    }
+    spec.transformData($, inputValue)
+
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: expectedResult },
+    })
+  })
+
   it.each([
     {
       inputFormat: 'formsgDateField',

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -28,6 +28,21 @@ const supportedFormats = z.enum([
   ...commonDateFormats,
 ])
 
+// Map strict formats to lenient equivalents for parsing
+// Single-letter tokens (d, L, h) accept both padded and non-padded input
+const toLenientFormatMap: Record<string, string> = {
+  'dd/LL/yy': 'd/L/yy',
+  'dd/LL/yyyy': 'd/L/yyyy',
+  'dd LLL yyyy': 'd LLL yyyy',
+  'dd LLLL yyyy': 'd LLLL yyyy',
+  'yyyy/LL/dd': 'yyyy/L/d',
+  'yyyy-LL-dd': 'yyyy-L-d',
+  'hh:mm a': 'h:mm a',
+  'hh:mm:ss a': 'h:mm:ss a',
+  'dd LLL yyyy hh:mm a': 'd LLL yyyy h:mm a',
+  'dd LLL yyyy hh:mm:ss a': 'd LLL yyyy h:mm:ss a',
+}
+
 const formatConverters = Object.assign({
   formsgSubmissionTime: {
     description: 'FormSG submission time',
@@ -46,8 +61,11 @@ const formatConverters = Object.assign({
       // At time of this comment, the only effective difference between en-US
       // and en-SG is September - the former only accepts "Sep", and the latter
       // only accepts "Sept"
+      //
+      // We use 'd MMM yyyy' (single-letter d) for lenient parsing to accept
+      // both single and double-padded day input (e.g., '5 Apr 2024' or '05 Apr 2024')
 
-      const dateTime = DateTime.fromFormat(input, 'dd MMM yyyy', {
+      const dateTime = DateTime.fromFormat(input, 'd MMM yyyy', {
         locale: 'en-US',
       })
 
@@ -56,7 +74,7 @@ const formatConverters = Object.assign({
       }
 
       // en-US parsing failed, fall back to en-SG.
-      return DateTime.fromFormat(input, 'dd MMM yyyy')
+      return DateTime.fromFormat(input, 'd MMM yyyy')
     },
     stringify: (dateTime: DateTime): string =>
       dateTime.toPlumberFormat('dd MMM yyyy'),
@@ -64,25 +82,29 @@ const formatConverters = Object.assign({
   ...Object.fromEntries(
     commonDateFormats
       .filter((format) => format !== 'dd LLL yyyy') // Exclude repeated option due to formsgDateField
-      .map((format) => [
-        format,
-        {
-          description: format,
-          parse: (input: string): DateTime => {
-            const result = DateTime.fromFormat(input, format, {
-              locale: 'en-US',
-            })
-            if (result.isValid) {
-              return result
-            }
-            return DateTime.fromFormat(input, format, {
-              locale: 'en-SG',
-            })
+      .map((format) => {
+        // Use lenient format for parsing (accepts both padded and non-padded)
+        const parseFormat = toLenientFormatMap[format] ?? format
+        return [
+          format,
+          {
+            description: format,
+            parse: (input: string): DateTime => {
+              const result = DateTime.fromFormat(input, parseFormat, {
+                locale: 'en-US',
+              })
+              if (result.isValid) {
+                return result
+              }
+              return DateTime.fromFormat(input, parseFormat, {
+                locale: 'en-SG',
+              })
+            },
+            stringify: (dateTime: DateTime): string =>
+              dateTime.toPlumberFormat(format),
           },
-          stringify: (dateTime: DateTime): string =>
-            dateTime.toPlumberFormat(format),
-        },
-      ]),
+        ]
+      }),
   ),
 }) satisfies Record<z.infer<typeof supportedFormats>, DateFormatConverter>
 

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -164,6 +164,9 @@ describe('Condition is true', () => {
     // yyyy/L/d accepts both padded and non-padded
     { field: '2024/11/04', text: '2024/11/05', expectedResult: true },
     { field: '2024/11/4', text: '2024/11/5', expectedResult: true },
+    // yyyy-L-d accepts both padded and non-padded
+    { field: '2024-11-04', text: '2024-11-05', expectedResult: true },
+    { field: '2024-11-4', text: '2024-11-5', expectedResult: true },
     // d LLL yyyy h:mm a accepts both padded and non-padded
     {
       field: '04 Nov 2024 09:30 AM',

--- a/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/condition-is-true.test.ts
@@ -94,6 +94,23 @@ describe('Condition is true', () => {
     expect(result).toEqual(expectedResult)
   })
 
+  it.each([
+    { field: 'hello', text: 'hello', expectedResult: true },
+    { field: 'hello', text: 'he', expectedResult: true },
+    { field: 'hello', text: 'llo', expectedResult: false },
+    { field: '9.9', text: 9, expectedResult: true },
+    { field: '9.9', text: 1, expectedResult: false },
+  ])('supports begins', ({ field, text, expectedResult }) => {
+    const result = conditionIsTrue({
+      field,
+      is: 'is',
+      condition: 'begins',
+      text,
+    })
+
+    expect(result).toEqual(expectedResult)
+  })
+
   // check all date formats
   it.each([
     { text: '05/11/24', expectedResult: true }, // 'dd/LL/yy'
@@ -125,6 +142,63 @@ describe('Condition is true', () => {
 
     expect(result).toEqual(expectedResult)
   })
+
+  // Test that date formats accept both single-padded and double-padded input
+  it.each([
+    // d/L/yy accepts both padded and non-padded
+    { field: '04/11/24', text: '05/11/24', expectedResult: true },
+    { field: '4/11/24', text: '5/11/24', expectedResult: true },
+    // d/L/yyyy accepts both padded and non-padded
+    { field: '04/11/2024', text: '05/11/2024', expectedResult: true },
+    { field: '4/11/2024', text: '5/11/2024', expectedResult: true },
+    // d LLL yyyy accepts both padded and non-padded
+    { field: '04 Nov 2024', text: '05 Nov 2024', expectedResult: true },
+    { field: '4 Nov 2024', text: '5 Nov 2024', expectedResult: true },
+    // d LLLL yyyy accepts both padded and non-padded
+    {
+      field: '04 November 2024',
+      text: '05 November 2024',
+      expectedResult: true,
+    },
+    { field: '4 November 2024', text: '5 November 2024', expectedResult: true },
+    // yyyy/L/d accepts both padded and non-padded
+    { field: '2024/11/04', text: '2024/11/05', expectedResult: true },
+    { field: '2024/11/4', text: '2024/11/5', expectedResult: true },
+    // d LLL yyyy h:mm a accepts both padded and non-padded
+    {
+      field: '04 Nov 2024 09:30 AM',
+      text: '04 Nov 2024 10:30 AM',
+      expectedResult: true,
+    },
+    {
+      field: '4 Nov 2024 9:30 AM',
+      text: '4 Nov 2024 10:30 AM',
+      expectedResult: true,
+    },
+    // d LLL yyyy h:mm:ss a accepts both padded and non-padded
+    {
+      field: '04 Nov 2024 09:30:00 AM',
+      text: '04 Nov 2024 10:30:00 AM',
+      expectedResult: true,
+    },
+    {
+      field: '4 Nov 2024 9:30:00 AM',
+      text: '4 Nov 2024 10:30:00 AM',
+      expectedResult: true,
+    },
+  ])(
+    'accepts both single-padded and double-padded date input',
+    ({ field, text, expectedResult }) => {
+      const result = conditionIsTrue({
+        field,
+        is: 'is',
+        condition: 'before',
+        text,
+      })
+
+      expect(result).toEqual(expectedResult)
+    },
+  )
 
   it.each([
     { field: 'hello', text: 9.9, condition: 'equals', expectedResult: true },

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -35,6 +35,7 @@ const VALID_DATETIME_FORMATS = [
   'd LLL yyyy',
   'd LLLL yyyy',
   'yyyy/L/d',
+  'yyyy-L-d',
   'd LLL yyyy h:mm a',
   'd LLL yyyy h:mm:ss a',
 ]

--- a/packages/backend/src/apps/toolbox/common/condition-is-true.ts
+++ b/packages/backend/src/apps/toolbox/common/condition-is-true.ts
@@ -28,15 +28,15 @@ function compareNumbers(
   }
 }
 
-// support only formatter date formats
+// support only formatter date formats (single-letter tokens are more lenient)
 const VALID_DATETIME_FORMATS = [
-  'dd/LL/yy',
-  'dd/LL/yyyy',
-  'dd LLL yyyy',
-  'dd LLLL yyyy',
-  'yyyy/LL/dd',
-  'dd LLL yyyy hh:mm a',
-  'dd LLL yyyy hh:mm:ss a',
+  'd/L/yy',
+  'd/L/yyyy',
+  'd LLL yyyy',
+  'd LLLL yyyy',
+  'yyyy/L/d',
+  'd LLL yyyy h:mm a',
+  'd LLL yyyy h:mm:ss a',
 ]
 
 function compareDates(


### PR DESCRIPTION
## Problem

Right now, we always reject single padded dates but we can actually accommodate for both single padded and double padded dates

## Solution

Luxon allows for lenient date/time parsing to accept both single-padded (e.g., 5/4/24, 9:30 am) and double-padded (e.g., 05/04/24, 09:30 am) input. This improves user experience by not requiring strict zero-padding in date fields.    

## Changes
 1. Formatter date-time parsing (date-time-format.ts)                                                                                                                                                   
  - Added toLenientFormatMap to map strict formats to lenient equivalents for parsing                                                                                                                    
  - Updated formsgDateField to use d MMM yyyy (single-letter d) for lenient parsing                                                                                                                      
  - Output remains double-padded for consistency                                                                                                                                                         
                                                                                                                                                                                                         
  2. Toolbox condition comparison (condition-is-true.ts)                                                                                                                                                 
  - Updated VALID_DATETIME_FORMATS to use single-letter tokens (d, L, h) for lenient date comparison in before/after conditions                                                                          
                                                                                                                                                                                                         
  3. Delay timestamp generation (generate-timestamp.ts)                                                                                                                                                  
  - Updated VALID_DATETIME_FORMATS to use single-letter tokens for lenient parsing
 
## Tests
- [ ] Single and double-padded days, months and times work for formatter, formsg date field also should allow for both
- [ ] Output of date formatter should still be double-padded
- [ ] If-then branch comparison using before/after condition should work for both single and double-padded dates and times
- [ ] Only continue if comparison should work for both single and double-padded dates and times
- [ ] Delay until timestamp should allow for both single and double-padded dates and times