### PR TITLE
[AI-BUG-BASH-2] bug bash fixes

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -2,7 +2,11 @@
  * Feature flags
  */
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
-export const EXCEL_FEATURE_FLAG = 'app_m365-excel'
+
+/**
+ * App flags regex
+ */
+export const APP_FLAG_REGEX = /^app_.*$/
 
 /**
  * Feature flag fallbacks

--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -2,6 +2,7 @@
  * Feature flags
  */
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
+export const EXCEL_FEATURE_FLAG = 'app_m365-excel'
 
 /**
  * Feature flag fallbacks

--- a/packages/backend/src/helpers/build-system-prompt.test.ts
+++ b/packages/backend/src/helpers/build-system-prompt.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSystemPrompt } from './build-system-prompt'
+
+describe('buildSystemPrompt - Robustness Tests', () => {
+  it('should handle tables with varied spacing around app keys', () => {
+    const prompt = `## Available Actions
+
+| App | Display Name | Events |
+|---|---|---|
+|\`m365-excel\`|M365 Excel|\`createTableRow\`|
+| \`calculator\` | Calculator | \`add\` |
+|  \`tiles\`  |  Tiles  |  \`create\`  |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    // Should remove the table row for m365-excel
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+
+    // Should keep other apps
+    expect(result).toContain('`calculator`')
+    expect(result).toContain('`tiles`')
+
+    // Should have the safety note
+    expect(result).toContain(
+      'Note: this user does not have access to the following apps: m365-excel',
+    )
+  })
+
+  it('should handle tables with no spaces around pipes', () => {
+    const prompt = `|App|Display Name|Events|
+|---|---|---|
+|\`m365-excel\`|M365 Excel|\`createTableRow\`|
+|\`calculator\`|Calculator|\`add\`|`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should handle tables with extra whitespace', () => {
+    const prompt = `|  App  |  Display Name  |  Events  |
+|---|---|---|
+|  \`m365-excel\`  |  M365 Excel  |  \`createTableRow\`  |
+|  \`calculator\`  |  Calculator  |  \`add\`  |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should handle alias tables with different column counts', () => {
+    const prompt = `| User says | Maps to app | If restricted | Priority |
+|---|---|---|---|
+| "excel" | M365 Excel | Tiles | High |
+| "calc" | Calculator | N/A | Low |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    // Should remove the alias row for excel
+    expect(result).not.toContain('"excel"')
+    expect(result).not.toContain('M365 Excel')
+
+    // Should keep calculator alias
+    expect(result).toContain('"calc"')
+  })
+
+  it('should handle alias tables with fewer columns', () => {
+    const prompt = `| User says | Maps to app |
+|---|---|
+| "excel" | M365 Excel |
+| "calc" | Calculator |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('"excel"')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('"calc"')
+  })
+
+  it('should handle logic rules with varied indentation', () => {
+    const prompt = `## Logic Rules
+
+- M365 Excel: Use updateTableRow
+  - Tiles: Use updateRecord for storage
+    - Calculator: Use for math`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel', 'tiles'])
+
+    expect(result).not.toContain('M365 Excel: Use updateTableRow')
+    expect(result).not.toContain('Tiles: Use updateRecord')
+    expect(result).toContain('Calculator: Use for math')
+  })
+
+  it('should handle logic rules with bullet points (*)', () => {
+    const prompt = `## Logic Rules
+
+* M365 Excel: Use updateTableRow
+* Tiles: Use updateRecord
+* Calculator: Use for math`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('M365 Excel: Use updateTableRow')
+    expect(result).toContain('Tiles: Use updateRecord')
+  })
+
+  it('should handle case-insensitive app name matching in tables', () => {
+    const prompt = `| User says | Maps to app |
+|---|---|
+| "excel" | m365 excel |
+| "calc" | calculator |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    // Should remove the excel alias row (case-insensitive match)
+    expect(result).not.toContain('"excel"')
+    expect(result).not.toContain('m365 excel')
+
+    expect(result).toContain('"calc"')
+  })
+
+  it('should handle modified table headers without breaking', () => {
+    // Changed header from "App | Display Name" to "Application | Name"
+    const prompt = `| Application | Name | Events |
+|---|---|---|
+| \`m365-excel\` | M365 Excel | \`createTableRow\` |
+| \`calculator\` | Calculator | \`add\` |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should handle apps with special regex characters in names', () => {
+    // Test that regex escaping works for app keys with special chars
+    const prompt = `| App | Display Name |
+|---|---|
+| \`custom-api\` | Custom API |
+| \`postman-sms\` | SMS by Postman |`
+
+    const result = buildSystemPrompt(prompt, ['custom-api'])
+
+    expect(result).not.toContain('`custom-api`')
+    expect(result).not.toContain('Custom API')
+    expect(result).toContain('`postman-sms`')
+  })
+
+  it('should handle empty lines and extra newlines gracefully', () => {
+    const prompt = `## Available Actions
+
+
+| App | Display Name |
+
+|---|---|
+
+| \`m365-excel\` | M365 Excel |
+
+| \`calculator\` | Calculator |
+
+`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should still append safety note when no apps found in prompt', () => {
+    const prompt = `# Simple Prompt
+
+No tables here.`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel', 'unknown-app'])
+
+    // Should append the safety note even if no tables were found
+    expect(result).toContain(
+      'Note: this user does not have access to the following apps: m365-excel, unknown-app',
+    )
+  })
+
+  it('should handle app key appearing in non-table context without removing', () => {
+    const prompt = `# System Prompt
+
+When using m365-excel, always validate first.
+
+| App | Display Name |
+|---|---|
+| \`m365-excel\` | M365 Excel |
+| \`calculator\` | Calculator |`
+
+    const result = buildSystemPrompt(prompt, ['m365-excel'])
+
+    // Should remove the table row but keep the mention in prose
+    expect(result).toContain('When using m365-excel, always validate first')
+    expect(result).not.toContain('`m365-excel`')
+    expect(result).not.toContain('M365 Excel')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should handle display name with special characters', () => {
+    const prompt = `| App | Display Name |
+|---|---|
+| \`postman-sms\` | SMS by Postman |
+| \`calculator\` | Calculator |`
+
+    const result = buildSystemPrompt(prompt, ['postman-sms'])
+
+    expect(result).not.toContain('`postman-sms`')
+    expect(result).not.toContain('SMS by Postman')
+    expect(result).toContain('`calculator`')
+  })
+
+  it('should return unchanged prompt when restrictedApps is empty', () => {
+    const prompt = `## Available Actions
+
+| App | Display Name |
+|---|---|
+| \`m365-excel\` | M365 Excel |
+| \`calculator\` | Calculator |`
+
+    const result = buildSystemPrompt(prompt, [])
+
+    // Should return the exact same prompt (no safety note, no stripping)
+    expect(result).toBe(prompt)
+  })
+})

--- a/packages/backend/src/helpers/build-system-prompt.ts
+++ b/packages/backend/src/helpers/build-system-prompt.ts
@@ -1,0 +1,130 @@
+/**
+ * Builds a system prompt with restricted apps removed
+ *
+ * Strips restricted apps from:
+ * 1. Table rows (Available Actions, Available Triggers, User Context aliases)
+ * 2. Logic rule bullets (e.g., "- M365 Excel: Use updateTableRow")
+ *
+ * This implementation:
+ * - Uses regex for flexible whitespace matching
+ * - Tolerates extra/missing spaces in tables
+ * - Works with varied indentation
+ * - Pre-compiles patterns for efficiency
+ *
+ * Also appends a safety net note listing the restricted apps.
+ */
+
+const APP_DISPLAY_NAMES: Record<string, string> = {
+  formsg: 'FormSG',
+  webhook: 'Webhook',
+  scheduler: 'Scheduler',
+  gathersg: 'GatherSG',
+  calculator: 'Calculator',
+  'custom-api': 'Custom API',
+  delay: 'Delay',
+  formatter: 'Formatter',
+  lettersg: 'LetterSG',
+  'm365-excel': 'M365 Excel',
+  paysg: 'PaySG',
+  postman: 'Email by Postman',
+  'postman-sms': 'SMS by Postman',
+  slack: 'Slack',
+  'telegram-bot': 'Telegram',
+  tiles: 'Tiles',
+  toolbox: 'Toolbox',
+}
+
+/**
+ * Escapes special regex characters in a string
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Builds a system prompt with restricted apps removed
+ *
+ * @param basePrompt - The original system prompt (markdown)
+ * @param restrictedApps - Array of app keys that the user does not have access to
+ * @returns The modified prompt with restricted apps stripped and a safety net note appended
+ */
+export function buildSystemPrompt(
+  basePrompt: string,
+  restrictedApps: string[],
+): string {
+  if (restrictedApps.length === 0) {
+    return basePrompt
+  }
+
+  // Pre-compile regex patterns once (efficiency)
+  const patterns = restrictedApps.map((appKey) => {
+    const displayName = APP_DISPLAY_NAMES[appKey] || appKey
+    return {
+      appKey,
+      displayName,
+      // Match app key in backticks: `m365-excel`
+      backticks: new RegExp(`\\\`${escapeRegex(appKey)}\\\``),
+      // Match display name in table cell: | M365 Excel | (flexible spacing)
+      tableCell: new RegExp(`\\|[^|]*${escapeRegex(displayName)}[^|]*\\|`, 'i'),
+      // Match logic rule bullet: - M365 Excel: or * M365 Excel:
+      logicRule: new RegExp(
+        `^\\s*[-*]\\s*${escapeRegex(displayName)}\\s*:`,
+        'i',
+      ),
+    }
+  })
+
+  const lines = basePrompt.split('\n')
+  const filteredLines: string[] = []
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+
+    // Skip separator rows (always keep)
+    if (trimmed.includes('---')) {
+      filteredLines.push(line)
+      continue
+    }
+
+    // Check if this is a table row
+    const isTableRow = /^\|.*\|$/.test(trimmed)
+
+    // Check if line should be removed
+    let shouldRemove = false
+
+    for (const p of patterns) {
+      if (isTableRow) {
+        // For table rows: check for app key in backticks OR display name
+        if (p.backticks.test(line) || p.tableCell.test(line)) {
+          // Don't remove if it's a header row
+          const hasHeaderKeywords =
+            line.includes('App') ||
+            line.includes('Display Name') ||
+            line.includes('User says') ||
+            line.includes('Maps to')
+
+          if (!hasHeaderKeywords) {
+            shouldRemove = true
+            break
+          }
+        }
+      } else {
+        // For non-table lines: check for logic rule bullets
+        if (p.logicRule.test(line)) {
+          shouldRemove = true
+          break
+        }
+      }
+    }
+
+    if (!shouldRemove) {
+      filteredLines.push(line)
+    }
+  }
+
+  // Append safety note
+  const safetyNote = `\n\nNote: this user does not have access to the following apps: ${restrictedApps.join(
+    ', ',
+  )}.`
+  return filteredLines.join('\n') + safetyNote
+}

--- a/packages/backend/src/helpers/build-system-prompt.ts
+++ b/packages/backend/src/helpers/build-system-prompt.ts
@@ -14,25 +14,11 @@
  * Also appends a safety net note listing the restricted apps.
  */
 
-const APP_DISPLAY_NAMES: Record<string, string> = {
-  formsg: 'FormSG',
-  webhook: 'Webhook',
-  scheduler: 'Scheduler',
-  gathersg: 'GatherSG',
-  calculator: 'Calculator',
-  'custom-api': 'Custom API',
-  delay: 'Delay',
-  formatter: 'Formatter',
-  lettersg: 'LetterSG',
-  'm365-excel': 'M365 Excel',
-  paysg: 'PaySG',
-  postman: 'Email by Postman',
-  'postman-sms': 'SMS by Postman',
-  slack: 'Slack',
-  'telegram-bot': 'Telegram',
-  tiles: 'Tiles',
-  toolbox: 'Toolbox',
-}
+import apps from '@/apps'
+
+const APP_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
+  Object.values(apps).map((app) => [app.key, app.name]),
+)
 
 /**
  * Escapes special regex characters in a string

--- a/packages/backend/src/helpers/launch-darkly.ts
+++ b/packages/backend/src/helpers/launch-darkly.ts
@@ -33,3 +33,16 @@ export async function getLdFlagValue<T extends IJSONValue>(
     fallbackValue,
   )) as T
 }
+
+export async function getAllLdFlags(
+  userEmail: string | null,
+): Promise<Record<string, any>> {
+  const client = await getClient()
+
+  const allFlags = await client.allFlagsState({
+    kind: 'user',
+    key: userEmail ?? 'anonymous',
+  })
+
+  return allFlags.allValues()
+}

--- a/packages/backend/src/routes/api/__tests__/chat.itest.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.itest.ts
@@ -64,12 +64,6 @@ vi.mock('@/helpers/pair', () => ({
   },
 }))
 
-vi.mock('@/config/app', () => ({
-  default: {
-    appEnv: 'test',
-  },
-}))
-
 // Helper function to get and execute the POST handler from the chat router
 async function executeChatPostHandler(
   req: Partial<Request>,

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -177,14 +177,16 @@ describe('Chat Route Handler', () => {
   describe('Handler Behavior', () => {
     it('should process authenticated requests', async () => {
       // Context is set by middleware before reaching handler
-      mocks.getLdFlagValue.mockResolvedValueOnce({
-        enabled: true,
-        config: {
-          chatPromptName: 'aids-chat-v0',
-          chatReadinessPromptName: 'chat-readiness-v0',
-          version: 'production',
-        },
-      })
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'aids-chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -201,6 +203,11 @@ describe('Chat Route Handler', () => {
         'ai-builder',
         'test@plumber.gov.sg',
         expect.any(Object),
+      )
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'app_m365-excel',
+        'test@plumber.gov.sg',
+        false,
       )
     })
 
@@ -226,14 +233,16 @@ describe('Chat Route Handler', () => {
         isAdminOperation: false,
       }
 
-      mocks.getLdFlagValue.mockResolvedValueOnce({
-        enabled: true,
-        config: {
-          chatPromptName: 'chat-v0',
-          chatReadinessPromptName: 'chat-readiness-v0',
-          version: 'production',
-        },
-      })
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -251,6 +260,11 @@ describe('Chat Route Handler', () => {
         'feature-test@plumber.gov.sg',
         expect.any(Object),
       )
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'app_m365-excel',
+        'feature-test@plumber.gov.sg',
+        false,
+      )
     })
 
     it('should validate request body before processing', async () => {
@@ -259,14 +273,16 @@ describe('Chat Route Handler', () => {
         messages: [],
       }
 
-      mocks.getLdFlagValue.mockResolvedValueOnce({
-        enabled: true,
-        config: {
-          chatPromptName: 'chat-v0',
-          chatReadinessPromptName: 'chat-readiness-v0',
-          version: 'production',
-        },
-      })
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag
 
       await executeChatPostHandler(mockReq, mockRes)
 
@@ -292,6 +308,88 @@ describe('Chat Route Handler', () => {
         error: 'You do not have permissions to use AI Builder!',
       })
     })
+
+    it('should include Excel access in system message when user has Excel enabled', async () => {
+      let capturedMessages: any[] = []
+
+      // Capture the messages passed to streamText
+      mocks.streamText.mockImplementation((options) => {
+        capturedMessages = options.messages
+        return {
+          toUIMessageStream: vi.fn().mockReturnValue({
+            getReader: vi.fn().mockReturnValue({
+              read: vi.fn().mockResolvedValue({ done: true }),
+            }),
+          }),
+        }
+      })
+
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(true) // Excel feature flag enabled
+      mocks.getPrompt.mockResolvedValueOnce({
+        prompt: 'test prompt',
+        toJSON: vi.fn(),
+      })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      // Verify system message includes Excel access
+      expect(capturedMessages[0]).toMatchObject({
+        role: 'system',
+        content: expect.stringContaining('has access to the M365-Excel app'),
+      })
+    })
+
+    it('should indicate no Excel access in system message when user does not have Excel enabled', async () => {
+      let capturedMessages: any[] = []
+
+      // Capture the messages passed to streamText
+      mocks.streamText.mockImplementation((options) => {
+        capturedMessages = options.messages
+        return {
+          toUIMessageStream: vi.fn().mockReturnValue({
+            getReader: vi.fn().mockReturnValue({
+              read: vi.fn().mockResolvedValue({ done: true }),
+            }),
+          }),
+        }
+      })
+
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag disabled
+      mocks.getPrompt.mockResolvedValueOnce({
+        prompt: 'test prompt',
+        toJSON: vi.fn(),
+      })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      // Verify system message indicates no Excel access
+      expect(capturedMessages[0]).toMatchObject({
+        role: 'system',
+        content: expect.stringContaining(
+          'does not have access to the M365-Excel app',
+        ),
+      })
+    })
   })
 
   describe('Admin User Access', () => {
@@ -309,14 +407,16 @@ describe('Chat Route Handler', () => {
         isAdminOperation: true,
       }
 
-      mocks.getLdFlagValue.mockResolvedValueOnce({
-        enabled: true,
-        config: {
-          chatPromptName: 'chat-v0',
-          chatReadinessPromptName: 'chat-readiness-v0',
-          version: 'production',
-        },
-      })
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -333,6 +433,11 @@ describe('Chat Route Handler', () => {
         'ai-builder',
         'admin@plumber.gov.sg',
         expect.any(Object),
+      )
+      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
+        'app_m365-excel',
+        'admin@plumber.gov.sg',
+        false,
       )
     })
   })
@@ -384,15 +489,17 @@ describe('Chat Route Handler', () => {
         new Error('LLM service unavailable'),
       )
 
-      mocks.getLdFlagValue.mockResolvedValueOnce({
-        enabled: true,
-        config: {
-          chatPromptName: 'chat-v0',
-          chatReadinessPromptName: 'chat-readiness-v0',
-          chatReadinessModel: 'claude-haiku-4-5-20251001-v1:rsn',
-          version: 'production',
-        },
-      })
+      mocks.getLdFlagValue
+        .mockResolvedValueOnce({
+          enabled: true,
+          config: {
+            chatPromptName: 'chat-v0',
+            chatReadinessPromptName: 'chat-readiness-v0',
+            chatReadinessModel: 'claude-haiku-4-5-20251001-v1:rsn',
+            version: 'production',
+          },
+        })
+        .mockResolvedValueOnce(false) // Excel feature flag
       mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
         toJSON: vi.fn(),

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -390,7 +390,7 @@ describe('Chat Route Handler', () => {
       })
     })
 
-    it('should show empty restricted apps list when user has access to all apps', async () => {
+    it('should not append restricted apps note when user has access to all apps', async () => {
       let capturedMessages: any[] = []
 
       // Capture the messages passed to streamText
@@ -425,13 +425,15 @@ describe('Chat Route Handler', () => {
 
       await executeChatPostHandler(mockReq, mockRes)
 
-      // Verify system message shows empty restricted apps (empty string after "apps: ")
+      // Verify system message does NOT include the restricted apps note
+      // (no need to say "this user does not have access to: ." when list is empty)
       expect(capturedMessages[0]).toMatchObject({
         role: 'system',
-        content: expect.stringContaining(
-          'this user does not have access to the following apps: .',
-        ),
+        content: 'test prompt', // Just the base prompt, no note appended
       })
+      expect(capturedMessages[0].content).not.toContain(
+        'this user does not have access to the following apps',
+      )
     })
   })
 

--- a/packages/backend/src/routes/api/__tests__/chat.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getLdFlagValue: vi.fn(),
+  getAllLdFlags: vi.fn(),
   getPrompt: vi.fn(),
   getActiveTraceId: vi.fn(),
   updateActiveObservation: vi.fn(),
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/helpers/launch-darkly', () => ({
   getLdFlagValue: mocks.getLdFlagValue,
+  getAllLdFlags: mocks.getAllLdFlags,
 }))
 
 vi.mock('@/helpers/pair/get-prompt', () => ({
@@ -177,16 +179,15 @@ describe('Chat Route Handler', () => {
   describe('Handler Behavior', () => {
     it('should process authenticated requests', async () => {
       // Context is set by middleware before reaching handler
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'aids-chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'aids-chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({})
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -204,11 +205,7 @@ describe('Chat Route Handler', () => {
         'test@plumber.gov.sg',
         expect.any(Object),
       )
-      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'app_m365-excel',
-        'test@plumber.gov.sg',
-        false,
-      )
+      expect(mocks.getAllLdFlags).toHaveBeenCalledWith('test@plumber.gov.sg')
     })
 
     it('should throw error when context is missing user', async () => {
@@ -233,16 +230,15 @@ describe('Chat Route Handler', () => {
         isAdminOperation: false,
       }
 
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({})
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -260,10 +256,8 @@ describe('Chat Route Handler', () => {
         'feature-test@plumber.gov.sg',
         expect.any(Object),
       )
-      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'app_m365-excel',
+      expect(mocks.getAllLdFlags).toHaveBeenCalledWith(
         'feature-test@plumber.gov.sg',
-        false,
       )
     })
 
@@ -273,16 +267,15 @@ describe('Chat Route Handler', () => {
         messages: [],
       }
 
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({})
 
       await executeChatPostHandler(mockReq, mockRes)
 
@@ -309,7 +302,7 @@ describe('Chat Route Handler', () => {
       })
     })
 
-    it('should include Excel access in system message when user has Excel enabled', async () => {
+    it('should exclude Excel from restricted apps when user has Excel enabled', async () => {
       let capturedMessages: any[] = []
 
       // Capture the messages passed to streamText
@@ -324,16 +317,18 @@ describe('Chat Route Handler', () => {
         }
       })
 
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(true) // Excel feature flag enabled
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({
+        'app_m365-excel': true, // Excel enabled
+        'app_other-app': false, // Other app disabled
+      })
       mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
         toJSON: vi.fn(),
@@ -342,51 +337,99 @@ describe('Chat Route Handler', () => {
 
       await executeChatPostHandler(mockReq, mockRes)
 
-      // Verify system message includes Excel access
-      expect(capturedMessages[0]).toMatchObject({
-        role: 'system',
-        content: expect.stringContaining('has access to the M365-Excel app'),
-      })
-    })
-
-    it('should indicate no Excel access in system message when user does not have Excel enabled', async () => {
-      let capturedMessages: any[] = []
-
-      // Capture the messages passed to streamText
-      mocks.streamText.mockImplementation((options) => {
-        capturedMessages = options.messages
-        return {
-          toUIMessageStream: vi.fn().mockReturnValue({
-            getReader: vi.fn().mockReturnValue({
-              read: vi.fn().mockResolvedValue({ done: true }),
-            }),
-          }),
-        }
-      })
-
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag disabled
-      mocks.getPrompt.mockResolvedValueOnce({
-        prompt: 'test prompt',
-        toJSON: vi.fn(),
-      })
-      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
-
-      await executeChatPostHandler(mockReq, mockRes)
-
-      // Verify system message indicates no Excel access
+      // Verify system message does not include Excel in restricted apps
       expect(capturedMessages[0]).toMatchObject({
         role: 'system',
         content: expect.stringContaining(
-          'does not have access to the M365-Excel app',
+          'this user does not have access to the following apps: other-app',
+        ),
+      })
+      expect(capturedMessages[0].content).not.toContain('m365-excel')
+    })
+
+    it('should include Excel in restricted apps when user does not have Excel enabled', async () => {
+      let capturedMessages: any[] = []
+
+      // Capture the messages passed to streamText
+      mocks.streamText.mockImplementation((options) => {
+        capturedMessages = options.messages
+        return {
+          toUIMessageStream: vi.fn().mockReturnValue({
+            getReader: vi.fn().mockReturnValue({
+              read: vi.fn().mockResolvedValue({ done: true }),
+            }),
+          }),
+        }
+      })
+
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({
+        'app_m365-excel': false, // Excel disabled
+      })
+      mocks.getPrompt.mockResolvedValueOnce({
+        prompt: 'test prompt',
+        toJSON: vi.fn(),
+      })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      // Verify system message includes Excel in restricted apps
+      expect(capturedMessages[0]).toMatchObject({
+        role: 'system',
+        content: expect.stringContaining(
+          'this user does not have access to the following apps: m365-excel',
+        ),
+      })
+    })
+
+    it('should show empty restricted apps list when user has access to all apps', async () => {
+      let capturedMessages: any[] = []
+
+      // Capture the messages passed to streamText
+      mocks.streamText.mockImplementation((options) => {
+        capturedMessages = options.messages
+        return {
+          toUIMessageStream: vi.fn().mockReturnValue({
+            getReader: vi.fn().mockReturnValue({
+              read: vi.fn().mockResolvedValue({ done: true }),
+            }),
+          }),
+        }
+      })
+
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({
+        'app_m365-excel': true,
+        'some-other-flag': false, // Non-app flag
+      })
+      mocks.getPrompt.mockResolvedValueOnce({
+        prompt: 'test prompt',
+        toJSON: vi.fn(),
+      })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      // Verify system message shows empty restricted apps (empty string after "apps: ")
+      expect(capturedMessages[0]).toMatchObject({
+        role: 'system',
+        content: expect.stringContaining(
+          'this user does not have access to the following apps: .',
         ),
       })
     })
@@ -407,16 +450,15 @@ describe('Chat Route Handler', () => {
         isAdminOperation: true,
       }
 
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({})
       mocks.getPrompt
         .mockResolvedValueOnce({
           prompt: 'test prompt',
@@ -434,11 +476,7 @@ describe('Chat Route Handler', () => {
         'admin@plumber.gov.sg',
         expect.any(Object),
       )
-      expect(mocks.getLdFlagValue).toHaveBeenCalledWith(
-        'app_m365-excel',
-        'admin@plumber.gov.sg',
-        false,
-      )
+      expect(mocks.getAllLdFlags).toHaveBeenCalledWith('admin@plumber.gov.sg')
     })
   })
 
@@ -489,17 +527,16 @@ describe('Chat Route Handler', () => {
         new Error('LLM service unavailable'),
       )
 
-      mocks.getLdFlagValue
-        .mockResolvedValueOnce({
-          enabled: true,
-          config: {
-            chatPromptName: 'chat-v0',
-            chatReadinessPromptName: 'chat-readiness-v0',
-            chatReadinessModel: 'claude-haiku-4-5-20251001-v1:rsn',
-            version: 'production',
-          },
-        })
-        .mockResolvedValueOnce(false) // Excel feature flag
+      mocks.getLdFlagValue.mockResolvedValueOnce({
+        enabled: true,
+        config: {
+          chatPromptName: 'chat-v0',
+          chatReadinessPromptName: 'chat-readiness-v0',
+          chatReadinessModel: 'claude-haiku-4-5-20251001-v1:rsn',
+          version: 'production',
+        },
+      })
+      mocks.getAllLdFlags.mockResolvedValueOnce({})
       mocks.getPrompt.mockResolvedValueOnce({
         prompt: 'test prompt',
         toJSON: vi.fn(),

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -19,9 +19,9 @@ import appConfig from '@/config/app'
 import {
   AI_BUILDER_FEATURE_FLAG,
   AI_BUILDER_FEATURE_FLAG_FALLBACK,
-  EXCEL_FEATURE_FLAG,
+  APP_FLAG_REGEX,
 } from '@/config/flags'
-import { getLdFlagValue } from '@/helpers/launch-darkly'
+import { getAllLdFlags, getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import { getPrompt } from '@/helpers/pair/get-prompt'
@@ -42,20 +42,19 @@ const handleChatStream = observe(
       AI_BUILDER_FEATURE_FLAG_FALLBACK,
     )
 
-    // NOTE: we check the excel feature flag to tell the assistant whether the user has access to the M365-Excel app
-    // TODO(kevinkim-ogp): should send in all the allowed apps and actions to the assistant
-    const excelFeatureFlag = await getLdFlagValue(
-      EXCEL_FEATURE_FLAG,
-      context.currentUser.email,
-      false,
-    )
-
     if (!aiBuilderFlag.enabled) {
       res
         .status(403)
         .json({ error: 'You do not have permissions to use AI Builder!' })
       return
     }
+
+    // NOTE: we check LD for this user's access to apps
+    // we then pass it into the system prompt to tell the assistant which apps the user does not have access to
+    const allLdFlags = await getAllLdFlags(context.currentUser.email)
+    const restrictedApps = Object.keys(allLdFlags)
+      .filter((flag) => APP_FLAG_REGEX.test(flag) && allLdFlags[flag] === false)
+      .map((flag) => flag.replace('app_', ''))
 
     const {
       chatPromptName,
@@ -104,9 +103,11 @@ const handleChatStream = observe(
 
       const systemMessage = {
         role: 'system' as const,
-        content: `${prompt.prompt}\n\nNote: this user ${
-          excelFeatureFlag ? 'has' : 'does not have'
-        } access to the M365-Excel app.`,
+        content: `${
+          prompt.prompt
+        }\n\nNote: this user does not have access to the following apps: ${restrictedApps.join(
+          ', ',
+        )}.`,
       }
       const allMessages = [systemMessage, ...messages]
 

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -21,6 +21,7 @@ import {
   AI_BUILDER_FEATURE_FLAG_FALLBACK,
   APP_FLAG_REGEX,
 } from '@/config/flags'
+import { buildSystemPrompt } from '@/helpers/build-system-prompt'
 import { getAllLdFlags, getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
@@ -103,11 +104,7 @@ const handleChatStream = observe(
 
       const systemMessage = {
         role: 'system' as const,
-        content: `${
-          prompt.prompt
-        }\n\nNote: this user does not have access to the following apps: ${restrictedApps.join(
-          ', ',
-        )}.`,
+        content: buildSystemPrompt(prompt.prompt, restrictedApps),
       }
       const allMessages = [systemMessage, ...messages]
 

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -19,6 +19,7 @@ import appConfig from '@/config/app'
 import {
   AI_BUILDER_FEATURE_FLAG,
   AI_BUILDER_FEATURE_FLAG_FALLBACK,
+  EXCEL_FEATURE_FLAG,
 } from '@/config/flags'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
@@ -39,6 +40,14 @@ const handleChatStream = observe(
       AI_BUILDER_FEATURE_FLAG,
       context.currentUser.email,
       AI_BUILDER_FEATURE_FLAG_FALLBACK,
+    )
+
+    // NOTE: we check the excel feature flag to tell the assistant whether the user has access to the M365-Excel app
+    // TODO(kevinkim-ogp): should send in all the allowed apps and actions to the assistant
+    const excelFeatureFlag = await getLdFlagValue(
+      EXCEL_FEATURE_FLAG,
+      context.currentUser.email,
+      false,
     )
 
     if (!aiBuilderFlag.enabled) {
@@ -93,7 +102,12 @@ const handleChatStream = observe(
         model: MODEL_TYPE,
       })
 
-      const systemMessage = { role: 'system' as const, content: prompt.prompt }
+      const systemMessage = {
+        role: 'system' as const,
+        content: `${prompt.prompt}\n\nNote: this user ${
+          excelFeatureFlag ? 'has' : 'does not have'
+        } access to the M365-Excel app.`,
+      }
       const allMessages = [systemMessage, ...messages]
 
       const stream = createUIMessageStream({

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/NewBadge.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/NewBadge.tsx
@@ -1,8 +1,27 @@
 import { Badge } from '@opengovsg/design-system-react'
 
-export default function NewBadge() {
+const VARIANTS = {
+  primary: {
+    bgColor: 'interaction.muted.main.active',
+    color: 'primary.500',
+  },
+  secondary: {
+    bgColor: 'secondary.50',
+    color: 'secondary.700',
+  },
+}
+
+interface NewBadgeProps {
+  variant?: keyof typeof VARIANTS
+}
+
+export default function NewBadge(props: NewBadgeProps) {
+  const { variant = 'primary' } = props
+
+  const { bgColor, color } = VARIANTS[variant]
+
   return (
-    <Badge bgColor="interaction.muted.main.active" color="primary.500">
+    <Badge bgColor={bgColor} color={color}>
       New
     </Badge>
   )

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -131,7 +131,7 @@ export function useChatStream(options: UseChatStreamOptions) {
 
       navigate(`${URLS.EDITOR}/ai`, {
         state: {
-          ...location.state,
+          ...locationRef.current.state,
           chatInput: allMessages[allMessages.length - 1].text,
           chatMessages: allMessages,
           // When isChatReady is true: clear output to trigger step generation

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -32,7 +32,7 @@ export default function PromptInput({
 
   const handleSubmit = async (e: SyntheticEvent) => {
     e.preventDefault()
-    if (input?.trim()) {
+    if (input?.trim() && !isStreaming) {
       sendMessage(input)
       setInput('')
       if (textareaRef.current) {
@@ -75,11 +75,9 @@ export default function PromptInput({
         w="full"
         minH={showIdeas ? '120px' : '50px'}
         height="auto"
-        cursor={isStreaming ? 'not-allowed' : 'default'}
       >
         <Textarea
           ref={textareaRef}
-          disabled={isStreaming}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyPress}
@@ -92,12 +90,6 @@ export default function PromptInput({
           color="gray.900"
           _placeholder={{ color: 'gray.500' }}
           _focus={{ outline: 'none', boxShadow: 'none' }}
-          _disabled={{
-            opacity: 1,
-            bg: 'transparent',
-            color: 'gray.900',
-            cursor: 'not-allowed',
-          }}
           fontSize="base"
           lineHeight="6"
           maxH="calc(40vh - 100px)"

--- a/packages/frontend/src/pages/Flows/components/ModeTile.tsx
+++ b/packages/frontend/src/pages/Flows/components/ModeTile.tsx
@@ -50,7 +50,9 @@ export default function ModeTile(props: ModeTileProps) {
     <Tile
       icon={() => icon}
       flex={1}
-      {...(isNew && { badge: <NewBadge /> })}
+      {...(isNew && {
+        badge: <NewBadge variant="secondary" />,
+      })}
       {...rest}
     >
       <Text textStyle="subhead-1">{title}</Text>


### PR DESCRIPTION
### Fixes and tests

- [x] **Pipe** **name** **is** **preserved**
    - Chat till you see the Step Preview, observe that the name changes from 'Build with AI' to the suggested Pipe name
    - Continue chatting (type irrelevant things),
    - Pipe name should remain
- [x] Chat now factors in feature flagged apps (resolves PLU-691)
    - Fetches all LD flags, maps out which apps the user does not have access to, and passes it into the system prompt
    - Log in as `kevin_test@mas.gov.sg` or create another user in LD 'Test' environment
    - Try asking it for Excel (or the app your test user does not have access to)
    - Should tell you that you do not have access to that app
- [x] Prompt input remains enabled while streaming
    - The prompt input is no longer disabled after you type your prompt and hit 'enter' and send the message
    - Verify that you cannot send messages using 'enter' while the assistant is streaming
- [x] Max 30 steps
    - Even if the chat allows 30 steps, the `generateAiSteps` has a cap of 30 steps per Pipe