### PR TITLE
fix: add metadata for generateObject

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
@@ -83,7 +83,10 @@ describe('generateAiSteps mutation', () => {
   beforeEach(async () => {
     vi.resetAllMocks()
 
-    mocks.langfusePromptGet.mockResolvedValue({ prompt: 'system prompt' })
+    mocks.langfusePromptGet.mockResolvedValue({
+      prompt: 'system prompt',
+      toJSON: vi.fn(),
+    })
     mocks.getLdFlagValue.mockResolvedValue({
       enabled: true,
       config: {

--- a/packages/backend/src/graphql/__tests__/mutations/ai/schemas/action-steps-schema.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/schemas/action-steps-schema.test.ts
@@ -166,7 +166,7 @@ describe('actionStepsSchema validation', () => {
       expect(result.success).toBe(true)
     })
 
-    it('should reject if-then step missing depth parameter', () => {
+    it('should default depth to 0 if-then step missing depth parameter', () => {
       const steps = [
         {
           type: 'action' as StepEnumType,
@@ -189,7 +189,8 @@ describe('actionStepsSchema validation', () => {
       ]
 
       const result = actionStepsSchema.safeParse(steps)
-      expect(result.success).toBe(false)
+      expect(result.success).toBe(true)
+      expect(result.data[0].parameters?.depth).toBe(0)
     })
 
     it('should reject if-then step as last action', () => {

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -99,6 +99,16 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
           experimental_telemetry: {
             isEnabled: true,
             functionId: 'generate-steps',
+            metadata: {
+              name: 'generate-steps',
+              sessionId: sessionId || 'unknown',
+              userId: context.currentUser.email,
+              environment: appConfig.appEnv,
+              promptName,
+              promptVersion: version,
+              langfusePrompt: prompt.toJSON(),
+              tags: ['ai-builder', 'generate-steps'],
+            },
           },
         })
 

--- a/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
@@ -17,7 +17,7 @@ const baseActionSchema = z.object({
 })
 
 export const ifThenParametersSchema = z.object({
-  depth: z.literal(0),
+  depth: z.literal(0).default(0),
   branchName: z.string().default('Branch'),
 })
 

--- a/packages/backend/src/graphql/mutations/ai/schemas/schema-generator.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/schema-generator.ts
@@ -6,6 +6,8 @@ import {
   TOOLBOX_APP_KEY,
 } from '@/apps/toolbox/common/constants'
 
+import { ifThenParametersSchema } from './actions.zod'
+
 /**
  * Generates valid appKey enum from registered apps
  */
@@ -57,10 +59,7 @@ export function generateSchema(
         }
 
         if (isIfThenAction) {
-          extendedFields.parameters = z.object({
-            depth: z.literal(0),
-            branchName: z.string().default('Branch'),
-          })
+          extendedFields.parameters = ifThenParametersSchema.default({})
         }
 
         return baseSchema.extend(extendedFields)


### PR DESCRIPTION
### TL;DR

- `generateSteps` is not linked to the prompt properly when it errors out.
- LLM may generate If-then steps that do not contain with `depth` parameters

### Fix

- Add `metadata` to the `experimental_telemetry` object when calling `generateObject`
- Set the `depth`to default 0 if not provided

### Tests

Try to get an error when generating steps, then:

- [ ] Verify that you see a link out to the prompt that was used

### Screenshots

**Before**

![Screenshot 2026-04-20 at 3.08.43 PM.png](https://app.graphite.com/user-attachments/assets/4127e64b-4a61-422a-81ae-c70c71f14178.png)

**After**

![Screenshot 2026-04-20 at 3.18.09 PM.png](https://app.graphite.com/user-attachments/assets/74e1777c-dfce-4c87-a4db-6e5b1abb3adf.png)