### PR TITLE
[PLU-742] chore: add missing index for table-column-metadata table

### DIFF
--- a/packages/backend/src/db/migrations/20260517070824_add-table-column-metadata-index.ts
+++ b/packages/backend/src/db/migrations/20260517070824_add-table-column-metadata-index.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('table_column_metadata', (table) => {
+    table.index('table_id')
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('table_column_metadata', (table) => {
+    table.dropIndex('table_id')
+  })
+}


### PR DESCRIPTION
## Problem
Found out that there's a missing index on our `table_column_metadata` table on `table_id` when looking at our DB monitoring on Datadog.
<img width="1362" height="432" alt="Screenshot 2026-05-17 at 3 09 20 PM" src="https://github.com/user-attachments/assets/03b934e1-b51f-4f36-9fb6-3d43fa393e3d" />
<img width="1278" height="204" alt="image" src="https://github.com/user-attachments/assets/0aff270c-570c-4d19-8cd7-0de0c17e8c98" />

## Solution
- Adds missing table_id index via knex migration script

### Why not concurrently?
- our table is fairly small (~270k rows.) Will probably take 1-3 seconds to complete, can just run at night.
- will only lock INSERT/UPDATE/DELETE, SELECT is fine (running pipes will not be affected, since actions dont modify this table)
- no risk of broken partial index 

## Deployment notes
- [x] UAT
- [x] Staging
- [x] Prod