### PR TITLE
[AFTER-FIND-6] PLU-593 (feat): getStepVersion helper for mutations

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/create-mrf-steps.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/create-mrf-steps.itest.ts
@@ -97,6 +97,7 @@ describe('createMrfSteps', () => {
       expect(step.parameters).toEqual({ mrf: mrfWorkflow.actions[i] })
       expect(step.config?.stepName).toBe(mrfWorkflow.actions[i].defaultStepName)
       expect(step.connectionId).toBe(allSteps[0].connectionId)
+      expect(step.version).toBe(1)
     }
   })
 

--- a/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
+++ b/packages/backend/src/apps/formsg/triggers/new-submission/create-mrf-steps.ts
@@ -3,6 +3,7 @@ import { IGlobalVariable, IStep } from '@plumber/types'
 import get from 'lodash.get'
 import { raw, Transaction } from 'objection'
 
+import { getStepVersion } from '@/helpers/get-step-version'
 import Step from '@/models/step'
 
 import { ParsedMrfWorkflow } from '../../common/types'
@@ -168,6 +169,7 @@ export async function createMrfSteps(
         config: {
           stepName,
         },
+        version: getStepVersion(MRF_APP_KEY, MRF_KEY),
       })
       newMrfSteps.push(newStep)
       newMrfStepPositionToInsert = newStep.position + 1

--- a/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
+++ b/packages/backend/src/graphql/mutations/ai/create-flow-with-steps.ts
@@ -2,6 +2,7 @@ import type { IStep } from '@plumber/types'
 
 import z from 'zod/v3'
 
+import { getStepVersion } from '@/helpers/get-step-version'
 import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
@@ -93,6 +94,7 @@ const createFlowWithSteps: MutationResolvers['createFlowWithSteps'] = async (
     const normalizedSteps = [steps[0], ...normalizedActionSteps]
     const stepsToInsert = normalizedSteps.map((step: IStep) => {
       return {
+        version: getStepVersion(step.appKey, step.key),
         type: step.type,
         appKey: step.appKey,
         key: step.key,

--- a/packages/backend/src/graphql/mutations/create-step.ts
+++ b/packages/backend/src/graphql/mutations/create-step.ts
@@ -2,8 +2,8 @@ import { IStepConfig } from '@plumber/types'
 
 import { raw } from 'objection'
 
-import apps from '@/apps'
 import { BadUserInputError } from '@/errors/graphql-errors'
+import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
 import { validateApprovalConfig } from '@/helpers/validate-approval-config'
 import App from '@/models/app'
@@ -97,11 +97,7 @@ const createStep: MutationResolvers['createStep'] = async (
       })
       .where('position', '>=', validationResult.newStepPosition)
 
-    const app = input.appKey ? apps[input.appKey] : undefined
-    const version =
-      input.key && app?.stepTransformer
-        ? app.stepTransformer.getLatestStepVersion(input.key)
-        : 1
+    const version = getStepVersion(input.appKey, input.key)
 
     const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
       key: input.key,

--- a/packages/backend/src/graphql/mutations/duplicate-branch.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-branch.ts
@@ -3,6 +3,7 @@ import { IStepConfig } from '@plumber/types'
 import { raw } from 'objection'
 
 import { BadUserInputError } from '@/errors/graphql-errors'
+import { getStepVersion } from '@/helpers/get-step-version'
 import Step from '@/models/step'
 import { getConnection } from '@/services/connection'
 
@@ -81,6 +82,7 @@ const duplicateBranch: MutationResolvers['duplicateBranch'] = async (
         parameters,
         connectionId: connection?.id,
         config: config as IStepConfig,
+        version: getStepVersion(appKey, key),
       })
 
       newSteps.push(step)

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 
+import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
 import { updateStepVariables } from '@/helpers/update-duplicated-steps'
 import Flow from '@/models/flow'
@@ -83,6 +84,7 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
             oldToNewStepIdsMap,
           ),
           config: !isEmpty(prevStepConfig) ? prevStepConfig : undefined,
+          version: getStepVersion(oldStep.appKey, oldStep.key),
         })
       oldToNewStepIdsMap[oldStep.id] = duplicatedStep.id // update map after duplicating step
     }

--- a/packages/backend/src/helpers/__tests__/get-step-version.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-step-version.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getLatestStepVersion: vi.fn(),
+}))
+
+vi.mock('@/apps', () => ({
+  default: {
+    appWithTransformer: {
+      stepTransformer: {
+        getLatestStepVersion: mocks.getLatestStepVersion,
+      },
+    },
+    appWithoutTransformer: {},
+  },
+}))
+
+import { getStepVersion } from '../get-step-version'
+
+describe('getStepVersion', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns 1 when appKey is undefined', () => {
+    expect(getStepVersion(undefined, 'someKey')).toBe(1)
+  })
+
+  it('returns 1 when key is undefined', () => {
+    expect(getStepVersion('appWithTransformer', undefined)).toBe(1)
+  })
+
+  it('returns 1 when both appKey and key are undefined', () => {
+    expect(getStepVersion(undefined, undefined)).toBe(1)
+  })
+
+  it('returns 1 when the app does not have a stepTransformer', () => {
+    expect(getStepVersion('appWithoutTransformer', 'someKey')).toBe(1)
+  })
+
+  it('returns 1 when the app does not exist', () => {
+    expect(getStepVersion('nonExistentApp', 'someKey')).toBe(1)
+  })
+
+  it('returns the version from stepTransformer.getLatestStepVersion', () => {
+    mocks.getLatestStepVersion.mockReturnValue(3)
+
+    expect(getStepVersion('appWithTransformer', 'someKey')).toBe(3)
+    expect(mocks.getLatestStepVersion).toHaveBeenCalledWith('someKey')
+  })
+
+  it('returns 1 when stepTransformer.getLatestStepVersion returns nullish', () => {
+    mocks.getLatestStepVersion.mockReturnValue(null)
+
+    expect(getStepVersion('appWithTransformer', 'someKey')).toBe(1)
+  })
+})

--- a/packages/backend/src/helpers/flow-templates.ts
+++ b/packages/backend/src/helpers/flow-templates.ts
@@ -14,6 +14,7 @@ import type {
   FlowConfig,
   StepConfig,
 } from '@/graphql/__generated__/types.generated'
+import { getStepVersion } from '@/helpers/get-step-version'
 import Flow from '@/models/flow'
 import { createTableRows } from '@/models/tiles/dynamodb/table-row'
 import User from '@/models/user'
@@ -254,6 +255,7 @@ export async function createFlowFromTemplate(
         appKey,
         key: eventKey,
         parameters: updatedParameters,
+        version: getStepVersion(appKey, eventKey),
         config: {
           templateConfig: {
             appEventKey,

--- a/packages/backend/src/helpers/get-step-version.ts
+++ b/packages/backend/src/helpers/get-step-version.ts
@@ -1,0 +1,8 @@
+import apps from '@/apps'
+
+export function getStepVersion(appKey?: string, key?: string): number {
+  if (!appKey || !key) {
+    return 1
+  }
+  return apps[appKey]?.stepTransformer?.getLatestStepVersion(key) ?? 1
+}

--- a/packages/backend/src/helpers/transform-step-parameters.ts
+++ b/packages/backend/src/helpers/transform-step-parameters.ts
@@ -34,7 +34,8 @@ import type { IJSONObject } from '@plumber/types'
  *
  * The returned object has two functions:
  *   - `transformStepParameters(stepKey, stepParameters, version) => IJSONObject`
- *   - `getLatestStepVersion(stepKey) => number` — use this when creating new steps
+ *   - `getLatestStepVersion(stepKey) => number` — prefer `getStepVersion(appKey, key)` from `@/helpers/get-step-version` when creating new steps;
+ *      call this directly only when you already hold a `transformer` reference (e.g. update-step)
  *
  * @param transformers - Map of action key → ordered array of migration functions
  */


### PR DESCRIPTION
### TL;DR

Extracted step version resolution logic into a shared `getStepVersion` helper.

### What changed?

A new `getStepVersion(appKey, key)` helper was introduced that returns the latest step version from an app's `stepTransformer`, falling back to `1` if the app, key, or transformer is absent. This helper is now used consistently across `create-step`, `createTemplatedFlow`,`duplicate-branch`, `duplicate-flow`, and `create-flow-with-steps` mutations, replacing the previously inline and inconsistent version resolution logic. 

### How to test?

- [ ] Duplicate step: should use transformed parameters and latest version number
- [ ] Duplicate branch: should use transformed parameters and latest version number
- [ ] Create step: should use the `getStepVersion` helper can create steps correctly
- [ ] Template: should still create templates normally (no template with Excel at the moment, but placing it there first)
- [ ] Run the existing test suite to verify no regressions in the affected mutations.