### PR TITLE
PLU-704: standardise mrf date field format to follow non-mrf forms

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
@@ -1,3 +1,6 @@
+// you need to import this to make the toPlumberFormat method available
+import '@/types/luxon-extensions'
+
 import type { IGlobalVariable } from '@plumber/types'
 
 import { describe, expect, it, vi } from 'vitest'
@@ -346,6 +349,76 @@ describe('processResponsesV3', () => {
           answer: 'test',
         },
       ])
+    })
+  })
+
+  describe('date fields', () => {
+    it('converts DD/MM/YYYY to DD MMM YYYY format', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        dt1: { fieldType: 'date', answer: '29/03/2026' },
+      })
+
+      expect(result[0]).toMatchObject({
+        _id: 'dt1',
+        fieldType: 'date',
+        question: 'Date of birth',
+        answer: '29 Mar 2026',
+      })
+    })
+
+    it('should pad single digit dates with 0 in front', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        dt1: { fieldType: 'date', answer: '01/03/2026' },
+      })
+
+      expect(result[0]).toMatchObject({
+        _id: 'dt1',
+        fieldType: 'date',
+        question: 'Date of birth',
+        answer: '01 Mar 2026',
+      })
+    })
+
+    it('should use Sep not Sept for September', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        dt1: { fieldType: 'date', answer: '01/09/2026' },
+      })
+
+      expect(result[0]).toMatchObject({
+        _id: 'dt1',
+        fieldType: 'date',
+        question: 'Date of birth',
+        answer: '01 Sep 2026',
+      })
+    })
+
+    it('uses Question N fallback when field not in schema', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeFormSchema([]))
+
+      const result = await processResponsesV3($, 'formId', {
+        dt1: { fieldType: 'date', answer: '01/01/2025' },
+      })
+
+      expect(result[0].question).toBe('Question 1')
+      expect(result[0].answer).toBe('01 Jan 2025')
     })
   })
 

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -1,6 +1,7 @@
 import type { IGlobalVariable } from '@plumber/types'
 
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
+import { DateTime } from 'luxon'
 
 import logger from '@/helpers/logger'
 
@@ -120,6 +121,21 @@ export async function processResponsesV3(
         question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
         // we temporarily store the filename in answer, it will subsequently be replaced with the S3 ID from storeAttachmentInS3
         answer: value.answer.answer,
+      })
+      continue
+    }
+    if (value.fieldType === 'date') {
+      // Currently, v3 responses return the date as DD/MM/YYYY (e.g. 29/03/2026)
+      // We need to convert it to the standard FormSG date format (e.g. 29 Mar 2026)
+      const originalDateString = value.answer
+      const originalDate = DateTime.fromFormat(originalDateString, 'dd/MM/yyyy')
+      const convertedDateString = originalDate.toPlumberFormat('dd MMM yyyy')
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answer: convertedDateString,
       })
       continue
     }


### PR DESCRIPTION
## Changes

- standardize date field format from MRF form responses to follow non-MRF forms
- i.e. automatically convert dates from dd/MM/yyyy to dd MM yyyy (01/09/2026 to 01 Sep 2026)

## ![Screenshot 2026-04-01 at 3.21.18 PM.png](https://app.graphite.com/user-attachments/assets/d24982ce-53a7-4efb-9450-8203fc9db1c7.png)



## To test

- [ ] Submit an MRF form with date field, it should show the dd MM yyyy format
- [ ] New test cases should pass