### PR TITLE
PLU-720 (fix): only get ids for apps with connections

### DIFF
--- a/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-transfer-status.ts
@@ -129,7 +129,7 @@ const updateFlowTransferStatus: MutationResolvers['updateFlowTransferStatus'] =
       // get the connections and tables to be shared
       // intentionally exclude m365-excel as the connection has been nullified
       // and it should retain the user_id in the connections table
-      const connectionDetails = getConnectionDetails(
+      const connectionDetails = await getConnectionDetails(
         flow?.steps.filter((step) => step.appKey !== 'm365-excel'),
       )
       const sharedConnections = connectionDetails.connection

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -75,7 +75,7 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
         const flow = await Flow.query(trx)
           .withGraphFetched('steps')
           .findById(flowId)
-        const connectionDetails = getConnectionDetails(flow?.steps)
+        const connectionDetails = await getConnectionDetails(flow?.steps)
 
         if (!hasCollaborators) {
           // add all connections to the flow_connections table

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -24,7 +24,7 @@ describe('getConnectionDetails', () => {
     ...overrides,
   })
 
-  it('should not include any metadata for apps without connection fields', () => {
+  it('should not include any metadata for apps without connection fields', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'aisay',
@@ -43,7 +43,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     // Should return empty object since none of these apps have parameterKey defined
     expect(result).toEqual({
@@ -56,7 +56,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should not include metadata for apps without connection fields', () => {
+  it('should not include metadata for apps without connection fields', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'paysg',
@@ -69,7 +69,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     // Should return empty object since paysg has empty APP_CONNECTION_FIELDS
     expect(result).toEqual({
@@ -80,7 +80,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should include metadata for apps with parameterKey defined', () => {
+  it('should include metadata for apps with parameterKey defined', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'slack',
@@ -94,7 +94,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     expect(result).toEqual({
       connection: {
@@ -105,7 +105,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should handle multiple connections with different parameter keys', () => {
+  it('should handle multiple connections with different parameter keys', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'slack',
@@ -124,7 +124,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     expect(result).toEqual({
       connection: {
@@ -138,7 +138,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should not include duplicate parameter values for the same connection', () => {
+  it('should not include duplicate parameter values for the same connection', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'slack',
@@ -157,7 +157,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     expect(result).toEqual({
       connection: {
@@ -167,7 +167,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should handle steps without connectionId', () => {
+  it('should handle steps without connectionId', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'formatter',
@@ -181,7 +181,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     expect(result).toEqual({
       connection: {},
@@ -189,7 +189,7 @@ describe('getConnectionDetails', () => {
     })
   })
 
-  it('should handle steps with missing parameter values', () => {
+  it('should handle steps with missing parameter values', async () => {
     const steps: IStep[] = [
       createMockStep({
         appKey: 'slack',
@@ -203,7 +203,7 @@ describe('getConnectionDetails', () => {
       }),
     ]
 
-    const result = getConnectionDetails(steps)
+    const result = await getConnectionDetails(steps)
 
     expect(result).toEqual({
       connection: {
@@ -214,7 +214,7 @@ describe('getConnectionDetails', () => {
   })
 
   describe('special case: Tiles', () => {
-    it('should use tableId for tiles app regardless of connectionId', () => {
+    it('should use tableId for tiles app regardless of connectionId', async () => {
       const steps: IStep[] = [
         createMockStep({
           appKey: 'tiles',
@@ -226,7 +226,7 @@ describe('getConnectionDetails', () => {
         }),
       ]
 
-      const result = getConnectionDetails(steps)
+      const result = await getConnectionDetails(steps)
 
       expect(result).toEqual({
         connection: {},
@@ -234,7 +234,7 @@ describe('getConnectionDetails', () => {
       })
     })
 
-    it('should handle tiles step with empty parameters', () => {
+    it('should handle tiles step with empty parameters', async () => {
       const steps: IStep[] = [
         createMockStep({
           appKey: 'tiles',
@@ -242,7 +242,7 @@ describe('getConnectionDetails', () => {
         }),
       ]
 
-      const result = getConnectionDetails(steps)
+      const result = await getConnectionDetails(steps)
 
       expect(result).toEqual({
         connection: {},
@@ -250,7 +250,7 @@ describe('getConnectionDetails', () => {
       })
     })
 
-    it('should not include duplicate tableIds for tiles', () => {
+    it('should not include duplicate tableIds for tiles', async () => {
       const steps: IStep[] = [
         createMockStep({
           appKey: 'tiles',
@@ -269,7 +269,28 @@ describe('getConnectionDetails', () => {
         }),
       ]
 
-      const result = getConnectionDetails(steps)
+      const result = await getConnectionDetails(steps)
+
+      expect(result).toEqual({
+        connection: {},
+        table: ['table-123', 'table-456'],
+      })
+    })
+
+    it('should not include connection ids for Tiles steps', async () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          connectionId: 'tiles-connection-id',
+          parameters: { tableId: 'table-123' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'table-456' },
+        }),
+      ]
+
+      const result = await getConnectionDetails(steps)
 
       expect(result).toEqual({
         connection: {},
@@ -279,7 +300,7 @@ describe('getConnectionDetails', () => {
   })
 
   describe('mixed scenarios', () => {
-    it('should handle mix of apps with and without parameterKey defined', () => {
+    it('should handle mix of apps with and without parameterKey defined', async () => {
       const steps: IStep[] = [
         // Apps with empty APP_CONNECTION_FIELDS
         createMockStep({
@@ -310,7 +331,7 @@ describe('getConnectionDetails', () => {
         }),
       ]
 
-      const result = getConnectionDetails(steps)
+      const result = await getConnectionDetails(steps)
 
       expect(result).toEqual({
         connection: {
@@ -325,15 +346,15 @@ describe('getConnectionDetails', () => {
       })
     })
 
-    it('should handle empty steps array', () => {
-      const result = getConnectionDetails([])
+    it('should handle empty steps array', async () => {
+      const result = await getConnectionDetails([])
       expect(result).toEqual({
         connection: {},
         table: [],
       })
     })
 
-    it('should handle steps with unknown appKey', () => {
+    it('should handle steps with unknown appKey', async () => {
       const steps: IStep[] = [
         createMockStep({
           appKey: 'unknown-app' as any,
@@ -342,13 +363,11 @@ describe('getConnectionDetails', () => {
         }),
       ]
 
-      const result = getConnectionDetails(steps)
+      const result = await getConnectionDetails(steps)
 
-      // Should return empty object since unknown app is not in APP_CONNECTION_FIELDS
+      // Should return empty object since unknown app is not a valid app
       expect(result).toEqual({
-        connection: {
-          'unknown-app-connection-id': {},
-        },
+        connection: {},
         table: [],
       })
     })

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -1,5 +1,7 @@
 import { IStep } from '@plumber/types'
 
+import App from '@/models/app'
+
 /**
  * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
  * we only need to app apps that have fields that behave like connections.
@@ -34,14 +36,26 @@ export const APP_CONNECTION_FIELDS: Record<
   },
 }
 
-export function getConnectionDetails(steps: IStep[]): {
+export async function getConnectionDetails(steps: IStep[]): Promise<{
   connection: {
     [connectionId: string]: {
       [appKey: string]: string[]
     }
   }
   table: string[]
-} {
+}> {
+  /**
+   * NOTE: we fetch apps here to identify apps that should have connections
+   * Prior to the UI revamp, users could change the app/action without
+   * having to delete the step.
+   * There is a possibility where an app that should not have a `connection_id`
+   * like Tiles, could inherit a `connection_id` from a previous step.
+   */
+  const appsWithConnections = await App.getAllAppsWithConnections()
+  const appKeysWithConnections: string[] = appsWithConnections.map(
+    (app) => app.key,
+  )
+
   const connections: {
     connection: {
       [connectionId: string]: {
@@ -55,7 +69,7 @@ export function getConnectionDetails(steps: IStep[]): {
   }
 
   steps.map((step) => {
-    if (step.connectionId) {
+    if (step.connectionId && appKeysWithConnections.includes(step.appKey)) {
       connections.connection[step.connectionId] ??= {}
 
       const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey

--- a/packages/backend/src/models/app.ts
+++ b/packages/backend/src/models/app.ts
@@ -62,6 +62,11 @@ class App {
   static getAllAppsWithFunctions = memoize(async () => {
     return await this.findAll(null, false)
   })
+
+  static getAllAppsWithConnections = memoize(async () => {
+    const allApps = await this.findAll(null, false)
+    return allApps.filter((app) => app.auth)
+  })
 }
 
 export default App


### PR DESCRIPTION
### TL;DR

Fixed connection sharing logic to prevent apps without authentication from being incorrectly included in shared connections.

Previously, apps like Tiles, Calculator, etc could inherit connection IDs from previous steps when users changed app/action without deleting the step in the old UI. This caused apps that shouldn't have connections to be incorrectly included in the connection sharing logic, potentially leading to data inconsistencies.

### What changed?

- Added validation to only include connections for apps that actually support authentication
- Added new `getAllAppsWithConnections` method to App model to retrieve apps with auth capabilities

### How to test?

_Note: you need to recreate the scenario of an action without auth having a connection, to do this:_

1. Create a Pipe with steps that include apps without authentication (like Tiles, Calculator, Postman, etc)
2. Manually add a valid connection (Telegram, Slack, etc) to that that action in the DB

_Now do the test_:

Add collaborators

- [ ] Verify that the 'stray' connection was not added to `flow_connections` 
- [ ] Verify that the Editor does not have access to that connection, i.e., if they add the Telegram/Slack app, they should not see the connection in the dropdown

Pipe Transfer

- [ ] Verify that the 'stray' connection was not added to `flow_connections` 
- [ ] Verify that the Editor does not have access to that connection, i.e., if they add the Telegram/Slack app, they should not see the connection in the dropdown