### PR TITLE
PLU-679 (chore): improve Streamdown styles

### DIFF
--- a/packages/frontend/src/theme/components/Streamdown.tsx
+++ b/packages/frontend/src/theme/components/Streamdown.tsx
@@ -97,6 +97,9 @@ export function ChakraStreamdown({
         <Text textStyle="h6" mt={2} mb={2} {...props} />
       ),
       p: (props: React.ComponentProps<typeof Text>) => <Text {...props} />,
+      strong: (props: React.ComponentProps<'strong'>) => (
+        <Box as="strong" fontWeight="semibold" display="inline" {...props} />
+      ),
       code: (props: React.ComponentProps<typeof Code>) => (
         <Code colorScheme="gray" {...props} />
       ),
@@ -104,10 +107,18 @@ export function ChakraStreamdown({
         <Link color="blue.500" {...props} />
       ),
       ul: (props: React.ComponentProps<typeof List>) => (
-        <List styleType="disc" spacing={2} pl={4} {...props} />
+        <List styleType="disc" spacing={2} pl={4} m={4} {...props} />
       ),
       ol: (props: React.ComponentProps<typeof List>) => (
-        <List as="ol" styleType="decimal" spacing={6} pl={4} {...props} />
+        <List
+          as="ol"
+          styleType="decimal"
+          spacing={2}
+          pl={4}
+          m={2}
+          sx={{ 'li > ol': { listStyleType: 'lower-alpha' } }}
+          {...props}
+        />
       ),
       li: (props: React.ComponentProps<typeof ListItem>) => (
         <ListItem {...props} />


### PR DESCRIPTION
### TL;DR

Improved markdown rendering for bold text, lists, and nested ordered lists in the Streamdown component.

### What changed?

- Added a `strong` element renderer that applies `semibold` font weight with inline display
- Added margin to unordered lists for better spacing
- Reduced ordered list item spacing from `6` to `2` and added margin
- Added support for nested ordered lists using `lower-alpha` list style for second-level `ol` elements

### How to test?

- [x]  Verify that ordered lists have more margin (clarifications)
- [x]  Verify that unordered lists have more margin (general responses)
- [x]  Verify that the chat messages are still displayed properly

### Deploy notes

- [ ]  Promote `chat v97` to production