### PR TITLE
[DATABRICKS-7] PLU-600: add system-added connection auth with schema-existence verification

### DIFF
--- a/packages/backend/src/apps/databricks/auth/check-schema-exists.ts
+++ b/packages/backend/src/apps/databricks/auth/check-schema-exists.ts
@@ -1,0 +1,34 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import { databricksConfig } from '@/config/app-env-vars/databricks'
+import logger from '@/helpers/logger'
+
+import { createSession } from './create-client'
+
+export async function checkSchemaExists($: IGlobalVariable): Promise<boolean> {
+  // Open the session without an initialSchema; getSchemas() would fail against
+  // a schema that doesn't exist yet.
+  const { session, endSession } = await createSession($, { skipSchema: true })
+
+  try {
+    const { screenName } = $.auth.data
+    const schemaName = screenName as string
+    if (!schemaName) {
+      throw new Error('No connections found')
+    }
+    const operation = await session.getSchemas({
+      catalogName: databricksConfig.catalog,
+      schemaName,
+    })
+    const schemas = await operation.fetchAll()
+    return schemas.length > 0
+  } catch (error) {
+    logger.error('Failed to check schema existence in Databricks', {
+      event: 'databricks-check-schema-error',
+      error,
+    })
+    throw new Error('Failed to check schema existence in Databricks')
+  } finally {
+    await endSession()
+  }
+}

--- a/packages/backend/src/apps/databricks/auth/create-client.ts
+++ b/packages/backend/src/apps/databricks/auth/create-client.ts
@@ -12,7 +12,14 @@ import { constructSchemaName } from '../common/construct-schema-name'
 
 import { getDatabricksToken } from './token-persistence'
 
-export const createSession = async ($: IGlobalVariable) => {
+interface CreateSessionOptions {
+  skipSchema?: boolean
+}
+
+export const createSession = async (
+  $: IGlobalVariable,
+  options?: CreateSessionOptions,
+) => {
   const client: DBSQLClient = new DBSQLClient({
     logger: {
       log(level: LogLevel, message: string) {
@@ -36,13 +43,11 @@ export const createSession = async ($: IGlobalVariable) => {
     token,
   } satisfies ConnectionOptions
 
-  const schemaName = constructSchemaName($)
-
   let connectedClient: IDBSQLClient
   try {
     connectedClient = await client.connect(connectOptions)
     const session = await connectedClient.openSession({
-      initialSchema: schemaName,
+      initialSchema: options?.skipSchema ? undefined : constructSchemaName($),
       initialCatalog: databricksConfig.catalog,
     })
     const endSession = async () => {

--- a/packages/backend/src/apps/databricks/auth/get-system-added-connections.ts
+++ b/packages/backend/src/apps/databricks/auth/get-system-added-connections.ts
@@ -1,0 +1,51 @@
+import type { ISystemAddedConnectionAuth } from '@plumber/types'
+
+import { databricksConfig } from '@/config/app-env-vars/databricks'
+import User from '@/models/user'
+
+import { APP_KEY } from '../common/constants'
+import { constructSchemaNameFromEmail } from '../common/construct-schema-name'
+
+const getSystemAddedConnections: NonNullable<
+  ISystemAddedConnectionAuth['getSystemAddedConnections']
+> = async function (user) {
+  if (!(user instanceof User)) {
+    throw new Error(
+      'Invalid user object received by Databricks getSystemAddedConnections',
+    )
+  }
+
+  const connections = await user
+    .$relatedQuery('connections')
+    .select('connections.*')
+    .fullOuterJoinRelated('steps')
+    .where({
+      'connections.key': APP_KEY,
+    })
+    .countDistinct('steps.flow_id as flowCount')
+    .groupBy('connections.id')
+    .orderBy('created_at', 'desc')
+
+  if (connections.length === 0) {
+    const newConnection = await user
+      .$relatedQuery('connections')
+      .insertAndFetch({
+        key: APP_KEY,
+        formattedData: {
+          // Workspace hostname drives the "View workspace" link in the UI.
+          env: databricksConfig.serverHostname,
+          screenName: constructSchemaNameFromEmail(user.email),
+        },
+        verified: false,
+        draft: false,
+      })
+      .returning('*')
+
+    newConnection.flowCount = 0
+    connections.push(newConnection)
+  }
+
+  return connections
+}
+
+export default getSystemAddedConnections

--- a/packages/backend/src/apps/databricks/auth/index.ts
+++ b/packages/backend/src/apps/databricks/auth/index.ts
@@ -1,0 +1,15 @@
+import { ISystemAddedConnectionAuth } from '@plumber/types'
+
+import getSystemAddedConnections from './get-system-added-connections'
+import isStillVerified from './is-still-verified'
+
+const auth: ISystemAddedConnectionAuth = {
+  connectionType: 'system-added',
+  getSystemAddedConnections,
+  isStillVerified,
+  connectionModalLabel: {
+    chooseConnectionLabel: 'Connect to Databricks',
+  },
+}
+
+export default auth

--- a/packages/backend/src/apps/databricks/auth/is-still-verified.ts
+++ b/packages/backend/src/apps/databricks/auth/is-still-verified.ts
@@ -1,0 +1,24 @@
+import { IGlobalVariable } from '@plumber/types'
+
+import Connection from '@/models/connection'
+
+import { checkSchemaExists } from './check-schema-exists'
+
+const isStillVerified = async ($: IGlobalVariable) => {
+  const databricksConnection = await Connection.query().findById(
+    $.auth.connectionId,
+  )
+
+  if (!databricksConnection) {
+    return false
+  }
+
+  // Once a schema has been seen, we skip re-checking Databricks on every test
+  // to avoid opening a SQL session per call.
+  if (databricksConnection.verified) {
+    return true
+  }
+  return checkSchemaExists($)
+}
+
+export default isStillVerified

--- a/packages/backend/src/apps/databricks/common/constants.ts
+++ b/packages/backend/src/apps/databricks/common/constants.ts
@@ -1,0 +1,1 @@
+export const APP_KEY = 'databricks'

--- a/packages/backend/src/apps/databricks/common/construct-schema-name.ts
+++ b/packages/backend/src/apps/databricks/common/construct-schema-name.ts
@@ -1,10 +1,13 @@
 import { IGlobalVariable } from '@plumber/types'
 
-export const constructSchemaName = ($: IGlobalVariable) => {
+export const constructSchemaNameFromEmail = (email: string): string => {
+  return email.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase()
+}
+
+export const constructSchemaName = ($: IGlobalVariable): string => {
   const userEmail = $.user?.email
   if (!userEmail) {
     throw new Error('User email is required')
   }
-  // replace non-alphanumeric characters with underscore
-  return userEmail.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase()
+  return constructSchemaNameFromEmail(userEmail)
 }

--- a/packages/backend/src/apps/databricks/index.ts
+++ b/packages/backend/src/apps/databricks/index.ts
@@ -1,6 +1,7 @@
 import { IApp } from '@plumber/types'
 
 import actions from './actions'
+import auth from './auth'
 import dynamicData from './dynamic-data'
 
 const app: IApp = {
@@ -9,6 +10,7 @@ const app: IApp = {
   description: 'Store data for analytics and machine learning',
   iconUrl: '{BASE_URL}/apps/databricks/assets/favicon.svg',
   authDocUrl: '',
+  auth,
   beforeRequest: [],
   baseUrl: '',
   apiBaseUrl: '',


### PR DESCRIPTION
## TLDR

Add system-added connections for Databricks. This essentially only stores schema name (derived from email) and hostname (env). When a user first adds a Databricks step, the backend auto-provisions a connection row and verifies access by checking whether the user's schema exists in databricks. No frontend yet.

### What changed?

- Added `ISystemAddedConnectionAuth` wiring at `auth/index.ts` with `connectionType: 'system-added'`
- Added `getSystemAddedConnections` — returns the user's existing Databricks connection or inserts a new unverified one
- Added `isStillVerified` + `checkSchemaExists` — short-circuits if `connection.verified`, otherwise opens a schema-less session and checks if schema exist on db.
- Added `skipSchema` option to `createSession` so the verification session can open without an `initialSchema` (required because `getSchemas` on a non-existent schema would fail)
- Extracted `constructSchemaNameFromEmail(email)` for use outside request-scoped globals
- Added `APP_KEY = 'databricks'` shared constant