### PR TITLE
fix: reduce height jump on create flow modal

### DIFF
--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/FlowNameAndModeContent.tsx
@@ -53,15 +53,13 @@ export default function FlowNameAndModeContent({
         </Flex>
       </ModalBody>
       <ModalFooter>
-        {createMode && (
-          <Button
-            type="submit"
-            isDisabled={isButtonDisabled}
-            isLoading={loading}
-          >
-            Next <Icon boxSize={6} as={BiRightArrowAlt} />
-          </Button>
-        )}
+        <Button
+          type="submit"
+          isDisabled={!createMode || isButtonDisabled}
+          isLoading={loading}
+        >
+          Next <Icon boxSize={6} as={BiRightArrowAlt} />
+        </Button>
       </ModalFooter>
     </Form>
   )

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
@@ -39,19 +39,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
       closeOnEsc={false}
     >
       <ModalOverlay bg="base.canvas.overlay" />
-      <ModalContent
-        sx={{
-          // The theme applies `margin: auto` which re-centers the modal
-          // vertically on every height change (e.g. when the flow name input
-          // appears), causing the top to jump. Overriding with a fixed top
-          // margin pins the top edge so the modal only grows downward.
-          // CSS media query is used instead of useIsMobile to avoid a
-          // JS-driven re-render that would cause the same shift on open.
-          '@media (min-width: 48em)': {
-            margin: 'clamp(2rem, 15vh, 8rem) auto 0 !important',
-          },
-        }}
-      >
+      <ModalContent>
         <FlowNameAndModeContent
           isButtonDisabled={isButtonDisabled}
           loading={loading}

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
@@ -37,6 +37,7 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
       onClose={onClose}
       motionPreset="none"
       closeOnEsc={false}
+      isCentered
     >
       <ModalOverlay bg="base.canvas.overlay" />
       <ModalContent>

--- a/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
+++ b/packages/frontend/src/pages/Flows/components/CreateFlowModal/index.tsx
@@ -37,10 +37,21 @@ export default function CreateFlowModal(props: CreateFlowModalProps) {
       onClose={onClose}
       motionPreset="none"
       closeOnEsc={false}
-      isCentered
     >
       <ModalOverlay bg="base.canvas.overlay" />
-      <ModalContent>
+      <ModalContent
+        sx={{
+          // The theme applies `margin: auto` which re-centers the modal
+          // vertically on every height change (e.g. when the flow name input
+          // appears), causing the top to jump. Overriding with a fixed top
+          // margin pins the top edge so the modal only grows downward.
+          // CSS media query is used instead of useIsMobile to avoid a
+          // JS-driven re-render that would cause the same shift on open.
+          '@media (min-width: 48em)': {
+            margin: 'clamp(2rem, 15vh, 8rem) auto 0 !important',
+          },
+        }}
+      >
         <FlowNameAndModeContent
           isButtonDisabled={isButtonDisabled}
           loading={loading}


### PR DESCRIPTION
### TL;DR

Partially fixes the Create Flow modal jumping vertically when the 'Next' button appears.

### What changed?

Always show the 'Next' button but disable it when it cannot be clicked so that the modal height does not jump when choosing between 'Build with AI' or 'Use a template'

### How to test?

Verify that the modal does not jump when:

- [ ] Selecting 'Ai' or 'Templates' should enable 'Next' button without the modal jumping

Verify that all functions still work:

- [ ] 'Build with AI' opens to the AI Builder
- [ ] 'Use a template' directs to the Templates
- [ ] 'Start from scratch' still shows the name input and clicking 'Next' opens the new Pipe

### Pending fixes

Still need to fix the issue of modal jumping when selecting 'Start from scratch' as the Pipe name input will cause the modal's height to change