### PR TITLE
chore: remove isNew from for each action

### DIFF
--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -25,7 +25,6 @@ const action: IRawAction = {
   key: 'forEach',
   description: 'Repeat actions for each item',
   groupsLaterSteps: true,
-  isNew: true,
   linkToGuide:
     'https://guide.plumber.gov.sg/user-guides/actions/for-each-item-coming-soon',
   arguments: [


### PR DESCRIPTION
Removes the 'New' badge from the for-each action.