### PR TITLE
[SES-PHASE-1-5] - PLU-744: add suppression check for ses send email

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   createInvalidAttachmentsMessage: vi.fn(() => 'test invalid attachment body'),
   getLdFlagValue: vi.fn(async () => [] as string[]),
   sesSend: vi.fn(async () => ({})),
+  getSuppressedEmails: vi.fn(async () => [] as string[]),
 }))
 
 vi.mock('@/helpers/launch-darkly', () => ({
@@ -64,6 +65,12 @@ vi.mock('../../common/send-blacklist-email', () => ({
 vi.mock('../../common/send-invalid-attachments-email', () => ({
   sendInvalidAttachmentsEmail: mocks.sendInvalidAttachmentsEmail,
   createInvalidAttachmentsMessage: mocks.createInvalidAttachmentsMessage,
+}))
+
+vi.mock('@/models/email-suppression-entry', () => ({
+  default: {
+    getSuppressedEmails: mocks.getSuppressedEmails,
+  },
 }))
 
 describe('send transactional email', () => {

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -9,6 +9,7 @@ import HttpError from '@/errors/http'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { getSesClient, shouldUseSes } from '@/helpers/ses-email-helper'
+import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
 import {
   PostmanEmailDataOut,
@@ -201,7 +202,26 @@ export async function sendTransactionalEmails(
     !email.attachments?.length &&
     recipients.every((r) => shouldUseSes(r, sesEnabledDomains))
 
-  const promises = recipients.map(async (recipientEmail) => {
+  // Pre-send suppression check (SES path only)
+  let suppressedSet = new Set<string>()
+  if (useSes) {
+    const suppressedEmails = await EmailSuppressionEntry.getSuppressedEmails(
+      recipients,
+    )
+    suppressedSet = new Set(suppressedEmails)
+
+    if (suppressedSet.size > 0) {
+      logger.info('Suppressed emails filtered out before sending', {
+        event: 'pre-send-suppression-check',
+        suppressedCount: suppressedSet.size,
+        totalRecipients: recipients.length,
+      })
+    }
+  }
+
+  const activeRecipients = recipients.filter((r) => !suppressedSet.has(r))
+
+  const promises = activeRecipients.map(async (recipientEmail) => {
     try {
       if (useSes) {
         return await sendViaSes(recipientEmail, email)
@@ -231,7 +251,25 @@ export async function sendTransactionalEmails(
   let params: Omit<PostmanEmailDataOut, 'status' | 'recipient'>
   const errors: PostmanPromiseRejected[] = []
 
-  results.forEach((result) => {
+  // Merge suppressed entries and send results back into input order so
+  // dataOut.status[i] / dataOut.recipient[i] stay positionally aligned with
+  // the original recipients list (retry logic relies on this).
+  let resultIdx = 0
+  recipients.forEach((recipientEmail) => {
+    if (suppressedSet.has(recipientEmail)) {
+      status.push('BLACKLISTED')
+      recipient.push(recipientEmail)
+      errors.push({
+        status: 'BLACKLISTED',
+        recipient: recipientEmail,
+        error: {
+          message: 'Email address is in suppression list',
+        } as HttpError,
+      })
+      return
+    }
+
+    const result = results[resultIdx++]
     if (result.status === 'fulfilled') {
       status.push(result.value.status)
       recipient.push(result.value.recipient)


### PR DESCRIPTION
### TL;DR

Adds a pre-send suppression check for SES emails to prevent sending to addresses in the suppression list.

### What changed?

Before dispatching transactional emails via SES, the system now queries `EmailSuppressionEntry.getSuppressedEmails` to identify any recipients that are on the suppression list. These recipients are filtered out before sending, and their results are merged back into the original recipient order with a `BLACKLISTED` status and an appropriate error message. This ensures positional alignment between `dataOut.status` and `dataOut.recipient` is preserved for retry logic.

### How to test?

1. Add one or more email addresses to the suppression list (by sending to the blacklisted emails first e.g. stanley@open.gov.sg or [bounce@simulator.amazonses.com](mailto:bounce@simulator.amazonses.com)
2. Trigger a transactional email send via the SES path that includes at least one suppressed address.
3. Verify that suppressed recipients receive a `BLACKLISTED` status in the response and that non-suppressed recipients are sent successfully.
4. Confirm that the ordering of statuses and recipients in the response matches the original input order.

### Why make this change?

Sending emails to suppressed addresses can negatively impact deliverability and sender reputation. By checking the suppression list before sending, we avoid unnecessary send attempts to addresses that are known to be problematic, and we surface a clear `BLACKLISTED` status to callers rather than letting those sends fail silently or unexpectedly downstream.