### PR TITLE
feat(postman): redirect test-run emails to the test runner's address

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -548,7 +548,7 @@ describe('send transactional email', () => {
     })
   })
 
-  it('should send to all recipients in test runs', async () => {
+  it('skips partial retry and sends only to the test runner in test runs', async () => {
     const recipients = [
       'recipient1@open.gov.sg',
       'recipient2@open.gov.sg',
@@ -573,11 +573,11 @@ describe('send transactional email', () => {
     })
     $.execution.testRun = true
     await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
-    expect($.http.post).toBeCalledTimes(5)
+    expect($.http.post).toBeCalledTimes(1)
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        status: ['ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED'],
-        recipient: recipients,
+        status: ['ACCEPTED'],
+        recipient: [$.user.email],
         subject: 'test subject',
         body: 'test body',
         from: 'jack',
@@ -620,6 +620,70 @@ describe('send transactional email', () => {
         from: 'jack',
         reply_to: 'replyTo@open.gov.sg',
       },
+    })
+  })
+
+  describe('test-run recipient override', () => {
+    it("redirects email to the test runner's address and drops CCs when testRun is true", async () => {
+      $.step.parameters.destinationEmail = 'recipient@example.com'
+      $.step.parameters.destinationEmailCc = 'cc@example.com'
+      $.user.email = 'me@example.com'
+      $.execution.testRun = true
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.http.post).toBeCalledTimes(1)
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED'],
+          recipient: ['me@example.com'],
+          subject: 'test subject',
+          body: 'test body',
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
+    })
+
+    it('does not override recipients on a normal (non-test) run', async () => {
+      const recipients = ['recipient1@open.gov.sg', 'recipient2@open.gov.sg']
+      const ccRecipients = ['cc1@open.gov.sg', 'cc2@open.gov.sg']
+      $.step.parameters.destinationEmail = recipients.join(',')
+      $.step.parameters.destinationEmailCc = ccRecipients.join(',')
+      $.user.email = 'me@example.com'
+      $.execution.testRun = false
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED', 'ACCEPTED'],
+          recipient: recipients,
+          subject: 'test subject',
+          body: 'test body',
+          cc: ccRecipients,
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
+    })
+
+    it("collapses multiple configured recipients to the test runner's address in test mode", async () => {
+      $.step.parameters.destinationEmail = 'a@x.com, b@x.com, c@x.com'
+      $.step.parameters.destinationEmailCc = 'cc1@x.com, cc2@x.com'
+      $.user.email = 'me@example.com'
+      $.execution.testRun = true
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.http.post).toBeCalledTimes(1)
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED'],
+          recipient: ['me@example.com'],
+          subject: 'test subject',
+          body: 'test body',
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
     })
   })
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -40,6 +40,7 @@ const action: IRawAction = {
   name: 'Send email',
   key: 'sendTransactionalEmail',
   description: 'Sends an email using Postman',
+  testStepTooltip: 'Test email will only be sent to your email address.',
   arguments: transactionalEmailFields,
 
   preprocessVariable(key: string, value: unknown) {
@@ -93,9 +94,18 @@ const action: IRawAction = {
       replyTo,
       attachments = [],
     } = $.step.parameters
+    // During test runs, redirect all recipients to the test runner's own
+    // email so test sends never spam unrelated addresses configured on the
+    // step.
+    const effectiveDestinationEmail = $.execution.testRun
+      ? $.user.email
+      : destinationEmail
+    const effectiveDestinationEmailCc = $.execution.testRun
+      ? undefined
+      : destinationEmailCc
     const result = transactionalEmailSchema.safeParse({
-      destinationEmail,
-      destinationEmailCc,
+      destinationEmail: effectiveDestinationEmail,
+      destinationEmailCc: effectiveDestinationEmailCc,
       senderName,
       subject,
       body,


### PR DESCRIPTION
## Summary

- Sending a "Send email" test step previously delivered to whatever recipients were configured on the step. Builders iterating on a template could accidentally spam unrelated people.
- The action now rewrites both `destinationEmail` and `destinationEmailCc` to `\$.user.email` whenever `\$.execution.testRun` is true.
- Declares `testStepTooltip` (introduced in stacked PR 1, [#1642](https://github.com/opengovsg/plumber/pull/1642)) so the **Check step** / **Check step again** button shows "Test email will only be sent to your email address." on hover.
- Stacked on top of [#1642](https://github.com/opengovsg/plumber/pull/1642) — merge that first, then this rebases onto `develop-v2`.

## Test plan

- [x] New backend unit tests covering: test-run override, normal-run unaffected, multiple configured recipients collapsed to user's email in test mode.
- [x] Updated the existing "should send to all recipients in test runs" test, which encoded the old behavior, to assert the new collapse-to-test-runner behavior (partial-retry is still skipped in test runs — the test now exercises that with a single recipient).
- [x] `npm run -w backend test:unit` — passes (1511 passed; the 2 unrelated failures from `graphql-shield`/Node 22 also present on `develop-v2`).
- [x] `npm test -w frontend --run` — passes.
- [x] `tsc --noEmit` clean for backend and frontend.
- [ ] Manual: build a flow with Postman "Send email" pointing at a recipient that isn't the logged-in user, add CCs. Hover **Check step** → tooltip appears. Click it → only the logged-in user receives the test email; neither the configured recipient nor the CCs do. Open a non-Postman action and confirm no tooltip appears on the enabled Check step button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)