### PR TITLE
fix: set Rome env vars for SSM

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -279,20 +279,28 @@
       "valueFrom": "plumber-pair-foundry-image-model"
     },
     {
-      "name": "PAIR_ROME_PUBLIC_KEY",
-      "valueFrom": "plumber-pair-rome-public-key"
-    },
-    {
-      "name": "PAIR_ROME_SECRET_KEY",
-      "valueFrom": "plumber-pair-rome-secret-key"
-    },
-    {
       "name": "PAIR_ROME_CLOUDFLARE_ZERO_TRUST_CLIENT_KEY",
       "valueFrom": "plumber-pair-rome-cloudflare-zero-trust-client-key"
     },
     {
       "name": "PAIR_ROME_CLOUDFLARE_ZERO_TRUST_SECRET_KEY",
       "valueFrom": "plumber-pair-rome-cloudflare-zero-trust-secret-key"
+    },
+    {
+      "name": "PAIR_ROME_AI_BUILDER_PUBLIC_KEY",
+      "valueFrom": "plumber-pair-rome-ai-builder-public-key"
+    },
+    {
+      "name": "PAIR_ROME_AI_BUILDER_SECRET_KEY",
+      "valueFrom": "plumber-pair-rome-ai-builder-secret-key"
+    },
+    {
+      "name": "PAIR_ROME_PAIR_ACTION_PUBLIC_KEY",
+      "valueFrom": "plumber-pair-rome-pair-action-public-key"
+    },
+    {
+      "name": "PAIR_ROME_PAIR_ACTION_SECRET_KEY",
+      "valueFrom": "plumber-pair-rome-pair-action-secret-key"
     }
   ]
 }


### PR DESCRIPTION
### TL;DR

Replaced generic PAIR Rome API keys with service-specific keys for AI Builder and Pair Action components.

### What changed?

Removed the generic `PAIR_ROME_PUBLIC_KEY` and `PAIR_ROME_SECRET_KEY` environment variables and added four new service-specific environment variables:

- `PAIR_ROME_AI_BUILDER_PUBLIC_KEY` and `PAIR_ROME_AI_BUILDER_SECRET_KEY` for AI Builder service authentication
- `PAIR_ROME_PAIR_ACTION_PUBLIC_KEY` and `PAIR_ROME_PAIR_ACTION_SECRET_KEY` for Pair Action service authentication

### How to test?

1. Deploy the updated ECS configuration
2. Verify that AI Builder and Pair Action services can authenticate successfully with their respective API keys
3. Confirm that no services are attempting to use the removed generic PAIR Rome keys

### Post-deployment

- [ ] Delete `plumber-pair-rome-public-key` and `plumber-pair-rome-secret-key` from parameter store