### PR TITLE
[EXCEL-MULTI-LOOKUP-1] PLU-593 (feat): add maxRows arg for MultiRow inputs

### DIFF
--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -282,6 +282,7 @@ type ActionSubstepArgument {
 
   # Only for multirow
   subFields: [ActionSubstepArgument]
+  maxRows: String
 
   # Only for rich text
   customRteMenuOptions: [RteMenuOption]

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -282,7 +282,7 @@ type ActionSubstepArgument {
 
   # Only for multirow
   subFields: [ActionSubstepArgument]
-  maxRows: String
+  maxRows: Int
 
   # Only for rich text
   customRteMenuOptions: [RteMenuOption]

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -222,6 +222,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         type={type}
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
+        maxRows={schema.maxRows}
       />
     )
   }

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -64,9 +64,6 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     rules: { required },
   })
 
-  // Show add button if maxRows is not set, or if current row count is below the limit
-  const canAddRow = maxRows == null || rows.length < Number(maxRows)
-
   const handleAddRow = useCallback(() => {
     // NOTE: only need to use this flag to focus on the rte
     // if the first column is a variable-enabled string field
@@ -91,6 +88,8 @@ function MultiRow(props: MultiRowProps): JSX.Element {
         const rowsToRender =
           !rows.length && required ? [{ ...newRowDefaultValue }] : rows
         const canRemoveRow = !required || rowsToRender.length > 1
+        const canAddRow =
+          maxRows == null || rowsToRender.length < Number(maxRows)
 
         return (
           <Flex flexDir="column">

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -88,8 +88,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
         const rowsToRender =
           !rows.length && required ? [{ ...newRowDefaultValue }] : rows
         const canRemoveRow = !required || rowsToRender.length > 1
-        const canAddRow =
-          maxRows == null || rowsToRender.length < Number(maxRows)
+        const canAddRow = maxRows == null || rowsToRender.length < maxRows
 
         return (
           <Flex flexDir="column">

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -24,6 +24,7 @@ export type MultiRowProps = {
   showDivider?: boolean
   addRowButtonText?: string
   type?: string
+  maxRows?: number
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
 function MultiRow(props: MultiRowProps): JSX.Element {
@@ -36,6 +37,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     addRowButtonText,
     showDivider,
     type,
+    maxRows,
     ...forwardedInputCreatorProps
   } = props
 
@@ -61,6 +63,9 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     name,
     rules: { required },
   })
+
+  // Show add button if maxRows is not set, or if current row count is below the limit
+  const canAddRow = maxRows == null || rows.length < Number(maxRows)
 
   const handleAddRow = useCallback(() => {
     // NOTE: only need to use this flag to focus on the rte
@@ -171,15 +176,17 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               )
             })}
 
-            <Button
-              variant="outline"
-              leftIcon={<BiPlus />}
-              onClick={handleAddRow}
-              isDisabled={isEditorReadOnly}
-              maxW="fit-content"
-            >
-              {addRowButtonText ?? 'And'}
-            </Button>
+            {canAddRow && (
+              <Button
+                variant="outline"
+                leftIcon={<BiPlus />}
+                onClick={handleAddRow}
+                isDisabled={isEditorReadOnly}
+                maxW="fit-content"
+              >
+                {addRowButtonText ?? 'And'}
+              </Button>
+            )}
           </Flex>
         )
       }}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -451,6 +451,7 @@ export interface IFieldMultiRowMultiCol extends IBaseField {
   value?: string
   addRowButtonText?: string
   subFields: IFieldMultiRowMultiColSubField[]
+  maxRows?: number
 }
 
 export interface IFieldMultiRow extends IBaseField {
@@ -459,6 +460,7 @@ export interface IFieldMultiRow extends IBaseField {
   addRowButtonText?: string
 
   subFields: IField[]
+  maxRows?: number
 }
 
 export type TRteMenuOption =


### PR DESCRIPTION
### TL;DR

Add `maxRows` property to multirow components to limit the number of rows that can be added.

### What changed?

- Added `maxRows` field to the `ActionSubstepArgument` GraphQL schema
- Extended `MultiRowProps` and related interfaces to include optional `maxRows` property
- Implemented logic to conditionally show the "Add Row" button based on the `maxRows` limit
- Updated GraphQL query to fetch the `maxRows` value
- Added type definitions for `maxRows` in multirow field interfaces

### How to test?

- [ ] Update any action that uses `multirow` or `multirow-multicol` input with the `maxRows` argument
    - [ ] Verify that you can add rows up to the specified limit
    - [ ] Verify that the "Add Row" button disappears when the maximum number of rows is reached
- [ ] Verify that if `maxRows` is 1, you should not be able to add rows on init
- [ ] Verify that current `multirow` and `multirow-multicol` inputs still work as intended
    - [ ] Can still add rows
    - [ ] Can still delete rows