### PR TITLE
PLU-693 (chore): split foundry api keys by environment

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -268,7 +268,7 @@
     },
     {
       "name": "PAIR_FOUNDRY_API_KEY",
-      "valueFrom": "plumber-pair-foundry-api-key"
+      "valueFrom": "plumber-<ENVIRONMENT>-pair-foundry-api-key"
     },
     {
       "name": "PAIR_FOUNDRY_MODEL",


### PR DESCRIPTION
### TL;DR

Split Pair Foundry API Keys by environment

### Pre-deployment checks

Ensure that the parameters have been created in Parameter Store for all environments

- [x] UAT: `plumber-uat-pair-foundry-api-key`
- [x] Staging: `plumber-staging-pair-foundry-api-key`
- [x] Prod: `plumber-prod-pair-foundry-api-key`