### PR TITLE
feat: remove feature flagged apps from schema

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
@@ -1,13 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import generateAiSteps from '@/graphql/mutations/ai/generate-ai-steps'
-import { Action } from '@/graphql/mutations/ai/schemas/actions.zod'
-import { Trigger } from '@/graphql/mutations/ai/schemas/triggers.zod'
 
 const mocks = vi.hoisted(() => ({
   generateObject: vi.fn(),
   langfusePromptGet: vi.fn(),
-  getLdFlagValue: vi.fn(),
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
 }))
 
 vi.mock('ai', () => ({
@@ -23,7 +22,8 @@ vi.mock('@/helpers/langfuse', () => ({
 }))
 
 vi.mock('@/helpers/launch-darkly', () => ({
-  getLdFlagValue: mocks.getLdFlagValue,
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
 }))
 
 const DEFAULT_MOCKED_TRIGGER = {
@@ -68,6 +68,7 @@ const DEFAULT_MOCKED_OUTPUT = {
   object: {
     trigger: DEFAULT_MOCKED_TRIGGER,
     actions: DEFAULT_MOCKED_ACTIONS,
+    name: 'Build with AI',
   },
 }
 
@@ -87,13 +88,21 @@ describe('generateAiSteps mutation', () => {
       prompt: 'system prompt',
       toJSON: vi.fn(),
     })
-    mocks.getLdFlagValue.mockResolvedValue({
-      enabled: true,
-      config: {
-        generateStepsPromptName: 'generate-steps',
-        version: 'production',
+    mocks.getAllLdFlags.mockResolvedValue({
+      'ai-builder': {
+        enabled: true,
+        config: {
+          generateStepsPromptName: 'generate-steps',
+          version: 'production',
+        },
       },
     })
+    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
+    mocks.generateObject.mockImplementation(async ({ schema, ...payload }) => ({
+      object: schema.parse(
+        payload.outputObject ?? DEFAULT_MOCKED_OUTPUT.object,
+      ),
+    }))
 
     context = {
       currentUser: {
@@ -104,6 +113,7 @@ describe('generateAiSteps mutation', () => {
 
   it('should generate steps with valid input', async () => {
     mocks.generateObject.mockResolvedValueOnce(DEFAULT_MOCKED_OUTPUT)
+    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
 
     const result = await generateAiSteps(
       null,
@@ -132,15 +142,69 @@ describe('generateAiSteps mutation', () => {
 
   it('should map step positions correctly', async () => {
     mocks.generateObject.mockResolvedValueOnce(DEFAULT_MOCKED_OUTPUT)
+    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
 
     const result = await generateAiSteps(
       null,
       { input: DEFAULT_INPUT },
       context,
     )
+    const parsedResult = result as any
 
-    expect((result.trigger as Trigger).position).toBe(1)
-    expect((result.actions as Action[])[0].position).toBe(2)
-    expect((result.actions as Action[])[1].position).toBe(3)
+    expect(parsedResult.trigger.position).toBe(1)
+    expect(parsedResult.actions[0].position).toBe(2)
+    expect(parsedResult.actions[1].position).toBe(3)
+  })
+
+  it('should throw when generated output contains restricted app keys', async () => {
+    mocks.getRestrictedAppKeys.mockReturnValueOnce(['aisay'])
+    mocks.generateObject.mockImplementationOnce(async ({ schema }) => ({
+      object: schema.parse({
+        trigger: DEFAULT_MOCKED_TRIGGER,
+        actions: [
+          {
+            appKey: 'aisay',
+            key: 'sendMessage',
+            description: 'Send a generated AI message',
+            type: 'action',
+            config: {
+              stepName: 'Send AI message',
+              templateConfig: {},
+            },
+            position: 2,
+          },
+        ],
+        name: 'Build with AI',
+      }),
+    }))
+
+    await expect(
+      generateAiSteps(null, { input: DEFAULT_INPUT }, context),
+    ).rejects.toThrow('Invalid input')
+  })
+
+  it('should throw when generated output contains a restricted trigger app key', async () => {
+    mocks.getRestrictedAppKeys.mockReturnValueOnce(['gathersg'])
+    mocks.generateObject.mockImplementationOnce(async ({ schema }) => ({
+      object: schema.parse({
+        trigger: {
+          appKey: 'gathersg',
+          key: 'newCase',
+          description: 'This is a gathersg trigger',
+          position: 1,
+          type: 'trigger',
+          config: {
+            stepName: 'New GatherSG case',
+            templateConfig: {},
+          },
+        },
+        actions: DEFAULT_MOCKED_ACTIONS,
+        name: 'Build with AI',
+      }),
+    }))
+
+    await expect(
+      generateAiSteps(null, { input: DEFAULT_INPUT }, context),
+    ).rejects.toThrow('Invalid input')
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-flow-with-steps.itest.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { StepEnumType } from '@/graphql/__generated__/types.generated'
 import createFlowWithSteps from '@/graphql/mutations/ai/create-flow-with-steps'
@@ -6,6 +6,16 @@ import Flow from '@/models/flow'
 import Step from '@/models/step'
 import User from '@/models/user'
 import Context from '@/types/express/context'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
 
 describe('createFlowWithSteps mutation integration tests', () => {
   let testUser: User
@@ -15,6 +25,16 @@ describe('createFlowWithSteps mutation integration tests', () => {
     // Clean up database before each test
     await Step.query().delete()
     await Flow.query().delete()
+
+    mocks.getAllLdFlags.mockResolvedValue({
+      'ai-builder': {
+        enabled: true,
+        config: {
+          generateStepsPromptName: 'generate-steps',
+          version: 'production',
+        },
+      },
+    })
 
     testUser = await User.query().findOne({ email: 'tester@open.gov.sg' })
     context = {
@@ -644,7 +664,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
       expect(steps[3].parameters).toEqual({ depth: 0, branchName: 'Else' })
     })
 
-    it('should throw error when if-then step is missing depth parameter', async () => {
+    it('should not throw error when if-then step is missing depth parameter', async () => {
       const params = {
         input: {
           flowName: 'Test Flow',
@@ -667,6 +687,13 @@ describe('createFlowWithSteps mutation integration tests', () => {
                 // missing depth
               },
             },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
+              position: 3,
+              config: {},
+            },
           ],
           aiBuilderConfig: {
             type: 'form',
@@ -675,12 +702,13 @@ describe('createFlowWithSteps mutation integration tests', () => {
         },
       }
 
-      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
-        'Pipe contains invalid action steps',
-      )
+      const result = await createFlowWithSteps(null, params, context)
+      expect(result).toBeDefined()
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+      expect(steps[1].parameters).toEqual({ depth: 0, branchName: 'If' })
     })
 
     it('should not throw error when if-then step is missing branchName parameter', async () => {
@@ -723,6 +751,11 @@ describe('createFlowWithSteps mutation integration tests', () => {
 
       const result = await createFlowWithSteps(null, params, context)
       expect(result).toBeDefined()
+
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+      expect(steps[1].parameters).toEqual({ depth: 0, branchName: 'Branch' })
     })
 
     it('should throw error when if-then is the last step', async () => {
@@ -800,7 +833,7 @@ describe('createFlowWithSteps mutation integration tests', () => {
       expect(flows).toHaveLength(0)
     })
 
-    it('should throw error when if-then step has empty parameters object', async () => {
+    it('should not throw error when if-then step has empty parameters object', async () => {
       const params = {
         input: {
           flowName: 'Test Flow',
@@ -820,6 +853,53 @@ describe('createFlowWithSteps mutation integration tests', () => {
               config: {},
               parameters: {},
             },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'slack',
+              key: 'sendMessageToChannel',
+              position: 3,
+              config: {},
+            },
+          ],
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
+        },
+      }
+
+      const result = await createFlowWithSteps(null, params, context)
+      expect(result).toBeDefined()
+
+      const steps = await Step.query()
+        .where('flow_id', result.id)
+        .orderBy('position', 'asc')
+      expect(steps[1].parameters).toEqual({ depth: 0, branchName: 'Branch' })
+    })
+  })
+
+  describe('restricted app keys validation', () => {
+    it('should throw error when using a restricted action app key', async () => {
+      mocks.getRestrictedAppKeys.mockReturnValueOnce(['aisay'])
+
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'scheduler',
+              key: 'everyHour',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'aisay',
+              key: 'useGeneralisedModel',
+              position: 2,
+              config: {},
+            },
           ],
           aiBuilderConfig: {
             type: 'form',
@@ -831,9 +911,40 @@ describe('createFlowWithSteps mutation integration tests', () => {
       await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
         'Pipe contains invalid action steps',
       )
+    })
 
-      const flows = await Flow.query()
-      expect(flows).toHaveLength(0)
+    it('should throw error when using a restricted trigger app key', async () => {
+      mocks.getRestrictedAppKeys.mockReturnValueOnce(['gathersg'])
+
+      const params = {
+        input: {
+          flowName: 'Test Flow',
+          steps: [
+            {
+              type: 'trigger' as StepEnumType,
+              appKey: 'gathersg',
+              key: 'newInstantWorkflow',
+              position: 1,
+              config: {},
+            },
+            {
+              type: 'action' as StepEnumType,
+              appKey: 'postman',
+              key: 'sendTransactionalEmail',
+              position: 2,
+              config: {},
+            },
+          ],
+          aiBuilderConfig: {
+            type: 'form',
+            traceId: '123',
+          },
+        },
+      }
+
+      await expect(createFlowWithSteps(null, params, context)).rejects.toThrow(
+        'Pipe must always start with a trigger',
+      )
     })
   })
 })

--- a/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
@@ -2,19 +2,14 @@ import type { IStep } from '@plumber/types'
 
 import z from 'zod/v3'
 
+import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 
 import { MutationResolvers } from '../../__generated__/types.generated'
 
-import { actionStepsSchema } from './schemas/action-steps-schema'
+import { getActionStepsSchema } from './schemas/action-steps-schema'
 import { generateSchema } from './schemas/schema-generator'
-
-// Generate schema to validate trigger step against the available triggers in apps
-const triggerSchema = generateSchema(
-  z.object({ type: z.literal('trigger') }),
-  'trigger',
-)
 
 const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
   _parent,
@@ -24,6 +19,19 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
   const {
     input: { steps, flowName, aiBuilderConfig },
   } = params
+
+  const restrictedApps = getRestrictedAppKeys(
+    await getAllLdFlags(context.currentUser.email),
+  )
+
+  // Generate schema to validate trigger step against the available triggers in apps
+  // we also pass restricted apps into the schema so the assistant knows which apps the user cannot use
+  const triggerSchema = generateSchema(
+    z.object({ type: z.literal('trigger') }),
+    'trigger',
+    restrictedApps,
+  )
+  const actionStepsSchema = getActionStepsSchema(restrictedApps)
 
   const trimmedFlowName = flowName.trim()
   if (trimmedFlowName === '') {
@@ -75,7 +83,15 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
       },
     })
 
-    const stepsToInsert = steps.map((step: IStep) => {
+    const normalizedActionSteps = validatedActions.data.map(
+      (actionStep, index) => ({
+        ...steps[index + 1],
+        ...actionStep,
+      }),
+    )
+    // Keep the first step as the trigger; only action steps are rehydrated from validatedActions.
+    const normalizedSteps = [steps[0], ...normalizedActionSteps]
+    const stepsToInsert = normalizedSteps.map((step: IStep) => {
       return {
         type: step.type,
         appKey: step.appKey,

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -4,37 +4,36 @@ import z from 'zod/v3'
 import { fromZodError } from 'zod-validation-error'
 
 import appConfig from '@/config/app'
-import {
-  AI_BUILDER_FEATURE_FLAG,
-  AI_BUILDER_FEATURE_FLAG_FALLBACK,
-} from '@/config/flags'
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
+import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
 import { langfuseClient } from '@/helpers/langfuse'
-import { getLdFlagValue } from '@/helpers/launch-darkly'
+import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import JSONObject from '@/types/interfaces/json-object'
 
 import { MutationResolvers } from '../../__generated__/types.generated'
 
-import { Action, ACTIONS_SCHEMA } from './schemas/actions.zod'
+import { getActionsSchema } from './schemas/actions.zod'
 import { INPUT_SCHEMA } from './schemas/input.zod'
-import { TRIGGER_SCHEMA } from './schemas/triggers.zod'
+import { getTriggerSchema } from './schemas/triggers.zod'
 
 const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
   _parent,
   params,
   context,
 ) => {
-  const aiBuilderFlag = await getLdFlagValue(
-    AI_BUILDER_FEATURE_FLAG,
-    context.currentUser.email,
-    AI_BUILDER_FEATURE_FLAG_FALLBACK,
-  )
+  const allLdFlags = await getAllLdFlags(context.currentUser.email)
+  const aiBuilderFlag = getAiBuilderFlag(allLdFlags)
 
   if (!aiBuilderFlag.enabled) {
     throw new ForbiddenError('You do not have permissions to use AI Builder!')
   }
+
+  // NOTE: we pass restricted apps into the system prompt so the assistant knows which apps the user cannot use
+  const restrictedApps = getRestrictedAppKeys(allLdFlags)
+  const triggerSchema = getTriggerSchema(restrictedApps)
+  const actionsSchema = getActionsSchema(restrictedApps)
 
   const { generateStepsPromptName: promptName, version } = aiBuilderFlag.config
   let traceId
@@ -90,8 +89,8 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
         const { object } = await generateObject({
           model,
           schema: z.object({
-            trigger: TRIGGER_SCHEMA,
-            actions: ACTIONS_SCHEMA,
+            trigger: triggerSchema,
+            actions: actionsSchema,
             name: z.string().max(64).default('Build with AI'),
           }),
           system: systemPrompt,
@@ -127,7 +126,7 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
 
     return {
       ...result,
-      actions: (result.actions as Action[]).map((action: Action) => ({
+      actions: result.actions.map((action) => ({
         ...action,
         config: {
           ...action.config,

--- a/packages/backend/src/graphql/mutations/ai/schemas/action-steps-schema.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/action-steps-schema.ts
@@ -8,20 +8,27 @@ import { generateSchema } from './schema-generator'
 
 // Generate schema to validate action steps against the available actions in apps
 // This schema is used by createFlowWithSteps where description/config are optional
-const actionStepSchema = generateSchema(
-  z.object({
-    type: z.literal('action'),
-    description: z.string().optional(),
-    config: z.record(z.any()).optional(),
-  }),
-  'action',
-).refine(validateActionParameters, {
-  message:
-    'If-then steps must have parameters with depth: 0 and branchName (string)',
+const baseActionStepSchema = z.object({
+  type: z.literal('action'),
+  description: z.string().optional(),
+  config: z.record(z.any()).optional(),
 })
 
-export const actionStepsSchema = z
-  .array(actionStepSchema)
-  .min(1)
-  .max(29) // max of 30 steps including trigger
-  .superRefine(validateActionStepsRules)
+export function getActionStepsSchema(restrictedAppKeys: string[] = []) {
+  const actionStepSchema = generateSchema(
+    baseActionStepSchema,
+    'action',
+    restrictedAppKeys,
+  ).refine(validateActionParameters, {
+    message:
+      'If-then steps must have parameters with depth: 0 and branchName (string)',
+  })
+
+  return z
+    .array(actionStepSchema)
+    .min(1)
+    .max(29) // max of 30 steps including trigger
+    .superRefine(validateActionStepsRules)
+}
+
+export const actionStepsSchema = getActionStepsSchema()

--- a/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/actions.zod.ts
@@ -21,21 +21,26 @@ export const ifThenParametersSchema = z.object({
   branchName: z.string().default('Branch'),
 })
 
-const generatedSchema = generateSchema(baseActionSchema, 'action')
+function getActionSchema(restrictedAppKeys: string[] = []) {
+  const generatedSchema = generateSchema(
+    baseActionSchema,
+    'action',
+    restrictedAppKeys,
+  )
 
-export const ACTION_SCHEMA = generatedSchema.refine(validateActionParameters, {
-  message:
-    'Parameters are only allowed when key is ifThen (with depth: 0 and branchName)',
-})
+  return generatedSchema.refine(validateActionParameters, {
+    message:
+      'Parameters are only allowed when key is ifThen (with depth: 0 and branchName)',
+  })
+}
 
-export const ACTIONS_SCHEMA = z
-  .array(ACTION_SCHEMA)
-  .min(1)
-  .max(29) // max of 30 steps including trigger
-  .superRefine(validateActionStepsRules)
-
-// Type inference for TypeScript
-export type Action = z.infer<typeof ACTION_SCHEMA>
+export function getActionsSchema(restrictedAppKeys: string[] = []) {
+  return z
+    .array(getActionSchema(restrictedAppKeys))
+    .min(1)
+    .max(29) // max of 30 steps including trigger
+    .superRefine(validateActionStepsRules)
+}
 
 /**
  * Reusable validation function for individual action steps that enforces:

--- a/packages/backend/src/graphql/mutations/ai/schemas/schema-generator.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/schema-generator.ts
@@ -8,27 +8,12 @@ import {
 
 import { ifThenParametersSchema } from './actions.zod'
 
-/**
- * Generates valid appKey enum from registered apps
- */
-export function getAppKeys() {
-  return Object.keys(apps) as [string, ...string[]]
-}
-
-/**
- * Gets all action keys for a specific app
- */
-export function getActionKeys(appKey: string): string[] {
-  const app = apps[appKey]
-  return app?.actions?.map((action) => action.key) || []
-}
-
-/**
- * Gets all trigger keys for a specific app
- */
-export function getTriggerKeys(appKey: string): string[] {
-  const app = apps[appKey]
-  return app?.triggers?.map((trigger) => trigger.key) || []
+function getActiveApps(restrictedAppKeys: string[] = []) {
+  return Object.fromEntries(
+    Object.entries(apps).filter(
+      ([appKey]) => !restrictedAppKeys.includes(appKey),
+    ),
+  ) as typeof apps
 }
 
 /**
@@ -37,11 +22,16 @@ export function getTriggerKeys(appKey: string): string[] {
 export function generateSchema(
   baseSchema: z.ZodObject<any>,
   schemaType: 'action' | 'trigger',
+  restrictedAppKeys: string[] = [],
 ) {
-  const schemas = getAppKeys()
-    .flatMap((appKey) => {
+  const activeApps = getActiveApps(restrictedAppKeys)
+
+  const schemas = Object.entries(activeApps)
+    .flatMap(([appKey, app]) => {
       const keys =
-        schemaType === 'action' ? getActionKeys(appKey) : getTriggerKeys(appKey)
+        schemaType === 'action'
+          ? app?.actions?.map((action) => action.key) || []
+          : app?.triggers?.map((trigger) => trigger.key) || []
 
       if (keys.length === 0) {
         return []

--- a/packages/backend/src/graphql/mutations/ai/schemas/triggers.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/triggers.zod.ts
@@ -8,19 +8,6 @@ const baseTriggerSchema = z.object({
   type: z.literal('trigger'),
 })
 
-export const TRIGGER_SCHEMA = generateSchema(baseTriggerSchema, 'trigger')
-
-// Type inference for TypeScript
-export type Trigger = z.infer<typeof TRIGGER_SCHEMA>
-
-// Example usage with generateObject from the ai package:
-/*
-import { generateObject } from 'ai'
-import { TRIGGER_SCHEMA } from './triggers.zod'
-
-const result = await generateObject({
-  model: yourModel,
-  schema: TRIGGER_SCHEMA,
-  prompt: "Generate a trigger for...",
-})
-*/
+export function getTriggerSchema(restrictedAppKeys: string[] = []) {
+  return generateSchema(baseTriggerSchema, 'trigger', restrictedAppKeys)
+}


### PR DESCRIPTION
### TL;DR

Enforce restricted app keys from LD when generating AI steps, preventing users from using apps they don't have access to.

### What changed?

- Schema generation for triggers and actions now accepts a `restrictedAppKeys` parameter, filtering out disallowed apps before building the Zod validation schemas.
- `getTriggerSchema`, `getActionsSchema`, and `getActionStepsSchema` factory functions that accept restricted app keys at call time.
- Both `generateAiSteps` and `createFlowWithSteps` now fetch all LD flags via `getAllLdFlags` and derive restricted app keys using `getRestrictedAppKeys`, passing them into the schema factories. This means the AI will not suggest restricted apps, and any output containing them will fail validation.
- The `getAiBuilderFlag` helper is now used to extract the AI builder flag from the full set of LD flags, replacing the previous direct `getLdFlagValue` call.

### How to test?

- [ ] Verify that the trigger and action schema now remove the feature-flagged apps
- [ ] Verify that you cannot create a Pipe with restricted apps

_Sanity_ _check_

- [ ] Can still create a Pipe from AI Builder


Resolves PLU-725