### PR TITLE
PLU-679 (refactor): remove generateObject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33632,7 +33632,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -33865,6 +33864,7 @@
         "ulid": "3.0.0",
         "urlcat": "3.1.0",
         "winston": "^3.7.1",
+        "yaml": "2.8.3",
         "zod": "3.25.76",
         "zod-validation-error": "1.5.0"
       },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -92,6 +92,7 @@
     "ulid": "3.0.0",
     "urlcat": "3.1.0",
     "winston": "^3.7.1",
+    "yaml": "2.8.3",
     "zod": "3.25.76",
     "zod-validation-error": "1.5.0"
   },

--- a/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/ai/generate-ai-steps.test.ts
@@ -3,22 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import generateAiSteps from '@/graphql/mutations/ai/generate-ai-steps'
 
 const mocks = vi.hoisted(() => ({
-  generateObject: vi.fn(),
-  langfusePromptGet: vi.fn(),
   getAllLdFlags: vi.fn(),
   getRestrictedAppKeys: vi.fn(),
-}))
-
-vi.mock('ai', () => ({
-  generateObject: mocks.generateObject,
-}))
-
-vi.mock('@/helpers/langfuse', () => ({
-  langfuseClient: {
-    prompt: {
-      get: mocks.langfusePromptGet,
-    },
-  },
 }))
 
 vi.mock('@/helpers/launch-darkly', () => ({
@@ -26,83 +12,48 @@ vi.mock('@/helpers/launch-darkly', () => ({
   getRestrictedAppKeys: mocks.getRestrictedAppKeys,
 }))
 
-const DEFAULT_MOCKED_TRIGGER = {
-  appKey: 'formsg',
-  key: 'newSubmission',
-  description:
-    'This is a formsg trigger, which starts the workflow when a new submission is received',
-  position: 1,
-  type: 'trigger',
-  config: {
-    stepName: 'New FormSG submission',
-    templateConfig: {},
-  },
-}
-
-const DEFAULT_MOCKED_ACTIONS = [
-  {
-    appKey: 'postman',
-    key: 'sendTransactionalEmail',
-    description: 'This is a postman action, which sends a transactional email',
-    type: 'action',
-    config: {
-      stepName: 'Send a welcome email to the new user',
-      templateConfig: {},
-    },
-    position: 2,
-  },
-  {
-    appKey: 'postman-sms',
-    key: 'sendSms',
-    description: 'This is a postman action, which sends a SMS',
-    type: 'action',
-    config: {
-      stepName: 'Send a welcome SMS to the new user',
-      templateConfig: {},
-    },
-    position: 3,
-  },
-]
-
-const DEFAULT_MOCKED_OUTPUT = {
-  object: {
-    trigger: DEFAULT_MOCKED_TRIGGER,
-    actions: DEFAULT_MOCKED_ACTIONS,
-    name: 'Build with AI',
-  },
-}
+// A valid WORKFLOW_METADATA block using real app/trigger/action keys
+const VALID_WORKFLOW_METADATA = `
+<!-- WORKFLOW_METADATA
+name: Welcome Email Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    stepName: New form submission
+    description: Configure to trigger when a new FormSG submission is received
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    stepName: Send welcome email
+    description: Send a transactional email to the new user using their email address
+  - step: 3
+    appKey: postman-sms
+    key: sendSms
+    stepName: Send welcome SMS
+    description: Send an SMS to the new user using their phone number from the trigger
+-->
+`
 
 const DEFAULT_INPUT = {
-  prompt:
-    '#### Start the workflow\nNew FormSG submission\n\n#### Actions\nSend a welcome email to the new user\nSend a welcome SMS to the new user',
+  prompt: VALID_WORKFLOW_METADATA,
   sessionId: '123',
+  traceId: 'trace-abc',
 }
 
 describe('generateAiSteps mutation', () => {
   let context: any
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetAllMocks()
 
-    mocks.langfusePromptGet.mockResolvedValue({
-      prompt: 'system prompt',
-      toJSON: vi.fn(),
-    })
     mocks.getAllLdFlags.mockResolvedValue({
       'ai-builder': {
         enabled: true,
-        config: {
-          generateStepsPromptName: 'generate-steps',
-          version: 'production',
-        },
+        config: {},
       },
     })
-    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
-    mocks.generateObject.mockImplementation(async ({ schema, ...payload }) => ({
-      object: schema.parse(
-        payload.outputObject ?? DEFAULT_MOCKED_OUTPUT.object,
-      ),
-    }))
+    mocks.getRestrictedAppKeys.mockReturnValue([])
 
     context = {
       currentUser: {
@@ -111,100 +62,535 @@ describe('generateAiSteps mutation', () => {
     }
   })
 
-  it('should generate steps with valid input', async () => {
-    mocks.generateObject.mockResolvedValueOnce(DEFAULT_MOCKED_OUTPUT)
-    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
-
-    const result = await generateAiSteps(
-      null,
-      { input: DEFAULT_INPUT },
-      context,
-    )
-
-    expect(result.trigger).toStrictEqual(DEFAULT_MOCKED_TRIGGER)
-    expect(result.actions).toStrictEqual(DEFAULT_MOCKED_ACTIONS)
-  })
-
-  it('should throw an error if the input is invalid', async () => {
-    await expect(
-      generateAiSteps(
+  describe('valid WORKFLOW_METADATA', () => {
+    it('should parse trigger and actions correctly', async () => {
+      const result = await generateAiSteps(
         null,
-        {
-          input: {
-            prompt: 'gibberish',
-            sessionId: '123',
-          },
-        },
+        { input: DEFAULT_INPUT },
         context,
-      ),
-    ).rejects.toThrow('Prompt must be at least 15 characters')
+      )
+
+      const { trigger, actions } = result as any
+
+      expect(trigger).toMatchObject({
+        type: 'trigger',
+        appKey: 'formsg',
+        key: 'newSubmission',
+      })
+      expect(actions).toHaveLength(2)
+      expect(actions[0]).toMatchObject({
+        type: 'action',
+        appKey: 'postman',
+        key: 'sendTransactionalEmail',
+      })
+      expect(actions[1]).toMatchObject({
+        type: 'action',
+        appKey: 'postman-sms',
+        key: 'sendSms',
+      })
+    })
+
+    it('should use the name from WORKFLOW_METADATA', async () => {
+      const result = await generateAiSteps(
+        null,
+        { input: DEFAULT_INPUT },
+        context,
+      )
+
+      expect(result.name).toBe('Welcome Email Workflow')
+    })
+
+    it('should default name to "Build with AI" when not specified', async () => {
+      const promptWithoutName = `
+<!-- WORKFLOW_METADATA
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email
+-->
+`
+      const result = await generateAiSteps(
+        null,
+        { input: { ...DEFAULT_INPUT, prompt: promptWithoutName } },
+        context,
+      )
+
+      expect(result.name).toBe('Build with AI')
+    })
+
+    it('should set config.stepName from stepName field', async () => {
+      const result = await generateAiSteps(
+        null,
+        { input: DEFAULT_INPUT },
+        context,
+      )
+
+      expect((result.actions as any[])[0].config.stepName).toBe(
+        'Send welcome email',
+      )
+    })
+
+    it('should fall back to key for config.stepName when stepName is absent', async () => {
+      const promptWithoutStepName = `
+<!-- WORKFLOW_METADATA
+name: Welcome Email Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: Configure to trigger when a new FormSG submission is received
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send a transactional email to the new user
+-->
+`
+      const result = await generateAiSteps(
+        null,
+        { input: { ...DEFAULT_INPUT, prompt: promptWithoutStepName } },
+        context,
+      )
+
+      expect((result.actions as any[])[0].config.stepName).toBe(
+        'sendTransactionalEmail',
+      )
+    })
+
+    it('should map branchName to parameters.branchName for if-then steps', async () => {
+      const promptWithIfThen = `
+<!-- WORKFLOW_METADATA
+name: Priority Routing
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    stepName: New form submission
+    description: Configure to trigger when a new FormSG submission is received
+  - step: 2
+    appKey: toolbox
+    key: ifThen
+    stepName: Check priority
+    description: Set the condition to check if the priority field equals High
+    branchName: Priority is High
+  - step: 3
+    appKey: postman
+    key: sendTransactionalEmail
+    stepName: Send high priority email
+    description: Send an email for high priority submissions
+-->
+`
+      const result = await generateAiSteps(
+        null,
+        { input: { ...DEFAULT_INPUT, prompt: promptWithIfThen } },
+        context,
+      )
+
+      const { actions } = result as any
+      expect(actions[0].parameters).toStrictEqual({
+        depth: 0,
+        branchName: 'Priority is High',
+      })
+    })
+
+    it('should add templateConfig to each action', async () => {
+      const result = await generateAiSteps(
+        null,
+        { input: DEFAULT_INPUT },
+        context,
+      )
+
+      for (const action of result.actions as any[]) {
+        expect(action.config.templateConfig).toStrictEqual({})
+      }
+    })
+
+    it('should pass through the traceId from input', async () => {
+      const result = await generateAiSteps(
+        null,
+        { input: { ...DEFAULT_INPUT, traceId: 'chat-trace-xyz' } },
+        context,
+      )
+
+      expect(result.traceId).toBe('chat-trace-xyz')
+    })
   })
 
-  it('should map step positions correctly', async () => {
-    mocks.generateObject.mockResolvedValueOnce(DEFAULT_MOCKED_OUTPUT)
-    mocks.getRestrictedAppKeys.mockReturnValueOnce([])
-
-    const result = await generateAiSteps(
-      null,
-      { input: DEFAULT_INPUT },
-      context,
-    )
-    const parsedResult = result as any
-
-    expect(parsedResult.trigger.position).toBe(1)
-    expect(parsedResult.actions[0].position).toBe(2)
-    expect(parsedResult.actions[1].position).toBe(3)
-  })
-
-  it('should throw when generated output contains restricted app keys', async () => {
-    mocks.getRestrictedAppKeys.mockReturnValueOnce(['aisay'])
-    mocks.generateObject.mockImplementationOnce(async ({ schema }) => ({
-      object: schema.parse({
-        trigger: DEFAULT_MOCKED_TRIGGER,
-        actions: [
+  describe('invalid WORKFLOW_METADATA', () => {
+    it('should throw when no WORKFLOW_METADATA block is present', async () => {
+      await expect(
+        generateAiSteps(
+          null,
           {
-            appKey: 'aisay',
-            key: 'sendMessage',
-            description: 'Send a generated AI message',
-            type: 'action',
-            config: {
-              stepName: 'Send AI message',
-              templateConfig: {},
+            input: {
+              ...DEFAULT_INPUT,
+              prompt:
+                'Just a regular assistant response with no workflow metadata',
             },
-            position: 2,
           },
-        ],
-        name: 'Build with AI',
-      }),
-    }))
+          context,
+        ),
+      ).rejects.toThrow(
+        'Unable to generate the workflow. Modify the prompt and try again.',
+      )
+    })
 
-    await expect(
-      generateAiSteps(null, { input: DEFAULT_INPUT }, context),
-    ).rejects.toThrow('Invalid input')
+    it('should throw when WORKFLOW_METADATA contains malformed YAML', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+: this is not valid yaml: [unclosed bracket
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Unable to generate the workflow. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when WORKFLOW_METADATA has no steps field', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Unable to generate the workflow. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when WORKFLOW_METADATA has an empty steps array', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps: []
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Unable to generate the workflow. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when trigger appKey does not exist', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: nonexistent-app
+    key: someKey
+    description: Some trigger
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Invalid trigger detected. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when action key is invalid for the given appKey', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: postman
+    key: nonExistentAction
+    description: Some action
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'Invalid action detected at step 2. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when WORKFLOW_METADATA has only a trigger with no actions', async () => {
+      // actionsSchema requires min 1 action — falls through to fromZodError
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('Array must contain at least 1 element')
+    })
+
+    it('should throw when trigger uses a restricted app', async () => {
+      mocks.getRestrictedAppKeys.mockReturnValue(['formsg'])
+
+      await expect(
+        generateAiSteps(null, { input: DEFAULT_INPUT }, context),
+      ).rejects.toThrow(
+        'Invalid trigger detected. Modify the prompt and try again.',
+      )
+    })
+
+    it('should throw when if-then is the last action with nothing after it', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email
+  - step: 3
+    appKey: toolbox
+    key: ifThen
+    description: Check condition with nothing after
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'If-then actions must have another action immediately after them',
+      )
+    })
+
+    it('should throw when if-then actions are consecutive', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: toolbox
+    key: ifThen
+    description: First if-then
+  - step: 3
+    appKey: toolbox
+    key: ifThen
+    description: Second if-then immediately after
+  - step: 4
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'If-then actions cannot be consecutive - must alternate with non-if-then actions',
+      )
+    })
+
+    it('should throw when for-each is placed after an if-then', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: toolbox
+    key: ifThen
+    description: Check condition
+  - step: 3
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email after if-then
+  - step: 4
+    appKey: toolbox
+    key: forEach
+    description: Loop after if-then (invalid)
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow(
+        'For-each action cannot be placed after an if-then action',
+      )
+    })
+
+    it('should throw when a delay action is placed after a for-each', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: toolbox
+    key: forEach
+    description: Loop through rows
+  - step: 3
+    appKey: delay
+    key: delayFor
+    description: Wait after loop (invalid)
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('Delay action cannot be added after a for-each step')
+    })
+
+    it('should throw when WORKFLOW_METADATA contains more than one for-each', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              ...DEFAULT_INPUT,
+              prompt: `<!-- WORKFLOW_METADATA
+name: My Workflow
+steps:
+  - step: 1
+    appKey: formsg
+    key: newSubmission
+    description: New FormSG submission
+  - step: 2
+    appKey: toolbox
+    key: forEach
+    description: Loop through each row
+  - step: 3
+    appKey: postman
+    key: sendTransactionalEmail
+    description: Send email
+  - step: 4
+    appKey: toolbox
+    key: forEach
+    description: Loop again
+-->`,
+            },
+          },
+          context,
+        ),
+      ).rejects.toThrow('There can only be 1 for-each action in each pipe')
+    })
+
+    it('should throw when an action uses a restricted app', async () => {
+      // postman is action at index 0 → step 2
+      mocks.getRestrictedAppKeys.mockReturnValue(['postman'])
+
+      await expect(
+        generateAiSteps(null, { input: DEFAULT_INPUT }, context),
+      ).rejects.toThrow(
+        'Invalid action detected at step 2. Modify the prompt and try again.',
+      )
+    })
   })
 
-  it('should throw when generated output contains a restricted trigger app key', async () => {
-    mocks.getRestrictedAppKeys.mockReturnValueOnce(['gathersg'])
-    mocks.generateObject.mockImplementationOnce(async ({ schema }) => ({
-      object: schema.parse({
-        trigger: {
-          appKey: 'gathersg',
-          key: 'newCase',
-          description: 'This is a gathersg trigger',
-          position: 1,
-          type: 'trigger',
-          config: {
-            stepName: 'New GatherSG case',
-            templateConfig: {},
+  describe('input validation', () => {
+    it('should throw when prompt is too short', async () => {
+      await expect(
+        generateAiSteps(
+          null,
+          {
+            input: {
+              prompt: 'too short',
+              sessionId: '123',
+              traceId: 'trace-123',
+            },
           },
-        },
-        actions: DEFAULT_MOCKED_ACTIONS,
-        name: 'Build with AI',
-      }),
-    }))
+          context,
+        ),
+      ).rejects.toThrow('Prompt must be at least 15 characters')
+    })
 
-    await expect(
-      generateAiSteps(null, { input: DEFAULT_INPUT }, context),
-    ).rejects.toThrow('Invalid input')
+    it('should throw when AI Builder flag is disabled', async () => {
+      mocks.getAllLdFlags.mockResolvedValue({
+        'ai-builder': { enabled: false, config: {} },
+      })
+
+      await expect(
+        generateAiSteps(null, { input: DEFAULT_INPUT }, context),
+      ).rejects.toThrow('You do not have permissions to use AI Builder!')
+    })
   })
 })

--- a/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/generate-ai-steps.ts
@@ -1,15 +1,14 @@
-import { startActiveObservation } from '@langfuse/tracing'
-import { generateObject } from 'ai'
 import z from 'zod/v3'
-import { fromZodError } from 'zod-validation-error'
 
-import appConfig from '@/config/app'
 import { BadUserInputError, ForbiddenError } from '@/errors/graphql-errors'
 import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
-import { langfuseClient } from '@/helpers/langfuse'
+import {
+  formatWorkflowError,
+  parseWorkflowMetadata,
+  WorkflowData,
+} from '@/helpers/ai/parse-workflow-metadata'
 import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
-import { model, MODEL_TYPE } from '@/helpers/pair'
 import JSONObject from '@/types/interfaces/json-object'
 
 import { MutationResolvers } from '../../__generated__/types.generated'
@@ -30,99 +29,29 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
     throw new ForbiddenError('You do not have permissions to use AI Builder!')
   }
 
-  // NOTE: we pass restricted apps into the system prompt so the assistant knows which apps the user cannot use
   const restrictedApps = getRestrictedAppKeys(allLdFlags)
   const triggerSchema = getTriggerSchema(restrictedApps)
   const actionsSchema = getActionsSchema(restrictedApps)
 
-  const { generateStepsPromptName: promptName, version } = aiBuilderFlag.config
-  let traceId
+  let workflowData: WorkflowData | undefined
 
   try {
     const validatedInput = INPUT_SCHEMA.parse(params.input)
-    const { prompt: userPrompt, sessionId } = validatedInput
+    const { prompt: userPrompt, traceId } = validatedInput
 
     if (!context.currentUser) {
       throw new ForbiddenError('Not authorised!')
     }
 
-    // NOTE: we get the entire prompt object so that we can pass it to generation.update
-    // to link the generation to the prompt in Rome (Langfuse)
-    const prompt = await langfuseClient.prompt.get(promptName, {
-      label: version,
+    workflowData = parseWorkflowMetadata(userPrompt)
+
+    const schema = z.object({
+      trigger: triggerSchema,
+      actions: actionsSchema,
+      name: z.string().max(64).default('Build with AI'),
     })
-    const { prompt: systemPrompt } = prompt
 
-    const result = await startActiveObservation(
-      'generate-steps',
-      async (trace) => {
-        const tags = ['ai-builder', 'generate-steps']
-
-        traceId = trace.traceId
-        trace.updateTrace({
-          userId: context.currentUser.email,
-          environment: appConfig.appEnv,
-          tags,
-          sessionId: sessionId ?? '',
-        })
-
-        trace.update({
-          input: {
-            prompt: userPrompt,
-          },
-        })
-
-        const generation = trace.startObservation(
-          'generate-steps',
-          {
-            model: MODEL_TYPE,
-            input: [
-              { role: 'system', content: systemPrompt },
-              { role: 'user', content: userPrompt },
-            ],
-          },
-          { asType: 'generation' },
-        )
-
-        generation.update({ prompt })
-
-        const { object } = await generateObject({
-          model,
-          schema: z.object({
-            trigger: triggerSchema,
-            actions: actionsSchema,
-            name: z.string().max(64).default('Build with AI'),
-          }),
-          system: systemPrompt,
-          prompt: userPrompt,
-          experimental_telemetry: {
-            isEnabled: true,
-            functionId: 'generate-steps',
-            metadata: {
-              name: 'generate-steps',
-              sessionId: sessionId || 'unknown',
-              userId: context.currentUser.email,
-              environment: appConfig.appEnv,
-              promptName,
-              promptVersion: version,
-              langfusePrompt: prompt.toJSON(),
-              tags: ['ai-builder', 'generate-steps'],
-            },
-          },
-        })
-
-        trace.update({
-          output: {
-            trigger: object.trigger,
-            actions: object.actions,
-          },
-        })
-
-        generation.update({ output: object }).end()
-
-        return object
-      },
-    )
+    const result = schema.parse(workflowData)
 
     return {
       ...result,
@@ -130,20 +59,30 @@ const generateAiSteps: MutationResolvers['generateAiSteps'] = async (
         ...action,
         config: {
           ...action.config,
-          templateConfig: {}, // add this by default so it does not complain
+          templateConfig: {},
         },
       })),
       traceId,
     } as JSONObject
   } catch (error) {
+    if (error instanceof BadUserInputError || error instanceof ForbiddenError) {
+      throw error
+    }
+
+    if (error instanceof z.ZodError) {
+      const message = formatWorkflowError(error, workflowData)
+      logger.error('Error generating ai steps', {
+        error,
+        message,
+        user: context.currentUser.email,
+      })
+      throw new BadUserInputError(message)
+    }
+
     logger.error('Error generating ai steps', {
       error,
       user: context.currentUser.email,
     })
-
-    if (error instanceof z.ZodError) {
-      throw new BadUserInputError(fromZodError(error).details[0].message)
-    }
 
     throw new Error('Encountered an error, please try again.')
   }

--- a/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
+++ b/packages/backend/src/graphql/mutations/ai/schemas/input.zod.ts
@@ -7,4 +7,5 @@ export const INPUT_SCHEMA = z.object({
     .min(15, 'Prompt must be at least 15 characters')
     .max(10000, 'Prompt must not exceed 10000 characters'),
   sessionId: z.string().nullish(),
+  traceId: z.string().nullish(),
 })

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -141,6 +141,7 @@ type Mutation {
 input GenerateAiStepsInput {
   prompt: String!
   sessionId: String
+  traceId: String
 }
 
 input FeedbackInput {

--- a/packages/backend/src/helpers/ai/parse-workflow-metadata.ts
+++ b/packages/backend/src/helpers/ai/parse-workflow-metadata.ts
@@ -1,0 +1,113 @@
+import { parse as parseYaml } from 'yaml'
+import z from 'zod/v3'
+import { fromZodError } from 'zod-validation-error'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import { BadUserInputError } from '@/errors/graphql-errors'
+
+export const WORKFLOW_METADATA_MARKER = '<!-- WORKFLOW_METADATA'
+export const WORKFLOW_METADATA_REGEX =
+  /<!--\s*WORKFLOW_METADATA\s*([\s\S]*?)-->/
+
+export type WorkflowData = ReturnType<typeof parseWorkflowMetadata>
+
+// Converts a ZodError into a user-facing message with workflow-specific context.
+// - invalid_union: the appKey/key combo didn't match any known app, so we report
+//   which step (trigger or action at step N) is invalid.
+// - custom: emitted by validateActionStepsRules (if-then, for-each, delay
+//   ordering rules); those messages are already human-readable, so pass through.
+// - fallback: fromZodError for anything else (e.g. missing fields, array length).
+function formatWorkflowError(
+  error: z.ZodError,
+  workflowData?: WorkflowData,
+): string {
+  for (const issue of error.issues) {
+    if (issue.code === z.ZodIssueCode.invalid_union) {
+      const [field, index] = issue.path
+
+      if (field === 'trigger' && workflowData) {
+        return `Invalid trigger detected. Modify the prompt and try again.`
+      }
+
+      if (field === 'actions' && typeof index === 'number' && workflowData) {
+        // actions[0] is step 2 (step 1 is the trigger), so offset by 2
+        const stepNum = index + 2
+        return `Invalid action detected at step ${stepNum}. Modify the prompt and try again.`
+      }
+    }
+
+    if (issue.code === z.ZodIssueCode.custom && issue.message) {
+      return issue.message
+    }
+  }
+
+  return fromZodError(error).message
+}
+
+function parseWorkflowMetadata(text: string) {
+  const match = text.match(WORKFLOW_METADATA_REGEX)
+  if (!match) {
+    throw new BadUserInputError(
+      'Unable to generate the workflow. Modify the prompt and try again.',
+    )
+  }
+
+  let parsed: any
+  try {
+    parsed = parseYaml(match[1].trim())
+  } catch {
+    throw new BadUserInputError(
+      'Unable to generate the workflow. Modify the prompt and try again.',
+    )
+  }
+
+  if (
+    !parsed?.steps ||
+    !Array.isArray(parsed.steps) ||
+    parsed.steps.length === 0
+  ) {
+    throw new BadUserInputError(
+      'Unable to generate the workflow. Modify the prompt and try again.',
+    )
+  }
+
+  const [firstStep, ...remainingSteps] = parsed.steps
+
+  return {
+    name: String(parsed.name ?? 'Build with AI').slice(0, 64),
+    trigger: {
+      type: 'trigger' as const,
+      appKey: firstStep.appKey,
+      key: firstStep.key,
+      description: String(firstStep.description ?? ''),
+    },
+    actions: remainingSteps.map((step: any) => {
+      const isIfThen =
+        step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.IF_THEN
+
+      return {
+        type: 'action' as const,
+        appKey: step.appKey,
+        key: step.key,
+        // description → templateConfig.customTemplate: setup guide shown above the step (max 100 chars)
+        description: String(step.description ?? '').slice(0, 100),
+        config: {
+          // stepName → step title label (max 64 chars); falls back to key if omitted
+          stepName: String(step.stepName ?? step.key ?? '').slice(0, 64),
+        },
+        // if-then requires parameters with depth and branchName for branch labelling
+        ...(isIfThen && {
+          parameters: {
+            depth: 0,
+            branchName: String(step.branchName ?? 'Branch'),
+          },
+        }),
+      }
+    }),
+  }
+}
+
+export { formatWorkflowError, parseWorkflowMetadata }

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -18,6 +18,7 @@ import { Router } from 'express'
 import appConfig from '@/config/app'
 import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
 import { getPrompt } from '@/helpers/ai/get-prompt'
+import { WORKFLOW_METADATA_MARKER } from '@/helpers/ai/parse-workflow-metadata'
 import { buildSystemPrompt } from '@/helpers/build-system-prompt'
 import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
@@ -141,7 +142,7 @@ const handleChatStream = observe(
                  * The system prompt tells the LLM to generate this marker
                  */
                 const isChatReady = event.text.includes(
-                  '<!-- WORKFLOW_METADATA',
+                  WORKFLOW_METADATA_MARKER,
                 )
 
                 // Write chat readiness status as a data annotation

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -51,6 +51,7 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
   const {
     flowName,
     chatInput,
+    chatMessages,
     output,
     steps,
     triggerStep,
@@ -62,6 +63,10 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
     ddSessionId,
     clearPersistedState,
   } = useAiBuilderContext()
+
+  const chatTraceId = chatMessages?.findLast(
+    (m) => !m.isUser && m.traceId,
+  )?.traceId
 
   const isMobile = useIsMobile()
   const navigate = useNavigate()
@@ -98,6 +103,7 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
             input: {
               prompt,
               sessionId: ddSessionId,
+              traceId: chatTraceId,
             },
           },
           context: {
@@ -114,7 +120,7 @@ export default function StepsPreview({ isReadyForPreview }: StepsPreviewProps) {
         setError(true)
       }
     },
-    [generateAiStepsMutation, ddSessionId],
+    [generateAiStepsMutation, ddSessionId, chatTraceId],
   )
 
   const onGenerateAiSteps = useCallback(async () => {

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -44,8 +44,8 @@ function AiBuilderContent() {
   // - New messages beyond persisted state
   // - Currently streaming a response
   const hasUnsavedWork = useMemo(
-    () => chatMessages.length > 0 || messages.length > 0 || isStreaming,
-    [chatMessages.length, messages.length, isStreaming],
+    () => chatMessages?.length > 0 || messages.length > 0 || isStreaming,
+    [chatMessages?.length, messages.length, isStreaming],
   )
 
   // Guard navigation - clear persisted state when user confirms exit


### PR DESCRIPTION
### TL;DR

Replace the LLM-based `generateObject` step generation with direct parsing of a `WORKFLOW_METADATA` block embedded in the AI chat response.

### What changed?

- The `generateAiSteps` mutation no longer calls `generateObject` or fetches a Langfuse prompt. Instead, it expects the incoming `prompt` field to contain a `<!-- WORKFLOW_METADATA ... -->` HTML comment block with YAML-encoded workflow steps.
- A new `parseWorkflowMetadata` helper extracts and validates the YAML block, mapping the first step as the trigger and remaining steps as actions.
- A new `formatWorkflowError` helper converts `ZodError` instances into user-facing messages, distinguishing between invalid trigger/action app keys, custom rule violations (if-then, for-each, delay ordering), and generic schema errors.
- `traceId` is now a required field on `GenerateAiStepsInput` (both GraphQL schema and Zod input schema). The frontend reads the `traceId` from the last non-user chat message and passes it through to the mutation.
- The `yaml` package is added as a production dependency of the backend package.
- All existing tests for `generateAiSteps` have been rewritten to cover the new parsing path, including valid metadata, malformed YAML, missing/empty steps, invalid app/action keys, restricted apps, and toolbox action ordering rules (if-then, for-each, delay).

### How to test?

- [ ] Verify that you can what with the AI Builder, and the steps generated match the chat output.
- [ ] Test error cases by getting the AI Builder to give you actions you should not get and should not be able to generate the steps (this may or may not be possible, might have to prompt a bit harder)