### PR TITLE
PLU-642 (chore): allow admin to create pipe transfer

### DIFF
--- a/packages/backend/src/helpers/authentication.ts
+++ b/packages/backend/src/helpers/authentication.ts
@@ -106,6 +106,7 @@ const authentication = shield(
       retryExecutionStep: or(isAuthenticated, isAdminOperation),
       bulkRetryExecutions: or(isAuthenticated, isAdminOperation),
       updateFlowStatus: or(isAuthenticated, isAdminOperation),
+      createFlowTransfer: or(isAuthenticated, isAdminOperation),
       requestOtp: rateLimitRule({ window: '1s', max: 5 }),
       verifyOtp: rateLimitRule({ window: '1s', max: 5 }),
       // Not OTP, but no real reason to be looser than OTP.


### PR DESCRIPTION
### TL;DR

Allow admins to create pipe transfer.

### How to test?

- [ ] Attempt to call the `createFlowTransfer` mutation without authentication and verify it is rejected.
- [ ] Attempt to call the `createFlowTransfer` mutation with a valid authenticated session and verify it succeeds (this is you creating a Pipe transfer on Plumber).
- [ ] Attempt to call the `createFlowTransfer` mutation as an admin operation and verify it succeeds (use Unclog to do this).

_Verify_ _that_ _the_ _Pipe_ _still_ _works_ _after_ _accepting_ _the_ _Pipe_ _Transfer_

- [ ] Verify that connections are shared and can still be used