### PR TITLE
chore: add changes for retry button

### DIFF
--- a/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryAllButton.tsx
@@ -1,6 +1,7 @@
 import { IExecution } from '@plumber/types'
 
 import { useCallback, useContext, useState } from 'react'
+import { BiFastForward } from 'react-icons/bi'
 import { TbArrowForwardUpDouble } from 'react-icons/tb'
 import { useMutation } from '@apollo/client'
 import { Icon } from '@chakra-ui/react'
@@ -10,12 +11,33 @@ import { BULK_RETRY_EXECUTIONS_FLAG } from '@/config/flags'
 import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { BULK_RETRY_EXECUTIONS } from '@/graphql/mutations/bulk-retry-executions'
 
-interface RetryAllButtonProps {
-  execution: IExecution
+import { RetryVariant } from './RetryButton'
+
+const variantConfigs: Record<
+  RetryVariant,
+  { text: string; icon: React.ReactElement }
+> = {
+  retry: {
+    text: 'Retry all failures for this pipe',
+    icon: <Icon boxSize={6} as={TbArrowForwardUpDouble} />,
+  },
+  resume: {
+    text: 'Resume all paused executions for this workflow',
+    icon: <Icon boxSize={6} as={BiFastForward} />,
+  },
 }
 
-export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
+interface RetryAllButtonProps {
+  execution: IExecution
+  variant?: RetryVariant
+}
+
+export const RetryAllButton = ({
+  execution,
+  variant = 'retry',
+}: RetryAllButtonProps) => {
   const flowId = execution.flow?.id
+  const config = variantConfigs[variant]
   const { getFlagValue } = useContext(LaunchDarklyContext)
   const toast = useToast()
   const [isBulkRetrying, setIsBulkRetrying] = useState(false)
@@ -60,14 +82,14 @@ export const RetryAllButton = ({ execution }: RetryAllButtonProps) => {
   return (
     <Button
       variant="clear"
-      leftIcon={<Icon boxSize={6} as={TbArrowForwardUpDouble} />}
+      leftIcon={config.icon}
       isLoading={isBulkRetrying}
       isDisabled={hasBulkRetried}
       spinner={<Spinner fontSize={24} />}
       size="md"
       onClick={onBulkRetryExecutions}
     >
-      Retry all failures for this pipe
+      {config.text}
     </Button>
   )
 }

--- a/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
+++ b/packages/frontend/src/components/ExecutionStep/components/RetryButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { BiErrorCircle, BiRedo } from 'react-icons/bi'
+import { BiErrorCircle, BiPlay, BiRedo } from 'react-icons/bi'
 import { useMutation } from '@apollo/client'
 import { HStack, Icon, Text } from '@chakra-ui/react'
 import { Button, useToast } from '@opengovsg/design-system-react'
@@ -8,23 +8,51 @@ import client from '@/graphql/client'
 import { RETRY_EXECUTION_STEP } from '@/graphql/mutations/retry-execution-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
 
+export type RetryVariant = 'retry' | 'resume'
+
+interface VariantConfig {
+  defaultText: string
+  successMessage: string
+  icon: JSX.Element
+  successText: string
+  failureText: string
+}
+
+const variantConfigs: Record<RetryVariant, VariantConfig> = {
+  retry: {
+    defaultText: 'Retry',
+    successMessage:
+      'Retry has been enqueued. Your page should reload after a few seconds with the updated status.',
+    icon: <Icon boxSize={6} as={BiRedo} />,
+    successText: 'Retry started',
+    failureText: 'Retry failed',
+  },
+  resume: {
+    defaultText: 'Resume',
+    successMessage:
+      'Resume has been enqueued. Your page should reload after a few seconds with the updated status.',
+    icon: <Icon boxSize={6} as={BiPlay} />,
+    successText: 'Resume started',
+    failureText: 'Resume failed',
+  },
+}
+
 interface RetryButtonProps {
   executionStepId: string
   customButtonText?: string
+  variant?: RetryVariant
 }
-
-const retryIcon = <Icon boxSize={6} as={BiRedo} />
 
 const RetryButton = ({
   executionStepId,
   customButtonText,
+  variant = 'retry',
 }: RetryButtonProps) => {
   const [isRetrySuccessful, setIsRetrySuccessful] = useState<boolean | null>(
     null,
   )
   const toast = useToast()
-  const retrySuccessMessage =
-    'Retry has been enqueued. Please reload your page after a few seconds to see updated status.'
+  const config = variantConfigs[variant]
 
   const [retryExecutionStep] = useMutation(RETRY_EXECUTION_STEP, {
     variables: {
@@ -34,7 +62,7 @@ const RetryButton = ({
     },
     onCompleted: () => {
       toast({
-        title: retrySuccessMessage,
+        title: config.successMessage,
         status: 'success',
         duration: 3000,
         isClosable: true,
@@ -58,10 +86,10 @@ const RetryButton = ({
     return (
       <Button
         variant="clear"
-        leftIcon={retryIcon}
+        leftIcon={config.icon}
         onClick={() => retryExecutionStep()}
       >
-        {customButtonText ?? 'Retry'}
+        {customButtonText ?? config.defaultText}
       </Button>
     )
   } else {
@@ -76,7 +104,7 @@ const RetryButton = ({
       >
         <Icon as={BiErrorCircle} boxSize={6} />
         <Text textStyle="subhead-1">
-          {isRetrySuccessful ? 'Retry started' : 'Retry failed'}
+          {isRetrySuccessful ? config.successText : config.failureText}
         </Text>
       </HStack>
     )

--- a/packages/frontend/src/components/ExecutionStep/index.tsx
+++ b/packages/frontend/src/components/ExecutionStep/index.tsx
@@ -88,12 +88,14 @@ export default function ExecutionStep({
           <HStack>
             {!isInForEach && canRetry && (
               <>
-                <RetryAllButton execution={execution} />
+                <RetryAllButton
+                  execution={execution}
+                  variant={isDelayPaused ? 'resume' : 'retry'}
+                />
                 <RetryButton
                   executionStepId={executionStep.id}
-                  customButtonText={
-                    isDelayPaused ? 'Resume' : customRetryButtonText
-                  }
+                  customButtonText={customRetryButtonText}
+                  variant={isDelayPaused ? 'resume' : undefined}
                 />
               </>
             )}


### PR DESCRIPTION
## Details
- Added RetryVariant type ('retry' | 'resume')  for both Retry and RetryAll buttons
- Kept the customButtonText prop for text override (e.g., "Retry without attachments")                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                          
 ## Tests                                                                                                                                                                                                        
- [ ] Normal error should still show Retry variant
- [ ] Retry without attachments still show Retry variant
- [ ] For each failed item still show Retry variant
- [ ] Delay until past timestamp errors should show Resume button variant