### PR TITLE
feat: new create pipe button

### DIFF
--- a/packages/frontend/src/pages/Flows/components/CreatePipeButton.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreatePipeButton.tsx
@@ -1,0 +1,88 @@
+import { useContext, useState } from 'react'
+import { BiSolidMagicWand } from 'react-icons/bi'
+import { useNavigate } from 'react-router-dom'
+import { Box, Flex } from '@chakra-ui/react'
+import { Badge, Button, IconButton } from '@opengovsg/design-system-react'
+
+import { AI_BUILDER_FEATURE_FLAG } from '@/config/flags'
+import * as URLS from '@/config/urls'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+
+const LOCAL_STORAGE_AI_BUILDER_NEW_CLICKED = 'ai-builder-new-clicked'
+
+interface CreatePipeButtonProps {
+  onOpen: () => void
+}
+
+export default function CreatePipeButton(props: CreatePipeButtonProps) {
+  const { onOpen } = props
+
+  const navigate = useNavigate()
+
+  // TODO (kevinkim-ogp): remove the flag value once GA
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const aiBuilderFlag = getFlagValue(AI_BUILDER_FEATURE_FLAG, {
+    enabled: false,
+  })
+  const canUseAiBuilder = aiBuilderFlag.enabled
+
+  const [showAiBuilderNewBadge, setShowAiBuilderNewBadge] = useState(() => {
+    if (typeof window === 'undefined') {
+      return true
+    }
+    return localStorage.getItem(LOCAL_STORAGE_AI_BUILDER_NEW_CLICKED) !== 'true'
+  })
+
+  // TODO (kevinkim-ogp): can default to button without the new badge once GA
+  if (canUseAiBuilder) {
+    return (
+      <Flex gap={0.5}>
+        <Button
+          data-test="create-flow-button"
+          onClick={onOpen}
+          borderTopRightRadius={0}
+          borderBottomRightRadius={0}
+        >
+          Create Pipe
+        </Button>
+        <Box
+          position="relative"
+          {...(showAiBuilderNewBadge && { mr: '1.25rem' })}
+        >
+          <IconButton
+            aria-label="Create Pipe"
+            icon={<BiSolidMagicWand />}
+            onClick={() => {
+              localStorage.setItem(LOCAL_STORAGE_AI_BUILDER_NEW_CLICKED, 'true')
+              setShowAiBuilderNewBadge(false)
+              navigate(`${URLS.EDITOR}/ai`)
+            }}
+            borderTopLeftRadius={0}
+            borderBottomLeftRadius={0}
+          />
+          {showAiBuilderNewBadge && (
+            <Badge
+              position="absolute"
+              top="0"
+              right="0"
+              transform="translate(50%, -50%)"
+              backgroundColor="secondary.700"
+              fontSize="10px"
+              fontWeight={500}
+              borderRadius="12px"
+              pointerEvents="none"
+            >
+              New
+            </Badge>
+          )}
+        </Box>
+      </Flex>
+    )
+  }
+
+  return (
+    <Button data-test="create-flow-button" onClick={onOpen}>
+      Create Pipe
+    </Button>
+  )
+}

--- a/packages/frontend/src/pages/Flows/index.tsx
+++ b/packages/frontend/src/pages/Flows/index.tsx
@@ -3,7 +3,7 @@ import type { IFlow } from '@plumber/types'
 import { ReactElement, useEffect, useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { Box, Center, Flex, useDisclosure } from '@chakra-ui/react'
-import { Button, Pagination } from '@opengovsg/design-system-react'
+import { Pagination } from '@opengovsg/design-system-react'
 
 import Container from '@/components/Container'
 import DebouncedSearchInput from '@/components/DebouncedSearchInput'
@@ -16,6 +16,7 @@ import { usePaginationAndFilter } from '@/hooks/usePaginationAndFilter'
 
 import ApproveTransfersInfobox from './components/ApproveTransfersInfobox'
 import CreateFlowModal from './components/CreateFlowModal'
+import CreatePipeButton from './components/CreatePipeButton'
 import EmptyFlows from './components/EmptyFlows'
 import {
   CreateFlowContextProvider,
@@ -113,11 +114,7 @@ export default function Flows(): ReactElement {
                 onChange={(input) => setSearchParams({ input })}
               />
             }
-            createComponent={
-              <Button data-test="create-flow-button" onClick={onOpen}>
-                Create Pipe
-              </Button>
-            }
+            createComponent={<CreatePipeButton onOpen={onOpen} />}
           />
         )}
 


### PR DESCRIPTION
## TL;DR
Updates the current "Create Pipe" button with an additional "AI" button that navigates directly to the AI Builder.

## Tests
- [x] Only users with access to the AI Builder should see the 'AI' button
- [x] 'AI' button navigates you directly to `/editor/ai`
- [x] 'New' badge is shown if you have not clicked on the 'AI' button
    - [x] Badge disappears once you click on it
    - [x] Badge does not show when you refresh
- [x] Create Pipe button functionality remains unchanged
    - [x] Can still use Build with AI, Use a template, and Start from scratch
