### PR TITLE
[COLLAB-CON-6] (feat): editor can add their tiles

### DIFF
--- a/packages/backend/src/graphql/mutations/delete-flow.ts
+++ b/packages/backend/src/graphql/mutations/delete-flow.ts
@@ -27,6 +27,7 @@ const deleteFlow: MutationResolvers['deleteFlow'] = async (
   await flow.$relatedQuery('executions').delete()
   await flow.$relatedQuery('steps').delete()
   await flow.$relatedQuery('pendingTransfer').delete()
+  await flow.$relatedQuery('flowConnections').delete()
 
   // delete attachments from s3
   // Note: specify object keys individually, cannot delete entire folder

--- a/packages/backend/src/graphql/mutations/tiles/delete-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/delete-table.ts
@@ -1,3 +1,4 @@
+import FlowConnections from '@/models/flow-connections'
 import TableCollaborator from '@/models/table-collaborators'
 import TableMetadata from '@/models/table-metadata'
 
@@ -23,6 +24,12 @@ const deleteTable: MutationResolvers['deleteTable'] = async (
     await TableCollaborator.query().where({ table_id: params.input.id }).patch({
       deletedAt: new Date().toISOString(),
     })
+
+    // remove the table from the flow connections table
+    await FlowConnections.query(trx)
+      .where({ connection_id: params.input.id, connection_type: 'table' })
+      .delete()
+
     await table.$query(trx).delete()
   })
 

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -104,38 +104,29 @@ const updateStep: MutationResolvers['updateStep'] = async (
     /**
      * NOTE: we need to update flow connections for apps with connections:
      * Tiles:
-     * 1. add the collaborator to the flow connections table
+     * 1. add the tile to the flow connections table
      * 2. add the collaborator to the table collaborators table
      *
-     * TODO (kevinkim-ogp): phase 2
-     * collaborator should be able to add their own tiles,
-     * and the owner will be added as an editor to the Tile
-     *
      * Other connections:
-     * 1. add the collaborator to the flow connections table
-     *
-     * TODO (kevinkim-ogp): phase 2
-     * collaborator should be able to add their own connections,
-     * it will be tied to this specific flow only
+     * 1. add the connection to the flow connections table
      */
-    if (step.flow.role === 'owner') {
-      const appKey = updatedStep?.appKey
+    const appKey = updatedStep?.appKey
 
-      // tiles special handling
-      if (appKey === 'tiles' && updatedStep?.parameters?.tableId) {
-        await addFlowTableConnection({
-          flowId: updatedStep.flowId,
-          tableId: updatedStep.parameters.tableId as string,
-          addedBy: context.currentUser.id,
-          trx,
-        })
-      } else if (updatedStep?.connectionId) {
-        await addFlowConnection({
-          step: updatedStep,
-          addedBy: context.currentUser.id,
-          trx,
-        })
-      }
+    // tiles special handling
+    if (appKey === 'tiles' && updatedStep?.parameters?.tableId) {
+      await addFlowTableConnection({
+        flowId: updatedStep.flowId,
+        tableId: updatedStep.parameters.tableId as string,
+        addedBy: context.currentUser.id,
+        flowOwnerId: step.flow.userId,
+        trx,
+      })
+    } else if (step.flow.role === 'owner' && updatedStep?.connectionId) {
+      await addFlowConnection({
+        step: updatedStep,
+        addedBy: context.currentUser.id,
+        trx,
+      })
     }
 
     // update the flow's last updated

--- a/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
+++ b/packages/backend/src/graphql/mutations/upsert-flow-collaborator.ts
@@ -142,6 +142,7 @@ const upsertFlowCollaborator: MutationResolvers['upsertFlowCollaborator'] =
                 flowId,
                 tableId,
                 addedBy: context.currentUser.id,
+                flowOwnerId: flow.userId,
                 trx,
               })
             }),

--- a/packages/backend/src/graphql/queries/get-dynamic-data.ts
+++ b/packages/backend/src/graphql/queries/get-dynamic-data.ts
@@ -33,12 +33,25 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
     return null
   }
 
+  /**
+   * if the user is a viewer:
+   *   - use the flow owner's user so that they can see all the options.
+   * if the user is an editor:
+   *   - we need to check whether the current app is a readOnly (i.e., the editor does not have access to modify the connection).
+   *   - if the editor can modify the connection, they would already have access to the options via the flow_connections table.
+   * if the user is an owner:
+   *   - use the current user so that they can see their own options.
+   */
+  const shouldUseOwnerUser =
+    step.flow.role === 'viewer' ||
+    APP_CONNECTION_FIELDS[step.appKey]?.editorReadOnly
+
   const $ = await globalVariable({
     connection,
     app,
     flow: step.flow,
     step,
-    user: step.flow.user,
+    user: shouldUseOwnerUser ? step.flow.user : context.currentUser,
   })
 
   const command = app.dynamicData.find((data) => data.key === dynamicDataKey)
@@ -55,13 +68,12 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
    * filter out the dynamic data to only show the options that have been shared with the user
    *
    * Tiles:
-   * - only show the Tiles that have been shared
+   * - show the Tiles that have been shared
+   * - show the user's own Tiles (can be added and shared)
    *
    * Other connections:
    * - only show the connections that have been shared
    *
-   * TODO (kevinkim-ogp): phase 2
-   * - collaborator should be able to add their own Tiles
    */
   if (
     step.flow.role !== 'owner' &&
@@ -70,18 +82,28 @@ const getDynamicData: QueryResolvers['getDynamicData'] = async (
   ) {
     switch (step.appKey) {
       case 'tiles': {
-        const flowConnections = await context.currentUser
-          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
-          .where({
-            connection_type: 'table',
-            'flow_connections.flow_id': step.flowId,
-          })
+        /**
+         * we still need to filter the data for viewers as they should only
+         * see the Tiles that have been shared in this Pipe.
+         * they should not be able to see their own or the owner's Tiles
+         */
+        if (step.flow.role === 'viewer') {
+          const flowConnections = await context.currentUser
+            .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+            .where({
+              connection_type: 'table',
+              'flow_connections.flow_id': step.flowId,
+            })
 
-        return fetchedData.data.filter((data) =>
-          flowConnections.some(
-            (flowConnection) => flowConnection.connectionId === data.value,
-          ),
-        )
+          return fetchedData.data.filter((data) =>
+            flowConnections.some(
+              (flowConnection) => flowConnection.connectionId === data.value,
+            ),
+          )
+        }
+
+        // editors and owners should see both the shared and all their own Tiles
+        return fetchedData.data
       }
 
       default: {

--- a/packages/backend/src/helpers/add-flow-connection.ts
+++ b/packages/backend/src/helpers/add-flow-connection.ts
@@ -18,6 +18,7 @@ interface AddTableFlowConnectionParams {
   flowId: string
   tableId: string
   addedBy: string
+  flowOwnerId: string
   trx?: Transaction
 }
 
@@ -63,6 +64,7 @@ async function addFlowTableConnection({
   flowId,
   tableId,
   addedBy,
+  flowOwnerId,
   trx,
 }: AddTableFlowConnectionParams): Promise<void> {
   // COLLABORATORS:
@@ -84,6 +86,18 @@ async function addFlowTableConnection({
     flowId,
     trx,
   })
+
+  // now that editors can also add their own tiles, we also need to add the flow owner
+  // as an editor to the tile
+  // if the addedBy === flowOwnerId, the owner is adding their own Tile so we can skip this
+  if (addedBy !== flowOwnerId) {
+    await TableCollaborator.upgradeOrInsertCollaborator({
+      userId: flowOwnerId,
+      tableId,
+      role: 'editor',
+      trx,
+    })
+  }
 
   // use Promise.all so that we use the addCollaborator function, which checks
   // if the collaborator already exists to avoid duplicates

--- a/packages/backend/src/helpers/get-shared-connection-details.ts
+++ b/packages/backend/src/helpers/get-shared-connection-details.ts
@@ -19,11 +19,17 @@ export const APP_CONNECTION_FIELDS: Record<
   {
     parameterKey?: string
     dynamicDataKey?: string
+    /**
+     * if true, collaborator will not able to modify the connection for the app,
+     * but they can still use the owner's connection
+     */
+    editorReadOnly?: boolean
   }
 > = {
   'm365-excel': {
     parameterKey: 'fileId',
     dynamicDataKey: 'listFiles',
+    editorReadOnly: true,
   },
   lettersg: {},
   slack: {},

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -9,6 +9,7 @@ import { doesActionProcessFiles } from '@/helpers/actions'
 import Base from './base'
 import Execution from './execution'
 import FlowCollaborator from './flow-collaborators'
+import FlowConnections from './flow-connections'
 import FlowTransfer from './flow-transfers'
 import ExtendedQueryBuilder from './query-builder'
 import Step from './step'
@@ -137,6 +138,14 @@ class Flow extends Base {
       },
       filter(builder: ExtendedQueryBuilder<FlowCollaborator>) {
         builder.whereNull('deleted_at')
+      },
+    },
+    flowConnections: {
+      relation: Base.HasManyRelation,
+      modelClass: FlowConnections,
+      join: {
+        from: `${this.tableName}.id`,
+        to: `${FlowConnections.tableName}.flow_id`,
       },
     },
   })


### PR DESCRIPTION
### TL;DR

- Allow editors to add their own tiles 
- Update cleanup

### What changed?

- Editors can now add their own tiles to flows, with the flow owner automatically granted owner permissions on those tiles
- **Dynamic Data Filtering**: Updated `getDynamicData` to show editors both shared tiles and their own tiles, while viewers only see shared tiles in the current flow
- **Connection Management**: Removed owner-only restriction for adding tile connections while maintaining it for other connection types
- **Delete** **Tile** **from** `flow_connections` when the Tile is deleted
- Delete all connections in `flow_connections` when the Pipe is deleted

### How to test?

_Adding_ _Tiles_ _as_ _an_ _Editor_

- [ ] Verify that Editor can view their own Tiles in the selector
- [ ] Verify that all Pipe collaborators are added to the Tiles with the correct roles
    - [ ] Viewers added as viewers
    - [ ] Editors added as editors
    - [ ] Owner added as **editor**
- [ ] Verify that Owner can still add their own Tiles and the Pipe collaborators are added correctly
- [ ] Verify that Viewer still cannot add Tile

_Deleting_ _Pipe_

- [ ] Verify that connections in `flow_connections` are also deleted

_Deleting_ _Tile_

- [ ]  Verify that Tile connections in `flow_connections` are also deleted