### PR TITLE
PLU-700: incorrect ordering in variables suggestions popper

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
@@ -3,6 +3,7 @@ import { IExecutionStep, TDataOutMetadatumType } from '@plumber/types'
 import { useContext, useMemo, useState } from 'react'
 
 import { EditorContext } from '@/contexts/Editor'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { Flow } from '@/graphql/__generated__/graphql'
 import {
   extractVariables,
@@ -20,6 +21,7 @@ export function useAttachmentOptions(
   variableTypes: TDataOutMetadatumType[] | null,
 ) {
   const { allApps } = useContext(EditorContext)
+  const { stepIdToOrder } = useContext(StepsToDisplayContext)
   const [options, setOptions] = useState<CheckboxVariable[]>([])
 
   const uploadedItems = useMemo(() => {
@@ -29,7 +31,7 @@ export function useAttachmentOptions(
 
   const suggestions = useMemo(() => {
     const filteredVars = filterVariables(
-      extractVariables(priorExecutionSteps, allApps),
+      extractVariables(priorExecutionSteps, stepIdToOrder, allApps),
       (v: Variable) => {
         const variableType = v.type ?? 'text'
         return variableTypes?.includes(variableType) ?? false
@@ -58,7 +60,13 @@ export function useAttachmentOptions(
         addNew: true,
       },
     ].filter(Boolean) as StepWithVariables[]
-  }, [priorExecutionSteps, allApps, uploadedItems, variableTypes])
+  }, [
+    priorExecutionSteps,
+    stepIdToOrder,
+    allApps,
+    uploadedItems,
+    variableTypes,
+  ])
 
   return {
     options,

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -83,7 +83,6 @@ function ControlledAutocomplete(
   } = props
   const { allApps, readOnly } = useContext(EditorContext)
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
-
   /**
    * allow extraction of specific variables to a dropdown, e.g., files from FormSG
    */

--- a/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
+++ b/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
@@ -36,7 +36,8 @@ export function useTestDetails(
   const lastErrorDetails = currentTestExecutionStep?.errorDetails
 
   const testVariables = currentTestExecutionStep
-    ? extractVariables([currentTestExecutionStep], allApps)[0]?.output ?? []
+    ? extractVariables([currentTestExecutionStep], undefined, allApps)[0]
+        ?.output ?? []
     : null
 
   return {

--- a/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
+++ b/packages/frontend/src/components/MultiSelect/helpers/extract-variables-as-items.ts
@@ -8,12 +8,19 @@ import { ComboboxItem } from '@opengovsg/design-system-react'
 
 import { extractVariables } from '@/helpers/variables'
 
+/**
+ * @deprecated this function is unused, current resides in MultiSelect component
+ */
 function extractVariablesAsItems(
   executionSteps: IExecutionStep[],
   allowedTypes: TDataOutMetadatumType[] | null,
   allApps: IApp[],
 ): ComboboxItem[] {
-  const stepsWithVariables = extractVariables(executionSteps, allApps)
+  const stepsWithVariables = extractVariables(
+    executionSteps,
+    undefined,
+    allApps,
+  )
 
   const result: ComboboxItem[] = []
   for (const step of stepsWithVariables) {

--- a/packages/frontend/src/components/MultiSelect/index.tsx
+++ b/packages/frontend/src/components/MultiSelect/index.tsx
@@ -25,6 +25,8 @@ interface MultiSelectProps {
 }
 
 /**
+ * @deprecated this component is unused
+ * -------------------------------------
  * Currently only supports multiple select from variables.
  * FUTURE: single select, hard coded options, freeSolo
  */
@@ -40,7 +42,6 @@ function MultiSelect(props: MultiSelectProps): React.ReactElement {
   const { control } = useFormContext()
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { allApps, readOnly } = useContext(EditorContext)
-
   const items = useMemo(
     () => extractVariablesAsItems(priorExecutionSteps, variableTypes, allApps),
     [priorExecutionSteps, variableTypes, allApps],

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -31,6 +31,7 @@ import escapeHtml from 'escape-html'
 
 import { EditorContext } from '@/contexts/Editor'
 import { StepExecutionsContext } from '@/contexts/StepExecutions'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import {
   extractVariables,
   filterVariables,
@@ -116,13 +117,14 @@ const Editor = ({
   noVariablesMessage,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
+  const { stepIdToOrder } = useContext(StepsToDisplayContext)
   const { allApps } = useContext(EditorContext)
   const isMobile = useIsMobile()
   const isMulticol = parentType === 'multicol'
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
-      extractVariables(priorExecutionSteps, allApps),
+      extractVariables(priorExecutionSteps, stepIdToOrder, allApps),
       (variable) => {
         const variableType = variable.type ?? 'text'
         if (variableTypes) {
@@ -134,7 +136,7 @@ const Editor = ({
     )
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]
-  }, [allApps, priorExecutionSteps, variableTypes])
+  }, [allApps, priorExecutionSteps, stepIdToOrder, variableTypes])
 
   const extensions: Array<any> = [
     Placeholder.configure({

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -168,7 +168,11 @@ export const EditorProvider = ({
   )
 
   const [stepsWithVars, varInfoMap] = useMemo(() => {
-    const stepsWithVars = extractVariables(testExecutionSteps, allApps)
+    const stepsWithVars = extractVariables(
+      testExecutionSteps,
+      undefined,
+      allApps,
+    )
     const info = genVariableInfoMap(stepsWithVars)
     return [stepsWithVars, info]
   }, [testExecutionSteps, allApps])

--- a/packages/frontend/src/helpers/__tests__/variables.test.ts
+++ b/packages/frontend/src/helpers/__tests__/variables.test.ts
@@ -306,6 +306,77 @@ describe('variables', () => {
       })
     })
 
+    describe('stepIdToOrder', () => {
+      it('uses stepIdToOrder for step name when provided', () => {
+        executionSteps.push({
+          dataOut: {
+            numberProp: 456,
+          },
+          id: 'execution-step-id-2',
+          stepId: 'step2-id',
+          step: {
+            position: 2,
+            appKey: 'App2',
+            key: 'Action2',
+          },
+          appKey: 'App2',
+        } as unknown as IExecutionStep)
+
+        const stepIdToOrder = {
+          'step1-id': 3,
+          'step2-id': 5,
+        }
+        const result = extractVariables(executionSteps, stepIdToOrder)
+        expect(result[0].name).toBe('3. App1')
+        expect(result[1].name).toBe('5. App2')
+      })
+
+      it('falls back to index + 1 when stepIdToOrder is empty', () => {
+        executionSteps.push({
+          dataOut: {
+            numberProp: 456,
+          },
+          id: 'execution-step-id-2',
+          stepId: 'step2-id',
+          step: {
+            position: 2,
+            appKey: 'App2',
+            key: 'Action2',
+          },
+          appKey: 'App2',
+        } as unknown as IExecutionStep)
+
+        const result = extractVariables(executionSteps)
+        expect(result[0].name).toBe('1. App1')
+        expect(result[1].name).toBe('2. App2')
+      })
+
+      it('falls back to index + 1 for steps not in stepIdToOrder', () => {
+        executionSteps.push({
+          dataOut: {
+            numberProp: 456,
+          },
+          id: 'execution-step-id-2',
+          stepId: 'step2-id',
+          step: {
+            position: 2,
+            appKey: 'App2',
+            key: 'Action2',
+          },
+          appKey: 'App2',
+        } as unknown as IExecutionStep)
+
+        const stepIdToOrder = {
+          'step1-id': 7,
+          // step2-id not provided
+        }
+        const result = extractVariables(executionSteps, stepIdToOrder)
+        expect(result[0].name).toBe('7. App1')
+        // falls back to index + 1 (step2 is at index 1, so 2)
+        expect(result[1].name).toBe('2. App2')
+      })
+    })
+
     describe('process arrays in dataout', () => {
       it('data without formsg checkbox field will have the array flat-mapped', () => {
         executionSteps[0].dataOut = {

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -195,6 +195,8 @@ const process = (
 
 export function extractVariables(
   executionSteps: IExecutionStep[],
+  // this only needs to be passed in if you need the step order to be displayed (e.g. in the suggestions popper)
+  stepIdToOrder: Record<string, number> = {},
   allApps?: IApp[],
 ): StepWithVariables[] {
   if (!executionSteps) {
@@ -220,10 +222,12 @@ export function extractVariables(
         const { stepName } = getStepName(allApps || [], executionStep?.step)
         // sort variable by order key in-place
         sortVariables(variables)
+        const stepOrder = stepIdToOrder[executionStep.stepId] ?? index + 1
+
         return {
           id: executionStep.stepId,
 
-          name: `${index + 1}. ${stepName}`,
+          name: `${stepOrder}. ${stepName}`,
           output: variables,
         }
       })


### PR DESCRIPTION
## Summary
- `extractVariables` now accepts an optional stepIdToOrder mapping to display the correct step number in variable suggestions (e.g., "3. FormSG" instead of always using array index + 1)
- Consumers that display variables in the suggestions popper (RichTextEditor, useAttachmentOptions) pass stepIdToOrder from StepsToDisplayContext; other call sites use the default fallback
- Marks unused MultiSelect component and extractVariablesAsItems helper as @deprecated
## Test plan
- [ ]  Verify variable suggestion poppers in attachment suggestions show correct step numbers (even with combination of MRF and If-Then)

![image.png](https://app.graphite.com/user-attachments/assets/0f84aa98-6c86-4cad-a758-c3dd57fba6fc.png)

- [ ] Verify that variable suggestion popper in RichTextEditors show correct step numbers (even with combination of MRF and If-Then)

![image.png](https://app.graphite.com/user-attachments/assets/42567e7c-a62a-4662-b937-d417934499da.png)

