### PR TITLE
fix: hide draft connections

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/get-flow-connections.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-flow-connections.itest.ts
@@ -218,6 +218,7 @@ describe('getFlowConnections', () => {
         key: 'slack',
         formattedData: { screenName: 'My Slack Workspace' },
         userId: owner.id,
+        draft: false,
       })
 
       await FlowConnections.query().insert({
@@ -274,6 +275,7 @@ describe('getFlowConnections', () => {
         key: 'slack',
         formattedData: { screenName: 'My Slack Workspace' },
         userId: owner.id,
+        draft: false,
       })
 
       await FlowConnections.query().insert({
@@ -321,6 +323,26 @@ describe('getFlowConnections', () => {
           }),
         ]),
       )
+    })
+
+    it('should ignore draft connections', async () => {
+      const connection = await Connection.query().insert({
+        key: 'slack',
+        formattedData: { screenName: 'My Slack Workspace' },
+        userId: owner.id,
+        draft: true,
+      })
+
+      await FlowConnections.query().insert({
+        flowId: flow.id,
+        connectionId: connection.id,
+        addedBy: owner.id,
+        connectionType: 'connection',
+      })
+
+      const result = await getFlowConnections({}, { flowId: flow.id }, context)
+
+      expect(result).toHaveLength(0)
     })
   })
 })

--- a/packages/backend/src/graphql/queries/get-flow-connections.ts
+++ b/packages/backend/src/graphql/queries/get-flow-connections.ts
@@ -41,6 +41,9 @@ const getFlowConnections: QueryResolvers['getFlowConnections'] = async (
       user: true,
       table: true,
     })
+    .modifyGraph('connection', (builder) => {
+      builder.where('draft', false)
+    })
 
   /**
    * we check if there are any flow connections for the flow first


### PR DESCRIPTION
### TL;DR

Hides draft connections

### Tests

Open a Pipe with Collaborators, add a new Connection, but put the wrong API key.

- [ ] Verify that the draft connection does not appear in the Connections table