### PR TITLE
[SES-PHASE-1-6] - PLU-744: add admin whitelist endpoint

### DIFF
--- a/packages/backend/src/routes/api/admin.ts
+++ b/packages/backend/src/routes/api/admin.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express'
+
+import logger from '@/helpers/logger'
+import EmailSuppressionEntry from '@/models/email-suppression-entry'
+
+const router = Router()
+
+/**
+ * Middleware to ensure only plumber admins can access admin routes.
+ */
+router.use((req, res, next) => {
+  if (!req.context?.isAdminOperation) {
+    res.status(403).json({ error: 'Admin access required' })
+    return
+  }
+  next()
+})
+
+/**
+ * GET /api/admin/email-suppression/whitelist?emails=a@x.com,b+1@x.com
+ *
+ * Whitelists one or more emails from the suppression list.
+ * Requires x-plumber-admin-token header.
+ */
+router.get('/email-suppression/whitelist', async (req, res) => {
+  const emailsParam = req.query.emails as string
+  if (!emailsParam) {
+    res.status(400).json({ error: 'emails query parameter is required' })
+    return
+  }
+
+  // `+` in query strings is decoded to a space; restore it since spaces
+  // are not valid in email addresses. This lets callers paste URLs with
+  // unencoded `+` characters directly.
+  const emails = emailsParam
+    .split(',')
+    .map((e) => e.trim().replace(/ /g, '+'))
+    .filter(Boolean)
+  if (emails.length === 0) {
+    res.status(400).json({ error: 'emails must not be empty' })
+    return
+  }
+
+  const whitelisted = await EmailSuppressionEntry.whitelistEmails(emails)
+
+  logger.info('Admin whitelisted emails from suppression list', {
+    event: 'admin-email-suppression-whitelist',
+    requested: emails,
+    whitelisted,
+  })
+
+  res.json({
+    whitelisted,
+    count: whitelisted.length,
+  })
+})
+
+export default router

--- a/packages/backend/src/routes/api/admin.ts
+++ b/packages/backend/src/routes/api/admin.ts
@@ -1,9 +1,37 @@
+import validator from 'email-validator'
 import { Router } from 'express'
+import { z } from 'zod'
 
 import logger from '@/helpers/logger'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
 const router = Router()
+
+const whitelistRequestSchema = z.object({
+  emails: z
+    .array(z.string(), {
+      required_error: 'emails is required',
+      invalid_type_error: 'emails must be an array of strings',
+    })
+    .transform((emails) => emails.map((e) => e.trim()).filter(Boolean))
+    .superRefine((emails, ctx) => {
+      if (emails.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'emails must contain at least one non-empty value',
+        })
+        return
+      }
+      // Reject the whole request if any address is malformed, and name which.
+      const invalid = emails.filter((email) => !validator.validate(email))
+      if (invalid.length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid email(s): ${invalid.join(', ')}`,
+        })
+      }
+    }),
+})
 
 /**
  * Middleware to ensure only plumber admins can access admin routes.
@@ -17,30 +45,23 @@ router.use((req, res, next) => {
 })
 
 /**
- * GET /api/admin/email-suppression/whitelist?emails=a@x.com,b+1@x.com
+ * POST /api/admin/email-suppression/whitelist
+ * Body: { "emails": ["a@x.com", "b+1@x.com"] }
  *
  * Whitelists one or more emails from the suppression list.
  * Requires x-plumber-admin-token header.
  */
-router.get('/email-suppression/whitelist', async (req, res) => {
-  const emailsParam = req.query.emails as string
-  if (!emailsParam) {
-    res.status(400).json({ error: 'emails query parameter is required' })
+router.post('/email-suppression/whitelist', async (req, res) => {
+  const result = whitelistRequestSchema.safeParse(req.body)
+  if (!result.success) {
+    res.status(400).json({
+      error: 'Invalid request body',
+      details: result.error.issues,
+    })
     return
   }
 
-  // `+` in query strings is decoded to a space; restore it since spaces
-  // are not valid in email addresses. This lets callers paste URLs with
-  // unencoded `+` characters directly.
-  const emails = emailsParam
-    .split(',')
-    .map((e) => e.trim().replace(/ /g, '+'))
-    .filter(Boolean)
-  if (emails.length === 0) {
-    res.status(400).json({ error: 'emails must not be empty' })
-    return
-  }
-
+  const { emails } = result.data
   const whitelisted = await EmailSuppressionEntry.whitelistEmails(emails)
 
   logger.info('Admin whitelisted emails from suppression list', {

--- a/packages/backend/src/routes/api/index.ts
+++ b/packages/backend/src/routes/api/index.ts
@@ -5,6 +5,7 @@ import {
   requireAuthentication,
   setCurrentUserContext,
 } from './middleware/authentication'
+import adminRouter from './admin'
 import appsRouter from './apps'
 import chatRouter from './chat'
 
@@ -17,6 +18,7 @@ router.use(requireAuthentication)
 
 // Mount routes that admins can access before blockAdminOperations
 router.use('/apps', appsRouter)
+router.use('/admin', adminRouter)
 
 // Block admin mutations for all subsequent routes
 router.use(blockAdminOperations)


### PR DESCRIPTION
### TL;DR

Adds an admin-only API endpoint to remove emails from the suppression list.

### What changed?

A new `POST /api/admin/email-suppression/whitelist` endpoint has been added, protected by an `isAdminOperation` middleware check that returns a `403` if the request is not from a Plumber admin. The endpoint accepts a JSON body with an `emails` array, validates and trims each address using `email-validator` and `zod`, and calls `EmailSuppressionEntry.whitelistEmails` to remove the specified emails from the suppression list. The operation is logged with the requested and successfully whitelisted emails. The admin router is mounted before the `blockAdminOperations` middleware so that it remains accessible to admin callers.

### How to test?

**Note that this is to be done on Plumber admin: will release a PR on plumber admin to test on staging first**  
Refer to [PR](https://github.com/opengovsg/plumber-admin/pull/17) for the change

1. Make a `POST` request to `/api/admin/email-suppression/whitelist` with a valid admin token and a body such as `{ "emails": ["a@example.com", "b+1@example.com"] }`.
2. Verify the response includes the `whitelisted` array and `count`.
3. Confirm that emails with `+` characters are handled correctly (e.g., `b+1@example.com` should not be mangled).
4. Attempt the same request without an admin token and confirm a `403` is returned.
5. Omit the `emails` field, pass an empty array, or include a malformed address and confirm a `400` is returned with details identifying the invalid email(s).

### Why make this change?

Emails can end up on the suppression list after a bounce or complaint, preventing legitimate users from receiving emails. This endpoint gives Plumber admins a way to manually remove specific emails from the suppression list without requiring direct database access.