### PR TITLE
PLU-718: add fix for excel error

### DIFF
--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -165,7 +165,7 @@ const action: IRawAction = {
     if (!tableHeaderInfoResponse.data.values?.[0]?.length) {
       throw new StepError(
         'Could not read table headers.',
-        'Your Excel table may span the maximum number of columns (XFD). Try deleting any unused columns at the end of the table.',
+        'Your Excel table may span the maximum number of columns (XFD). Delete unused columns at the end of the table.',
       )
     }
 

--- a/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts
@@ -159,6 +159,16 @@ const action: IRawAction = {
         tableId,
       },
     })
+
+    // This occurs when a user selected all the columns and created a table by accident...
+    // Reference: https://learn.microsoft.com/en-us/answers/questions/1837007/excel-api-cant-reach-data-on-the-last-column-xfd
+    if (!tableHeaderInfoResponse.data.values?.[0]?.length) {
+      throw new StepError(
+        'Could not read table headers.',
+        'Your Excel table may span the maximum number of columns (XFD). Try deleting any unused columns at the end of the table.',
+      )
+    }
+
     const tableHeaderInfo: TableHeaderInfo = {
       rowIndex: tableHeaderInfoResponse.data.rowIndex,
       columnNames: tableHeaderInfoResponse.data.values[0],

--- a/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
+++ b/packages/backend/src/apps/m365-excel/common/get-top-n-table-rows.ts
@@ -83,8 +83,8 @@ export async function getTopNTableRows(
 
     if (rangeParseResult.success === false) {
       throw new StepError(
-        'Invalid table range',
-        'Check your Excel file and try again',
+        'Could not read table headers.',
+        'Your Excel table may span the maximum number of columns (XFD). Delete unused columns at the end of the table.',
       )
     }
 


### PR DESCRIPTION
## Problem

When a table spans all 16,384 columns (up to column XFD), the Graph API returns null for values on range-level endpoints like /headerRowRange.
Reference: https://learn.microsoft.com/en-us/answers/questions/1837007/excel-api-cant-reach-data-on-the-last-column-xfd

## Solution
Add a StepError to check and ask the user to not be foolish...

## Tests
1. Add an Excel table with the max number of columns
2. Test creating a table row on excel
3. Should throw a proper step error
