### PR TITLE
PLU-552: chore: add change to stop retrying m365 504 errors

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -17,7 +17,7 @@ import StepError from '@/errors/step'
 import createHttpClient, { type IHttpClient } from '@/helpers/http-client'
 
 import m365ExcelApp from '../..'
-import { EXCEL_504_ERROR_CODE } from '../../common/interceptors/request-error-handler'
+import { EXCEL_504_MAX_ATTEMPTS } from '../../common/interceptors/request-error-handler'
 
 function mockAxiosAdapterToThrowOnce(
   status: AxiosResponse['status'],
@@ -219,7 +219,7 @@ describe('M365 request error handlers', () => {
     )
   })
 
-  it('throws RetriableError with EXCEL_504 errorCode on 504 (live run)', async () => {
+  it('throws RetriableError with custom max attempts on 504 (live run)', async () => {
     // Default $ doesn't have execution.testRun, so this is the live run path
     mockAxiosAdapterToThrowOnce(504)
     await http
@@ -231,7 +231,7 @@ describe('M365 request error handlers', () => {
         expect(error).toBeInstanceOf(RetriableError)
         expect(error.delayType).toEqual('step')
         expect(error.delayInMs).toEqual(DEFAULT_DELAY_MS)
-        expect(error.errorCode).toEqual(EXCEL_504_ERROR_CODE)
+        expect(error.maxAttempts).toEqual(EXCEL_504_MAX_ATTEMPTS)
         // Message contains the user-friendly error (will be saved as errorDetails)
         expect(error.message).toContain('Excel request timed out')
       })

--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -17,6 +17,7 @@ import StepError from '@/errors/step'
 import createHttpClient, { type IHttpClient } from '@/helpers/http-client'
 
 import m365ExcelApp from '../..'
+import { EXCEL_504_ERROR_CODE } from '../../common/interceptors/request-error-handler'
 
 function mockAxiosAdapterToThrowOnce(
   status: AxiosResponse['status'],
@@ -218,9 +219,55 @@ describe('M365 request error handlers', () => {
     )
   })
 
-  it('throws a StepError with formula guidance on 504 (no auto-retry)', async () => {
+  it('throws RetriableError with EXCEL_504 errorCode on 504 (live run)', async () => {
+    // Default $ doesn't have execution.testRun, so this is the live run path
     mockAxiosAdapterToThrowOnce(504)
     await http
+      .get('/test-url')
+      .then(() => {
+        expect.unreachable()
+      })
+      .catch((error): void => {
+        expect(error).toBeInstanceOf(RetriableError)
+        expect(error.delayType).toEqual('step')
+        expect(error.delayInMs).toEqual(DEFAULT_DELAY_MS)
+        expect(error.errorCode).toEqual(EXCEL_504_ERROR_CODE)
+        // Message contains the user-friendly error (will be saved as errorDetails)
+        expect(error.message).toContain('Excel request timed out')
+      })
+    expect(mocks.logWarning).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 504'),
+      expect.objectContaining({ event: 'm365-http-504' }),
+    )
+  })
+
+  it('throws StepError immediately on 504 (test run)', async () => {
+    // Create http client with testRun: true
+    const $testRun = {
+      auth: {
+        data: {
+          tenantKey: 'test-tenant',
+        },
+      },
+      step: {
+        position: 1,
+      },
+      app: {
+        name: 'M365 Excel',
+      },
+      execution: {
+        testRun: true,
+      },
+    } as unknown as IGlobalVariable
+    const httpTestRun = createHttpClient({
+      $: $testRun,
+      baseURL: 'http://localhost/mock-m365-graph-api',
+      beforeRequest: [],
+      requestErrorHandler: m365ExcelApp.requestErrorHandler,
+    })
+
+    mockAxiosAdapterToThrowOnce(504)
+    await httpTestRun
       .get('/test-url')
       .then(() => {
         expect.unreachable()
@@ -229,9 +276,11 @@ describe('M365 request error handlers', () => {
         expect(error).toBeInstanceOf(StepError)
         expect(error.message).toContain('Excel request timed out')
         expect(error.message).toContain('long-running formulas')
-        // We intentionally don't set a cause to prevent auto-retry
-        expect(error.cause).toBeUndefined()
       })
+    expect(mocks.logWarning).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 504'),
+      expect.objectContaining({ event: 'm365-http-504' }),
+    )
   })
 
   it('throws a RetriableError with default step delay on ETIMEDOUT', async () => {

--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import HttpError from '@/errors/http'
 import RetriableError, { DEFAULT_DELAY_MS } from '@/errors/retriable-error'
+import StepError from '@/errors/step'
 import createHttpClient, { type IHttpClient } from '@/helpers/http-client'
 
 import m365ExcelApp from '../..'
@@ -89,6 +90,12 @@ describe('M365 request error handlers', () => {
         data: {
           tenantKey: 'test-tenant',
         },
+      },
+      step: {
+        position: 1,
+      },
+      app: {
+        name: 'M365 Excel',
       },
     } as unknown as IGlobalVariable
     http = createHttpClient({
@@ -209,6 +216,22 @@ describe('M365 request error handlers', () => {
       expect.stringContaining('HTTP 509'),
       expect.objectContaining({ event: 'm365-http-509' }),
     )
+  })
+
+  it('throws a StepError with formula guidance on 504 (no auto-retry)', async () => {
+    mockAxiosAdapterToThrowOnce(504)
+    await http
+      .get('/test-url')
+      .then(() => {
+        expect.unreachable()
+      })
+      .catch((error): void => {
+        expect(error).toBeInstanceOf(StepError)
+        expect(error.message).toContain('Excel request timed out')
+        expect(error.message).toContain('long-running formulas')
+        // We intentionally don't set a cause to prevent auto-retry
+        expect(error.cause).toBeUndefined()
+      })
   })
 
   it('throws a RetriableError with default step delay on ETIMEDOUT', async () => {

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -104,7 +104,6 @@ const handle500and502and503: ThrowingHandler = function ($, error) {
 // Test runs: fail immediately with helpful message.
 // Live runs: retry up to 3 times, then fail with helpful message.
 //
-export const EXCEL_504_ERROR_CODE = 'EXCEL_504'
 export const EXCEL_504_MAX_ATTEMPTS = 3
 const EXCEL_504_ERROR_MESSAGE = {
   name: 'Excel request timed out',
@@ -137,7 +136,7 @@ const handle504: ThrowingHandler = function ($, error) {
     error: EXCEL_504_ERROR_MESSAGE,
     delayType: 'step',
     delayInMs: 'default',
-    errorCode: EXCEL_504_ERROR_CODE,
+    maxAttempts: EXCEL_504_MAX_ATTEMPTS,
   })
 }
 

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -101,16 +101,44 @@ const handle500and502and503: ThrowingHandler = function ($, error) {
 
 //
 // Handle 504 Gateway Timeout - typically caused by long-running formulas.
-// We intentionally don't pass the HttpError as cause to prevent auto-retry,
-// since retrying won't help if the file has long-running formulas.
+// Test runs: fail immediately with helpful message.
+// Live runs: retry up to 3 times, then fail with helpful message.
 //
-const handle504: ThrowingHandler = function ($) {
-  throw new StepError(
-    'Excel request timed out',
+export const EXCEL_504_ERROR_CODE = 'EXCEL_504'
+export const EXCEL_504_MAX_ATTEMPTS = 3
+const EXCEL_504_ERROR_MESSAGE = {
+  name: 'Excel request timed out',
+  solution:
     'Your Excel file most likely has long-running formulas. Please either simplify the formulas or set the calculation options (under the Formulas tab) to manual instead of automatic.',
-    $.step.position,
-    $.app.name,
-  )
+}
+
+const handle504: ThrowingHandler = function ($, error) {
+  logger.warn('Received HTTP 504 from MS Graph', {
+    event: 'm365-http-504',
+    tenant: $.auth?.data?.tenantKey as string,
+    baseUrl: error.response.config.baseURL,
+    url: error.response.config.url,
+    flowId: $.flow?.id,
+    stepId: $.step?.id,
+    executionId: $.execution?.id,
+  })
+
+  // For test runs, fail immediately with user-friendly message
+  if ($.execution?.testRun) {
+    throw new StepError(
+      EXCEL_504_ERROR_MESSAGE.name,
+      EXCEL_504_ERROR_MESSAGE.solution,
+    )
+  }
+
+  // For live runs, throw RetriableError with user-friendly message
+  // The message will be saved as errorDetails, so it's correct from the start
+  throw new RetriableError({
+    error: EXCEL_504_ERROR_MESSAGE,
+    delayType: 'step',
+    delayInMs: 'default',
+    errorCode: EXCEL_504_ERROR_CODE,
+  })
 }
 
 //

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -1,6 +1,7 @@
 import type { IApp } from '@plumber/types'
 
 import RetriableError from '@/errors/retriable-error'
+import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 import { parseRetryAfterToMs } from '@/helpers/parse-retry-after-to-ms'
 
@@ -99,6 +100,20 @@ const handle500and502and503: ThrowingHandler = function ($, error) {
 }
 
 //
+// Handle 504 Gateway Timeout - typically caused by long-running formulas.
+// We intentionally don't pass the HttpError as cause to prevent auto-retry,
+// since retrying won't help if the file has long-running formulas.
+//
+const handle504: ThrowingHandler = function ($) {
+  throw new StepError(
+    'Excel request timed out',
+    'Your Excel file most likely has long-running formulas. Please either simplify the formulas or set the calculation options (under the Formulas tab) to manual instead of automatic.',
+    $.step.position,
+    $.app.name,
+  )
+}
+
+//
 // Handle exceeding bandwidth limit
 //
 const handle509: ThrowingHandler = function ($, error) {
@@ -131,6 +146,8 @@ const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
     case 502: // Bad gateway
     case 503: // Transient error
       return handle500and502and503($, error)
+    case 504: // Gateway timeout - likely due to long-running formulas
+      return handle504($, error)
     case 509: // Bandwidth limit reached
       return handle509($, error)
     default:

--- a/packages/backend/src/errors/retriable-error.ts
+++ b/packages/backend/src/errors/retriable-error.ts
@@ -6,6 +6,8 @@ interface RetriableErrorParams {
   error: ConstructorParameters<typeof BaseError>[0]
   delayInMs: number | 'default'
   delayType: 'step' | 'group' | 'queue'
+  /** Optional error code for custom retry behavior (e.g., different max attempts) */
+  errorCode?: string
 }
 
 /**
@@ -35,11 +37,18 @@ interface RetriableErrorParams {
 export default class RetriableError extends BaseError {
   delayInMs: number
   delayType: RetriableErrorParams['delayType']
+  errorCode?: string
 
-  constructor({ error, delayInMs, delayType }: RetriableErrorParams) {
+  constructor({
+    error,
+    delayInMs,
+    delayType,
+    errorCode,
+  }: RetriableErrorParams) {
     super(error)
 
     this.delayInMs = delayInMs === 'default' ? DEFAULT_DELAY_MS : delayInMs
     this.delayType = delayType
+    this.errorCode = errorCode
   }
 }

--- a/packages/backend/src/errors/retriable-error.ts
+++ b/packages/backend/src/errors/retriable-error.ts
@@ -6,8 +6,8 @@ interface RetriableErrorParams {
   error: ConstructorParameters<typeof BaseError>[0]
   delayInMs: number | 'default'
   delayType: 'step' | 'group' | 'queue'
-  /** Optional error code for custom retry behavior (e.g., different max attempts) */
-  errorCode?: string
+  /** Optional override for the max number of job attempts before failing. */
+  maxAttempts?: number
 }
 
 /**
@@ -37,18 +37,18 @@ interface RetriableErrorParams {
 export default class RetriableError extends BaseError {
   delayInMs: number
   delayType: RetriableErrorParams['delayType']
-  errorCode?: string
+  maxAttempts?: number
 
   constructor({
     error,
     delayInMs,
     delayType,
-    errorCode,
+    maxAttempts,
   }: RetriableErrorParams) {
     super(error)
 
     this.delayInMs = delayInMs === 'default' ? DEFAULT_DELAY_MS : delayInMs
     this.delayType = delayType
-    this.errorCode = errorCode
+    this.maxAttempts = maxAttempts
   }
 }

--- a/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
+++ b/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
@@ -5,12 +5,25 @@ import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { type Span } from 'dd-trace'
 import get from 'lodash.get'
 
+import {
+  EXCEL_504_ERROR_CODE,
+  EXCEL_504_MAX_ATTEMPTS,
+} from '@/apps/m365-excel/common/interceptors/request-error-handler'
 import HttpError from '@/errors/http'
 import RetriableError from '@/errors/retriable-error'
 import StepError from '@/errors/step'
 import ExecutionStep from '@/models/execution-step'
 
 import { MAXIMUM_JOB_ATTEMPTS } from '../default-job-configuration'
+
+/**
+ * Map of error codes to their custom max attempts.
+ * When max attempts is reached, the job fails with the error message
+ * that was already set in errorDetails (from RetriableError).
+ */
+const ERROR_CODE_MAX_ATTEMPTS: Record<string, number> = {
+  [EXCEL_504_ERROR_CODE]: EXCEL_504_MAX_ATTEMPTS,
+}
 import { parseRetryAfterToMs } from '../parse-retry-after-to-ms'
 
 /**
@@ -33,16 +46,17 @@ function handleRetriableError(
   executionError: RetriableError,
   context: HandleFailedStepAndThrowParams['context'],
 ): never {
-  const { delayType, delayInMs } = executionError
+  const { delayType, delayInMs, errorCode } = executionError
   const { worker, job, isQueueDelayable } = context
+
+  // Use custom max attempts if errorCode has one configured
+  const maxAttempts = errorCode
+    ? ERROR_CODE_MAX_ATTEMPTS[errorCode] ?? MAXIMUM_JOB_ATTEMPTS
+    : MAXIMUM_JOB_ATTEMPTS
 
   switch (delayType) {
     case 'queue':
-      checkIfAttemptsExhausted(
-        job.attemptsStarted,
-        MAXIMUM_JOB_ATTEMPTS,
-        executionError,
-      )
+      checkIfAttemptsExhausted(job.attemptsStarted, maxAttempts, executionError)
       if (isQueueDelayable) {
         worker.rateLimit(delayInMs)
         throw WorkerPro.RateLimitError()
@@ -56,11 +70,7 @@ function handleRetriableError(
       // off a small alert.
       throw executionError
     case 'group': {
-      checkIfAttemptsExhausted(
-        job.attemptsStarted,
-        MAXIMUM_JOB_ATTEMPTS,
-        executionError,
-      )
+      checkIfAttemptsExhausted(job.attemptsStarted, maxAttempts, executionError)
       const groupId = job.opts?.group?.id
       if (groupId) {
         worker.rateLimitGroup(job, delayInMs)
@@ -72,7 +82,9 @@ function handleRetriableError(
       throw executionError
     }
     case 'step':
-      // Finally, OK to pass this through to our worker's retry handler
+      // Check if max attempts reached for custom error codes
+      checkIfAttemptsExhausted(job.attemptsStarted, maxAttempts, executionError)
+      // OK to pass this through to our worker's retry handler
       throw executionError
   }
 }
@@ -168,12 +180,21 @@ export function handleFailedStepAndThrow(
     throw new UnrecoverableError(JSON.stringify(errorDetails))
   } catch (finalError) {
     // Update span and execution status as necessary.
+    // Use custom max attempts if the error has an errorCode configured
+    const errorCode =
+      executionError instanceof RetriableError
+        ? executionError.errorCode
+        : undefined
+    const effectiveMaxAttempts = errorCode
+      ? ERROR_CODE_MAX_ATTEMPTS[errorCode] ?? MAXIMUM_JOB_ATTEMPTS
+      : MAXIMUM_JOB_ATTEMPTS
+
     const isRetriable =
       !(finalError instanceof UnrecoverableError) &&
       // -1 is needed because BullMQ only increments attemptsMade _after_ the
       // job processor finishes, but we're currently still inside the job
       // processor.
-      job.attemptsMade < MAXIMUM_JOB_ATTEMPTS - 1
+      job.attemptsMade < effectiveMaxAttempts - 1
 
     span?.addTags({
       willRetry: isRetriable ? 'true' : 'false',

--- a/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
+++ b/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
@@ -5,25 +5,12 @@ import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { type Span } from 'dd-trace'
 import get from 'lodash.get'
 
-import {
-  EXCEL_504_ERROR_CODE,
-  EXCEL_504_MAX_ATTEMPTS,
-} from '@/apps/m365-excel/common/interceptors/request-error-handler'
 import HttpError from '@/errors/http'
 import RetriableError from '@/errors/retriable-error'
 import StepError from '@/errors/step'
 import ExecutionStep from '@/models/execution-step'
 
 import { MAXIMUM_JOB_ATTEMPTS } from '../default-job-configuration'
-
-/**
- * Map of error codes to their custom max attempts.
- * When max attempts is reached, the job fails with the error message
- * that was already set in errorDetails (from RetriableError).
- */
-const ERROR_CODE_MAX_ATTEMPTS: Record<string, number> = {
-  [EXCEL_504_ERROR_CODE]: EXCEL_504_MAX_ATTEMPTS,
-}
 import { parseRetryAfterToMs } from '../parse-retry-after-to-ms'
 
 /**
@@ -46,13 +33,15 @@ function handleRetriableError(
   executionError: RetriableError,
   context: HandleFailedStepAndThrowParams['context'],
 ): never {
-  const { delayType, delayInMs, errorCode } = executionError
+  const {
+    delayType,
+    delayInMs,
+    maxAttempts: customMaxAttempts,
+  } = executionError
   const { worker, job, isQueueDelayable } = context
 
-  // Use custom max attempts if errorCode has one configured
-  const maxAttempts = errorCode
-    ? ERROR_CODE_MAX_ATTEMPTS[errorCode] ?? MAXIMUM_JOB_ATTEMPTS
-    : MAXIMUM_JOB_ATTEMPTS
+  // Use the error's custom max attempts if it specified one
+  const maxAttempts = customMaxAttempts ?? MAXIMUM_JOB_ATTEMPTS
 
   switch (delayType) {
     case 'queue':
@@ -180,14 +169,11 @@ export function handleFailedStepAndThrow(
     throw new UnrecoverableError(JSON.stringify(errorDetails))
   } catch (finalError) {
     // Update span and execution status as necessary.
-    // Use custom max attempts if the error has an errorCode configured
-    const errorCode =
-      executionError instanceof RetriableError
-        ? executionError.errorCode
-        : undefined
-    const effectiveMaxAttempts = errorCode
-      ? ERROR_CODE_MAX_ATTEMPTS[errorCode] ?? MAXIMUM_JOB_ATTEMPTS
-      : MAXIMUM_JOB_ATTEMPTS
+    // Use the error's custom max attempts if it specified one.
+    const effectiveMaxAttempts =
+      (executionError instanceof RetriableError
+        ? executionError.maxAttempts
+        : undefined) ?? MAXIMUM_JOB_ATTEMPTS
 
     const isRetriable =
       !(finalError instanceof UnrecoverableError) &&


### PR DESCRIPTION
## Problem
Felt like there's no need to retry 504 timeout errors especially most of the times its just long running formulas.
I realise that power automate has the same issue and they just let the execution run for 15 mins and then it fails as a gateway timeout issue similar to us.

## Solution
Temporary fix:
- Format 504 errors as a `StepError` and give the exact solution to update their excel file instead of praying that they look at our guide or they will end up sending in a ticket to Plumber support

### What changed
- request-error-handler.ts — new handle504 that branches on test vs live run:
  - Test run → fails immediately with StepError ("Excel request timed out... long-running formulas")
  - Live run → throws RetriableError with errorCode: EXCEL_504_ERROR_CODE
- retriable-error.ts — added optional errorCode field to carry custom retry identity
- handle-failed-step-and-throw.ts — new ERROR_CODE_MAX_ATTEMPTS map (EXCEL_504 → 3), and handleRetriableError now uses it to cap retries per error code

## Before & After Screenshots

**BEFORE**:
<img width="2554" height="1310" alt="image" src="https://github.com/user-attachments/assets/92fea33b-9ff8-4658-932e-7f6769b0e48d" />

**AFTER**:
<img width="1164" height="308" alt="image" src="https://github.com/user-attachments/assets/54ba142d-f53a-44da-9649-ae0edefb9500" />

## Tests
Create an excel file with long running formulas -- i can pass you a file if needed
Before publishing the pipe
1. Set the excel file calculation options to be `Automatic`
2. Try creating an excel row in test step and it should give that new formatted error
3. Set the excel file calculation options to be `Manual`, wait for 5-10 minutes if necessary
4. Try creating an excel row in test step and it should not have any error

Publish the pipe and test live executions
1. Publish the pipe and test a live execution (should succeed)
2. Set the calculation options back to `Automatic`
3. Test another live execution and the new formatted error should appear and auto-retry should be done
  - 504 on attempt 1, 2 → job retries (RetriableError rethrown)
  - 504 on attempt 3 → job stops with UnrecoverableError, error message from RetriableError is preserved in errorDetails
5. Test that you can retry the failed execution and it should still fail
6. Then set the calculation options back to `Manual`
7. Test that you can retry the failed execution and it should now succeed


### Regression:
  - Other 5xx errors (500, 502, 503) → unaffected, still use their existing handlers
  - Non-m365 apps with step-type RetriableError → now capped at MAXIMUM_JOB_ATTEMPTS (new behaviour — verify this is safe)
  - Warning log fires on 504 with event: 'm365-http-504'

