### PR TITLE
[EXCEL-MULTI-LOOKUP-5] PLU-593 (feat): support multiple filters

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-row-impl.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-row-impl.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import StepError from '@/errors/step'
+
+import getTableRowImpl from '../../actions/get-table-row/implementation'
+import getTopNTableRows from '../../common/get-top-n-table-rows'
+
+// Mock the getTopNTableRows function
+vi.mock('../../common/get-top-n-table-rows')
+
+describe('getTableRowImpl', () => {
+  const mockSession = {} as any
+  const mockGlobalVariable = {} as any
+  const tableId = '{test-table-id}'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(getTopNTableRows).mockResolvedValue({
+      columns: ['Name', 'Email', 'Age', 'Group', 'RSVP-ed'],
+      rows: [
+        ['Alice', 'alice@example.com', '25', 'A', 'Yes'],
+        ['Bob', 'bob@example.com', '30', 'B', 'No'],
+        ['Charlie', 'charlie@example.com', '35', 'A', 'Yes'],
+        ['David', 'david@example.com', '40', 'B', 'No'],
+        ['Eve', 'eve@example.com', '45', 'C', 'Yes'],
+        ['Frank', 'frank@example.com', '50', 'C', 'No'],
+      ],
+      headerSheetRowIndex: 0,
+    })
+  })
+
+  describe('single filter', () => {
+    it('should find a row matching single filter', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Name', lookupValue: 'Bob' }],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 1,
+        sheetRowNumber: 3,
+        row: ['Bob', 'bob@example.com', '30', 'B', 'No'],
+        columns: ['Name', 'Email', 'Age', 'Group', 'RSVP-ed'],
+      })
+    })
+
+    it('should return null when no row matches single filter', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Group', lookupValue: 'D' }],
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should throw error when lookup column does not exist', async () => {
+      await expect(
+        getTableRowImpl({
+          $: mockGlobalVariable,
+          session: mockSession,
+          tableId,
+          filters: [{ lookupColumn: 'NonExistent', lookupValue: 'value' }],
+        }),
+      ).rejects.toThrow(StepError)
+    })
+  })
+
+  describe('multiple filters', () => {
+    it('should find a row matching all filters', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Group', lookupValue: 'A' },
+          { lookupColumn: 'RSVP-ed', lookupValue: 'Yes' },
+        ],
+      })
+
+      // Should match Alice (first matching row, Charlie also matches)
+      expect(result).toEqual({
+        tableRowIndex: 0,
+        sheetRowNumber: 2,
+        row: ['Alice', 'alice@example.com', '25', 'A', 'Yes'],
+        columns: ['Name', 'Email', 'Age', 'Group', 'RSVP-ed'],
+      })
+    })
+
+    it('should find the first row when multiple rows match all filters', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Group', lookupValue: 'A' },
+          { lookupColumn: 'RSVP-ed', lookupValue: 'Yes' },
+        ],
+      })
+
+      // Alice and Charlie both match (Group=A, RSVP-ed=Yes), should return Alice
+      expect(result).toEqual({
+        tableRowIndex: 0,
+        sheetRowNumber: 2,
+        row: ['Alice', 'alice@example.com', '25', 'A', 'Yes'],
+        columns: ['Name', 'Email', 'Age', 'Group', 'RSVP-ed'],
+      })
+    })
+
+    it('should return null when only some filters match', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Group', lookupValue: 'B' },
+          { lookupColumn: 'RSVP-ed', lookupValue: 'Yes' },
+        ],
+      })
+
+      // Bob and David are Group B, but both have RSVP-ed=No
+      expect(result).toBeNull()
+    })
+
+    it('should return null when no rows match any filter', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Group', lookupValue: 'D' },
+          { lookupColumn: 'Email', lookupValue: 'nonexistent@example.com' },
+        ],
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should handle three or more filters', async () => {
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Name', lookupValue: 'Charlie' },
+          { lookupColumn: 'Group', lookupValue: 'A' },
+          { lookupColumn: 'RSVP-ed', lookupValue: 'Yes' },
+        ],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 2,
+        sheetRowNumber: 4,
+        row: ['Charlie', 'charlie@example.com', '35', 'A', 'Yes'],
+        columns: ['Name', 'Email', 'Age', 'Group', 'RSVP-ed'],
+      })
+    })
+
+    it('should throw error when any filter column does not exist', async () => {
+      await expect(
+        getTableRowImpl({
+          $: mockGlobalVariable,
+          session: mockSession,
+          tableId,
+          filters: [
+            { lookupColumn: 'Group', lookupValue: 'A' },
+            { lookupColumn: 'NonExistent', lookupValue: 'value' },
+          ],
+        }),
+      ).rejects.toThrow(StepError)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty table rows', async () => {
+      vi.mocked(getTopNTableRows).mockResolvedValue({
+        columns: ['Name', 'Email'],
+        rows: [],
+        headerSheetRowIndex: 0,
+      })
+
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Name', lookupValue: 'Alice' }],
+      })
+
+      expect(result).toBeNull()
+    })
+
+    it('should handle empty string lookup values', async () => {
+      vi.mocked(getTopNTableRows).mockResolvedValue({
+        columns: ['Name', 'Email'],
+        rows: [
+          ['Alice', ''],
+          ['Bob', 'bob@example.com'],
+        ],
+        headerSheetRowIndex: 0,
+      })
+
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [
+          { lookupColumn: 'Name', lookupValue: 'Alice' },
+          { lookupColumn: 'Email', lookupValue: '' },
+        ],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 0,
+        sheetRowNumber: 2,
+        row: ['Alice', ''],
+        columns: ['Name', 'Email'],
+      })
+    })
+
+    it('should calculate correct sheetRowNumber with non-zero headerSheetRowIndex', async () => {
+      vi.mocked(getTopNTableRows).mockResolvedValue({
+        columns: ['Name', 'Email'],
+        rows: [
+          ['Alice', 'alice@example.com'],
+          ['Bob', 'bob@example.com'],
+        ],
+        headerSheetRowIndex: 5, // Header is at row 6 (0-indexed row 5)
+      })
+
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Name', lookupValue: 'Bob' }],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 1,
+        sheetRowNumber: 8, // headerIndex(5) + tableRowIndex(1) + 2
+        row: ['Bob', 'bob@example.com'],
+        columns: ['Name', 'Email'],
+      })
+    })
+
+    it('should find last row when it matches', async () => {
+      vi.mocked(getTopNTableRows).mockResolvedValue({
+        columns: ['Name', 'Status'],
+        rows: [
+          ['Alice', 'Inactive'],
+          ['Bob', 'Inactive'],
+          ['Charlie', 'Active'],
+        ],
+        headerSheetRowIndex: 0,
+      })
+
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Status', lookupValue: 'Active' }],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 2,
+        sheetRowNumber: 4,
+        row: ['Charlie', 'Active'],
+        columns: ['Name', 'Status'],
+      })
+    })
+
+    it('should match exact values (case sensitive)', async () => {
+      vi.mocked(getTopNTableRows).mockResolvedValue({
+        columns: ['Name', 'Email'],
+        rows: [
+          ['alice', 'alice@example.com'],
+          ['Alice', 'alice2@example.com'],
+        ],
+        headerSheetRowIndex: 0,
+      })
+
+      const result = await getTableRowImpl({
+        $: mockGlobalVariable,
+        session: mockSession,
+        tableId,
+        filters: [{ lookupColumn: 'Name', lookupValue: 'Alice' }],
+      })
+
+      expect(result).toEqual({
+        tableRowIndex: 1,
+        sheetRowNumber: 3,
+        row: ['Alice', 'alice2@example.com'],
+        columns: ['Name', 'Email'],
+      })
+    })
+  })
+})

--- a/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/actions/get-table-rows.itest.ts
@@ -24,6 +24,12 @@ const { transformStepParameters } = stepTransformer
 const getHexEncodedColumnName = (columnName: string) =>
   Buffer.from(columnName).toString('hex')
 
+const getColumnObject = (columnName: string) => ({
+  id: getHexEncodedColumnName(columnName),
+  name: columnName,
+  value: `data.rows.*.data.${getHexEncodedColumnName(columnName)}`,
+})
+
 // Mock dependencies
 const mocks = vi.hoisted(() => ({
   WorkbookSession: {
@@ -87,14 +93,14 @@ describe('getTableRowsAction', () => {
 
     // Setup default mock implementations
     mocks.getTopNTableRows.mockResolvedValue({
-      columns: ['Column1', 'Column2'],
+      columns: ['Column1', 'Column2', 'Column3', 'Column4'],
       rows: [
-        ['non-matching', 'data1'],
-        ['test-value', 'data2'],
-        ['test-value', 'data3'],
-        ['', 'data4'],
-        ['row5', ''],
-        ['', 'data6'],
+        ['non-matching', 'data1', 'a', '1'],
+        ['test-value', 'data2', 'b', '2'],
+        ['test-value', 'data3', 'a', '3'],
+        ['', 'data4', 'a', '3'],
+        ['row5', '', 'b', '2'],
+        ['', 'data6', 'c', '1'],
       ],
       headerSheetRowIndex: 0,
     })
@@ -140,18 +146,7 @@ describe('getTableRowsAction', () => {
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
         data: {
-          columns: expect.arrayContaining([
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            }),
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            }),
-          ]),
+          columns: [getColumnObject('Column1'), getColumnObject('Column2')],
           rows: [],
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
         },
@@ -164,38 +159,36 @@ describe('getTableRowsAction', () => {
     await getTableRowsAction.run($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
-      raw: expect.objectContaining({
+      raw: {
         rowsFound: 2, // Two rows match 'test-value'
         data: {
-          columns: expect.arrayContaining([
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            }),
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            }),
-          ]),
-          rows: expect.arrayContaining([
-            expect.objectContaining({
+          columns: [
+            getColumnObject('Column1'),
+            getColumnObject('Column2'),
+            getColumnObject('Column3'),
+            getColumnObject('Column4'),
+          ],
+          rows: [
+            {
               data: {
                 [getHexEncodedColumnName('Column1')]: 'test-value',
                 [getHexEncodedColumnName('Column2')]: 'data2',
+                [getHexEncodedColumnName('Column3')]: 'b',
+                [getHexEncodedColumnName('Column4')]: '2',
               },
-            }),
-            expect.objectContaining({
+            },
+            {
               data: {
                 [getHexEncodedColumnName('Column1')]: 'test-value',
                 [getHexEncodedColumnName('Column2')]: 'data3',
+                [getHexEncodedColumnName('Column3')]: 'a',
+                [getHexEncodedColumnName('Column4')]: '3',
               },
-            }),
-          ]),
+            },
+          ],
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
         },
-      }),
+      },
     })
 
     // Verify the rowData contains the expected rows
@@ -223,38 +216,36 @@ describe('getTableRowsAction', () => {
     await getTableRowsAction.run($)
 
     expect($.setActionItem).toHaveBeenCalledWith({
-      raw: expect.objectContaining({
+      raw: {
         rowsFound: 2,
         data: {
-          columns: expect.arrayContaining([
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            }),
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            }),
-          ]),
-          rows: expect.arrayContaining([
-            expect.objectContaining({
+          columns: [
+            getColumnObject('Column1'),
+            getColumnObject('Column2'),
+            getColumnObject('Column3'),
+            getColumnObject('Column4'),
+          ],
+          rows: [
+            {
               data: {
                 [getHexEncodedColumnName('Column1')]: '',
                 [getHexEncodedColumnName('Column2')]: 'data4',
+                [getHexEncodedColumnName('Column3')]: 'a',
+                [getHexEncodedColumnName('Column4')]: '3',
               },
-            }),
-            expect.objectContaining({
+            },
+            {
               data: {
                 [getHexEncodedColumnName('Column1')]: '',
                 [getHexEncodedColumnName('Column2')]: 'data6',
+                [getHexEncodedColumnName('Column3')]: 'c',
+                [getHexEncodedColumnName('Column4')]: '1',
               },
-            }),
-          ]),
+            },
+          ],
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
         },
-      }),
+      },
     })
 
     // Verify the rowData contains the expected rows
@@ -292,16 +283,10 @@ describe('getTableRowsAction', () => {
       raw: {
         data: {
           columns: [
-            {
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            },
-            {
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            },
+            getColumnObject('Column1'),
+            getColumnObject('Column2'),
+            getColumnObject('Column3'),
+            getColumnObject('Column4'),
           ],
           rows: [],
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
@@ -334,32 +319,21 @@ describe('getTableRowsAction', () => {
 
     // Should find the exact case match
     expect($.setActionItem).toHaveBeenCalledWith({
-      raw: expect.objectContaining({
+      raw: {
         rowsFound: 1,
         data: {
-          rows: expect.arrayContaining([
-            expect.objectContaining({
+          rows: [
+            {
               data: {
                 [getHexEncodedColumnName('Column1')]: 'TEST-VALUE',
                 [getHexEncodedColumnName('Column2')]: 'data2',
               },
-            }),
-          ]),
-          columns: expect.arrayContaining([
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            }),
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            }),
-          ]),
+            },
+          ],
+          columns: [getColumnObject('Column1'), getColumnObject('Column2')],
           inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
         },
-      }),
+      },
     })
   })
 
@@ -381,18 +355,7 @@ describe('getTableRowsAction', () => {
       raw: expect.objectContaining({
         rowsFound: 500, // Should be limited to 500 rows
         data: {
-          columns: expect.arrayContaining([
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column1'),
-              name: 'Column1',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column1')}`,
-            }),
-            expect.objectContaining({
-              id: getHexEncodedColumnName('Column2'),
-              name: 'Column2',
-              value: `data.rows.*.data.${getHexEncodedColumnName('Column2')}`,
-            }),
-          ]),
+          columns: [getColumnObject('Column1'), getColumnObject('Column2')],
           rows: expect.arrayContaining(
             Array.from({ length: 500 }, (_, i) =>
               expect.objectContaining({
@@ -424,5 +387,113 @@ describe('getTableRowsAction', () => {
     expect(rowData[499].data[getHexEncodedColumnName('Column2')]).toBe(
       'data500',
     )
+  })
+
+  describe('multiple filters', () => {
+    it('should find rows matching all filters', async () => {
+      $.step.parameters.filters = [
+        { lookupColumn: 'Column3', lookupValue: 'a' },
+        { lookupColumn: 'Column4', lookupValue: '3' },
+      ]
+
+      await getTableRowsAction.run($)
+
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          rowsFound: 2,
+          data: {
+            columns: [
+              getColumnObject('Column1'),
+              getColumnObject('Column2'),
+              getColumnObject('Column3'),
+              getColumnObject('Column4'),
+            ],
+            rows: [
+              {
+                data: {
+                  [getHexEncodedColumnName('Column1')]: 'test-value',
+                  [getHexEncodedColumnName('Column2')]: 'data3',
+                  [getHexEncodedColumnName('Column3')]: 'a',
+                  [getHexEncodedColumnName('Column4')]: '3',
+                },
+              },
+              {
+                data: {
+                  [getHexEncodedColumnName('Column1')]: '',
+                  [getHexEncodedColumnName('Column2')]: 'data4',
+                  [getHexEncodedColumnName('Column3')]: 'a',
+                  [getHexEncodedColumnName('Column4')]: '3',
+                },
+              },
+            ],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+        },
+      })
+
+      const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock
+        .calls[0][0]
+      const rowData = call.raw.data.rows
+      expect(rowData).toHaveLength(2)
+    })
+
+    it('should return no rows when only some filters match', async () => {
+      $.step.parameters.filters = [
+        { lookupColumn: 'Column1', lookupValue: 'test-value' },
+        { lookupColumn: 'Column2', lookupValue: 'non-matching' },
+      ]
+
+      await getTableRowsAction.run($)
+
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          data: {
+            columns: [
+              getColumnObject('Column1'),
+              getColumnObject('Column2'),
+              getColumnObject('Column3'),
+              getColumnObject('Column4'),
+            ],
+            rows: [],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+          rowsFound: 0,
+        },
+      })
+    })
+
+    it('should handle empty string in multiple filters', async () => {
+      $.step.parameters.filters = [
+        { lookupColumn: 'Column1', lookupValue: '' },
+        { lookupColumn: 'Column2', lookupValue: 'data4' },
+      ]
+
+      await getTableRowsAction.run($)
+
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          rowsFound: 1,
+          data: {
+            columns: [
+              getColumnObject('Column1'),
+              getColumnObject('Column2'),
+              getColumnObject('Column3'),
+              getColumnObject('Column4'),
+            ],
+            rows: [
+              {
+                data: {
+                  [getHexEncodedColumnName('Column1')]: '',
+                  [getHexEncodedColumnName('Column2')]: 'data4',
+                  [getHexEncodedColumnName('Column3')]: 'a',
+                  [getHexEncodedColumnName('Column4')]: '3',
+                },
+              },
+            ],
+            inputSource: FOR_EACH_INPUT_SOURCE.M365_EXCEL,
+          },
+        },
+      })
+    })
   })
 })

--- a/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
@@ -3,7 +3,7 @@ import type { IGlobalVariable } from '@plumber/types'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { fileIdSchema, tableIdSchema } from '../../common/schema'
+import { fileIdSchema, filtersSchema, tableIdSchema } from '../../common/schema'
 
 const VALID_FILE_ID = '1234ABCD1234ABCD1234ABCD1234ABCD'
 const VALID_TABLE_ID = `{${VALID_FILE_ID}}`
@@ -76,6 +76,61 @@ describe('validate dynamic fields', () => {
           $,
         }),
       ).toHaveProperty('success', true)
+    })
+  })
+})
+
+describe('filtersSchema', () => {
+  describe('invalid filters', () => {
+    it('rejects empty array', () => {
+      expect(filtersSchema.safeParse([])).toHaveProperty('success', false)
+    })
+
+    it('rejects duplicate lookup columns', () => {
+      expect(
+        filtersSchema.safeParse([
+          { lookupColumn: 'Name', lookupValue: 'Alice' },
+          { lookupColumn: 'Name', lookupValue: 'Bob' },
+        ]),
+      ).toHaveProperty('success', false)
+    })
+
+    it('rejects multiple duplicates across filters', () => {
+      expect(
+        filtersSchema.safeParse([
+          { lookupColumn: 'Name', lookupValue: 'Alice' },
+          { lookupColumn: 'Age', lookupValue: '30' },
+          { lookupColumn: 'Name', lookupValue: 'Bob' },
+        ]),
+      ).toHaveProperty('success', false)
+    })
+  })
+
+  describe('valid filters', () => {
+    it('accepts a single filter', () => {
+      expect(
+        filtersSchema.safeParse([
+          { lookupColumn: 'Name', lookupValue: 'Alice' },
+        ]),
+      ).toHaveProperty('success', true)
+    })
+
+    it('accepts multiple filters with unique columns', () => {
+      expect(
+        filtersSchema.safeParse([
+          { lookupColumn: 'Name', lookupValue: 'Alice' },
+          { lookupColumn: 'Age', lookupValue: '30' },
+          { lookupColumn: 'Department', lookupValue: 'Engineering' },
+        ]),
+      ).toHaveProperty('success', true)
+    })
+
+    it('defaults lookupValue to empty string when omitted', () => {
+      const result = filtersSchema.safeParse([{ lookupColumn: 'Name' }])
+      expect(result).toHaveProperty('success', true)
+      if (result.success) {
+        expect(result.data[0].lookupValue).toBe('')
+      }
     })
   })
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
@@ -2,7 +2,7 @@ import type { IGlobalVariable } from '@plumber/types'
 
 import type { z } from 'zod'
 
-import { lookupParametersSchema } from '@/apps/m365-excel/common/schema'
+import { filtersSchema } from '@/apps/m365-excel/common/schema'
 import StepError from '@/errors/step'
 
 import getTopNTableRows from '../../../common/get-top-n-table-rows'
@@ -19,7 +19,7 @@ interface GetTableRowImplParams {
   $: IGlobalVariable
   session: WorkbookSession
   tableId: string
-  filters: z.infer<typeof lookupParametersSchema>['filters']
+  filters: z.infer<typeof filtersSchema>
 }
 
 interface GetTableRowImplResults {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/implementation/index.ts
@@ -1,5 +1,8 @@
 import type { IGlobalVariable } from '@plumber/types'
 
+import type { z } from 'zod'
+
+import { lookupParametersSchema } from '@/apps/m365-excel/common/schema'
 import StepError from '@/errors/step'
 
 import getTopNTableRows from '../../../common/get-top-n-table-rows'
@@ -16,8 +19,7 @@ interface GetTableRowImplParams {
   $: IGlobalVariable
   session: WorkbookSession
   tableId: string
-  lookupValue: string
-  lookupColumn: string
+  filters: z.infer<typeof lookupParametersSchema>['filters']
 }
 
 interface GetTableRowImplResults {
@@ -71,7 +73,7 @@ interface GetTableRowImplResults {
 export default async function getTableRowImpl(
   args: GetTableRowImplParams,
 ): Promise<GetTableRowImplResults | null> {
-  const { $, session, tableId, lookupValue, lookupColumn } = args
+  const { $, session, tableId, filters } = args
 
   const { columns, rows, headerSheetRowIndex } = await getTopNTableRows(
     $,
@@ -80,16 +82,23 @@ export default async function getTableRowImpl(
     MAX_ROWS,
   )
 
-  const columnIndex = columns.indexOf(lookupColumn)
-  if (columnIndex === -1) {
-    throw new StepError(
-      `Column "${lookupColumn}" does not exist in your table.`,
-      `Check that your Excel table contains the "${lookupColumn}" column.`,
-    )
-  }
+  const columnIndices = filters.map(({ lookupColumn }) => {
+    const idx = columns.indexOf(lookupColumn)
+    if (idx === -1) {
+      throw new StepError(
+        `Column "${lookupColumn}" does not exist in your table.`,
+        `Check that your Excel table contains the "${lookupColumn}" column.`,
+      )
+    }
+    return idx
+  })
 
   for (const [rowIndex, row] of rows.entries()) {
-    if (row[columnIndex] === lookupValue) {
+    if (
+      filters.every(
+        ({ lookupValue }, i) => row[columnIndices[i]] === lookupValue,
+      )
+    ) {
       return {
         tableRowIndex: rowIndex,
         sheetRowNumber: rowIndex + headerSheetRowIndex + 2,

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -74,7 +74,7 @@ const action: IRawAction = {
       type: 'multirow-multicol' as const,
       required: true,
       subFields: LOOKUP_CONDITIONS_SUBFIELDS,
-      maxRows: 1, // Phase 1: Restrict to single filter
+      maxRows: 3,
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',
@@ -102,15 +102,13 @@ const action: IRawAction = {
     }
 
     const { fileId, tableId, filters } = parametersParseResult.data
-    const { lookupColumn, lookupValue } = filters![0]
 
     const session = await WorkbookSession.acquire($, fileId)
     const results = await getTableRowImpl({
       $,
       session,
       tableId,
-      lookupValue,
-      lookupColumn,
+      filters,
     })
 
     if (!results) {

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -79,7 +79,7 @@ const action: IRawAction = {
       type: 'multirow-multicol' as const,
       required: true,
       subFields: LOOKUP_CONDITIONS_SUBFIELDS,
-      maxRows: 1, // Phase 1: Restrict to single filter
+      maxRows: 3,
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',
@@ -102,7 +102,6 @@ const action: IRawAction = {
     }
 
     const { fileId, tableId, filters } = parametersParseResult.data
-    const { lookupColumn, lookupValue } = filters![0]
 
     const session = await WorkbookSession.acquire($, fileId)
     const { columns: rawColumns, rows } = await getTopNTableRows(
@@ -112,18 +111,25 @@ const action: IRawAction = {
       MAX_ROWS,
     )
 
-    const columnIndex = rawColumns.indexOf(lookupColumn)
-    if (columnIndex === -1) {
-      throw new StepError(
-        `Column "${lookupColumn}" does not exist in your table.`,
-        `Check that your Excel table contains the "${lookupColumn}" column.`,
-      )
-    }
+    const columnIndices = filters.map(({ lookupColumn }) => {
+      const idx = rawColumns.indexOf(lookupColumn)
+      if (idx === -1) {
+        throw new StepError(
+          `Column "${lookupColumn}" does not exist in your table.`,
+          `Check that your Excel table contains the "${lookupColumn}" column.`,
+        )
+      }
+      return idx
+    })
 
     const rowsToReturn: { data: Record<string, string> }[] = []
 
     for (const [_, row] of rows.entries()) {
-      if (row[columnIndex] === lookupValue) {
+      if (
+        filters.every(
+          ({ lookupValue }, i) => row[columnIndices[i]] === lookupValue,
+        )
+      ) {
         rowsToReturn.push({
           data: convertRowToHexKeyedObject({ row, columns: rawColumns }),
         })

--- a/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/update-table-row/index.ts
@@ -101,7 +101,6 @@ const action: IRawAction = {
 
     const { fileId, tableId, filters, columnsToUpdate } =
       parametersParseResult.data
-    const { lookupColumn, lookupValue } = filters![0]
 
     //
     // Find index of row to update
@@ -115,8 +114,7 @@ const action: IRawAction = {
       $,
       session,
       tableId,
-      lookupValue,
-      lookupColumn,
+      filters,
     })
 
     if (!findRowResults) {

--- a/packages/backend/src/apps/m365-excel/common/schema.ts
+++ b/packages/backend/src/apps/m365-excel/common/schema.ts
@@ -38,6 +38,15 @@ export const filtersSchema = z
     }),
   )
   .min(1, { message: 'Please add at least one lookup condition.' })
+  .refine(
+    (filters) => {
+      const columns = filters.map((f) => f.lookupColumn)
+      return new Set(columns).size === columns.length
+    },
+    {
+      message: 'Each lookup condition must use a different column.',
+    },
+  )
 
 export const lookupParametersSchema = z.object({
   fileId: fileIdSchema,


### PR DESCRIPTION
### TL;DR

Update M365 Excel "Get Table Row", "Get Table Rows", and "Update Table Row" actions to support up to 3 lookup filters.

### What changed?

- The `maxRows` limit on the lookup conditions field for "Get Table Row", "Get Table Rows", and "Update Table Row" actions has been increased from 1 to 3, allowing users to specify up to 3 column/value filter conditions.
- `getTableRowImpl` and the "Get Table Rows" action now accept a `filters` array instead of a single `lookupColumn`/`lookupValue` pair. Rows are matched only when **all** filters match (AND logic).
- Column index resolution and row matching logic have been updated to iterate over all provided filters.
- Integration tests for "Get Table Rows" have been updated to use the `filters` array parameter and expanded to cover multi-filter scenarios (all match, partial match, empty string values).
- A new unit test file for `getTableRowImpl` covers single filter, multiple filters, and edge cases (empty rows, empty string values, non-zero header row index, case-sensitive matching).

### How to test?

- [ ] Verify that you can add up to 3 lookup conditions
    - [ ] Get table row
    - [ ] Get multiple table rows
    - [ ] Update table row
- [ ] Verify that the lookup conditions are applied correctly
    - [ ] Get table row should only return 1 row
    - [ ] Get multiple table rows
    - [ ] Update table row