### PR TITLE
fix: prevent zoom on Tiles when on mobile

### DIFF
--- a/packages/frontend/src/pages/Tile/index.tsx
+++ b/packages/frontend/src/pages/Tile/index.tsx
@@ -155,6 +155,10 @@ export default function Tile(): JSX.Element | null {
       <Helmet>
         <meta name="robots" content="noindex,nofollow" />
         <title>{name} | Tile</title>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+        />
       </Helmet>
       <Flex
         flexDir={{ base: 'column' }}


### PR DESCRIPTION
### To test

Open Tiles on safari iOS, try tapping on a cell.
**Expected behaviour**
It should NOT automatically zoom in.