### PR TITLE
hotfix: handle invalid secret key for mrf forms gracefully

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -212,6 +212,15 @@ describe('decrypt form response - MRF specific', () => {
       )
     })
 
+    it('should return verified: false when decryption fails', async () => {
+      mocks.cryptoV3Decrypt.mockReturnValueOnce(null)
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({ verified: false, internalId: null })
+      expect(mocks.consoleWarn).toHaveBeenCalled()
+    })
+
     it('should not call v3 attachment decryption when no attachmentDownloadUrls', async () => {
       $.flow.hasFileProcessingActions = true
 

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -183,7 +183,7 @@ describe('decrypt form response', () => {
         FAILED_DECRYPT_RESPONSE,
       )
       expect(decryptMock).toHaveBeenCalledTimes(1)
-      expect(mocks.consoleError).toHaveBeenCalledWith(
+      expect(mocks.consoleWarn).toHaveBeenCalledWith(
         'Unable to decrypt formsg response',
       )
     })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -107,6 +107,13 @@ export async function decryptFormResponse(
 
   if (version >= 3) {
     const decryptedSubmission = formSgSdk.cryptoV3.decrypt(formSecretKey, data)
+
+    // If decryption fails (aka invalid form secret key), return false
+    if (decryptedSubmission == null) {
+      logger.warn('Unable to decrypt MRF formsg response')
+      return { verified: false, internalId: null }
+    }
+
     const responsesV3 = decryptedSubmission?.responses
     const mappedResponses = await processResponsesV3(
       $,
@@ -295,7 +302,7 @@ export async function decryptFormResponse(
     }
   } else {
     // Could not decrypt the submission
-    logger.error('Unable to decrypt formsg response')
+    logger.warn('Unable to decrypt formsg response')
     return { verified: false, internalId: null }
   }
 }


### PR DESCRIPTION
## Changes
Added null check for FormSG v3 decryption failures

### What changed?

- Added validation to check if `decryptedSubmission` is null after calling `formSgSdk.cryptoV3.decrypt()`
- When decryption fails, the function now returns `{ verified: false, internalId: null }` with a warning log
- Added corresponding test case to verify the new null check behavior
- Changed console level for decryption failure from `error` to `warn`

### How to test?

- Connect an MRF form
- Then connect another MRF form
- Submit the old form. It should handle it properly