### PR TITLE
PLU-723 (fix): Pipe collaborators not added to new Tile created from action

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/tiles/create-table.itest.ts
@@ -1,11 +1,18 @@
+import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import createTable from '@/graphql/mutations/tiles/create-table'
+import Flow from '@/models/flow'
+import FlowConnections from '@/models/flow-connections'
+import TableCollaborator from '@/models/table-collaborators'
 import * as ddbTableRowFunctions from '@/models/tiles/dynamodb/table-row/functions'
 import * as pgTableFunctions from '@/models/tiles/pg/table-functions'
 import * as pgTableRowFunctions from '@/models/tiles/pg/table-row-functions'
 import { DatabaseType } from '@/models/tiles/types'
+import User from '@/models/user'
 import Context from '@/types/express/context'
+
+import { generateMockCollaborator, generateMockUser } from '../flow.mock'
 
 import { generateMockContext } from './table.mock'
 import { checkIfTableExists } from './tiles-pg-helper'
@@ -21,6 +28,22 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/helpers/launch-darkly', () => ({
   getLdFlagValue: mocks.getLdFlagValue,
 }))
+
+async function generateFlowWithCollaborators(ownerId: string) {
+  const flow = await Flow.query().insert({
+    id: randomUUID(),
+    name: 'Test Flow',
+    userId: ownerId,
+  })
+
+  const editor = await generateMockUser('editor')
+  const viewer = await generateMockUser('viewer')
+
+  await generateMockCollaborator(flow.id, editor.id, ownerId, 'editor')
+  await generateMockCollaborator(flow.id, viewer.id, ownerId, 'viewer')
+
+  return { flow, editor, viewer }
+}
 
 describe.each([['pg'], ['ddb']])(
   'create table mutation: %s',
@@ -93,6 +116,115 @@ describe.each([['pg'], ['ddb']])(
       await expect(
         createTable(null, { input: { name: '', isBlank: false } }, context),
       ).rejects.toThrow()
+    })
+
+    describe('with flowId - table_collaborators updates', () => {
+      let testFlow: Flow
+      let flowEditor: User
+      let flowViewer: User
+
+      beforeEach(async () => {
+        const flowData = await generateFlowWithCollaborators(
+          context.currentUser.id,
+        )
+        testFlow = flowData.flow
+        flowEditor = flowData.editor
+        flowViewer = flowData.viewer
+      })
+
+      it('should add all flow collaborators to table_collaborators when flowId is provided', async () => {
+        mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+
+        const table = await createTable(
+          null,
+          {
+            input: {
+              name: 'Flow Table',
+              isBlank: true,
+              flowId: testFlow.id,
+            },
+          },
+          context,
+        )
+
+        // Verify flow owner is added as table editor
+        const ownerCollab = await TableCollaborator.query().findOne({
+          user_id: testFlow.userId,
+          table_id: table.id,
+        })
+        expect(ownerCollab).toBeDefined()
+        expect(ownerCollab.role).toBe('owner')
+
+        // Verify flow editor is added as table editor
+        const editorCollab = await TableCollaborator.query().findOne({
+          user_id: flowEditor.id,
+          table_id: table.id,
+        })
+        expect(editorCollab).toBeDefined()
+        expect(editorCollab.role).toBe('editor')
+
+        // Verify flow viewer is added as table viewer
+        const viewerCollab = await TableCollaborator.query().findOne({
+          user_id: flowViewer.id,
+          table_id: table.id,
+        })
+        expect(viewerCollab).toBeDefined()
+        expect(viewerCollab.role).toBe('viewer')
+
+        // Verify flow connection is created
+        const flowConnection = await FlowConnections.query().findOne({
+          flow_id: testFlow.id,
+          connection_id: table.id,
+        })
+        expect(flowConnection).toBeDefined()
+        expect(flowConnection.connectionType).toBe('table')
+      })
+
+      it('should throw error when user is not the flow owner', async () => {
+        mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+
+        // Create context with flow editor (not owner)
+        const editorContext: Context = {
+          req: null,
+          res: null,
+          currentUser: flowEditor,
+          isAdminOperation: false,
+        }
+
+        await expect(
+          createTable(
+            null,
+            {
+              input: {
+                name: 'Editor Flow Table',
+                isBlank: true,
+                flowId: testFlow.id,
+              },
+            },
+            editorContext,
+          ),
+        ).rejects.toThrow()
+      })
+
+      it('should throw error when flowId does not exist', async () => {
+        mocks.getLdFlagValue.mockResolvedValueOnce(databaseType)
+
+        const nonExistentFlowId = randomUUID()
+
+        await expect(
+          createTable(
+            null,
+            {
+              input: {
+                name: 'Flow Table',
+                isBlank: true,
+                flowId: nonExistentFlowId,
+              },
+            },
+            context,
+          ),
+        ).rejects.toThrow()
+      })
     })
   },
 )

--- a/packages/backend/src/graphql/mutations/tiles/create-table.ts
+++ b/packages/backend/src/graphql/mutations/tiles/create-table.ts
@@ -1,4 +1,5 @@
 import { MutationResolvers } from '@/graphql/__generated__/types.generated'
+import { addFlowTableConnection } from '@/helpers/add-flow-connection'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import TableMetadata from '@/models/table-metadata'
 import { getTableOperations } from '@/models/tiles/factory'
@@ -28,7 +29,7 @@ const createTable: MutationResolvers['createTable'] = async (
   params,
   context,
 ) => {
-  const { name: tableName, isBlank: isBlankTable } = params.input
+  const { name: tableName, isBlank: isBlankTable, flowId } = params.input
 
   if (!tableName) {
     throw new Error('Table name is required')
@@ -67,6 +68,28 @@ const createTable: MutationResolvers['createTable'] = async (
     await tableOperations.createTableRows({
       tableId: table.id,
       dataArray: PLACEHOLDER_ROWS,
+    })
+  }
+
+  /**
+   * COLLABORATORS
+   * Owners have the ability to create tables from within the Pipe Editor.
+   *
+   * If the Pipe has collaborators, we need to:
+   *   1. Add the Pipe collaborators as Tile collaborators
+   *   2. Add the Tile to the `flow_connections` table
+   */
+  if (flowId) {
+    const flow = await context.currentUser
+      .$relatedQuery('flows')
+      .findById(flowId)
+      .throwIfNotFound()
+
+    await addFlowTableConnection({
+      flowId,
+      tableId: table.id,
+      addedBy: context.currentUser.id,
+      flowOwnerId: flow.userId,
     })
   }
 

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -962,6 +962,7 @@ enum DatabaseType {
 input CreateTableInput {
   name: String!
   isBlank: Boolean!
+  flowId: String
 }
 
 input TableColumnConfigInput {

--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -29,6 +29,7 @@ interface CreateNewOptionProps {
   inputValue: string
   parameters: Record<string, unknown>
   addNewId?: DropdownAddNewId
+  flowId?: string
 }
 
 export function useCreateNewOption(setValue: (newValue: string) => void) {
@@ -36,7 +37,12 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
   const [updateTable] = useMutation(UPDATE_TABLE)
   const [isCreatingNewOption, setIsCreatingNewOption] = useState(false)
   const createNewOption = useCallback(
-    async ({ inputValue, addNewId, parameters }: CreateNewOptionProps) => {
+    async ({
+      inputValue,
+      addNewId,
+      parameters,
+      flowId,
+    }: CreateNewOptionProps) => {
       if (!inputValue.trim() || !addNewId) {
         return
       }
@@ -50,6 +56,7 @@ export function useCreateNewOption(setValue: (newValue: string) => void) {
                 input: {
                   name: inputValue.trim(),
                   isBlank: true,
+                  flowId,
                 },
               },
             })

--- a/packages/frontend/src/components/ControlledAutocomplete/index.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/index.tsx
@@ -81,7 +81,7 @@ function ControlledAutocomplete(
     isSearchable,
     variableTypes = null,
   } = props
-  const { allApps, readOnly } = useContext(EditorContext)
+  const { allApps, readOnly, flowId } = useContext(EditorContext)
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   /**
    * allow extraction of specific variables to a dropdown, e.g., files from FormSG
@@ -144,9 +144,16 @@ function ControlledAutocomplete(
         inputValue,
         addNewId: addNewOption?.id,
         parameters: getValues('parameters'),
+        flowId,
       })
     },
-    [addNewOption?.id, createNewOption, getValues, onNewOptionModalClose],
+    [
+      addNewOption?.id,
+      createNewOption,
+      getValues,
+      onNewOptionModalClose,
+      flowId,
+    ],
   )
 
   const onNewOptionInlineSelected = useCallback(


### PR DESCRIPTION
### TL;DR

Owners can create a new Tile from the 'Create row' action, but collaborators were not automatically added.  
This is inconsistent with selecting an existing Tile, which correctly syncs collaborators.

### What changed?

- The `createTable` mutation now accepts an optional `flowId` input parameter.
- When a `flowId` is provided, `addFlowTableConnection` is called to sync Pipe collaborators (editors, viewers) to the newly created table with their corresponding roles.
- The `ControlledAutocomplete` component now reads `flowId` from `EditorContext` and passes it through when creating a new table option inline, ensuring the flow association is preserved during table creation from the Pipe Editor.

### How to test?

_Creating_ _Tile_ _from_ _the_ _action  
_First, create or open a Pipe that you OWN and has collaborators.

- [ ] Verify that you can create a new Tile from the 'Create row' action.
- [ ] Verify that your Pipe collaborators have also been added as Tile collaborators with the same roles.

Then, delete the collaborators from that SAME Pipe.

- [ ] Verify that you can create a new Tile and NO collaborators are added.

_Sanity_ _check_

- [ ] Verify that Tile can still be created from the 'Create Tile' button in the Tiles page.
- [ ] Verify that Tile can still be created from the 'Create row' action in the Pipe editor when there are no collaborators.