### PR TITLE
PLU-721 fix: tile export not working if no rows

### DIFF
--- a/packages/frontend/src/pages/Tile/components/TableBanner/ExportCsvButton.tsx
+++ b/packages/frontend/src/pages/Tile/components/TableBanner/ExportCsvButton.tsx
@@ -3,11 +3,11 @@ import { BiChevronDown, BiExport } from 'react-icons/bi'
 import { ButtonProps, MenuButton, MenuItem, MenuList } from '@chakra-ui/react'
 import { Button, Menu } from '@opengovsg/design-system-react'
 import { saveAs } from 'file-saver'
-import { unparse } from 'papaparse'
 
 import { dateString } from '@/helpers/dateTime'
 
 import { useTableContext } from '../../contexts/TableContext'
+import { buildCsv } from '../../helpers/build-csv'
 
 const ExportCsvButton = (props: ButtonProps) => {
   const { allDataRef, filteredDataRef, tableColumns, tableName } =
@@ -19,22 +19,11 @@ const ExportCsvButton = (props: ButtonProps) => {
         filtered && filteredDataRef.current.length
           ? filteredDataRef.current
           : allDataRef.current
-      const columnIdToNameMap: Record<string, string> = {}
-      tableColumns.forEach((column) => {
-        columnIdToNameMap[column.id] = column.name
-      })
 
-      const mappedData = dataToSave.map((dataRow) => {
-        const row: Record<string, string> = {}
-        Object.entries(dataRow).forEach(([key, value]) => {
-          row[columnIdToNameMap[key]] = value
-        })
-        return row
-      })
-
-      const csvString = unparse(mappedData, {
-        columns: tableColumns.map((column) => column.name),
-      })
+      const csvString = buildCsv(dataToSave, tableColumns)
+      if (csvString === null) {
+        return
+      }
 
       const filename = `${tableName
         .trim()

--- a/packages/frontend/src/pages/Tile/helpers/__tests__/build-csv.test.ts
+++ b/packages/frontend/src/pages/Tile/helpers/__tests__/build-csv.test.ts
@@ -1,0 +1,101 @@
+import type { ITableColumnMetadata } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import type { GenericRowData } from '../../types'
+import { buildCsv } from '../build-csv'
+
+const cols = (...names: string[]): ITableColumnMetadata[] =>
+  names.map((name, i) => ({
+    id: `col${i + 1}`,
+    name,
+    position: i,
+    config: {},
+  })) as unknown as ITableColumnMetadata[]
+
+describe('buildCsv', () => {
+  it('returns null when there are no columns (nothing to export)', () => {
+    expect(buildCsv([], [])).toBeNull()
+    expect(
+      buildCsv(
+        [{ rowId: 'r1', col1: 'orphan' } as unknown as GenericRowData],
+        [],
+      ),
+    ).toBeNull()
+  })
+
+  it('produces a header-only CSV when there are columns but no rows', () => {
+    expect(buildCsv([], cols('Name', 'Email'))).toBe('Name,Email\r\n')
+  })
+
+  it('produces header + data rows when rows are present', () => {
+    const columns = cols('Name', 'Email')
+    const rows = [
+      { rowId: 'r1', col1: 'Alice', col2: 'alice@example.com' },
+      { rowId: 'r2', col1: 'Bob', col2: 'bob@example.com' },
+    ] as unknown as GenericRowData[]
+
+    expect(buildCsv(rows, columns)).toBe(
+      'Name,Email\r\nAlice,alice@example.com\r\nBob,bob@example.com',
+    )
+  })
+
+  it('escapes values containing commas by wrapping them in double quotes', () => {
+    const columns = cols('Name', 'Address')
+    const rows = [
+      { rowId: 'r1', col1: 'Alice', col2: '1 Main St, Apt 2' },
+    ] as unknown as GenericRowData[]
+
+    expect(buildCsv(rows, columns)).toBe(
+      'Name,Address\r\nAlice,"1 Main St, Apt 2"',
+    )
+  })
+
+  it('escapes values containing double quotes by doubling them', () => {
+    const columns = cols('Name', 'Quote')
+    const rows = [
+      { rowId: 'r1', col1: 'Alice', col2: 'She said "hi"' },
+    ] as unknown as GenericRowData[]
+
+    expect(buildCsv(rows, columns)).toBe(
+      'Name,Quote\r\nAlice,"She said ""hi"""',
+    )
+  })
+
+  it('escapes values containing newlines by wrapping them in double quotes', () => {
+    const columns = cols('Name', 'Note')
+    const rows = [
+      { rowId: 'r1', col1: 'Alice', col2: 'line1\nline2' },
+    ] as unknown as GenericRowData[]
+
+    expect(buildCsv(rows, columns)).toBe('Name,Note\r\nAlice,"line1\nline2"')
+  })
+
+  it('escapes column names containing commas/quotes', () => {
+    const columns = cols('Name, Full', 'He said "x"')
+    expect(buildCsv([], columns)).toBe('"Name, Full","He said ""x"""\r\n')
+  })
+
+  it('maps row keys (column IDs) to column names in the output header', () => {
+    const columns = cols('First Name', 'Last Name')
+    const rows = [
+      { rowId: 'r1', col1: 'Ada', col2: 'Lovelace' },
+    ] as unknown as GenericRowData[]
+
+    const csv = buildCsv(rows, columns)
+    expect(csv).toContain('First Name,Last Name')
+    expect(csv).toContain('Ada,Lovelace')
+    // rowId should not appear under an undefined column
+    expect(csv).not.toContain('undefined')
+    expect(csv).not.toContain('r1')
+  })
+
+  it('emits an empty cell for a column missing from a row', () => {
+    const columns = cols('Name', 'Email')
+    const rows = [
+      { rowId: 'r1', col1: 'Alice' }, // no col2
+    ] as unknown as GenericRowData[]
+
+    expect(buildCsv(rows, columns)).toBe('Name,Email\r\nAlice,')
+  })
+})

--- a/packages/frontend/src/pages/Tile/helpers/build-csv.ts
+++ b/packages/frontend/src/pages/Tile/helpers/build-csv.ts
@@ -1,0 +1,49 @@
+import type { ITableColumnMetadata } from '@plumber/types'
+
+import { unparse } from 'papaparse'
+
+import type { GenericRowData } from '../types'
+
+/**
+ * Builds a CSV string from table data. Returns null if there are no columns —
+ * the caller should skip writing a file in that case.
+ *
+ * - With rows: produces header + data rows, mapping column IDs to column names.
+ * - Without rows: produces a header-only CSV so the user gets a usable template.
+ *
+ * Values containing commas, quotes, or newlines are escaped per RFC 4180
+ * (delegated to papaparse).
+ */
+export function buildCsv(
+  rows: GenericRowData[],
+  columns: ITableColumnMetadata[],
+): string | null {
+  if (columns.length === 0) {
+    return null
+  }
+
+  const columnNames = columns.map((c) => c.name)
+
+  if (rows.length === 0) {
+    return unparse({ fields: columnNames, data: [] })
+  }
+
+  const columnIdToNameMap: Record<string, string> = {}
+  columns.forEach((c) => {
+    columnIdToNameMap[c.id] = c.name
+  })
+
+  const mappedData = rows.map((dataRow) => {
+    const row: Record<string, string> = {}
+    Object.entries(dataRow).forEach(([key, value]) => {
+      // Skip keys without a matching column (e.g. rowId) so they don't
+      // appear under an `undefined` column header.
+      if (columnIdToNameMap[key] !== undefined) {
+        row[columnIdToNameMap[key]] = value
+      }
+    })
+    return row
+  })
+
+  return unparse(mappedData, { columns: columnNames })
+}


### PR DESCRIPTION
### What changed?

- Created a new `buildCsv` helper function that handles CSV generation from table data and column metadata
- Moved CSV generation logic out of the `ExportCsvButton` component into the reusable helper

### How to test?

- Export Tile with rows
- Export tile without rows
- Export tile with commas and semicolons in header