### PR TITLE
[AI-BUG-BASH-4] more bug bash fixes

### DIFF
--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -127,7 +127,10 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
       traceId,
     } as JSONObject
   } catch (error) {
-    logger.error('Error generating ai steps', { error })
+    logger.error('Error generating ai steps', {
+      error,
+      user: context.currentUser.email,
+    })
 
     if (error instanceof z.ZodError) {
       throw new BadUserInputError(fromZodError(error).details[0].message)

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -95,8 +95,20 @@ export function useChatStream(options: UseChatStreamOptions) {
             ...(msg.traceId && { metadata: { traceId: msg.traceId } }),
           }))
 
-        // Prepend initial messages to maintain full conversation context
-        const allMessages = [...initialMsgs, ...messages]
+        // Prepend initial messages to maintain full conversation context.
+        // Filter out assistant messages with no text content — these can be left
+        // behind when the user stops the stream before any output is produced,
+        // and would fail backend schema validation.
+        const allMessages = [...initialMsgs, ...messages].filter((msg) => {
+          if (msg.role !== 'assistant') {
+            return true
+          }
+          return (msg.parts ?? []).some(
+            (part) =>
+              part.type === 'text' &&
+              !!(part as { type: string; text?: string }).text?.trim(),
+          )
+        })
 
         const body = {
           messages: allMessages,
@@ -180,6 +192,13 @@ export function useChatStream(options: UseChatStreamOptions) {
         messagesToTransform = messagesToTransform.slice(0, -1)
       }
     }
+
+    // Filter out assistant messages with no text content — these are left behind
+    // when the user stops the stream before any output is produced
+    messagesToTransform = messagesToTransform.filter(
+      (msg) =>
+        msg.role !== 'assistant' || extractTextContent(msg).trim().length > 0,
+    )
 
     const transformedMessages = transformMessages(messagesToTransform)
     const combined = deduplicateMessages([

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -121,6 +121,12 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
     const prompt = chatInput
     const aiSteps = await generateAiSteps(prompt)
 
+    // Avoid navigating with undefined output on error, which would reset
+    // location state and re-trigger the useEffect that watches `output`
+    if (!aiSteps) {
+      return
+    }
+
     navigate(location.pathname, {
       state: {
         ...location.state,
@@ -150,11 +156,6 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
       }
     }
   }, [])
-
-  const retryGenerateAiSteps = useCallback(async () => {
-    setError(false)
-    await generateAiSteps(chatInput)
-  }, [generateAiSteps, chatInput])
 
   /** FOR EACH STEPS COMPUTATION */
   const forEachSteps = groupedSteps[0]
@@ -252,7 +253,7 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
             </a>
             .
           </Text>
-          <Button onClick={retryGenerateAiSteps}>Try again</Button>
+          <Button onClick={onGenerateAiSteps}>Try again</Button>
         </Flex>
       </Center>
     )

--- a/packages/frontend/src/pages/Flows/components/FlowNameInput.tsx
+++ b/packages/frontend/src/pages/Flows/components/FlowNameInput.tsx
@@ -23,6 +23,7 @@ export default function FlowNameInput({
           onChange={handleInputChange}
           value={flowName}
           required
+          autoFocus
         />
       </FormControl>
     </Flex>


### PR DESCRIPTION
### Fixes

- [ ] Can continue chatting after stopping a stream
    - Send a message, press the 'stop' button before any text is returned
    - Send another message, should continue streaming normally
    - Send a message, press the 'stop' button before the text completes streaming
    - Send another message, should continue streaming normally

- [ ] 'Try again' button at error page actually retries and shows the steps if available
    - Try to force an error in the step preview, otherwise add a `throw new Error('test')` in the `generateAiSteps` mutation
    - Should see the error page with the 'Try again' button
    - Click 'Try again', should generate the steps and display correctly
