### PR TITLE
[AIBOTS-3] PLU-599 (feat): implement queue for aibots

### DIFF
--- a/packages/backend/src/apps/__tests__/queue.test.ts
+++ b/packages/backend/src/apps/__tests__/queue.test.ts
@@ -1,0 +1,52 @@
+import '@/apps'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import aibotsApp from '../aibots'
+
+const mocks = vi.hoisted(() => ({
+  stepQueryResult: vi.fn(),
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: mocks.stepQueryResult,
+      })),
+    })),
+  },
+}))
+
+describe('AIBots Queue', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sets group ID to the connection ID', async () => {
+    mocks.stepQueryResult.mockResolvedValueOnce({
+      connectionId: 'mock-connection-id',
+      key: 'sendQuery',
+      appKey: 'aibots',
+    })
+    const groupConfig = await aibotsApp.queue.getGroupConfigForJob({
+      flowId: 'test-flow-id',
+      stepId: 'test-step-id',
+      executionId: 'test-step-id',
+    })
+    expect(groupConfig).toEqual({
+      id: 'mock-connection-id',
+    })
+  })
+
+  it('sets group concurrency to 1', () => {
+    expect(aibotsApp.queue.groupLimits).toEqual({
+      type: 'concurrency',
+      concurrency: 1,
+    })
+  })
+
+  it('avoids bursting via a leaky bucket approach', () => {
+    expect(aibotsApp.queue.queueRateLimit.max).toEqual(2)
+  })
+})

--- a/packages/backend/src/apps/aibots/index.ts
+++ b/packages/backend/src/apps/aibots/index.ts
@@ -3,6 +3,7 @@ import { IApp } from '@plumber/types'
 import addAuthHeader from './common/add-auth-header'
 import actions from './actions'
 import auth from './auth'
+import queue from './queue'
 
 const app: IApp = {
   name: 'AIBots',
@@ -10,13 +11,13 @@ const app: IApp = {
   description: 'Integrate with your customised AI Bot',
   iconUrl: '{BASE_URL}/apps/aibots/assets/favicon.svg',
   authDocUrl: '',
-  // TODO: update this to PROD once aibots releases the PROD API
   baseUrl: 'https://aibots.gov.sg',
   apiBaseUrl: 'https://api.aibots.gov.sg/v1.0/api',
   primaryColor: '',
   category: 'ai',
   auth,
   actions,
+  queue,
   beforeRequest: [addAuthHeader],
 }
 

--- a/packages/backend/src/apps/aibots/queue/index.ts
+++ b/packages/backend/src/apps/aibots/queue/index.ts
@@ -1,0 +1,29 @@
+import type { IAppQueue } from '@plumber/types'
+
+import Step from '@/models/step'
+
+const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
+  jobData,
+) => {
+  const step = await Step.query().findById(jobData.stepId).throwIfNotFound()
+
+  return {
+    id: step.connectionId,
+  }
+}
+
+const queueSettings = {
+  getGroupConfigForJob,
+  groupLimits: {
+    type: 'concurrency',
+    concurrency: 1,
+  },
+  queueRateLimit: {
+    max: 2,
+    duration: 1000,
+  },
+  isQueueDelayable: false,
+  workerType: 'action',
+} satisfies IAppQueue
+
+export default queueSettings


### PR DESCRIPTION
### TL;DR

Added queue configuration for the AIBots app to manage job processing with connection-based grouping and rate limiting.

### What changed?

- Added queue configuration to the AIBots app with connection ID-based job grouping
- Implemented concurrency limit of 1 per connection group
- Set rate limiting to maximum 2 jobs per second using a leaky bucket approach

### How to test?

Run the new test:

```bash
npm run test packages/backend/src/apps/__tests__/queue.test.ts
```

The tests verify:

- Group ID is correctly set to the connection ID
- Concurrency is limited to 1 per group
- Rate limiting is configured with max 2 jobs