### PR TITLE
fix: only fetch execution steps for each iteration

### DIFF
--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -314,6 +314,7 @@ describe('getStepContext', () => {
       stepPositions: {},
       isForEachStep: false,
       isLastStep: false,
+      isInsideForEach: false,
     })
   })
 
@@ -476,6 +477,19 @@ describe('getStepContext', () => {
     ({ step, expected }) => {
       const context = getStepContext(mockFlow, step)
       expect(context.isForEachStep).toBe(expected)
+    },
+  )
+
+  it.each([
+    { step: mockFlow.steps[0], expected: false }, // trigger before for-each
+    { step: mockFlow.steps[1], expected: false }, // the for-each step itself
+    { step: mockFlow.steps[2], expected: true }, // action inside for-each
+    { step: mockFlow.steps[3], expected: true }, // last action inside for-each
+  ])(
+    'should return correct isInsideForEach for step $step.id',
+    ({ step, expected }) => {
+      const context = getStepContext(mockFlow, step)
+      expect(context.isInsideForEach).toBe(expected)
     },
   )
 })

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -479,19 +479,6 @@ describe('getStepContext', () => {
       expect(context.isForEachStep).toBe(expected)
     },
   )
-
-  it.each([
-    { step: mockFlow.steps[0], expected: false }, // trigger before for-each
-    { step: mockFlow.steps[1], expected: false }, // the for-each step itself
-    { step: mockFlow.steps[2], expected: true }, // action inside for-each
-    { step: mockFlow.steps[3], expected: true }, // last action inside for-each
-  ])(
-    'should return correct isInsideForEach for step $step.id',
-    ({ step, expected }) => {
-      const context = getStepContext(mockFlow, step)
-      expect(context.isInsideForEach).toBe(expected)
-    },
-  )
 })
 
 describe('computeForEachParameters', () => {

--- a/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
+++ b/packages/backend/src/helpers/__tests__/compute-for-each-parameters.test.ts
@@ -314,7 +314,6 @@ describe('getStepContext', () => {
       stepPositions: {},
       isForEachStep: false,
       isLastStep: false,
-      isInsideForEach: false,
     })
   })
 

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -29,7 +29,7 @@ export type ForEachContext = {
  * - stepPositions: map of step ids and their corresponding positions
  * - isForEachStep: whether the step is a for-each step
  * - isLastStep: whether the step is the last step in the pipe
- * - isInsideForEach: whether the step is within the for-each loop
+
  */
 export function getStepContext(
   flow: Flow,
@@ -39,7 +39,6 @@ export function getStepContext(
   stepPositions: Record<string, number>
   isForEachStep: boolean
   isLastStep: boolean
-  isInsideForEach: boolean
 } {
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
@@ -59,7 +58,6 @@ export function getStepContext(
       stepPositions: {},
       isForEachStep,
       isLastStep: false,
-      isInsideForEach: false,
     }
   }
 
@@ -94,14 +92,12 @@ export function getStepContext(
   )
 
   const forEachStepPosition = forEachSteps[0].position
-  const isInsideForEach = stepPositions[step.id] > forEachStepPosition
 
   return {
     forEachStepPosition,
     stepPositions,
     isForEachStep,
     isLastStep: lastStepId === step.id,
-    isInsideForEach,
   }
 }
 

--- a/packages/backend/src/helpers/compute-for-each-parameters.ts
+++ b/packages/backend/src/helpers/compute-for-each-parameters.ts
@@ -29,6 +29,7 @@ export type ForEachContext = {
  * - stepPositions: map of step ids and their corresponding positions
  * - isForEachStep: whether the step is a for-each step
  * - isLastStep: whether the step is the last step in the pipe
+ * - isInsideForEach: whether the step is within the for-each loop
  */
 export function getStepContext(
   flow: Flow,
@@ -38,6 +39,7 @@ export function getStepContext(
   stepPositions: Record<string, number>
   isForEachStep: boolean
   isLastStep: boolean
+  isInsideForEach: boolean
 } {
   const isForEachStep =
     step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.FOR_EACH
@@ -57,6 +59,7 @@ export function getStepContext(
       stepPositions: {},
       isForEachStep,
       isLastStep: false,
+      isInsideForEach: false,
     }
   }
 
@@ -90,11 +93,15 @@ export function getStepContext(
     },
   )
 
+  const forEachStepPosition = forEachSteps[0].position
+  const isInsideForEach = stepPositions[step.id] > forEachStepPosition
+
   return {
-    forEachStepPosition: forEachSteps[0].position,
+    forEachStepPosition,
     stepPositions,
     isForEachStep,
     isLastStep: lastStepId === step.id,
+    isInsideForEach,
   }
 }
 

--- a/packages/backend/src/services/__tests__/action.itest.ts
+++ b/packages/backend/src/services/__tests__/action.itest.ts
@@ -175,33 +175,12 @@ describe('processAction - priorExecutionSteps filtering', () => {
       mocks.computeParameters.mock.calls[0][1]
     const capturedIds = capturedSteps.map((s) => s.id).sort()
 
-    // trigger and for-each (no iteration) + action1 iteration 2 only
+    // action-before and for-each (no iteration) + action1 iteration 2 only
     expect(capturedIds).toEqual(
       [actionBeforeExecStep.id, forEachExecStep.id, action1Iter2.id].sort(),
     )
     expect(capturedIds).not.toContain(action1Iter1.id)
     expect(capturedIds).not.toContain(action1Iter3.id)
-  })
-
-  it('fetches only null-iteration steps when inside for-each with no iteration in metadata', async () => {
-    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
-    const forEachExecStep = await insertExecutionStep(forEachStep.id)
-    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
-
-    await processAction({
-      flowId: flow.id,
-      executionId: execution.id,
-      stepId: actionStep1.id,
-    })
-
-    const capturedSteps: ExecutionStep[] =
-      mocks.computeParameters.mock.calls[0][1]
-    const capturedIds = capturedSteps.map((s) => s.id).sort()
-
-    expect(capturedIds).toEqual(
-      [actionBeforeExecStep.id, forEachExecStep.id].sort(),
-    )
-    expect(capturedIds).not.toContain(action1Iter1.id)
   })
 
   it('fetches action1 steps only for the same iteration when processing action2', async () => {
@@ -224,7 +203,7 @@ describe('processAction - priorExecutionSteps filtering', () => {
       mocks.computeParameters.mock.calls[0][1]
     const capturedIds = capturedSteps.map((s) => s.id).sort()
 
-    // action2 should see: trigger, for-each, and action1 iter 2 only
+    // action2 should see: action-before, for-each, and action1 iter 2 only
     expect(capturedIds).toEqual(
       [actionBeforeExecStep.id, forEachExecStep.id, action1Iter2.id].sort(),
     )

--- a/packages/backend/src/services/__tests__/action.itest.ts
+++ b/packages/backend/src/services/__tests__/action.itest.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/apps/toolbox/common/constants'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+
+import { processAction } from '../action'
+
+const mocks = vi.hoisted(() => ({
+  computeParameters: vi.fn(),
+  getForEachMetadata: vi.fn(),
+  enqueueActionJob: vi.fn(),
+}))
+
+vi.mock('@/helpers/compute-parameters', () => ({
+  default: mocks.computeParameters,
+}))
+
+vi.mock('@/services/helpers/get-for-each-metadata', () => ({
+  default: mocks.getForEachMetadata,
+}))
+
+vi.mock('@/queues/action', () => ({
+  enqueueActionJob: mocks.enqueueActionJob,
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn() },
+}))
+
+describe('processAction - priorExecutionSteps filtering', () => {
+  let flow: Flow
+  let execution: Execution
+  let actionBeforeStep: Step
+  let forEachStep: Step
+  let actionStep1: Step
+  let actionStep2: Step
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mocks.computeParameters.mockReturnValue({})
+
+    const user = await User.query().findOne({ email: 'tester@open.gov.sg' })
+
+    flow = await Flow.query().insertGraphAndFetch({
+      userId: user.id,
+      name: 'test-for-each-flow',
+      steps: [
+        {
+          appKey: 'mock-app',
+          key: 'mock-trigger',
+          type: 'trigger',
+          position: 1,
+          status: 'completed',
+        },
+        {
+          appKey: 'mock-app',
+          key: 'mock-action-before',
+          type: 'action',
+          position: 2,
+          status: 'completed',
+        },
+        {
+          appKey: TOOLBOX_APP_KEY,
+          key: TOOLBOX_ACTIONS.FOR_EACH,
+          type: 'action',
+          position: 3,
+          status: 'completed',
+        },
+        {
+          appKey: 'mock-app',
+          key: 'mock-action-1',
+          type: 'action',
+          position: 4,
+          status: 'completed',
+        },
+        {
+          appKey: 'mock-app',
+          key: 'mock-action-2',
+          type: 'action',
+          position: 5,
+          status: 'completed',
+        },
+      ],
+    })
+    ;[, actionBeforeStep, forEachStep, actionStep1, actionStep2] = flow.steps
+
+    execution = await Execution.query().insertAndFetch({
+      flowId: flow.id,
+      testRun: false,
+    })
+
+    vi.spyOn(Step.prototype, 'getApp').mockResolvedValue({
+      key: 'mock-app',
+      apiBaseUrl: null,
+      beforeRequest: [],
+      requestErrorHandler: null,
+    } as any)
+
+    vi.spyOn(Step.prototype, 'getActionCommand').mockResolvedValue({
+      run: vi.fn().mockResolvedValue({}),
+      preprocessVariable: undefined,
+    } as any)
+
+    vi.spyOn(Step.prototype, 'getNextStep').mockResolvedValue(null)
+    vi.spyOn(Step.prototype, 'getTriggerCommand').mockResolvedValue({
+      type: 'polling',
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function insertExecutionStep(
+    stepId: string,
+    iteration?: number,
+  ): Promise<ExecutionStep> {
+    return ExecutionStep.query().insertAndFetch({
+      executionId: execution.id,
+      stepId,
+      status: 'success',
+      dataOut: {},
+      ...(iteration !== undefined && { metadata: { iteration } }),
+    })
+  }
+
+  it('fetches all execution steps when not inside a for-each', async () => {
+    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
+    const forEachExecStep = await insertExecutionStep(forEachStep.id)
+    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
+    const action1Iter2 = await insertExecutionStep(actionStep1.id, 2)
+
+    await processAction({
+      flowId: flow.id,
+      executionId: execution.id,
+      stepId: actionBeforeStep.id,
+    })
+
+    const capturedSteps: ExecutionStep[] =
+      mocks.computeParameters.mock.calls[0][1]
+    const capturedIds = capturedSteps.map((s) => s.id).sort()
+
+    expect(capturedIds).toEqual(
+      [
+        actionBeforeExecStep.id,
+        forEachExecStep.id,
+        action1Iter1.id,
+        action1Iter2.id,
+      ].sort(),
+    )
+  })
+
+  it('fetches only null-iteration steps and same-iteration steps when inside for-each', async () => {
+    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
+    const forEachExecStep = await insertExecutionStep(forEachStep.id)
+    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
+    const action1Iter2 = await insertExecutionStep(actionStep1.id, 2)
+    const action1Iter3 = await insertExecutionStep(actionStep1.id, 3)
+
+    await processAction({
+      flowId: flow.id,
+      executionId: execution.id,
+      stepId: actionStep1.id,
+      metadata: { iteration: 2 },
+    })
+
+    const capturedSteps: ExecutionStep[] =
+      mocks.computeParameters.mock.calls[0][1]
+    const capturedIds = capturedSteps.map((s) => s.id).sort()
+
+    // trigger and for-each (no iteration) + action1 iteration 2 only
+    expect(capturedIds).toEqual(
+      [actionBeforeExecStep.id, forEachExecStep.id, action1Iter2.id].sort(),
+    )
+    expect(capturedIds).not.toContain(action1Iter1.id)
+    expect(capturedIds).not.toContain(action1Iter3.id)
+  })
+
+  it('fetches only null-iteration steps when inside for-each with no iteration in metadata', async () => {
+    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
+    const forEachExecStep = await insertExecutionStep(forEachStep.id)
+    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
+
+    await processAction({
+      flowId: flow.id,
+      executionId: execution.id,
+      stepId: actionStep1.id,
+    })
+
+    const capturedSteps: ExecutionStep[] =
+      mocks.computeParameters.mock.calls[0][1]
+    const capturedIds = capturedSteps.map((s) => s.id).sort()
+
+    expect(capturedIds).toEqual(
+      [actionBeforeExecStep.id, forEachExecStep.id].sort(),
+    )
+    expect(capturedIds).not.toContain(action1Iter1.id)
+  })
+
+  it('fetches action1 steps only for the same iteration when processing action2', async () => {
+    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
+    const forEachExecStep = await insertExecutionStep(forEachStep.id)
+    // action1 has run for iterations 1, 2, and 3
+    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
+    const action1Iter2 = await insertExecutionStep(actionStep1.id, 2)
+    const action1Iter3 = await insertExecutionStep(actionStep1.id, 3)
+
+    // now processing action2 for iteration 2
+    await processAction({
+      flowId: flow.id,
+      executionId: execution.id,
+      stepId: actionStep2.id,
+      metadata: { iteration: 2 },
+    })
+
+    const capturedSteps: ExecutionStep[] =
+      mocks.computeParameters.mock.calls[0][1]
+    const capturedIds = capturedSteps.map((s) => s.id).sort()
+
+    // action2 should see: trigger, for-each, and action1 iter 2 only
+    expect(capturedIds).toEqual(
+      [actionBeforeExecStep.id, forEachExecStep.id, action1Iter2.id].sort(),
+    )
+    expect(capturedIds).not.toContain(action1Iter1.id)
+    expect(capturedIds).not.toContain(action1Iter3.id)
+  })
+})

--- a/packages/backend/src/services/__tests__/action.itest.ts
+++ b/packages/backend/src/services/__tests__/action.itest.ts
@@ -210,4 +210,38 @@ describe('processAction - priorExecutionSteps filtering', () => {
     expect(capturedIds).not.toContain(action1Iter1.id)
     expect(capturedIds).not.toContain(action1Iter3.id)
   })
+
+  it('does not throw when test-running a step inside for-each without iteration metadata', async () => {
+    // mirrors how test-step.ts invokes processAction: testRun: true with no metadata.
+    // With the iteration filter bound to `undefined`, knex throws an undefined-binding
+    // error before computeParameters is reached.
+    const actionBeforeExecStep = await insertExecutionStep(actionBeforeStep.id)
+    const forEachExecStep = await insertExecutionStep(forEachStep.id)
+    const action1Iter1 = await insertExecutionStep(actionStep1.id, 1)
+    const action1Iter2 = await insertExecutionStep(actionStep1.id, 2)
+
+    await processAction({
+      flowId: flow.id,
+      executionId: execution.id,
+      stepId: actionStep1.id,
+      testRun: true,
+    })
+
+    expect(mocks.computeParameters).toHaveBeenCalledTimes(1)
+
+    const capturedSteps: ExecutionStep[] =
+      mocks.computeParameters.mock.calls[0][1]
+    const capturedIds = capturedSteps.map((s) => s.id).sort()
+
+    // without an iteration to scope to, the filter should be skipped and all
+    // prior execution steps should be visible (same behavior as not-inside-for-each)
+    expect(capturedIds).toEqual(
+      [
+        actionBeforeExecStep.id,
+        forEachExecStep.id,
+        action1Iter1.id,
+        action1Iter2.id,
+      ].sort(),
+    )
+  })
 })

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,6 +1,7 @@
 import type { IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { ref } from 'objection'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -103,8 +104,13 @@ export const processAction = async (options: ProcessActionOptions) => {
     .findById(executionId)
     .throwIfNotFound()
 
-  const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
-    getStepContext(flow, step)
+  const {
+    forEachStepPosition,
+    stepPositions,
+    isForEachStep,
+    isLastStep,
+    isInsideForEach,
+  } = getStepContext(flow, step)
 
   // we use this to indicate an iteration in the for-each is complete
   if (!testRun && forEachStepPosition > -1 && isLastStep && metadata) {
@@ -121,11 +127,22 @@ export const processAction = async (options: ProcessActionOptions) => {
     metadata,
   })
 
-  const priorExecutionSteps = await ExecutionStep.query().where({
-    execution_id: $.execution.id,
-    // only get successful execution steps
-    status: 'success',
-  })
+  const priorExecutionSteps = await ExecutionStep.query()
+    .where({
+      execution_id: $.execution.id,
+      // only get successful execution steps
+      status: 'success',
+    })
+    .where((builder) => {
+      // NOTE: when the step is within a for-each loop, we only want to retrieve the execution steps before the for-each
+      // and all the execution steps for the current iteration.
+      if (isInsideForEach) {
+        builder.whereNull(ref('metadata:iteration'))
+        if (metadata?.iteration !== undefined) {
+          builder.orWhere(ref('metadata:iteration'), metadata.iteration)
+        }
+      }
+    })
 
   const actionCommand = await step.getActionCommand()
   const forEachContext: ForEachContext = {

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,7 +1,6 @@
 import type { IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
-import { ref } from 'objection'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -137,10 +136,11 @@ export const processAction = async (options: ProcessActionOptions) => {
       // NOTE: when the step is within a for-each loop, we only want to retrieve the execution steps before the for-each
       // and all the execution steps for the current iteration.
       if (isInsideForEach) {
-        builder.whereNull(ref('metadata:iteration'))
-        if (metadata?.iteration !== undefined) {
-          builder.orWhere(ref('metadata:iteration'), metadata.iteration)
-        }
+        builder.whereRaw(`(execution_steps.metadata ->> 'iteration') is null`)
+        builder.orWhereRaw(
+          `(execution_steps.metadata ->> 'iteration')::int = ?`,
+          [metadata.iteration],
+        )
       }
     })
 

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -103,13 +103,8 @@ export const processAction = async (options: ProcessActionOptions) => {
     .findById(executionId)
     .throwIfNotFound()
 
-  const {
-    forEachStepPosition,
-    stepPositions,
-    isForEachStep,
-    isLastStep,
-    isInsideForEach,
-  } = getStepContext(flow, step)
+  const { forEachStepPosition, stepPositions, isForEachStep, isLastStep } =
+    getStepContext(flow, step)
 
   // we use this to indicate an iteration in the for-each is complete
   if (!testRun && forEachStepPosition > -1 && isLastStep && metadata) {
@@ -135,7 +130,7 @@ export const processAction = async (options: ProcessActionOptions) => {
     .where((builder) => {
       // NOTE: when the step is within a for-each loop, we only want to retrieve the execution steps before the for-each
       // and all the execution steps for the current iteration.
-      if (isInsideForEach) {
+      if (metadata.iteration !== undefined) {
         builder.whereRaw(`(execution_steps.metadata ->> 'iteration') is null`)
         builder.orWhereRaw(
           `(execution_steps.metadata ->> 'iteration')::int = ?`,


### PR DESCRIPTION
## Problem
The execution context model treats all prior step outputs as live variables for the entire pipe execution, including across loop iterations. This compounds badly with loops over large outputs.

## Solution
Only fetch the execution steps for the specific iteration when inside a loop.

## Tests
- [ ] Verify that Pipes with For-each still work as intended
  - [ ] Using Tiles - Find multiple rows
  - [ ] Using Excel - Get multiple table rows
  - [ ] Using FormSG - Table field
- [ ] Verify that Pipes without For-each still work as intended
