### PR TITLE
[COLLAB-CON-5] PLU-661 (feat): editor can add, delete connections

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-connection.itest.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { CreateConnectionInput } from '@/graphql/__generated__/types.generated'
+import createConnection from '@/graphql/mutations/create-connection'
+import Connection from '@/models/connection'
+import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import {
+  generateMockCollaborator,
+  generateMockFlow,
+  generateMockUser,
+} from './flow.mock'
+
+describe('createConnection', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testFlow: Flow
+  let defaultInput: CreateConnectionInput
+
+  beforeEach(async () => {
+    await FlowConnections.query().delete()
+    await Connection.query().delete()
+    await Flow.query().delete()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    testFlow = await generateMockFlow(context, randomUUID())
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
+
+    defaultInput = {
+      key: 'slack',
+      formattedData: { screenName: 'Test Slack' },
+      flowId: testFlow.id,
+    }
+  })
+
+  describe('without flowId', () => {
+    it('should not create connection without a flowId', async () => {
+      await expect(
+        createConnection(
+          null,
+          {
+            // @ts-expect-error - intentionally exclude the flowId
+            input: {
+              key: 'slack',
+              formattedData: { screenName: 'Test Slack' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('with flowId', () => {
+    it('should add connection to flow_connections', async () => {
+      await createConnection(null, { input: defaultInput }, context)
+
+      const flowConnections = await FlowConnections.query()
+      expect(flowConnections).toHaveLength(1)
+    })
+
+    describe('access control', () => {
+      it('should allow owner to create connection', async () => {
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        expect(result).toBeDefined()
+        expect(result.key).toBe('slack')
+      })
+
+      it('should allow editor to create connection', async () => {
+        context.currentUser = editor
+
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        expect(result).toBeDefined()
+      })
+
+      it('should not allow viewer to create connection', async () => {
+        context.currentUser = viewer
+
+        await expect(
+          createConnection(null, { input: defaultInput }, context),
+        ).rejects.toThrow()
+      })
+
+      it('should not allow non-collaborator to create connection', async () => {
+        context.currentUser = nonCollaborator
+
+        await expect(
+          createConnection(
+            null,
+            { input: { ...defaultInput, flowId: testFlow.id } },
+            context,
+          ),
+        ).rejects.toThrow()
+      })
+    })
+
+    describe('userId assignment', () => {
+      it('editor-created connection has userId null (collaborator-added)', async () => {
+        context.currentUser = editor
+
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const connection = await Connection.query().findById(result.id)
+        expect(connection.userId).toBeNull()
+      })
+
+      it('owner-created connection has owner userId', async () => {
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const connection = await Connection.query().findById(result.id)
+        expect(connection.userId).toBe(owner.id)
+      })
+    })
+
+    describe('flow_connections tracking', () => {
+      it('editor-created connection is added to flow_connections', async () => {
+        context.currentUser = editor
+
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const flowConnection = await FlowConnections.query().findOne({
+          flow_id: testFlow.id,
+          connection_id: result.id,
+        })
+
+        expect(flowConnection).toBeDefined()
+        expect(flowConnection.connectionType).toBe('connection')
+        expect(flowConnection.addedBy).toBe(editor.id)
+      })
+
+      it('owner-created connection is added to flow_connections when flow has collaborators', async () => {
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const flowConnection = await FlowConnections.query().findOne({
+          flow_id: testFlow.id,
+          connection_id: result.id,
+        })
+
+        expect(flowConnection).toBeDefined()
+        expect(flowConnection.addedBy).toBe(owner.id)
+      })
+
+      it('owner-created connection is NOT added to flow_connections when flow has no collaborators', async () => {
+        const soloFlow = await generateMockFlow(context, randomUUID())
+
+        const result = await createConnection(
+          null,
+          { input: { ...defaultInput, flowId: soloFlow.id } },
+          context,
+        )
+
+        const flowConnection = await FlowConnections.query().findOne({
+          flow_id: soloFlow.id,
+          connection_id: result.id,
+        })
+
+        expect(flowConnection).toBeUndefined()
+      })
+    })
+
+    describe('access control boundary', () => {
+      it('collaborator-added connection (userId null) does not appear in editor personal connections', async () => {
+        context.currentUser = editor
+
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const personalConnections = await editor.$relatedQuery('connections')
+        const found = personalConnections.find((c) => c.id === result.id)
+
+        expect(found).toBeUndefined()
+      })
+
+      it('collaborator-added connection (userId null) does not appear in owner personal connections', async () => {
+        context.currentUser = editor
+
+        const result = await createConnection(
+          null,
+          { input: defaultInput },
+          context,
+        )
+
+        const ownerConnections = await owner.$relatedQuery('connections')
+        const found = ownerConnections.find((c) => c.id === result.id)
+
+        expect(found).toBeUndefined()
+      })
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/delete-flow-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/delete-flow-connection.itest.ts
@@ -109,12 +109,22 @@ describe('deleteFlowConnection', () => {
       expect(result).toBe(true)
     })
 
-    it('should not allow editor to delete flow connection', async () => {
+    it('should allow editor to delete flow connection', async () => {
       context.currentUser = editor
+      await FlowConnections.query().insert({
+        flowId: testFlow.id,
+        connectionId: testConnection.id,
+        connectionType: 'connection',
+        addedBy: editor.id,
+      })
 
-      await expect(
-        deleteFlowConnection(null, { input: defaultInput }, context),
-      ).rejects.toThrow('You do not have access to this flow')
+      const result = await deleteFlowConnection(
+        null,
+        { input: defaultInput },
+        context,
+      )
+
+      expect(result).toBe(true)
     })
 
     it('should not allow viewer to delete flow connection', async () => {

--- a/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-connection.itest.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import updateConnection from '@/graphql/mutations/update-connection'
+import Connection from '@/models/connection'
+import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import {
+  generateMockCollaborator,
+  generateMockFlow,
+  generateMockUser,
+} from './flow.mock'
+
+describe('updateConnection', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let testFlow: Flow
+  let ownerConnection: Connection
+  let collaboratorConnection: Connection
+
+  beforeEach(async () => {
+    await FlowConnections.query().delete()
+    await Connection.query().delete()
+    await Flow.query().delete()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+    editor = await generateMockUser('editor')
+
+    testFlow = await generateMockFlow(context, randomUUID())
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+
+    // Owner's personal connection (has userId)
+    ownerConnection = await Connection.query().insertAndFetch({
+      userId: owner.id,
+      key: 'slack',
+      formattedData: { screenName: 'Owner Slack' },
+      verified: false,
+    })
+
+    // Collaborator-added connection (userId null, tracked via flow_connections)
+    collaboratorConnection = await Connection.query().insertAndFetch({
+      userId: null,
+      key: 'slack',
+      formattedData: { screenName: 'Shared Slack' },
+      verified: false,
+    })
+
+    await FlowConnections.query().insert({
+      flowId: testFlow.id,
+      connectionId: collaboratorConnection.id,
+      connectionType: 'connection',
+      addedBy: editor.id,
+    })
+  })
+
+  describe('ownership guard', () => {
+    it('should not allow editor to update owner personal connection shared to flow', async () => {
+      // Setup: Owner's personal connection (userId = owner.id)
+      // is shared to flow via flow_connections
+      await FlowConnections.query().insert({
+        flowId: testFlow.id,
+        connectionId: ownerConnection.id, // Personal connection with userId set!
+        connectionType: 'connection',
+        addedBy: owner.id,
+      })
+
+      context.currentUser = editor
+
+      // Editor tries to update - should hit ownership guard
+      await expect(
+        updateConnection(
+          null,
+          {
+            input: {
+              id: ownerConnection.id,
+              flowId: testFlow.id,
+              formattedData: { malicious: 'data' },
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'You cannot update a personal connection that you do not own',
+      )
+    })
+
+    it('should allow editor to update shared connection they created', async () => {
+      context.currentUser = editor
+
+      const result = await updateConnection(
+        null,
+        {
+          input: {
+            id: collaboratorConnection.id,
+            flowId: testFlow.id,
+            formattedData: { screenName: 'Updated Shared Slack' },
+          },
+        },
+        context,
+      )
+
+      expect(result.id).toBe(collaboratorConnection.id)
+      expect(result.formattedData.screenName).toBe('Updated Shared Slack')
+    })
+
+    it('should allow owner to update their own personal connection', async () => {
+      const result = await updateConnection(
+        null,
+        {
+          input: {
+            id: ownerConnection.id,
+            flowId: testFlow.id,
+            formattedData: { screenName: 'Updated Owner Slack' },
+          },
+        },
+        context,
+      )
+
+      expect(result.id).toBe(ownerConnection.id)
+      expect(result.formattedData.screenName).toBe('Updated Owner Slack')
+    })
+
+    it('should allow owner to update shared connection in their flow', async () => {
+      const result = await updateConnection(
+        null,
+        {
+          input: {
+            id: collaboratorConnection.id,
+            flowId: testFlow.id,
+            formattedData: { screenName: 'Owner Updated Shared' },
+          },
+        },
+        context,
+      )
+
+      expect(result.id).toBe(collaboratorConnection.id)
+      expect(result.formattedData.screenName).toBe('Owner Updated Shared')
+    })
+  })
+})

--- a/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/verify-connection.itest.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import verifyConnection from '@/graphql/mutations/verify-connection'
+import Connection from '@/models/connection'
+import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
+import User from '@/models/user'
+import Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import {
+  generateMockCollaborator,
+  generateMockFlow,
+  generateMockUser,
+} from './flow.mock'
+
+const mocks = vi.hoisted(() => ({
+  verifyCredentials: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/models/app', () => ({
+  default: {
+    findOneByKey: vi.fn().mockResolvedValue({
+      key: 'slack',
+      auth: {
+        verifyCredentials: mocks.verifyCredentials,
+      },
+    }),
+  },
+}))
+
+describe('verifyConnection', () => {
+  let context: Context
+  let owner: User
+  let editor: User
+  let viewer: User
+  let nonCollaborator: User
+  let testFlow: Flow
+  let ownerConnection: Connection
+  let collaboratorConnection: Connection
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    await FlowConnections.query().delete()
+    await Connection.query().delete()
+    await Flow.query().delete()
+
+    context = await generateMockContext()
+    owner = context.currentUser
+    editor = await generateMockUser('editor')
+    viewer = await generateMockUser('viewer')
+    nonCollaborator = await generateMockUser('nonCollaborator')
+
+    testFlow = await generateMockFlow(context, randomUUID())
+    await generateMockCollaborator(testFlow.id, editor.id, owner.id, 'editor')
+    await generateMockCollaborator(testFlow.id, viewer.id, owner.id, 'viewer')
+
+    // Owner's personal connection (has userId)
+    ownerConnection = await Connection.query().insertAndFetch({
+      userId: owner.id,
+      key: 'slack',
+      formattedData: { screenName: 'Owner Slack' },
+      verified: false,
+    })
+
+    // Collaborator-added connection (userId null, tracked via flow_connections)
+    collaboratorConnection = await Connection.query().insertAndFetch({
+      userId: null,
+      key: 'slack',
+      formattedData: { screenName: 'Shared Slack' },
+      verified: false,
+    })
+
+    await FlowConnections.query().insert({
+      flowId: testFlow.id,
+      connectionId: collaboratorConnection.id,
+      connectionType: 'connection',
+      addedBy: editor.id,
+    })
+  })
+
+  describe('access control', () => {
+    it('should allow owner to verify their personal connection', async () => {
+      const result = await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe(ownerConnection.id)
+    })
+
+    it('should allow editor to verify a flow connection', async () => {
+      context.currentUser = editor
+
+      const result = await verifyConnection(
+        null,
+        { input: { id: collaboratorConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      expect(result).toBeDefined()
+      expect(result.id).toBe(collaboratorConnection.id)
+    })
+
+    it('should not allow viewer to verify connection', async () => {
+      context.currentUser = viewer
+
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id, flowId: testFlow.id } },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should not allow non-collaborator to verify connection', async () => {
+      context.currentUser = nonCollaborator
+
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id, flowId: testFlow.id } },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('owner path - fetches from personal connections', () => {
+    it('should verify connection belonging to owner', async () => {
+      const result = await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      expect(result.id).toBe(ownerConnection.id)
+      expect(mocks.verifyCredentials).toHaveBeenCalledOnce()
+    })
+
+    it('should not allow owner to verify a connection they do not own', async () => {
+      // Create a connection owned by the editor
+      const editorPersonalConnection = await Connection.query().insertAndFetch({
+        userId: editor.id,
+        key: 'slack',
+        formattedData: { screenName: 'Editor Personal Slack' },
+        verified: false,
+      })
+
+      await expect(
+        verifyConnection(
+          null,
+          {
+            input: {
+              id: editorPersonalConnection.id,
+              flowId: testFlow.id,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('editor path - fetches from flow_connections', () => {
+    it('should verify connection that exists in flow_connections', async () => {
+      context.currentUser = editor
+
+      const result = await verifyConnection(
+        null,
+        { input: { id: collaboratorConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      expect(result.id).toBe(collaboratorConnection.id)
+      expect(mocks.verifyCredentials).toHaveBeenCalledOnce()
+    })
+
+    it('should not allow editor to verify connection not in their flow_connections', async () => {
+      context.currentUser = editor
+
+      // connectionId that exists but is NOT in this flow's flow_connections
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id, flowId: testFlow.id } },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('should not allow editor to verify owner personal connection shared to flow', async () => {
+      // Setup: Owner's personal connection (userId = owner.id)
+      // is shared to flow via flow_connections
+      await FlowConnections.query().insert({
+        flowId: testFlow.id,
+        connectionId: ownerConnection.id, // Personal connection with userId set!
+        connectionType: 'connection',
+        addedBy: owner.id,
+      })
+
+      context.currentUser = editor
+
+      // Editor tries to verify - should hit ownership guard, not "not found"
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: ownerConnection.id, flowId: testFlow.id } },
+          context,
+        ),
+      ).rejects.toThrow(
+        'You cannot update a personal connection that you do not own',
+      )
+    })
+
+    it('should not allow editor to verify a connection from a different flow', async () => {
+      context.currentUser = editor
+
+      // Create another flow with its own connection
+      const otherFlow = await generateMockFlow(context, randomUUID())
+      await generateMockCollaborator(
+        otherFlow.id,
+        editor.id,
+        owner.id,
+        'editor',
+      )
+
+      const otherFlowConnection = await Connection.query().insertAndFetch({
+        userId: null,
+        key: 'slack',
+        formattedData: { screenName: 'Other Flow Slack' },
+        verified: false,
+      })
+      await FlowConnections.query().insert({
+        flowId: otherFlow.id,
+        connectionId: otherFlowConnection.id,
+        connectionType: 'connection',
+        addedBy: editor.id,
+      })
+
+      // Editor tries to verify a connection from otherFlow, but passes testFlow's id
+      await expect(
+        verifyConnection(
+          null,
+          { input: { id: otherFlowConnection.id, flowId: testFlow.id } },
+          context,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('post-verification state', () => {
+    it('should mark connection as verified and non-draft after successful verification', async () => {
+      await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      const updated = await Connection.query().findById(ownerConnection.id)
+      expect(updated.verified).toBe(true)
+      expect(updated.draft).toBe(false)
+    })
+
+    it('should call verifyCredentials exactly once', async () => {
+      await verifyConnection(
+        null,
+        { input: { id: ownerConnection.id, flowId: testFlow.id } },
+        context,
+      )
+
+      expect(mocks.verifyCredentials).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/packages/backend/src/graphql/mutations/create-connection.ts
+++ b/packages/backend/src/graphql/mutations/create-connection.ts
@@ -1,4 +1,5 @@
 import App from '@/models/app'
+import Connection from '@/models/connection'
 import FlowConnections from '@/models/flow-connections'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -13,27 +14,40 @@ const createConnection: MutationResolvers['createConnection'] = async (
 ) => {
   await App.findOneByKey(params.input.key)
 
-  const newConnection = await context.currentUser
-    .$relatedQuery('connections')
-    .insert({
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findOne({
+      id: params.input.flowId,
+    })
+    .throwIfNotFound()
+
+  const isCollaboratorAdded = flow.role === 'editor'
+
+  const newConnection = await Connection.transaction(async (trx) => {
+    const newConnection = await Connection.query(trx).insertAndFetch({
       key: params.input.key,
       formattedData: params.input.formattedData,
       verified: false,
+      // Note: if this is a collaborator added connection, the userId is null
+      // as it is a shared connection that belongs to a Pipe and not a specific user
+      userId: isCollaboratorAdded ? null : context.currentUser.id,
     })
 
-  /**
-   * COLLABORATORS
-   * If the flowId is provided and the flow has collaborators, we add this to the flow_connections table.
-   * We add regardless of whether its a draft, so that it can be used by collaborators later.
-   */
-  if (params.input.flowId) {
+    /**
+     * COLLABORATORS
+     * If the flowId is provided and the flow has collaborators, we add this to the flow_connections table.
+     * We add regardless of whether its a draft, so that it can be used by collaborators later.
+     */
     await FlowConnections.addFlowConnection({
       flowId: params.input.flowId,
       connectionId: newConnection.id,
       addedBy: context.currentUser.id,
       connectionType: 'connection',
+      trx,
     })
-  }
+
+    return newConnection
+  })
 
   return newConnection
 }

--- a/packages/backend/src/graphql/mutations/delete-flow-connection.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow-connection.ts
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql'
+import { GraphQLError } from 'graphql/error'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import { BadUserInputError } from '@/errors/graphql-errors/bad-user-input'
@@ -21,10 +21,10 @@ const deleteFlowConnection: MutationResolvers['deleteFlowConnection'] = async (
 
   try {
     return await FlowConnections.transaction(async (trx) => {
-      // this user needs to first be a flow owner to delete the flow connection
+      // this user needs to first be a flow owner or editor to delete the flow connection
       const flow = await context.currentUser
-        .$relatedQuery('flows', trx)
-        .findOne({ id: flowId })
+        .withAccessibleFlows({ requiredRole: 'editor' })
+        .findById(flowId)
 
       if (!flow) {
         throw new ForbiddenError('You do not have access to this flow')

--- a/packages/backend/src/graphql/mutations/generate-auth-url.ts
+++ b/packages/backend/src/graphql/mutations/generate-auth-url.ts
@@ -1,8 +1,10 @@
 import axios from 'axios'
 
 import GenerateAuthUrlError from '@/errors/generate-auth-url'
+import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -11,12 +13,27 @@ const generateAuthUrl: MutationResolvers['generateAuthUrl'] = async (
   params,
   context,
 ) => {
-  const connection = await context.currentUser
-    .$relatedQuery('connections')
-    .findOne({
-      id: params.input.id,
-    })
-    .throwIfNotFound()
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findById(params.input.flowId)
+    .throwIfNotFound({ message: 'You do not have access to this flow' })
+
+  const connection = await getConnection({
+    context,
+    connectionId: params.input.id,
+    flowId: params.input.flowId,
+    includeOwnConnections: flow.role === 'owner',
+  })
+
+  // GUARD: Prevent updating personal connections owned by others
+  if (
+    connection.userId !== null &&
+    connection.userId !== context.currentUser.id
+  ) {
+    throw new ForbiddenError(
+      'You cannot generate an auth URL for a personal connection that you do not own',
+    )
+  }
 
   if (!connection.formattedData) {
     return null

--- a/packages/backend/src/graphql/mutations/update-connection.ts
+++ b/packages/backend/src/graphql/mutations/update-connection.ts
@@ -1,3 +1,6 @@
+import { ForbiddenError } from '@/errors/graphql-errors'
+import { getConnection } from '@/services/connection'
+
 import type { MutationResolvers } from '../__generated__/types.generated'
 
 // Sensitive graphql variables redacted in morgan.ts and datadog's Sensitive Data
@@ -8,12 +11,27 @@ const updateConnection: MutationResolvers['updateConnection'] = async (
   params,
   context,
 ) => {
-  let connection = await context.currentUser
-    .$relatedQuery('connections')
-    .findOne({
-      id: params.input.id,
-    })
-    .throwIfNotFound()
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findById(params.input.flowId)
+    .throwIfNotFound({ message: 'You do not have access to this flow' })
+
+  let connection = await getConnection({
+    context,
+    connectionId: params.input.id,
+    flowId: params.input.flowId,
+    includeOwnConnections: flow.role === 'owner',
+  })
+
+  // GUARD: Prevent updating personal connections owned by others
+  if (
+    connection.userId !== null &&
+    connection.userId !== context.currentUser.id
+  ) {
+    throw new ForbiddenError(
+      'You cannot update a personal connection that you do not own',
+    )
+  }
 
   connection = await connection.$query().patchAndFetch({
     formattedData: {

--- a/packages/backend/src/graphql/mutations/verify-connection.ts
+++ b/packages/backend/src/graphql/mutations/verify-connection.ts
@@ -2,8 +2,10 @@
  * TODO: remove this file and reuse test connection endpoint
  */
 
+import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import App from '@/models/app'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -12,12 +14,27 @@ const verifyConnection: MutationResolvers['verifyConnection'] = async (
   params,
   context,
 ) => {
-  let connection = await context.currentUser
-    .$relatedQuery('connections')
-    .findOne({
-      id: params.input.id,
-    })
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findById(params.input.flowId)
     .throwIfNotFound()
+
+  let connection = await getConnection({
+    context,
+    connectionId: params.input.id,
+    flowId: params.input.flowId,
+    includeOwnConnections: flow.role === 'owner',
+  })
+
+  // GUARD: Prevent updating personal connections owned by others
+  if (
+    connection.userId !== null &&
+    connection.userId !== context.currentUser.id
+  ) {
+    throw new ForbiddenError(
+      'You cannot update a personal connection that you do not own',
+    )
+  }
 
   const app = await App.findOneByKey(connection.key)
   const $ = await globalVariable({ connection, app, user: context.currentUser })

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -550,16 +550,18 @@ type BulkRetryIterationsResult {
 input CreateConnectionInput {
   key: String!
   formattedData: JSONObject!
-  flowId: String
+  flowId: String!
 }
 
 input GenerateAuthUrlInput {
   id: String!
+  flowId: String!
 }
 
 input UpdateConnectionInput {
   id: String!
   formattedData: JSONObject!
+  flowId: String!
 }
 
 input ResetConnectionInput {
@@ -568,6 +570,7 @@ input ResetConnectionInput {
 
 input VerifyConnectionInput {
   id: String!
+  flowId: String!
 }
 
 input DeleteConnectionInput {

--- a/packages/backend/src/helpers/add-authentication-steps.ts
+++ b/packages/backend/src/helpers/add-authentication-steps.ts
@@ -37,6 +37,10 @@ const authenticationStepsWithoutAuthUrl = [
         name: 'id',
         value: '{createConnection.id}',
       },
+      {
+        name: 'flowId',
+        value: '{flowId}',
+      },
     ],
   },
 ]
@@ -68,6 +72,10 @@ const authenticationStepsWithAuthUrl = [
         name: 'id',
         value: '{createConnection.id}',
       },
+      {
+        name: 'flowId',
+        value: '{flowId}',
+      },
     ],
   },
   {
@@ -92,6 +100,10 @@ const authenticationStepsWithAuthUrl = [
         name: 'formattedData',
         value: '{openAuthPopup.all}',
       },
+      {
+        name: 'flowId',
+        value: '{flowId}',
+      },
     ],
   },
   {
@@ -101,6 +113,10 @@ const authenticationStepsWithAuthUrl = [
       {
         name: 'id',
         value: '{createConnection.id}',
+      },
+      {
+        name: 'flowId',
+        value: '{flowId}',
       },
     ],
   },

--- a/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
+++ b/packages/frontend/src/components/AppConnectionContextMenu/index.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@opengovsg/design-system-react'
 import * as URLS from '@/config/urls'
 
 type Action = {
-  type: 'test' | 'reconnect' | 'delete' | 'viewFlows'
+  type: 'test' | 'delete' | 'viewFlows'
 }
 
 type ContextMenuProps = {
@@ -55,15 +55,6 @@ export default function ContextMenu(
 
           <MenuItem onClick={createActionHandler({ type: 'test' })}>
             Test connection
-          </MenuItem>
-
-          {/* TODO: deprecate this action */}
-          <MenuItem
-            as={Link}
-            to={URLS.APP_RECONNECT_CONNECTION(appKey, connectionId)}
-            onClick={createActionHandler({ type: 'reconnect' })}
-          >
-            Edit connection
           </MenuItem>
 
           <MenuItem

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ChooseConnectionDropdown.tsx
@@ -1,11 +1,10 @@
 import { type IApp } from '@plumber/types'
 
-import { useCallback, useContext } from 'react'
+import { useCallback } from 'react'
 import { FormControl } from '@chakra-ui/react'
 import { FormLabel } from '@opengovsg/design-system-react'
 
 import { SingleSelect } from '@/components/SingleSelect'
-import { EditorContext } from '@/contexts/Editor'
 
 import { DEFAULT_ADD_CONNECTION_LABEL } from '../constants'
 
@@ -28,7 +27,6 @@ function ChooseConnectionDropdown({
   application,
   onAddNewConnection,
 }: ChooseConnectionDropdownProps) {
-  const { flow } = useContext(EditorContext)
   const onSelectionChange = useCallback(
     (value: string) => {
       onChange(value, false)
@@ -36,8 +34,7 @@ function ChooseConnectionDropdown({
     [onChange],
   )
 
-  const canAddNew =
-    application?.auth?.connectionType === 'user-added' && flow.role === 'owner'
+  const canAddNew = application?.auth?.connectionType === 'user-added'
   const items = [...connectionOptions]
 
   return (

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -63,7 +63,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
     ) && flow?.role === 'editor'
   const isReadOnly =
     // flow is an empty object if it is not in the editor
-    (Object.keys(flow).length > 0 && flow?.role !== 'owner') || readOnly
+    (Object.keys(flow).length > 0 && flow?.role === 'viewer') || readOnly
 
   const computedName = namePrefix ? `${namePrefix}.${name}` : name
   const { data, loading, refetch } = useDynamicData(

--- a/packages/frontend/src/config/urls.ts
+++ b/packages/frontend/src/config/urls.ts
@@ -24,12 +24,6 @@ export const APP_PATTERN = '/app/:appKey'
 export const APP_CONNECTIONS = (appKey: string): string =>
   `/app/${appKey}/connections`
 export const APP_CONNECTIONS_PATTERN = '/app/:appKey/connections'
-export const APP_RECONNECT_CONNECTION = (
-  appKey: string,
-  connectionId: string,
-): string => `/app/${appKey}/connections/${connectionId}/reconnect`
-export const APP_RECONNECT_CONNECTION_PATTERN =
-  '/app/:appKey/connections/:connectionId/reconnect'
 export const APP_FLOWS = (appKey: string): string => `/app/${appKey}/flows`
 export const APP_FLOWS_FOR_CONNECTION = (
   appKey: string,

--- a/packages/frontend/src/pages/Application/index.tsx
+++ b/packages/frontend/src/pages/Application/index.tsx
@@ -24,19 +24,6 @@ type ApplicationParams = {
   connectionId?: string
 }
 
-const ReconnectConnection = (props: any): React.ReactElement => {
-  const { application, onClose } = props
-  const { connectionId } = useParams() as ApplicationParams
-
-  return (
-    <AddAppConnection
-      onClose={onClose}
-      application={application}
-      connectionId={connectionId}
-    />
-  )
-}
-
 export default function Application(): React.ReactElement | null {
   const connectionsPathMatch = useMatch({
     path: URLS.APP_CONNECTIONS_PATTERN,
@@ -137,17 +124,6 @@ export default function Application(): React.ReactElement | null {
           path="/connections/add"
           element={
             <AddAppConnection onClose={goToApplicationPage} application={app} />
-          }
-        />
-
-        {/* TODO: deprecate this route */}
-        <Route
-          path="/connections/:connectionId/reconnect"
-          element={
-            <ReconnectConnection
-              application={app}
-              onClose={goToApplicationPage}
-            />
           }
         />
       </Routes>


### PR DESCRIPTION
## Changes

This pull request enables editors to create and delete connections within Pipes, expanding collaboration capabilities beyond Pipe owners.

### Connection Management

- Editors can now create connections for Pipes they have edit access to
- Editors can delete connections for Pipes they have edit access to

### Access Control Updates

- `verifyConnection` mutation now requires `flowId` parameter and enforces editor-level access
- Connection creation distinguishes between personal connections (owner) and shared connections (editor-added)
- Editor-created connections have `userId: null` and are tracked via `flow_connections` table

## Tests
### Creating connection(s)
#### Non-OAuth connections (e.g., Telegram, FormSG)
- [ ] Owner can create a connection for their own flow
  - [ ] Connection has `userId = owner.id` in `connections`
  - [ ] Connection is added to `flow_connections` when flow has collaborators
  - [ ] Connection is NOT added to `flow_connections` when flow has no collaborators
- [ ] Editor can create a connection for a flow they collaborate on
  - [ ] Connection has `userId = null` in `connections` (collaborator-added, not user-owned)
  - [ ] Connection is added to `flow_connections` with correct `addedBy`
  - [ ] Connection does not appear in the editor's personal connections in the `connections` table (i.e., `userId` is null)
  - [ ] Connection (`userId = null`) does not appear in the owner's personal connections  in the `connections` table (i.e., `userId` is null)
- [ ] Viewer cannot create a connection
- [ ] Non-collaborator cannot create a connection

#### OAuth connections (e.g., Slack)
- [ ] Owner can create a connection for their own flow
  - [ ] Connection has `userId = owner.id` in `connections`
  - [ ] Connection is added to `flow_connections` when flow has collaborators
  - [ ] Connection is NOT added to `flow_connections` when flow has no collaborators
- [ ] Editor can create a connection for a flow they collaborate on
  - [ ] Connection has `userId = null` in `connections` (collaborator-added, not user-owned)
  - [ ] Connection is added to `flow_connections` with correct `addedBy`
  - [ ] Connection does not appear in the editor's personal connections in the `connections` table (i.e., `userId` is null)
  - [ ] Connection (`userId = null`) does not appear in the owner's personal connections  in the `connections` table (i.e., `userId` is null)
- [ ] Viewer cannot create a connection
- [ ] Non-collaborator cannot create a connection

### Modifying connection(s)
- [ ] Owner can see their own connections + Editor-added connections
- [ ] Owner can use their own connections
- [ ] Owner can use connections that an Editor added
- [ ] Editor can see all flow connections (i.e., Owner-added and Editor-added)
- [ ] Editor can still use connections that Owner added

### Deleting connections
- [ ] Owner can delete a flow connection
- [ ] Editor can delete a flow connection
- [ ] Viewer cannot delete a flow connection

### Viewers
- [ ] Connections are still verified when viewers view the Pipe
