### PR TITLE
[SES-PHASE-1-7] - PLU-744: add env vars for ses and sqs

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -309,6 +309,18 @@
     {
       "name": "DATABRICKS_CLIENT_SECRET",
       "valueFrom": "plumber-<ENVIRONMENT>-databricks-client-secret"
+    },
+    {
+      "name": "SES_ROLE_ARN",
+      "valueFrom": "plumber-ses-role-arn"
+    },
+    {
+      "name": "SES_CONFIGURATION_SET",
+      "valueFrom": "plumber-<ENVIRONMENT>-ses-configuration-set"
+    },
+    {
+      "name": "SQS_QUEUE_URL",
+      "valueFrom": "plumber-<ENVIRONMENT>-sqs-queue-url"
     }
   ]
 }


### PR DESCRIPTION
### TL;DR

Adds SES and SQS environment variable references to the ECS configuration.

### What changed?

Three new environment variable entries have been added to the ECS environment configuration:

- `SES_ROLE_ARN` — sourced from `plumber-ses-role-arn`
- `SES_CONFIGURATION_SET` — sourced from `plumber-<ENVIRONMENT>-ses-configuration-set`
- `SQS_QUEUE_URL` — sourced from `plumber-<ENVIRONMENT>-sqs-queue-url`

A missing newline at the end of the file has also been added.

### How to test?

**Note: Tested on UAT**

Deploy to a non-production environment and verify that the SES and SQS environment variables are correctly injected into the running ECS task. Confirm the values resolve properly from their respective secrets/parameter store entries.

### Why make this change?

These environment variables are required to support SES email sending (via an assumed IAM role and configuration set) and SQS queue integration within the ECS-hosted service.