### PR TITLE
[EXCEL-MULTI-LOOKUP-2] feat: patch parameters

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 import StepError from '@/errors/step'
 import { generateMockContext } from '@/graphql/__tests__/mutations/tiles/table.mock'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
 import Context from '@/types/express/context'
 
 import m365Excel from '../..'
@@ -68,6 +70,9 @@ describe('getTableRowsAction', () => {
       setActionItem: vi.fn(),
       http: {
         request: vi.fn(),
+      },
+      execution: {
+        testRun: false,
       },
     } as unknown as IGlobalVariable
 
@@ -396,5 +401,63 @@ describe('getTableRowsAction', () => {
     expect(rowData[499].data[getHexEncodedColumnName('Column2')]).toBe(
       'data500',
     )
+  })
+
+  /**
+   * TODO (kevinkim-ogp): remove this entire describe block when
+   * patchParameters is removed from get-table-rows.
+   * These tests only guard the temporary DB patch during test runs.
+   */
+  describe('patchParameters (temporary patch-parameters-temp)', () => {
+    it('does not call Step.query when execution.testRun is false', async () => {
+      const stepQuerySpy = vi.spyOn(Step, 'query')
+      await getTableRowsAction.run($)
+      expect(stepQuerySpy).not.toHaveBeenCalled()
+    })
+
+    it('when execution.testRun is true, patches the step row with filters from lookup fields', async () => {
+      const context = await generateMockContext()
+      const flow = await Flow.query().insert({
+        userId: context.currentUser.id,
+        name: 'get-table-rows patchParameters test flow',
+      })
+
+      const parameters = {
+        fileId: 'test-file-id',
+        tableId: '{test-table-id}',
+        lookupColumn: 'Column1',
+        lookupValue: 'patch-test-lookup',
+      }
+
+      const dbStep = await Step.query().insert({
+        flowId: flow.id,
+        key: getTableRowsAction.key,
+        appKey: 'm365-excel',
+        type: 'action',
+        position: 2,
+        status: 'completed',
+        parameters: { ...parameters },
+      })
+
+      $.flow.id = flow.id
+      $.flow.userId = context.currentUser.id
+      $.step.id = dbStep.id
+      $.step.parameters = { ...parameters }
+      $.execution.testRun = true
+
+      await getTableRowsAction.run($)
+
+      const updated = await Step.query().findById(dbStep.id).throwIfNotFound()
+
+      expect(updated.parameters).toMatchObject({
+        ...parameters,
+        filters: [
+          {
+            lookupColumn: parameters.lookupColumn,
+            lookupValue: parameters.lookupValue,
+          },
+        ],
+      })
+    })
   })
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import { LOOKUP_CONDITIONS_SUBFIELDS } from '../../common/constants'
 import patchParameters from '../../common/patch-parameters-temp'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
@@ -111,6 +112,19 @@ const action: IRawAction = {
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',
+      },
+    },
+    {
+      label: 'Lookup conditions',
+      description:
+        'If multiple rows meet the conditions, the topmost entry will be returned. Lookup values are case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.',
+      key: 'filters',
+      type: 'multirow-multicol' as const,
+      required: true,
+      subFields: LOOKUP_CONDITIONS_SUBFIELDS,
+      maxRows: 1,
+      hiddenIf: {
+        op: 'always_true',
       },
     },
   ],

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import patchParameters from '../../common/patch-parameters-temp'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
 import { RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024 } from '../../FOR_RELEASE_PERIOD_ONLY'
@@ -120,6 +121,9 @@ const action: IRawAction = {
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
       await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
+
+      // TODO (kevinkim-ogp): remove this once we have moved to the
+      await patchParameters($)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -128,6 +128,8 @@ const action: IRawAction = {
       },
     },
   ],
+  // TODO (kevinkim-ogp): update this to ['lookupColumn', 'lookupValue'] once we have moved to the new multi lookup
+  ignoredArgs: ['filters'],
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -125,6 +125,8 @@ const action: IRawAction = {
       },
     },
   ],
+  // TODO (kevinkim-ogp): update this to ['lookupColumn', 'lookupValue'] once we have moved to the new multi lookup
+  ignoredArgs: ['filters'],
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -5,7 +5,10 @@ import z from 'zod'
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 import StepError from '@/errors/step'
 
-import { GET_TABLE_ROWS_LIMIT } from '../../common/constants'
+import {
+  GET_TABLE_ROWS_LIMIT,
+  LOOKUP_CONDITIONS_SUBFIELDS,
+} from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
 import patchParameters from '../../common/patch-parameters-temp'
 import { convertRowToHexKeyedObject } from '../../common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record'
@@ -107,6 +110,19 @@ const action: IRawAction = {
       type: 'string' as const,
       required: false,
       variables: true,
+    },
+    {
+      key: 'filters',
+      label: 'Lookup conditions',
+      description:
+        'Lookup values are case sensitive and should not include units (e.g., $5.20 → 5.2). Leave blank to search for empty cells.',
+      type: 'multirow-multicol' as const,
+      required: true,
+      subFields: LOOKUP_CONDITIONS_SUBFIELDS,
+      maxRows: 1, // Phase 1: Restrict to single filter
+      hiddenIf: {
+        op: 'always_true',
+      },
     },
   ],
 

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -7,6 +7,7 @@ import StepError from '@/errors/step'
 
 import { GET_TABLE_ROWS_LIMIT } from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
+import patchParameters from '../../common/patch-parameters-temp'
 import { convertRowToHexKeyedObject } from '../../common/workbook-helpers/tables/convert-row-to-hex-encoded-row-record'
 import WorkbookSession from '../../common/workbook-session'
 import { MAX_ROWS } from '../get-table-row/implementation'
@@ -112,6 +113,11 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
+    if ($.execution.testRun) {
+      // TODO (kevinkim-ogp): remove this once we have moved to the new multi lookup
+      await patchParameters($)
+    }
+
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)
     if (parametersParseResult.success === false) {
       throw new StepError(

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -82,6 +82,8 @@ const action: IRawAction = {
       ],
     },
   ],
+  // TODO (kevinkim-ogp): update this to ['lookupColumn', 'lookupValue'] once we have moved to the new multi lookup
+  ignoredArgs: ['filters'],
 
   getDataOutMetadata,
 

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -4,6 +4,7 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
+import patchParameters from '../../common/patch-parameters-temp'
 import { sanitiseInputValue } from '../../common/sanitise-formula-input'
 import {
   constructMsGraphValuesArrayForRowWrite,
@@ -88,6 +89,9 @@ const action: IRawAction = {
     // FOR RELEASE ONLY TO STEM ANY THUNDERING HERDS; REMOVE AFTER 21 Jul 2024.
     if ($.execution.testRun) {
       await RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024($.user?.email, $)
+
+      // TODO (kevinkim-ogp): remove this once we have moved to the new multi lookup
+      await patchParameters($)
     }
 
     const parametersParseResult = parametersSchema.safeParse($.step.parameters)

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -5,3 +5,44 @@ export const APP_KEY = 'm365-excel'
 export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
 
 export const GET_TABLE_ROWS_LIMIT = 500
+
+export const LOOKUP_CONDITIONS_SUBFIELDS = [
+  {
+    placeholder: 'Lookup column',
+    key: 'lookupColumn',
+    type: 'dropdown' as const,
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    source: {
+      type: 'query' as const,
+      name: 'getDynamicData' as const,
+      arguments: [
+        {
+          name: 'key',
+          value: 'listTableColumns',
+        },
+        {
+          name: 'parameters.fileId',
+          value: '{parameters.fileId}',
+        },
+        {
+          name: 'parameters.tableId',
+          value: '{parameters.tableId}',
+        },
+      ],
+    },
+    customStyle: { flex: 2 },
+  },
+  {
+    key: 'lookupValue' as const,
+    placeholder: 'Lookup value',
+    // We don't support matching on Excel-formatted text because it's very
+    // weird (e.g. currency cells have a trailing space), and will lead to too
+    // much user confusion.
+    type: 'string' as const,
+    required: false,
+    variables: true,
+    customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
+  },
+]

--- a/packages/backend/src/apps/m365-excel/common/patch-parameters-temp.ts
+++ b/packages/backend/src/apps/m365-excel/common/patch-parameters-temp.ts
@@ -8,27 +8,24 @@ import Step from '@/models/step'
  *
  * We manually patch the step's parameter's so that it contains the new 'filters' field.
  * this ensures that the 'filters' field is automatically populated when we move to this.
+ *
+ * We also update $.step.parameters in memory so that the filters are automatically populated
+ * in the ExecutionStep's dataIn when the test run is executed.
  */
 const patchParameters = async ($: IGlobalVariable) => {
   try {
-    //  manually patch the step's parameter's so that it contains the new 'filters' field.
+    // Transform in memory - add filters
+    $.step.parameters.filters = [
+      {
+        lookupColumn: $.step.parameters.lookupColumn,
+        lookupValue: $.step.parameters.lookupValue,
+      },
+    ]
+
+    // Persist to database
     await Step.query()
-      .patch({
-        parameters: {
-          ...$.step.parameters,
-          filters: [
-            {
-              lookupColumn: $.step.parameters.lookupColumn,
-              lookupValue: $.step.parameters.lookupValue,
-            },
-          ],
-        },
-      })
-      .where({
-        'steps.id': $.step.id,
-        'steps.flow_id': $.flow.id,
-        'steps.app_key': 'm365-excel',
-      })
+      .patch({ parameters: $.step.parameters })
+      .where({ 'steps.id': $.step.id })
       .throwIfNotFound()
   } catch (error) {
     // NOTE: we do not want to throw error here so that the test run can continue

--- a/packages/backend/src/apps/m365-excel/common/patch-parameters-temp.ts
+++ b/packages/backend/src/apps/m365-excel/common/patch-parameters-temp.ts
@@ -1,0 +1,43 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import logger from '@/helpers/logger'
+import Step from '@/models/step'
+
+/**
+ * TODO(kevinkim-ogp): remove this after patching the database for all remaining steps
+ *
+ * We manually patch the step's parameter's so that it contains the new 'filters' field.
+ * this ensures that the 'filters' field is automatically populated when we move to this.
+ */
+const patchParameters = async ($: IGlobalVariable) => {
+  try {
+    //  manually patch the step's parameter's so that it contains the new 'filters' field.
+    await Step.query()
+      .patch({
+        parameters: {
+          ...$.step.parameters,
+          filters: [
+            {
+              lookupColumn: $.step.parameters.lookupColumn,
+              lookupValue: $.step.parameters.lookupValue,
+            },
+          ],
+        },
+      })
+      .where({
+        'steps.id': $.step.id,
+        'steps.flow_id': $.flow.id,
+        'steps.app_key': 'm365-excel',
+      })
+      .throwIfNotFound()
+  } catch (error) {
+    // NOTE: we do not want to throw error here so that the test run can continue
+    // if this failed, we can still patch it later on
+    logger.error(
+      'Failed to patch the executionStep and step parameters during test run',
+      error,
+    )
+  }
+}
+
+export default patchParameters

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -209,6 +209,8 @@ type Action {
   isNew: Boolean
   linkToGuide: String
   substeps: [ActionSubstep]
+
+  ignoredArgs: [String]
 }
 
 type ActionSubstep {
@@ -832,6 +834,8 @@ type Trigger {
   substeps: [TriggerSubstep]
   isNew: Boolean
   noAuthRequired: Boolean
+
+  ignoredArgs: [String]
 }
 
 type TriggerInstructions {

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -1,4 +1,9 @@
-import { IBaseTrigger, IStep, ITriggerInstructions } from '@plumber/types'
+import {
+  IBaseTrigger,
+  IJSONObject,
+  IStep,
+  ITriggerInstructions,
+} from '@plumber/types'
 
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -21,6 +26,7 @@ import {
 } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
+import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { validateStepParams } from '@/helpers/validateStepParams'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
@@ -36,6 +42,7 @@ import {
   getInfoBoxDetails,
   isSameAppAndAppKey,
   matchParamsToDataIn,
+  omitHiddenParameterKeys,
 } from './utils'
 
 const defaultTriggerInstructions: ITriggerInstructions = {
@@ -134,12 +141,29 @@ export default function FlowStepTestController(
   // isLastTestExecutionCurrent is false if the form values are saved but not tested
   const isLastTestExecutionCurrent = useMemo(() => {
     const formValues = formContext.getValues()
+
+    /**
+     * TODO (kevinkim-ogp): remove this once the Excel multi lookup is done
+     * as we should not have fields that are always hidden.
+     *
+     * NOTE: we filter out hidden parameters from the form values
+     * so that the 'dataIn' comparison is not affected by hidden parameters
+     */
+    const setupActionSubstep = substeps.find((s) => s.key === 'setUpAction')
+    const hiddenParameters = setupActionSubstep?.arguments?.filter((a) =>
+      isFieldHidden(a.hiddenIf, formValues.parameters),
+    )
+    const hiddenParametersKeys = hiddenParameters?.map((h) => h.key)
+
     return matchParamsToDataIn(
       currentTestExecutionStep?.dataIn,
-      formValues.parameters,
+      omitHiddenParameterKeys(
+        formValues.parameters as IJSONObject,
+        hiddenParametersKeys,
+      ),
       varInfoMap,
     )
-  }, [currentTestExecutionStep, formContext, varInfoMap])
+  }, [currentTestExecutionStep?.dataIn, formContext, substeps, varInfoMap])
 
   const [infoBoxVariant, infoBoxText] = getInfoBoxDetails({
     isDirty,

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -1,9 +1,4 @@
-import {
-  IBaseTrigger,
-  IJSONObject,
-  IStep,
-  ITriggerInstructions,
-} from '@plumber/types'
+import { IBaseTrigger, IStep, ITriggerInstructions } from '@plumber/types'
 
 import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -26,7 +21,6 @@ import {
 } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
-import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { validateStepParams } from '@/helpers/validateStepParams'
 import { useStepMetadata } from '@/hooks/useStepMetadata'
 
@@ -42,7 +36,6 @@ import {
   getInfoBoxDetails,
   isSameAppAndAppKey,
   matchParamsToDataIn,
-  omitHiddenParameterKeys,
 } from './utils'
 
 const defaultTriggerInstructions: ITriggerInstructions = {
@@ -143,27 +136,23 @@ export default function FlowStepTestController(
     const formValues = formContext.getValues()
 
     /**
-     * TODO (kevinkim-ogp): remove this once the Excel multi lookup is done
-     * as we should not have fields that are always hidden.
-     *
-     * NOTE: we filter out hidden parameters from the form values
-     * so that the 'dataIn' comparison is not affected by hidden parameters
+     * hiddenKeys are used to filter out ignored arguments from the form values and dataIn
+     * so that the comparison is not affected by ignored arguments
      */
-    const setupActionSubstep = substeps.find((s) => s.key === 'setUpAction')
-    const hiddenParameters = setupActionSubstep?.arguments?.filter((a) =>
-      isFieldHidden(a.hiddenIf, formValues.parameters),
-    )
-    const hiddenParametersKeys = hiddenParameters?.map((h) => h.key)
+    const hiddenKeys = selectedActionOrTrigger?.ignoredArgs || []
 
     return matchParamsToDataIn(
       currentTestExecutionStep?.dataIn,
-      omitHiddenParameterKeys(
-        formValues.parameters as IJSONObject,
-        hiddenParametersKeys,
-      ),
+      formValues.parameters,
       varInfoMap,
+      hiddenKeys,
     )
-  }, [currentTestExecutionStep?.dataIn, formContext, substeps, varInfoMap])
+  }, [
+    currentTestExecutionStep?.dataIn,
+    formContext,
+    selectedActionOrTrigger,
+    varInfoMap,
+  ])
 
   const [infoBoxVariant, infoBoxText] = getInfoBoxDetails({
     isDirty,

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -125,13 +125,17 @@ const deepCompare = (a: any, b: any, varInfoMap: VariableInfoMap): boolean => {
  * NOTE: it also validates the variable value as dataIn is based on the extracted value
  */
 export const matchParamsToDataIn = (
-  dataIn?: IJSONObject,
-  params?: IJSONObject,
+  rawDataIn?: IJSONObject,
+  rawParams?: IJSONObject,
   varInfoMap?: VariableInfoMap,
+  hiddenKeys?: string[],
 ) => {
-  if (!dataIn || !params || !varInfoMap) {
+  if (!rawDataIn || !rawParams || !varInfoMap) {
     return false
   }
+
+  const dataIn = omitHiddenParameterKeys(rawDataIn, hiddenKeys)
+  const params = omitHiddenParameterKeys(rawParams, hiddenKeys)
 
   // If both are empty objects, return true
   if (Object.keys(dataIn).length === 0 && Object.keys(params).length === 0) {

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -351,3 +351,26 @@ export function getForEachDataMessage(
   const numberOfItems = getForEachIterationCount(testExecutionSteps, step.id)
   return `This for-each action will run on ${numberOfItems} items. The first item is shown below.`
 }
+
+/**
+ * * TODO (kevinkim-ogp): remove this once the Excel multi lookup is done
+ * as we should not have fields that are always hidden.
+ *
+ * Drops keys (e.g. hidden setUpAction fields) while keeping IJSONObject typing.
+ */
+export function omitHiddenParameterKeys(
+  parameters: IJSONObject,
+  hiddenKeys: string[] | undefined,
+): IJSONObject {
+  if (!hiddenKeys?.length) {
+    return { ...parameters }
+  }
+  const visible: IJSONObject = {}
+  for (const key of Object.keys(parameters)) {
+    if (hiddenKeys.includes(key)) {
+      continue
+    }
+    visible[key] = parameters[key]
+  }
+  return visible
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -801,6 +801,14 @@ export interface IBaseTrigger {
 
   // if true, the trigger does not require authentication
   noAuthRequired?: boolean
+
+  /**
+   * Allows specifying argument keys to ignore when processing the step parameters.
+   * ---
+   * This will be used when there is patching or migration of step parameters,
+   * without modifying the dataOut
+   */
+  ignoredArgs?: string[]
 }
 
 export interface IRawTrigger extends IBaseTrigger {
@@ -916,6 +924,14 @@ export interface IBaseAction {
 
   // if true, the action does not require authentication
   noAuthRequired?: boolean
+
+  /**
+   * Allows specifying argument keys to ignore when processing the step parameters.
+   * ---
+   * This will be used when there is patching or migration of step parameters,
+   * without modifying the dataOut
+   */
+  ignoredArgs?: string[]
 }
 
 export interface IRawAction extends IBaseAction {


### PR DESCRIPTION
## Changes

### Temporary `patchParameters` function

Introduces a temporary `patchParameters` function that migrates legacy `lookupColumn` and `lookupValue` parameters to the new `filters` array format for Excel Get table row and Get multiple table rows actions during test execution.

### Hidden `filters` argument that supports multiple lookup condition

Adds the `multirow-multicol`argument for filters to enable multiple lookup conditions. However, this is currently set to `hiddenIf: { op: always_true`so that the input remains hidden and the parameters in `dataIn` are also hidden when checking the test step result.

### Hides hidden parameters in

Updates the FlowStepTestController to exclude hidden form fields when comparing current form values against the last test execution data, preventing false negatives in the test status check.

## Tests

_Backward compatibility:_ _create_ _a_ _Pipe_ _with_ _Get_ _table_ _row_, _Get_ _multiple_ _table_ _rows,_ _and_ _Update_ _table_ _row_ _actions_ _first_ _before_ _checking_ _out_ _to_ _this_ _branch,_ _publish_ _the_ _Pipe._

- [ ] Verify that the Get table row action still works properly
- [ ] Verify that the Get table rows actions still work properly
- [ ] Verify that the Update table row actions still work properly

_Patching function_

- [ ] Verify that creating a new Get table row action still works as intended
    - [ ] Verify that the `filters` parameter is created and an array of ONE object. This object should contain `lookupColumn` and `lookupValue` and correspond to the original `lookupColumn` and `lookupValue` parameters
- [ ] Verify that creating a new Get multiple table rows action still works as intended
    - [ ] Verify that the `filters` parameter is created and an array of ONE object. This object should contain `lookupColumn` and `lookupValue` and correspond to the original `lookupColumn` and `lookupValue` parameters
- [ ] Verify that creating a new Update table row action still works as intended
    - [ ] Verify that the `filters` parameter is created and an array of ONE object. This object should contain `lookupColumn` and `lookupValue` and correspond to the original `lookupColumn` and `lookupValue` parameters
- [ ] Verify that checking step on an **existing** Get table row action also patches the parameters
- [ ] Verify that checking step on an **existing** Get multiple table rows action also patches the parameters
- [ ] Verify that checking step on an **existing** Update table row action also patches the parameters