### PR TITLE
PLU-755: automatic retries for transient db errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ tmp/
 
 # claude stuff
 .claude/settings.local.json
+
+docs/plans

--- a/packages/backend/src/helpers/__tests__/retry-on-transient-db-error.test.ts
+++ b/packages/backend/src/helpers/__tests__/retry-on-transient-db-error.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  isTransientDbError,
+  retryOnTransientDbError,
+} from '../retry-on-transient-db-error'
+
+const mocks = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    warn: mocks.logWarn,
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+function makePgError(code: string): Error & { code: string } {
+  const err = new Error(`pg error ${code}`) as Error & { code: string }
+  err.code = code
+  return err
+}
+
+function makeObjectionWrappedError(
+  code: string,
+): Error & { nativeError: { code: string } } {
+  const err = new Error('DBError') as Error & {
+    nativeError: { code: string }
+  }
+  err.nativeError = { code }
+  return err
+}
+
+describe('isTransientDbError', () => {
+  it.each([
+    '08000',
+    '08001',
+    '08003',
+    '08004',
+    '08006',
+    '57P01',
+    '57P02',
+    '57P03',
+  ])('returns true for postgres SQLSTATE %s', (code) => {
+    expect(isTransientDbError(makePgError(code))).toBe(true)
+  })
+
+  it.each(['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'EPIPE', 'ENOTFOUND'])(
+    'returns true for socket error %s',
+    (code) => {
+      expect(isTransientDbError(makePgError(code))).toBe(true)
+    },
+  )
+
+  it('returns true when the transient code is on nativeError (Objection DBError)', () => {
+    expect(isTransientDbError(makeObjectionWrappedError('57P01'))).toBe(true)
+  })
+
+  it.each(['23505', '23502', '23503', '08007', 'SOMETHING_ELSE'])(
+    'returns false for non-transient code %s',
+    (code) => {
+      expect(isTransientDbError(makePgError(code))).toBe(false)
+    },
+  )
+
+  it.each([
+    'Connection terminated unexpectedly',
+    'server closed the connection unexpectedly',
+    // Case + surrounding context should still match.
+    'Error: Connection terminated unexpectedly while idle',
+  ])('returns true for transient pg driver message: %s', (message) => {
+    expect(isTransientDbError(new Error(message))).toBe(true)
+  })
+
+  it.each([
+    'connection terminated',
+    'Client has encountered a connection error and is not queryable',
+    'terminating connection due to administrator command',
+  ])('returns false for messages not in the allowlist: %s', (message) => {
+    expect(isTransientDbError(new Error(message))).toBe(false)
+  })
+
+  it('matches a transient message when wrapped by Objection (nativeError.message)', () => {
+    const err = new Error('DBError') as Error & {
+      nativeError: { message: string }
+    }
+    err.nativeError = { message: 'Connection terminated unexpectedly' }
+    expect(isTransientDbError(err)).toBe(true)
+  })
+
+  it('returns false for an unrelated message without a code', () => {
+    expect(isTransientDbError(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for non-error values', () => {
+    expect(isTransientDbError(null)).toBe(false)
+    expect(isTransientDbError(undefined)).toBe(false)
+    expect(isTransientDbError('string')).toBe(false)
+  })
+})
+
+describe('retryOnTransientDbError', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    mocks.logWarn.mockReset()
+  })
+
+  it('returns the value on first try without retrying', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+
+    await expect(retryOnTransientDbError(fn)).resolves.toBe('ok')
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(mocks.logWarn).not.toHaveBeenCalled()
+  })
+
+  it('retries after a transient failure and succeeds', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(makePgError('57P01'))
+      .mockResolvedValueOnce('ok')
+
+    const promise = retryOnTransientDbError(fn, {
+      initialDelayMs: 100,
+      maxDelayMs: 1000,
+      context: { flowId: 'flow-1' },
+    })
+
+    // First attempt rejects synchronously on the microtask queue.
+    await vi.advanceTimersByTimeAsync(0)
+    // Backoff of 100ms (Math.random() => 0) before the retry.
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(mocks.logWarn).toHaveBeenCalledTimes(1)
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      'Retrying DB operation after transient error',
+      expect.objectContaining({
+        event: 'db-retry',
+        attempt: 1,
+        nextAttempt: 2,
+        maxAttempts: 3,
+        errorCode: '57P01',
+        delayMs: 100,
+        flowId: 'flow-1',
+      }),
+    )
+  })
+
+  it('throws after exhausting maxAttempts on repeated transient errors', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const err = makePgError('08006')
+    const fn = vi.fn().mockRejectedValue(err)
+
+    const promise = retryOnTransientDbError(fn, {
+      initialDelayMs: 100,
+      maxDelayMs: 1000,
+    })
+    // Swallow unhandled rejection while we advance timers.
+    promise.catch((): undefined => undefined)
+
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100) // first backoff
+    await vi.advanceTimersByTimeAsync(200) // second backoff
+
+    await expect(promise).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(mocks.logWarn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry non-transient errors', async () => {
+    const err = makePgError('23505') // unique_violation
+    const fn = vi.fn().mockRejectedValue(err)
+
+    await expect(retryOnTransientDbError(fn)).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(mocks.logWarn).not.toHaveBeenCalled()
+  })
+
+  it('respects a custom maxAttempts', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const err = makePgError('57P01')
+    const fn = vi.fn().mockRejectedValue(err)
+
+    const promise = retryOnTransientDbError(fn, {
+      maxAttempts: 2,
+      initialDelayMs: 100,
+    })
+    promise.catch((): undefined => undefined)
+
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(promise).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(2)
+    expect(mocks.logWarn).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps the actual sleep delay at maxDelayMs even with maximum jitter', async () => {
+    vi.useFakeTimers()
+    // Max jitter — without a cap on the final delay this would be 2 * prevFullDelay.
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+
+    const err = makePgError('57P01')
+    const fn = vi.fn().mockRejectedValue(err)
+
+    const promise = retryOnTransientDbError(fn, {
+      maxAttempts: 4,
+      initialDelayMs: 100,
+      maxDelayMs: 300,
+    })
+    promise.catch((): undefined => undefined)
+
+    await vi.advanceTimersByTimeAsync(0)
+    // attempt 1: prevFull=100, delay=100+100=200 (below cap)
+    await vi.advanceTimersByTimeAsync(200)
+    // attempt 2: prevFull=200, delay=200+200=400 → capped to 300
+    await vi.advanceTimersByTimeAsync(300)
+    // attempt 3: prevFull=300 (capped), delay=300+300=600 → capped to 300
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect(promise).rejects.toBe(err)
+    expect(fn).toHaveBeenCalledTimes(4)
+
+    const loggedDelays = mocks.logWarn.mock.calls.map(
+      ([, payload]) => (payload as { delayMs: number }).delayMs,
+    )
+    expect(loggedDelays).toEqual([200, 300, 300])
+    for (const delay of loggedDelays) {
+      expect(delay).toBeLessThanOrEqual(300)
+    }
+  })
+
+  it('unwraps Objection-wrapped transient errors', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(makeObjectionWrappedError('57P01'))
+      .mockResolvedValueOnce('ok')
+
+    const promise = retryOnTransientDbError(fn, { initialDelayMs: 100 })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(100)
+
+    await expect(promise).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/backend/src/helpers/retry-on-transient-db-error.ts
+++ b/packages/backend/src/helpers/retry-on-transient-db-error.ts
@@ -1,0 +1,163 @@
+import logger from './logger'
+
+/**
+  attempt 1 fails → wait ~1s to 2s
+  attempt 2 fails → wait ~2s to 4s
+  attempt 3 → throws
+ */
+const DEFAULT_MAX_ATTEMPTS = 3
+const DEFAULT_INITIAL_DELAY_MS = 1000
+const DEFAULT_MAX_DELAY_MS = 5000
+
+// Postgres SQLSTATE codes for connection / shutdown errors that are safe to
+// retry. Application errors (unique violations, NOT NULL, FK, etc.) are
+// intentionally excluded.
+const TRANSIENT_PG_CODES = new Set([
+  '08000', // connection_exception
+  '08001', // sqlclient_unable_to_establish_sqlconnection
+  '08003', // connection_does_not_exist
+  '08004', // sqlserver_rejected_establishment_of_sqlconnection
+  '08006', // connection_failure
+  '57P01', // admin_shutdown
+  '57P02', // crash_shutdown
+  '57P03', // cannot_connect_now
+])
+
+const TRANSIENT_SOCKET_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EPIPE',
+  'ENOTFOUND',
+])
+
+// Knex wraps some errors; fall back to message match for the common ones.
+// Keep this list short and specific.
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  'connection terminated unexpectedly',
+  'server closed the connection unexpectedly',
+]
+
+function extractErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') {
+    return undefined
+  }
+  const e = err as { code?: unknown; nativeError?: { code?: unknown } }
+  if (typeof e.code === 'string') {
+    return e.code
+  }
+  if (e.nativeError && typeof e.nativeError.code === 'string') {
+    return e.nativeError.code
+  }
+  return undefined
+}
+
+function extractErrorMessages(err: unknown): string[] {
+  if (!err || typeof err !== 'object') {
+    return []
+  }
+  const e = err as {
+    message?: unknown
+    nativeError?: { message?: unknown }
+  }
+  const messages: string[] = []
+  if (typeof e.message === 'string') {
+    messages.push(e.message)
+  }
+  if (e.nativeError && typeof e.nativeError.message === 'string') {
+    messages.push(e.nativeError.message)
+  }
+  return messages
+}
+
+function extractErrorMessage(err: unknown): string | undefined {
+  return extractErrorMessages(err)[0]
+}
+
+export function isTransientDbError(err: unknown): boolean {
+  const code = extractErrorCode(err)
+  if (
+    code &&
+    (TRANSIENT_PG_CODES.has(code) || TRANSIENT_SOCKET_CODES.has(code))
+  ) {
+    return true
+  }
+  return extractErrorMessages(err).some((message) => {
+    const lower = message.toLowerCase()
+    return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) =>
+      lower.includes(fragment),
+    )
+  })
+}
+
+export interface RetryOnTransientDbErrorOpts {
+  maxAttempts?: number
+  initialDelayMs?: number
+  maxDelayMs?: number
+  context?: Record<string, unknown>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function retryOnTransientDbError<T>(
+  fn: () => PromiseLike<T>,
+  opts: RetryOnTransientDbErrorOpts = {},
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+  const initialDelayMs = opts.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS
+  const maxDelayMs = opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS
+  const context = opts.context
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn()
+    } catch (err) {
+      if (!isTransientDbError(err)) {
+        throw err
+      }
+      const isFinalAttempt = attempt >= maxAttempts
+      if (isFinalAttempt) {
+        logger.error('Giving up after transient DB error retries', {
+          event: 'db-retry-exhausted',
+          attempts: attempt,
+          maxAttempts,
+          errorCode: extractErrorCode(err),
+          errorMessage: extractErrorMessage(err),
+          ...context,
+        })
+        throw err
+      }
+
+      // Jitter style matches helpers/backoff.ts: wait at least the previous
+      // full delay, plus up to that delay again as jitter. Capped at maxDelayMs.
+      const prevFullDelay = Math.min(
+        Math.pow(2, attempt - 1) * initialDelayMs,
+        maxDelayMs,
+      )
+      const delayMs = Math.min(
+        prevFullDelay + Math.round(Math.random() * prevFullDelay),
+        maxDelayMs,
+      )
+
+      logger.warn('Retrying DB operation after transient error', {
+        event: 'db-retry',
+        attempt,
+        nextAttempt: attempt + 1,
+        maxAttempts,
+        errorCode: extractErrorCode(err),
+        errorMessage: extractErrorMessage(err),
+        delayMs,
+        ...context,
+      })
+
+      await sleep(delayMs)
+    }
+  }
+
+  // Unreachable in practice: the loop returns on success or throws on the final
+  // failed attempt. This exists only to satisfy TypeScript's control-flow
+  // analysis, since a bounded for-loop can in principle complete normally.
+  throw new Error('retryOnTransientDbError: loop exited without returning')
+}

--- a/packages/backend/src/services/__tests__/db-retry.itest.ts
+++ b/packages/backend/src/services/__tests__/db-retry.itest.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from 'crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
+import Execution from '@/models/execution'
+import ExecutionStep from '@/models/execution-step'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+
+import { processTrigger } from '../trigger'
+
+const mocks = vi.hoisted(() => ({
+  shouldTriggerProceed: vi.fn(),
+  loggerWarn: vi.fn(),
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
+}))
+
+vi.mock('@/services/helpers/should-trigger-proceed', () => ({
+  shouldTriggerProceed: mocks.shouldTriggerProceed,
+}))
+
+// The retry helper logs via logger.warn / logger.error; stub it so those calls
+// don't depend on the real (Datadog) logger during the test.
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    warn: mocks.loggerWarn,
+    error: mocks.loggerError,
+    info: mocks.loggerInfo,
+  },
+}))
+
+// Simulates a Postgres failover / connection-drop error that the retry helper
+// classifies as transient (SQLSTATE 57P01 = admin_shutdown).
+function makeTransientPgError(): Error & { code: string } {
+  const err = new Error(
+    'terminating connection due to administrator command',
+  ) as Error & { code: string }
+  err.code = '57P01'
+  return err
+}
+
+describe('transient DB retry idempotency (real DB)', () => {
+  let flow: Flow
+  let triggerStep: Step
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const user = await User.query().findOne({ email: 'tester@open.gov.sg' })
+    flow = await Flow.query().insertGraphAndFetch({
+      userId: user.id,
+      name: 'db-retry-test-flow',
+      steps: [
+        {
+          appKey: 'mock-app',
+          key: 'mock-trigger',
+          type: 'trigger',
+          position: 1,
+          status: 'completed',
+        },
+      ],
+    })
+    triggerStep = flow.steps[0]
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('processTrigger', () => {
+    it('creates exactly one execution + execution step when the insert transaction is retried after a transient error', async () => {
+      mocks.shouldTriggerProceed.mockResolvedValue({ shouldExecute: true })
+
+      // Force the first committed transaction to surface a transient error (as
+      // if the connection dropped after COMMIT), then succeed on the retry. The
+      // retry re-runs the same closure, which reuses the precomputed ids and so
+      // must hit the onConflict path instead of inserting duplicate rows.
+      const realTransaction = Execution.transaction.bind(Execution)
+      let txCalls = 0
+      vi.spyOn(Execution, 'transaction').mockImplementation(((
+        ...args: unknown[]
+      ) => {
+        txCalls += 1
+        return (realTransaction as (...a: unknown[]) => Promise<unknown>)(
+          ...args,
+        ).then((result) => {
+          if (txCalls === 1) {
+            throw makeTransientPgError()
+          }
+          return result
+        })
+      }) as typeof Execution.transaction)
+
+      const result = await processTrigger({
+        flowId: flow.id,
+        stepId: triggerStep.id,
+        triggerItem: {
+          raw: { field: 'value' },
+          meta: { internalId: 'retry-internal-1' },
+        },
+        testRun: false,
+      })
+
+      // The retry actually fired.
+      expect(txCalls).toBe(2)
+
+      // No orphaned / duplicate rows: exactly one execution and one step.
+      const executions = await Execution.query().where({ flow_id: flow.id })
+      expect(executions).toHaveLength(1)
+      const executionSteps = await ExecutionStep.query().where({
+        execution_id: result.executionId,
+      })
+      expect(executionSteps).toHaveLength(1)
+
+      // The committed step is returned to the caller (the trigger worker reads
+      // executionStep.isFailed, so this must not be null).
+      expect(result.executionStep).not.toBeNull()
+      expect(result.executionStep?.id).toBe(executionSteps[0].id)
+      expect(result.executionStep?.isFailed).toBe(false)
+    }, 20000)
+  })
+
+  describe('retryOnTransientDbError + onConflict refetch', () => {
+    let execution: Execution
+
+    beforeEach(async () => {
+      execution = await Execution.query().insertAndFetch({
+        flowId: flow.id,
+        testRun: false,
+      })
+    })
+
+    it('does not insert a duplicate and returns the already-committed row when a transient error fires after commit', async () => {
+      // This mirrors the exact persistence pattern used by processTrigger /
+      // processAction / processSubTrigger: a precomputed id + insertAndFetch +
+      // onConflict('id').ignore().
+      const executionStepId = randomUUID()
+      let attempts = 0
+
+      const result = await retryOnTransientDbError(
+        async () => {
+          attempts += 1
+          // The retry re-runs with the SAME precomputed id. Vary the payload by
+          // attempt so we can prove the retry refetches the first (committed)
+          // row rather than overwriting it or inserting a second one.
+          const attemptLabel = attempts === 1 ? 'first' : 'second'
+          const row = await ExecutionStep.query()
+            .insertAndFetch({
+              id: executionStepId,
+              executionId: execution.id,
+              stepId: triggerStep.id,
+              status: 'success',
+              dataIn: {},
+              dataOut: { attempt: attemptLabel },
+              appKey: 'mock-app',
+              key: 'mock-trigger',
+            })
+            .onConflict('id')
+            .ignore()
+
+          if (attempts === 1) {
+            // Row is committed at this point; simulate the connection dropping
+            // before the client receives the response.
+            throw makeTransientPgError()
+          }
+          return row
+        },
+        { initialDelayMs: 1, maxDelayMs: 5 },
+      )
+
+      expect(attempts).toBe(2)
+
+      // Exactly one row exists for the precomputed id...
+      const rows = await ExecutionStep.query().where({ id: executionStepId })
+      expect(rows).toHaveLength(1)
+
+      // ...and the returned row is the one committed on the first attempt, not
+      // the (ignored) retry payload.
+      expect(result?.id).toBe(executionStepId)
+      expect(result?.dataOut).toEqual({ attempt: 'first' })
+    })
+
+    it('does not retry non-transient errors and leaves the committed row intact', async () => {
+      const executionStepId = randomUUID()
+      let attempts = 0
+
+      await expect(
+        retryOnTransientDbError(async () => {
+          attempts += 1
+          await ExecutionStep.query()
+            .insertAndFetch({
+              id: executionStepId,
+              executionId: execution.id,
+              stepId: triggerStep.id,
+              status: 'success',
+              dataIn: {},
+              dataOut: {},
+              appKey: 'mock-app',
+              key: 'mock-trigger',
+            })
+            .onConflict('id')
+            .ignore()
+
+          // A non-transient application error (unique violation) must propagate
+          // untouched, with no retry.
+          const err = new Error('non-transient failure') as Error & {
+            code: string
+          }
+          err.code = '23505'
+          throw err
+        }),
+      ).rejects.toMatchObject({ code: '23505' })
+
+      expect(attempts).toBe(1)
+      const rows = await ExecutionStep.query().where({ id: executionStepId })
+      expect(rows).toHaveLength(1)
+    })
+  })
+})

--- a/packages/backend/src/services/__tests__/trigger.itest.ts
+++ b/packages/backend/src/services/__tests__/trigger.itest.ts
@@ -6,6 +6,14 @@ import Step from '@/models/step'
 
 import { processTrigger } from '../trigger'
 
+// processTrigger chains `.onConflict('id').ignore()` after insert/insertAndFetch,
+// so the mocks must return a query-builder-like object rather than resolving directly.
+const mockInsertChain = (resolved: unknown) => ({
+  onConflict: vi.fn().mockReturnValue({
+    ignore: vi.fn().mockResolvedValue(resolved),
+  }),
+})
+
 describe('processTrigger', () => {
   it('should prevent duplicate executions from concurrent requests', async () => {
     // Setup test data
@@ -36,16 +44,18 @@ describe('processTrigger', () => {
       internalId,
       testRun: false,
       $relatedQuery: vi.fn().mockReturnValue({
-        insertAndFetch: vi.fn().mockResolvedValue({
-          id: randomUUID(),
-          stepId,
-          status: 'success',
-          dataIn: {},
-          dataOut: triggerItem.raw,
-          errorDetails: null,
-          appKey: 'formsg',
-          metadata: {},
-        }),
+        insertAndFetch: vi.fn().mockReturnValue(
+          mockInsertChain({
+            id: randomUUID(),
+            stepId,
+            status: 'success',
+            dataIn: {},
+            dataOut: triggerItem.raw,
+            errorDetails: null,
+            appKey: 'formsg',
+            metadata: {},
+          }),
+        ),
       }),
     }
 
@@ -58,10 +68,11 @@ describe('processTrigger', () => {
         lockAcquired = false
         return Promise.resolve(result)
       }),
+      transaction: vi.fn().mockImplementation((cb) => cb({})),
     } as any)
 
     vi.spyOn(Execution, 'query').mockReturnValue({
-      insert: vi.fn().mockResolvedValue(mockExecution),
+      insert: vi.fn().mockReturnValue(mockInsertChain(mockExecution)),
       where: vi.fn().mockReturnValue({
         first: vi.fn().mockResolvedValue(null),
       }),
@@ -134,28 +145,33 @@ describe('processTrigger', () => {
       // Mock knex raw query for advisory lock - lock acquired successfully
       vi.spyOn(Execution, 'knex').mockReturnValue({
         raw: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+        transaction: vi.fn().mockImplementation((cb) => cb({})),
       } as any)
 
       // Mock Execution query to return null (no existing execution)
       vi.spyOn(Execution, 'query').mockReturnValue({
-        insert: vi.fn().mockResolvedValue({
-          id: randomUUID(),
-          flowId,
-          internalId: triggerItem.meta.internalId,
-          testRun: false,
-          $relatedQuery: vi.fn().mockReturnValue({
-            insertAndFetch: vi.fn().mockResolvedValue({
-              id: randomUUID(),
-              stepId,
-              status: 'success',
-              dataIn: {},
-              dataOut: triggerItem.raw,
-              errorDetails: null,
-              appKey: 'gathersg',
-              metadata: {},
+        insert: vi.fn().mockReturnValue(
+          mockInsertChain({
+            id: randomUUID(),
+            flowId,
+            internalId: triggerItem.meta.internalId,
+            testRun: false,
+            $relatedQuery: vi.fn().mockReturnValue({
+              insertAndFetch: vi.fn().mockReturnValue(
+                mockInsertChain({
+                  id: randomUUID(),
+                  stepId,
+                  status: 'success',
+                  dataIn: {},
+                  dataOut: triggerItem.raw,
+                  errorDetails: null,
+                  appKey: 'gathersg',
+                  metadata: {},
+                }),
+              ),
             }),
           }),
-        }),
+        ),
         where: vi.fn().mockReturnValue({
           first: vi.fn().mockResolvedValue(null),
         }),
@@ -194,16 +210,18 @@ describe('processTrigger', () => {
         internalId,
         testRun: false,
         $relatedQuery: vi.fn().mockReturnValue({
-          insertAndFetch: vi.fn().mockResolvedValue({
-            id: randomUUID(),
-            stepId,
-            status: 'success',
-            dataIn: {},
-            dataOut: triggerItem.raw,
-            errorDetails: null,
-            appKey: 'gathersg',
-            metadata: {},
-          }),
+          insertAndFetch: vi.fn().mockReturnValue(
+            mockInsertChain({
+              id: randomUUID(),
+              stepId,
+              status: 'success',
+              dataIn: {},
+              dataOut: triggerItem.raw,
+              errorDetails: null,
+              appKey: 'gathersg',
+              metadata: {},
+            }),
+          ),
         }),
       }
 
@@ -216,12 +234,13 @@ describe('processTrigger', () => {
           lockAcquired = false
           return Promise.resolve(result)
         }),
+        transaction: vi.fn().mockImplementation((cb) => cb({})),
       } as any)
 
       // Mock Execution query
       // First request: finds no existing execution, creates new one
       // Second request: fails to acquire lock, returns early
-      const mockInsert = vi.fn().mockResolvedValue(mockExecution)
+      const mockInsert = vi.fn().mockReturnValue(mockInsertChain(mockExecution))
 
       vi.spyOn(Execution, 'query').mockReturnValue({
         insert: mockInsert,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -1,6 +1,7 @@
 import type { IActionRunResult, TestRunStepMetadata } from '@plumber/types'
 
 import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { randomUUID } from 'crypto'
 
 import {
   FOR_EACH_ITERATION_DELAY,
@@ -17,6 +18,7 @@ import computeParameters from '@/helpers/compute-parameters'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
@@ -209,19 +211,28 @@ export const processAction = async (options: ProcessActionOptions) => {
     })
   }
 
-  const executionStep = await execution
-    .$relatedQuery('executionSteps')
-    .insertAndFetch({
-      stepId: $.step.id,
-      status,
-      dataIn: computedParameters,
-      dataOut: $.actionOutput.data?.raw ?? null,
-      errorDetails: $.actionOutput.error ?? null,
-      appKey: $.app.key,
-      jobId,
-      key: step.key,
-      metadata: { ...metadata, ...$.actionOutput.data?.meta },
-    })
+  // we generate an execution step id here instead of relying on the db generation to prevent possibility of duplicate entry during retries
+  const executionStepId = randomUUID()
+  const executionStep = await retryOnTransientDbError(
+    () =>
+      execution
+        .$relatedQuery('executionSteps')
+        .insertAndFetch({
+          id: executionStepId,
+          stepId: $.step.id,
+          status,
+          dataIn: computedParameters,
+          dataOut: $.actionOutput.data?.raw ?? null,
+          errorDetails: $.actionOutput.error ?? null,
+          appKey: $.app.key,
+          jobId,
+          key: step.key,
+          metadata: { ...metadata, ...$.actionOutput.data?.meta },
+        })
+        .onConflict('id')
+        .ignore(),
+    { context: { executionId: execution.id, stepId: $.step.id, jobId } },
+  )
 
   let nextStep = null
   switch (runResult.nextStep?.command) {

--- a/packages/backend/src/services/sub-trigger.ts
+++ b/packages/backend/src/services/sub-trigger.ts
@@ -1,8 +1,10 @@
 import type { ITriggerItem, SubtriggerData } from '@plumber/types'
 
+import { randomUUID } from 'crypto'
 import get from 'lodash.get'
 
 import logger from '@/helpers/logger'
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
@@ -107,35 +109,45 @@ export const processSubTrigger = async (
     return null
   }
 
-  const executionStep = await ExecutionStep.transaction(async (trx) => {
-    // Check if the execution step already exists
-    const existing = await ExecutionStep.query(trx)
-      .findOne({
-        execution_id: execution.id,
-        step_id: mrfStep.id,
-      })
-      .forUpdate() // Prevents race conditions
+  // we generate an execution step id here instead of relying on the db generation to prevent possibility of duplicate entry during retries
+  const executionStepId = randomUUID()
+  const executionStep = await retryOnTransientDbError(
+    () =>
+      ExecutionStep.transaction(async (trx) => {
+        // Check if the execution step already exists
+        const existing = await ExecutionStep.query(trx)
+          .findOne({
+            execution_id: execution.id,
+            step_id: mrfStep.id,
+          })
+          .forUpdate() // Prevents race conditions
 
-    // if the execution step already exists, do not process again
-    if (existing) {
-      logger.warn({
-        event: 'sub-trigger-execution-step-already-exists',
-        executionId: execution.id,
-        stepId: mrfStep.id,
-      })
-      // we don't throw an error so formsg does not retry the webhook
-      return null
-    }
-    // Create the execution step for the MRF action step
-    return await ExecutionStep.query(trx).insertAndFetch({
-      stepId: mrfStep.id,
-      executionId: execution.id,
-      dataIn: mrfStep.parameters,
-      dataOut: triggerItem.raw,
-      appKey: mrfStep.appKey,
-      key: mrfStep.key,
-    })
-  })
+        // if the execution step already exists, do not process again
+        if (existing) {
+          logger.warn({
+            event: 'sub-trigger-execution-step-already-exists',
+            executionId: execution.id,
+            stepId: mrfStep.id,
+          })
+          // we don't throw an error so formsg does not retry the webhook
+          return null
+        }
+        // Create the execution step for the MRF action step
+        return await ExecutionStep.query(trx)
+          .insertAndFetch({
+            id: executionStepId,
+            stepId: mrfStep.id,
+            executionId: execution.id,
+            dataIn: mrfStep.parameters,
+            dataOut: triggerItem.raw,
+            appKey: mrfStep.appKey,
+            key: mrfStep.key,
+          })
+          .onConflict('id')
+          .ignore()
+      }),
+    { context: { flowId, executionId: execution.id, stepId: mrfStep.id } },
+  )
 
   return {
     executionId: execution.id,

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -1,7 +1,9 @@
 import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
+import { randomUUID } from 'crypto'
 import { z } from 'zod'
 
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
@@ -67,29 +69,49 @@ export const processTrigger = async (
     }
   }
 
-  // non-FormSG triggers or test runs proceed without advisory lock
-  const execution = await Execution.query().insert({
-    flowId,
-    testRun,
-    internalId: triggerItem?.meta.internalId,
-    ...(error && { status: 'failure' }),
-  })
-
   // We store all metadata except internalId
   const { internalId: _, ...metadataToStore } = triggerItem?.meta ?? {}
 
-  const executionStep = await execution
-    .$relatedQuery('executionSteps')
-    .insertAndFetch({
-      stepId: step.id,
-      status: error ? 'failure' : 'success',
-      dataIn: step.parameters,
-      dataOut: !error ? triggerItem?.raw : null,
-      errorDetails: error,
-      appKey: step.appKey,
-      metadata: metadataToStore ?? {},
-      key: step.key,
-    })
+  // non-FormSG triggers or test runs proceed without advisory lock.
+  // Both inserts share one transaction so a partial failure rolls back before
+  // any retry, avoiding orphan execution rows with no step.
+  // we generate an execution id and execution step id here instead of relying on the db generation to prevent possibility of duplicate entry during retries
+  const executionId = randomUUID()
+  const executionStepId = randomUUID()
+  const { execution, executionStep } = await retryOnTransientDbError(
+    () =>
+      Execution.transaction(async (trx) => {
+        const execution = await Execution.query(trx)
+          .insert({
+            id: executionId,
+            flowId,
+            testRun,
+            internalId: triggerItem?.meta.internalId,
+            ...(error && { status: 'failure' }),
+          })
+          .onConflict('id')
+          .ignore()
+
+        const executionStep = await execution
+          .$relatedQuery('executionSteps', trx)
+          .insertAndFetch({
+            id: executionStepId,
+            stepId: step.id,
+            status: error ? 'failure' : 'success',
+            dataIn: step.parameters,
+            dataOut: !error ? triggerItem?.raw : null,
+            errorDetails: error,
+            appKey: step.appKey,
+            metadata: metadataToStore ?? {},
+            key: step.key,
+          })
+          .onConflict('id')
+          .ignore()
+
+        return { execution, executionStep }
+      }),
+    { context: { flowId, stepId } },
+  )
 
   const customWebhookResponse = getCustomWebhookResponse(step)
 


### PR DESCRIPTION
### TL;DR

Adds automatic retry logic for transient database errors (db failover, temporary blips) in triggers, sub-triggers and actions.

### What changed?

A new `retryOnTransientDbError` helper wraps any async function and retries it up to 3 times (by default) when the thrown error is identified as transient. Transient errors are detected by checking:

- Postgres SQLSTATE codes for connection/shutdown errors (`08000`, `08006`, `57P01`, etc.)
- Node.js socket error codes (`ECONNRESET`, `ETIMEDOUT`, `EPIPE`, etc.)
- Known pg driver error message fragments (e.g. `"connection terminated unexpectedly"`)
- Objection.js-wrapped errors via `nativeError`

Retries use exponential backoff with jitter, capped at a configurable `maxDelayMs`. Each retry attempt is logged as a warning with structured context; exhausted retries are logged as errors before re-throwing.

The helper is applied to:

- **`processTrigger`**: The `Execution` and `ExecutionStep` inserts are now wrapped in a single transaction and retried together, preventing orphaned execution rows if a partial failure occurs mid-retry.
- **`processAction`**: The `ExecutionStep` insert is wrapped with retry context including `executionId`, `stepId`, and `jobId`.
- **`processSubTrigger`**: The existing `ExecutionStep` transaction is wrapped with retry context including `flowId`, `executionId`, and `stepId`.

### How to test?

- [x]  Smoke test:

1. Modify the action worker 
    1. Add a delay of 5 seconds before inserting into execution steps
    2. Console log before and after the delay
2. Run the pipe
3. Kill docker postgres during the delay, see that it is retrying

Test log output:

```
[worker] STARTTT DELAYYYY
[worker] ENDDD DELAYYYY
[worker] Connection Error: Connection ended unexpectedly
[worker] Connection Error: Connection ended unexpectedly
[worker] {
[worker]   dd: {
[worker]     trace_id: '1345899740278042520',
[worker]     span_id: '1345899740278042520',
[worker]     service: 'plumber',
[worker]     version: '1.65.2',
[worker]     env: 'development'
[worker]   },
[worker]   event: 'db-retry',
[worker]   attempt: 1,
[worker]   nextAttempt: 2,
[worker]   maxAttempts: 3,
[worker]   errorCode: 'ECONNREFUSED',
[worker]   errorMessage: '',
[worker]   delayMs: 1397,
[worker]   executionId: '44db8559-5d02-4d28-9d61-e4c4dc8a51f6',
[worker]   stepId: '6abca909-20b1-4971-883f-e057c80d2e72',
[worker]   jobId: '7',
[worker]   level: 'warn',
[worker]   message: 'Retrying DB operation after transient error',
[worker]   timestamp: '2026-05-25T08:21:51.639Z'
[worker] }
[worker] {
[worker]   dd: {
[worker]     trace_id: '1345899740278042520',
[worker]     span_id: '1345899740278042520',
[worker]     service: 'plumber',
[worker]     version: '1.65.2',
[worker]     env: 'development'
[worker]   },
[worker]   event: 'db-retry',
[worker]   attempt: 2,
[worker]   nextAttempt: 3,
[worker]   maxAttempts: 3,
[worker]   errorCode: 'ECONNREFUSED',
[worker]   errorMessage: '',
[worker]   delayMs: 3613,
[worker]   executionId: '44db8559-5d02-4d28-9d61-e4c4dc8a51f6',
[worker]   stepId: '6abca909-20b1-4971-883f-e057c80d2e72',
[worker]   jobId: '7',
[worker]   level: 'warn',
[worker]   message: 'Retrying DB operation after transient error',
[worker]   timestamp: '2026-05-25T08:21:53.041Z'
[worker] }
[worker] {
[worker]   dd: { service: 'plumber', version: '1.65.2', env: 'development' },
[worker]   queueName: 'action',
[worker]   job: {
[worker]     flowId: '438c7670-a0e8-474c-af49-e4f9dfa478a1',
[worker]     executionId: '44db8559-5d02-4d28-9d61-e4c4dc8a51f6',
[worker]     stepId: '6abca909-20b1-4971-883f-e057c80d2e72'
[worker]   },
[worker]   workerVersion: '1.65.2',
[worker]   level: 'info',
[worker]   message: '[action] JOB ID: 7 - FLOW ID: 438c7670-a0e8-474c-af49-e4f9dfa478a1 has completed!',
[worker]   timestamp: '2026-05-25T08:21:56.705Z'
[worker] }
```

