### PR TITLE
[AFTER-FIND-5] (feat): update step with latest version

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step.itest.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { NotFoundError } from 'objection'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import apps from '@/apps'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import updateStep from '@/graphql/mutations/update-step'
 import Flow from '@/models/flow'
@@ -485,6 +486,121 @@ describe('updateStep mutation', () => {
         })
       },
     )
+  })
+
+  describe('version assignment', () => {
+    it('does not include version in patch when app has no stepTransformer', async () => {
+      // postman has no stepTransformer
+      await updateStep(null, { input: { ...genericInputParams } }, context)
+
+      expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(
+        mockStepId,
+        expect.not.objectContaining({ version: expect.anything() }),
+      )
+    })
+
+    it('transforms parameters and sets latest version when app has a stepTransformer', async () => {
+      const mockTransformStepParameters = vi
+        .fn()
+        .mockReturnValue({ transformed: true })
+      const mockGetLatestStepVersion = vi.fn().mockReturnValue(3)
+      const originalPostman = apps['postman']
+      apps['postman'] = {
+        ...originalPostman,
+        stepTransformer: {
+          transformStepParameters: mockTransformStepParameters,
+          getLatestStepVersion: mockGetLatestStepVersion,
+        },
+      }
+
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: context.currentUser,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        stepVersion: 1,
+        stepConnection: { id: mockConnectionId, userId: owner.id },
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      try {
+        await updateStep(null, { input: { ...genericInputParams } }, context)
+
+        expect(mockTransformStepParameters).toHaveBeenCalledWith(
+          'sendTransactionalEmail',
+          genericInputParams.parameters,
+          1, // step.version is undefined in mock, falls back to 1
+        )
+        expect(mockGetLatestStepVersion).toHaveBeenCalledWith(
+          'sendTransactionalEmail',
+        )
+        expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(
+          mockStepId,
+          expect.objectContaining({
+            parameters: { transformed: true },
+            version: 3,
+          }),
+        )
+      } finally {
+        apps['postman'] = originalPostman
+      }
+    })
+
+    it('uses step.version from DB (not frontend) when transforming — stale frontend fix', async () => {
+      const mockTransformStepParameters = vi
+        .fn()
+        .mockReturnValue({ upgraded: true })
+      const mockGetLatestStepVersion = vi.fn().mockReturnValue(2)
+      const originalPostman = apps['postman']
+      apps['postman'] = {
+        ...originalPostman,
+        stepTransformer: {
+          transformStepParameters: mockTransformStepParameters,
+          getLatestStepVersion: mockGetLatestStepVersion,
+        },
+      }
+
+      // DB step is at version 1 (old format)
+      context.currentUser.withAccessibleSteps = createMockWithAccessibleSteps({
+        owner,
+        currentUser: context.currentUser,
+        stepKey: 'sendTransactionalEmail',
+        stepAppKey: 'postman',
+        stepVersion: 1,
+        stepConnection: { id: mockConnectionId, userId: owner.id },
+        flowUpdatedAt: testFlowISODateString,
+      })
+
+      try {
+        // Frontend sends params in old format (stale)
+        await updateStep(
+          null,
+          {
+            input: {
+              ...genericInputParams,
+              parameters: { oldFormatParam: 'value' },
+            },
+          },
+          context,
+        )
+
+        // Transformer should be called with DB version (1), not whatever frontend thinks
+        expect(mockTransformStepParameters).toHaveBeenCalledWith(
+          'sendTransactionalEmail',
+          { oldFormatParam: 'value' },
+          1,
+        )
+        expect(patchAndFetchByIdSpy).toHaveBeenCalledWith(
+          mockStepId,
+          expect.objectContaining({
+            parameters: { upgraded: true },
+            version: 2,
+          }),
+        )
+      } finally {
+        apps['postman'] = originalPostman
+      }
+    })
   })
 
   describe('FlowConnections integration', () => {

--- a/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/with-accessible.mock.ts
@@ -29,6 +29,7 @@ interface MockWithAccessibleStepsOptions {
   stepStatus?: string
   stepRole?: string
   stepConfig?: Record<string, any>
+  stepVersion?: number
   stepNotFound?: boolean
   flowUpdatedAt?: string
 }
@@ -44,6 +45,7 @@ export function createMockWithAccessibleSteps({
   stepStatus = 'completed',
   stepRole = 'owner',
   stepConfig = {},
+  stepVersion,
   stepNotFound = false,
   flowUpdatedAt = MOCK_FLOW_UPDATED_AT,
 }: MockWithAccessibleStepsOptions) {
@@ -67,6 +69,7 @@ export function createMockWithAccessibleSteps({
             status: stepStatus,
             role: stepRole,
             flowId,
+            version: stepVersion,
             connection: stepAppKey === 'tiles' ? {} : stepConnection,
             config: stepConfig,
             flow: {

--- a/packages/backend/src/graphql/mutations/update-step.ts
+++ b/packages/backend/src/graphql/mutations/update-step.ts
@@ -1,4 +1,5 @@
 import { IAction } from '@/../../types'
+import apps from '@/apps'
 import { BadUserInputError } from '@/errors/graphql-errors'
 import {
   addFlowConnection,
@@ -82,12 +83,29 @@ const updateStep: MutationResolvers['updateStep'] = async (
     const stepName = input?.config?.stepName ?? step?.config?.stepName
     const existingConfig = step?.config ?? {}
 
+    let parameters = input.parameters
+    let version = step.version
+
+    // transform the parameters if the step has a stepTransformer
+    const transformer = input.key
+      ? apps[input.appKey]?.stepTransformer
+      : undefined
+    if (transformer) {
+      parameters = transformer.transformStepParameters(
+        input.key,
+        input.parameters,
+        version,
+      )
+      version = transformer.getLatestStepVersion(input.key)
+    }
+
     const updatedStep = await Step.query(trx)
       .patchAndFetchById(input.id, {
         key: input.key,
         appKey: input.appKey,
         connectionId: input.connection.id,
-        parameters: input.parameters,
+        parameters,
+        version,
         status: shouldInvalidate ? 'incomplete' : step.status,
         updatedBy: context.currentUser.id,
         config: {


### PR DESCRIPTION
### TL;DR

Step parameters are now transformed and versioned on save when an app defines a `stepTransformer`.

### What changed?

When `updateStep` is called, it now checks if the app associated with the step defines a `stepTransformer`. If one exists, the step's parameters are passed through `transformStepParameters` using the **DB-stored version** (not the version sent from the frontend), and the step is saved with the latest version returned by `getLatestStepVersion`. If no `stepTransformer` is defined, behavior is unchanged and no `version` field is written to the patch.

### How to test?

_How_ _to_ _simulate_ _an_ _old_ _version:_

- Load your app without a `stepTransformer`, open the editor to that action step
- Add a `stepTransformer` to your app
- Restart the app (make sure the frontend does not reload)
- Save the step or check step
- [ ] Verify that the step is saved with the latest version and transformed parameters

_Sanity_ _check_

- [ ] Verify that updating steps without transformation still works
- [ ] Verify that checking steps without transformation still works