### PR TITLE
PLU-710: map uinFin (Step 1) to uinFin

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -324,73 +324,104 @@ describe('decrypt form response - MRF specific', () => {
     })
   })
 
-  describe('attachment storage ID suffix for MRF', () => {
-    it('should suffix storageId with workflowStep for MRF attachments', async () => {
-      $.flow.hasFileProcessingActions = true
-      const workflowContent = makeWorkflowContent(2)
-      $.request.body.data.workflowContent = workflowContent
-      $.request.body.data.attachmentDownloadUrls = {
-        attachmentField1: 'https://example.com/download/1',
-      }
-      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
-
+  describe('verifiedSubmitterInfo for MRF submissions', () => {
+    it('should map "uinFin (Step 1)" to uinFin and sgidUinFin', async () => {
+      $.request.body.data.workflowContent = makeWorkflowContent(1)
       mocks.cryptoV3Decrypt.mockReturnValueOnce({
-        responses: {
-          attachmentField1: {
-            fieldType: 'attachment',
-            answer: { answer: 'myfile.pdf' },
-          },
-        },
-        verified: undefined,
-      })
-      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
-        attachmentField1: {
-          filename: 'myfile.pdf',
-          content: Buffer.from('file content'),
-        },
+        responses: {},
+        verified: { 'uinFin (Step 1)': 'S1234567A' },
       })
 
       await decryptFormResponse($)
 
-      expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
-        $,
-        'submissionId-2',
-        expect.anything(),
-        expect.anything(),
-      )
+      expect($.request.body.verifiedSubmitterInfo).toEqual({
+        uinFin: 'S1234567A',
+        sgidUinFin: 'S1234567A',
+      })
     })
 
-    it('should not suffix storageId for non-MRF attachments', async () => {
-      $.flow.hasFileProcessingActions = true
-      $.request.body.data.attachmentDownloadUrls = {
-        attachmentField1: 'https://example.com/download/1',
-      }
-      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
-
+    it('should still map plain uinFin key correctly', async () => {
+      $.request.body.data.workflowContent = makeWorkflowContent(0)
       mocks.cryptoV3Decrypt.mockReturnValueOnce({
-        responses: {
-          attachmentField1: {
-            fieldType: 'attachment',
-            answer: { answer: 'myfile.pdf' },
-          },
-        },
-        verified: undefined,
-      })
-      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
-        attachmentField1: {
-          filename: 'myfile.pdf',
-          content: Buffer.from('file content'),
-        },
+        responses: {},
+        verified: { uinFin: 'S1234567A' },
       })
 
       await decryptFormResponse($)
 
-      expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
-        $,
-        'submissionId',
-        expect.anything(),
-        expect.anything(),
-      )
+      expect($.request.body.verifiedSubmitterInfo).toEqual({
+        uinFin: 'S1234567A',
+        sgidUinFin: 'S1234567A',
+      })
+    })
+    describe('attachment storage ID suffix for MRF', () => {
+      it('should suffix storageId with workflowStep for MRF attachments', async () => {
+        $.flow.hasFileProcessingActions = true
+        const workflowContent = makeWorkflowContent(2)
+        $.request.body.data.workflowContent = workflowContent
+        $.request.body.data.attachmentDownloadUrls = {
+          attachmentField1: 'https://example.com/download/1',
+        }
+        $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
+
+        mocks.cryptoV3Decrypt.mockReturnValueOnce({
+          responses: {
+            attachmentField1: {
+              fieldType: 'attachment',
+              answer: { answer: 'myfile.pdf' },
+            },
+          },
+          verified: undefined,
+        })
+        mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+          attachmentField1: {
+            filename: 'myfile.pdf',
+            content: Buffer.from('file content'),
+          },
+        })
+
+        await decryptFormResponse($)
+
+        expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
+          $,
+          'submissionId-2',
+          expect.anything(),
+          expect.anything(),
+        )
+      })
+
+      it('should not suffix storageId for non-MRF attachments', async () => {
+        $.flow.hasFileProcessingActions = true
+        $.request.body.data.attachmentDownloadUrls = {
+          attachmentField1: 'https://example.com/download/1',
+        }
+        $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
+
+        mocks.cryptoV3Decrypt.mockReturnValueOnce({
+          responses: {
+            attachmentField1: {
+              fieldType: 'attachment',
+              answer: { answer: 'myfile.pdf' },
+            },
+          },
+          verified: undefined,
+        })
+        mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+          attachmentField1: {
+            filename: 'myfile.pdf',
+            content: Buffer.from('file content'),
+          },
+        })
+
+        await decryptFormResponse($)
+
+        expect(mocks.storeAttachmentInS3).toHaveBeenCalledWith(
+          $,
+          'submissionId',
+          expect.anything(),
+          expect.anything(),
+        )
+      })
     })
   })
 })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -242,6 +242,7 @@ export async function decryptFormResponse(
       for (const key of Object.keys(submission.verified)) {
         let value = submission.verified[key]
 
+        // @deprecated: filterNrics not supported new pipes
         if (NRIC_VERIFIED_FIELDS.has(key)) {
           value = filterNric($, value)
           if (!value) {
@@ -250,7 +251,14 @@ export async function decryptFormResponse(
         }
 
         // for backwards compatibility with old forms that were created with sgID authType
-        if (key === 'uinFin' || key === 'sgidUinFin') {
+        if (
+          key === 'uinFin' ||
+          key === 'sgidUinFin' ||
+          // v3 mrf forms send nric as "uinFin (Step 1)"
+          // brackets break the variable regex and is not the same as mock data
+          // we need to map it back to uinFin
+          key.startsWith('uinFin')
+        ) {
           verifiedSubmitterInfo['uinFin'] = value
           verifiedSubmitterInfo['sgidUinFin'] = value
         } else {


### PR DESCRIPTION
## Changes

- fix issue where the variable for myinfo nric cannot be used in MRF-connected pipes
    - main cause: the key for mrf is "verifiedSubmitterInfo.uinFin (Step 1)" instead of just "verifiedSubmitterInfo.uinFin". As a result, it breaks the variable regex.
    - fix by mapping to original key 

## ![image.png](https://app.graphite.com/user-attachments/assets/310f14e7-4071-4de0-b50f-1d91b518cd51.png)



## Tests

- [ ] Submit an MRF form with myinfo login (enable collect uin/fin), you should be able to use the uin/fin in subsequent steps properly