### PR TITLE
PLU-708 (chore): design improvements

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/get-data-out-metadata.test.ts
@@ -1,0 +1,129 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { assert, describe, expect, it } from 'vitest'
+
+import getDataOutMetadata from '@/apps/pair/actions/process-image/get-data-out-metadata'
+
+describe('process-image getDataOutMetadata', () => {
+  it('should return null when dataOut is null', async () => {
+    const executionStep = {
+      dataOut: null,
+    } as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+    expect(result).toBeNull()
+  })
+
+  it('should return null when dataOut is undefined', async () => {
+    const executionStep = {} as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+    expect(result).toBeNull()
+  })
+
+  it('should convert underscores to spaces in labels', async () => {
+    const executionStep = {
+      dataOut: {
+        Signature_present: 'yes',
+        Document_type: 'invoice',
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(result['Signature_present']).toEqual({
+      label: 'Signature present',
+      type: 'ai_response',
+    })
+    expect(result['Document_type']).toEqual({
+      label: 'Document type',
+      type: 'ai_response',
+    })
+  })
+
+  it('should handle field names without underscores', async () => {
+    const executionStep = {
+      dataOut: {
+        signature: 'yes',
+        confidence: '0.95',
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(result['signature']).toEqual({
+      label: 'signature',
+      type: 'ai_response',
+    })
+    expect(result['confidence']).toEqual({
+      label: 'confidence',
+      type: 'ai_response',
+    })
+  })
+
+  it('should handle multiple underscores correctly', async () => {
+    const executionStep = {
+      dataOut: {
+        field__with__multiple__underscores: 'value',
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(result['field__with__multiple__underscores']).toEqual({
+      label: 'field  with  multiple  underscores',
+      type: 'ai_response',
+    })
+  })
+
+  it('should handle mixed fields with and without underscores', async () => {
+    const executionStep = {
+      dataOut: {
+        Signature_present: 'yes',
+        Document_type: 'invoice',
+        confidence: '0.95',
+        total_amount: '150.00',
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(Object.keys(result)).toHaveLength(4)
+    expect(result['Signature_present'].label).toBe('Signature present')
+    expect(result['Document_type'].label).toBe('Document type')
+    expect(result['confidence'].label).toBe('confidence')
+    expect(result['total_amount'].label).toBe('total amount')
+  })
+
+  it('should set type to ai_response for all fields', async () => {
+    const executionStep = {
+      dataOut: {
+        field1: 'value1',
+        field_2: 'value2',
+        Field_Three: 'value3',
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(result['field1'].type).toBe('ai_response')
+    expect(result['field_2'].type).toBe('ai_response')
+    expect(result['Field_Three'].type).toBe('ai_response')
+  })
+
+  it('should return empty object when dataOut is empty object', async () => {
+    const executionStep = {
+      dataOut: {},
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(executionStep)
+
+    assert(result !== null)
+    expect(result).toEqual({})
+  })
+})

--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
@@ -102,7 +102,6 @@ describe('process-image schema', () => {
           })
           assert(result.success === true)
           assert(result.data.responseFields[0].fieldName === expected)
-          assert(result.data.responseFields[0].originalFieldName === input)
         },
       )
 
@@ -344,15 +343,8 @@ describe('process-image schema', () => {
       assert(result.data.image.length === 1)
       assert(result.data.responseFields.length === 3)
       assert(result.data.responseFields[0].fieldName === 'Signature_present')
-      assert(
-        result.data.responseFields[0].originalFieldName === 'Signature present',
-      )
       assert(result.data.responseFields[1].fieldName === 'Document_type')
-      assert(
-        result.data.responseFields[1].originalFieldName === 'Document type',
-      )
       assert(result.data.responseFields[2].fieldName === 'confidence')
-      assert(result.data.responseFields[2].originalFieldName === 'confidence')
     })
   })
 })

--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
@@ -1,0 +1,358 @@
+import { assert, describe, expect, it } from 'vitest'
+
+import { schema } from '@/apps/pair/actions/process-image/schema'
+
+describe('process-image schema', () => {
+  describe('image validation', () => {
+    it('should accept valid image array with one item', () => {
+      const result = schema.safeParse({
+        image: ['s3-id-123'],
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.image[0] === 's3-id-123')
+    })
+
+    it('should reject empty image array', () => {
+      const result = schema.safeParse({
+        image: [],
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('An image must be selected')
+      }
+    })
+
+    it('should reject multiple images', () => {
+      const result = schema.safeParse({
+        image: ['s3-id-123', 's3-id-456'],
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe('Only one image allowed')
+      }
+    })
+
+    it('should require image field', () => {
+      const result = schema.safeParse({
+        responseFields: [
+          {
+            fieldName: 'signature',
+            description: 'Check for signature',
+          },
+        ],
+      })
+      assert(result.success === false)
+    })
+  })
+
+  describe('responseFields validation', () => {
+    describe('fieldName validation', () => {
+      it.each(['field1', 'fieldname', 'Field123', 'ABC123', 'fieldName'])(
+        'should accept valid field names with alphanumeric only: %s',
+        (fieldName) => {
+          const result = schema.safeParse({
+            image: ['s3-id-123'],
+            responseFields: [
+              {
+                fieldName,
+                description: 'test description',
+              },
+            ],
+          })
+          assert(result.success === true)
+          // After transformation, no spaces
+          assert(result.data.responseFields[0].fieldName === fieldName)
+        },
+      )
+
+      it.each([
+        { input: 'field name', expected: 'field_name' },
+        { input: 'Signature present', expected: 'Signature_present' },
+        { input: 'field  with  spaces', expected: 'field__with__spaces' },
+        { input: 'has multiple   spaces', expected: 'has_multiple___spaces' },
+      ])(
+        'should transform spaces to underscores: $input -> $expected',
+        ({ input, expected }) => {
+          const result = schema.safeParse({
+            image: ['s3-id-123'],
+            responseFields: [
+              {
+                fieldName: input,
+                description: 'test description',
+              },
+            ],
+          })
+          assert(result.success === true)
+          assert(result.data.responseFields[0].fieldName === expected)
+          assert(result.data.responseFields[0].originalFieldName === input)
+        },
+      )
+
+      it.each([
+        'field_name',
+        'field-name',
+        'field@name',
+        'field.name',
+        'field#name',
+        'field!name',
+        'field$name',
+      ])(
+        'should reject field names with invalid characters: %s',
+        (fieldName) => {
+          const result = schema.safeParse({
+            image: ['s3-id-123'],
+            responseFields: [{ fieldName, description: 'test description' }],
+          })
+          assert(result.success === false)
+        },
+      )
+
+      it('should reject empty field names', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: '',
+              description: 'test description',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should reject field names longer than 64 characters', () => {
+        const longName = 'a'.repeat(65)
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: longName,
+              description: 'test description',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should accept field names exactly 64 characters long', () => {
+        const maxName = 'a'.repeat(64)
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: maxName,
+              description: 'test description',
+            },
+          ],
+        })
+        assert(result.success === true)
+      })
+
+      it('should not accept duplicate field names after transformation (case-insensitive)', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'Field Name',
+              description: 'test description 1',
+            },
+            {
+              fieldName: 'field name',
+              description: 'test description 2',
+            },
+          ],
+        })
+        assert(result.success === false)
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            'Output names must be unique (case-insensitive)',
+          )
+        }
+      })
+
+      it('should detect duplicates after space-to-underscore transformation', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field name',
+              description: 'test description 1',
+            },
+            {
+              fieldName: 'Field Name',
+              description: 'test description 2',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+    })
+
+    describe('description validation', () => {
+      it('should accept valid descriptions', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+              description: 'This is a valid description',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(
+          result.data.responseFields[0].description ===
+            'This is a valid description',
+        )
+      })
+
+      it('should reject empty descriptions', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+              description: '',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should reject descriptions longer than 128 characters', () => {
+        const longDescription = 'a'.repeat(129)
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+              description: longDescription,
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+
+      it('should accept descriptions exactly 128 characters long', () => {
+        const maxDescription = 'a'.repeat(128)
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+              description: maxDescription,
+            },
+          ],
+        })
+        assert(result.success === true)
+      })
+
+      it('should require description field', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+            },
+          ],
+        })
+        assert(result.success === false)
+      })
+    })
+
+    describe('multiple fields validation', () => {
+      it('should accept multiple valid response fields', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'Signature present',
+              description: 'Check if signature is present',
+            },
+            {
+              fieldName: 'Document type',
+              description: 'Type of document',
+            },
+            {
+              fieldName: 'field3',
+              description: 'Another field',
+            },
+          ],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields.length === 3)
+        assert(result.data.responseFields[0].fieldName === 'Signature_present')
+        assert(result.data.responseFields[1].fieldName === 'Document_type')
+        assert(result.data.responseFields[2].fieldName === 'field3')
+      })
+
+      it('should reject empty response fields array', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [],
+        })
+        assert(result.success === false)
+      })
+
+      it('should require at least one response field', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+        })
+        assert(result.success === false)
+      })
+    })
+  })
+
+  describe('complete schema validation', () => {
+    it('should validate a complete configuration with transformations', () => {
+      const result = schema.safeParse({
+        image: ['s3-id-abc123'],
+        responseFields: [
+          {
+            fieldName: 'Signature present',
+            description: 'Whether the image contains a handwritten signature',
+          },
+          {
+            fieldName: 'Document type',
+            description: 'Type of document in the image',
+          },
+          {
+            fieldName: 'confidence',
+            description: 'Confidence level of the analysis',
+          },
+        ],
+      })
+      assert(result.success === true)
+      assert(result.data.image.length === 1)
+      assert(result.data.responseFields.length === 3)
+      assert(result.data.responseFields[0].fieldName === 'Signature_present')
+      assert(
+        result.data.responseFields[0].originalFieldName === 'Signature present',
+      )
+      assert(result.data.responseFields[1].fieldName === 'Document_type')
+      assert(
+        result.data.responseFields[1].originalFieldName === 'Document type',
+      )
+      assert(result.data.responseFields[2].fieldName === 'confidence')
+      assert(result.data.responseFields[2].originalFieldName === 'confidence')
+    })
+  })
+})

--- a/packages/backend/src/apps/pair/actions/process-image/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/get-data-out-metadata.ts
@@ -14,7 +14,7 @@ async function getDataOutMetadata(
 
   const metadata = Object.keys(dataOut).reduce((acc, key) => {
     acc[key] = {
-      label: key,
+      label: key.replace(/_/g, ' '),
       type: 'ai_response',
     }
     return acc

--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -17,37 +17,43 @@ import { schema } from './schema'
 const model = engineProvider.chat(appConfig.pair.foundry.imageModel)
 
 const action: IRawAction = {
-  name: 'Process image',
+  name: 'Process an image',
   key: 'processImage',
-  description: 'Process an image',
+  description: 'Extract information from an image or PDF',
   arguments: [
     {
       label: 'Image',
+      description: 'Select an image from a previous step or upload one',
       key: 'image',
       type: 'attachment' as const,
       required: true,
       variableTypes: ['file'],
       // TODO(kevinkim-ogp): restrict the supported file types
+      maxFiles: 1,
     },
     {
-      label: 'Response field(s)',
+      label: 'What do you want to extract?',
+      description: 'Use these as variables in later steps',
       key: 'responseFields',
       type: 'multirow-multicol' as const,
       required: true,
+      addRowButtonText: 'Add another',
       subFields: [
         {
-          key: 'fieldName',
-          placeholder: 'Field name',
-          type: 'string',
-          required: true,
-          customStyle: { flex: 1 },
-        },
-        {
           key: 'description',
-          placeholder: 'Description',
+          label: 'What to look for',
+          placeholder: 'Whether the image contains a handwritten signature',
           type: 'string',
           required: true,
           customStyle: { flex: 3 },
+        },
+        {
+          key: 'fieldName',
+          label: 'Output name',
+          placeholder: 'Signature present',
+          type: 'string',
+          required: true,
+          customStyle: { flex: 1 },
         },
       ],
     },

--- a/packages/backend/src/apps/pair/actions/process-image/schema.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/schema.ts
@@ -10,32 +10,41 @@ export const schema = z.object({
     }),
   responseFields: z
     .array(
-      z.object({
-        fieldName: z
-          .string()
-          .min(1, { message: 'Field name is required' })
-          .max(64, { message: 'Field name cannot be more than 64 characters' })
-          .regex(/^[a-zA-Z0-9_-]+$/, {
-            message:
-              'Field name cannot contain spaces. Use only letters, numbers, underscores (_), and hyphens (-)',
-          }),
+      z
+        .object({
+          fieldName: z
+            .string()
+            .min(1, { message: 'Output name is required' })
+            .max(64, {
+              message: 'Output name cannot be more than 64 characters',
+            })
+            .regex(/^[a-zA-Z0-9\s]+$/, {
+              message:
+                'Output name can only contain letters, numbers, and spaces',
+            }),
 
-        description: z
-          .string()
-          .min(1, { message: 'Description is required' })
-          .max(128, {
-            message: 'Description cannot be more than 128 characters',
-          }),
-      }),
+          description: z
+            .string()
+            .min(1, { message: 'Description is required' })
+            .max(128, {
+              message: 'Description cannot be more than 128 characters',
+            }),
+        })
+        .transform((field) => ({
+          fieldName: field.fieldName.replace(/\s/g, '_'),
+          originalFieldName: field.fieldName,
+          description: field.description,
+        })),
     )
     .min(1, { message: 'At least one response field is required' })
     .refine(
       (fields) => {
+        // After transformation, check uniqueness of sanitized field names
         const names = fields.map((f) => f.fieldName.toLowerCase())
         return new Set(names).size === names.length
       },
       {
-        message: 'Field names must be unique (case-insensitive)',
+        message: 'Output names must be unique (case-insensitive)',
       },
     ),
 })

--- a/packages/backend/src/apps/pair/actions/process-image/schema.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/schema.ts
@@ -18,7 +18,7 @@ export const schema = z.object({
             .max(64, {
               message: 'Output name cannot be more than 64 characters',
             })
-            .regex(/^[a-zA-Z0-9\s]+$/, {
+            .regex(/^[a-zA-Z0-9 ]+$/, {
               message:
                 'Output name can only contain letters, numbers, and spaces',
             }),
@@ -31,8 +31,7 @@ export const schema = z.object({
             }),
         })
         .transform((field) => ({
-          fieldName: field.fieldName.replace(/\s/g, '_'),
-          originalFieldName: field.fieldName,
+          fieldName: field.fieldName.replace(/ /g, '_'),
           description: field.description,
         })),
     )


### PR DESCRIPTION
### TL;DR

Improved the process-image action with better field name handling and enhanced UI labels.

### What changed?

- Added automatic conversion of spaces to underscores in field names (e.g., "Signature present" becomes "Signature_present")
- Updated schema to allow spaces in field names during input
- Update `getDataOutMetadata`to convert it back to the original field name the user set
- Updated action name to "Process an image", added descriptions, and reordered form fields for better UX

### How to test?

_Field_ _names_

- [ ] Create a process-image action with field names containing spaces (e.g., "Document type", "Signature present")  
Verify the fields are accepted and transformed correctly (spaces become underscores internally)
- [ ] Check that duplicate field names are properly detected (case-insensitive)
- [ ] Confirm that the output metadata displays labels with spaces instead of underscores

_Max_ _files_

- [ ] Verify that only 1 file can be selected

_Sanity_ _check_

- [ ] Verify that action can process images dynamically based on the input