### PR TITLE
[AFTER-FIND-3] (feat): create function to get latest step version

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/transform-step-parameters.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/transform-step-parameters.test.ts
@@ -2,7 +2,10 @@ import { IJSONObject } from '@plumber/types'
 
 import { describe, expect, it } from 'vitest'
 
-import { transformStepParameters } from '../../common/transform-step-parameters'
+import {
+  getLatestStepVersion,
+  transformStepParameters,
+} from '../../common/transform-step-parameters'
 
 // There is 1 transformer (v1→v2), so latest version is 2.
 describe('transformStepParameters', () => {
@@ -364,6 +367,18 @@ describe('transformStepParameters', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('getLatestStepVersion', () => {
+    it('returns 2 for actions with one transformer', () => {
+      expect(getLatestStepVersion('getTableRow')).toBe(2)
+      expect(getLatestStepVersion('getTableRows')).toBe(2)
+      expect(getLatestStepVersion('updateTableRow')).toBe(2)
+    })
+
+    it('returns 1 for actions with no transformers', () => {
+      expect(getLatestStepVersion('createTableRow')).toBe(1)
     })
   })
 

--- a/packages/backend/src/apps/m365-excel/__tests__/common/transform-step-parameters.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/transform-step-parameters.test.ts
@@ -2,10 +2,9 @@ import { IJSONObject } from '@plumber/types'
 
 import { describe, expect, it } from 'vitest'
 
-import {
-  getLatestStepVersion,
-  transformStepParameters,
-} from '../../common/transform-step-parameters'
+import { stepTransformer } from '../../common/transform-step-parameters'
+
+const { transformStepParameters, getLatestStepVersion } = stepTransformer
 
 // There is 1 transformer (v1→v2), so latest version is 2.
 describe('transformStepParameters', () => {

--- a/packages/backend/src/apps/m365-excel/common/transform-step-parameters.ts
+++ b/packages/backend/src/apps/m365-excel/common/transform-step-parameters.ts
@@ -1,6 +1,6 @@
 import type { IJSONObject } from '@plumber/types'
 
-import { createStepParameterTransformer } from '@/helpers/transform-step-parameters'
+import { createVersionedStepTransformer } from '@/helpers/transform-step-parameters'
 
 const ACTION_TRANSFORMERS: Record<
   string,
@@ -54,5 +54,5 @@ export function transformLookupConditionsToFilters(
   return parameters
 }
 
-export const transformStepParameters =
-  createStepParameterTransformer(ACTION_TRANSFORMERS)
+export const { transformStepParameters, getLatestStepVersion } =
+  createVersionedStepTransformer(ACTION_TRANSFORMERS)

--- a/packages/backend/src/apps/m365-excel/common/transform-step-parameters.ts
+++ b/packages/backend/src/apps/m365-excel/common/transform-step-parameters.ts
@@ -54,5 +54,5 @@ export function transformLookupConditionsToFilters(
   return parameters
 }
 
-export const { transformStepParameters, getLatestStepVersion } =
+export const stepTransformer =
   createVersionedStepTransformer(ACTION_TRANSFORMERS)

--- a/packages/backend/src/helpers/__tests__/transform-step-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/transform-step-parameters.test.ts
@@ -2,18 +2,19 @@ import type { IJSONObject } from '@plumber/types'
 
 import { describe, expect, it, vi } from 'vitest'
 
-import { createStepParameterTransformer } from '../transform-step-parameters'
+import { createVersionedStepTransformer } from '../transform-step-parameters'
 
 const transformerA = vi.fn((p: IJSONObject) => ({ ...p, a: true }))
 const transformerB = vi.fn((p: IJSONObject) => ({ ...p, b: true }))
 const transformerC = vi.fn((p: IJSONObject) => ({ ...p, c: true }))
 
 // 3 transformers: A (v1→v2), B (v2→v3), C (v3→v4). Latest version is 4.
-const transform = createStepParameterTransformer({
-  myAction: [transformerA, transformerB, transformerC],
-})
+const { transformStepParameters: transform, getLatestStepVersion } =
+  createVersionedStepTransformer({
+    myAction: [transformerA, transformerB, transformerC],
+  })
 
-describe('createStepParameterTransformer', () => {
+describe('createVersionedStepTransformer', () => {
   it('version 1: runs all transformers (A → B → C)', () => {
     const result = transform('myAction', { x: 1 }, 1)
     expect(result).toEqual({ x: 1, a: true, b: true, c: true })
@@ -41,5 +42,15 @@ describe('createStepParameterTransformer', () => {
   it('returns parameters unchanged for unknown action keys', () => {
     const input = { x: 1 }
     expect(transform('unknownAction', input, 1)).toEqual(input)
+  })
+})
+
+describe('getLatestStepVersion', () => {
+  it('returns transformers.length + 1 for a known action', () => {
+    expect(getLatestStepVersion('myAction')).toBe(4)
+  })
+
+  it('returns 1 for an unknown action (no transformers)', () => {
+    expect(getLatestStepVersion('unknownAction')).toBe(1)
   })
 })

--- a/packages/backend/src/helpers/transform-step-parameters.ts
+++ b/packages/backend/src/helpers/transform-step-parameters.ts
@@ -28,19 +28,20 @@ import type { IJSONObject } from '@plumber/types'
  *   getTableRow: [migrateV1toV2, migrateV2toV3],
  * }
  *
- * export const transformStepParameters =
- *   createStepParameterTransformer(ACTION_TRANSFORMERS)
+ * export const { transformStepParameters, getLatestStepVersion } =
+ *   createVersionedStepTransformer(ACTION_TRANSFORMERS)
  * ```
  *
- * The returned function has the signature:
- *   `transformStepParameters(stepKey, stepParameters, version) => IJSONObject`
+ * The returned object has two functions:
+ *   - `transformStepParameters(stepKey, stepParameters, version) => IJSONObject`
+ *   - `getLatestStepVersion(stepKey) => number` — use this when creating new steps
  *
  * @param transformers - Map of action key → ordered array of migration functions
  */
-function createStepParameterTransformer(
+function createVersionedStepTransformer(
   transformers: Record<string, ((parameters: IJSONObject) => IJSONObject)[]>,
 ) {
-  return function transformStepParameters(
+  function transformStepParameters(
     stepKey: string,
     stepParameters: IJSONObject,
     stepVersion: number,
@@ -63,6 +64,14 @@ function createStepParameterTransformer(
         stepParameters,
       )
   }
+
+  // Version N+1 is the latest, where N is the number of transformers.
+  // New steps should be created at this version so no transformation is needed.
+  function getLatestStepVersion(stepKey: string): number {
+    return (transformers[stepKey]?.length ?? 0) + 1
+  }
+
+  return { transformStepParameters, getLatestStepVersion }
 }
 
-export { createStepParameterTransformer }
+export { createVersionedStepTransformer }

--- a/packages/backend/src/models/step.ts
+++ b/packages/backend/src/models/step.ts
@@ -321,8 +321,8 @@ class Step extends Base {
    */
   async $afterFind(): Promise<void> {
     const app = apps[this.appKey]
-    if (app?.transformStepParameters && this.key && this.parameters) {
-      this.parameters = app.transformStepParameters(
+    if (app?.stepTransformer && this.key && this.parameters) {
+      this.parameters = app.stepTransformer.transformStepParameters(
         this.key,
         this.parameters,
         this.version,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -663,32 +663,28 @@ export interface IApp {
   setupMessage?: SetupMessage
 
   /**
-   * Optional transformation function for step parameters.
+   * Optional versioned step parameter transformer for an app.
    *
-   * Enables zero-downtime parameter format migrations by transforming
-   * legacy parameters to the current format when steps are fetched from
-   * the database or executed.
+   * Both functions must be provided together — use `createVersionedStepTransformer`
+   * from `@/helpers/transform-step-parameters` which returns them as a coupled pair.
    *
-   * Example: Excel actions migrated from individual `lookupColumn` and
-   * `lookupValue` parameters to a `filters` array. This function transforms
-   * old format to new on-the-fly.
+   * Enables zero-downtime parameter format migrations by transforming legacy
+   * parameters to the current format when steps are fetched or executed.
    *
-   * @param stepKey - The step key  (e.g., 'getTableRow')
-   * @param stepParameters - The step parameters from database
-   * @param stepVersion - The step version
-   * @returns Transformed parameters in current format
+   * `transformStepParameters` — called on every step fetch (afterFind hook); applies
+   * all migrations from `stepVersion` onwards.
+   *
+   * `getLatestStepVersion` — used when creating new steps so they start at the
+   * latest version and require no transformation.
    */
-  transformStepParameters?: (
-    stepKey: string,
-    stepParameters: IJSONObject,
-    stepVersion: number,
-  ) => IJSONObject
-
-  /**
-   * Returns the latest version number for the given step key.
-   * New steps should be created at this version so no transformation is needed.
-   */
-  getLatestStepVersion?: (stepKey: string) => number
+  stepTransformer?: {
+    transformStepParameters: (
+      stepKey: string,
+      stepParameters: IJSONObject,
+      stepVersion: number,
+    ) => IJSONObject
+    getLatestStepVersion: (stepKey: string) => number
+  }
 }
 
 export type AppCategory = 'data' | 'communication' | 'logic' | 'others' | 'ai'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -683,6 +683,12 @@ export interface IApp {
     stepParameters: IJSONObject,
     stepVersion: number,
   ) => IJSONObject
+
+  /**
+   * Returns the latest version number for the given step key.
+   * New steps should be created at this version so no transformation is needed.
+   */
+  getLatestStepVersion?: (stepKey: string) => number
 }
 
 export type AppCategory = 'data' | 'communication' | 'logic' | 'others' | 'ai'


### PR DESCRIPTION
### TL;DR

- Adds a `getLatestVersion` function to fetch the latest version for the step
- Refactored `createVersionedStepTransformer` to return both`transformStepParameters` and `getLatestStepVersion` as a coupled pair. This ensures that we expose both functions in the app.

### Tests

- [ ] Verify that function makes sense as no transformer has been added yet. 

_Sanity_ _check_

- [ ] Verify that you can still create steps
- [ ] Verify that you can check step
- [ ] Verify that you can modify step