### PR TITLE
refactor: create RTE with presets

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
@@ -3,52 +3,9 @@ import { assert, describe, expect, it } from 'vitest'
 import { schema } from '@/apps/pair/actions/send-prompt/schema'
 
 describe('call-pair schema', () => {
-  describe('promptType validation', () => {
-    it('should accept valid prompt types', () => {
-      const validTypes = [
-        'analyse',
-        'categorise',
-        'summarise',
-        'write',
-        'custom',
-      ]
-
-      validTypes.forEach((promptType) => {
-        const result = schema.safeParse({
-          promptType,
-          prompt: 'test prompt',
-          responseFields: [
-            {
-              fieldName: 'summary',
-              fieldType: 'text',
-            },
-          ],
-        })
-        assert(result.success === true)
-        assert(result.data.promptType === promptType)
-      })
-    })
-
-    it('should reject invalid prompt types', () => {
-      const result = schema.safeParse({
-        promptType: 'invalid',
-        prompt: 'test prompt',
-      })
-      assert(result.success === false)
-    })
-
-    it('should require promptType', () => {
-      const result = schema.safeParse({
-        prompt: 'test prompt',
-      })
-      assert(result.success === false)
-    })
-  })
-
   describe('prompt validation', () => {
     it('should accept valid non-empty prompts', () => {
       const result = schema.safeParse({
-        promptType: 'analyse',
         prompt: 'Analyze this document',
         responseFields: [
           {
@@ -63,16 +20,13 @@ describe('call-pair schema', () => {
 
     it('should reject empty prompts', () => {
       const result = schema.safeParse({
-        promptType: 'analyse',
         prompt: '',
       })
       assert(result.success === false)
     })
 
     it('should require prompt field', () => {
-      const result = schema.safeParse({
-        promptType: 'analyse',
-      })
+      const result = schema.safeParse({})
       assert(result.success === false)
     })
   })
@@ -90,7 +44,6 @@ describe('call-pair schema', () => {
         'should accept valid field names with letters, numbers, and spaces: %s',
         (fieldName) => {
           const result = schema.safeParse({
-            promptType: 'analyse',
             prompt: 'test prompt',
             responseFields: [
               {
@@ -118,7 +71,6 @@ describe('call-pair schema', () => {
         'should reject field names with invalid characters: %s',
         (fieldName) => {
           const result = schema.safeParse({
-            promptType: 'analyse',
             prompt: 'test prompt',
             responseFields: [{ fieldName, fieldType: 'text' }],
           })
@@ -128,7 +80,6 @@ describe('call-pair schema', () => {
 
       it('should reject empty field names', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -143,7 +94,6 @@ describe('call-pair schema', () => {
       it('should reject field names longer than 64 characters', () => {
         const longName = 'a'.repeat(65)
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -158,7 +108,6 @@ describe('call-pair schema', () => {
       it('should accept field names exactly 64 characters long', () => {
         const maxName = 'a'.repeat(64)
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -172,7 +121,6 @@ describe('call-pair schema', () => {
 
       it('should not accept duplicate field names (case-insensitive)', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -201,7 +149,6 @@ describe('call-pair schema', () => {
     describe('fieldType validation', () => {
       it('should accept text field type', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -216,7 +163,6 @@ describe('call-pair schema', () => {
 
       it('should accept number field type', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -231,7 +177,6 @@ describe('call-pair schema', () => {
 
       it('should accept category field type with valid categories', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -247,7 +192,6 @@ describe('call-pair schema', () => {
 
       it('should reject invalid field types', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -261,7 +205,6 @@ describe('call-pair schema', () => {
 
       it('should reject empty response fields', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [],
         })
@@ -280,7 +223,6 @@ describe('call-pair schema', () => {
     describe('fieldCategories validation', () => {
       it('should require fieldCategories when fieldType is category', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -299,7 +241,6 @@ describe('call-pair schema', () => {
 
       it('should accept valid comma-separated categories', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -314,7 +255,6 @@ describe('call-pair schema', () => {
 
       it('should accept categories without spaces', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -329,7 +269,6 @@ describe('call-pair schema', () => {
 
       it('should reject empty categories when fieldType is category', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -353,7 +292,6 @@ describe('call-pair schema', () => {
         'should reject categories with empty items after trimming: %s',
         (fieldCategories) => {
           const result = schema.safeParse({
-            promptType: 'analyse',
             prompt: 'test prompt',
             responseFields: [
               {
@@ -378,7 +316,6 @@ describe('call-pair schema', () => {
         'should reject categories with duplicates (case-insensitive): %s',
         (fieldCategories) => {
           const result = schema.safeParse({
-            promptType: 'analyse',
             prompt: 'test prompt',
             responseFields: [
               {
@@ -399,7 +336,6 @@ describe('call-pair schema', () => {
 
       it('should allow fieldCategories to be optional when fieldType is not category', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -416,7 +352,6 @@ describe('call-pair schema', () => {
     describe('multiple fields validation', () => {
       it('should accept multiple valid response fields', () => {
         const result = schema.safeParse({
-          promptType: 'analyse',
           prompt: 'test prompt',
           responseFields: [
             {
@@ -462,7 +397,6 @@ describe('call-pair schema', () => {
         ],
       })
       assert(result.success === true)
-      assert(result.data.promptType === 'analyse')
       assert(result.data.responseFields.length === 3)
     })
   })

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -8,6 +8,7 @@ import StepError, { GenericSolution } from '@/errors/step'
 import {
   DEFAULT_PROMPT_VALUES,
   DEFAULT_RESPONSE_FIELDS_VALUES,
+  PROMPT_PRESETS,
 } from '../../common/constants'
 import generateObject from '../../common/generate-object'
 import { generateSchemaFromFields } from '../../common/generate-schema'
@@ -24,24 +25,6 @@ const action: IRawAction = {
     'Enter a custom prompt to summarise, categorise or analyse data with Pair',
   arguments: [
     {
-      label: 'What would you like to do?',
-      key: 'promptType',
-      type: 'dropdown' as const,
-      required: true,
-      options: [
-        { label: 'Analyse', value: 'analyse' },
-        { label: 'Categorise', value: 'categorise' },
-        { label: 'Summarise', value: 'summarise' },
-        { label: 'Write', value: 'write' },
-        {
-          label: 'Custom prompt',
-          value: 'custom',
-          description: 'Do it yourself',
-        },
-      ],
-      showOptionValue: false,
-    },
-    {
       label: 'Describe what you want Pair to do',
       key: 'prompt',
       type: 'rich-text' as const,
@@ -56,10 +39,21 @@ const action: IRawAction = {
        * this feature simple.
        */
       customRteMenuOptions: [],
-      defaultValue: {
-        fieldKey: 'promptType',
-        options: DEFAULT_PROMPT_VALUES,
-      },
+      presets: PROMPT_PRESETS.map((preset) => ({
+        key: preset.key,
+        label: preset.label,
+        description: preset.description,
+        assignments: [
+          {
+            fieldKey: 'prompt',
+            value: DEFAULT_PROMPT_VALUES[preset.key],
+          },
+          {
+            fieldKey: 'responseFields',
+            value: DEFAULT_RESPONSE_FIELDS_VALUES[preset.key],
+          },
+        ],
+      })),
     },
     {
       label: 'Define how you want Pair to structure what it extracts',
@@ -68,7 +62,7 @@ const action: IRawAction = {
       type: 'multirow-multicol' as const,
       required: true,
       hiddenIf: {
-        fieldKey: 'promptType',
+        fieldKey: 'prompt',
         op: 'is_empty',
       },
       addRowButtonText: 'Add output',
@@ -107,10 +101,6 @@ const action: IRawAction = {
           customStyle: { flex: 3 },
         },
       ],
-      defaultValue: {
-        fieldKey: 'promptType',
-        options: DEFAULT_RESPONSE_FIELDS_VALUES,
-      },
     },
   ],
 

--- a/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
@@ -6,7 +6,6 @@ import {
 } from '../../common/schema'
 
 export const schema = z.object({
-  promptType: z.enum(['analyse', 'categorise', 'summarise', 'write', 'custom']),
   prompt: z.string().min(1),
   responseFields: z
     .array(

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -34,9 +34,8 @@ export const PROMPT_PRESETS = [
  */
 export const DEFAULT_PROMPT_VALUES = {
   analyse: [
-    '<span style="margin: 0;font-weight: bold;">',
-    'Analyse the following content and provide insights on:',
-    '</span>',
+    '<p style="margin: 0;font-weight: bold;">Analyse the following content and provide insights on:</p>',
+    '<p></p>',
     '<span ',
     'data-type="variable" ',
     'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse" ',
@@ -44,6 +43,7 @@ export const DEFAULT_PROMPT_VALUES = {
     'data-value>',
     '{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse}}',
     '</span>',
+    '<p></p>',
     '<p style="margin: 0;font-weight: bold;">Focus on:</p>',
     '<p>- Key patterns or trends</p>',
     '<p>- Strengths and weaknesses</p>',

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -1,99 +1,112 @@
-import dedent from 'dedent'
+export const PROMPT_PRESETS = [
+  {
+    key: 'summarise',
+    label: 'Summarise',
+    description: 'Pull out the key points and main takeaways',
+  },
+  {
+    key: 'analyse',
+    label: 'Analyse',
+    description: 'Find patterns, strengths, and what to do next',
+  },
+  {
+    key: 'categorise',
+    label: 'Categorise',
+    description: 'Group responses into themes or labels',
+  },
+  {
+    key: 'write',
+    label: 'Write',
+    description: 'Generate content from a brief',
+  },
+] as const
 
+/**
+ * Default HTML prompt templates for Pair presets.
+ *
+ * NOTE:
+ * The editor currently normalizes input by converting every `\n` into `<br>`.
+ * To avoid introducing unintended extra spacing in rich-text templates, we
+ * store each preset as an array of HTML fragments and join them with `''`,
+ * producing a single newline-free HTML string.
+ *
+ * This keeps the source readable while ensuring rendered output remains stable.
+ */
 export const DEFAULT_PROMPT_VALUES = {
-  analyse: dedent`
-    <p style="margin: 0;font-weight: bold;">
-      Analyse the following content and provide insights on:
-    </p>
-    <p></p>
-    <p style="margin: 0">
-      <span
-        data-type="variable"
-        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse"
-        data-label="Replace this with the content to analyse"
-        data-value
-        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
-        to analyse}}</span
-      >
-    </p>
-    <p style="margin: 0"></p>
-    <p style="margin: 0;font-weight: bold;">Focus on:</p>
-    <p>- Key patterns or trends</p>
-    <p>- Strengths and weaknesses</p>
-    <p>- Implications or recommendations</p>
-    <p>- Supporting evidence for your conclusions</p>
-    <p></p>
-    <p style="margin: 0;font-weight: bold;">
-      Present your analysis in a structured format with clear reasoning.
-    </p>
-  `,
+  analyse: [
+    '<span style="margin: 0;font-weight: bold;">',
+    'Analyse the following content and provide insights on:',
+    '</span>',
+    '<span ',
+    'data-type="variable" ',
+    'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse" ',
+    'data-label="Replace this with the content to analyse" ',
+    'data-value>',
+    '{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to analyse}}',
+    '</span>',
+    '<p style="margin: 0;font-weight: bold;">Focus on:</p>',
+    '<p>- Key patterns or trends</p>',
+    '<p>- Strengths and weaknesses</p>',
+    '<p>- Implications or recommendations</p>',
+    '<p>- Supporting evidence for your conclusions</p>',
+    '<p></p>',
+    '<p style="margin: 0;font-weight: bold;">',
+    'Present your analysis in a structured format with clear reasoning.',
+    '</p>',
+  ].join(''),
 
-  categorise: dedent`
-    <p>Categorise the following content into relevant groups or themes:</p>
-    <p></p>
-    <p>
-      <span
-        data-type="variable"
-        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise"
-        data-label="Replace this with the content to categorise"
-        data-value
-        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
-        to categorise}}</span
-      >
-    </p>
-    <p></p>
-    <p>
-      Provide clear category labels and explain your reasoning for each grouping.
-    </p>
-  `,
+  categorise: [
+    '<p>Categorise the following content into relevant groups or themes:</p>',
+    '<p></p>',
+    '<p>',
+    '<span ',
+    'data-type="variable" ',
+    'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise" ',
+    'data-label="Replace this with the content to categorise" ',
+    'data-value>',
+    '{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to categorise}}',
+    '</span>',
+    '</p>',
+    '<p></p>',
+    '<p>Provide clear category labels and explain your reasoning for each grouping.</p>',
+  ].join(''),
 
-  summarise: dedent`
-    <p>
-      Summarise the following content, highlighting the key points and main
-      takeaways:
-    </p>
-    <p></p>
-    <p>
-      <span
-        data-type="variable"
-        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise"
-        data-label="Replace this with the content to summarise"
-        data-value
-        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
-        to summarise}}</span
-      >
-    </p>
-    <p></p>
-    <p>
-      Focus on the most important information and present it in a clear, concise
-      format.
-    </p>
-  `,
+  summarise: [
+    '<p>Summarise the following content, highlighting the key points and main takeaways:</p>',
+    '<p></p>',
+    '<p>',
+    '<span ',
+    'data-type="variable" ',
+    'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise" ',
+    'data-label="Replace this with the content to summarise" ',
+    'data-value>',
+    '{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to summarise}}',
+    '</span>',
+    '</p>',
+    '<p></p>',
+    '<p>Focus on the most important information and present it in a clear, concise format.</p>',
+  ].join(''),
 
-  write: dedent`
-    <p>
-      Write
-      <span
-        data-type="variable"
-        data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to write"
-        data-label="Replace this with the content to write"
-        data-value
-        >{{step.00000000-0000-0000-0000-000000000000.Replace this with the content
-        to write}}</span
-      >
-      based on the following requirements:
-    </p>
-    <p></p>
-    <p><strong>Topic/Subject</strong>: [Specify topic]</p>
-    <p><strong>Purpose</strong>: [Explain the intended use]</p>
-    <p><strong>Audience</strong>: [Describe target audience]</p>
-    <p><strong>Tone</strong>: [Professional/Formal/Conversational]</p>
-    <p><strong>Length</strong>: [Specify word count or length]</p>
-    <p>
-      <strong>Additional requirements</strong>: [Any specific guidelines or
-      constraints]
-    </p>
-  `,
+  write: [
+    '<p>',
+    'Write ',
+    '<span ',
+    'data-type="variable" ',
+    'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the content to write" ',
+    'data-label="Replace this with the content to write" ',
+    'data-value>',
+    '{{step.00000000-0000-0000-0000-000000000000.Replace this with the content to write}}',
+    '</span>',
+    ' based on the following requirements:',
+    '</p>',
+    '<p></p>',
+    '<p><strong>Topic/Subject</strong>: [Specify topic]</p>',
+    '<p><strong>Purpose</strong>: [Explain the intended use]</p>',
+    '<p><strong>Audience</strong>: [Describe target audience]</p>',
+    '<p><strong>Tone</strong>: [Professional/Formal/Conversational]</p>',
+    '<p><strong>Length</strong>: [Specify word count or length]</p>',
+    '<p><strong>Additional requirements</strong>: [Any specific guidelines or constraints]</p>',
+  ].join(''),
 
   custom: `<p>Enter your custom prompt</p>`,
 }

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -295,6 +295,7 @@ type ActionSubstepArgument {
   # Only for rich text
   customRteMenuOptions: [RteMenuOption]
   supportTableDisplay: Boolean
+  presets: JSONObject
 
   # Only for attachments
   maxFiles: Int

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -295,7 +295,7 @@ type ActionSubstepArgument {
   # Only for rich text
   customRteMenuOptions: [RteMenuOption]
   supportTableDisplay: Boolean
-  presets: JSONObject
+  presets: [ActionSubStepPreset]
 
   # Only for attachments
   maxFiles: Int
@@ -315,6 +315,18 @@ type ActionSubstepArgumentSource {
 type ActionSubstepArgumentSourceArgument {
   name: String
   value: String
+}
+
+type ActionSubStepPresetAssignment {
+  fieldKey: String!
+  value: JSONObject
+}
+
+type ActionSubStepPreset {
+  key: String!
+  label: String!
+  description: String!
+  assignments: [ActionSubStepPresetAssignment!]!
 }
 
 type App {

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -9,6 +9,7 @@ import DragDropInput from '@/components/DragDropInput'
 import MultiRow from '@/components/MultiRow'
 import MultiSelect from '@/components/MultiSelect'
 import RichTextEditor from '@/components/RichTextEditor'
+import RichTextEditorWithPresets from '@/components/RichTextEditorWithPresets'
 import TextField from '@/components/TextField'
 import { EditorContext } from '@/contexts/Editor'
 import { getDefaultValue } from '@/helpers/editor'
@@ -140,6 +141,24 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
   }
 
   if (type === 'rich-text') {
+    if (schema?.presets?.length) {
+      return (
+        <RichTextEditorWithPresets
+          name={computedName}
+          basePath={namePrefix}
+          presets={schema?.presets}
+          required={required}
+          label={label}
+          description={description}
+          placeholder={placeholder}
+          variablesEnabled={variables}
+          noVariablesMessage={noVariablesMessage}
+          customRteMenuOptions={schema?.customRteMenuOptions}
+          defaultValue={getDefaultValue(formContext, schema?.defaultValue)}
+        />
+      )
+    }
+
     return (
       <RichTextEditor
         name={computedName}

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -322,6 +322,38 @@
   }
 }
 
+.editor--borderless {
+  border: none;
+  border-radius: 0;
+  height: 100%;
+  justify-content: flex-start;
+
+  &:focus-within {
+    border: none;
+    box-shadow: none;
+  }
+
+  .editor__content {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: stretch;
+  }
+
+  .editor__content > .tiptap {
+    flex: 1 1 auto;
+    min-height: 9rem;
+  }
+
+  .editor__content > .tiptap.ProseMirror {
+    height: 100%;
+    max-height: none;
+  }
+
+  .editor__content .ProseMirror {
+    min-height: 9rem !important;
+  }
+}
+
 .single-line-editor {
   white-space: nowrap;
   overflow-x: auto;

--- a/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
+++ b/packages/frontend/src/components/RichTextEditor/RichTextEditor.scss
@@ -354,6 +354,10 @@
   }
 }
 
+.editor-with-presets__trigger {
+  height: 100%;
+}
+
 .single-line-editor {
   white-space: nowrap;
   overflow-x: auto;

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -105,6 +105,7 @@ interface EditorProps {
   customRteMenuOptions?: TRteMenuOption[]
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
+  containerClassName?: string
 }
 const Editor = ({
   onChange,
@@ -123,6 +124,7 @@ const Editor = ({
   customRteMenuOptions,
   isDisplayOnly = false,
   supportTableDisplay,
+  containerClassName,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
@@ -323,7 +325,7 @@ const Editor = ({
         placement={getPopoverPlacement(editor)}
       >
         <div
-          className="editor"
+          className={`editor ${containerClassName ?? ''}`.trim()}
           onClick={(e) => {
             e.stopPropagation()
             openSuggestions()
@@ -415,6 +417,7 @@ interface RichTextEditorProps {
   customRteMenuOptions?: TRteMenuOption[]
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
+  containerClassName?: string
 }
 const RichTextEditor = ({
   required,
@@ -435,6 +438,7 @@ const RichTextEditor = ({
   customRteMenuOptions,
   isDisplayOnly = false,
   supportTableDisplay,
+  containerClassName,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -487,6 +491,7 @@ const RichTextEditor = ({
             customRteMenuOptions={customRteMenuOptions}
             isDisplayOnly={isDisplayOnly}
             supportTableDisplay={supportTableDisplay}
+            containerClassName={containerClassName}
           />
         )}
       />

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -107,7 +107,6 @@ interface EditorProps {
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
   containerClassName?: string
-  formControlClassName?: string
   triggerContainerClassName?: string
 }
 const Editor = ({
@@ -329,7 +328,7 @@ const Editor = ({
         placement={getPopoverPlacement(editor)}
       >
         <div
-          className={`editor ${containerClassName ?? ''}`.trim()}
+          className={clsx('editor', containerClassName)}
           onClick={(e) => {
             e.stopPropagation()
             openSuggestions()

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -28,6 +28,7 @@ import Text from '@tiptap/extension-text'
 import Underline from '@tiptap/extension-underline'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import clsx from 'clsx'
 import escapeHtml from 'escape-html'
 
 import { EditorContext } from '@/contexts/Editor'
@@ -106,6 +107,8 @@ interface EditorProps {
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
   containerClassName?: string
+  formControlClassName?: string
+  triggerContainerClassName?: string
 }
 const Editor = ({
   onChange,
@@ -125,6 +128,7 @@ const Editor = ({
   isDisplayOnly = false,
   supportTableDisplay,
   containerClassName,
+  triggerContainerClassName,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
@@ -346,7 +350,12 @@ const Editor = ({
           {...(isDisplayOnly && { style: { border: 'none' } })}
         >
           <PopoverTrigger>
-            <Box className={isMulticol ? 'single-line-editor' : undefined}>
+            <Box
+              className={clsx(
+                isMulticol && 'single-line-editor',
+                triggerContainerClassName,
+              )}
+            >
               {shouldShowMenuBar && (
                 <MenuBar
                   editor={editor}
@@ -418,6 +427,7 @@ interface RichTextEditorProps {
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
   containerClassName?: string
+  triggerContainerClassName?: string
 }
 const RichTextEditor = ({
   required,
@@ -439,6 +449,7 @@ const RichTextEditor = ({
   isDisplayOnly = false,
   supportTableDisplay,
   containerClassName,
+  triggerContainerClassName,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -492,6 +503,7 @@ const RichTextEditor = ({
             isDisplayOnly={isDisplayOnly}
             supportTableDisplay={supportTableDisplay}
             containerClassName={containerClassName}
+            triggerContainerClassName={triggerContainerClassName}
           />
         )}
       />

--- a/packages/frontend/src/components/RichTextEditorWithPresets/index.tsx
+++ b/packages/frontend/src/components/RichTextEditorWithPresets/index.tsx
@@ -1,0 +1,170 @@
+import type { IJSONValue, IPreset, TRteMenuOption } from '@plumber/types'
+
+import { useContext, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { Box, Divider, Flex, Text } from '@chakra-ui/react'
+import { FormLabel } from '@opengovsg/design-system-react'
+
+import RichTextEditor from '@/components/RichTextEditor'
+import { EditorContext } from '@/contexts/Editor'
+
+interface RichTextEditorWithPresetsProps {
+  name: string
+  basePath?: string
+  presets: IPreset[]
+  required?: boolean
+  label?: string
+  description?: string
+  placeholder?: string
+  variablesEnabled?: boolean
+  noVariablesMessage?: string
+  customRteMenuOptions?: TRteMenuOption[]
+  defaultValue?: string | IJSONValue
+}
+
+const isEmptyEditorValue = (value?: string) => {
+  if (!value) {
+    return true
+  }
+
+  const normalized = value
+    .replace(/<br\s*\/?>/gi, '')
+    .replace(/<[^>]*>/g, '')
+    .trim()
+  return normalized.length === 0
+}
+
+export default function RichTextEditorWithPresets({
+  name,
+  basePath,
+  presets,
+  required,
+  label,
+  description,
+  placeholder,
+  variablesEnabled,
+  noVariablesMessage,
+  customRteMenuOptions,
+  defaultValue,
+}: RichTextEditorWithPresetsProps): JSX.Element {
+  const { setValue, watch } = useFormContext()
+  const { readOnly } = useContext(EditorContext)
+  const [editorVersion, setEditorVersion] = useState(0)
+
+  const editorValue = watch(name) as string | undefined
+  const showPresets = useMemo(
+    () => isEmptyEditorValue(editorValue),
+    [editorValue],
+  )
+
+  const handleSelectPreset = (preset: IPreset) => {
+    if (readOnly) {
+      return
+    }
+
+    for (const assignment of preset.assignments) {
+      const targetFieldPath = basePath
+        ? `${basePath}.${assignment.fieldKey}`
+        : assignment.fieldKey
+      setValue(targetFieldPath, assignment.value, {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+    }
+    // Re-mount editor so Tiptap reflects the new externally-driven value.
+    setEditorVersion((version) => version + 1)
+  }
+
+  return (
+    <Box>
+      {label && (
+        <FormLabel
+          isRequired={required}
+          description={description}
+          style={{ whiteSpace: 'pre-wrap' }}
+        >
+          {label}
+        </FormLabel>
+      )}
+
+      <Box
+        border="1px solid rgba(0, 0, 0, 0.23)"
+        borderRadius="md"
+        overflow="hidden"
+        _focusWithin={{
+          borderColor: 'primary.500',
+          boxShadow: '0 0 0 1px var(--chakra-colors-primary-500)',
+        }}
+      >
+        <Flex align="stretch" direction={{ base: 'column', lg: 'row' }}>
+          <Box
+            flex={1}
+            display="flex"
+            sx={{
+              '& > [data-test="text-input-group"]': {
+                display: 'flex',
+                flexDirection: 'column',
+                height: '100%',
+              },
+              '& > [data-test="text-input-group"] > .editor': {
+                flex: 1,
+              },
+              '& > [data-test="text-input-group"] > .editor > [id^="popover-trigger-"]':
+                {
+                  height: '100%',
+                },
+            }}
+          >
+            <RichTextEditor
+              key={`${name}-${editorVersion}`}
+              required={required}
+              name={name}
+              placeholder={placeholder}
+              variablesEnabled={variablesEnabled}
+              isRich
+              noVariablesMessage={noVariablesMessage}
+              customRteMenuOptions={customRteMenuOptions}
+              defaultValue={defaultValue}
+              containerClassName="editor--borderless"
+            />
+          </Box>
+
+          {showPresets && presets.length > 0 && (
+            <Box
+              w={{ base: '100%', lg: '24rem' }}
+              maxW="24rem"
+              bg="white"
+              borderTopWidth={{ base: '1px', lg: 0 }}
+              borderLeftWidth={{ base: 0, lg: '1px' }}
+              borderColor="base.divider.subtle"
+            >
+              {presets.map((preset, index) => (
+                <Box key={preset.key}>
+                  <Box
+                    px={4}
+                    py={3}
+                    role="button"
+                    cursor={readOnly ? 'not-allowed' : 'pointer'}
+                    onClick={() => handleSelectPreset(preset)}
+                    opacity={readOnly ? 0.6 : 1}
+                    _hover={
+                      readOnly
+                        ? undefined
+                        : {
+                            bg: 'primary.50',
+                          }
+                    }
+                  >
+                    <Text textStyle="caption-1">{preset.label}</Text>
+                    <Text textStyle="caption-2">{preset.description}</Text>
+                  </Box>
+                  {index < presets.length - 1 && <Divider />}
+                </Box>
+              ))}
+            </Box>
+          )}
+        </Flex>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/frontend/src/components/RichTextEditorWithPresets/index.tsx
+++ b/packages/frontend/src/components/RichTextEditorWithPresets/index.tsx
@@ -22,7 +22,7 @@ interface RichTextEditorWithPresetsProps {
   defaultValue?: string | IJSONValue
 }
 
-const isEmptyEditorValue = (value?: string) => {
+const isEditorValueEmpty = (value?: string) => {
   if (!value) {
     return true
   }
@@ -53,7 +53,7 @@ export default function RichTextEditorWithPresets({
 
   const editorValue = watch(name) as string | undefined
   const showPresets = useMemo(
-    () => isEmptyEditorValue(editorValue),
+    () => isEditorValueEmpty(editorValue),
     [editorValue],
   )
 
@@ -97,24 +97,7 @@ export default function RichTextEditorWithPresets({
         }}
       >
         <Flex align="stretch" direction={{ base: 'column', lg: 'row' }}>
-          <Box
-            flex={1}
-            display="flex"
-            sx={{
-              '& > [data-test="text-input-group"]': {
-                display: 'flex',
-                flexDirection: 'column',
-                height: '100%',
-              },
-              '& > [data-test="text-input-group"] > .editor': {
-                flex: 1,
-              },
-              '& > [data-test="text-input-group"] > .editor > [id^="popover-trigger-"]':
-                {
-                  height: '100%',
-                },
-            }}
-          >
+          <Box flex={1} display="flex">
             <RichTextEditor
               key={`${name}-${editorVersion}`}
               required={required}
@@ -126,6 +109,7 @@ export default function RichTextEditorWithPresets({
               customRteMenuOptions={customRteMenuOptions}
               defaultValue={defaultValue}
               containerClassName="editor--borderless"
+              triggerContainerClassName="editor-with-presets__trigger"
             />
           </Box>
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -525,10 +525,34 @@ export interface IFieldRichText extends IBaseField {
   // Enables table variable insertion with preview and column selection
   // When true, table variables will be rendered as TableVariablePill in the editor
   supportTableDisplay?: boolean
+  presets?: IPreset[]
 
   // Specifies the order and what menu options to show in the RTE
   // 'Divider' is specified manually to determine when a divider should be shown
   customRteMenuOptions?: TRteMenuOption[]
+}
+
+/**
+ * A selectable preset shown beside rich-text inputs.
+ *
+ * Selecting a preset applies one or more field assignments to sibling fields
+ * in the same form scope (e.g. `prompt`, `responseFields`).
+ */
+export interface IPreset {
+  key: string
+  label: string
+  description: string
+  assignments: IPresetAssignment[]
+}
+
+/**
+ * A single field update applied when a preset is selected.
+ *
+ * `fieldKey` is relative to the current form scope/base path.
+ */
+export interface IPresetAssignment {
+  fieldKey: string
+  value: IJSONValue
 }
 
 export interface IFieldDragDrop extends IBaseField {


### PR DESCRIPTION
### TL;DR

- Removes the "What would you like to do?" dropdown
- Creates a new RTE component that shows the "presets" on the right of the RTE

### What changed?

- Removed the `promptType` dropdown field from the Pair send-prompt action. Preset selection is now handled directly within the rich-text editor UI.
- Introduced a `PROMPT_PRESETS` constant that defines the available presets (Summarise, Analyse, Categorise, Write) with labels and descriptions.
- Refactored `DEFAULT_PROMPT_VALUES` HTML templates from `dedent` template literals to arrays of HTML fragments joined with `''`, preventing the editor from introducing unintended extra line breaks via `\n`\-to-`<br>` normalisation.
- Added a new `RichTextEditorWithPresets` component that renders a split-panel layout: the rich-text editor on the left and a clickable preset list on the right. The preset panel is only shown when the editor is empty. Selecting a preset populates both the `prompt` and `responseFields` fields simultaneously via `IPreset` assignments.
- Added a `containerClassName` prop to `RichTextEditor` and an `editor--borderless` CSS variant to allow the editor to render without its own border when embedded inside the preset panel's shared border container.
- Exposed `presets` on the `ActionSubstepArgument` GraphQL type and `IFieldRichText` TypeScript interface, with new `IPreset` and `IPresetAssignment` types.
- `InputCreator` now renders `RichTextEditorWithPresets` instead of `RichTextEditor` when a field has presets defined.
- The `hiddenIf` condition for `responseFields` now watches the `prompt` field instead of the removed `promptType` field.

### How to test?

_New_ RTE with _presets_

- [ ] Presets are displayed by default when the new action is created
- [ ] Typing in the RTE removes the presets
- [ ] Selecting the preset automatically populates the RTE and clears the presets
- [ ] Clearing the RTE shows the presets again
- [ ] Presets are rendered properly i.e., with proper spacing and formatting

_Sanity_ _check_

- [ ] Other actions using `rich-text` are rendered correctly and function correctly i.e., Postman
    - [ ] Can format text
    - [ ] Can add tables
    - [ ] Can add images
    - [ ] Can render saved parameters properly