### PR TITLE
fix: email reply to validation

### DIFF
--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -116,12 +116,20 @@ export const transactionalEmailSchema = z.object({
       message: 'The total number of CC recipient emails must not exceed 49',
     })
     .optional(),
-  replyTo: z.preprocess((value) => {
-    if (typeof value !== 'string') {
-      return value
-    }
-    return value.trim() === '' ? undefined : value.trim()
-  }, z.string().email({ message: 'Invalid reply to email' }).optional()),
+  replyTo: z.preprocess(
+    (value) => {
+      if (typeof value !== 'string') {
+        return value
+      }
+      return value.trim() === '' ? undefined : value.trim()
+    },
+    z
+      .string()
+      .refine((value) => validator.validate(value), {
+        message: 'Invalid reply to email',
+      })
+      .optional(),
+  ),
   senderName: z
     .string()
     .min(1, { message: 'Empty sender name' })


### PR DESCRIPTION
### TL;DR
Updates the validation logic for the `replyTo` field in the `transactionalEmailSchema` to use the same `validator.validate` as 'To' and 'CC' instead of `zod.email()`

* Previously blocks `/` in valid emails