### PR TITLE
[SES-PHASE-1-2] - PLU-744: add migration and email suppression model

### DIFF
--- a/packages/backend/src/db/migrations/20260519100000_create_email_suppression.ts
+++ b/packages/backend/src/db/migrations/20260519100000_create_email_suppression.ts
@@ -1,0 +1,43 @@
+import { Knex } from 'knex'
+
+/**
+ * email_suppression stores emails that should not be sent to via SES.
+ *
+ * Only two kinds of events lead to a row here:
+ *  - reason='BOUNCE'    -> permanent SES bounces (transient bounces are ignored)
+ *  - reason='COMPLAINT' -> SES complaints (except 'not-spam', which whitelists)
+ *
+ * reason_detail is optional sub-classification for triage / debugging only:
+ *  - For BOUNCE: SES bounceSubType (e.g. 'NoEmail', 'General', 'Suppressed')
+ *  - For COMPLAINT: SES complaintFeedbackType (e.g. 'abuse', 'fraud', 'virus')
+ *
+ * deleted_at exists for consistency with the project-wide soft-delete
+ * convention (see Base model + ExtendedQueryBuilder) and is expected to
+ * stay NULL — no code path here soft-deletes suppression rows. The upsert
+ * resets it defensively in case a future cleanup script ever does.
+ */
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable('email_suppression', (table) => {
+    table
+      .uuid('id')
+      .primary()
+      .notNullable()
+      .defaultTo(knex.raw('gen_random_uuid()'))
+    table.string('email', 255).notNullable().unique()
+    table.string('reason', 20).notNullable()
+    table.string('reason_detail', 50).nullable()
+    table.string('ses_message_id', 255).nullable()
+    table.integer('whitelist_count').notNullable().defaultTo(0)
+    table.timestamp('last_whitelisted_at', { useTz: true }).nullable()
+    table.timestamp('deleted_at', { useTz: true }).nullable()
+    table.timestamps(true, true) // created_at, updated_at with defaults
+
+    // Enforce the invariant at the DB layer — transient bounces and
+    // unknown event types must never end up in this table.
+    table.check("reason IN ('BOUNCE', 'COMPLAINT')")
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTable('email_suppression')
+}

--- a/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
+++ b/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
@@ -90,6 +90,37 @@ describe('EmailSuppressionEntry model', () => {
       expect(row.reasonDetail).toBe('NoEmail')
     })
 
+    it('should undelete (reset deleted_at) when upserting onto a soft-deleted row', async () => {
+      // Create then soft-delete the row.
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+      })
+      await EmailSuppressionEntry.query().where({ email: testEmail }).delete()
+
+      // Sanity: the row is now hidden from normal (soft-delete-filtered) queries.
+      const hiddenBefore = await EmailSuppressionEntry.query().findOne({
+        email: testEmail,
+      })
+      expect(hiddenBefore).toBeUndefined()
+
+      // Re-suppression event for the same email should undelete + update it.
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'COMPLAINT',
+        reasonDetail: 'abuse',
+      })
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: testEmail,
+      })
+      expect(row).toBeDefined()
+      expect(row.deletedAt).toBeNull()
+      expect(row.reason).toBe('COMPLAINT')
+      expect(row.reasonDetail).toBe('abuse')
+    })
+
     it('should reject invalid reason values via DB CHECK constraint', async () => {
       await expect(
         EmailSuppressionEntry.upsertSuppression({
@@ -97,6 +128,38 @@ describe('EmailSuppressionEntry model', () => {
           reason: 'TRANSIENT' as never,
         }),
       ).rejects.toThrow()
+    })
+
+    it('should lowercase the email before storing', async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'MixedCase@Example.com',
+        reason: 'BOUNCE',
+      })
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'mixedcase@example.com',
+      })
+      expect(row).toBeDefined()
+      expect(row.email).toBe('mixedcase@example.com')
+    })
+
+    it('should treat differently-cased emails as the same row', async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'dupe@example.com',
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+      })
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'DUPE@example.com',
+        reason: 'COMPLAINT',
+        reasonDetail: 'abuse',
+      })
+
+      const rows = await EmailSuppressionEntry.query().where({
+        email: 'dupe@example.com',
+      })
+      expect(rows).toHaveLength(1)
+      expect(rows[0].reason).toBe('COMPLAINT')
     })
   })
 
@@ -133,6 +196,13 @@ describe('EmailSuppressionEntry model', () => {
     it('should return empty array for empty input', async () => {
       const result = await EmailSuppressionEntry.getSuppressedEmails([])
       expect(result).toEqual([])
+    })
+
+    it('should match suppressed emails case-insensitively', async () => {
+      const result = await EmailSuppressionEntry.getSuppressedEmails([
+        'SUPPRESSED@Example.com',
+      ])
+      expect(result).toEqual(['suppressed@example.com'])
     })
   })
 
@@ -181,6 +251,18 @@ describe('EmailSuppressionEntry model', () => {
     it('should return empty array for empty input', async () => {
       const result = await EmailSuppressionEntry.whitelistEmails([])
       expect(result).toEqual([])
+    })
+
+    it('should whitelist case-insensitively', async () => {
+      const result = await EmailSuppressionEntry.whitelistEmails([
+        'SUPPRESSED@Example.com',
+      ])
+      expect(result).toEqual(['suppressed@example.com'])
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'suppressed@example.com',
+      })
+      expect(row.lastWhitelistedAt).not.toBeNull()
     })
   })
 })

--- a/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
+++ b/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import EmailSuppressionEntry from '../email-suppression-entry'
+
+describe('EmailSuppressionEntry model', () => {
+  const testEmail = 'bounce@example.com'
+
+  describe('upsertSuppression', () => {
+    it('should insert a new suppression record', async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+        sesMessageId: 'msg-001',
+      })
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: testEmail,
+      })
+      expect(row).toBeDefined()
+      expect(row.reason).toBe('BOUNCE')
+      expect(row.reasonDetail).toBe('NoEmail')
+      expect(row.sesMessageId).toBe('msg-001')
+      expect(row.whitelistCount).toBe(0)
+      expect(row.lastWhitelistedAt).toBeNull()
+    })
+
+    it('should be idempotent — re-inserting same email updates fields', async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+      })
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'General',
+        sesMessageId: 'msg-002',
+      })
+
+      const rows = await EmailSuppressionEntry.query().where({
+        email: testEmail,
+      })
+      expect(rows).toHaveLength(1)
+      expect(rows[0].reasonDetail).toBe('General')
+      expect(rows[0].sesMessageId).toBe('msg-002')
+      expect(rows[0].whitelistCount).toBe(0)
+    })
+
+    it('should increment whitelist_count when re-suppressing a whitelisted email', async () => {
+      // Suppress
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+      })
+      // Whitelist
+      await EmailSuppressionEntry.whitelistEmails([testEmail])
+      // Re-suppress
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+      })
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: testEmail,
+      })
+      expect(row.whitelistCount).toBe(1)
+      expect(row.lastWhitelistedAt).toBeNull()
+    })
+
+    it('should overwrite reason and reasonDetail to reflect latest event', async () => {
+      // First event: complaint
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'COMPLAINT',
+        reasonDetail: 'abuse',
+      })
+      // Subsequent event: permanent bounce overwrites
+      await EmailSuppressionEntry.upsertSuppression({
+        email: testEmail,
+        reason: 'BOUNCE',
+        reasonDetail: 'NoEmail',
+      })
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: testEmail,
+      })
+      expect(row.reason).toBe('BOUNCE')
+      expect(row.reasonDetail).toBe('NoEmail')
+    })
+
+    it('should reject invalid reason values via DB CHECK constraint', async () => {
+      await expect(
+        EmailSuppressionEntry.upsertSuppression({
+          email: testEmail,
+          reason: 'TRANSIENT' as never,
+        }),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('getSuppressedEmails', () => {
+    beforeEach(async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'suppressed@example.com',
+        reason: 'BOUNCE',
+      })
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'whitelisted@example.com',
+        reason: 'BOUNCE',
+      })
+      await EmailSuppressionEntry.whitelistEmails(['whitelisted@example.com'])
+    })
+
+    it('should return only suppressed emails', async () => {
+      const result = await EmailSuppressionEntry.getSuppressedEmails([
+        'suppressed@example.com',
+        'whitelisted@example.com',
+        'unknown@example.com',
+      ])
+      expect(result).toEqual(['suppressed@example.com'])
+    })
+
+    it('should return empty array when no emails are suppressed', async () => {
+      const result = await EmailSuppressionEntry.getSuppressedEmails([
+        'whitelisted@example.com',
+        'unknown@example.com',
+      ])
+      expect(result).toEqual([])
+    })
+
+    it('should return empty array for empty input', async () => {
+      const result = await EmailSuppressionEntry.getSuppressedEmails([])
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('whitelistEmails', () => {
+    beforeEach(async () => {
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'suppressed@example.com',
+        reason: 'BOUNCE',
+      })
+    })
+
+    it('should whitelist a suppressed email and return it', async () => {
+      const result = await EmailSuppressionEntry.whitelistEmails([
+        'suppressed@example.com',
+      ])
+      expect(result).toEqual(['suppressed@example.com'])
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'suppressed@example.com',
+      })
+      expect(row.lastWhitelistedAt).not.toBeNull()
+    })
+
+    it('should not return emails that are not suppressed or do not exist', async () => {
+      const result = await EmailSuppressionEntry.whitelistEmails([
+        'unknown@example.com',
+      ])
+      expect(result).toEqual([])
+    })
+
+    it('should not reset whitelist_count', async () => {
+      await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
+      await EmailSuppressionEntry.upsertSuppression({
+        email: 'suppressed@example.com',
+        reason: 'BOUNCE',
+      })
+      await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'suppressed@example.com',
+      })
+      expect(row.whitelistCount).toBe(1)
+      expect(row.lastWhitelistedAt).not.toBeNull()
+    })
+
+    it('should return empty array for empty input', async () => {
+      const result = await EmailSuppressionEntry.whitelistEmails([])
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/packages/backend/src/models/__tests__/email-suppression-entry.test.ts
+++ b/packages/backend/src/models/__tests__/email-suppression-entry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import EmailSuppressionEntry from '@/models/email-suppression-entry'
+
+describe('EmailSuppressionEntry model', () => {
+  describe('tableName', () => {
+    it('should use email_suppression table', () => {
+      expect(EmailSuppressionEntry.tableName).toBe('email_suppression')
+    })
+  })
+
+  describe('jsonSchema', () => {
+    it('should require email and reason', () => {
+      expect(EmailSuppressionEntry.jsonSchema.required).toEqual([
+        'email',
+        'reason',
+      ])
+    })
+  })
+
+  describe('getSuppressedEmails', () => {
+    it('should return empty array for empty input', async () => {
+      const result = await EmailSuppressionEntry.getSuppressedEmails([])
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('whitelistEmails', () => {
+    it('should return empty array for empty input', async () => {
+      const result = await EmailSuppressionEntry.whitelistEmails([])
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/packages/backend/src/models/email-suppression-entry.ts
+++ b/packages/backend/src/models/email-suppression-entry.ts
@@ -1,0 +1,163 @@
+import { raw } from 'objection'
+
+import Base from './base'
+
+/**
+ * The kind of SES event that caused a suppression.
+ *
+ * Only these two reach the table:
+ *  - BOUNCE    -> SES Bounce event with bounceType='Permanent'
+ *  - COMPLAINT -> SES Complaint event (any feedback type except 'not-spam')
+ *
+ * Transient/Undetermined bounces and 'not-spam' complaints never produce
+ * a row: transient bounces are logged-only, and 'not-spam' triggers an
+ * auto-whitelist instead of suppression.
+ */
+export type SuppressionReason = 'BOUNCE' | 'COMPLAINT'
+
+/**
+ * Allowed (reason, reasonDetail) pairings — for documentation only.
+ *
+ * BOUNCE:
+ *  - 'NoEmail'                  email address does not exist
+ *  - 'General'                  generic permanent failure
+ *  - 'Suppressed'               on SES account-level suppression list
+ *  - 'OnAccountSuppressionList' same as Suppressed (older naming)
+ *
+ * COMPLAINT:
+ *  - 'abuse'                    marked as spam
+ *  - 'fraud'                    reported as fraud
+ *  - 'virus'                    reported as virus
+ *  - 'other'                    unspecified
+ *
+ * reasonDetail is informational only — suppression checks only look at the
+ * row's existence + last_whitelisted_at, never at reason/reasonDetail.
+ */
+
+class EmailSuppressionEntry extends Base {
+  id!: string
+  email!: string
+  reason!: SuppressionReason
+  reasonDetail?: string
+  sesMessageId?: string
+  whitelistCount!: number
+  lastWhitelistedAt?: string
+
+  static tableName = 'email_suppression'
+
+  static jsonSchema = {
+    type: 'object',
+    required: ['email', 'reason'],
+
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      email: { type: 'string', maxLength: 255 },
+      reason: { type: 'string', enum: ['BOUNCE', 'COMPLAINT'] },
+      reasonDetail: { type: ['string', 'null'], maxLength: 50 },
+      sesMessageId: { type: ['string', 'null'], maxLength: 255 },
+      whitelistCount: { type: 'integer' },
+      lastWhitelistedAt: {
+        type: ['string', 'null'],
+        format: 'date-time',
+      },
+    },
+  }
+
+  /**
+   * Upsert a suppression record from an SES bounce/complaint event.
+   *
+   * Two paths:
+   *   1. New email -> insert a fresh row (whitelist_count = 0, suppressed)
+   *   2. Existing email (conflict on UNIQUE(email)) -> update existing row
+   *
+   * On conflict:
+   *   - Overwrites reason / reason_detail / ses_message_id with latest event
+   *   - Re-suppresses the row (last_whitelisted_at = NULL)
+   *   - Increments whitelist_count ONLY if the email was whitelisted before
+   *     this event — a signal that an admin's whitelist decision was wrong
+   *   - Resets deleted_at so a previously soft-deleted row becomes visible
+   *     to the suppression check again
+   *
+   * Idempotent: safe to call multiple times for the same event.
+   */
+  static async upsertSuppression(params: {
+    email: string
+    reason: SuppressionReason
+    reasonDetail?: string
+    sesMessageId?: string
+  }): Promise<void> {
+    const { email, reason, reasonDetail, sesMessageId } = params
+
+    await this.query()
+      .insert({
+        email,
+        reason,
+        reasonDetail: reasonDetail ?? null,
+        sesMessageId: sesMessageId ?? null,
+        whitelistCount: 0,
+        lastWhitelistedAt: null,
+      })
+      .onConflict('email')
+      .merge({
+        reason,
+        reasonDetail: reasonDetail ?? null,
+        sesMessageId: sesMessageId ?? null,
+        lastWhitelistedAt: null,
+        // increment only when re-suppressing a previously whitelisted email
+        whitelistCount: raw(
+          `CASE
+            WHEN email_suppression.last_whitelisted_at IS NOT NULL
+            THEN email_suppression.whitelist_count + 1
+            ELSE email_suppression.whitelist_count
+          END`,
+        ),
+        // undelete: re-suppression should always be visible to suppression checks
+        deletedAt: null,
+      })
+  }
+
+  /**
+   * Check which emails from a list are currently suppressed.
+   * An email is suppressed if it exists in the table AND last_whitelisted_at IS NULL.
+   *
+   * Returns the subset of input emails that are suppressed.
+   */
+  static async getSuppressedEmails(emails: string[]): Promise<string[]> {
+    if (emails.length === 0) {
+      return []
+    }
+
+    const results = await this.query()
+      .select('email')
+      .whereIn('email', emails)
+      .whereNull('last_whitelisted_at')
+
+    return results.map((row) => row.email)
+  }
+
+  /**
+   * Whitelist one or more emails (admin force-whitelist).
+   * Sets last_whitelisted_at = now() for emails that are currently suppressed.
+   * Does NOT reset whitelist_count.
+   *
+   * Returns the list of emails that were actually whitelisted
+   * (i.e. were suppressed and are now whitelisted).
+   */
+  static async whitelistEmails(emails: string[]): Promise<string[]> {
+    if (emails.length === 0) {
+      return []
+    }
+
+    const results = await this.query()
+      .patch({
+        lastWhitelistedAt: new Date().toISOString(),
+      })
+      .whereIn('email', emails)
+      .whereNull('last_whitelisted_at')
+      .returning('email')
+
+    return results.map((row) => row.email)
+  }
+}
+
+export default EmailSuppressionEntry

--- a/packages/backend/src/models/email-suppression-entry.ts
+++ b/packages/backend/src/models/email-suppression-entry.ts
@@ -1,3 +1,4 @@
+import type { ModelOptions, QueryContext } from 'objection'
 import { raw } from 'objection'
 
 import Base from './base'
@@ -63,6 +64,28 @@ class EmailSuppressionEntry extends Base {
     },
   }
 
+  // Lowercase email on write so stored rows have a canonical casing.
+  // Suppression matching must be case-insensitive — the read methods below
+  // lowercase their inputs to match. (Email parsing elsewhere in the codebase
+  // already lowercases, e.g. recipient parsing + the dataOut schema.)
+  async $beforeInsert(queryContext: QueryContext): Promise<void> {
+    await super.$beforeInsert(queryContext)
+    if (this.email) {
+      this.email = this.email.toLowerCase()
+    }
+  }
+
+  async $beforeUpdate(
+    opts: ModelOptions,
+    queryContext: QueryContext,
+  ): Promise<void> {
+    await super.$beforeUpdate(opts, queryContext)
+    // `email` is absent on patches that don't touch it (e.g. whitelistEmails).
+    if (this.email) {
+      this.email = this.email.toLowerCase()
+    }
+  }
+
   /**
    * Upsert a suppression record from an SES bounce/complaint event.
    *
@@ -89,6 +112,13 @@ class EmailSuppressionEntry extends Base {
     const { email, reason, reasonDetail, sesMessageId } = params
 
     await this.query()
+      // Safeguard because deleted_at should always be null:
+      // The base query builder appends `deleted_at IS NULL` to every query,
+      // which would otherwise land on the ON CONFLICT ... DO UPDATE clause and
+      // skip the merge for a soft-deleted row — leaving it deleted instead of
+      // re-suppressed. withSoftDeleted() drops that filter so the upsert can
+      // undelete (reset deleted_at below).
+      .withSoftDeleted()
       .insert({
         email,
         reason,
@@ -103,6 +133,7 @@ class EmailSuppressionEntry extends Base {
         reasonDetail: reasonDetail ?? null,
         sesMessageId: sesMessageId ?? null,
         lastWhitelistedAt: null,
+        updatedAt: new Date().toISOString(),
         // increment only when re-suppressing a previously whitelisted email
         whitelistCount: raw(
           `CASE
@@ -123,13 +154,17 @@ class EmailSuppressionEntry extends Base {
    * Returns the subset of input emails that are suppressed.
    */
   static async getSuppressedEmails(emails: string[]): Promise<string[]> {
-    if (emails.length === 0) {
+    const lowercasedEmails = emails
+      .map((e) => e.trim().toLowerCase())
+      .filter((e) => e.length > 0)
+
+    if (lowercasedEmails.length === 0) {
       return []
     }
 
     const results = await this.query()
       .select('email')
-      .whereIn('email', emails)
+      .whereIn('email', lowercasedEmails)
       .whereNull('last_whitelisted_at')
 
     return results.map((row) => row.email)
@@ -148,11 +183,12 @@ class EmailSuppressionEntry extends Base {
       return []
     }
 
+    const lowercasedEmails = emails.map((email) => email.toLowerCase())
     const results = await this.query()
       .patch({
         lastWhitelistedAt: new Date().toISOString(),
       })
-      .whereIn('email', emails)
+      .whereIn('email', lowercasedEmails)
       .whereNull('last_whitelisted_at')
       .returning('email')
 


### PR DESCRIPTION
### TL;DR

Introduces an `email_suppression` table and `EmailSuppressionEntry` model to track emails that should not receive outbound mail due to SES permanent bounces or complaints.

### What changed?

- Added a new `email_suppression` database table via migration, storing the email address, suppression reason (`BOUNCE` or `COMPLAINT`), optional reason detail, SES message ID, whitelist count, and soft-delete/whitelist timestamps. A DB-level `CHECK` constraint enforces that only `BOUNCE` and `COMPLAINT` reasons are stored.
- Added the `EmailSuppressionEntry` Objection.js model with three static methods:
    - `upsertSuppression` — inserts or updates a suppression record from an SES event. On conflict, it overwrites the reason fields, re-suppresses the email, and increments `whitelist_count` only if the email had previously been whitelisted.
    - `getSuppressedEmails` — filters a list of emails down to those currently suppressed (i.e. present in the table with `last_whitelisted_at IS NULL`).
    - `whitelistEmails` — sets `last_whitelisted_at` on currently suppressed emails, effectively un-suppressing them without resetting the whitelist counter.

### How to test?

Nothing much to test because this just creates the new table and some functions.

- Run the integration tests in `email-suppression-entry.itest.ts`, which cover upsert idempotency, whitelist count incrementing, re-suppression after whitelisting, `getSuppressedEmails` filtering, and `whitelistEmails` behaviour.
- Run the unit tests in `email-suppression-entry.test.ts` for schema and empty-input edge cases.
- Apply the migration and verify the `email_suppression` table is created with the expected columns and `CHECK` constraint.

### Why make this change?

To prevent sending emails to addresses that have permanently bounced or filed spam complaints via SES. Continuing to send to such addresses harms sender reputation and violates email best practices. This model provides the persistence layer needed to honour those suppression signals and allow admins to override them when appropriate.