### PR TITLE
feat: add testStepTooltip property for action/trigger test buttons

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/get-app.test.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-app.test.ts
@@ -1,0 +1,114 @@
+import fs from 'fs'
+import path from 'path'
+
+import { buildSchema, graphql } from 'graphql'
+import { describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findOneByKey: vi.fn(),
+}))
+
+vi.mock('@/models/app', () => ({
+  default: {
+    findOneByKey: mocks.findOneByKey,
+  },
+}))
+
+const buildAppSchema = async () => {
+  const typeDefs = fs.readFileSync(
+    path.resolve(__dirname, '../../schema.graphql'),
+    'utf8',
+  )
+  const schema = buildSchema(typeDefs)
+  const { default: getApp } = await import('@/graphql/queries/get-app')
+  return { schema, getApp }
+}
+
+const context = {
+  currentUser: { id: 'test-user' },
+} as any
+
+describe('GraphQL Action/Trigger testStepTooltip field', () => {
+  it('returns testStepTooltip on Action when set on the action object', async () => {
+    mocks.findOneByKey.mockResolvedValue({
+      key: 'postman',
+      name: 'Postman',
+      iconUrl: '',
+      actions: [
+        {
+          key: 'sendEmail',
+          name: 'Send email',
+          description: '',
+          testStepTooltip:
+            'Test email will only be sent to your email address.',
+        },
+        {
+          key: 'noTooltipAction',
+          name: 'Other',
+          description: '',
+        },
+      ],
+    })
+
+    const { schema, getApp } = await buildAppSchema()
+    const result = await graphql({
+      schema,
+      source: `query GetApp { getApp(key: "postman") { actions { key testStepTooltip } } }`,
+      contextValue: context,
+      rootValue: {
+        getApp: (args: any) => getApp(null as any, args, context),
+      },
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.getApp).toEqual({
+      actions: [
+        {
+          key: 'sendEmail',
+          testStepTooltip:
+            'Test email will only be sent to your email address.',
+        },
+        {
+          key: 'noTooltipAction',
+          testStepTooltip: null,
+        },
+      ],
+    })
+  })
+
+  it('returns testStepTooltip on Trigger when set on the trigger object', async () => {
+    mocks.findOneByKey.mockResolvedValue({
+      key: 'someApp',
+      name: 'Some App',
+      iconUrl: '',
+      triggers: [
+        {
+          key: 'someTrigger',
+          name: 'Some trigger',
+          description: '',
+          testStepTooltip: 'Test trigger note.',
+        },
+      ],
+    })
+
+    const { schema, getApp } = await buildAppSchema()
+    const result = await graphql({
+      schema,
+      source: `query GetApp { getApp(key: "someApp") { triggers { key testStepTooltip } } }`,
+      contextValue: context,
+      rootValue: {
+        getApp: (args: any) => getApp(null as any, args, context),
+      },
+    })
+
+    expect(result.errors).toBeUndefined()
+    expect(result.data?.getApp).toEqual({
+      triggers: [
+        {
+          key: 'someTrigger',
+          testStepTooltip: 'Test trigger note.',
+        },
+      ],
+    })
+  })
+})

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -212,6 +212,7 @@ type Action {
   setupMessage: SetupMessage
   isNew: Boolean
   linkToGuide: String
+  testStepTooltip: String
   substeps: [ActionSubstep]
 }
 
@@ -860,6 +861,7 @@ type Trigger {
   substeps: [TriggerSubstep]
   isNew: Boolean
   noAuthRequired: Boolean
+  testStepTooltip: String
 }
 
 type TriggerInstructions {

--- a/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/CheckAgainButton.tsx
@@ -12,6 +12,7 @@ import {
   MenuItem,
   MenuList,
   Text,
+  Tooltip,
 } from '@chakra-ui/react'
 import { Button, IconButton, Menu } from '@opengovsg/design-system-react'
 
@@ -28,10 +29,12 @@ interface CheckAgainButtonProps {
   isDisabled: boolean
   step: IStep
   executionStepMetadata?: IExecutionStepMetadata
+  tooltip?: string
 }
 
 export function CheckAgainButton(props: CheckAgainButtonProps) {
-  const { isUnstyledInfobox, onClick, isLoading, isDisabled, step } = props
+  const { isUnstyledInfobox, onClick, isLoading, isDisabled, step, tooltip } =
+    props
   const isFormSgTrigger =
     step.appKey === FORMSG_APP_KEY && step.key === FORMSG_TRIGGER_KEY
   const isFormSgAction =
@@ -44,17 +47,24 @@ export function CheckAgainButton(props: CheckAgainButtonProps) {
     return <FormSGCheckAgainButton {...props} />
   }
   return (
-    <Button
-      variant={isUnstyledInfobox ? 'solid' : 'outline'}
-      onClick={() => onClick()}
-      isLoading={isLoading}
-      colorScheme={isUnstyledInfobox ? 'primary' : 'black'}
-      size="sm"
-      isDisabled={isDisabled}
-      data-test="check-again-button"
+    <Tooltip
+      label={tooltip}
+      isDisabled={!tooltip || isDisabled}
+      aria-label="check step again tooltip"
+      hasArrow
     >
-      Check step again
-    </Button>
+      <Button
+        variant={isUnstyledInfobox ? 'solid' : 'outline'}
+        onClick={() => onClick()}
+        isLoading={isLoading}
+        colorScheme={isUnstyledInfobox ? 'primary' : 'black'}
+        size="sm"
+        isDisabled={isDisabled}
+        data-test="check-again-button"
+      >
+        Check step again
+      </Button>
+    </Tooltip>
   )
 }
 

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -60,22 +60,27 @@ type CheckStepTooltipProps = {
   isDisabled: boolean
   isReadOnly: boolean
   hasDeletedVars?: boolean
+  tooltip?: string
   children: React.ReactNode
 }
 
 const CheckStepTooltip = (props: CheckStepTooltipProps) => {
-  const { children, hasDeletedVars, isDisabled, isReadOnly } = props
+  const { children, hasDeletedVars, isDisabled, isReadOnly, tooltip } = props
+  // `isDisabled` here forwards Chakra Tooltip semantics: truthy means the
+  // button is currently enabled (so the disabled-state hint should be hidden).
+  const isButtonEnabled = isDisabled
+  const disabledLabel = isReadOnly
+    ? 'Unpublish your pipe to check step'
+    : hasDeletedVars
+    ? 'Remove variables from deleted steps to check step'
+    : 'Complete required fields to check step'
+  const label = isButtonEnabled ? tooltip : disabledLabel
+  const tooltipHidden = isButtonEnabled && !tooltip
   return (
     <Tooltip
-      label={
-        isReadOnly
-          ? 'Unpublish your pipe to check step'
-          : hasDeletedVars
-          ? 'Remove variables from deleted steps to check step'
-          : 'Complete required fields to check step'
-      }
+      label={label}
       aria-label="check step tooltip"
-      isDisabled={isDisabled}
+      isDisabled={tooltipHidden}
       hasArrow
     >
       {children}
@@ -116,6 +121,8 @@ export default function FlowStepTestController(
     substeps,
     isAiStep,
   } = useStepMetadata(step)
+
+  const testStepTooltip = selectedActionOrTrigger?.testStepTooltip
 
   const {
     isTestSuccessful,
@@ -344,6 +351,7 @@ export default function FlowStepTestController(
                     isDisabled={!isValid || readOnly}
                     step={step}
                     executionStepMetadata={currentTestExecutionStep?.metadata}
+                    tooltip={testStepTooltip}
                   />
                 </Flex>
               </Flex>
@@ -383,6 +391,7 @@ export default function FlowStepTestController(
                 hasDeletedVars={hasDeletedVars}
                 isDisabled={shouldAllowCheckStep}
                 isReadOnly={readOnly}
+                tooltip={testStepTooltip}
               >
                 <Button
                   onClick={() => handleSaveAndTest()}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -812,6 +812,10 @@ export interface IBaseTrigger {
 
   // if true, the trigger does not require authentication
   noAuthRequired?: boolean
+
+  // If set, shown as a tooltip on the test-step button to warn users about
+  // non-obvious test-run behavior (e.g. recipients being rewritten).
+  testStepTooltip?: string
 }
 
 export interface IRawTrigger extends IBaseTrigger {
@@ -927,6 +931,10 @@ export interface IBaseAction {
 
   // if true, the action does not require authentication
   noAuthRequired?: boolean
+
+  // If set, shown as a tooltip on the test-step button to warn users about
+  // non-obvious test-run behavior (e.g. recipients being rewritten).
+  testStepTooltip?: string
 }
 
 export interface IRawAction extends IBaseAction {


### PR DESCRIPTION
## Summary

- Adds an opt-in `testStepTooltip?: string` property to `IBaseAction` and `IBaseTrigger` so individual actions/triggers can warn users about non-obvious test-run behavior (e.g. recipients being rewritten).
- Surfaces it through the GraphQL `Action` / `Trigger` types and renders it as a Chakra tooltip on the **Check step** and **Check step again** buttons (non-FormSG branch) when those buttons are enabled.
- No app declares the property yet — this PR is behavior-neutral on its own. PR 2 (Postman send-email) opts in.

This is **stacked PR 1 of 2**.

## Test plan

- [x] `npm run -w backend test:unit` — passes (2 unrelated pre-existing failures: `graphql-instance.test.ts` / `authentication.test.ts` blocked by a `graphql-shield`/Node 22 `util.isUndefined` issue that exists on `develop-v2`).
- [x] `npm test -w frontend --run` — passes.
- [x] `tsc --noEmit` clean for backend and frontend.
- [ ] Manual smoke: confirm no existing action shows an unexpected tooltip on the enabled "Check step" button (only disabled-state tooltips appear, since no app declares the field yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)