### PR TITLE
[AFTER-FIND-4] (feat): create step with latest version

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/create-step.itest.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import apps from '@/apps'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import createStep from '@/graphql/mutations/create-step'
 import Flow from '@/models/flow'
@@ -447,6 +448,77 @@ describe('createStep mutation integration tests', async () => {
 
     expect(newStep).toBeDefined()
     expect((newStep as any).connectionId).toBeNull()
+  })
+
+  describe('version assignment', () => {
+    it('defaults to version 1 when app has no stepTransformer', async () => {
+      // postman has no stepTransformer - version should default to 1
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
+            previousStep: { id: existingSteps[0].id },
+            key: 'sendTransactionalEmail',
+            appKey: 'postman',
+            parameters: {},
+          },
+        },
+        context,
+      )
+
+      expect((newStep as any).version).toBe(1)
+    })
+
+    it('defaults to version 1 when no appKey is provided', async () => {
+      const newStep = await createStep(
+        null,
+        {
+          input: {
+            flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
+            previousStep: { id: existingSteps[2].id },
+          },
+        },
+        context,
+      )
+
+      expect((newStep as any).version).toBe(1)
+    })
+
+    it('uses the version from stepTransformer.getLatestStepVersion when app has a stepTransformer', async () => {
+      const mockGetLatestStepVersion = vi.fn().mockReturnValue(3)
+      const originalPostman = (apps as any)['postman']
+      apps['postman'] = {
+        ...originalPostman,
+        stepTransformer: {
+          getLatestStepVersion: mockGetLatestStepVersion,
+          transformStepParameters: vi.fn(),
+        },
+      }
+
+      try {
+        const newStep = await createStep(
+          null,
+          {
+            input: {
+              flow: { id: testFlow.id, updatedAt: testFlowTimestampString },
+              previousStep: { id: existingSteps[0].id },
+              key: 'sendTransactionalEmail',
+              appKey: 'postman',
+              parameters: {},
+            },
+          },
+          context,
+        )
+
+        expect(mockGetLatestStepVersion).toHaveBeenCalledWith(
+          'sendTransactionalEmail',
+        )
+        expect((newStep as any).version).toBe(3)
+      } finally {
+        ;(apps as any)['postman'] = originalPostman
+      }
+    })
   })
 
   describe('updatedAt and updatedBy validation', () => {

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,6 +2,7 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
+import apps from '@/apps'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import logger from '@/helpers/logger'
 import { validateApprovalConfig } from '@/helpers/validate-approval-config'
@@ -96,6 +97,12 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .where('position', '>=', validationResult.newStepPosition)
 
+    const app = input.appKey ? apps[input.appKey] : undefined
+    const version =
+      input.key && app?.stepTransformer
+        ? app.stepTransformer.getLatestStepVersion(input.key)
+        : 1
+
     const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
       key: input.key,
       appKey: input.appKey,
@@ -104,6 +111,7 @@ const createStep: MutationResolvers['createStep'] = async (
       parameters: input.parameters,
       connectionId: input.connection?.id,
       config: input.config as IStepConfig,
+      version,
     })
 
     // NOTE: add flow connection to the flow_connections table


### PR DESCRIPTION
### TL;DR

Steps now have a `version` assigned at creation time based on the app's `stepTransformer`.

### What changed?

When creating a step, the mutation now looks up the app's `stepTransformer` (if one exists) and calls `getLatestStepVersion` with the step key to determine the version to store. If no `appKey` is provided, no `stepTransformer` exists on the app, or no step key is given, the version defaults to `1`.

### How to test?

_To actually test, create a stepTransformer for any app_

- [ ] Verify that old steps are modified to the new parameters
- [ ] Verify that newly created steps use the latest version number

_Sanity_ _check_

- [ ] Verify that you can still create steps
- [ ] Verify that you can check step
- [ ] Verify that you can modify step