### PR TITLE
feat: add maxFiles, multirow column labels

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -296,6 +296,9 @@ type ActionSubstepArgument {
 
   # Only for rich text
   customRteMenuOptions: [RteMenuOption]
+
+  # Only for attachments
+  maxFiles: Int
 }
 
 type DropdownClickableLink {

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -27,6 +27,7 @@ interface AttachmentSuggestionsProps {
   description?: string
   required?: boolean
   variableTypes?: TDataOutMetadatumType[]
+  maxFiles?: number
 }
 
 function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
@@ -37,6 +38,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     label,
     variableTypes = null,
     defaultValue = [],
+    maxFiles,
   } = props
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const cancelRef = useRef<HTMLButtonElement>(null)
@@ -99,6 +101,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
           variable,
           options,
           getValues(name),
+          maxFiles,
         )
         if (!isValid) {
           setError(name, { type: 'invalidFile', message: error })
@@ -107,7 +110,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
         }
       }
     },
-    [getValues, name, setError, options],
+    [getValues, name, setError, options, maxFiles],
   )
 
   useOutsideClick({

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -170,6 +170,7 @@ export function validateFiles(
   file: File | CheckboxVariable,
   options: CheckboxVariable[],
   currentSelection: string[],
+  maxFiles: number = MAX_NUM_FILES,
 ): FileSizeValidationResult {
   const fileSize = file.size ?? 0
   const selectedOptions = options.filter((o) =>
@@ -182,10 +183,10 @@ export function validateFiles(
   const totalSize = currentTotalSize + fileSize
   const currentFileCount = currentSelection.length + 1
 
-  if (currentFileCount > MAX_NUM_FILES) {
+  if (currentFileCount > maxFiles) {
     return {
       isValid: false,
-      error: 'Total number of files cannot exceed 10',
+      error: `Total number of files cannot exceed ${maxFiles}`,
     }
   }
 

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -198,6 +198,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         description={description}
         variableTypes={schema.variableTypes}
         required={required}
+        maxFiles={schema.maxFiles}
       />
     )
   }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -48,9 +48,21 @@ export default function MultiCol(props: MultiColProps) {
     subFIndex: number,
   ) => {
     const { type, variables } = subF
+
+    // Only show labels, descriptions, and tooltips on the first row
+    const schemaWithConditionalLabel =
+      index === 0
+        ? subF
+        : {
+            ...subF,
+            label: undefined,
+            description: undefined,
+            tooltipText: undefined,
+          }
+
     return (
       <InputCreator
-        schema={subF}
+        schema={schemaWithConditionalLabel}
         namePrefix={name}
         parentType="multicol"
         autoFocus={subFIndex === 0 && type === 'string' && variables}
@@ -60,7 +72,7 @@ export default function MultiCol(props: MultiColProps) {
   }
 
   return (
-    <Flex flexDir={isMobile ? 'column' : 'row'} gap={2} alignItems="center">
+    <Flex flexDir={isMobile ? 'column' : 'row'} gap={2} alignItems="flex-end">
       {subFields.map((subF, subFIndex) => {
         const showDeleteButton = subFIndex === 0 && canRemoveRow
         return isMobile ? (

--- a/packages/frontend/src/graphql/queries/get-apps.ts
+++ b/packages/frontend/src/graphql/queries/get-apps.ts
@@ -198,6 +198,7 @@ export const GET_APPS = gql`
             tooltipText
             value
             noVariablesMessage
+            maxFiles
             options {
               label
               description

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -448,6 +448,9 @@ export interface IFieldAttachment extends IBaseField {
   type: 'attachment'
   value?: string
   variableTypes?: TDataOutMetadatumType[]
+
+  // Only for attachments
+  maxFiles?: number
 }
 
 export interface IFieldMultiline extends IBaseField {


### PR DESCRIPTION
### TL;DR

- Added support for configurable maximum file limits in attachment fields
- Allow MultiCol input fields to show Labels for the first row

### What changed?

- Added `maxFiles` attachment field types
- Updated `AttachmentSuggestions` component to accept and use a `maxFiles` prop
- Modified file validation logic to use the configurable limit instead of the hardcoded `MAX_NUM_FILES` constant
- Updated error messages to display the actual file limit
- Allow Multicol to show labels on the first row
- Fixed MultiCol component alignment of inputs and delete button

### How to test?

`maxFiles`

- [ ] Add `maxFiles` to the postman attachment field 
- [ ] Verify that the limit is respected

_MultiCol_ _labels_

- [ ] Add a `Label`to a `multirow-multicol` field e.g., in Tiles or If-then
- [ ] Verify that the Labels are shown only for the first row
- [ ] Verify that the delete button is still aligned with the inputs