### PR TITLE
[AI-BUG-BASH-3] feat: handle max messages limit

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -17,6 +17,7 @@ export const AI_BUILDER_FEATURE_FLAG_FALLBACK = {
     chatPromptName: 'chat',
     chatReadinessPromptName: 'chat-readiness-check',
     chatReadinessModel: 'claude-haiku-4-5-20251001-v1:rsn',
+    chatSummaryPromptName: 'chat-summary',
     generateStepsPromptName: 'generate-steps',
     version: 'production',
   },

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -33,6 +33,8 @@ import { getChatReadiness } from './get-chat-readiness'
 import { serializeMessagesForLangfuse } from './helpers'
 import { chatRequestSchema } from './schema'
 
+const MAX_MESSAGES = 50
+
 const handleChatStream = observe(
   async (req: AuthenticatedRequest, res: Response) => {
     const abortController = new AbortController()
@@ -61,6 +63,7 @@ const handleChatStream = observe(
       chatPromptName,
       chatReadinessPromptName,
       chatReadinessModel,
+      chatSummaryPromptName,
       version,
     } = aiBuilderFlag.config
 
@@ -82,9 +85,6 @@ const handleChatStream = observe(
         rawMessages as Parameters<typeof convertToModelMessages>[0],
       )
 
-      // Get the prompt from Langfuse
-      const prompt = await getPrompt(chatPromptName, version)
-
       // Manually capture serializable input for Langfuse
       updateActiveObservation({
         input: {
@@ -94,6 +94,15 @@ const handleChatStream = observe(
 
       // Get the active trace ID from Langfuse context
       const traceId = getActiveTraceId() || ''
+
+      // +1 for the system message
+      const isAtLimit = messages.length + 1 >= MAX_MESSAGES
+
+      // Get the prompt from Langfuse
+      const prompt = await getPrompt(
+        isAtLimit ? chatSummaryPromptName : chatPromptName,
+        version,
+      )
 
       logger.info('Starting AI chat stream', {
         traceId,
@@ -126,7 +135,11 @@ const handleChatStream = observe(
                 promptName: chatPromptName,
                 promptVersion: version,
                 langfusePrompt: prompt.toJSON(),
-                tags: ['ai-builder', 'chat', 'stream'],
+                tags: [
+                  'ai-builder',
+                  'stream',
+                  isAtLimit ? 'chat-summary' : 'chat',
+                ],
               },
             },
             abortSignal: abortController.signal,
@@ -140,15 +153,19 @@ const handleChatStream = observe(
                 updateActiveObservation({ output: event })
                 updateActiveTrace({ output: event })
 
-                // Check if chat is ready for step generation using a fast structured call
-                const isChatReady = await getChatReadiness({
-                  context,
-                  promptName: chatReadinessPromptName,
-                  promptVersion: version,
-                  llmResponse: event.text,
-                  sessionId: sessionId || '',
-                  modelId: chatReadinessModel,
-                })
+                let isChatReady = false
+                if (!isAtLimit) {
+                  // Check if chat is ready for step generation using a fast structured call
+                  // only do this if the chat is not at the limit yet
+                  isChatReady = await getChatReadiness({
+                    context,
+                    promptName: chatReadinessPromptName,
+                    promptVersion: version,
+                    llmResponse: event.text,
+                    sessionId: sessionId || '',
+                    modelId: chatReadinessModel,
+                  })
+                }
 
                 // Write chat readiness status as a data annotation
                 // NOTE: type MUST start with "data-" - SDK enforces this

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -52,16 +52,24 @@ export function useChatStream(options: UseChatStreamOptions) {
   const { ddSessionId } = useAiBuilderContext()
 
   // Track step readiness from data-isChatReady annotation
-  // Initialize based on whether initialMessages contains a ready message
-  const initialIsReady = !!options?.initialMessages?.findLast(
-    (msg) => msg.isChatReady,
+  // Initialize based on whether initialMessages contains a ready message.
+  // Lazy initializer avoids re-running findLast on every render (useState only
+  // uses the initial value on mount).
+  const [isReady, setIsReady] = useState(
+    () => !!options?.initialMessages?.findLast((msg) => msg.isChatReady),
   )
-  const [isReady, setIsReady] = useState(initialIsReady)
 
   // Use ref to always access the latest location state in callbacks
   // This ensures onFinish sees updates made by other components (e.g., StepsPreview)
   const locationRef = useRef(location)
   locationRef.current = location
+
+  // Use ref to always access the latest initialMessages in callbacks.
+  // useChat captures its transport/onFinish on mount, so without a ref,
+  // prepareSendMessagesRequest and onFinish would use stale initialMessages
+  // (e.g. the old 50 messages after clicking "New Chat").
+  const initialMessagesRef = useRef(options?.initialMessages)
+  initialMessagesRef.current = options?.initialMessages
 
   const {
     messages: aiMessages,
@@ -75,13 +83,17 @@ export function useChatStream(options: UseChatStreamOptions) {
       api: '/api/chat',
       credentials: 'include',
       prepareSendMessagesRequest: ({ messages }) => {
-        // Convert initialMessages to the format expected by the API
-        const initialMsgs = (options?.initialMessages || []).map((msg) => ({
-          id: msg.id,
-          role: msg.isUser ? 'user' : 'assistant',
-          parts: [{ type: 'text', text: msg.text }],
-          ...(msg.traceId && { metadata: { traceId: msg.traceId } }),
-        }))
+        // Filter out any initialMessages already tracked by the AI SDK to avoid
+        // duplicates (the SDK accumulates messages across exchanges in its own state)
+        const aiMessageIds = new Set(messages.map((m) => m.id))
+        const initialMsgs = (initialMessagesRef.current || [])
+          .filter((msg) => !aiMessageIds.has(msg.id))
+          .map((msg) => ({
+            id: msg.id,
+            role: msg.isUser ? 'user' : 'assistant',
+            parts: [{ type: 'text', text: msg.text }],
+            ...(msg.traceId && { metadata: { traceId: msg.traceId } }),
+          }))
 
         // Prepend initial messages to maintain full conversation context
         const allMessages = [...initialMsgs, ...messages]
@@ -114,7 +126,7 @@ export function useChatStream(options: UseChatStreamOptions) {
 
       // Combine initial messages with new messages to preserve full history
       const allMessages = deduplicateMessages([
-        ...(options?.initialMessages || []),
+        ...(initialMessagesRef.current || []),
         ...transformedMessages,
       ])
 
@@ -149,7 +161,9 @@ export function useChatStream(options: UseChatStreamOptions) {
     },
   })
 
-  // Transform AI SDK messages to our Message format
+  // Transform AI SDK messages to our Message format.
+  // Uses options?.initialMessages directly (not the ref) so the memo re-runs
+  // reactively when initialMessages changes (e.g., after "New Chat").
   const messages = useMemo<Message[]>(() => {
     const isActivelyStreaming = status === 'streaming' || status === 'submitted'
     const initialMsgs = options?.initialMessages || []

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -7,6 +7,7 @@ import { DefaultChatTransport } from 'ai'
 
 import * as URLS from '@/config/urls'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
+import { MAX_MESSAGES } from '@/pages/AiBuilder/constants'
 import {
   deduplicateMessages,
   extractTextContent,
@@ -65,6 +66,7 @@ export function useChatStream(options: UseChatStreamOptions) {
   const {
     messages: aiMessages,
     sendMessage,
+    setMessages,
     status,
     error: aiError,
     stop,
@@ -202,6 +204,11 @@ export function useChatStream(options: UseChatStreamOptions) {
     return ''
   }, [aiMessages, status])
 
+  const resetChat = useCallback(() => {
+    setMessages([])
+    setIsReady(false)
+  }, [setMessages])
+
   // Wrapper for sendMessage that matches the expected signature
   const sendMessageWrapper = useCallback(
     (userPrompt: string) => {
@@ -223,5 +230,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     error: aiError?.message || null,
     sendMessage: sendMessageWrapper,
     cancelStream: stop,
+    resetChat,
+    hasReachedLimit: messages.length >= MAX_MESSAGES,
   }
 }

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -11,16 +11,18 @@ import { GET_APPS } from '@/graphql/queries/get-apps'
 import { getStepGroupTypeAndCaption, getStepStructure } from '@/helpers/toolbox'
 import { Message } from '@/hooks/useChatStream'
 
-interface AIBuilderSharedProps {
+export interface AIBuilderDraftState {
   flowName: string
   chatInput: string
   chatMessages: Message[]
-  output: {
-    trigger: IStep
-    actions: IStep[]
-    traceId: string
-  }
+  // output can be populated (IStep values) or the initial empty state (empty strings)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  output: Record<string, any>
+}
+
+interface AIBuilderSharedProps extends AIBuilderDraftState {
   clearPersistedState: () => void
+  setChatState: (state: AIBuilderDraftState) => void
 }
 
 interface AiBuilderStep extends IStep {
@@ -59,7 +61,6 @@ export const useAiBuilderContext = () => {
 
 interface AiBuilderContextProviderProps extends AIBuilderSharedProps {
   children: React.ReactNode
-  clearPersistedState: () => void
 }
 
 export const AiBuilderContextProvider = ({
@@ -69,6 +70,7 @@ export const AiBuilderContextProvider = ({
   chatMessages,
   output,
   clearPersistedState,
+  setChatState,
 }: AiBuilderContextProviderProps) => {
   const isMobile = useIsMobile()
   const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
@@ -149,6 +151,7 @@ export const AiBuilderContextProvider = ({
         stepGroupCaption,
         ddSessionId,
         clearPersistedState,
+        setChatState,
         isDrawerOpen,
         setIsDrawerOpen,
       }}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/MessageLimitBanner.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/MessageLimitBanner.tsx
@@ -18,16 +18,16 @@ export default function MessageLimitBanner({
     >
       <Flex alignItems="center" justifyContent="space-between" gap={4}>
         <Text textStyle="body-1">
-          You&apos;ve reached the message limit. Copy the summary above and
-          start a new chat.
+          Message limit reached. Your progress will carry over when you continue
+          in a new chat.
         </Text>
         <Button
           onClick={onNewChat}
           colorScheme="primary"
-          size="sm"
+          size="xs"
           flexShrink={0}
         >
-          New Chat
+          Continue in new chat
         </Button>
       </Flex>
     </Box>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/MessageLimitBanner.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/MessageLimitBanner.tsx
@@ -1,0 +1,35 @@
+import { Box, Button, Flex, Text } from '@chakra-ui/react'
+
+interface MessageLimitBannerProps {
+  onNewChat: () => void
+}
+
+export default function MessageLimitBanner({
+  onNewChat,
+}: MessageLimitBannerProps) {
+  return (
+    <Box
+      bg="utility.feedback.warning-subtle"
+      px={4}
+      py={3}
+      borderRadius="md"
+      border="1px"
+      borderColor="utility.feedback.warning"
+    >
+      <Flex alignItems="center" justifyContent="space-between" gap={4}>
+        <Text textStyle="body-1">
+          You&apos;ve reached the message limit. Copy the summary above and
+          start a new chat.
+        </Text>
+        <Button
+          onClick={onNewChat}
+          colorScheme="primary"
+          size="sm"
+          flexShrink={0}
+        >
+          New Chat
+        </Button>
+      </Flex>
+    </Box>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -2,6 +2,7 @@ import {
   type FormEvent,
   type KeyboardEvent,
   type SyntheticEvent,
+  useEffect,
   useRef,
   useState,
 } from 'react'
@@ -16,6 +17,7 @@ interface PromptInputProps {
   isStreaming: boolean
   showIdeas?: boolean
   placeholder?: string
+  initialValue?: string
   sendMessage: (message: string) => void
   cancelStream: () => void
 }
@@ -24,10 +26,11 @@ export default function PromptInput({
   isStreaming,
   showIdeas = false,
   placeholder = 'Send a message',
+  initialValue = '',
   sendMessage,
   cancelStream,
 }: PromptInputProps) {
-  const [input, setInput] = useState<string>('')
+  const [input, setInput] = useState<string>(initialValue)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const handleSubmit = async (e: SyntheticEvent) => {
@@ -57,6 +60,14 @@ export default function PromptInput({
     target.style.height = 'auto'
     target.style.height = Math.min(target.scrollHeight, maxHeight) + 'px'
   }
+
+  // Trigger resize on mount if initialValue is pre-filled
+  useEffect(() => {
+    if (initialValue) {
+      handleResize()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // only show idea buttons if showIdeas is true and the user has not entered any text
   const shouldShowIdeas = showIdeas && !input?.trim()

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -9,6 +9,7 @@ import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import ChatMessages from '@/pages/AiBuilder/components/ChatMessages'
 import { PLACEHOLDER_MESSAGES } from '@/pages/AiBuilder/constants'
 
+import MessageLimitBanner from './MessageLimitBanner'
 import PromptInput from './PromptInput'
 import ScrollButton from './ScrollButton'
 import SideDrawer from './SideDrawer'
@@ -20,6 +21,9 @@ interface ChatInterfaceProps {
   isReadyForPreview: boolean
   sendMessage: (message: string) => void
   cancelStream: () => void
+  resetChat: () => void
+  hasReachedLimit: boolean
+  clearPersistedState: () => void
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
@@ -30,6 +34,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     isReadyForPreview,
     sendMessage,
     cancelStream,
+    resetChat,
+    hasReachedLimit,
+    clearPersistedState,
   } = props
   const navigate = useNavigate()
   const location = useLocation()
@@ -37,6 +44,21 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     useAiBuilderContext()
 
   const hasMessages = messages.length > 0 || isStreaming
+
+  const handleNewChat = useCallback(() => {
+    cancelStream()
+    resetChat()
+    clearPersistedState()
+    navigate(`${URLS.EDITOR}/ai`, {
+      state: {
+        flowName: 'Build with AI',
+        chatInput: '',
+        chatMessages: [],
+        output: { trigger: '', actions: '', name: 'Build with AI' },
+      },
+      replace: true,
+    })
+  }, [cancelStream, resetChat, clearPersistedState, navigate])
 
   const handleOpenPreview = useCallback(() => {
     if (chatInput !== messages[messages.length - 1].text) {
@@ -144,11 +166,15 @@ export default function ChatInterface(props: ChatInterfaceProps) {
               flexDirection="column"
             >
               <ScrollButton />
-              <PromptInput
-                sendMessage={sendMessage}
-                isStreaming={isStreaming}
-                cancelStream={cancelStream}
-              />
+              {hasReachedLimit ? (
+                <MessageLimitBanner onNewChat={handleNewChat} />
+              ) : (
+                <PromptInput
+                  sendMessage={sendMessage}
+                  isStreaming={isStreaming}
+                  cancelStream={cancelStream}
+                />
+              )}
               {!isMobile && (
                 <Text
                   textStyle="caption-1"

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -23,7 +23,6 @@ interface ChatInterfaceProps {
   cancelStream: () => void
   resetChat: () => void
   hasReachedLimit: boolean
-  clearPersistedState: () => void
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
@@ -36,29 +35,50 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     cancelStream,
     resetChat,
     hasReachedLimit,
-    clearPersistedState,
   } = props
   const navigate = useNavigate()
   const location = useLocation()
-  const { flowName, chatInput, isMobile, isDrawerOpen, setIsDrawerOpen } =
-    useAiBuilderContext()
+  const {
+    flowName,
+    chatInput,
+    isMobile,
+    isDrawerOpen,
+    setIsDrawerOpen,
+    setChatState,
+  } = useAiBuilderContext()
 
   const hasMessages = messages.length > 0 || isStreaming
 
   const handleNewChat = useCallback(() => {
     cancelStream()
     resetChat()
-    clearPersistedState()
-    navigate(`${URLS.EDITOR}/ai`, {
-      state: {
-        flowName: 'Build with AI',
-        chatInput: '',
-        chatMessages: [],
-        output: { trigger: '', actions: '', name: 'Build with AI' },
-      },
-      replace: true,
-    })
-  }, [cancelStream, resetChat, clearPersistedState, navigate])
+    setIsDrawerOpen(false)
+
+    // Extract continuation prompt from the last assistant message (between first pair of triple backticks)
+    const lastMessage = messages[messages.length - 1]
+    const match = lastMessage?.text?.match(/```\n([\s\S]*?)\n```/)
+    const continuationPrompt = match ? match[1].trim() : ''
+
+    const newState = {
+      flowName: 'Build with AI',
+      chatInput: continuationPrompt,
+      chatMessages: [],
+      output: { trigger: '', actions: '', name: 'Build with AI', traceId: '' },
+    }
+
+    // Synchronously update persisted state so the next render sees empty messages
+    // immediately (avoids a stale intermediate render with old messages)
+    setChatState(newState)
+
+    navigate(`${URLS.EDITOR}/ai`, { state: newState, replace: true })
+  }, [
+    cancelStream,
+    resetChat,
+    setIsDrawerOpen,
+    setChatState,
+    navigate,
+    messages,
+  ])
 
   const handleOpenPreview = useCallback(() => {
     if (chatInput !== messages[messages.length - 1].text) {
@@ -112,6 +132,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             isStreaming={isStreaming}
             cancelStream={cancelStream}
             showIdeas
+            initialValue={chatInput}
             placeholder={
               PLACEHOLDER_MESSAGES[Date.now() % PLACEHOLDER_MESSAGES.length]
             }

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -54,9 +54,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat()
     setIsDrawerOpen(false)
 
-    // Extract continuation prompt from the last assistant message (between first pair of triple backticks)
+    // Extract continuation prompt from the last assistant message (between <code> tags)
     const lastMessage = messages[messages.length - 1]
-    const match = lastMessage?.text?.match(/```\n([\s\S]*?)\n```/)
+    const match = lastMessage?.text?.match(/<code[^>]*>([\s\S]*?)<\/code>/)
     const continuationPrompt = match ? match[1].trim() : ''
 
     const newState = {

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -37,3 +37,6 @@ export const PLACEHOLDER_MESSAGES = [
   "Describe what you have in mind and we'll show you what's possible",
   "Share what you're trying to do and we'll help you figure out the best way to automate it",
 ]
+
+// Maximum number of messages allowed in a conversation (hard limit)
+export const MAX_MESSAGES = 50

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -32,6 +32,8 @@ function AiBuilderContent() {
     isReady: isReadyForPreview,
     sendMessage,
     cancelStream,
+    resetChat,
+    hasReachedLimit,
   } = useChatStream({ initialMessages: chatMessages })
 
   const cancelRef = useRef(null)
@@ -105,6 +107,9 @@ function AiBuilderContent() {
             isReadyForPreview={isReadyForPreview}
             sendMessage={sendMessage}
             cancelStream={cancelStream}
+            resetChat={resetChat}
+            hasReachedLimit={hasReachedLimit}
+            clearPersistedState={clearPersistedState}
           />
         </Container>
       </Flex>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -109,7 +109,6 @@ function AiBuilderContent() {
             cancelStream={cancelStream}
             resetChat={resetChat}
             hasReachedLimit={hasReachedLimit}
-            clearPersistedState={clearPersistedState}
           />
         </Container>
       </Flex>
@@ -158,6 +157,7 @@ export default function AiBuilder() {
       chatMessages={chatMessages}
       output={output}
       clearPersistedState={clearPersistedState}
+      setChatState={setPersistedState}
     >
       <AiBuilderContent />
     </AiBuilderContextProvider>

--- a/packages/frontend/src/theme/components/Streamdown.tsx
+++ b/packages/frontend/src/theme/components/Streamdown.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react'
+import { MdCheck, MdContentCopy } from 'react-icons/md'
 import {
+  Box,
   Code,
+  IconButton,
   Link,
   List,
   ListItem,
@@ -11,8 +14,57 @@ import {
   Th,
   Thead,
   Tr,
+  useClipboard,
 } from '@chakra-ui/react'
 import { Streamdown } from 'streamdown'
+
+function extractText(node: React.ReactNode): string {
+  if (typeof node === 'string') {
+    return node
+  }
+  if (typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractText).join('')
+  }
+  if (node !== null && typeof node === 'object' && 'props' in node) {
+    return extractText((node as React.ReactElement).props.children)
+  }
+  return ''
+}
+
+function CodeBlock(props: React.ComponentProps<'pre'>) {
+  const { onCopy, hasCopied } = useClipboard(extractText(props.children))
+
+  return (
+    <Box position="relative" my={4} width="100%">
+      <IconButton
+        aria-label="Copy code"
+        icon={hasCopied ? <MdCheck /> : <MdContentCopy />}
+        size="xs"
+        variant="clear"
+        colorScheme="gray"
+        position="absolute"
+        top={2}
+        right={2}
+        onClick={onCopy}
+        zIndex={1}
+      />
+      <Box
+        as="pre"
+        p={4}
+        pr={10}
+        bg="gray.100"
+        borderRadius="md"
+        overflowX="auto"
+        fontSize="sm"
+        whiteSpace="pre-wrap"
+        {...props}
+      />
+    </Box>
+  )
+}
 
 interface ChakraStreamdownProps {
   children: string
@@ -72,6 +124,7 @@ export function ChakraStreamdown({
       tr: (props: React.ComponentProps<typeof Tr>) => <Tr {...props} />,
       th: (props: React.ComponentProps<typeof Th>) => <Th {...props} />,
       td: (props: React.ComponentProps<typeof Td>) => <Td {...props} />,
+      pre: (props: React.ComponentProps<'pre'>) => <CodeBlock {...props} />,
     }),
     [],
   )


### PR DESCRIPTION
_Note: pending design changes to the message limit banner, but functionality should not change_

### TL;DR

Added a 50-message limit to chat conversations with automatic summarisation and reset functionality when the limit is reached. The 'New chat' restarts the conversation with the input automatically filled with the summary.

### What changed?

- Implemented a `MAX_MESSAGES` constant set to 50 for both frontend and backend
- Added `chatSummaryPromptName` configuration flag for AI Builder
- Modified chat stream handler to use summary prompt when message limit is reached
- Chat readiness checks are disabled when at the message limit
- Added `MessageLimitBanner` component that appears when limit is reached
- Enhanced `useChatStream` hook with `resetChat` function and `hasReachedLimit` status
- Added copy functionality to code blocks in the Streamdown component
- Updated Langfuse tags to distinguish between regular chat and summary operations

### How to test?

1. Start a chat conversation in the AI Builder
2. Send messages until reaching the 50-message limit (or lower the limit in local dev)
3. Verify that the message limit banner appears with a "New Chat" button
4. Confirm that the prompt input is replaced by the banner when at limit
5. Verify code blocks in chat messages now have a copy button
6. Test the "New Chat" button resets the conversation and auto-fills with the summary

### Screenshots

![Screenshot 2026-03-19 at 3.20.50 PM.png](https://app.graphite.com/user-attachments/assets/0cb7b0b6-8ea5-43e6-8486-063241a6f78c.png)