### PR TITLE
fix: editor cannot connect formsg

### DIFF
--- a/packages/backend/src/graphql/mutations/register-connection.ts
+++ b/packages/backend/src/graphql/mutations/register-connection.ts
@@ -1,9 +1,11 @@
 import type { IApp, IGlobalVariable } from '@plumber/types'
 
 import apps from '@/apps'
+import { ForbiddenError } from '@/errors/graphql-errors'
 import globalVariable from '@/helpers/global-variable'
 import type Connection from '@/models/connection'
 import type User from '@/models/user'
+import { getConnection } from '@/services/connection'
 
 import type { MutationResolvers } from '../__generated__/types.generated'
 
@@ -26,8 +28,10 @@ async function makeGlobalVariableForPerFlowRegistration(
   flowId: string,
 ): Promise<IGlobalVariable> {
   const flow = await currentUser
-    .$relatedQuery('flows')
-    .findById(flowId)
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findOne({
+      id: flowId,
+    })
     .throwIfNotFound()
 
   return await globalVariable({
@@ -45,10 +49,29 @@ const registerConnection: MutationResolvers['registerConnection'] = async (
 ) => {
   const { connectionId, flowId } = params.input
 
-  const connection = await context.currentUser
-    .$relatedQuery('connections')
-    .findById(connectionId)
+  const flow = await context.currentUser
+    .withAccessibleFlows({ requiredRole: 'editor' })
+    .findOne({
+      id: flowId,
+    })
     .throwIfNotFound()
+
+  const connection = await getConnection({
+    context,
+    connectionId,
+    flowId,
+    includeOwnConnections: flow.role === 'owner',
+  })
+
+  // GUARD: Prevent updating personal connections owned by others
+  if (
+    connection.userId !== null &&
+    connection.userId !== context.currentUser.id
+  ) {
+    throw new ForbiddenError(
+      'You cannot register a personal connection that you do not own',
+    )
+  }
 
   const app = apps[connection.key]
   if (!app) {

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -36,6 +36,7 @@ export const optionGenerator = (
   appKey: string,
 ): ConnectionDropdownOption => {
   const screenName = connection?.formattedData?.screenName as string
+  const description = connection?.description as string
   if (appKey === 'formsg') {
     // old form connections will have env as undefined and be treated as prod
     const env = (connection?.formattedData?.env as string) ?? 'prod'
@@ -52,7 +53,7 @@ export const optionGenerator = (
     return {
       label: `${env === 'prod' ? '' : `[${env.toUpperCase()}] `}${formTitle}`,
       value: connection?.id as string,
-      description: formId,
+      description: description ? `${formId} - ${description}` : formId,
       env,
     }
   }


### PR DESCRIPTION
## Problem
Editors of Pipes are unable to connect the FormSG they added to the Pipe.

_How to replicate_:
1. Open a Pipe where you are an Editor
2. Add a FormSG connection
3. Try to connect to that FormSG connection <-- fails here

## What changed
`registerConnection` mutation now supports editors adding FormSG connections to shared flows.

Previously, `registerConnection` fetched the connection by querying only the current user's own connections. This meant that if an editor was configuring a step in a shared flow, they couldn't register a connection, even one they personally own because the query would fail to find it if the connection wasn't directly related to them as the flow owner.

The fix makes two key changes:
* Flow access is now checked via `withAccessibleFlows`: The resolver first verifies the requesting user has at least editor access to the flow (previously, `makeGlobalVariableForPerFlowRegistration` queried `$relatedQuery('flows')` which only returned flows the user owns). This allows editors of shared flows to proceed.
* Connection lookup is delegated to `getConnection`: Instead of only looking up the user's own connections, the resolver now uses `getConnection` (which understands shared flow context) and passes `includeOwnConnections: flow.role === 'owner'` to scope what's visible. 
    * A guard is added to prevent an editor from registering a personal connection that belongs to someone else, they can only register connections they own, or shared/team connections scoped to the flow.

## Tests
- [ ] Verify that Editor can now add a FormSG and connect to it in the Pipe
    - [ ] Verify that this FormSG is added to `connections` without a `user_id`
    - [ ] Verify that this FormSG is added to `flow_connections` with the correct `connection_id` and `flow_id`
    - [ ] Verify that the frontend also has 'This connection can only be used in this Pipe' in the dropdown
- [ ] Verify that Editor CANNOT add a new Excel connection

_Sanity check_
- [ ] Verify that Editor can still add other connections (e.g. Telegram / Slack)
- [ ] Verify that Editor can still add their Tiles

## Before & After Screenshots

**BEFORE**:
<img width="1506" height="796" alt="Screenshot 2026-05-12 at 10 05 49 AM" src="https://github.com/user-attachments/assets/837d1921-89c7-4e6c-b537-a6c93d88204a" />

**AFTER**:
Should see the successful connection. Note that if the Pipe Owner is not an Editor of the form, the Owner will see that connection is not verified.