### PR TITLE
[AFTER-FIND-1] (feat): afterFind hook in Step model

### DIFF
--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -310,6 +310,19 @@ class Step extends Base {
       })
     }
   }
+
+  /**
+   * This hook transforms step parameters to ensure the frontend always receives
+   * data in the latest format, even when the database contains legacy formats.
+   *
+   * This approach allows zero-downtime migrations without database updates.
+   */
+  async $afterFind(): Promise<void> {
+    const app = apps[this.appKey]
+    if (app?.transformStepParameters && this.key && this.parameters) {
+      this.parameters = app.transformStepParameters(this.key, this.parameters)
+    }
+  }
 }
 
 export default Step

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -661,6 +661,26 @@ export interface IApp {
    * precedence.
    */
   setupMessage?: SetupMessage
+
+  /**
+   * Optional transformation function for step parameters.
+   *
+   * Enables zero-downtime parameter format migrations by transforming
+   * legacy parameters to the current format when steps are fetched from
+   * the database or executed.
+   *
+   * Example: Excel actions migrated from individual `lookupColumn` and
+   * `lookupValue` parameters to a `filters` array. This function transforms
+   * old format to new on-the-fly.
+   *
+   * @param actionKey - The action identifier (e.g., 'getTableRow')
+   * @param parameters - The step parameters from database
+   * @returns Transformed parameters in current format
+   */
+  transformStepParameters?: (
+    actionKey: string,
+    parameters: IJSONObject,
+  ) => IJSONObject
 }
 
 export type AppCategory = 'data' | 'communication' | 'logic' | 'others' | 'ai'


### PR DESCRIPTION
### TL;DR

Adds support for zero-downtime step parameter migrations via a new `transformStepParameters` hook on app definitions.

### What changed?

A new optional `transformStepParameters` function has been added to the `IApp` interface. When defined, this function is automatically invoked in the `$afterFind` lifecycle hook on the `Step` model, transforming stored parameters into the current expected format before they are returned to the frontend or used during execution.

### Why make this change?

When parameter formats change for an action, existing steps stored in the database become stale. Previously, this required a database migration to update all affected rows. By applying transformations at read time via `$afterFind`, legacy parameter formats can be seamlessly upgraded on-the-fly, enabling zero-downtime migrations without touching the database.

### Tests

_These are just sanity checks that adding this hook does not break Pipe functionality._

- [ ] Verify that existing Step parameters are not modified (no `transformStepParameters` specified for any app yet)
- [ ] Verify that executing 'Check step' still works
- [ ] Veify that published Pipes still execute and work properly