### PR TITLE
PLU-591: [show-multiple-rows-3]: add preprocess to postman email

### DIFF
--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -4,6 +4,8 @@ import { SafeParseError } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import StepError from '@/errors/step'
+import { TableVariableMarker } from '@/helpers/compute-parameters'
+import { formatTable } from '@/helpers/format-table-variable'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
@@ -22,12 +24,49 @@ import { sendInvalidAttachmentsEmail } from '../../common/send-invalid-attachmen
 import { throwPostmanStepError } from '../../common/throw-errors'
 
 import getDataOutMetadata from './get-data-out-metadata'
+/**
+ * Type guard to check if a value is a TableVariableMarker
+ */
+function isTableMarker(value: unknown): value is TableVariableMarker {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '__type' in value &&
+    (value as TableVariableMarker).__type === 'table'
+  )
+}
 
 const action: IRawAction = {
   name: 'Send email',
   key: 'sendTransactionalEmail',
   description: 'Sends an email using Postman',
   arguments: transactionalEmailFields,
+
+  preprocessVariable(key: string, value: unknown) {
+    // Handle table variable markers - convert to HTML table
+    if (isTableMarker(value)) {
+      // Only allow table rendering in the body field
+      if (key !== 'body') {
+        // Return placeholder for unsupported fields
+        return '[Table variables are only supported in the email body]'
+      }
+
+      const result = formatTable(value.data, {
+        selectedColumnIds: value.selectedColumnIds,
+      })
+
+      if (result.success === false) {
+        // Return error message as placeholder instead of failing the step
+        return `[Table Error: ${result.message}]`
+      }
+
+      return result.output
+    }
+
+    // Return unchanged for non-table values
+    return value
+  },
+
   doesFileProcessing: (step: Step) => {
     return (
       step.parameters.attachments &&

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -43,6 +43,14 @@ export const transactionalEmailFields: IField[] = [
     type: 'rich-text' as const,
     required: true,
     variables: true,
+    variableTypes: [
+      'text',
+      'array',
+      'tile_row_id',
+      'approval',
+      'ai_response',
+      'table',
+    ],
   },
   {
     label: 'Recipient email(s)',

--- a/packages/backend/src/helpers/compute-parameters.ts
+++ b/packages/backend/src/helpers/compute-parameters.ts
@@ -172,21 +172,20 @@ function findAndSubstituteVariables(
 
       // NOTE: dataValue could be an array if it is not processed on variables.ts
       // which is the case for formSG checkbox only, this is to deal with forEach next time
-      if (preprocessVariable) {
-        return preprocessVariable(parameterKey, dataValue)
-      }
-
+      let resolvedValue = dataValue
       if (Array.isArray(dataValue)) {
         // NOTE: we do not stringify the array if its a for each step
         // to avoid having to parse it back into an array again
-        if (isForEachStep) {
-          return dataValue
+        if (!isForEachStep) {
+          resolvedValue = dataValue.join(', ')
         }
-
-        return dataValue.join(', ')
       }
 
-      return dataValue
+      if (preprocessVariable) {
+        return preprocessVariable(parameterKey, resolvedValue)
+      }
+
+      return resolvedValue
     }
 
     return part

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -489,6 +489,7 @@ export type TRteMenuOption =
 export interface IFieldRichText extends IBaseField {
   type: 'rich-text'
   value?: string
+  variableTypes?: TDataOutMetadatumType[]
 
   // Specifies the order and what menu options to show in the RTE
   // 'Divider' is specified manually to determine when a divider should be shown


### PR DESCRIPTION
### TL;DR

Added support for table variables in Postman transactional email body with HTML table rendering and error handling.

### What changed?

- Added `preprocessVariable` function to the send transactional email action that converts table variable markers to HTML tables
- Implemented type guard `isTableMarker` to identify table variable markers
- Restricted table variable usage to the email body field only, showing placeholder text for other fields
- Added graceful error handling that displays error messages instead of failing the entire step
- Updated the body field configuration to accept table variables alongside existing variable types
- Extended `IFieldRichText` interface to support `variableTypes` specification

### How to test?

1. Create a workflow with a Postman send transactional email step
2. Use a table variable in the email body field and verify it renders as an HTML table
3. Try using a table variable in other fields (subject, recipient) and confirm placeholder text appears
4. Test with malformed table data to ensure error messages display properly instead of step failure
5. Verify existing variable types (text, array, etc.) continue to work as expected

### Why make this change?

This enhancement allows users to include structured tabular data in their transactional emails, making it easier to send formatted reports, lists, or other structured information. The restriction to body-only usage and graceful error handling ensures the feature is both useful and robust.