### PR TITLE
[DATABRICKS-9] PLU-600: add onboarding modal and per-connection workspace link

### DIFF
--- a/packages/backend/src/apps/databricks/actions/create-row.ts
+++ b/packages/backend/src/apps/databricks/actions/create-row.ts
@@ -2,14 +2,11 @@ import { IGlobalVariable, IRawAction } from '@plumber/types'
 
 import { z } from 'zod'
 
-import { databricksConfig } from '@/config/app-env-vars/databricks'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 
 import { createSession } from '../auth/create-client'
 import { columnNameSchema, tableNameSchema } from '../common/schema'
-
-const databricksTableUrl = `https://${databricksConfig.serverHostname}/explore/tables/${databricksConfig.catalog}`
 
 const insertRowSchema = z.object({
   tableName: tableNameSchema,
@@ -49,10 +46,6 @@ const createRowAction: IRawAction = {
         id: 'databricks-createTable',
         type: 'modal',
         label: 'Create a new table',
-      },
-      clickableLink: {
-        label: 'View databricks dashboard',
-        url: databricksTableUrl,
       },
     },
     {

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -181,6 +181,7 @@ function ChooseConnectionSubstep(
                 href={connectionStatus.connectionLink.url}
                 target="_blank"
                 ml={2}
+                isExternal
               >
                 {connectionStatus.connectionLink.text}
               </Link>

--- a/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
+++ b/packages/frontend/src/components/ChooseConnectionSubstep/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '../FlowStepConfigurationModal/ChooseAndAddConnection'
 import {
   APP_ALLOWING_EMPTY_CONNECTION,
+  DATABRICKS_APP_KEY,
   EXCEL_APP_KEY,
 } from '../FlowStepConfigurationModal/constants'
 
@@ -48,6 +49,17 @@ const formLinkGenerator = (connectionOption: ConnectionDropdownOption) => {
 
 const excelFolderLinkGenerator = (userEmail: string) => {
   return `https://gccprod-my.sharepoint.com/shared?id=%2Fsites%2FGOVTECH%2Dplumber%2FShared%20Documents%2F${userEmail}&listurl=https%3A%2F%2Fgccprod%2Esharepoint%2Ecom%2Fsites%2FGOVTECH%2Dplumber%2FShared%20Documents`
+}
+
+const databricksWorkspaceLinkGenerator = (
+  connectionOption: ConnectionDropdownOption,
+) => {
+  const { env, label } = connectionOption
+  if (!env) {
+    return null
+  }
+  // `env` is the workspace hostname (Databricks has multiple workspaces per environment)
+  return `https://${env}/explore/data/workspace/${label}`
 }
 
 function ChooseConnectionSubstep(
@@ -128,6 +140,11 @@ function ChooseConnectionSubstep(
         connectionLink = {
           url: excelFolderLinkGenerator(currentUser?.email ?? ''),
           text: '(View folder)',
+        }
+      } else if (application.key === DATABRICKS_APP_KEY) {
+        connectionLink = {
+          url: databricksWorkspaceLinkGenerator(connectionOption) ?? '',
+          text: '(View workspace)',
         }
       }
 

--- a/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
+++ b/packages/frontend/src/components/ControlledAutocomplete/AddNewOptionModal.tsx
@@ -78,7 +78,7 @@ const ADD_NEW_OPTION_CONFIGS: Partial<
   'databricks-createTable': {
     modalHeader: 'Create a new table',
     inputLabel: 'Table name',
-    description: 'Only lowercase letters, numbers and underscores allowed.',
+    description: 'Only letters, numbers and underscores allowed.',
     buttonLabel: 'Create',
     validate: validateDatabricksTableName,
   },

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureDatabricksConnection.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/ConfigureDatabricksConnection.tsx
@@ -1,0 +1,186 @@
+import type { IApp } from '@plumber/types'
+
+import { useContext, useEffect } from 'react'
+import { useQuery } from '@apollo/client'
+import {
+  Flex,
+  Link,
+  ListItem,
+  ModalBody,
+  ModalHeader,
+  OrderedList,
+  Spinner,
+  Text,
+} from '@chakra-ui/react'
+import {
+  Button,
+  Infobox,
+  ModalCloseButton,
+} from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
+import { GET_APP_CONNECTIONS } from '@/graphql/queries/get-app-connections'
+
+import BackButton from '../BackButton'
+import { DATABRICKS_APP_KEY } from '../constants'
+import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
+import { useConnectionVerification } from '../hooks/useConnectionRegistration'
+
+import ConnectionHeader from './ConnectionHeader'
+
+function NotOnboardedContent({
+  onRecheck,
+  isLoading,
+}: {
+  onRecheck: () => Promise<void>
+  isLoading: boolean
+}) {
+  return (
+    <Flex flexDir="column" gap={4}>
+      <Infobox variant="warning">
+        The Govtech Data Platform requires onboarding before use. It looks like
+        you&apos;re not onboarded yet.
+      </Infobox>
+
+      <Text>How to get access:</Text>
+      <OrderedList ml={8} spacing={2}>
+        <ListItem>
+          Join <b>#ask-cdo</b> channel on GovTech Slack
+        </ListItem>
+        <ListItem>
+          Click on <b>Onboarding Request</b> button and follow the instructions.
+        </ListItem>
+        <ListItem>
+          Come back and click <b>Check access</b> below
+        </ListItem>
+      </OrderedList>
+
+      <Text fontSize="md" mb={2}>
+        For more information, please refer to{' '}
+        <Link
+          display="inline"
+          href="https://go.gov.sg/gdp-onboarding"
+          isExternal
+        >
+          this guide
+        </Link>
+        .
+      </Text>
+
+      <Button isFullWidth size="lg" onClick={onRecheck} isLoading={isLoading}>
+        Check access
+      </Button>
+    </Flex>
+  )
+}
+
+function OnboardedContent({
+  handleSubmit,
+}: {
+  handleSubmit: () => Promise<void>
+}) {
+  return (
+    <Flex flexDir="column" gap={3}>
+      <Infobox variant="success">
+        Your access to the Govtech Data Platform has been verified!
+      </Infobox>
+      <Button isFullWidth onClick={handleSubmit} mt={4}>
+        Continue
+      </Button>
+    </Flex>
+  )
+}
+
+interface ConfigureDatabricksConnectionProps {
+  onBack: () => void
+  onCreateOrUpdateStep: (connectionId: string) => Promise<void>
+}
+
+export default function ConfigureDatabricksConnection(
+  props: ConfigureDatabricksConnectionProps,
+) {
+  const { onBack, onCreateOrUpdateStep } = props
+  const { flowId } = useContext(EditorContext)
+  const { modalState, step } = useContext(FlowStepConfigurationContext)
+  const { selectedApp, selectedConnectionId } = modalState
+  const connectionModalLabel = selectedApp?.auth?.connectionModalLabel
+
+  // Fallback query in case the modal is reached without selectedConnectionId set
+  // (ChooseAppAndEvent normally populates it, but not all entry points do).
+  const { data: appConnectionsData, loading: connectionsLoading } = useQuery(
+    GET_APP_CONNECTIONS,
+    {
+      variables: { key: DATABRICKS_APP_KEY, flowId },
+    },
+  )
+
+  const connectionId =
+    selectedConnectionId ??
+    appConnectionsData?.getApp?.connections?.[0]?.id ??
+    ''
+
+  const { testResult, testResultLoading, testConnection } =
+    useConnectionVerification({
+      supportsConnectionRegistration: false,
+    })
+
+  useEffect(() => {
+    if (connectionId) {
+      testConnection(connectionId)
+    }
+  }, [connectionId, testConnection])
+
+  const isLoading = connectionsLoading || testResultLoading
+  const isConnectionVerified =
+    !isLoading && testResult?.connectionVerified === true
+
+  const renderBody = () => {
+    if (isLoading) {
+      return (
+        <Flex alignItems="center" flexDir="column" py={8}>
+          <Spinner size="xl" color="primary.500" thickness="4px" />
+          <Text textStyle="header-1" mt={8}>
+            Checking for access...
+          </Text>
+        </Flex>
+      )
+    }
+    if (isConnectionVerified) {
+      return (
+        <OnboardedContent
+          handleSubmit={async () => await onCreateOrUpdateStep(connectionId)}
+        />
+      )
+    }
+    return (
+      <NotOnboardedContent
+        onRecheck={async () => {
+          if (connectionId) {
+            await testConnection(connectionId)
+          }
+        }}
+        isLoading={testResultLoading}
+      />
+    )
+  }
+
+  return (
+    <>
+      <ModalHeader pt={0} mt={-4}>
+        {!isConnectionVerified && (!step?.key || !step?.appKey) && (
+          <BackButton onBack={onBack} />
+        )}
+        <ConnectionHeader
+          selectedApp={selectedApp as IApp}
+          headerText={
+            connectionModalLabel?.chooseConnectionLabel ??
+            'Connect to Databricks'
+          }
+        />
+      </ModalHeader>
+      <ModalCloseButton mt={2} size="xs" colorScheme="secondary" />
+
+      <ModalBody>{renderBody()}</ModalBody>
+    </>
+  )
+}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -8,12 +8,13 @@ import { MrfContext } from '@/contexts/MrfContext'
 import { GET_APP_CONNECTIONS } from '@/graphql/queries/get-app-connections'
 import { getMrfApprovalConfig } from '@/helpers/formsg'
 
-import { EXCEL_APP_KEY } from '../constants'
+import { DATABRICKS_APP_KEY, EXCEL_APP_KEY } from '../constants'
 import { FlowStepConfigurationContext } from '../FlowStepConfigurationContext'
 import InvalidModalScreen from '../InvalidModalScreen'
 
 import AddConnection from './AddConnection'
 import ChooseConnection from './ChooseConnection'
+import ConfigureDatabricksConnection from './ConfigureDatabricksConnection'
 import ConfigureExcelConnection from './ConfigureExcelConnection'
 
 interface ChooseAndAddConnectionProps {
@@ -60,6 +61,7 @@ export const optionGenerator = (
     label: screenName ?? 'Unnamed',
     value: connection?.id as string,
     description: connection?.description ?? undefined,
+    env: connection?.formattedData?.env as string | undefined,
   }
 }
 
@@ -213,6 +215,19 @@ export default function ChooseAndAddConnection(
   ) {
     return (
       <ConfigureExcelConnection
+        onBack={() => patchModalState({ currentScreen: 'choose-event' })}
+        onCreateOrUpdateStep={onCreateOrUpdateStep}
+      />
+    )
+  }
+
+  if (
+    selectedApp?.key === DATABRICKS_APP_KEY &&
+    selectedEvent &&
+    currentScreen === 'configure-databricks-connection'
+  ) {
+    return (
+      <ConfigureDatabricksConnection
         onBack={() => patchModalState({ currentScreen: 'choose-event' })}
         onCreateOrUpdateStep={onCreateOrUpdateStep}
       />

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -37,7 +37,8 @@ function FlowStepConfigurationModalContent({
   if (
     currentScreen === 'choose-connection' ||
     currentScreen === 'add-connection' ||
-    currentScreen === 'configure-excel-connection'
+    currentScreen === 'configure-excel-connection' ||
+    currentScreen === 'configure-databricks-connection'
   ) {
     return <ChooseAndAddConnection onClose={onClose} />
   }


### PR DESCRIPTION
### TL;DR

Completes the Databricks onboarding flow. Adds the modal that walks non-onboarded users through the `#ask-cdo` Slack process, and adds a "(View workspace)" link in the connection dropdown that deep-links to the user's Databricks workspace. Removes the old hardcoded "View databricks dashboard" catalog link from `Create a new row` (replaced by the per-connection workspace link).

### What changed?

- **New** `ConfigureDatabricksConnection` modal: shows a loading spinner while checking schema existence, then either the onboarding instructions ("Check access" button + link to the guide) or the success state ("Continue" button)
- Wired the new screen into `ChooseAndAddConnection` and `FlowStepConfigurationModal`
- Added `env` (workspace hostname) to the connection option shape and a `databricksWorkspaceLinkGenerator` in `ChooseConnectionSubstep`
- Removed the old hardcoded catalog link from `databricks/actions/create-row.ts` (replaced by the per-connection workspace link)

### How to test?

**Not onboarded** \*\*(**login with a user with no schema e.g. [youremail+1@open.gov.sg](mailto:youremail+1@open.gov.sg))

- [ ] Add a databricks action --> modal shows onboarding instructions and a `Check access` button
- [ ] Click **Check access** → loading spinner, then stays on the onboarding screen (until schema exists)

![Screenshot 2026-04-22 at 5.02.33 PM.png](https://app.graphite.com/user-attachments/assets/3d309420-edcf-48f8-9916-3f6acc1f1121.png)

**Onboarded User** \*\*(**login with a user with a schema in databricks)

- [ ] Add a databricks action -> you should see this modal with success infobox.

    ![Screenshot 2026-04-22 at 4.58.13 PM.png](https://app.graphite.com/user-attachments/assets/4b9defee-1ebe-4de4-b584-ab7a758c7ef0.png)

    Click **Continue** → step is created and modal closes
- [ ] Next to the Databricks connection, it should show **(View workspace)** → URL is `https://<workspace-hostname>/explore/data/workspace/<schema>`
- [ ] Subsequent databricks step, should skip the setup modal.