### PR TITLE
PLU-719 (fix): ignore deleted tiles and connections

### DIFF
--- a/packages/backend/src/apps/tiles/common/get-transfer-details.ts
+++ b/packages/backend/src/apps/tiles/common/get-transfer-details.ts
@@ -14,11 +14,14 @@ async function getTransferDetails(
     }
   }
 
-  const table = await TableMetadata.query()
-    .findById(tableId)
-    .throwIfNotFound({
-      message: `Table connection cannot be found for table id: ${tableId}`,
-    })
+  const table = await TableMetadata.query().findById(tableId)
+  if (!table) {
+    return {
+      position: $.step.position,
+      appName: $.app.name,
+      instructions: `Tile has been deleted`,
+    }
+  }
 
   return {
     position: $.step.position,

--- a/packages/backend/src/graphql/mutations/create-flow-transfer.ts
+++ b/packages/backend/src/graphql/mutations/create-flow-transfer.ts
@@ -1,5 +1,6 @@
 import FlowTransfer from '@/models/flow-transfers'
 import TableCollaborator from '@/models/table-collaborators'
+import TableMetadata from '@/models/table-metadata'
 import User from '@/models/user'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
@@ -60,16 +61,32 @@ const createFlowTransfer: MutationResolvers['createFlowTransfer'] = async (
       (step) => step.appKey === 'tiles' && step.parameters?.tableId,
     ) ?? []
 
+  // Filter out deleted tables before checking permissions
+  const tableIds = tilesSteps.map((step) => step.parameters.tableId as string)
+  const existingTableIds = new Set<string>()
+
+  if (tableIds.length > 0) {
+    const existingTables = await TableMetadata.query()
+      .select('id')
+      .whereIn('id', tableIds)
+
+    existingTables.forEach((table) => {
+      existingTableIds.add(table.id)
+    })
+  }
+
   // check that the current owner has the rights to make the new owner
-  // an editor of all the Tiles in the Pipe
+  // an editor of all the Tiles in the Pipe (only for existing tables)
   await Promise.all(
-    tilesSteps.map(async (step) => {
-      await TableCollaborator.hasAccess(
-        context.currentUser.id,
-        step.parameters.tableId as string,
-        'editor',
-      )
-    }),
+    tilesSteps
+      .filter((step) => existingTableIds.has(step.parameters.tableId as string))
+      .map(async (step) => {
+        await TableCollaborator.hasAccess(
+          context.currentUser.id,
+          step.parameters.tableId as string,
+          'editor',
+        )
+      }),
   )
 
   const newTransfer: FlowTransfer = await context.currentUser

--- a/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-shared-connection-details.test.ts
@@ -1,10 +1,54 @@
 import { IStep } from '@plumber/types'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import App from '@/models/app'
+import Connection from '@/models/connection'
+import TableMetadata from '@/models/table-metadata'
 
 import { getConnectionDetails } from '../get-shared-connection-details'
 
+vi.mock('@/models/app')
+vi.mock('@/models/connection')
+vi.mock('@/models/table-metadata')
+
 describe('getConnectionDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Default mock: all apps have connections (matches pre-existing behavior)
+    vi.mocked(App.getAllAppsWithConnections).mockResolvedValue([
+      { key: 'aisay', auth: {} },
+      { key: 'custom-api', auth: {} },
+      { key: 'formsg', auth: {} },
+      { key: 'slack', auth: {} },
+      { key: 'lettersg', auth: {} },
+      { key: 'm365-excel', auth: {} },
+      { key: 'paysg', auth: {} },
+      { key: 'postman-sms', auth: {} },
+      { key: 'slack', auth: {} },
+      { key: 'telegram-bot', auth: {} },
+    ] as any)
+
+    // Default mock: all connections exist (optimistic path)
+    vi.mocked(Connection.query).mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      whereIn: vi.fn().mockImplementation((_, ids) => {
+        // Return all requested IDs as existing
+        return Promise.resolve(ids.map((id: string) => ({ id })))
+      }),
+    } as any)
+
+    // Default mock: all tables exist (optimistic path)
+    vi.mocked(TableMetadata.query).mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      whereIn: vi.fn().mockImplementation((_, ids) => {
+        // Return all requested IDs as existing
+        return Promise.resolve(ids.map((id: string) => ({ id })))
+      }),
+    } as any)
+  })
+
   const createMockStep = (overrides: Partial<IStep> = {}): IStep => ({
     id: 'step-1',
     flowId: 'flow-1',
@@ -300,6 +344,140 @@ describe('getConnectionDetails', () => {
   })
 
   describe('mixed scenarios', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('should filter out deleted connections', async () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'existing-connection-id',
+          parameters: { channel: 'general' },
+        }),
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'deleted-connection-id',
+          parameters: { channel: 'random' },
+        }),
+        createMockStep({
+          appKey: 'm365-excel',
+          connectionId: 'deleted-excel-connection-id',
+          parameters: { fileId: 'file-123' },
+        }),
+      ]
+
+      // Mock Connection.query to return only the existing connection
+      vi.mocked(Connection.query).mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockResolvedValue([
+          { id: 'existing-connection-id' },
+          // deleted-connection-id is not returned
+          // deleted-excel-connection-id is not returned
+        ]),
+      } as any)
+
+      const result = await getConnectionDetails(steps)
+
+      // Should only include the existing connection
+      expect(result).toEqual({
+        connection: {
+          'existing-connection-id': {},
+        },
+        table: [],
+      })
+
+      // Verify that Connection.query was called with the correct connection IDs
+      expect(Connection.query).toHaveBeenCalled()
+    })
+
+    it('should filter out deleted tables', async () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'existing-table-id' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'deleted-table-id' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'another-deleted-table-id' },
+        }),
+      ]
+
+      // Mock TableMetadata.query to return only the existing table
+      vi.mocked(TableMetadata.query).mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockResolvedValue([
+          { id: 'existing-table-id' },
+          // deleted-table-id is not returned
+          // another-deleted-table-id is not returned
+        ]),
+      } as any)
+
+      const result = await getConnectionDetails(steps)
+
+      // Should only include the existing table
+      expect(result).toEqual({
+        connection: {},
+        table: ['existing-table-id'],
+      })
+
+      // Verify that TableMetadata.query was called
+      expect(TableMetadata.query).toHaveBeenCalled()
+    })
+
+    it('should filter out both deleted connections and deleted tables', async () => {
+      const steps: IStep[] = [
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'existing-connection-id',
+          parameters: { channel: 'general' },
+        }),
+        createMockStep({
+          appKey: 'slack',
+          connectionId: 'deleted-connection-id',
+          parameters: { channel: 'random' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'existing-table-id' },
+        }),
+        createMockStep({
+          appKey: 'tiles',
+          parameters: { tableId: 'deleted-table-id' },
+        }),
+      ]
+
+      // Mock Connection.query to return only the existing connection
+      vi.mocked(Connection.query).mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockResolvedValue([{ id: 'existing-connection-id' }]),
+      } as any)
+
+      // Mock TableMetadata.query to return only the existing table
+      vi.mocked(TableMetadata.query).mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockResolvedValue([{ id: 'existing-table-id' }]),
+      } as any)
+
+      const result = await getConnectionDetails(steps)
+
+      // Should only include the existing connection and table
+      expect(result).toEqual({
+        connection: {
+          'existing-connection-id': {},
+        },
+        table: ['existing-table-id'],
+      })
+
+      // Verify that both queries were called
+      expect(Connection.query).toHaveBeenCalled()
+      expect(TableMetadata.query).toHaveBeenCalled()
+    })
+
     it('should handle mix of apps with and without parameterKey defined', async () => {
       const steps: IStep[] = [
         // Apps with empty APP_CONNECTION_FIELDS

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -1,6 +1,8 @@
 import { IStep } from '@plumber/types'
 
 import App from '@/models/app'
+import Connection from '@/models/connection'
+import TableMetadata from '@/models/table-metadata'
 
 /**
  * THIS MUST BE UPDATED WHEN A NEW APP OR NEW DYNAMIC FIELD IS ADDED
@@ -68,8 +70,13 @@ export async function getConnectionDetails(steps: IStep[]): Promise<{
     table: [],
   }
 
-  steps.map((step) => {
+  const connectionIdsFromSteps = new Set<string>()
+  const tableIdsFromSteps = new Set<string>()
+
+  // Single pass: build connections object and collect connection/table IDs
+  steps.forEach((step) => {
     if (step.connectionId && appKeysWithConnections.includes(step.appKey)) {
+      connectionIdsFromSteps.add(step.connectionId)
       connections.connection[step.connectionId] ??= {}
 
       const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
@@ -99,11 +106,50 @@ export async function getConnectionDetails(steps: IStep[]): Promise<{
       const paramKey = APP_CONNECTION_FIELDS[step.appKey]?.parameterKey
       const paramValue = step.parameters[paramKey] as string
 
-      if (paramValue && !connections.table.includes(paramValue)) {
-        connections.table.push(paramValue)
+      if (paramValue) {
+        tableIdsFromSteps.add(paramValue)
+        if (!connections.table.includes(paramValue)) {
+          connections.table.push(paramValue)
+        }
       }
     }
   })
+
+  // Query database in parallel to check which connections and tables actually exist
+  const [existingConnections, existingTables] = await Promise.all([
+    connectionIdsFromSteps.size > 0
+      ? Connection.query()
+          .select('id')
+          .whereIn('id', Array.from(connectionIdsFromSteps))
+      : Promise.resolve([]),
+    tableIdsFromSteps.size > 0
+      ? TableMetadata.query()
+          .select('id')
+          .whereIn('id', Array.from(tableIdsFromSteps))
+      : Promise.resolve([]),
+  ])
+
+  // Remove connections that don't exist in the database
+  if (connectionIdsFromSteps.size > 0) {
+    const existingConnectionIds = new Set(
+      existingConnections.map((conn) => conn.id),
+    )
+
+    Object.keys(connections.connection).forEach((connectionId) => {
+      if (!existingConnectionIds.has(connectionId)) {
+        delete connections.connection[connectionId]
+      }
+    })
+  }
+
+  // Remove tables that don't exist in the database
+  if (tableIdsFromSteps.size > 0) {
+    const existingTableIds = new Set(existingTables.map((table) => table.id))
+
+    connections.table = connections.table.filter((tableId) =>
+      existingTableIds.has(tableId),
+    )
+  }
 
   return connections
 }

--- a/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
+++ b/packages/frontend/src/components/EditorSettings/FlowTransfer/FlowTransferConnections.tsx
@@ -17,12 +17,16 @@ function StepConnectionDisplay(props: ITransferDetails) {
       <Badge colorScheme="warning">
         Step {position}: {appName}
       </Badge>
-      <Text textStyle="body-1" color="base.content.default">
-        {connectionName}
-      </Text>
-      <Text textStyle="body-1" color="base.content.medium">
-        {instructions}
-      </Text>
+      {connectionName && (
+        <Text textStyle="body-1" color="base.content.default">
+          {connectionName}
+        </Text>
+      )}
+      {instructions && (
+        <Text textStyle="body-1" color="base.content.medium">
+          {instructions}
+        </Text>
+      )}
     </Flex>
   )
 }
@@ -67,7 +71,7 @@ export default function FlowTransferConnections() {
           {showConnections ? 'Hide connections' : 'Show connections'}
         </Text>
         {showConnections && (
-          <Box>
+          <Box display="flex" flexDir="column" gap={2}>
             {flowTransferDetails.map(
               ({ appName, position, connectionName, instructions }, index) => (
                 <StepConnectionDisplay


### PR DESCRIPTION
### TL;DR

- Users cannot add collaborators when the Pipe is using a deleted Tile or a connection
- Users cannot accept a Pipe transfer if it was referencing a deleted Tile or connection

Also resolves PLU-647.

### What changed?

- Updated `createFlowTransfer` mutation to check if tables exist in the database before validating permissions for Tiles steps
- Updated `getConnectionDetails` helper to query the database and filter out deleted connections and tables from the results

### How to test?

**Adding** **collaborators**

- [ ] Verify that you can add collaborators if the Pipe is using a deleted Tile
- [ ] Verify that you can add collaborators if the Pipe is using a deleted connection

**Pipe** **transfer**

- [ ] Verify that you can create a Pipe Transfer if the Pipe is using a deleted Tile
- [ ] Verify that you can create a Pipe Transfer if the Pipe is using a deleted connection

**Delete** **connection** **after** **creating** **Pipe** **transfer**

- [ ] Verify that you can accept a Pipe transfer if the Tile is deleted after the transfer was initiated
- [ ] Verify that you can accept a Pipe transfer if the connection is deleted after the transfer was initiated