### PR TITLE
PLU-591: [show-multiple-rows-1]: add helper functions

### DIFF
--- a/packages/backend/src/helpers/__tests__/format-table-variable.test.ts
+++ b/packages/backend/src/helpers/__tests__/format-table-variable.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatTable } from '../format-table-variable'
+
+const COLS = [
+  { id: 'col1', name: 'Name' },
+  { id: 'col2', name: 'Email' },
+]
+
+const ROWS = [
+  { data: { col1: 'Alice', col2: 'alice@example.com' } },
+  { data: { col1: 'Bob', col2: 'bob@example.com' } },
+]
+
+describe('formatTable', () => {
+  describe('invalid structure', () => {
+    it.each([null, undefined, 'string', 42, []])(
+      'returns invalid_structure for %s',
+      (input) => {
+        expect(
+          formatTable(input, { selectedColumnIds: ['col1'] }),
+        ).toMatchObject({
+          success: false,
+          error: 'invalid_structure',
+        })
+      },
+    )
+
+    it('returns invalid_structure when rows is missing', () => {
+      expect(
+        formatTable({ columns: COLS }, { selectedColumnIds: ['col1'] }),
+      ).toMatchObject({
+        success: false,
+        error: 'invalid_structure',
+      })
+    })
+
+    it('returns invalid_structure when columns is missing', () => {
+      expect(
+        formatTable({ rows: ROWS }, { selectedColumnIds: ['col1'] }),
+      ).toMatchObject({
+        success: false,
+        error: 'invalid_structure',
+      })
+    })
+
+    it('returns invalid_structure when a column is missing id', () => {
+      expect(
+        formatTable(
+          { rows: [], columns: [{ name: 'No ID' }] },
+          { selectedColumnIds: ['col1'] },
+        ),
+      ).toMatchObject({ success: false, error: 'invalid_structure' })
+    })
+
+    it('returns invalid_structure when a column is missing name', () => {
+      expect(
+        formatTable(
+          { rows: [], columns: [{ id: 'col1' }] },
+          { selectedColumnIds: ['col1'] },
+        ),
+      ).toMatchObject({ success: false, error: 'invalid_structure' })
+    })
+
+    it('returns invalid_structure when a column is null', () => {
+      expect(
+        formatTable(
+          { rows: [], columns: [null] },
+          { selectedColumnIds: ['col1'] },
+        ),
+      ).toMatchObject({
+        success: false,
+        error: 'invalid_structure',
+      })
+    })
+  })
+
+  describe('column selection', () => {
+    it('returns no_columns when selectedColumnIds is an empty array', () => {
+      expect(
+        formatTable({ rows: [], columns: COLS }, { selectedColumnIds: [] }),
+      ).toMatchObject({ success: false, error: 'no_columns' })
+    })
+
+    it('renders only selected columns', () => {
+      const result = formatTable(
+        { rows: ROWS, columns: COLS },
+        { selectedColumnIds: ['col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('Name')
+        expect(result.output).not.toContain('Email')
+      }
+    })
+
+    it('renders selected columns in the specified order', () => {
+      const result = formatTable(
+        { rows: ROWS, columns: COLS },
+        { selectedColumnIds: ['col2', 'col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output.indexOf('Email')).toBeLessThan(
+          result.output.indexOf('Name'),
+        )
+      }
+    })
+
+    it('returns invalid_columns when a selected column does not exist', () => {
+      expect(
+        formatTable(
+          { rows: ROWS, columns: COLS },
+          { selectedColumnIds: ['col1', 'nonexistent'] },
+        ),
+      ).toMatchObject({
+        success: false,
+        error: 'invalid_columns',
+        invalidColumns: ['nonexistent'],
+      })
+    })
+
+    it('collects all invalid column ids in the error', () => {
+      expect(
+        formatTable(
+          { rows: ROWS, columns: COLS },
+          { selectedColumnIds: ['bad1', 'bad2'] },
+        ),
+      ).toMatchObject({
+        success: false,
+        error: 'invalid_columns',
+        invalidColumns: ['bad1', 'bad2'],
+      })
+    })
+  })
+
+  describe('no_columns', () => {
+    it('returns no_columns when columns array is empty', () => {
+      expect(
+        formatTable({ rows: [], columns: [] }, { selectedColumnIds: [] }),
+      ).toMatchObject({ success: false, error: 'no_columns' })
+    })
+  })
+
+  describe('HTML output structure', () => {
+    it('wraps output in a border-collapsed table with tbody', () => {
+      const result = formatTable(
+        { rows: [], columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toMatch(
+          /^<table style="border-collapse: collapse;"><tbody>/,
+        )
+        expect(result.output).toMatch(/<\/tbody><\/table>$/)
+      }
+    })
+
+    it('renders column names in the header row with header styling', () => {
+      const result = formatTable(
+        { rows: [], columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain(
+          'background-color: #F3F4F6; font-weight: 600;',
+        )
+        expect(result.output).toContain('<p style="margin: 0;">Name</p>')
+        expect(result.output).toContain('<p style="margin: 0;">Email</p>')
+      }
+    })
+
+    it('produces only a header row when rows array is empty', () => {
+      const result = formatTable(
+        { rows: [], columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output.match(/<tr>/g)).toHaveLength(1)
+      }
+    })
+
+    it('renders first data row with white background', () => {
+      const result = formatTable(
+        { rows: [ROWS[0]], columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('background-color: #FFFFFF;')
+      }
+    })
+
+    it('renders second data row with gray background', () => {
+      const result = formatTable(
+        { rows: ROWS, columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('background-color: #F9FAFB;')
+      }
+    })
+
+    it('renders cell values in the correct column order', () => {
+      const result = formatTable(
+        { rows: [ROWS[0]], columns: COLS },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output.indexOf('Alice')).toBeLessThan(
+          result.output.indexOf('alice@example.com'),
+        )
+      }
+    })
+  })
+
+  describe('HTML escaping', () => {
+    it('escapes HTML special characters in column names', () => {
+      const cols = [{ id: 'c1', name: '<script>alert(1)</script>' }]
+      const result = formatTable(
+        { rows: [], columns: cols },
+        { selectedColumnIds: ['c1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).not.toContain('<script>')
+        expect(result.output).toContain('&lt;script&gt;')
+      }
+    })
+
+    it('escapes HTML special characters in cell values', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: { col1: '<b>bold</b> & "quoted" & \'single\'' } }],
+          columns: [{ id: 'col1', name: 'Content' }],
+        },
+        { selectedColumnIds: ['col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).not.toContain('<b>')
+        expect(result.output).toContain(
+          '&lt;b&gt;bold&lt;/b&gt; &amp; &quot;quoted&quot; &amp; &#039;single&#039;',
+        )
+      }
+    })
+  })
+
+  describe('cell value serialization', () => {
+    it('renders null cell values as empty strings', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: { col1: null } }],
+          columns: [{ id: 'col1', name: 'Name' }],
+        },
+        { selectedColumnIds: ['col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('<p style="margin: 0;"></p>')
+      }
+    })
+
+    it('renders undefined cell values as empty strings', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: {} }],
+          columns: [{ id: 'col1', name: 'Name' }],
+        },
+        { selectedColumnIds: ['col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('<p style="margin: 0;"></p>')
+      }
+    })
+
+    it('serializes object cell values as JSON (HTML-escaped)', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: { col1: { nested: 'value' } } }],
+          columns: [{ id: 'col1', name: 'Data' }],
+        },
+        { selectedColumnIds: ['col1'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain(
+          '{&quot;nested&quot;:&quot;value&quot;}',
+        )
+      }
+    })
+
+    it('renders boolean cell values as strings', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: { col1: true, col2: false } }],
+          columns: COLS,
+        },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('<p style="margin: 0;">true</p>')
+        expect(result.output).toContain('<p style="margin: 0;">false</p>')
+      }
+    })
+
+    it('renders numeric cell values as strings', () => {
+      const result = formatTable(
+        {
+          rows: [{ data: { col1: 42, col2: 3.14 } }],
+          columns: COLS,
+        },
+        { selectedColumnIds: ['col1', 'col2'] },
+      )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.output).toContain('<p style="margin: 0;">42</p>')
+        expect(result.output).toContain('<p style="margin: 0;">3.14</p>')
+      }
+    })
+  })
+})

--- a/packages/backend/src/helpers/format-table-variable.ts
+++ b/packages/backend/src/helpers/format-table-variable.ts
@@ -1,0 +1,183 @@
+/**
+ * Table Variable Formatting Utility
+ *
+ * Converts table data from execution steps into HTML format
+ * for use in transactional emails.
+ */
+
+import { safeHtml } from './html-utils'
+
+export interface TableColumn {
+  id: string
+  name: string
+  value?: string
+}
+
+export interface TableRow {
+  rowId?: string
+  data: Record<string, unknown>
+}
+
+export interface TableData {
+  rows: TableRow[]
+  columns: TableColumn[]
+  inputSource?: string
+}
+
+export interface FormatTableOptions {
+  selectedColumnIds: string[]
+}
+
+export type FormatTableResult =
+  | {
+      success: true
+      output: string
+    }
+  | {
+      success: false
+      error: 'invalid_columns' | 'no_columns' | 'invalid_structure'
+      message: string
+      invalidColumns?: string[]
+    }
+
+/**
+ * Converts cell value to string, handling various types
+ */
+function cellToString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+/**
+ * Formats table data as an HTML table with inline CSS for email compatibility
+ * Simple black borders with background colors matching the preview
+ */
+function formatAsHtml(rows: TableRow[], columns: TableColumn[]): string {
+  const headerBg = '#F3F4F6' // gray.100
+  const rowOddBg = '#FFFFFF' // white
+  const rowEvenBg = '#F9FAFB' // gray.50
+  const cell = 'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
+
+  const headerCells = columns
+    .map(
+      (col) =>
+        safeHtml`<td style="${cell} background-color: ${headerBg}; font-weight: 600;"><p style="margin: 0;">${col.name}</p></td>`,
+    )
+    .join('')
+
+  const dataRows = rows
+    .map((row, i) => {
+      const bg = i % 2 === 0 ? rowOddBg : rowEvenBg
+      const cells = columns
+        .map(
+          (col) =>
+            safeHtml`<td style="${cell} background-color: ${bg};"><p style="margin: 0;">${cellToString(
+              row.data[col.id],
+            )}</p></td>`,
+        )
+        .join('')
+      return `<tr>${cells}</tr>`
+    })
+    .join('')
+
+  return `<table style="border-collapse: collapse;"><tbody><tr>${headerCells}</tr>${dataRows}</tbody></table>`
+}
+
+/**
+ * Validates table data structure
+ */
+function validateTableData(tableData: unknown): tableData is TableData {
+  if (!tableData || typeof tableData !== 'object') {
+    return false
+  }
+
+  const data = tableData as Record<string, unknown>
+
+  if (!Array.isArray(data.rows) || !Array.isArray(data.columns)) {
+    return false
+  }
+
+  for (const col of data.columns) {
+    if (
+      typeof col !== 'object' ||
+      col === null ||
+      typeof (col as TableColumn).id !== 'string' ||
+      typeof (col as TableColumn).name !== 'string'
+    ) {
+      return false
+    }
+  }
+
+  for (const row of data.rows) {
+    if (
+      typeof row !== 'object' ||
+      row === null ||
+      typeof (row as TableRow).data !== 'object' ||
+      (row as TableRow).data === null
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * Main function to format table data into HTML
+ */
+export function formatTable(
+  tableData: unknown,
+  options: FormatTableOptions,
+): FormatTableResult {
+  if (!validateTableData(tableData)) {
+    return {
+      success: false,
+      error: 'invalid_structure',
+      message:
+        'Invalid table data structure. Expected { rows: Array, columns: Array }',
+    }
+  }
+
+  const { rows, columns } = tableData
+  const { selectedColumnIds } = options
+
+  const columnMap = new Map(columns.map((col) => [col.id, col]))
+  const columnsToUse: TableColumn[] = []
+  const invalidColumns: string[] = []
+
+  for (const colId of selectedColumnIds) {
+    const col = columnMap.get(colId)
+    if (col) {
+      columnsToUse.push(col)
+    } else {
+      invalidColumns.push(colId)
+    }
+  }
+
+  if (invalidColumns.length > 0) {
+    return {
+      success: false,
+      error: 'invalid_columns',
+      message: `Invalid column IDs: ${invalidColumns.join(', ')}`,
+      invalidColumns,
+    }
+  }
+
+  if (columnsToUse.length === 0) {
+    return {
+      success: false,
+      error: 'no_columns',
+      message: 'No columns to display',
+    }
+  }
+
+  return {
+    success: true,
+    output: formatAsHtml(rows, columnsToUse),
+  }
+}

--- a/packages/backend/src/helpers/hex-encoding.ts
+++ b/packages/backend/src/helpers/hex-encoding.ts
@@ -1,0 +1,17 @@
+/**
+ * Encodes a UTF-8 string to hexadecimal representation
+ *
+ * @example
+ * hexEncode('table:col1,col2') // '7461626c653a636f6c312c636f6c32'
+ */
+export const hexEncode = (str: string): string =>
+  Buffer.from(str, 'utf8').toString('hex')
+
+/**
+ * Decodes a hexadecimal string back to UTF-8
+ *
+ * @example
+ * hexDecode('7461626c653a636f6c312c636f6c32') // 'table:col1,col2'
+ */
+export const hexDecode = (hex: string): string =>
+  Buffer.from(hex, 'hex').toString('utf8')


### PR DESCRIPTION
### TL;DR

Added utilities for converting table data to HTML format for transactional emails and hex encoding/decoding for variable modifiers.

### What changed?

Created two new utility modules:

1. **`format-table-variable.ts`** - Converts table data from execution steps into HTML tables for email compatibility:
   - Validates table data structure with proper TypeScript interfaces
   - Supports column selection through `selectedColumnIds` option
   - Generates HTML with inline CSS styling (alternating row colors, borders)
   - Includes XSS protection through HTML escaping
   - Returns structured success/error results with detailed error messages

2. **`hex-encoding.ts`** - Provides hex encoding/decoding functions for variable modifiers:
   - `hexEncode()` converts UTF-8 strings to hexadecimal representation
   - `hexDecode()` converts hex strings back to UTF-8
   - Designed for safe regex parsing of table variable syntax like `table:col1,col2`

### How to test?

1. **Table formatting**: Import `formatTable` and test with sample table data containing rows and columns arrays
2. **Column selection**: Test with `selectedColumnIds` option to verify column filtering works correctly
3. **Error handling**: Test with invalid data structures, missing columns, or empty column lists
4. **Hex encoding**: Test `hexEncode('table:col1,col2')` and `hexDecode()` with the resulting hex string

### Why make this change?

These utilities enable table variable functionality in transactional emails by providing a robust way to convert execution step data into properly formatted HTML tables, while the hex encoding ensures safe and predictable parsing of variable modifiers in email templates.