### PR TITLE
PLU-622: handle failed to fetch dynamically imported module error

### DIFF
--- a/packages/frontend/src/components/ErrorPage/index.tsx
+++ b/packages/frontend/src/components/ErrorPage/index.tsx
@@ -1,0 +1,29 @@
+import { Box, Flex, Heading, Icon, Text } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+
+import { BrokenPipeIcon } from '@/components/Icons'
+
+export default function ErrorPage({ is404 }: { is404?: boolean }): JSX.Element {
+  return (
+    <Flex minH="100vh" align="center" justify="center" bg="primary.50" px={4}>
+      <Box textAlign="center" maxW="md">
+        <Icon as={BrokenPipeIcon} boxSize="120px" color="primary.200" />
+        <Text
+          fontSize="8xl"
+          fontWeight="bold"
+          color="primary.200"
+          lineHeight="1"
+          mt={4}
+        >
+          {is404 ? '404' : 'Oops'}
+        </Text>
+        <Heading as="h1" size="lg" color="base.content.strong" mt={4}>
+          {is404 ? 'This pipe leads nowhere' : 'Something went wrong'}
+        </Heading>
+        <Button mt={8} as="a" href="/">
+          Back to home
+        </Button>
+      </Box>
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/Icons/BrokenPipeIcon.tsx
+++ b/packages/frontend/src/components/Icons/BrokenPipeIcon.tsx
@@ -1,0 +1,39 @@
+import { createIcon } from '@chakra-ui/react'
+
+export const BrokenPipeIcon = createIcon({
+  displayName: 'BrokenPipeIcon',
+  viewBox: '0 0 64 64',
+  defaultProps: {
+    fill: 'none',
+    stroke: 'currentColor',
+    strokeWidth: '2.5',
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  },
+  path: (
+    <>
+      {/* Left coupling */}
+      <rect x="4" y="18" width="8" height="24" rx="2" />
+      {/* Left pipe body - top and bottom lines only, broken at crack */}
+      <line x1="12" y1="22" x2="27" y2="22" />
+      <line x1="12" y1="38" x2="27" y2="38" />
+
+      {/* Right coupling */}
+      <rect x="52" y="18" width="8" height="24" rx="2" />
+      {/* Right pipe body - top and bottom lines */}
+      <line x1="37" y1="22" x2="52" y2="22" />
+      <line x1="35" y1="38" x2="52" y2="38" />
+
+      {/* Crack - jagged line from top of pipe downward through bottom */}
+      <path d="M27,22 L30,27 L26,30 L31,34 L28,38" />
+      <path d="M37,22 L34,27 L38,30 L33,34 L35,38" />
+
+      {/* Water droplet - rounded bottom, pointed top */}
+      <path
+        d="M32,43 C32,43 28,50 28,53 A4,4 0 0,0 36,53 C36,50 32,43 32,43 Z"
+        fill="currentColor"
+        stroke="currentColor"
+      />
+    </>
+  ),
+})

--- a/packages/frontend/src/components/Icons/index.ts
+++ b/packages/frontend/src/components/Icons/index.ts
@@ -1,1 +1,2 @@
+export * from './BrokenPipeIcon'
 export * from './PipeIcon'

--- a/packages/frontend/src/components/ThemeProvider/index.tsx
+++ b/packages/frontend/src/components/ThemeProvider/index.tsx
@@ -3,6 +3,7 @@ import { Box } from '@chakra-ui/react'
 import { ThemeProvider as ChakraThemeProvider } from '@opengovsg/design-system-react'
 
 import { useDefaultZoom } from '@/hooks/useGovtBrowser'
+import { useHandleDynamicLoadError } from '@/hooks/useHandleDynamicLoadError'
 
 import { theme as chakraTheme } from '../../theme'
 
@@ -16,6 +17,7 @@ const ThemeProvider = ({
   // This is a workaround to fix the issue of toasts appearing behind modal overlays
   const ref = useRef<HTMLDivElement>(null)
   useDefaultZoom()
+  useHandleDynamicLoadError()
   return (
     <ChakraThemeProvider
       theme={chakraTheme}

--- a/packages/frontend/src/hooks/useHandleDynamicLoadError.ts
+++ b/packages/frontend/src/hooks/useHandleDynamicLoadError.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+
+const CHUNK_RELOAD_KEY = 'chunk-reload'
+
+export function useHandleDynamicLoadError() {
+  useEffect(() => {
+    const handler = (event: Event) => {
+      event.preventDefault()
+      // Use sessionStorage to track whether we've already attempted a reload.
+      // Without this guard, a persistent chunk error would cause an infinite
+      // reload loop. On the first error we reload to fetch fresh assets; if
+      // the error still occurs after the reload, we clear the flag and bail
+      // so the user isn't stuck in a loop.
+      if (!sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1')
+        window.location.reload()
+      } else {
+        sessionStorage.removeItem(CHUNK_RELOAD_KEY)
+      }
+    }
+
+    window.addEventListener('vite:preloadError', handler)
+    return () => window.removeEventListener('vite:preloadError', handler)
+  }, [])
+}

--- a/packages/frontend/src/routes.tsx
+++ b/packages/frontend/src/routes.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { createRoutesFromElements, Route } from 'react-router-dom'
 
+import ErrorPage from '@/components/ErrorPage'
 import Layout from '@/components/Layout'
 import PublicLayout from '@/components/PublicLayout'
 import * as URLS from '@/config/urls'
@@ -27,7 +28,7 @@ const Landing = lazy(() => import('@/pages/Landing'))
 const Tile = lazy(() => import('@/pages/Tile'))
 
 export default createRoutesFromElements(
-  <Route path="/">
+  <Route path="/" errorElement={<ErrorPage />}>
     <Route
       path={URLS.LOGIN_SGID_REDIRECT}
       element={
@@ -177,13 +178,7 @@ export default createRoutesFromElements(
       }
     />
 
-    <Route
-      element={
-        <Layout>
-          <div>404</div>
-        </Layout>
-      }
-    />
+    <Route path="*" element={<ErrorPage is404 />} />
 
     <Route path={`${URLS.USE_CASES}/*`} element={<UseCasesRoutes />} />
   </Route>,


### PR DESCRIPTION
## Problem

Currently, when user has an active session during deployment and it tries to load a dynamically imported module like Tiles. It will show the unstyled react router default error screen.

<img width="2470" height="194" alt="image" src="https://github.com/user-attachments/assets/99b72292-b411-4995-aacb-38c176e6a553" />

## Solution

1. When this happens vite emits an error vite:preloadError,
- catch this and refresh
- make sure it refreshes only once (by storing in sessionStorage) to prevent infinite refresh

2. Show better error page.
<img width="1752" height="1236" alt="image" src="https://github.com/user-attachments/assets/84f663b7-2994-4abc-9066-a127335d4b56" />

## To test
- lazy type will show