### PR TITLE
PLU-591: [show-multiple-rows-2]: modified step regex and add table variable marker

### DIFF
--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -6,13 +6,33 @@ import {
   computeForEachParameters,
   ForEachContext,
 } from '@/helpers/compute-for-each-parameters'
+import { hexDecode } from '@/helpers/hex-encoding'
 import logger from '@/helpers/logger'
 import ExecutionStep from '@/models/execution-step'
 
 import Step from '../models/step'
 
+/**
+ * Regex to match step variables with optional hex-encoded modifier
+ *
+ * Format: {{step.<uuid>.<path>}} or {{step.<uuid>.<path>|<hexModifier>}}
+ *
+ * Examples:
+ * - {{step.abc-123-def.data}}
+ * - {{step.abc-123-def.data|7461626c653a636f6c31}} (with hex-encoded "table:col1")
+ */
 const variableRegExp =
-  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+}})/g
+  /({{step\.[\da-f]{8}-(?:[\da-f]{4}-){3}[\da-f]{12}(?:\.[\da-zA-Z-_ ]+)+(?:\|[a-fA-F0-9]+)?}})/g
+
+/**
+ * Marker object returned when a table modifier is detected.
+ * This is processed by the action's preprocessVariable function.
+ */
+export interface TableVariableMarker {
+  __type: 'table'
+  data: unknown
+  selectedColumnIds: string[]
+}
 
 function findAndSubstituteVariables(
   // i.e. the `key` corresponding to this variable's form field in defineAction
@@ -76,7 +96,14 @@ function findAndSubstituteVariables(
     const isVariable = part.match(variableRegExp)
     if (isVariable) {
       const stepIdAndKeyPath = part.replace(/{{step.|}}/g, '') as string
-      const [stepId, ...keyPaths] = stepIdAndKeyPath.split('.')
+
+      // Check for hex-encoded modifier (e.g., "|7461626c653a636f6c31")
+      const modifierMatch = stepIdAndKeyPath.match(/\|([a-fA-F0-9]+)$/)
+      const cleanStepIdAndKeyPath = modifierMatch
+        ? stepIdAndKeyPath.replace(/\|[a-fA-F0-9]+$/, '')
+        : stepIdAndKeyPath
+
+      const [stepId, ...keyPaths] = cleanStepIdAndKeyPath.split('.')
       const executionStep = executionSteps.find((executionStep) => {
         return executionStep.stepId === stepId
       })
@@ -96,6 +123,51 @@ function findAndSubstituteVariables(
           stepId,
           forEachContext,
         })
+      }
+
+      // Handle hex-encoded modifier (e.g., table:col1,col2)
+      if (modifierMatch) {
+        const decodedModifier = hexDecode(modifierMatch[1])
+        const [modifierType, ...modifierArgs] = decodedModifier.split(':')
+
+        if (modifierType === 'table') {
+          // Parse column IDs from modifier args (e.g., "col1,col2,col3")
+          const selectedColumnIds = modifierArgs[0]
+            ? modifierArgs[0].split(',').filter(Boolean)
+            : []
+
+          // Handle FormSG tables where dataValue is a stringified JSON
+          let tableData = dataValue
+          if (typeof dataValue === 'string') {
+            try {
+              tableData = JSON.parse(dataValue)
+            } catch {
+              // Not valid JSON, keep as-is (will fail validation in formatTable)
+            }
+          }
+
+          // Return marker object for preprocessVariable to handle
+          const marker: TableVariableMarker = {
+            __type: 'table',
+            data: tableData,
+            selectedColumnIds,
+          }
+
+          if (preprocessVariable) {
+            return preprocessVariable(parameterKey, marker)
+          }
+
+          // If no preprocessVariable, return original variable string
+          // to avoid [object Object] in string context
+          return part
+        }
+
+        // Unknown modifier type - return original variable string
+        logger.warn('Unsupported variable modifier type', {
+          event: 'unsupported-variable-modifier-type',
+          modifierType,
+        })
+        return part
       }
 
       // NOTE: dataValue could be an array if it is not processed on variables.ts


### PR DESCRIPTION
### TL;DR

Added support for hex-encoded modifiers in step variables to enable table column selection functionality.

### What changed?

- Extended the variable regex pattern to support optional hex-encoded modifiers in the format `{{step.<uuid>.<path>|<hexModifier>}}`
- Added parsing logic to decode hex-encoded modifiers and extract table column selection information
- Introduced `TableVariableMarker` interface to pass table data and selected column IDs to action preprocessors
- Added error handling for invalid hex encoding with appropriate logging

### How to test?

1. Create a step variable with a hex-encoded table modifier: `{{step.abc-123-def.data|7461626c653a636f6c31}}`
2. Verify the modifier is correctly decoded (hex example decodes to "table:col1")
3. Test with FormSG table data to ensure JSON parsing works correctly
4. Verify that invalid hex encoding falls back gracefully and logs warnings
5. Confirm that variables without modifiers continue to work as before

### Why make this change?

This enables dynamic table column selection in step variables, allowing users to specify which columns from table data should be processed by subsequent actions. The hex encoding approach keeps the variable syntax clean while supporting complex modifier parameters.