### PR TITLE
PLU-753: create pipe killswitch

### DIFF
--- a/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
+++ b/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
@@ -218,4 +218,20 @@ describe('webhook handler', () => {
       expect(mocks.response.sendStatus).toHaveReturnedWith(200)
     })
   })
+
+  describe('pipe force clog', () => {
+    beforeEach(() => {
+      mocks.flow.config = {}
+    })
+
+    it('returns 423 and does not process the trigger or enqueue a job', async () => {
+      mocks.flow.config = { isForceClogged: true }
+
+      await webhookHandler(request, mocks.response)
+
+      expect(mocks.response.sendStatus).toHaveReturnedWith(423)
+      expect(mocks.processTrigger).not.toHaveBeenCalled()
+      expect(mocks.enqueueActionJob).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
+++ b/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
@@ -219,13 +219,13 @@ describe('webhook handler', () => {
     })
   })
 
-  describe('pipe killswitch', () => {
+  describe('pipe force clog', () => {
     beforeEach(() => {
       mocks.flow.config = {}
     })
 
     it('returns 500 and does not process the trigger or enqueue a job', async () => {
-      mocks.flow.config = { isKillswitched: true }
+      mocks.flow.config = { isForceClogged: true }
 
       await webhookHandler(request, mocks.response)
 

--- a/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
+++ b/packages/backend/src/controllers/__tests__/webhooks/handler.test.ts
@@ -218,4 +218,20 @@ describe('webhook handler', () => {
       expect(mocks.response.sendStatus).toHaveReturnedWith(200)
     })
   })
+
+  describe('pipe killswitch', () => {
+    beforeEach(() => {
+      mocks.flow.config = {}
+    })
+
+    it('returns 500 and does not process the trigger or enqueue a job', async () => {
+      mocks.flow.config = { isKillswitched: true }
+
+      await webhookHandler(request, mocks.response)
+
+      expect(mocks.response.sendStatus).toHaveReturnedWith(500)
+      expect(mocks.processTrigger).not.toHaveBeenCalled()
+      expect(mocks.enqueueActionJob).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -63,6 +63,10 @@ export default async (request: IRequest, response: Response) => {
     return response.sendStatus(404)
   }
 
+  if (flow.config?.isForceClogged) {
+    return response.sendStatus(423)
+  }
+
   const { maxQps = DEFAULT_MAX_QPS, rejectIfOverMaxQps = true } =
     flow.config ?? {}
 

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -63,6 +63,10 @@ export default async (request: IRequest, response: Response) => {
     return response.sendStatus(404)
   }
 
+  if (flow.config?.isKillswitched) {
+    return response.sendStatus(500)
+  }
+
   const { maxQps = DEFAULT_MAX_QPS, rejectIfOverMaxQps = true } =
     flow.config ?? {}
 

--- a/packages/backend/src/controllers/webhooks/handler.ts
+++ b/packages/backend/src/controllers/webhooks/handler.ts
@@ -63,7 +63,7 @@ export default async (request: IRequest, response: Response) => {
     return response.sendStatus(404)
   }
 
-  if (flow.config?.isKillswitched) {
+  if (flow.config?.isForceClogged) {
     return response.sendStatus(500)
   }
 

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -39,6 +39,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
     delete prevConfig['attachments']
     delete prevConfig['errorConfig']
     delete prevConfig['maxQps']
+    delete prevConfig['isForceClogged']
 
     const duplicatedFlow = await context.currentUser
       .$relatedQuery('flows', trx)

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -77,6 +77,9 @@ class Flow extends Base {
               },
             },
           },
+          isForceClogged: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -77,7 +77,7 @@ class Flow extends Base {
               },
             },
           },
-          isKillswitched: {
+          isForceClogged: {
             type: 'boolean',
           },
         },

--- a/packages/backend/src/models/flow.ts
+++ b/packages/backend/src/models/flow.ts
@@ -77,6 +77,9 @@ class Flow extends Base {
               },
             },
           },
+          isKillswitched: {
+            type: 'boolean',
+          },
         },
       },
     },

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -1,0 +1,169 @@
+import { IFlowConfig } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { processAction } from '../action'
+
+const mocks = vi.hoisted(() => {
+  const executionStep = {
+    id: 'exec-step-id',
+    isFailed: false,
+    status: 'success',
+  }
+  const execution = {
+    id: 'execution-id',
+    $relatedQuery: vi.fn(() => ({
+      insertAndFetch: vi.fn(() => ({
+        onConflict: vi.fn(() => ({
+          ignore: vi.fn(() => () => executionStep),
+        })),
+      })),
+    })),
+  }
+  const step = {
+    id: 'step-id',
+    appKey: 'webhook',
+    parameters: {},
+    key: 'new-submission',
+    config: {},
+    getApp: vi.fn(() => ({ key: 'webhook' })),
+    getActionCommand: vi.fn(() => ({
+      run: vi.fn(),
+      preprocessVariable: undefined,
+    })),
+    getNextStep: vi.fn(() => null),
+    $relatedQuery: vi.fn(() => null),
+  }
+  const flow = {
+    id: 'flow-id',
+    config: null as IFlowConfig | null,
+    user: { email: 'test@example.com' },
+    steps: [] as unknown[],
+  }
+
+  return {
+    step,
+    flow,
+    execution,
+    executionStep,
+    globalVariable: vi.fn(() => ({
+      step: { parameters: {} },
+      actionOutput: { data: null, error: null },
+      execution: { id: 'execution-id' },
+      app: { key: 'webhook' },
+    })),
+  }
+})
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.step),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/flow', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        withGraphJoined: vi.fn(() => ({
+          withGraphFetched: vi.fn(() => ({
+            throwIfNotFound: vi.fn(() => mocks.flow),
+          })),
+        })),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.execution),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/execution-step', () => {
+  const chainable: Record<string, unknown> = {}
+  chainable.where = vi.fn(() => chainable)
+  chainable.then = (onFulfilled: (value: unknown[]) => unknown) =>
+    onFulfilled([])
+  return {
+    default: {
+      query: vi.fn(() => chainable),
+    },
+  }
+})
+
+vi.mock('@/helpers/compute-for-each-parameters', () => ({
+  getStepContext: vi.fn(() => ({
+    forEachStepPosition: -1,
+    stepPositions: [],
+    isForEachStep: false,
+    isLastStep: false,
+  })),
+}))
+
+vi.mock('@/helpers/compute-parameters', () => ({
+  default: vi.fn(() => ({})),
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: mocks.globalVariable,
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('@/services/helpers/get-for-each-metadata', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/queues/action', () => ({
+  enqueueActionJob: vi.fn(),
+}))
+
+const OPTIONS = {
+  flowId: 'flow-id',
+  stepId: 'step-id',
+  executionId: 'execution-id',
+}
+
+describe('processAction', () => {
+  beforeEach(() => {
+    mocks.flow.config = null
+    mocks.executionStep.isFailed = false
+    mocks.executionStep.status = 'success'
+  })
+
+  describe('Force clogging', () => {
+    it('throws an UnrecoverableError when flow.config.isForceClogged is true', async () => {
+      mocks.flow.config = { isForceClogged: true }
+
+      await expect(processAction(OPTIONS)).rejects.toThrow(
+        'Pipe flow-id has been force clogged',
+      )
+    })
+
+    it('does not throw UnrecoverableError when flow.config.isForceClogged is false', async () => {
+      mocks.flow.config = { isForceClogged: false }
+
+      const result = await processAction(OPTIONS)
+      expect(result.executionError).toBeNull()
+    })
+
+    it('does not throw error when flow has no config', async () => {
+      mocks.flow.config = null
+
+      const result = await processAction(OPTIONS)
+      expect(result.executionError).toBeNull()
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -136,9 +136,9 @@ describe('processAction', () => {
     mocks.executionStep.status = 'success'
   })
 
-  describe('pipe killswitch', () => {
-    it('sets executionError to UnrecoverableError when flow.config.isKillswitched is true', async () => {
-      mocks.flow.config = { isKillswitched: true }
+  describe('pipe force clog', () => {
+    it('sets executionError to UnrecoverableError when flow.config.isForceClogged is true', async () => {
+      mocks.flow.config = { isForceClogged: true }
       mocks.executionStep.isFailed = true
       mocks.executionStep.status = 'failure'
 
@@ -147,8 +147,8 @@ describe('processAction', () => {
       expect(result.executionError).toBeInstanceOf(UnrecoverableError)
     })
 
-    it('does not set executionError when flow.config.isKillswitched is false', async () => {
-      mocks.flow.config = { isKillswitched: false }
+    it('does not set executionError when flow.config.isForceClogged is false', async () => {
+      mocks.flow.config = { isForceClogged: false }
 
       const result = await processAction(OPTIONS)
 

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -86,13 +86,17 @@ vi.mock('@/models/execution', () => ({
   },
 }))
 
-vi.mock('@/models/execution-step', () => ({
-  default: {
-    query: vi.fn(() => ({
-      where: vi.fn(() => []),
-    })),
-  },
-}))
+vi.mock('@/models/execution-step', () => {
+  const chainable: Record<string, unknown> = {}
+  chainable.where = vi.fn(() => chainable)
+  chainable.then = (onFulfilled: (value: unknown[]) => unknown) =>
+    onFulfilled([])
+  return {
+    default: {
+      query: vi.fn(() => chainable),
+    },
+  }
+})
 
 vi.mock('@/helpers/compute-for-each-parameters', () => ({
   getStepContext: vi.fn(() => ({
@@ -136,30 +140,25 @@ describe('processAction', () => {
     mocks.executionStep.status = 'success'
   })
 
-  describe('pipe force clog', () => {
-    it('sets executionError to UnrecoverableError when flow.config.isForceClogged is true', async () => {
+  describe('Force clogging', () => {
+    it('throws an UnrecoverableError when flow.config.isForceClogged is true', async () => {
       mocks.flow.config = { isForceClogged: true }
-      mocks.executionStep.isFailed = true
-      mocks.executionStep.status = 'failure'
 
       const result = await processAction(OPTIONS)
-
       expect(result.executionError).toBeInstanceOf(UnrecoverableError)
     })
 
-    it('does not set executionError when flow.config.isForceClogged is false', async () => {
+    it('does not throw UnrecoverableError when flow.config.isForceClogged is false', async () => {
       mocks.flow.config = { isForceClogged: false }
 
       const result = await processAction(OPTIONS)
-
       expect(result.executionError).toBeNull()
     })
 
-    it('does not set executionError when flow has no config', async () => {
+    it('does not throw error when flow has no config', async () => {
       mocks.flow.config = null
 
       const result = await processAction(OPTIONS)
-
       expect(result.executionError).toBeNull()
     })
   })

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -1,3 +1,5 @@
+import { IFlowConfig } from '@plumber/types'
+
 import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -31,9 +33,9 @@ const mocks = vi.hoisted(() => {
   }
   const flow = {
     id: 'flow-id',
-    config: null as { isKillswitched?: boolean } | null,
+    config: null as IFlowConfig | null,
     user: { email: 'test@example.com' },
-    steps: [],
+    steps: [] as unknown[],
   }
 
   return {

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -1,0 +1,160 @@
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { processAction } from '../action'
+
+const mocks = vi.hoisted(() => {
+  const executionStep = { id: 'exec-step-id', isFailed: false, status: 'success' }
+  const execution = {
+    id: 'execution-id',
+    $relatedQuery: vi.fn(() => ({
+      insertAndFetch: vi.fn(() => executionStep),
+    })),
+  }
+  const step = {
+    id: 'step-id',
+    appKey: 'webhook',
+    parameters: {},
+    key: 'new-submission',
+    config: {},
+    getApp: vi.fn(() => ({ key: 'webhook' })),
+    getActionCommand: vi.fn(() => ({
+      run: vi.fn(),
+      preprocessVariable: undefined,
+    })),
+    getNextStep: vi.fn(() => null),
+    $relatedQuery: vi.fn(() => null),
+  }
+  const flow = {
+    id: 'flow-id',
+    config: null as { isKillswitched?: boolean } | null,
+    user: { email: 'test@example.com' },
+    steps: [],
+  }
+
+  return {
+    step,
+    flow,
+    execution,
+    executionStep,
+    globalVariable: vi.fn(() => ({
+      step: { parameters: {} },
+      actionOutput: { data: null, error: null },
+      execution: { id: 'execution-id' },
+      app: { key: 'webhook' },
+    })),
+  }
+})
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.step),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/flow', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        withGraphJoined: vi.fn(() => ({
+          withGraphFetched: vi.fn(() => ({
+            throwIfNotFound: vi.fn(() => mocks.flow),
+          })),
+        })),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.execution),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/execution-step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      where: vi.fn(() => []),
+    })),
+  },
+}))
+
+vi.mock('@/helpers/compute-for-each-parameters', () => ({
+  getStepContext: vi.fn(() => ({
+    forEachStepPosition: -1,
+    stepPositions: [],
+    isForEachStep: false,
+    isLastStep: false,
+  })),
+}))
+
+vi.mock('@/helpers/compute-parameters', () => ({
+  default: vi.fn(() => ({})),
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: mocks.globalVariable,
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+
+vi.mock('@/services/helpers/get-for-each-metadata', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@/queues/action', () => ({
+  enqueueActionJob: vi.fn(),
+}))
+
+const OPTIONS = {
+  flowId: 'flow-id',
+  stepId: 'step-id',
+  executionId: 'execution-id',
+}
+
+describe('processAction', () => {
+  beforeEach(() => {
+    mocks.flow.config = null
+    mocks.executionStep.isFailed = false
+    mocks.executionStep.status = 'success'
+  })
+
+  describe('pipe killswitch', () => {
+    it('sets executionError to UnrecoverableError when flow.config.isKillswitched is true', async () => {
+      mocks.flow.config = { isKillswitched: true }
+      mocks.executionStep.isFailed = true
+      mocks.executionStep.status = 'failure'
+
+      const result = await processAction(OPTIONS)
+
+      expect(result.executionError).toBeInstanceOf(UnrecoverableError)
+    })
+
+    it('does not set executionError when flow.config.isKillswitched is false', async () => {
+      mocks.flow.config = { isKillswitched: false }
+
+      const result = await processAction(OPTIONS)
+
+      expect(result.executionError).toBeNull()
+    })
+
+    it('does not set executionError when flow has no config', async () => {
+      mocks.flow.config = null
+
+      const result = await processAction(OPTIONS)
+
+      expect(result.executionError).toBeNull()
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/action.test.ts
+++ b/packages/backend/src/services/__tests__/action.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { processAction } from '../action'
 
 const mocks = vi.hoisted(() => {
-  const executionStep = { id: 'exec-step-id', isFailed: false, status: 'success' }
+  const executionStep = {
+    id: 'exec-step-id',
+    isFailed: false,
+    status: 'success',
+  }
   const execution = {
     id: 'execution-id',
     $relatedQuery: vi.fn(() => ({

--- a/packages/backend/src/services/__tests__/trigger.itest.ts
+++ b/packages/backend/src/services/__tests__/trigger.itest.ts
@@ -1,3 +1,5 @@
+import { IFlowConfig } from '@plumber/types'
+
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -30,10 +32,13 @@ describe('processTrigger', () => {
       id: stepId,
       appKey: 'formsg',
       parameters: {},
+      flow: { id: flowId, config: null as IFlowConfig | null },
     }
     vi.spyOn(Step, 'query').mockReturnValue({
       findById: vi.fn().mockReturnValue({
-        throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+        withGraphFetched: vi.fn().mockReturnValue({
+          throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+        }),
       }),
     } as any)
 
@@ -121,10 +126,15 @@ describe('processTrigger', () => {
         id: stepId,
         appKey: 'gathersg',
         parameters: {},
+        flow: {
+          id: flowId,
+        },
       }
       vi.spyOn(Step, 'query').mockReturnValue({
         findById: vi.fn().mockReturnValue({
-          throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+          withGraphFetched: vi.fn().mockReturnValue({
+            throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+          }),
         }),
       } as any)
     })

--- a/packages/backend/src/services/__tests__/trigger.itest.ts
+++ b/packages/backend/src/services/__tests__/trigger.itest.ts
@@ -1,3 +1,5 @@
+import { IFlowConfig } from '@plumber/types'
+
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -22,7 +24,7 @@ describe('processTrigger', () => {
       id: stepId,
       appKey: 'formsg',
       parameters: {},
-      flow: { id: flowId, config: null },
+      flow: { id: flowId, config: null as IFlowConfig | null },
     }
     vi.spyOn(Step, 'query').mockReturnValue({
       findById: vi.fn().mockReturnValue({
@@ -113,7 +115,9 @@ describe('processTrigger', () => {
         id: stepId,
         appKey: 'gathersg',
         parameters: {},
-        flow: { id: flowId, config: null },
+        flow: {
+          id: flowId,
+        },
       }
       vi.spyOn(Step, 'query').mockReturnValue({
         findById: vi.fn().mockReturnValue({

--- a/packages/backend/src/services/__tests__/trigger.itest.ts
+++ b/packages/backend/src/services/__tests__/trigger.itest.ts
@@ -22,10 +22,13 @@ describe('processTrigger', () => {
       id: stepId,
       appKey: 'formsg',
       parameters: {},
+      flow: { id: flowId, config: null },
     }
     vi.spyOn(Step, 'query').mockReturnValue({
       findById: vi.fn().mockReturnValue({
-        throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+        withGraphFetched: vi.fn().mockReturnValue({
+          throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+        }),
       }),
     } as any)
 
@@ -110,10 +113,13 @@ describe('processTrigger', () => {
         id: stepId,
         appKey: 'gathersg',
         parameters: {},
+        flow: { id: flowId, config: null },
       }
       vi.spyOn(Step, 'query').mockReturnValue({
         findById: vi.fn().mockReturnValue({
-          throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+          withGraphFetched: vi.fn().mockReturnValue({
+            throwIfNotFound: vi.fn().mockResolvedValue(mockStep),
+          }),
         }),
       } as any)
     })

--- a/packages/backend/src/services/__tests__/trigger.test.ts
+++ b/packages/backend/src/services/__tests__/trigger.test.ts
@@ -1,0 +1,100 @@
+import { IFlowConfig } from '@plumber/types'
+
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { processTrigger } from '../trigger'
+
+const mocks = vi.hoisted(() => {
+  const executionStep = { id: 'exec-step-id', isFailed: false }
+  const execution = {
+    id: 'execution-id',
+    $relatedQuery: vi.fn(() => ({
+      insertAndFetch: vi.fn(() => ({
+        onConflict: vi.fn(() => ({
+          ignore: vi.fn(() => executionStep),
+        })),
+      })),
+    })),
+  }
+
+  const flow = {
+    id: 'flow-id',
+    config: null as IFlowConfig | null,
+  }
+
+  return {
+    step: {
+      id: 'step-id',
+      appKey: 'webhook',
+      parameters: {},
+      key: 'new-submission',
+      config: {},
+      flow,
+    },
+    flow,
+    execution,
+    shouldTriggerProceed: vi.fn(() => ({ shouldExecute: true })),
+  }
+})
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        withGraphFetched: vi.fn(() => ({
+          throwIfNotFound: vi.fn(() => mocks.step),
+        })),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/services/helpers/should-trigger-proceed', () => ({
+  shouldTriggerProceed: mocks.shouldTriggerProceed,
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    query: vi.fn(() => ({
+      insert: vi.fn(() => ({
+        onConflict: vi.fn(() => ({
+          ignore: vi.fn(() => mocks.execution),
+        })),
+      })),
+    })),
+    transaction: vi.fn((callback) => callback('mock-trx')),
+  },
+}))
+
+describe('processTrigger', () => {
+  beforeEach(() => {
+    mocks.flow.config = null
+  })
+
+  describe('Force clogging', () => {
+    it('throws UnrecoverableError when flow.config.isForceClogged is true', async () => {
+      mocks.flow.config = { isForceClogged: true }
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).rejects.toThrow(UnrecoverableError)
+    })
+
+    it('does not throw when flow.config.isForceClogged is false', async () => {
+      mocks.flow.config = { isForceClogged: false }
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).resolves.toMatchObject({ shouldExecute: true })
+    })
+
+    it('does not throw when flow has no config', async () => {
+      mocks.flow.config = null
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).resolves.toMatchObject({ shouldExecute: true })
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/trigger.test.ts
+++ b/packages/backend/src/services/__tests__/trigger.test.ts
@@ -1,0 +1,94 @@
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { processTrigger } from '../trigger'
+
+const mocks = vi.hoisted(() => {
+  const executionStep = { id: 'exec-step-id', isFailed: false }
+  const execution = {
+    id: 'execution-id',
+    $relatedQuery: vi.fn(() => ({
+      insertAndFetch: vi.fn(() => executionStep),
+    })),
+  }
+
+  return {
+    step: {
+      id: 'step-id',
+      appKey: 'webhook',
+      parameters: {},
+      key: 'new-submission',
+      config: {},
+    },
+    flow: {
+      id: 'flow-id',
+      config: null as { isKillswitched?: boolean } | null,
+    },
+    execution,
+    shouldTriggerProceed: vi.fn(() => ({ shouldExecute: true })),
+  }
+})
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.step),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/models/flow', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: vi.fn(() => mocks.flow),
+      })),
+    })),
+  },
+}))
+
+vi.mock('@/services/helpers/should-trigger-proceed', () => ({
+  shouldTriggerProceed: mocks.shouldTriggerProceed,
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    query: vi.fn(() => ({
+      insert: vi.fn(() => mocks.execution),
+    })),
+  },
+}))
+
+describe('processTrigger', () => {
+  beforeEach(() => {
+    mocks.flow.config = null
+  })
+
+  describe('pipe killswitch', () => {
+    it('throws UnrecoverableError when flow.config.isKillswitched is true', async () => {
+      mocks.flow.config = { isKillswitched: true }
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).rejects.toThrow(UnrecoverableError)
+    })
+
+    it('does not throw when flow.config.isKillswitched is false', async () => {
+      mocks.flow.config = { isKillswitched: false }
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).resolves.toMatchObject({ shouldExecute: true })
+    })
+
+    it('does not throw when flow has no config', async () => {
+      mocks.flow.config = null
+
+      await expect(
+        processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
+      ).resolves.toMatchObject({ shouldExecute: true })
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/trigger.test.ts
+++ b/packages/backend/src/services/__tests__/trigger.test.ts
@@ -1,3 +1,5 @@
+import { IFlowConfig } from '@plumber/types'
+
 import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,7 +16,7 @@ const mocks = vi.hoisted(() => {
 
   const flow = {
     id: 'flow-id',
-    config: null as { isKillswitched?: boolean } | null,
+    config: null as IFlowConfig | null,
   }
 
   return {
@@ -61,17 +63,17 @@ describe('processTrigger', () => {
     mocks.flow.config = null
   })
 
-  describe('pipe killswitch', () => {
-    it('throws UnrecoverableError when flow.config.isKillswitched is true', async () => {
-      mocks.flow.config = { isKillswitched: true }
+  describe('pipe force clog', () => {
+    it('throws UnrecoverableError when flow.config.isForceClogged is true', async () => {
+      mocks.flow.config = { isForceClogged: true }
 
       await expect(
         processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),
       ).rejects.toThrow(UnrecoverableError)
     })
 
-    it('does not throw when flow.config.isKillswitched is false', async () => {
-      mocks.flow.config = { isKillswitched: false }
+    it('does not throw when flow.config.isForceClogged is false', async () => {
+      mocks.flow.config = { isForceClogged: false }
 
       await expect(
         processTrigger({ flowId: 'flow-id', stepId: 'step-id' }),

--- a/packages/backend/src/services/__tests__/trigger.test.ts
+++ b/packages/backend/src/services/__tests__/trigger.test.ts
@@ -12,6 +12,11 @@ const mocks = vi.hoisted(() => {
     })),
   }
 
+  const flow = {
+    id: 'flow-id',
+    config: null as { isKillswitched?: boolean } | null,
+  }
+
   return {
     step: {
       id: 'step-id',
@@ -19,11 +24,9 @@ const mocks = vi.hoisted(() => {
       parameters: {},
       key: 'new-submission',
       config: {},
+      flow,
     },
-    flow: {
-      id: 'flow-id',
-      config: null as { isKillswitched?: boolean } | null,
-    },
+    flow,
     execution,
     shouldTriggerProceed: vi.fn(() => ({ shouldExecute: true })),
   }
@@ -33,17 +36,9 @@ vi.mock('@/models/step', () => ({
   default: {
     query: vi.fn(() => ({
       findById: vi.fn(() => ({
-        throwIfNotFound: vi.fn(() => mocks.step),
-      })),
-    })),
-  },
-}))
-
-vi.mock('@/models/flow', () => ({
-  default: {
-    query: vi.fn(() => ({
-      findById: vi.fn(() => ({
-        throwIfNotFound: vi.fn(() => mocks.flow),
+        withGraphFetched: vi.fn(() => ({
+          throwIfNotFound: vi.fn(() => mocks.step),
+        })),
       })),
     })),
   },

--- a/packages/backend/src/services/__tests__/trigger.test.ts
+++ b/packages/backend/src/services/__tests__/trigger.test.ts
@@ -63,7 +63,7 @@ describe('processTrigger', () => {
     mocks.flow.config = null
   })
 
-  describe('pipe force clog', () => {
+  describe('Force clogging', () => {
     it('throws UnrecoverableError when flow.config.isForceClogged is true', async () => {
       mocks.flow.config = { isForceClogged: true }
 

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -101,6 +101,11 @@ export const processAction = async (options: ProcessActionOptions) => {
     .withGraphJoined('user')
     .withGraphFetched('steps')
     .throwIfNotFound()
+
+  if (flow.config?.isForceClogged) {
+    throw new UnrecoverableError(`Pipe ${flowId} has been force clogged`)
+  }
+
   const execution = await Execution.query()
     .findById(executionId)
     .throwIfNotFound()

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -159,6 +159,10 @@ export const processAction = async (options: ProcessActionOptions) => {
   let runResult: IActionRunResult = {}
   let executionError: unknown = null
   try {
+    if (flow.config?.isKillswitched) {
+      throw new UnrecoverableError(`Pipe ${flowId} has been killed via killswitch`)
+    }
+
     // Cannot assign directly to runResult due to void return type.
     const result =
       testRun && actionCommand.testRun

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -159,8 +159,8 @@ export const processAction = async (options: ProcessActionOptions) => {
   let runResult: IActionRunResult = {}
   let executionError: unknown = null
   try {
-    if (flow.config?.isKillswitched) {
-      throw new UnrecoverableError(`Pipe ${flowId} has been killswitched`)
+    if (flow.config?.isForceClogged) {
+      throw new UnrecoverableError(`Pipe ${flowId} has been force clogged`)
     }
 
     // Cannot assign directly to runResult due to void return type.

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -160,7 +160,7 @@ export const processAction = async (options: ProcessActionOptions) => {
   let executionError: unknown = null
   try {
     if (flow.config?.isKillswitched) {
-      throw new UnrecoverableError(`Pipe ${flowId} has been killed via killswitch`)
+      throw new UnrecoverableError(`Pipe ${flowId} has been killswitched`)
     }
 
     // Cannot assign directly to runResult due to void return type.

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,5 +1,6 @@
 import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { randomUUID } from 'crypto'
 import { z } from 'zod'
 
@@ -55,7 +56,14 @@ export const processTrigger = async (
 ): Promise<ProcessTriggerResult> => {
   const { flowId, stepId, triggerItem, error, testRun } = options
 
-  const step = await Step.query().findById(stepId).throwIfNotFound()
+  const step = await Step.query()
+    .findById(stepId)
+    .withGraphFetched('flow')
+    .throwIfNotFound()
+
+  if (step.flow?.config?.isForceClogged) {
+    throw new UnrecoverableError(`Pipe ${flowId} has been force clogged`)
+  }
 
   // only need to check if can proceed if there is no error and not a test run
   // if error, skip and let the error throw

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -5,7 +5,6 @@ import { z } from 'zod'
 
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
-import Flow from '@/models/flow'
 import Step from '@/models/step'
 
 import { shouldTriggerProceed } from './helpers/should-trigger-proceed'
@@ -55,11 +54,13 @@ export const processTrigger = async (
 ): Promise<ProcessTriggerResult> => {
   const { flowId, stepId, triggerItem, error, testRun } = options
 
-  const step = await Step.query().findById(stepId).throwIfNotFound()
-  const flow = await Flow.query().findById(flowId).throwIfNotFound()
+  const step = await Step.query()
+    .findById(stepId)
+    .withGraphFetched('flow')
+    .throwIfNotFound()
 
-  if (flow.config?.isKillswitched) {
-    throw new UnrecoverableError(`Pipe ${flowId} has been killed via killswitch`)
+  if (step.flow?.config?.isKillswitched) {
+    throw new UnrecoverableError(`Pipe ${flowId} has been killswitched`)
   }
 
   // only need to check if can proceed if there is no error and not a test run

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,9 +1,11 @@
 import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import { z } from 'zod'
 
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
 import Step from '@/models/step'
 
 import { shouldTriggerProceed } from './helpers/should-trigger-proceed'
@@ -54,6 +56,11 @@ export const processTrigger = async (
   const { flowId, stepId, triggerItem, error, testRun } = options
 
   const step = await Step.query().findById(stepId).throwIfNotFound()
+  const flow = await Flow.query().findById(flowId).throwIfNotFound()
+
+  if (flow.config?.isKillswitched) {
+    throw new UnrecoverableError(`Pipe ${flowId} has been killed via killswitch`)
+  }
 
   // only need to check if can proceed if there is no error and not a test run
   // if error, skip and let the error throw

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -59,8 +59,8 @@ export const processTrigger = async (
     .withGraphFetched('flow')
     .throwIfNotFound()
 
-  if (step.flow?.config?.isKillswitched) {
-    throw new UnrecoverableError(`Pipe ${flowId} has been killswitched`)
+  if (step.flow?.config?.isForceClogged) {
+    throw new UnrecoverableError(`Pipe ${flowId} has been force clogged`)
   }
 
   // only need to check if can proceed if there is no error and not a test run

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -225,6 +225,7 @@ export interface IFlowConfig {
   aiBuilderConfig?: {
     traceId: string // trace id on Rome (Langfuse)
   }
+  isForceClogged?: boolean
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -224,7 +224,7 @@ export interface IFlowConfig {
   aiBuilderConfig?: {
     traceId: string // trace id on Rome (Langfuse)
   }
-  isKillswitched?: boolean
+  isForceClogged?: boolean
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -224,6 +224,7 @@ export interface IFlowConfig {
   aiBuilderConfig?: {
     traceId: string // trace id on Rome (Langfuse)
   }
+  isKillswitched?: boolean
 }
 
 export type NotificationRecipients = 'editor' | 'viewer'


### PR DESCRIPTION
## Problem
In very very rare cases, we may need to killswitch pipes even when they're in the middle of executing.

## Solution
Add a new `isForceClogged` flag to our pipe config. If this is set to `true`, actions and triggers will error out:
1. Webhook triggers will return HTTP 500
2. Other triggers and actions will throw unrecoverable error.

## Tests
- [x] Check that pipes without a config run as per normal 
- [x] Check that pipes with a config object, but without the `isForceClogged` flag, run as per normal
- [x] Check that pipes with `isForceClogged = true` run as per normal
- [x] Check that web triggers for pipes with `isForceClogged = true` return HTTP 500
- [x] Check that actions for pipes with `isForceClogged = true` result in `UnrecoverableError`
- [x] Check that non-web triggers (e.g. scheduler) for pipes with `isForceClogged = true` result in `UnrecoverableError`