### PR TITLE
chore: assign more cpu to worker from server container

### DIFF
--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -2,12 +2,14 @@
   "containerDefinitions": [
     {
       "name": "server",
-      "cpu": 1024,
+      "cpu": 512,
       "command": ["npm", "run", "start"],
-      "environment": [{
-        "name": "NODE_OPTIONS",
-        "value": "--max-old-space-size=3072"
-      }],
+      "environment": [
+        {
+          "name": "NODE_OPTIONS",
+          "value": "--max-old-space-size=3072"
+        }
+      ],
       "portMappings": [
         {
           "containerPort": 8080,
@@ -28,7 +30,7 @@
     },
     {
       "name": "worker",
-      "cpu": 512,
+      "cpu": 1024,
       "command": ["npm", "run", "start:worker"],
       "essential": true,
       "stopTimeout": 120,


### PR DESCRIPTION
## Problem
We're sub-optimally distributing the cpu reservation for each container right now since `worker`  tend to use much more cpu compared to `server`.

<img width="1455" height="566" alt="image" src="https://github.com/user-attachments/assets/658a0d8c-ad9c-43a3-bc0f-fcacbfc6be78" />

## Solution

Assign more cpu to workers in task definition. In practice, this wouldnt do much since Fargate already reassigns unutilized cpu to containers during runtime when needed. That's why we see a spike of cpu to 200%.