### PR TITLE
PLU-685: prevent mrf step renaming on frontend

### DIFF
--- a/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
+++ b/packages/frontend/src/components/EditorRightDrawer/StepHeader.tsx
@@ -32,7 +32,8 @@ export default function StepHeader(props: StepHeaderProps) {
     setCurrentStepId,
     setShouldWarnOnLeave,
   } = useContext(EditorContext)
-  const { defaultStepName, displayPosition, stepName } = useStepMetadata(step)
+  const { defaultStepName, displayPosition, stepName, isMrfStep } =
+    useStepMetadata(step)
 
   const handleClose = () => {
     if (shouldWarnOnLeave) {
@@ -72,7 +73,8 @@ export default function StepHeader(props: StepHeaderProps) {
           key={step.id}
           value={stepName}
           onSave={onSave}
-          readOnly={isReadOnlyEditor}
+          // We don't allow editing the step name for MRF steps
+          readOnly={isReadOnlyEditor || isMrfStep}
           placeholder={defaultStepName}
           allowEmpty={true}
         />

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -95,9 +95,13 @@ export function useStepMetadata(
     [readOnly, selectedActionOrTrigger, step?.key],
   )
 
+  // isMrfStep = includes both trigger and mrf action steps
   const isMrfStep = useMemo(() => {
+    if (isTrigger && !!step?.parameters?.mrf) {
+      return true
+    }
     return mrfSteps.some((mrfStep) => mrfStep.id === step?.id)
-  }, [mrfSteps, step?.id])
+  }, [isTrigger, mrfSteps, step?.id, step?.parameters?.mrf])
 
   const isApprovalStep = useMemo(() => {
     if (!step?.id) {


### PR DESCRIPTION
## Changes

- Prevent step names for MRF steps from being edited

## ![Screenshot 2026-04-01 at 3.47.50 PM.png](https://app.graphite.com/user-attachments/assets/e30d2764-969a-4f85-9875-5bbfbaa54d4d.png)



## Tests

- [ ] Connect an MRF form with workflow steps, you should not be able to update the step names for the trigger and subsequent mrf actions steps 
- [ ] Connect an MRF form with NO workflow steps, the step name should be editable. On check step the edited step name should persist as well.