### PR TITLE
fix: reinstate form header variables, but hide for mrf

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/new-submission.test.ts
@@ -529,9 +529,10 @@ describe('new submission trigger', () => {
       )
     })
 
-    it('hides header fields', async () => {
+    it('should hide header answers but not questions', async () => {
       const metadata = await trigger.getDataOutMetadata(executionStep)
-      expect(metadata.fields.headerFieldId.isHidden).toEqual(true)
+      expect(metadata.fields.headerFieldId.answer.isHidden).toBe(true)
+      expect(metadata.fields.headerFieldId.question.isHidden).toBeFalsy()
     })
 
     it('collapses question variables', async () => {
@@ -539,19 +540,6 @@ describe('new submission trigger', () => {
       expect(metadata.fields.textFieldId.question.isCollapsedByDefault).toEqual(
         true,
       )
-    })
-
-    it('hides attachment questions', async () => {
-      executionStep.dataOut.fields = {
-        fileFieldId: {
-          question: 'Attach a file.',
-          answer: 's3:bucket_name:abcd/efg/my file.txt',
-          fieldType: 'attachment',
-        },
-      }
-
-      const metadata = await trigger.getDataOutMetadata(executionStep)
-      expect(metadata.fields.fileFieldId.question.isHidden).toEqual(true)
     })
 
     it('should handle null dataOut', async () => {

--- a/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formsg/common/get-data-out-metadata.ts
@@ -26,10 +26,7 @@ function buildQuestionMetadatum(fieldData: IJSONObject): IDataOutMetadatum {
     question.label = 'Header'
   }
 
-  if (
-    fieldData.fieldType === 'attachment' ||
-    fieldData.fieldType === 'signature'
-  ) {
+  if (fieldData.fieldType === 'signature') {
     question['isHidden'] = true
   }
 
@@ -356,25 +353,49 @@ async function getDataOutMetadata(
   })
 
   /**
-   * We ignore all 'image' and 'section' (aka headers) field types
+   * This is a hack to match the question number to the form as closely as possible.
+   * In formsg, the headers are not numbered, so we need to exclude them from the question number.
+   * But we also need to keep track of the headers between questions, so we can order them correctly.
+   * The regenerated order will be like so:
+   * Example given form:
+   * Header 0.0001
+   * Header 0.0002
+   * Question 1
+   * Question 2
+   * Sub Heading 2.0001
+   * Question 3
+   * Header 3.0001
+   * Sub Heading 3.0002
+   * Question 4
+   * Sub Heading 4.0001
+   * Question 4
+   * We ignore all 'image' field types
    * Paragraphs are not returned in encryptedContent
    */
   let questionOrder = 0
+  let headerOrderBetweenQuestions = 0
   for (const [fieldId, fieldData] of fields) {
     // ignore image fields, dont even increment question order
-    if (fieldData.fieldType === 'image' || fieldData.fieldType === 'section') {
+    if (fieldData.fieldType === 'image') {
       fieldMetadata[fieldId] = { isHidden: true }
       continue
     }
 
-    // increment question order for each field
-    questionOrder++
-    fieldData.order = questionOrder
+    if (fieldData.fieldType === 'section') {
+      headerOrderBetweenQuestions++
+      fieldData.order = questionOrder + headerOrderBetweenQuestions / 1000
+    } else {
+      // reset header order between questions
+      headerOrderBetweenQuestions = 0
+      // increment question order for each field
+      questionOrder++
+      fieldData.order = questionOrder
 
-    // if this is an MRF step, we only show the fields that are editable
-    if (questionIdsToShowForMrf && !questionIdsToShowForMrf.has(fieldId)) {
-      fieldMetadata[fieldId] = { isHidden: true }
-      continue
+      // if this is an MRF step, we only show the fields that are editable
+      if (questionIdsToShowForMrf && !questionIdsToShowForMrf.has(fieldId)) {
+        fieldMetadata[fieldId] = { isHidden: true }
+        continue
+      }
     }
 
     fieldMetadata[fieldId] = {

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-mock-data.ts
@@ -195,6 +195,8 @@ function patchMockData(
 ) {
   const formFields = formDetails.form.form_fields as Array<FormField>
 
+  const isMrf = formDetails.form.responseMode === 'multirespondent'
+
   // for myinfo children fields
   const newChildrenSubfieldResponses = Object.create(null)
   let childrenObjectIndex = 0 // to support the rare case of multiple child records form fields similar to how FormSG does it
@@ -214,9 +216,11 @@ function patchMockData(
       }
 
       // formsg payload doesnt contain this anyways, so we dont return in mock data
+      // in mrf forms only, sections are also not returned in the payload
       if (
         mockData.responses[formFields[i]._id].fieldType === 'statement' ||
-        mockData.responses[formFields[i]._id].fieldType === 'image'
+        mockData.responses[formFields[i]._id].fieldType === 'image' ||
+        (isMrf && mockData.responses[formFields[i]._id].fieldType === 'section')
       ) {
         delete mockData.responses[formFields[i]._id]
         continue


### PR DESCRIPTION
### Changes

1. Reinstate Header variables. but keep it hidden for MRF. 
2. Show **attachment** field questions

### What changed?

- Header field questions are now visible (updated unit tests)
- Reinstated fractional ordering system for section headers (e.g., 2.9991, 3.9992) to maintain proper sequence between numbered questions
- Added logic to exclude section fields from MRF mock data since they dont appear in real payloads

### How to test?

1. For non-MRF forms, ensure the header variables are ordered according to the form

![image.png](https://app.graphite.com/user-attachments/assets/6abcb2f0-74d1-481d-8cfc-d6cdf25690ad.png)

![image.png](https://app.graphite.com/user-attachments/assets/410cabd8-b02f-464b-8cea-02ad56dae1cd.png)

2. For MRF fields, make sure that the header fields are not visible in mock data.

3. Attachment questions should now be visible.

