### PR TITLE
[EXCEL-MULTI-LOOKUP-3] PLU-593 (chore): update excel schemas to accept both formats

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
@@ -3,7 +3,12 @@ import type { IGlobalVariable } from '@plumber/types'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { fileIdSchema, tableIdSchema } from '../../common/schema'
+import {
+  baseLookupParametersSchema,
+  fileIdSchema,
+  lookupParametersSchema,
+  tableIdSchema,
+} from '../../common/schema'
 
 const VALID_FILE_ID = '1234ABCD1234ABCD1234ABCD1234ABCD'
 const VALID_TABLE_ID = `{${VALID_FILE_ID}}`
@@ -76,6 +81,224 @@ describe('validate dynamic fields', () => {
           $,
         }),
       ).toHaveProperty('success', true)
+    })
+  })
+})
+
+describe('baseLookupParametersSchema', () => {
+  describe('accepts old format', () => {
+    it('with lookupColumn and lookupValue', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          lookupColumn: 'Email',
+          lookupValue: 'test@example.com',
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with lookupColumn only', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          lookupColumn: 'Status',
+        }),
+      ).toHaveProperty('success', true)
+    })
+  })
+
+  describe('accepts new format', () => {
+    it('with filters array', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Email',
+              lookupValue: 'test@example.com',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with multiple filters', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Status',
+              lookupValue: 'Active',
+            },
+            {
+              lookupColumn: 'Department',
+              lookupValue: 'Engineering',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with empty filters array', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [],
+        }),
+      ).toHaveProperty('success', true)
+    })
+  })
+
+  describe('accepts both formats together', () => {
+    it('with both old and new parameters', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          lookupColumn: 'OldColumn',
+          lookupValue: 'old value',
+          filters: [
+            {
+              lookupColumn: 'NewColumn',
+              lookupValue: 'new value',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+  })
+
+  describe('accepts without lookup parameters', () => {
+    it('with only fileId and tableId', () => {
+      expect(
+        baseLookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+        }),
+      ).toHaveProperty('success', true)
+    })
+  })
+})
+
+describe('lookupParametersSchema (with validation)', () => {
+  describe('accepts valid formats', () => {
+    it('accepts old format with lookupColumn', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          lookupColumn: 'Email',
+          lookupValue: 'test@example.com',
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('accepts new format with filters', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Email',
+              lookupValue: 'test@example.com',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('accepts both formats together', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          lookupColumn: 'OldColumn',
+          filters: [
+            {
+              lookupColumn: 'NewColumn',
+              lookupValue: 'new value',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+  })
+
+  describe('rejects invalid formats', () => {
+    it('rejects when neither format provided', () => {
+      const result = lookupParametersSchema.safeParse({
+        fileId: VALID_FILE_ID,
+        tableId: VALID_TABLE_ID,
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Either lookup column/value or filters must be provided',
+        )
+      }
+    })
+
+    it('rejects empty filters array without old format', () => {
+      const result = lookupParametersSchema.safeParse({
+        fileId: VALID_FILE_ID,
+        tableId: VALID_TABLE_ID,
+        filters: [],
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Either lookup column/value or filters must be provided',
+        )
+      }
+    })
+
+    it('rejects null filters without old format', () => {
+      const result = lookupParametersSchema.safeParse({
+        fileId: VALID_FILE_ID,
+        tableId: VALID_TABLE_ID,
+        filters: null,
+      })
+
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects undefined filters without old format', () => {
+      const result = lookupParametersSchema.safeParse({
+        fileId: VALID_FILE_ID,
+        tableId: VALID_TABLE_ID,
+        filters: undefined,
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Either lookup column/value or filters must be provided',
+        )
+      }
+    })
+
+    it('rejects with only lookupValue (no lookupColumn)', () => {
+      const result = lookupParametersSchema.safeParse({
+        fileId: VALID_FILE_ID,
+        tableId: VALID_TABLE_ID,
+        lookupValue: 'some value',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(
+          'Either lookup column/value or filters must be provided',
+        )
+      }
     })
   })
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/schemas.ts
@@ -1,19 +1,10 @@
 import z from 'zod'
 
-import { fileIdSchema, tableIdSchema } from '../../common/schema'
+import { lookupParametersSchema } from '../../common/schema'
 import { hexEncodedRowRecordSchema } from '../../common/workbook-helpers/tables'
 
-export const parametersSchema = z.object({
-  fileId: fileIdSchema,
-  tableId: tableIdSchema,
-  // Populated by dynamic data, so no need to trim.
-  lookupColumn: z.string().min(1, {
-    message: 'Please select a column to lookup from.',
-  }),
-  // * We don't trim as we want to match _exactly_ on the user's input.
-  // * We allow empty strings to support optional form fields.
-  lookupValue: z.string().default(''),
-})
+// Use the validated lookup parameters schema from common
+export const parametersSchema = lookupParametersSchema
 
 export const dataOutSchema = z.discriminatedUnion('foundRow', [
   z.object({ foundRow: z.literal(false) }),

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/schemas.ts
@@ -2,19 +2,10 @@ import z from 'zod'
 
 import { FOR_EACH_INPUT_SOURCE } from '@/apps/toolbox/common/constants'
 
-import { fileIdSchema, tableIdSchema } from '../../common/schema'
+import { lookupParametersSchema } from '../../common/schema'
 
-export const parametersSchema = z.object({
-  fileId: fileIdSchema,
-  tableId: tableIdSchema,
-  // Populated by dynamic data, so no need to trim.
-  lookupColumn: z.string().min(1, {
-    message: 'Please select a column to lookup from.',
-  }),
-  // * We don't trim as we want to match _exactly_ on the user's input.
-  // * We allow empty strings to support optional form fields.
-  lookupValue: z.string().default(''),
-})
+// Use the validated lookup parameters schema from common
+export const parametersSchema = lookupParametersSchema
 
 export const dataOutSchema = z.object({
   rowsFound: z.number(),

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/schemas.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/schemas.ts
@@ -1,39 +1,44 @@
 import z from 'zod'
 
+import {
+  baseLookupParametersSchema,
+  withLookupValidation,
+} from '../../common/schema'
 import { hexEncodedRowRecordSchema } from '../../common/workbook-helpers/tables'
-import { parametersSchema as getTableRowParametersSchema } from '../get-table-row/schemas'
 
-export const parametersSchema = getTableRowParametersSchema.extend({
-  columnsToUpdate: z
-    .array(
-      z.object({
-        // Populated by dynamic data, so no need to trim.
-        columnName: z
-          .string()
-          .min(1, { message: 'Please select a column to update.' }),
-        // We allow empty strings to support optional form fields.
-        value: z.string(),
-      }),
-    )
-    .min(1, { message: 'Please input at least 1 column to update.' })
-    .superRefine((columnsToUpdate, context) => {
-      // Shoud not have repeated columns
-      const seenColumnNames = new Set<string>()
+export const parametersSchema = withLookupValidation(
+  baseLookupParametersSchema.extend({
+    columnsToUpdate: z
+      .array(
+        z.object({
+          // Populated by dynamic data, so no need to trim.
+          columnName: z
+            .string()
+            .min(1, { message: 'Please select a column to update.' }),
+          // We allow empty strings to support optional form fields.
+          value: z.string(),
+        }),
+      )
+      .min(1, { message: 'Please input at least 1 column to update.' })
+      .superRefine((columnsToUpdate, context) => {
+        // Should not have repeated columns
+        const seenColumnNames = new Set<string>()
 
-      for (const columnToUpdate of columnsToUpdate) {
-        if (seenColumnNames.has(columnToUpdate.columnName)) {
-          context.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Column '${columnToUpdate.columnName}' can only be updated once. Remove duplicate '${columnToUpdate.columnName}' columns from the 'Set up row to update' section.`,
-            fatal: true,
-          })
-          return z.NEVER
+        for (const columnToUpdate of columnsToUpdate) {
+          if (seenColumnNames.has(columnToUpdate.columnName)) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Column '${columnToUpdate.columnName}' can only be updated once. Remove duplicate '${columnToUpdate.columnName}' columns from the 'Set up row to update' section.`,
+              fatal: true,
+            })
+            return z.NEVER
+          }
+
+          seenColumnNames.add(columnToUpdate.columnName)
         }
-
-        seenColumnNames.add(columnToUpdate.columnName)
-      }
-    }),
-})
+      }),
+  }),
+)
 
 export const updateRowValuesResponseSchema = z
   .object({

--- a/packages/backend/src/apps/m365-excel/common/schema.ts
+++ b/packages/backend/src/apps/m365-excel/common/schema.ts
@@ -26,3 +26,56 @@ export const worksheetIdSchema = z
   .trim()
   .regex(WORKSHEET_ID_REGEX, { message: 'Invalid worksheet ID format.' })
   .min(1, { message: 'Please select a worksheet to lookup from.' })
+
+// Base schema object that can be extended by other actions (e.g., update-table-row)
+export const baseLookupParametersSchema = z.object({
+  fileId: fileIdSchema,
+  tableId: tableIdSchema,
+  // Old parameters - optional for backward compatibility
+  lookupColumn: z
+    .string()
+    .min(1, {
+      message: 'Please select a column to lookup from.',
+    })
+    .optional(),
+  lookupValue: z.string().default('').optional(),
+  // New parameters
+  filters: z
+    .array(
+      z.object({
+        lookupColumn: z.string().min(1),
+        lookupValue: z.string().default(''),
+      }),
+    )
+    .optional(),
+})
+
+/**
+ * Helper to add lookup parameter validation refinement.
+ * Ensures at least one format (old or new) is provided.
+ */
+export function withLookupValidation<T extends z.ZodObject<any>>(
+  schema: T,
+): z.ZodEffects<T, z.infer<T>, z.infer<T>> {
+  return schema.refine(
+    (data: z.infer<T>) => {
+      // At least one format must be provided
+      const hasOldFormat =
+        'lookupColumn' in data && data.lookupColumn !== undefined
+      const hasNewFormat =
+        'filters' in data &&
+        data.filters &&
+        Array.isArray(data.filters) &&
+        data.filters.length > 0
+      return hasOldFormat || hasNewFormat
+    },
+    {
+      message: 'Either lookup column/value or filters must be provided',
+    },
+  )
+}
+
+// Validated lookup parameters schema for actions that don't need to extend
+export const lookupParametersSchema = withLookupValidation(
+  baseLookupParametersSchema,
+)


### PR DESCRIPTION
### TL;DR

Add multi-filter lookup schema for M365 Excel actions, enabling rows to be looked up using multiple column/value pairs instead of a single column.

### What changed?

Added `baseLookupParametersSchema` and `lookupParametersSchema` to the M365 Excel common schema module. These schemas support both the existing single `lookupColumn`/`lookupValue` format (for backward compatibility) and a new `filters` array format that allows multiple column/value pairs to be specified.

A `withLookupValidation` helper function enforces that at least one lookup format is provided — either a `lookupColumn` or a non-empty `filters` array.

The `get-table-row`, `get-table-rows`, and `update-table-row` actions now use these shared schemas instead of defining their own inline lookup parameter definitions.

### Tests

- [ ] Verify that existing Pipes still work as intended
    - [ ] Get table row
    - [ ] Get multiple table rows
    - [ ] Update table row