### PR TITLE
[EXCEL-MULTI-LOOKUP-6] PLU-593 (feat): implement max lookup conditions validation

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/schema.test.ts
@@ -3,7 +3,12 @@ import type { IGlobalVariable } from '@plumber/types'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
 
-import { fileIdSchema, filtersSchema, tableIdSchema } from '../../common/schema'
+import {
+  fileIdSchema,
+  filtersSchema,
+  lookupParametersSchema,
+  tableIdSchema,
+} from '../../common/schema'
 
 const VALID_FILE_ID = '1234ABCD1234ABCD1234ABCD1234ABCD'
 const VALID_TABLE_ID = `{${VALID_FILE_ID}}`
@@ -131,6 +136,77 @@ describe('filtersSchema', () => {
       if (result.success) {
         expect(result.data[0].lookupValue).toBe('')
       }
+    })
+  })
+})
+
+describe('lookupParametersSchema', () => {
+  describe('accepts new format', () => {
+    it('with filters array', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Email',
+              lookupValue: 'test@example.com',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with multiple filters', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Status',
+              lookupValue: 'Active',
+            },
+            {
+              lookupColumn: 'Department',
+              lookupValue: 'Engineering',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with exactly 3 filters (max allowed)', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [
+            {
+              lookupColumn: 'Status',
+              lookupValue: 'Active',
+            },
+            {
+              lookupColumn: 'Department',
+              lookupValue: 'Engineering',
+            },
+            {
+              lookupColumn: 'Level',
+              lookupValue: 'Senior',
+            },
+          ],
+        }),
+      ).toHaveProperty('success', true)
+    })
+
+    it('with empty filters array', () => {
+      expect(
+        lookupParametersSchema.safeParse({
+          fileId: VALID_FILE_ID,
+          tableId: VALID_TABLE_ID,
+          filters: [],
+        }),
+      ).toHaveProperty('success', false)
     })
   })
 })

--- a/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-row/index.ts
@@ -4,7 +4,10 @@ import z from 'zod'
 
 import StepError from '@/errors/step'
 
-import { LOOKUP_CONDITIONS_SUBFIELDS } from '../../common/constants'
+import {
+  LOOKUP_CONDITIONS_SUBFIELDS,
+  MAX_LOOKUP_CONDITIONS,
+} from '../../common/constants'
 import { lookupParametersSchema } from '../../common/schema'
 import { convertRowToHexEncodedRowRecord } from '../../common/workbook-helpers/tables'
 import WorkbookSession from '../../common/workbook-session'
@@ -74,7 +77,7 @@ const action: IRawAction = {
       type: 'multirow-multicol' as const,
       required: true,
       subFields: LOOKUP_CONDITIONS_SUBFIELDS,
-      maxRows: 3,
+      maxRows: MAX_LOOKUP_CONDITIONS,
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',

--- a/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
+++ b/packages/backend/src/apps/m365-excel/actions/get-table-rows/index.ts
@@ -8,6 +8,7 @@ import StepError from '@/errors/step'
 import {
   GET_TABLE_ROWS_LIMIT,
   LOOKUP_CONDITIONS_SUBFIELDS,
+  MAX_LOOKUP_CONDITIONS,
 } from '../../common/constants'
 import getTopNTableRows from '../../common/get-top-n-table-rows'
 import { lookupParametersSchema } from '../../common/schema'
@@ -79,7 +80,7 @@ const action: IRawAction = {
       type: 'multirow-multicol' as const,
       required: true,
       subFields: LOOKUP_CONDITIONS_SUBFIELDS,
-      maxRows: 3,
+      maxRows: MAX_LOOKUP_CONDITIONS,
       hiddenIf: {
         fieldKey: 'tableId',
         op: 'is_empty',

--- a/packages/backend/src/apps/m365-excel/common/constants.ts
+++ b/packages/backend/src/apps/m365-excel/common/constants.ts
@@ -6,6 +6,8 @@ export const MS_GRAPH_OAUTH_BASE_URL = 'https://login.microsoftonline.com'
 
 export const GET_TABLE_ROWS_LIMIT = 500
 
+export const MAX_LOOKUP_CONDITIONS = 3
+
 export const LOOKUP_CONDITIONS_SUBFIELDS = [
   {
     placeholder: 'Lookup column',

--- a/packages/backend/src/apps/m365-excel/common/schema.ts
+++ b/packages/backend/src/apps/m365-excel/common/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { MAX_LOOKUP_CONDITIONS } from './constants'
+
 /**
  * Very loose regex to just accept only alphanumeric characters and dashes
  * since there is no proper public documentation with M365
@@ -38,6 +40,9 @@ export const filtersSchema = z
     }),
   )
   .min(1, { message: 'Please add at least one lookup condition.' })
+  .max(MAX_LOOKUP_CONDITIONS, {
+    message: `You can only add up to ${MAX_LOOKUP_CONDITIONS} lookup conditions.`,
+  })
   .refine(
     (filters) => {
       const columns = filters.map((f) => f.lookupColumn)


### PR DESCRIPTION
### TL;DR

Extracts the maximum lookup conditions limit (3) into a shared constant and enforces it at the schema validation level.

### What changed?

Introduces `MAX_LOOKUP_CONDITIONS` constant and is now used in place of the hardcoded value `3` across the `get-table-row` and `get-table-rows` actions. The `baseLookupParametersSchema` now enforces this limit via a `.max()` validation with a user-facing error message: _"You can only add up to 3 lookup conditions."_

### How to test?

- [ ] Verify that you cannot create more than 3 lookup conditons (will need to call the GraphQL mutation directly)
- [ ] Verify that you can still create the action with 1-3 condition