### PR TITLE
[SES-PHASE-1-8] - PLU-744: add bounce rate tracking (exploration)

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -73,6 +73,10 @@ vi.mock('@/models/email-suppression-entry', () => ({
   },
 }))
 
+vi.mock('@/helpers/metrics', () => ({
+  incrementMetric: vi.fn(),
+}))
+
 describe('send transactional email', () => {
   let $: IGlobalVariable
 

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -8,6 +8,7 @@ import appConfig from '@/config/app'
 import HttpError from '@/errors/http'
 import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
+import { incrementMetric } from '@/helpers/metrics'
 import { getSesClient, shouldUseSes } from '@/helpers/ses-email-helper'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
@@ -158,6 +159,7 @@ async function sendViaSes(
       }),
     }),
   )
+  incrementMetric('ses.email.sent')
 
   // TODO: remove this log once the SES rollout is verified and stable.
   logger.info('Email sent via SES', {

--- a/packages/backend/src/helpers/metrics.ts
+++ b/packages/backend/src/helpers/metrics.ts
@@ -1,0 +1,10 @@
+import tracer from './tracer'
+
+export function incrementMetric(
+  name: string,
+  tags: Record<string, string> = {},
+): void {
+  tracer.dogstatsd.increment(name, 1, {
+    ...tags,
+  })
+}

--- a/packages/backend/src/helpers/process-ses-event.ts
+++ b/packages/backend/src/helpers/process-ses-event.ts
@@ -1,4 +1,5 @@
 import logger from '@/helpers/logger'
+import { incrementMetric } from '@/helpers/metrics'
 import { SesEvent, SesEventType } from '@/helpers/ses-event-parser'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
@@ -27,6 +28,11 @@ export async function processSesEvent(data: SesEventInput): Promise<void> {
   // needed, and the union is exhaustive.
   if (sesEvent.eventType === SesEventType.Bounce) {
     const { bounceType, bounceSubType, bouncedRecipients } = sesEvent.bounce
+
+    incrementMetric('ses.email.bounce', {
+      bounce_type: bounceType,
+      bounce_sub_type: bounceSubType ?? 'unknown',
+    })
 
     if (bounceType === 'Permanent') {
       // TODO: add micro-optimisation for upsertSuppression to blacklist multiple recipient emails in phase 2
@@ -63,6 +69,10 @@ export async function processSesEvent(data: SesEventInput): Promise<void> {
 
   if (sesEvent.eventType === SesEventType.Complaint) {
     const { complainedRecipients, complaintFeedbackType } = sesEvent.complaint
+
+    incrementMetric('ses.email.complaint', {
+      complaint_feedback_type: complaintFeedbackType ?? 'other',
+    })
 
     if (complaintFeedbackType === 'not-spam') {
       // Auto-whitelist: recipient marked the email as not-spam

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -4,6 +4,7 @@ import { fromTemporaryCredentials } from '@aws-sdk/credential-providers'
 import appConfig from '@/config/app'
 
 import logger from './logger'
+import { incrementMetric } from './metrics'
 
 let sesClient: SESv2Client | null = null
 
@@ -82,6 +83,7 @@ export async function sendEmailViaSes({
         }),
       }),
     )
+    incrementMetric('ses.email.sent')
   } catch (e) {
     logger.error('Error sending email via SES', {
       error: e,


### PR DESCRIPTION
### TL;DR

Add DogStatsD metrics tracking for SES email events (sent, bounced, complained).

### WHY???
- AWS reviews/suspends senders whose bounce rate stays above ~5/10% or complaint rate above ~0.5%.
- SES's own CloudWatch reputation metrics are account-level, not per-configuration-set.
- We can track and monitor internally since we have full context of whether an email is bounced or not

### What changed?

A new `incrementMetric` helper wraps the DogStatsD tracer client to provide a reusable way to emit counter metrics. This helper is now called in three places:

- When an email is successfully sent via SES (in both `email-helper.ts` and `ses-email-helper.ts`), emitting `ses.email.sent`
- When a bounce event is processed, emitting `ses.email.bounce` tagged with `bounce_type` and `bounce_sub_type`
- When a complaint event is processed, emitting `ses.email.complaint` tagged with `complaint_feedback_type`

### How to test?

To test locally, DogStatsD writes UDP packets to `127.0.0.1:8125`. Sniff with `nc`:

```sh
# Terminal A — listen
nc -ul 8125

```

```sh
# Terminal B — start app
cd packages/backend && npm run dev
```

Tried testing on `uat`
- Trigger a transactional email send and verify the `ses.email.sent` metric appears in Datadog
- Simulate or observe a bounce/complaint SES event being processed and verify the corresponding metrics appear with the correct tags in Datadog
- Run the existing test suite, which has been updated to mock the new `incrementMetric` helper

### Why make this change?

Visibility into SES email delivery health was limited. By tracking sent, bounce, and complaint counts as metrics in Datadog, we can monitor delivery rates, detect spikes in bounces or complaints, and set up alerts without relying solely on logs.