### PR TITLE
PLU-666: clean up step errors

### DIFF
--- a/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
+++ b/packages/backend/src/apps/aisay/actions/use-generalised-model/index.ts
@@ -68,20 +68,13 @@ const action: IRawAction = {
     if (!result.success) {
       const { stepErrorName, stepErrorSolution } = getValidationError(result)
 
-      throw new StepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError(stepErrorName, stepErrorSolution)
     }
 
     if (!$.auth.data?.clientId || !$.auth.data?.clientSecret) {
       throw new StepError(
         'Missing client ID or client secret',
         'Please check the client ID and client secret',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -114,13 +107,7 @@ const action: IRawAction = {
     } catch (err) {
       logger.error(err)
       const { stepErrorName, stepErrorSolution } = parseError(err)
-      throw new StepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-        err,
-      )
+      throw new StepError(stepErrorName, stepErrorSolution, err)
     }
   },
 } satisfies IRawAction

--- a/packages/backend/src/apps/aisay/actions/use-specific-model/index.ts
+++ b/packages/backend/src/apps/aisay/actions/use-specific-model/index.ts
@@ -55,8 +55,6 @@ const action: IRawAction = {
       throw new StepError(
         'Missing client ID or client secret',
         'Please check the client ID and client secret',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -64,12 +62,7 @@ const action: IRawAction = {
     if (!result.success) {
       const { stepErrorName, stepErrorSolution } = getValidationError(result)
 
-      throw new StepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError(stepErrorName, stepErrorSolution)
     }
 
     try {
@@ -101,12 +94,7 @@ const action: IRawAction = {
       logger.error(err)
       const { stepErrorName, stepErrorSolution } = parseError(err)
 
-      throw new StepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError(stepErrorName, stepErrorSolution)
     }
   },
 } satisfies IRawAction

--- a/packages/backend/src/apps/calculator/actions/perform-calculation/index.ts
+++ b/packages/backend/src/apps/calculator/actions/perform-calculation/index.ts
@@ -49,22 +49,16 @@ const action = {
         throw new StepError(
           `Configuration problem: '${firstZodParseError(error)}'`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       } else if (error instanceof Error) {
         throw new StepError(
           `Error performing calculation: '${formatBigJsErrorMessage(error)}'`,
           'Ensure that you have entered valid numbers.',
-          $.step.position,
-          $.app.name,
         )
       } else {
         throw new StepError(
           'Error performing calculation',
           'Ensure that you have entered valid numbers.',
-          $.step.position,
-          $.app.name,
         )
       }
     }

--- a/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
+++ b/packages/backend/src/apps/calculator/actions/round-to-decimal-places/index.ts
@@ -45,22 +45,16 @@ const action = {
         throw new StepError(
           `Configuration problem: '${firstZodParseError(error)}'`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       } else if (error instanceof Error) {
         throw new StepError(
           `Error performing rounding: '${formatBigJsErrorMessage(error)}'`,
           'Ensure that you have entered valid numbers.',
-          $.step.position,
-          $.app.name,
         )
       } else {
         throw new StepError(
           `Error performing rounding`,
           'Ensure that you have entered valid numbers.',
-          $.step.position,
-          $.app.name,
         )
       }
     }

--- a/packages/backend/src/apps/custom-api/actions/http-request/index.ts
+++ b/packages/backend/src/apps/custom-api/actions/http-request/index.ts
@@ -204,8 +204,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 
@@ -213,8 +211,6 @@ const action: IRawAction = {
         throw new StepError(
           RECURSIVE_WEBHOOK_ERROR,
           'Ensure that you are not redirecting back to a plumber URL.',
-          $.step.position,
-          $.app.name,
         )
       }
 
@@ -228,8 +224,6 @@ const action: IRawAction = {
         throw new StepError(
           err.message,
           'If you think this is a mistake, please contact us.',
-          $.step.position,
-          $.app.name,
         )
       }
 
@@ -237,8 +231,6 @@ const action: IRawAction = {
         throw new StepError(
           `HTTP request exceeded timeout of ${timeout / 1000}s`,
           'The request took too long to respond.',
-          $.step.position,
-          $.app.name,
           err,
         )
       }
@@ -251,8 +243,6 @@ const action: IRawAction = {
             : err.message
         } `,
         'Check your custom app based on the status code and retry again.',
-        $.step.position,
-        $.app.name,
         err,
       )
     }

--- a/packages/backend/src/apps/delay/actions/delay-for/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-for/index.ts
@@ -53,8 +53,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid delay for value entered',
         'Check that the value is a valid number.',
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/delay/actions/delay-until/index.ts
+++ b/packages/backend/src/apps/delay/actions/delay-until/index.ts
@@ -114,8 +114,6 @@ const action: IRawAction = {
       throw new StepError(
         'Incorrect date or time format',
         `* Date must be in DD MMM YYYY and time in HH:MM format.\n* If you're using a variable, make sure it returns values in these formats.`,
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -138,8 +136,6 @@ const action: IRawAction = {
         throw new StepError(
           'Delay until timestamp entered is in the past',
           'This action was scheduled to run at a time that has already passed. Click "Retry" to skip the delay and continue the Pipe now.',
-          $.step.position,
-          $.app.name,
         )
       }
     }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/transform-data.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/transform-data.ts
@@ -59,8 +59,6 @@ function getParams($: IGlobalVariable) /* inferred return type */ {
     throw new StepError(
       `Configuration problem: '${firstZodParseError(error)}'`,
       GenericSolution.ReconfigureInvalidField,
-      $.step.position,
-      $.app.name,
     )
   }
 }
@@ -87,8 +85,6 @@ export const transformData: TransformSpec['transformData'] = async (
     throw new StepError(
       `Error processing dates: '${error.message}'`,
       'Ensure that you have selected the correct date format, and that time periods to add / subtract are valid numbers.',
-      $.step.position,
-      $.app.name,
     )
   }
 }

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -29,8 +29,6 @@ function getParams($: IGlobalVariable) /* inferred return type */ {
     throw new StepError(
       `Configuration problem: '${firstZodParseError(error)}'`,
       GenericSolution.ReconfigureInvalidField,
-      $.step.position,
-      $.app.name,
     )
   }
 }
@@ -63,8 +61,6 @@ export const spec = {
       throw new StepError(
         `Error with the original value: '${error.message}'`,
         'Ensure that you have selected the correct date format for your original value.',
-        $.step.position,
-        $.app.name,
       )
     }
   },

--- a/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
+++ b/packages/backend/src/apps/formsg/actions/mrf-submission/index.ts
@@ -21,8 +21,6 @@ function validateMrfStep($: IGlobalVariable): ParsedMrfWorkflowStep {
     throw new StepError(
       'Misconfigured MRF step',
       'Reconnect your MRF form and try again.',
-      $.step.position,
-      $.app.name,
     )
   }
   return mrf
@@ -128,8 +126,6 @@ const action: IRawAction = {
       throw new StepError(
         'Previous executable step not found',
         'The previous executable step was not found. This should not happen.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -186,8 +182,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid MRF data: submitted steps are not valid',
         'Click check step to sync your MRF form and try again.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -199,8 +193,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid MRF data: unable to find submitted step',
         'Click check step to sync your MRF form and try again.',
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/get-workflow-data.ts
@@ -17,8 +17,6 @@ export function parseWorkflowData(
     throw new StepError(
       'Invalid MRF data',
       'Reconnect your MRF form and try again.',
-      $.step.position,
-      $.app.name,
     )
   }
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/index.ts
@@ -78,8 +78,6 @@ const trigger: IRawTrigger = {
       throw new StepError(
         'Missing FormSG connection',
         'Click on choose connection and set up your form credentials.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -89,8 +87,6 @@ const trigger: IRawTrigger = {
       throw new StepError(
         'Something went wrong',
         'Invalid test run metadata. Please refresh and try again.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -126,8 +122,6 @@ const trigger: IRawTrigger = {
         throw new StepError(
           'Error syncing MRF steps',
           'This should not happen, please contact support.',
-          $.step.position,
-          $.app.name,
         )
       }
     } else {
@@ -138,8 +132,6 @@ const trigger: IRawTrigger = {
         throw new StepError(
           'Error removing MRF steps',
           'This should not happen, please contact support.',
-          $.step.position,
-          $.app.name,
         )
       }
     }

--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -164,18 +164,14 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.path[0]}: ${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
       if (error instanceof HttpError) {
-        throwGatherSGStepError({ $, error })
+        throwGatherSGStepError(error)
       }
       throw new StepError(
         `An error occurred: '${error.message}'`,
         'Please check that you have configured your step correctly',
-        $.step.position,
-        $.app.name,
       )
     }
   },

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -42,8 +42,6 @@ const action: IRawAction = {
         throw new StepError(
           `Invalid case uuid: ${caseUuid}`,
           'Please check that you have configured your step correctly',
-          $.step.position,
-          $.app.name,
           error,
         )
       }
@@ -53,8 +51,6 @@ const action: IRawAction = {
         throw new StepError(
           `No data found for case ${caseUuid}`,
           'Please check that you have configured your step correctly',
-          $.step.position,
-          $.app.name,
         )
       }
 
@@ -78,8 +74,6 @@ const action: IRawAction = {
       throw new StepError(
         `An error occurred: '${error.message}'`,
         'Please check that you have configured your step correctly',
-        $.step.position,
-        $.app.name,
       )
     }
   },

--- a/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/tag-or-untag-case/index.ts
@@ -72,20 +72,16 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 
       if (error instanceof HttpError) {
-        throwGatherSGStepError({ $, error })
+        throwGatherSGStepError(error)
       }
 
       throw new StepError(
         `An error occurred: '${error.message}'`,
         'Please check that you have configured your step correctly',
-        $.step.position,
-        $.app.name,
       )
     }
   },

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -137,20 +137,16 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message}`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 
       if (error instanceof HttpError) {
-        throwGatherSGStepError({ $, error })
+        throwGatherSGStepError(error)
       }
 
       throw new StepError(
         `An error occurred: '${error.message}'`,
         'Please check that you have configured your step correctly',
-        $.step.position,
-        $.app.name,
       )
     }
   },

--- a/packages/backend/src/apps/gathersg/common/throw-errors.ts
+++ b/packages/backend/src/apps/gathersg/common/throw-errors.ts
@@ -1,20 +1,9 @@
-import { IGlobalVariable } from '@plumber/types'
-
 import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 
 import { GatherSGError } from './types'
 
-export default function throwGatherSGStepError({
-  $,
-  error,
-}: {
-  $: IGlobalVariable
-  error: HttpError
-}) {
-  const position = $.step.position
-  const appName = $.app.name
-
+export default function throwGatherSGStepError(error: HttpError) {
   const { code, message, details } =
     (error.response?.data?.error as GatherSGError) || {}
   const errorStatus = error.response?.status
@@ -23,8 +12,6 @@ export default function throwGatherSGStepError({
     throw new StepError(
       message,
       'Check that you have entered a valid case status.',
-      position,
-      appName,
       error,
     )
   }
@@ -36,8 +23,6 @@ export default function throwGatherSGStepError({
       `Check that you have provided values for required fields and entered the correct value type (e.g., numbers, strings, etc.) for: ${invalidFields.join(
         ', ',
       )}`,
-      position,
-      appName,
       error,
     )
   }
@@ -46,8 +31,6 @@ export default function throwGatherSGStepError({
     throw new StepError(
       'Insufficient permissions to perform this action',
       'Please check that you have been granted sufficient permissions for your API key.',
-      position,
-      appName,
       error,
     )
   }
@@ -57,8 +40,6 @@ export default function throwGatherSGStepError({
     throw new StepError(
       message,
       'Check that you have entered an existing case uuid.',
-      position,
-      appName,
       error,
     )
   }
@@ -67,8 +48,6 @@ export default function throwGatherSGStepError({
   throw new StepError(
     `An error occurred: ${message}`,
     'Please check that you have configured your step correctly',
-    position,
-    appName,
     error,
   )
 }

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/index.ts
@@ -48,8 +48,6 @@ const trigger: IRawTrigger = {
         throw new StepError(
           'Encryption key is not valid',
           `Encryption key must ${error}`,
-          $.step.position,
-          $.app.name,
         )
       }
     }

--- a/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
+++ b/packages/backend/src/apps/lettersg/actions/create-letter/index.ts
@@ -11,17 +11,11 @@ import { downloadAndStoreAttachmentInS3 } from '../../helpers/attachment'
 import getDataOutMetadata from './get-data-out-metadata'
 import { requestSchema, responseSchema } from './schema'
 
-function handleZodError(
-  error: ZodError,
-  position: number,
-  appName: string,
-): never {
+function handleZodError(error: ZodError): never {
   const firstError = fromZodError(error).details[0]
   throw new StepError(
     `${firstError.message}`,
     GenericSolution.ReconfigureInvalidField,
-    position,
-    appName,
   )
 }
 
@@ -119,14 +113,14 @@ const action: IRawAction = {
     const payloadResult = requestSchema.safeParse($.step.parameters)
 
     if (payloadResult.success === false) {
-      handleZodError(payloadResult.error, $.step.position, $.app.name)
+      handleZodError(payloadResult.error)
     }
 
     const rawResponse = await $.http.post('/v1/letters', payloadResult.data)
     const responseResult = responseSchema.safeParse(rawResponse.data)
 
     if (responseResult.success === false) {
-      handleZodError(responseResult.error, $.step.position, $.app.name)
+      handleZodError(responseResult.error)
     }
 
     const response = responseResult.data

--- a/packages/backend/src/apps/lettersg/common/request-error-handler.ts
+++ b/packages/backend/src/apps/lettersg/common/request-error-handler.ts
@@ -25,8 +25,6 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
           missingFields.length === 0 ? '' : `: ${missingFields.join(', ')}`
         }`,
         'Check that you have entered all the fields and values in the letter parameters.',
-        $.step.position,
-        $.app.name,
       )
     }
   }
@@ -44,8 +42,6 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
   throw new StepError(
     `An error occurred: '${error.message}'`,
     'Please check that you have configured your step correctly',
-    $.step.position,
-    $.app.name,
   )
 }
 

--- a/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
+++ b/packages/backend/src/apps/m365-excel/FOR_RELEASE_PERIOD_ONLY.ts
@@ -38,8 +38,6 @@ function throwError($?: IGlobalVariable): never {
     throw new StepError(
       'Excel has reached its limit',
       'There are too many users testing Excel at this moment. Try testing your step again later.',
-      $.step.position,
-      $.app.name,
     )
   } else {
     throw new Error(

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -26,8 +26,6 @@ function buildRowUpdateArgs(
     throw new StepError(
       `Error creating table row: ${err.message}`,
       'Double check that your step is configured correctly',
-      $.step.position,
-      $.app.name,
     )
   }
 }
@@ -146,8 +144,6 @@ const action: IRawAction = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/actions/get-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-cell-values/index.ts
@@ -87,8 +87,6 @@ const action: IRawAction = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 
@@ -96,12 +94,7 @@ const action: IRawAction = {
 
     // Basic sanity checks
     if (cells.length > 3) {
-      throw new StepError(
-        'Too many cells',
-        'Please only input up to 3 cells',
-        $.step.position,
-        $.app.key,
-      )
+      throw new StepError('Too many cells', 'Please only input up to 3 cells')
     }
 
     for (const cell of cells) {
@@ -109,8 +102,6 @@ const action: IRawAction = {
         throw new StepError(
           `Invalid cell address ${cell.address}`,
           'Please specify cell addresses in A1 notation.',
-          $.step.position,
-          $.app.key,
         )
       }
     }

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
@@ -85,8 +85,6 @@ export default async function getTableRowImpl(
     throw new StepError(
       `Column "${lookupColumn}" does not exist in your table.`,
       `Check that your Excel table contains the "${lookupColumn}" column.`,
-      $.step.position,
-      $.app.name,
     )
   }
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -128,8 +128,6 @@ const action: IRawAction = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -117,8 +117,6 @@ const action: IRawAction = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 
@@ -138,8 +136,6 @@ const action: IRawAction = {
       throw new StepError(
         `Column "${lookupColumn}" does not exist in your table.`,
         `Check that your Excel table contains the "${lookupColumn}" column.`,
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -96,8 +96,6 @@ const action: IRawAction = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 
@@ -170,8 +168,6 @@ const action: IRawAction = {
       throw new StepError(
         `Received invalid row data after update: '${updateRowValuesParseResult.error.issues[0].message}'`,
         'Double check your Excel file and retry the step if needed',
-        $.step.position,
-        $.app.name,
       )
     }
     const updatedRow = updateRowValuesParseResult.data

--- a/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/write-cell-values/index.ts
@@ -94,8 +94,6 @@ const action: IRawAction = {
       throw new StepError(
         'Action is set up incorrectly.',
         parametersParseResult.error.issues[0].message,
-        $.step?.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
+++ b/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
@@ -85,8 +85,6 @@ export async function getTopNTableRows(
       throw new StepError(
         'Invalid table range',
         'Check your Excel file and try again',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -98,8 +96,6 @@ export async function getTopNTableRows(
       throw new StepError(
         `Your Excel table has more than ${n.toLocaleString()} rows.`,
         `Reduce the number of rows and try again.`,
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -117,8 +113,6 @@ export async function getTopNTableRows(
         throw new StepError(
           'Your Excel table is too large',
           'Reduce the number of rows or columns and try again.',
-          $.step.position,
-          $.app.name,
           error,
         )
       }
@@ -167,8 +161,6 @@ export async function getTopNTableRowsOld(
     throw new StepError(
       'Received invalid table data',
       'Double check your Excel file and retry the step if needed',
-      $.step.position,
-      $.app.name,
     )
   }
 
@@ -178,8 +170,6 @@ export async function getTopNTableRowsOld(
     throw new StepError(
       'Excel table is missing the header row',
       'Ensure that your Excel table has a header row',
-      $.step.position,
-      $.app.name,
     )
   }
 
@@ -188,8 +178,6 @@ export async function getTopNTableRowsOld(
     throw new StepError(
       `Your Excel table has more than ${n.toLocaleString()} rows.`,
       `Reduce the number of rows and try again.`,
-      $.step.position,
-      $.app.name,
     )
   }
 

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-table-columns/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-table-columns/index.ts
@@ -25,8 +25,6 @@ const dynamicData: IDynamicData = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-tables/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-tables/index.ts
@@ -25,8 +25,6 @@ const dynamicData: IDynamicData = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/dynamic-data/list-worksheets/index.ts
+++ b/packages/backend/src/apps/m365-excel/dynamic-data/list-worksheets/index.ts
@@ -25,8 +25,6 @@ const dynamicData: IDynamicData = {
       throw new StepError(
         'There was a problem with the input.',
         parametersParseResult.error.issues[0].message,
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission-subscription/index.ts
@@ -150,8 +150,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message} under set up step`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 

--- a/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment-form-submission/index.ts
@@ -136,8 +136,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message} under set up step`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 

--- a/packages/backend/src/apps/paysg/actions/create-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/create-payment/index.ts
@@ -129,8 +129,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message} at "${firstError.path}"`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 

--- a/packages/backend/src/apps/paysg/actions/get-payment/index.ts
+++ b/packages/backend/src/apps/paysg/actions/get-payment/index.ts
@@ -46,8 +46,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message} at "${firstError.path}"`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 

--- a/packages/backend/src/apps/paysg/actions/send-email/index.ts
+++ b/packages/backend/src/apps/paysg/actions/send-email/index.ts
@@ -47,8 +47,6 @@ const action: IRawAction = {
         throw new StepError(
           `${firstError.message} at "${firstError.path}"`,
           GenericSolution.ReconfigureInvalidField,
-          $.step.position,
-          $.app.name,
         )
       }
 

--- a/packages/backend/src/apps/postman-sms/actions/send-sms/index.ts
+++ b/packages/backend/src/apps/postman-sms/actions/send-sms/index.ts
@@ -59,8 +59,6 @@ const action = {
       throw new StepError(
         `Configuration problem: ${firstZodParseError(parsedParams.error)}`,
         GenericSolution.ReconfigureInvalidField,
-        $.step.position,
-        $.app.name,
       )
     }
     const authData = authDataSchema.safeParse($.auth.data)
@@ -68,8 +66,6 @@ const action = {
       throw new StepError(
         `Invalid connection data: ${firstZodParseError(authData.error)}`,
         GenericSolution.MalformedConnectionData,
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
+++ b/packages/backend/src/apps/postman-sms/common/request-error-handler.ts
@@ -58,17 +58,10 @@ const requestErrorHandler: IApp['requestErrorHandler'] = async function (
         throw new StepError(
           'Campaign template was not set up correctly',
           'Ensure that you have followed the instructions in our guide to set up your campaign template.',
-          $.step.position,
-          $.app.name,
         )
       }
 
-      throw new StepError(
-        'Error sending SMS',
-        error.message,
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError('Error sending SMS', error.message)
   }
 }
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -66,12 +66,7 @@ const action: IRawAction = {
         ? 'This attachment was not stored in the last submission. Please make a new submission with attachments to successfully configure this pipe.'
         : 'Reconfigure the invalid field and try again.'
 
-      throw new StepError(
-        stepErrorName,
-        stepErrorSolution,
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError(stepErrorName, stepErrorSolution)
     }
 
     let recipientsToSend = result.data.destinationEmail

--- a/packages/backend/src/apps/postman/common/parameters-helper.ts
+++ b/packages/backend/src/apps/postman/common/parameters-helper.ts
@@ -61,7 +61,7 @@ export async function filterAttachments({
     attachmentsList?.map(async (attachment) => {
       // We verify the flowId here to ensure that the attachment is from the same flow and not
       // maliciously/ manually injected by another user who does not have access to this attachment
-      const obj = await getObjectFromS3Id(attachment, { flowId: $.flow.id }, $)
+      const obj = await getObjectFromS3Id(attachment, { flowId: $.flow.id })
       const fileName = obj.name
       const fileType = obj.name.split('.').pop()?.toLowerCase()
 

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -85,9 +85,6 @@ export function throwPostmanStepError({
   invalidAttachments: string[]
   isRetryWithoutAttachments: boolean
 }) {
-  const position = $.step.position
-  const appName = $.app.name
-
   const hasInvalidAttachments = invalidAttachments.length > 0
   const invalidAttachmentsSolution = getInvalidAttachmentSolution({
     invalidAttachments,
@@ -135,14 +132,12 @@ export function throwPostmanStepError({
         throw new PartialStepError({
           name,
           solution,
-          position,
-          appName,
           partialRetry: {
             buttonMessage,
           },
         })
       }
-      throw new StepError(name, solution, position, appName, error)
+      throw new StepError(name, solution, error)
     }
     case 'RATE-LIMITED':
       // this will be auto-retried later on
@@ -155,16 +150,12 @@ export function throwPostmanStepError({
       throw new StepError(
         'Password-protected attachment(s)',
         `Check that the attachment(s) are not password-protected.`,
-        position,
-        appName,
         error,
       )
     case 'ATTACHMENT-SIZE-EXCEEDED':
       throw new StepError(
         'Total attachment size exceeded',
         'Check that the attachments do not exceed 10MB in total.',
-        position,
-        appName,
         error,
       )
     case 'INTERMITTENT-ERROR':
@@ -195,22 +186,18 @@ export function throwPostmanStepError({
         // throw StepError for test runs so that user cannot publish the pipe
         // until the error is fixed
         if ($.execution.testRun) {
-          throw new StepError(name, solution, position, appName, error)
+          throw new StepError(name, solution, error)
         }
 
         throw new PartialStepError({
           name,
           solution: invalidAttachmentsSolution,
-          position,
-          appName,
           partialRetry: { buttonMessage: '' }, // nothing to retry
         })
       }
       throw new StepError(
         'Something went wrong',
         'Please contact plumber@open.gov.sg for assistance.',
-        position,
-        appName,
         error,
       )
   }

--- a/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
+++ b/packages/backend/src/apps/telegram-bot/actions/send-message/index.ts
@@ -72,8 +72,6 @@ const action: IRawAction = {
       throw new StepError(
         'Empty message text',
         'Check that the message text is not empty, especially if variables are used.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -97,7 +95,7 @@ const action: IRawAction = {
         raw: response.data,
       })
     } catch (err) {
-      await throwSendMessageError(err, $.step, $.app.name, $.execution.testRun)
+      await throwSendMessageError(err, $.step, $.execution.testRun)
     }
   },
 }

--- a/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
+++ b/packages/backend/src/apps/telegram-bot/common/throw-errors.ts
@@ -11,11 +11,8 @@ import Step, { StepContext } from '@/models/step'
 export async function throwSendMessageError(
   err: HttpError,
   step: IGlobalVariable['step'],
-  appName: string,
   testRun: boolean,
 ): Promise<never> {
-  const position = step.position
-
   // catch telegram errors with different error format for ETIMEDOUT and ECONNRESET: e.g. details: { error: 'connect ECONNREFUSED 127.0.0.1:3002' }
   const errorDetails = JSON.stringify(get(err, 'details', {}))
   const errorString = JSON.stringify(get(err, 'details.error', ''))
@@ -62,8 +59,6 @@ export async function throwSendMessageError(
         throw new StepError(
           'No permission for bot',
           'Please give permission for your bot in telegram to send messages in the group chat used in your action.',
-          position,
-          appName,
           err,
         )
       } else if (errorString.includes('supergroup')) {
@@ -98,24 +93,18 @@ export async function throwSendMessageError(
         throw new StepError(
           'Supergroup chat upgrade',
           'Please re-connect the chat ID because chat ID changes when your group gets upgraded to a supergroup chat.',
-          position,
-          appName,
           err,
         )
       } else if (errorString.includes('chat not found')) {
         throw new StepError(
           'Incorrect bot configuration',
           'Check that a valid chat ID is used. Otherwise, remove and re-add the bot into the group. Make sure that you send a message to the bot before the bot can send messages to you.',
-          position,
-          appName,
           err,
         )
       } else if (errorString.includes('message thread not found')) {
         throw new StepError(
           'Incorrect topic configuration',
           'Check that a valid topic ID is used.',
-          position,
-          appName,
           err,
         )
       } else {
@@ -126,16 +115,12 @@ export async function throwSendMessageError(
       throw new StepError(
         'Forbidden',
         'Check that the bot is added in the group chat used in your action.',
-        position,
-        appName,
         err,
       )
     case 429:
       throw new StepError(
         'Rate limit exceeded',
         'Too many messages are being sent. Please wait for a minute before retrying and avoid sending more than 20 messages per minute to the same group.',
-        position,
-        appName,
         err,
       )
     case 504:

--- a/packages/backend/src/apps/tiles/actions/create-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/create-row/index.ts
@@ -104,8 +104,6 @@ const action: IRawAction = {
       throw new StepError(
         'Tile not found',
         'Tile may have been deleted. Please check your tile.',
-        $.step.position,
-        'tiles',
       )
     }
 
@@ -124,8 +122,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid column ID(s)',
         'Column(s) may have been deleted or modified. Please check your tile and pipe setup.',
-        $.step.position,
-        $.app.name,
       )
     }
 

--- a/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-multiple-rows/index.ts
@@ -102,8 +102,6 @@ const action: IRawAction = {
       throw new StepError(
         'Tile not found',
         'Tile may have been deleted. Please check your tile.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -124,8 +122,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid filters',
         'One or more filters are invalid. Please check that the columns in your filters still exist',
-        $.step.position,
-        $.app.name,
       )
     }
     // Retrieve the manual scan limit override, converting it to a number.

--- a/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/find-single-row/index.ts
@@ -95,8 +95,6 @@ const action: IRawAction = {
       throw new StepError(
         'Tile not found',
         'Tile may have been deleted. Please check your tile.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -117,8 +115,6 @@ const action: IRawAction = {
       throw new StepError(
         'Invalid filters',
         'One or more filters are invalid. Please check that the columns in your filters still exist',
-        $.step.position,
-        $.app.name,
       )
     }
     // Retrieve the manual scan limit override, converting it to a number.

--- a/packages/backend/src/apps/tiles/actions/update-row/index.ts
+++ b/packages/backend/src/apps/tiles/actions/update-row/index.ts
@@ -133,8 +133,6 @@ const action: IRawAction = {
       throw new StepError(
         'Tile is required',
         'Please select a tile to update a row in.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -149,8 +147,6 @@ const action: IRawAction = {
       throw new StepError(
         'Tile not found',
         'Tile may have been deleted. Please check your tile.',
-        $.step.position,
-        $.app.name,
       )
     }
 
@@ -176,8 +172,6 @@ const action: IRawAction = {
         throw new StepError(
           'Unable to update row',
           'The value to add or subtract by must be a number.',
-          $.step.position,
-          $.app.name,
         )
       }
     }
@@ -252,12 +246,7 @@ const action: IRawAction = {
           })
           return
         }
-        throw new StepError(
-          'Failed to update row',
-          e.message,
-          $.step.position,
-          $.app.name,
-        )
+        throw new StepError('Failed to update row', e.message)
       }
       throw e
     }

--- a/packages/backend/src/apps/toolbox/actions/for-each/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/for-each/index.ts
@@ -59,12 +59,7 @@ const action: IRawAction = {
     const parsedResult = inputSchema.safeParse({ data: rawItems, testRun })
 
     if (parsedResult.success === false) {
-      throw new StepError(
-        'Invalid input list',
-        'Select a valid input list',
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError('Invalid input list', 'Select a valid input list')
     }
 
     try {
@@ -119,12 +114,7 @@ const action: IRawAction = {
       }
     } catch (err) {
       console.error(err)
-      throw new StepError(
-        'Invalid input list',
-        'Select a valid input list',
-        $.step.position,
-        $.app.name,
-      )
+      throw new StepError('Invalid input list', 'Select a valid input list')
     }
   },
 }

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -61,8 +61,6 @@ const action: IRawAction = {
       throw new StepError(
         err.message,
         'Check that the condition has been configured properly.',
-        $.step.position,
-        $.app.name,
       )
     }
     $.setActionItem({

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -20,8 +20,6 @@ const action: IRawAction = {
       throw new StepError(
         err.message,
         'Check that one of valid options in the condition dropdown is being selected.',
-        $.step.position,
-        $.app.name,
       )
     }
     $.setActionItem({

--- a/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/create-row/index.ts
@@ -26,8 +26,8 @@ const action: IRawAction = {
     },
   ],
 
-  async run($) {
-    throwVaultDeprecationError($)
+  async run(_) {
+    throwVaultDeprecationError()
   },
 }
 

--- a/packages/backend/src/apps/vault-workspace/actions/get-table-data/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/get-table-data/index.ts
@@ -27,8 +27,8 @@ const action: IRawAction = {
     },
   ],
 
-  async run($) {
-    throwVaultDeprecationError($)
+  async run(_) {
+    throwVaultDeprecationError()
   },
 }
 

--- a/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
+++ b/packages/backend/src/apps/vault-workspace/actions/update-table-data/index.ts
@@ -42,8 +42,8 @@ const action: IRawAction = {
     },
   ],
 
-  async run($) {
-    throwVaultDeprecationError($)
+  async run(_) {
+    throwVaultDeprecationError()
   },
 }
 

--- a/packages/backend/src/apps/vault-workspace/common/throw-vault-deprecation-error.ts
+++ b/packages/backend/src/apps/vault-workspace/common/throw-vault-deprecation-error.ts
@@ -1,12 +1,8 @@
-import type { IGlobalVariable } from '@plumber/types'
-
 import StepError from '@/errors/step'
 
-export function throwVaultDeprecationError($: IGlobalVariable) {
+export function throwVaultDeprecationError() {
   throw new StepError(
     'Vault workspace is deprecated',
     'Please use tiles or M365-excel instead.',
-    $.step.position,
-    $.app.name,
   )
 }

--- a/packages/backend/src/errors/partial-error.ts
+++ b/packages/backend/src/errors/partial-error.ts
@@ -4,8 +4,6 @@ import StepError from './step'
 interface PartialStepErrorArgs {
   name: string
   solution: string
-  position: number
-  appName: string
   partialRetry: {
     buttonMessage: string
   }
@@ -18,7 +16,7 @@ interface PartialStepErrorArgs {
  */
 export default class PartialStepError extends StepError {
   constructor(props: PartialStepErrorArgs) {
-    const { name, solution, position, appName, error, partialRetry } = props
-    super(name, solution, position, appName, error, { partialRetry })
+    const { name, solution, error, partialRetry } = props
+    super(name, solution, error, { partialRetry })
   }
 }

--- a/packages/backend/src/errors/step.ts
+++ b/packages/backend/src/errors/step.ts
@@ -14,16 +14,12 @@ export default class StepError extends Error {
   constructor(
     name: string,
     solution: string,
-    position: number,
-    appName: string,
     error?: HttpError,
     extraProperties?: Record<string, unknown>,
   ) {
     const stepError: IStepError = {
       name,
       solution,
-      position,
-      appName,
       details: error?.details as IJSONObject,
       ...extraProperties,
     }

--- a/packages/backend/src/helpers/__tests__/actions.test.ts
+++ b/packages/backend/src/helpers/__tests__/actions.test.ts
@@ -353,8 +353,6 @@ describe('action helper functions', () => {
           stepError: new StepError(
             'http-step-error',
             'test solution',
-            1,
-            'test-app',
             new HttpError({
               response: {
                 headers: {
@@ -366,12 +364,7 @@ describe('action helper functions', () => {
           isRetried: true,
         },
         {
-          stepError: new StepError(
-            'non-http-step-error',
-            'test solution',
-            1,
-            'test-app',
-          ),
+          stepError: new StepError('non-http-step-error', 'test solution'),
           isRetried: false,
         },
       ])(

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -1,5 +1,3 @@
-import { IGlobalVariable } from '@plumber/types'
-
 import type {
   GetObjectCommandInput,
   GetObjectCommandOutput,
@@ -77,7 +75,6 @@ export const MAX_FILE_SIZE = 1024 * 1024 * 10 // 10MB
 function throwAttachmentError(
   errorType: string,
   metadata: Record<string, string>,
-  $: IGlobalVariable,
 ) {
   let name
   let solution
@@ -100,7 +97,7 @@ function throwAttachmentError(
       break
   }
 
-  throw new StepError(name, solution, $.step.position, $.app.name)
+  throw new StepError(name, solution)
 }
 
 const s3Client = new S3Client({
@@ -286,7 +283,6 @@ export interface S3Object {
 export async function getObjectFromS3Id(
   id: string,
   metadataToCheck?: Record<string, string>,
-  $?: IGlobalVariable,
 ): Promise<S3Object> {
   const idData = parseS3Id(id)
   if (!idData) {
@@ -321,7 +317,7 @@ export async function getObjectFromS3Id(
           idData.objectKey,
         )
         if (!isValid) {
-          throwAttachmentError(scanStatus, metadata, $)
+          throwAttachmentError(scanStatus, metadata)
         }
       }
     }

--- a/packages/backend/src/models/flow-collaborators.ts
+++ b/packages/backend/src/models/flow-collaborators.ts
@@ -107,8 +107,6 @@ class FlowCollaborator extends Base {
           `Please ensure that you are ${
             requiredRole === 'viewer' ? 'a' : 'an'
           } ${requiredRole} of this pipe.`,
-          $.step.position,
-          $.app.name,
         )
       }
       throw new ForbiddenError(

--- a/packages/backend/src/models/table-collaborators.ts
+++ b/packages/backend/src/models/table-collaborators.ts
@@ -78,8 +78,6 @@ class TableCollaborator extends Base {
           `Please ensure that you are ${
             role === 'viewer' ? 'a' : 'an'
           } ${role} of this tile.`,
-          $.step.position,
-          $.app.name,
         )
       }
       throw new ForbiddenError(

--- a/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
+++ b/packages/frontend/src/components/ErrorResult/SpecificErrorResult.tsx
@@ -3,12 +3,7 @@ import { IStepError } from '@plumber/types'
 import Markdown from 'react-markdown'
 import { useMutation } from '@apollo/client'
 import { Box, Text } from '@chakra-ui/react'
-import {
-  Badge,
-  Button,
-  Infobox,
-  useToast,
-} from '@opengovsg/design-system-react'
+import { Button, Infobox, useToast } from '@opengovsg/design-system-react'
 
 import { RETRY_PARTIAL_STEP } from '@/graphql/mutations/retry-partial-step'
 import { GET_EXECUTION_STEPS } from '@/graphql/queries/get-execution-steps'
@@ -26,8 +21,7 @@ interface SpecificErrorResultProps {
 
 export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   const { errorDetails, isTestRun, executionStepId } = props
-  const { name, solution, position, appName, details, partialRetry } =
-    errorDetails
+  const { name, solution, details, partialRetry } = errorDetails
 
   const toast = useToast()
 
@@ -52,17 +46,6 @@ export default function SpecificErrorResult(props: SpecificErrorResultProps) {
   return (
     <Infobox variant="error" borderRadius="lg">
       <Box minW="0" w="full">
-        {/* Actual executions will not need to show step position and app name */}
-        {isTestRun && (
-          <Badge
-            mb={2}
-            bg="interaction.critical-subtle.default"
-            color="interaction.critical.default"
-          >
-            <Text>{`Step ${position}: ${appName} error`}</Text>
-          </Badge>
-        )}
-
         <Text mb={0.5} textStyle="subhead-1">
           {name}
         </Text>

--- a/packages/frontend/src/components/ErrorResult/index.tsx
+++ b/packages/frontend/src/components/ErrorResult/index.tsx
@@ -5,14 +5,7 @@ import SpecificErrorResult from './SpecificErrorResult'
 
 const isStepError = (value: IStepError | IJSONObject): value is IStepError => {
   // Narrowing type for IStepError using type predicate
-  return (
-    value &&
-    typeof value === 'object' &&
-    !!value.name &&
-    !!value.solution &&
-    !!value.position &&
-    !!value.appName
-  )
+  return value && typeof value === 'object' && !!value.name && !!value.solution
 }
 
 interface ErrorResultProps {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1031,8 +1031,6 @@ export interface ITestConnectionOutput
 export interface IStepError {
   name: string
   solution: string
-  position: number
-  appName: string
   details?: IJSONObject
   partialRetry?: {
     buttonMessage: string


### PR DESCRIPTION
## Problem

StepError still shows the position and app name badge because test step was for the entire pipe in the past.

## Solution
Clean up the code

## Details
- Types: Removed position and appName from IStepError interface in packages/types/index.d.ts
- StepError class: Simplified constructor to (name, solution, error?, extraProperties?)
- PartialStepError class: Removed position and appName from constructor interface
- All app files: Updated all StepError and PartialStepError calls across the codebase
- Frontend: Removed the Badge showing "Step X: AppName error" in ErrorResult components
- Tests: Updated test cases in actions.test.ts
  
## Before & After Screenshots

**BEFORE**:
<img width="1554" height="528" alt="image" src="https://github.com/user-attachments/assets/8d68fa3c-b911-4a57-a4e0-8871eeab8fb6" />

**AFTER**:
<img width="1774" height="1052" alt="image" src="https://github.com/user-attachments/assets/5b3c25ac-76ee-43ad-b723-ee818259dc0b" />

## Tests
- Make sure build works
- Linting and testing works
- Test a few errors from different apps e.g. Tiles, LetterSG, GatherSG