### PR TITLE
[DATABRICKS-6] PLU-600: expose connectionId on global variable and allow optional registerConnection

### DIFF
--- a/packages/backend/src/graphql/mutations/register-connection.ts
+++ b/packages/backend/src/graphql/mutations/register-connection.ts
@@ -79,7 +79,7 @@ const registerConnection: MutationResolvers['registerConnection'] = async (
     throw new Error('Connection is not verified')
   }
 
-  await app.auth.registerConnection($)
+  await app.auth.registerConnection?.($)
   return true
 }
 

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -64,6 +64,7 @@ const globalVariable = async (
         return null
       },
       data: connection?.formattedData,
+      connectionId: connection?.id,
     },
     app: app,
     flow: {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -956,6 +956,7 @@ export type IGlobalVariable = {
   auth: {
     set: (args: IJSONObject) => Promise<null>
     data: IJSONObject
+    connectionId?: string
   }
   app: IApp
   http?: IHttpClient


### PR DESCRIPTION
### Changes

- Added `connectionId?: string` to `IGlobalVariable.auth` in `@plumber/types`
- Populated `connectionId` from `connection?.id` in `globalVariable()`
- Optional-chained `app.auth.registerConnection?.($)` in the `registerConnection` mutation