### PR TITLE
[DATABRICKS-4] PLU-600:  add databricks create row action

### DIFF
--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -1,0 +1,159 @@
+import { IGlobalVariable, IRawAction } from '@plumber/types'
+
+import { z } from 'zod'
+
+import { databricksConfig } from '@/config/app-env-vars/databricks'
+import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
+
+import { createSession } from '../auth/create-client'
+import { columnNameSchema, tableNameSchema } from '../common/schema'
+
+const databricksTableUrl = `https://${databricksConfig.serverHostname}/explore/tables/${databricksConfig.catalog}`
+
+const insertRowSchema = z.object({
+  tableName: tableNameSchema,
+  rowData: z
+    .array(
+      z.object({
+        columnName: columnNameSchema,
+        columnValue: z.string(),
+      }),
+    )
+    .min(1, { message: 'At least one column is required' }),
+})
+
+const createRowAction: IRawAction = {
+  name: 'Create row',
+  key: 'createDatabricksTableRow',
+  description: 'Creates a new row in your databricks datable',
+  arguments: [
+    {
+      label: 'Select Table',
+      key: 'tableName',
+      type: 'dropdown' as const,
+      required: true,
+      variables: false,
+      showOptionValue: false,
+      source: {
+        type: 'query' as const,
+        name: 'getDynamicData' as const,
+        arguments: [
+          {
+            name: 'key',
+            value: 'databricks-list-table-names',
+          },
+        ],
+      },
+      addNewOption: {
+        id: 'databricks-createTable',
+        type: 'modal',
+        label: 'Create a new table',
+      },
+      clickableLink: {
+        label: 'View databricks dashboard',
+        url: databricksTableUrl,
+      },
+    },
+    {
+      label: 'New row data',
+      key: 'rowData',
+      type: 'multirow-multicol' as const,
+      required: true,
+      hiddenIf: {
+        fieldKey: 'tableName',
+        op: 'is_empty',
+      },
+      subFields: [
+        {
+          placeholder: 'Select or type to create a column',
+          key: 'columnName',
+          type: 'dropdown' as const,
+          required: true,
+          variables: false,
+          showOptionValue: false,
+          addNewOption: {
+            id: 'databricks-createTableColumn',
+            type: 'inline',
+            label: 'Create a new column',
+          },
+          source: {
+            type: 'query' as const,
+            name: 'getDynamicData' as const,
+            arguments: [
+              {
+                name: 'key',
+                value: 'databricks-list-table-columns',
+              },
+              {
+                name: 'parameters.tableName',
+                value: '{parameters.tableName}',
+              },
+            ],
+          },
+          customStyle: { flex: 3 },
+        },
+        {
+          placeholder: 'Value',
+          key: 'columnValue',
+          type: 'string' as const,
+          required: false,
+          variables: true,
+          customStyle: { flex: 5, minWidth: 0, maxWidth: '62.5%' },
+        },
+      ],
+    },
+  ],
+
+  async run($: IGlobalVariable) {
+    const parametersParseResult = insertRowSchema.safeParse($.step.parameters)
+    if (parametersParseResult.success === false) {
+      throw new StepError(
+        'Ensure your values are correct',
+        parametersParseResult.error.issues[0].message,
+      )
+    }
+    const { session, endSession } = await createSession($).catch((e) => {
+      throw new StepError('Failed to create session', e.message)
+    })
+    try {
+      const { tableName, rowData } = parametersParseResult.data
+      const columnNames = rowData.map((row) => row.columnName)
+      const columnValues = rowData.map((row) => row.columnValue)
+
+      const statement = `INSERT INTO \`${tableName}\` (${columnNames
+        .map((col) => `\`${col}\``)
+        .join(',')}) VALUES (${columnValues
+        .map((_val, index) => `:val${index}`)
+        .join(',')})`
+      const namedParameters = {} as Record<string, string>
+      for (let i = 0; i < columnValues.length; i++) {
+        namedParameters[`val${i}`] = columnValues[i]
+      }
+      const operation = await session.executeStatement(statement, {
+        namedParameters,
+      })
+      await operation.fetchAll()
+      await endSession()
+      $.setActionItem({
+        raw: {
+          success: true,
+        },
+      })
+    } catch (e) {
+      logger.error({
+        event: 'databricks-create-row',
+        stepId: $.step?.id,
+        flowId: $.flow?.id,
+        executionId: $.execution?.id,
+        testRun: $.execution?.testRun,
+        error: e,
+      })
+      throw new StepError('Failed to create row', e.message)
+    } finally {
+      await endSession()
+    }
+  },
+}
+
+export default createRowAction

--- a/packages/backend/src/apps/databricks/actions/index.ts
+++ b/packages/backend/src/apps/databricks/actions/index.ts
@@ -1,1 +1,3 @@
-export default []
+import createRow from './create-row'
+
+export default [createRow]


### PR DESCRIPTION
## Add create-row action for Databricks integration

Add create-row action with zod validation and parameterized SQL insert.
Supports dynamic table/column selection via dropdowns with inline
create-new-column and modal create-new-table options.

The action validates table and column names to only allow lowercase letters, numbers, and underscores. It constructs INSERT statements with named parameters for safe SQL execution and includes comprehensive error handling with structured logging.