### PR TITLE
PLU-427 (feat): preview postman dataOut body

### DIFF
--- a/packages/backend/src/apps/postman/actions/send-transactional-email/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/get-data-out-metadata.ts
@@ -1,0 +1,50 @@
+import { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut) {
+    return null
+  }
+
+  const metadata: IDataOutMetadata = {
+    subject: {
+      label: 'Email subject',
+      order: 1,
+    },
+    body: {
+      label: 'Body',
+      order: 2,
+      type: 'html',
+      displayedValue: 'Preview body',
+    },
+    recipient: {
+      label: 'Recipient email(s)',
+      order: 3,
+      type: 'array',
+    },
+    status: {
+      label: 'Status',
+      order: 4,
+      type: 'array',
+    },
+    cc: {
+      label: 'CC recipient email(s)',
+      order: 5,
+      type: 'array',
+    },
+    from: {
+      label: 'Sender',
+      order: 6,
+    },
+    reply_to: {
+      label: 'Reply-To email',
+      order: 7,
+    },
+  }
+
+  return metadata
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -21,6 +21,8 @@ import { sendBlacklistEmail } from '../../common/send-blacklist-email'
 import { sendInvalidAttachmentsEmail } from '../../common/send-invalid-attachments-email'
 import { throwPostmanStepError } from '../../common/throw-errors'
 
+import getDataOutMetadata from './get-data-out-metadata'
+
 const action: IRawAction = {
   name: 'Send email',
   key: 'sendTransactionalEmail',
@@ -32,6 +34,8 @@ const action: IRawAction = {
       (step.parameters.attachments as IJSONArray).length > 0
     )
   },
+
+  getDataOutMetadata,
 
   async run($) {
     const {

--- a/packages/frontend/src/components/RichTextEditor/ResizableImageExtension.tsx
+++ b/packages/frontend/src/components/RichTextEditor/ResizableImageExtension.tsx
@@ -1,6 +1,6 @@
 import { type CSSProperties, useCallback, useRef, useState } from 'react'
 import { RiSendToBack } from 'react-icons/ri'
-import TipTapImage from '@tiptap/extension-image'
+import TipTapImage, { type ImageOptions } from '@tiptap/extension-image'
 import {
   type NodeViewProps,
   NodeViewWrapper,
@@ -10,7 +10,19 @@ import {
 const MIN_WIDTH = 60
 const MAX_WIDTH = 750
 
-const ResizableImageTemplate = ({ node, updateAttributes }: NodeViewProps) => {
+export interface ResizableImageOptions extends ImageOptions {
+  /**
+   * Controls whether to show the resize handle. Defaults to true.
+   */
+  resizable?: boolean
+}
+
+const ResizableImageTemplate = ({
+  node,
+  updateAttributes,
+  extension,
+}: NodeViewProps) => {
+  const resizable = extension.options.resizable ?? true // default true
   const imgRef = useRef<HTMLImageElement>(null)
   const [resizingStyle, setResizingStyle] = useState<
     Pick<CSSProperties, 'width'> | undefined
@@ -68,29 +80,37 @@ const ResizableImageTemplate = ({ node, updateAttributes }: NodeViewProps) => {
           style={Object.assign(
             {},
             {
-              marginBottom: '-16px',
+              marginBottom: resizable ? '-16px' : undefined,
             },
             resizingStyle,
           )}
         />
 
-        <div
-          role="button"
-          tabIndex={0}
-          onMouseDown={handleMouseDown}
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-          }}
-        >
-          <RiSendToBack />
-        </div>
+        {resizable && (
+          <div
+            role="button"
+            tabIndex={0}
+            onMouseDown={handleMouseDown}
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <RiSendToBack />
+          </div>
+        )}
       </div>
     </NodeViewWrapper>
   )
 }
 
-const ResizableImageExtension = TipTapImage.extend({
+const ResizableImageExtension = TipTapImage.extend<ResizableImageOptions>({
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      resizable: true,
+    }
+  },
   addAttributes() {
     return {
       ...this.parent?.(),
@@ -101,6 +121,6 @@ const ResizableImageExtension = TipTapImage.extend({
   addNodeView() {
     return ReactNodeViewRenderer(ResizableImageTemplate)
   },
-}).configure({ inline: true })
+}).configure({ inline: true, resizable: true })
 
 export default ResizableImageExtension

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -145,7 +145,7 @@ const Editor = ({
     Placeholder.configure({
       placeholder,
     }),
-    !isDisplayOnly && StepVariable,
+    ...(isDisplayOnly ? [] : [StepVariable]),
     ImageResize.configure({
       inline: true,
       resizable: !isDisplayOnly,

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -84,9 +84,6 @@ const RICH_TEXT_EXTENSIONS = [
         'border:1px solid black;padding: 5px 10px;min-width: 100px;height: 15px;',
     },
   }),
-  ImageResize.configure({
-    inline: true,
-  }),
 ]
 
 interface EditorProps {
@@ -103,6 +100,7 @@ interface EditorProps {
   singleVariableSelection?: boolean
   noVariablesMessage?: string
   customRteMenuOptions?: TRteMenuOption[]
+  isDisplayOnly?: boolean
 }
 const Editor = ({
   onChange,
@@ -118,12 +116,14 @@ const Editor = ({
   autoFocus = false,
   noVariablesMessage,
   customRteMenuOptions,
+  isDisplayOnly = false,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
   const { allApps } = useContext(EditorContext)
   const isMobile = useIsMobile()
   const isMulticol = parentType === 'multicol'
+  const showMenuBar = isRich && !isDisplayOnly
 
   const [stepsWithVariables, varInfo] = useMemo(() => {
     const stepsWithVars = filterVariables(
@@ -145,7 +145,11 @@ const Editor = ({
     Placeholder.configure({
       placeholder,
     }),
-    StepVariable,
+    !isDisplayOnly && StepVariable,
+    ImageResize.configure({
+      inline: true,
+      resizable: !isDisplayOnly,
+    }),
   ]
 
   /**
@@ -160,7 +164,9 @@ const Editor = ({
     return escapeHtml(initialValue)
   }, [initialValue, isRich])
 
-  let content = substituteOldTemplates(unsubstituedValue, varInfo) // backward compatibility with old values from PowerInput
+  let content = isDisplayOnly
+    ? unsubstituedValue
+    : substituteOldTemplates(unsubstituedValue, varInfo) // backward compatibility with old values from PowerInput
   // convert new line character into br elem so tiptap can load the content correctly
   content = content.replaceAll('\n', '<br>')
 
@@ -289,10 +295,11 @@ const Editor = ({
           }
           closeSuggestions()
         }}
+        {...(isDisplayOnly && { style: { border: 'none' } })}
       >
         <PopoverTrigger>
           <Box className={isMulticol ? 'single-line-editor' : undefined}>
-            {isRich && (
+            {showMenuBar && (
               <MenuBar
                 editor={editor}
                 variableMap={varInfo}
@@ -308,6 +315,7 @@ const Editor = ({
                   e.preventDefault()
                 }
               }}
+              {...(isDisplayOnly && { style: { height: '60vh' } })}
             />
             <Portal>
               <PopoverContent
@@ -355,6 +363,7 @@ interface RichTextEditorProps {
   singleVariableSelection?: boolean
   noVariablesMessage?: string
   customRteMenuOptions?: TRteMenuOption[]
+  isDisplayOnly?: boolean
 }
 const RichTextEditor = ({
   required,
@@ -373,6 +382,7 @@ const RichTextEditor = ({
   singleVariableSelection,
   noVariablesMessage,
   customRteMenuOptions,
+  isDisplayOnly = false,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -411,7 +421,7 @@ const RichTextEditor = ({
           <Editor
             onChange={onChange}
             initialValue={value}
-            editable={!readOnly}
+            editable={!readOnly && !isDisplayOnly}
             placeholder={placeholder}
             variablesEnabled={variablesEnabled}
             isRich={isRich}
@@ -422,6 +432,7 @@ const RichTextEditor = ({
             singleVariableSelection={singleVariableSelection}
             noVariablesMessage={noVariablesMessage}
             customRteMenuOptions={customRteMenuOptions}
+            isDisplayOnly={isDisplayOnly}
           />
         )}
       />

--- a/packages/frontend/src/components/VariablesList/HtmlVariableModal.tsx
+++ b/packages/frontend/src/components/VariablesList/HtmlVariableModal.tsx
@@ -1,0 +1,59 @@
+import {
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react'
+
+import { Variable } from '@/helpers/variables'
+
+import RichTextEditor from '../RichTextEditor'
+
+interface VariableHtmlModalProps {
+  isOpen: boolean
+  onClose: () => void
+  variable: Variable
+}
+
+export default function VariableHtmlModal({
+  isOpen,
+  onClose,
+  variable,
+}: VariableHtmlModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="6xl"
+      motionPreset="none"
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent maxH="80vh" overflow="hidden" borderRadius="lg">
+        <ModalHeader
+          position="sticky"
+          top={0}
+          bg="white"
+          zIndex={1}
+          borderBottom="1px solid"
+          borderColor="base.divider.medium"
+        >
+          <Flex direction="column">Email body</Flex>
+          <ModalCloseButton />
+        </ModalHeader>
+        <ModalBody>
+          <RichTextEditor
+            name={variable.name}
+            defaultValue={variable.value as string}
+            isRich
+            variablesEnabled={false}
+            isDisplayOnly={true}
+          />
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
+++ b/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { MdOpenInNew } from 'react-icons/md'
 import { useDisclosure } from '@chakra-ui/react'
 
@@ -27,7 +27,7 @@ export default function VariableItemWithModal(
       variable.displayedValue !== 'Preview 0 row(s)') ||
     variable.type === 'html'
 
-  const ModalComponent = useMemo(() => {
+  const renderModal = () => {
     switch (variable.type) {
       case 'table':
         return (
@@ -47,7 +47,7 @@ export default function VariableItemWithModal(
           />
         )
     }
-  }, [currentTestExecutionStep, isOpen, onClose, variable])
+  }
 
   return (
     <>
@@ -59,7 +59,7 @@ export default function VariableItemWithModal(
         onClick={onClick ? onClick : canOpenModal ? onOpen : undefined}
         withIcon={onClick ? undefined : canOpenModal ? MdOpenInNew : undefined}
       />
-      {!onClick && ModalComponent}
+      {!onClick && renderModal()}
     </>
   )
 }

--- a/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
+++ b/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
@@ -1,0 +1,65 @@
+import { useContext, useMemo } from 'react'
+import { MdOpenInNew } from 'react-icons/md'
+import { useDisclosure } from '@chakra-ui/react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { Variable } from '@/helpers/variables'
+
+import HtmlVariableModal from './HtmlVariableModal'
+import TableVariableModal from './TableVariableModal'
+import { VariableItem } from '.'
+
+interface VariableItemWithModalProps {
+  variable: Variable
+  onClick?: (variable: Variable) => void
+}
+
+export default function VariableItemWithModal(
+  props: VariableItemWithModalProps,
+) {
+  const { onClick, variable } = props
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { currentTestExecutionStep } = useContext(EditorContext)
+
+  const canOpenModal =
+    // we do not want to show a table preview if there are no rows
+    (variable.type === 'table' &&
+      variable.displayedValue !== 'Preview 0 row(s)') ||
+    variable.type === 'html'
+
+  const ModalComponent = useMemo(() => {
+    switch (variable.type) {
+      case 'table':
+        return (
+          <TableVariableModal
+            variableId={variable.name}
+            isOpen={isOpen}
+            onClose={onClose}
+            currentExecutionStep={currentTestExecutionStep}
+          />
+        )
+      case 'html':
+        return (
+          <HtmlVariableModal
+            variable={variable}
+            isOpen={isOpen}
+            onClose={onClose}
+          />
+        )
+    }
+  }, [currentTestExecutionStep, isOpen, onClose, variable])
+
+  return (
+    <>
+      <VariableItem
+        key={`variable-${variable.name}`}
+        variable={variable}
+        // if onClick is provided, it means that the variable is being used in a Suggestions component
+        // no need to open the modal or show the icon
+        onClick={onClick ? onClick : canOpenModal ? onOpen : undefined}
+        withIcon={onClick ? undefined : canOpenModal ? MdOpenInNew : undefined}
+      />
+      {!onClick && ModalComponent}
+    </>
+  )
+}

--- a/packages/frontend/src/components/VariablesList/index.tsx
+++ b/packages/frontend/src/components/VariablesList/index.tsx
@@ -21,8 +21,9 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { type Variable } from '@/helpers/variables'
 import { POPOVER_MOTION_PROPS } from '@/theme/constants'
 
-import TableVariableItem from './TableVariableItem'
+import VariableItemWithModal from './VariableItemWithModal'
 
+const VARIABLES_WITH_MODALS = ['table', 'html']
 const VARIABLE_ITEM_HEIGHT = 77
 const SUGGESTION_VARIABLE_ITEM_HEIGHT = 61
 
@@ -233,6 +234,9 @@ export default function VariablesList(props: VariablesListProps) {
         {virtualizer.getVirtualItems().map((virtualItem) => {
           const variable = defaultVariables[virtualItem.index]
           const isLast = virtualItem.index === defaultVariables.length - 1
+          const isVariableWithModal = VARIABLES_WITH_MODALS.includes(
+            variable.type ?? 'text',
+          )
 
           return (
             <Box
@@ -244,8 +248,8 @@ export default function VariablesList(props: VariablesListProps) {
               width="100%"
               transform={`translateY(${virtualItem.start}px)`}
             >
-              {variable.type === 'table' ? (
-                <TableVariableItem variable={variable} onClick={onClick} />
+              {isVariableWithModal ? (
+                <VariableItemWithModal variable={variable} onClick={onClick} />
               ) : variable.isHidden ? null : (
                 <VariableItem
                   variable={variable}

--- a/packages/frontend/src/helpers/variables.ts
+++ b/packages/frontend/src/helpers/variables.ts
@@ -18,6 +18,7 @@ export const VISIBLE_VARIABLE_TYPES: TDataOutMetadatumType[] = [
   'tile_row_id',
   'approval',
   'ai_response',
+  'html',
 ]
 
 export interface StepWithVariables {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -62,6 +62,7 @@ export type TDataOutMetadatumType =
   | 'table'
   | 'approval'
   | 'ai_response'
+  | 'html'
 
 /**
  * This should only be defined on _leaf_ nodes (i.e. **primitive array


### PR DESCRIPTION
## TL;DR
Email by Postman `dataOut` shows raw HTML, which is not useful for the user.

## Solution
* Add `getDataOutMetadata` for Email by Postman actions so that test result is formatted properly.
* `Body` can now be previewed using the same Editor that is used to write the email.
 
### What changed?
* Added a new `getDataOutMetadata` function to provide metadata for email output fields, including a new `html` type for the body.
* Added an `isDisplayOnly` mode to the `RichTextEditor` and its underlying `Editor` component, disabling editing and variable insertion and hiding the menu bar when enabled. 
* Extended the image extension to support a `resizable` option, defaulting to `true`, and to hide the resize handle when not resizable. Image resizing is disabled in the preview.
*  Added a new modal component (`HtmlVariableModal`) for previewing HTML variable values in a display-only rich text editor.
* Refactored to use the new `VariableItemWithModal` component, which opens the appropriate modal for HTML and table variables.


## Tests
- [ ] Editor still works as intended, i.e., can use MenuBar to format text, add images, add tables, etc
- [ ] Editor is disabled when Pipe is published, but can still preview the email body
- [ ] Editor is disabled in the email preview
- [ ] Verify that email body preview is the same as when edited in the Editor
    - [ ] Variables are displayed as plain text instead of variable pills
    - [ ] Images are displayed properly and size should be same as in the Editor
    - [ ] Images cannot be resized in the preview
    - [ ] Tables are displayed properly
    - [ ] Text formatting is preserved, i.e. H1, H2, Bold, Italics, etc

__Backward compatibility__: create an email action while on `develop-v2` and check step first, then return to this branch to test.
- [ ] Verify that emails sent previously should have its `dataOut` parsed properly and the `Body` can be previewed in the modal.
- [ ] Verify that 'Find multiple rows' result can be previewed in the modal and is displayed properly in the table.