### PR TITLE
[BULLMQ-BATCH-1] PLU-524: repeatable jobs compatibility

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { NotFoundError } from 'objection'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import cronTimes from '@/apps/scheduler/common/cron-times'
 import {
@@ -13,12 +13,23 @@ import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
 import User from '@/models/user'
 import flowQueue from '@/queues/flow'
 
 import { generateMockContext } from './tiles/table.mock'
 import { generateMockCollaborator, generateMockUser } from './flow.mock'
+
+// Captured at module load before the outer `beforeEach` reassigns these to
+// vi.fn(); used by the real-BullMQ describe block to bypass the mocks.
+const realFlowQueue = {
+  add: flowQueue.add.bind(flowQueue),
+  getRepeatableJobs: flowQueue.getRepeatableJobs.bind(flowQueue),
+  removeRepeatableByKey: flowQueue.removeRepeatableByKey.bind(flowQueue),
+  obliterate: flowQueue.obliterate.bind(flowQueue),
+}
 
 // In these tests we simulate the chaining of queries on currentUser.$relatedQuery('flows')
 // and the additional methods on the flow: $query, getTriggerStep etc.
@@ -48,6 +59,29 @@ describe('updateFlowStatus', () => {
       userId: owner.id,
       active: false,
     })
+
+    // Seed steps so $beforeUpdate validations pass for tests that exercise the
+    // real DB row (transaction rollback + bullmq integration blocks).
+    await Step.query().insert([
+      {
+        flowId: fakeFlowId,
+        type: 'trigger',
+        position: 1,
+        status: 'completed',
+        appKey: 'scheduler',
+        key: 'everyHour',
+        parameters: {},
+      },
+      {
+        flowId: fakeFlowId,
+        type: 'action',
+        position: 2,
+        status: 'completed',
+        appKey: 'custom-api',
+        key: 'httpRequest',
+        parameters: {},
+      },
+    ])
 
     // Create a fake flow object with default values.
     fakeFlow = {
@@ -209,12 +243,13 @@ describe('updateFlowStatus', () => {
       updatedBy: owner.id,
     })
 
-    // jobName is constructed as "flow-<flow.id>"
+    // jobName is constructed as "flow-<flow.id>" and is also used as the
+    // custom repeatable key so we can identify the job by prefix later.
     expect(flowQueue.add).toHaveBeenCalledWith(
       `flow-${fakeFlow.id}`,
       { flowId: fakeFlow.id },
       {
-        repeat: { pattern: '0 * * * *' },
+        repeat: { pattern: '0 * * * *', key: `flow-${fakeFlow.id}` },
         jobId: fakeFlow.id,
         removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
         removeOnFail: REMOVE_AFTER_30_DAYS,
@@ -228,10 +263,13 @@ describe('updateFlowStatus', () => {
     // For deactivation, ensure the current flow is active and we are setting it to inactive.
     fakeFlow.active = true
 
-    // Simulate that a repeatable job exists for this flow.
+    // Simulate that a repeatable job exists for this flow. The new code finds
+    // the job via `key.startsWith("flow-<id>")`, so the mocked key must match
+    // that prefix.
+    const repeatableKey = `flow-${fakeFlow.id}`
     flowQueue.getRepeatableJobs = vi
       .fn()
-      .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
+      .mockResolvedValue([{ id: fakeFlow.id, key: repeatableKey }])
 
     const result = await updateFlowStatus(
       {},
@@ -246,7 +284,7 @@ describe('updateFlowStatus', () => {
       updatedBy: owner.id,
     })
 
-    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
+    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(repeatableKey)
     expect(result).toEqual(fakeFlow)
   })
 
@@ -400,6 +438,183 @@ describe('updateFlowStatus', () => {
       ).rejects.toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
+    })
+  })
+
+  describe('transaction rollback', () => {
+    it('rolls back the DB write when flowQueue.add fails during publish', async () => {
+      // Replace the mocked flow with the real DB row so $query.patch actually
+      // writes inside the transaction and rollback is observable
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      flowQueue.add = vi.fn().mockRejectedValue(new Error('queue down'))
+
+      await expect(
+        updateFlowStatus(
+          {},
+          { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+          context,
+        ),
+      ).rejects.toThrow('queue down')
+
+      const refetched = await Flow.query().findById(fakeFlow.id)
+      expect(refetched.active).toBe(false)
+      expect(refetched.publishedAt).toBeNull()
+    })
+
+    it('rolls back the DB write when removeRepeatableByKey fails during unpublish', async () => {
+      // Seed the row as active so we exercise the deactivate path. Use an
+      // instance patch so objection populates `opt.old` for $beforeUpdate.
+      const seedFlow = await Flow.query().findById(fakeFlow.id)
+      await seedFlow.$query().patch({
+        active: true,
+        publishedAt: new Date().toISOString(),
+      })
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      flowQueue.getRepeatableJobs = vi
+        .fn()
+        .mockResolvedValue([{ id: fakeFlow.id, key: `flow-${fakeFlow.id}` }])
+      flowQueue.removeRepeatableByKey = vi
+        .fn()
+        .mockRejectedValue(new Error('queue down'))
+
+      await expect(
+        updateFlowStatus(
+          {},
+          {
+            input: {
+              ...defaultInput,
+              active: false,
+              updatedAt: realFlow.updatedAt,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('queue down')
+
+      const refetched = await Flow.query().findById(fakeFlow.id)
+      expect(refetched.active).toBe(true)
+      expect(refetched.publishedAt).not.toBeNull()
+    })
+
+    it('logs a warning and does not call removeRepeatableByKey when no repeatable job is found on unpublish', async () => {
+      fakeFlow.active = true
+      // No repeatable job whose key starts with `flow-<id>`
+      flowQueue.getRepeatableJobs = vi
+        .fn()
+        .mockResolvedValue([{ id: 'someone-else', key: 'flow-someone-else' }])
+      flowQueue.removeRepeatableByKey = vi.fn().mockResolvedValue(undefined)
+
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+      const result = await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, active: false } },
+        context,
+      )
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `Bug: No repeatable job found for flow ${fakeFlow.id} when trying to remove repeatable job upon unpublishing.`,
+          flowId: fakeFlow.id,
+          jobName: `flow-${fakeFlow.id}`,
+        }),
+      )
+      expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
+      expect(result).toEqual(fakeFlow)
+
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe('bullmq integration (real Redis)', () => {
+    // The outer beforeEach replaced flowQueue methods with vi.fn(); restore
+    // the originals here so we exercise real BullMQ against the test container.
+    beforeEach(async () => {
+      flowQueue.add = realFlowQueue.add
+      flowQueue.getRepeatableJobs = realFlowQueue.getRepeatableJobs
+      flowQueue.removeRepeatableByKey = realFlowQueue.removeRepeatableByKey
+
+      // Use the real DB row + real $query so the patch persists inside the
+      // transaction (the test asserts via getRepeatableJobs, not patchSpy).
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+    })
+
+    afterEach(async () => {
+      // Redis is not reset between tests by the global setup, so clean up
+      // anything we wrote.
+      await realFlowQueue.obliterate({ force: true })
+    })
+
+    it('adds a repeatable job whose key matches the custom flow-<id> key on publish', async () => {
+      const realFlow = await Flow.query().findById(fakeFlow.id)
+
+      await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+        context,
+      )
+
+      const jobs = await flowQueue.getRepeatableJobs()
+      const job = jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`))
+      expect(job).toBeDefined()
+      // for the old bullmq@5.7.8 it accepts the repeat key but does not use it
+      // it still derives by concatenating the metadata
+      // we check the starting pattern to ensure compatibility with the newer bullmq@5 and the older bullmq@5 versions
+      expect(job.key).toMatch(new RegExp(`^flow-${fakeFlow.id}`))
+    })
+
+    it('removes the repeatable job on unpublish using the custom key', async () => {
+      // Publish first
+      let realFlow = await Flow.query().findById(fakeFlow.id)
+      await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+        context,
+      )
+
+      // Sanity-check the job is in Redis
+      let jobs = await flowQueue.getRepeatableJobs()
+      expect(
+        jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`)),
+      ).toBeDefined()
+
+      // Re-prime the mocked query with the now-active row for the unpublish
+      realFlow = await Flow.query().findById(fakeFlow.id)
+      ;(realFlow as any).steps = [{ position: 1 }, { position: 2 }]
+      ;(realFlow as any).getTriggerStep = fakeFlow.getTriggerStep
+      ;(realFlow as any).assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      await updateFlowStatus(
+        {},
+        {
+          input: {
+            ...defaultInput,
+            active: false,
+            updatedAt: realFlow.updatedAt,
+          },
+        },
+        context,
+      )
+
+      jobs = await flowQueue.getRepeatableJobs()
+      expect(
+        jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`)),
+      ).toBeUndefined()
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { NotFoundError } from 'objection'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import cronTimes from '@/apps/scheduler/common/cron-times'
 import {
@@ -14,11 +14,21 @@ import {
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
 import User from '@/models/user'
 import flowQueue from '@/queues/flow'
 
 import { generateMockContext } from './tiles/table.mock'
 import { generateMockCollaborator, generateMockUser } from './flow.mock'
+
+// Captured at module load before the outer `beforeEach` reassigns these to
+// vi.fn(); used by the real-BullMQ describe block to bypass the mocks.
+const realFlowQueue = {
+  add: flowQueue.add.bind(flowQueue),
+  getRepeatableJobs: flowQueue.getRepeatableJobs.bind(flowQueue),
+  removeRepeatableByKey: flowQueue.removeRepeatableByKey.bind(flowQueue),
+  obliterate: flowQueue.obliterate.bind(flowQueue),
+}
 
 // In these tests we simulate the chaining of queries on currentUser.$relatedQuery('flows')
 // and the additional methods on the flow: $query, getTriggerStep etc.
@@ -48,6 +58,29 @@ describe('updateFlowStatus', () => {
       userId: owner.id,
       active: false,
     })
+
+    // Seed steps so $beforeUpdate validations pass for tests that exercise the
+    // real DB row (transaction rollback + bullmq integration blocks).
+    await Step.query().insert([
+      {
+        flowId: fakeFlowId,
+        type: 'trigger',
+        position: 1,
+        status: 'completed',
+        appKey: 'scheduler',
+        key: 'everyHour',
+        parameters: {},
+      },
+      {
+        flowId: fakeFlowId,
+        type: 'action',
+        position: 2,
+        status: 'completed',
+        appKey: 'custom-api',
+        key: 'httpRequest',
+        parameters: {},
+      },
+    ])
 
     // Create a fake flow object with default values.
     fakeFlow = {
@@ -215,12 +248,13 @@ describe('updateFlowStatus', () => {
       updatedBy: owner.id,
     })
 
-    // jobName is constructed as "flow-<flow.id>"
+    // jobName is constructed as "flow-<flow.id>" and is also used as the
+    // custom repeatable key so we can identify the job by prefix later.
     expect(flowQueue.add).toHaveBeenCalledWith(
       `flow-${fakeFlow.id}`,
       { flowId: fakeFlow.id },
       {
-        repeat: { pattern: '0 * * * *' },
+        repeat: { pattern: '0 * * * *', key: `flow-${fakeFlow.id}` },
         jobId: fakeFlow.id,
         removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
         removeOnFail: REMOVE_AFTER_30_DAYS,
@@ -234,10 +268,13 @@ describe('updateFlowStatus', () => {
     // For deactivation, ensure the current flow is active and we are setting it to inactive.
     fakeFlow.active = true
 
-    // Simulate that a repeatable job exists for this flow.
+    // Simulate that a repeatable job exists for this flow. The new code finds
+    // the job via `key.startsWith("flow-<id>")`, so the mocked key must match
+    // that prefix.
+    const repeatableKey = `flow-${fakeFlow.id}`
     flowQueue.getRepeatableJobs = vi
       .fn()
-      .mockResolvedValue([{ id: fakeFlow.id, key: 'repeat-key' }])
+      .mockResolvedValue([{ id: fakeFlow.id, key: repeatableKey }])
 
     const result = await updateFlowStatus(
       {},
@@ -252,7 +289,7 @@ describe('updateFlowStatus', () => {
       updatedBy: owner.id,
     })
 
-    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith('repeat-key')
+    expect(flowQueue.removeRepeatableByKey).toHaveBeenCalledWith(repeatableKey)
     expect(result).toEqual(fakeFlow)
   })
 
@@ -406,6 +443,175 @@ describe('updateFlowStatus', () => {
       ).rejects.toThrow(
         'This Pipe has been edited by another user. Please refresh the page to see the latest changes and try again.',
       )
+    })
+  })
+
+  describe('transaction rollback', () => {
+    it('rolls back the DB write when flowQueue.add fails during publish', async () => {
+      // Replace the mocked flow with the real DB row so $query.patch actually
+      // writes inside the transaction and rollback is observable
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      flowQueue.add = vi.fn().mockRejectedValue(new Error('queue down'))
+
+      await expect(
+        updateFlowStatus(
+          {},
+          { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+          context,
+        ),
+      ).rejects.toThrow('queue down')
+
+      const refetched = await Flow.query().findById(fakeFlow.id)
+      expect(refetched.active).toBe(false)
+      expect(refetched.publishedAt).toBeNull()
+    })
+
+    it('rolls back the DB write when removeRepeatableByKey fails during unpublish', async () => {
+      // Seed the row as active so we exercise the deactivate path. Use an
+      // instance patch so objection populates `opt.old` for $beforeUpdate.
+      const seedFlow = await Flow.query().findById(fakeFlow.id)
+      await seedFlow.$query().patch({
+        active: true,
+        publishedAt: new Date().toISOString(),
+      })
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      flowQueue.getRepeatableJobs = vi
+        .fn()
+        .mockResolvedValue([{ id: fakeFlow.id, key: `flow-${fakeFlow.id}` }])
+      flowQueue.removeRepeatableByKey = vi
+        .fn()
+        .mockRejectedValue(new Error('queue down'))
+
+      await expect(
+        updateFlowStatus(
+          {},
+          {
+            input: {
+              ...defaultInput,
+              active: false,
+              updatedAt: realFlow.updatedAt,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('queue down')
+
+      const refetched = await Flow.query().findById(fakeFlow.id)
+      expect(refetched.active).toBe(true)
+      expect(refetched.publishedAt).not.toBeNull()
+    })
+
+    it('throws and does not call removeRepeatableByKey when no repeatable job is found on unpublish', async () => {
+      fakeFlow.active = true
+      // No repeatable job whose key starts with `flow-<id>`
+      flowQueue.getRepeatableJobs = vi
+        .fn()
+        .mockResolvedValue([{ id: 'someone-else', key: 'flow-someone-else' }])
+      flowQueue.removeRepeatableByKey = vi.fn().mockResolvedValue(undefined)
+
+      await expect(
+        updateFlowStatus(
+          {},
+          { input: { ...defaultInput, active: false } },
+          context,
+        ),
+      ).rejects.toThrow(
+        `No repeatable job found for flow ${fakeFlow.id} when trying to remove repeatable job upon unpublishing.`,
+      )
+
+      expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('bullmq integration (real Redis)', () => {
+    // The outer beforeEach replaced flowQueue methods with vi.fn(); restore
+    // the originals here so we exercise real BullMQ against the test container.
+    beforeEach(async () => {
+      flowQueue.add = realFlowQueue.add
+      flowQueue.getRepeatableJobs = realFlowQueue.getRepeatableJobs
+      flowQueue.removeRepeatableByKey = realFlowQueue.removeRepeatableByKey
+
+      // Use the real DB row + real $query so the patch persists inside the
+      // transaction (the test asserts via getRepeatableJobs, not patchSpy).
+      const realFlow: any = await Flow.query().findById(fakeFlow.id)
+      realFlow.steps = [{ position: 1 }, { position: 2 }]
+      realFlow.getTriggerStep = fakeFlow.getTriggerStep
+      realFlow.assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+    })
+
+    afterEach(async () => {
+      // Redis is not reset between tests by the global setup, so clean up
+      // anything we wrote.
+      await realFlowQueue.obliterate({ force: true })
+    })
+
+    it('adds a repeatable job whose key matches the custom flow-<id> key on publish', async () => {
+      const realFlow = await Flow.query().findById(fakeFlow.id)
+
+      await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+        context,
+      )
+
+      const jobs = await flowQueue.getRepeatableJobs()
+      const job = jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`))
+      expect(job).toBeDefined()
+      // for the old bullmq@5.7.8 it accepts the repeat key but does not use it
+      // it still derives by concatenating the metadata
+      // we check the starting pattern to ensure compatibility with the newer bullmq@5 and the older bullmq@5 versions
+      expect(job.key).toMatch(new RegExp(`^flow-${fakeFlow.id}`))
+    })
+
+    it('removes the repeatable job on unpublish using the custom key', async () => {
+      // Publish first
+      let realFlow = await Flow.query().findById(fakeFlow.id)
+      await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, updatedAt: realFlow.updatedAt } },
+        context,
+      )
+
+      // Sanity-check the job is in Redis
+      let jobs = await flowQueue.getRepeatableJobs()
+      expect(
+        jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`)),
+      ).toBeDefined()
+
+      // Re-prime the mocked query with the now-active row for the unpublish
+      realFlow = await Flow.query().findById(fakeFlow.id)
+      ;(realFlow as any).steps = [{ position: 1 }, { position: 2 }]
+      ;(realFlow as any).getTriggerStep = fakeFlow.getTriggerStep
+      ;(realFlow as any).assertNotUpdatedSince = vi.fn()
+      fakeQuery.throwIfNotFound.mockResolvedValue(realFlow)
+
+      await updateFlowStatus(
+        {},
+        {
+          input: {
+            ...defaultInput,
+            active: false,
+            updatedAt: realFlow.updatedAt,
+          },
+        },
+        context,
+      )
+
+      jobs = await flowQueue.getRepeatableJobs()
+      expect(
+        jobs.find((j) => j.key.startsWith(`flow-${fakeFlow.id}`)),
+      ).toBeUndefined()
     })
   })
 })

--- a/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-flow-status.itest.ts
@@ -13,6 +13,7 @@ import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
 import User from '@/models/user'
@@ -511,7 +512,7 @@ describe('updateFlowStatus', () => {
       expect(refetched.publishedAt).not.toBeNull()
     })
 
-    it('throws and does not call removeRepeatableByKey when no repeatable job is found on unpublish', async () => {
+    it('logs a warning and does not call removeRepeatableByKey when no repeatable job is found on unpublish', async () => {
       fakeFlow.active = true
       // No repeatable job whose key starts with `flow-<id>`
       flowQueue.getRepeatableJobs = vi
@@ -519,17 +520,25 @@ describe('updateFlowStatus', () => {
         .mockResolvedValue([{ id: 'someone-else', key: 'flow-someone-else' }])
       flowQueue.removeRepeatableByKey = vi.fn().mockResolvedValue(undefined)
 
-      await expect(
-        updateFlowStatus(
-          {},
-          { input: { ...defaultInput, active: false } },
-          context,
-        ),
-      ).rejects.toThrow(
-        `No repeatable job found for flow ${fakeFlow.id} when trying to remove repeatable job upon unpublishing.`,
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+
+      const result = await updateFlowStatus(
+        {},
+        { input: { ...defaultInput, active: false } },
+        context,
       )
 
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: `Bug: No repeatable job found for flow ${fakeFlow.id} when trying to remove repeatable job upon unpublishing.`,
+          flowId: fakeFlow.id,
+          jobName: `flow-${fakeFlow.id}`,
+        }),
+      )
       expect(flowQueue.removeRepeatableByKey).not.toHaveBeenCalled()
+      expect(result).toEqual(fakeFlow)
+
+      warnSpy.mockRestore()
     })
   })
 

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -6,6 +6,8 @@ import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import flowQueue from '@/queues/flow'
 
 import type { MutationResolvers, Step } from '../__generated__/types.generated'
@@ -57,44 +59,119 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   if (params.input.active) {
     validateFlowSteps(flow.steps)
   }
-
-  await flow.$query().patch({
-    active: params.input.active,
-    publishedAt: params.input.active ? new Date().toISOString() : null,
-    updatedBy: context.currentUser.id,
-    config: {
-      ...flow.config,
-    },
-  })
+  const jobName = `${JOB_NAME}-${flow.id}`
 
   const triggerStep = await flow.getTriggerStep()
   const trigger = await triggerStep.getTriggerCommand()
   const interval = trigger.getInterval?.(triggerStep.parameters)
   const repeatOptions = {
     pattern: interval || EVERY_15_MINUTES_CRON,
+    /**
+     * Why supply a custom repeat key instead of letting bullmq derive one?
+     * The default repeat-zset member differs across the bullmq upgrade: 5.7.8
+     * stores a readable concat (`flow-<id>:<id>:::<cron>`), while 5.70.2 stores
+     * the md5 HASH of that concat. Supplying our own key makes both versions
+     * store the job under a member we control (`flow-<id>`), so we can locate and
+     * remove it by prefix on either version — including after rolling the server
+     * back from 5.70.2 to 5.7.8.
+     */
+    key: jobName,
   }
 
-  if (trigger.type !== 'webhook') {
-    if (params.input.active) {
-      const jobName = `${JOB_NAME}-${flow.id}`
+  /**
+   * Patch first inside the transaction, then perform the queue op.
+   * If the queue add/remove fails, the patch is rolled back so the flow's
+   * active state stays consistent (best-effort) with whether
+   * the repeatable job exists.
+   */
+  await Flow.transaction(async (trx) => {
+    await flow.$query(trx).patch({
+      active: params.input.active,
+      publishedAt: params.input.active ? new Date().toISOString() : null,
+      updatedBy: context.currentUser.id,
+      config: {
+        ...flow.config,
+      },
+    })
 
-      await flowQueue.add(
-        jobName,
-        { flowId: flow.id },
-        {
-          repeat: repeatOptions,
-          jobId: flow.id,
-          removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-          removeOnFail: REMOVE_AFTER_30_DAYS,
-        },
-      )
-    } else {
-      const repeatableJobs = await flowQueue.getRepeatableJobs()
-      const job = repeatableJobs.find((job) => job.id === flow.id)
-
-      await flowQueue.removeRepeatableByKey(job.key)
+    if (trigger.type !== 'webhook') {
+      if (params.input.active) {
+        await flowQueue.add(
+          jobName,
+          { flowId: flow.id },
+          {
+            repeat: repeatOptions,
+            jobId: flow.id,
+            removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+            removeOnFail: REMOVE_AFTER_30_DAYS,
+          },
+        )
+      } else {
+        /**
+         * @deprecated
+         * Repeatable jobs and their helper functions are deprecated in favour of
+         * job schedulers, but we are deferring that migration.
+         *
+         * We locate the repeatable job by its `flow-<id>` key prefix rather than
+         * calling removeRepeatable(name, pattern, jobId): that helper reconstructs
+         * the zset member using the *running* library's key algorithm, so it can't
+         * find a job created under a different bullmq version. getRepeatableJobs()
+         * + a prefix match works for both the old readable-concat member and our
+         * custom-key member, so unpublish works across the 5.7.8 <-> 5.70.2
+         * upgrade in BOTH directions (including a rollback).
+         */
+        const repeatableJobs = await flowQueue.getRepeatableJobs()
+        const job = repeatableJobs.find((job) => job.key.startsWith(jobName))
+        if (!job) {
+          // No matching repeatable job: log a warning but allow the flow to be
+          // unpublished (there is nothing left that could fire).
+          logger.warn({
+            message: `Bug: No repeatable job found for flow ${flow.id} when trying to remove repeatable job upon unpublishing.`,
+            flowId: flow.id,
+            jobName,
+          })
+        } else {
+          /**
+           * Removing a repeatable job takes three calls, not one, to fully
+           * clean it up after a flow was published under bullmq 5.70.2 and
+           * is being unpublished after a rollback to 5.7.8 (the version
+           * installed here):
+           *
+           * 1. removeRepeatableByKey(job.key) removes the `repeat` zset
+           *    entry, so no further occurrences get scheduled.
+           * 2. remove(`repeat:${jobName}`) deletes a metadata hash that
+           *    5.70.2 writes at Redis key `repeat:<key>` whenever the job
+           *    is (re)added (it backs 5.70.2's getRepeatableJobs()
+           *    name/pattern/tz enrichment). 5.70.2's own removeRepeatable
+           *    script deletes this hash, but 5.7.8 has no notion of it and
+           *    never cleans it up, so it's orphaned in Redis after a
+           *    rollback unless removed explicitly. There's no dedicated
+           *    helper for this — a job id happens to map to the same Redis
+           *    key, so we (ab)use remove() here even though no job with
+           *    this id was ever enqueued.
+           * 3. remove(`repeat:${jobName}:${job.next}`) deletes the
+           *    already-scheduled next-run delayed job. On 5.7.8,
+           *    removeRepeatableByKey() recomputes this job's id by hashing
+           *    job.key instead of using it directly, so it computes the
+           *    wrong id and the real delayed job lingers. Both bullmq
+           *    versions build the real id as `repeat:<our custom
+           *    key>:<next-run millis>` when a custom repeat.key is
+           *    supplied, so this id is stable across the upgrade.
+           *
+           * Verified against both versions' shipped Lua scripts and against
+           * a real Redis instance: without calls 2 and 3, a flow published
+           * under 5.70.2 and unpublished after rolling back to 5.7.8 leaves
+           * both of these hashes behind in Redis forever.
+           */
+          await flowQueue.removeRepeatableByKey(job.key)
+          await flowQueue.remove(`repeat:${jobName}`)
+          if (job.next) {
+            await flowQueue.remove(`repeat:${jobName}:${job.next}`)
+          }
+        }
+      }
     }
-  }
+  })
 
   return flow
 }

--- a/packages/backend/src/graphql/mutations/update-flow-status.ts
+++ b/packages/backend/src/graphql/mutations/update-flow-status.ts
@@ -6,6 +6,8 @@ import {
   REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
 import flowQueue from '@/queues/flow'
 
 import type { MutationResolvers, Step } from '../__generated__/types.generated'
@@ -61,44 +63,71 @@ const updateFlowStatus: MutationResolvers['updateFlowStatus'] = async (
   if (params.input.active) {
     validateFlowSteps(flow.steps)
   }
-
-  await flow.$query().patch({
-    active: params.input.active,
-    publishedAt: params.input.active ? new Date().toISOString() : null,
-    updatedBy: context.currentUser.id,
-    config: {
-      ...flow.config,
-    },
-  })
+  const jobName = `${JOB_NAME}-${flow.id}`
 
   const triggerStep = await flow.getTriggerStep()
   const trigger = await triggerStep.getTriggerCommand()
   const interval = trigger.getInterval?.(triggerStep.parameters)
   const repeatOptions = {
     pattern: interval || EVERY_15_MINUTES_CRON,
+    /**
+     * Why use a custom repeatable key instead of the default one that bullmq generates?
+     * The old key was a concatenation of job name, job  id, tz(empty), and cron pattern. (i.e. flow-${flow.id}:${flow.id}:::0 * * * *)
+     * However, the new version of bullmq (latest v5) hashes the concatenated string, making it hard to derive or compare (i.e. abcdef123123123)
+     * Therefore, we are supplying our own repeatable key so we can identify both new and old repeatable jobs by their prefix (i.e. flow-${flow.id})
+     */
+    key: jobName,
   }
 
-  if (trigger.type !== 'webhook') {
-    if (params.input.active) {
-      const jobName = `${JOB_NAME}-${flow.id}`
+  /**
+   * Patch first inside the transaction, then perform the queue op.
+   * If the queue add/remove fails, the patch is rolled back so the flow's
+   * active state stays consistent (best-effort) with whether
+   * the repeatable job exists.
+   */
+  await Flow.transaction(async (trx) => {
+    await flow.$query(trx).patch({
+      active: params.input.active,
+      publishedAt: params.input.active ? new Date().toISOString() : null,
+      updatedBy: context.currentUser.id,
+      config: {
+        ...flow.config,
+      },
+    })
 
-      await flowQueue.add(
-        jobName,
-        { flowId: flow.id },
-        {
-          repeat: repeatOptions,
-          jobId: flow.id,
-          removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-          removeOnFail: REMOVE_AFTER_30_DAYS,
-        },
-      )
-    } else {
-      const repeatableJobs = await flowQueue.getRepeatableJobs()
-      const job = repeatableJobs.find((job) => job.id === flow.id)
-
-      await flowQueue.removeRepeatableByKey(job.key)
+    if (trigger.type !== 'webhook') {
+      if (params.input.active) {
+        await flowQueue.add(
+          jobName,
+          { flowId: flow.id },
+          {
+            repeat: repeatOptions,
+            jobId: flow.id,
+            removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+            removeOnFail: REMOVE_AFTER_30_DAYS,
+          },
+        )
+      } else {
+        /**
+         * @deprecated
+         * Repeatable jobs and its helper functions are now deprecated in favour of job schedulers.
+         * But deferring this change since this requires a migration of existing repeatable jobs
+         */
+        const repeatableJobs = await flowQueue.getRepeatableJobs()
+        const job = repeatableJobs.find((job) => job.key.startsWith(jobName))
+        // If no job found, we log a warning, but allow the flow to be unpublished.
+        if (!job) {
+          logger.warn({
+            message: `Bug: No repeatable job found for flow ${flow.id} when trying to remove repeatable job upon unpublishing.`,
+            flowId: flow.id,
+            jobName,
+          })
+        } else {
+          await flowQueue.removeRepeatableByKey(job.key)
+        }
+      }
     }
-  }
+  })
 
   return flow
 }


### PR DESCRIPTION
## Problem

To enable batching and groups to work together, we need to upgrade bullmq & bullmq pro to the latest version. However, this comes with some breaking changes.

In the latest version of bullmq, repeatable jobs are processed differently:

- Job ID is no longer available - this means that we cannot `find`repeatable jobs by their ID (which we currently do)
- Job Repeat Keys are generated differently: old version -> concatentation of a few metadata, new version -> some complicated hash
- Custom repeat keys dont work for old version

## Solution

Before upgrading the bullmq version, we want to ensure that jobs created with the new version can be handled by old code in case there's a need to rollback. This means that we want repeatable jobs created by the old bullmq version and new bullmq version to be compatible both forwards and backwards.

Old Job Repeat Key: `flow-11111-11111-11111-11111:1111-1111-1111-11111:::0 * * * * * *`

New Job Repeat Key: `flow-11111-11111-11111-11111`

So we can compare by their prefix.

**Another** **change:** wrap patching of the flow and modifying of the repeatable job in a transaction to try (best effort basis) to keep them in sync