### PR TITLE
fix: revert fast xml parser version due to breaking change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5891,18 +5891,6 @@
         "win32"
       ]
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -15901,9 +15889,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
       "funding": [
         {
           "type": "github",
@@ -15912,10 +15900,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "lodash-es": "4.18.1",
     "vite": "6.4.2",
     "immutable": "4.3.8",
-    "picomatch": "4.0.4",
-    "fast-xml-parser": "5.7.0"
+    "picomatch": "4.0.4"
   },
   "devDependencies": {
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",


### PR DESCRIPTION
## Problem

Upgrading `fast-xml-parser` to 5.7.0 caused a breaking change in a dependency: `@aws-sdk/xml-builder` that uses it as a sub-dependency.

The problem is that `@aws-sdk/xml-builder` requires the `fast-xml-parser` to be at 5.5.8 version and I clearly missed it.
Problem was verified here: https://github.com/aws/aws-sdk-js-v3/issues/7955

This causes issues with sending emails since S3 speaks XML on the wire, not JSON. So if S3, a proxy, or some middleware returns malformed XML or even plain text / HTML when the SDK is expecting XML, the SDK can throw a misleading deserialization error from an XML utility package.

## Solution

Update the version back to 5.5.8 till a fix is implemented on their end.

## Tests

- [ ] Both frontend and backend can be built successfully
- [ ] Tests and integrations tests work
- [ ] Uploaded attachments can be sent in an email successfully

## Important Note
Ok made sure that the other npm library updates did not have dependencies using it as a fixed version.
For example, `minimatch` depends on `brace-expansion` version "^5.0.2" so updating brace-expansion to 5.0.5 should not cause any breaking change
Did so and checed for the rest also: `dompurify`, `follow-redirects`, `protobufjs`, `markdown-it`, `js-yaml`, `yaml`
