### PR TITLE
chore: bumping axios to v1.15.0 patch vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11215,14 +11215,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -26542,10 +26542,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -33116,7 +33119,7 @@
         "ai": "5.0.81",
         "ajv-formats": "2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.7",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ]
   },
   "overrides": {
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "graphql-rate-limit": {
       "@graphql-tools/utils": {
         "graphql": "16.11.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,7 @@
     "ai": "5.0.81",
     "ajv-formats": "2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
addressing: https://github.com/advisories/GHSA-fvcv-3m26-pcqx