### PR TITLE
[BULLMQ-BATCH-3] PLU-524: scaffold BullMQ Pro batching infra

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.before-request.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.before-request.test.ts
@@ -51,6 +51,7 @@ vi.mock('@/helpers/logger', () => ({
 
 vi.mock('@/config/app-env-vars/m365', () => ({
   M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS: 1000,
+  M365_EXCEL_BATCH_ENABLED: false,
   isM365TenantKey: vi.fn(() => true),
 }))
 

--- a/packages/backend/src/apps/m365-excel/queue/index.ts
+++ b/packages/backend/src/apps/m365-excel/queue/index.ts
@@ -1,7 +1,19 @@
 import type { IAppQueue } from '@plumber/types'
 
-import { M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS } from '@/config/app-env-vars/m365'
+import {
+  M365_EXCEL_BATCH_ENABLED,
+  M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
+} from '@/config/app-env-vars/m365'
 import Step from '@/models/step'
+
+// Sized against two ceilings: (1) Microsoft Graph's 4MB request payload
+// limit on `POST /tables/:tableId/rows` — 20 typical rows fit with headroom;
+// (2) empirical sweet-spot for batch fill latency under our current traffic
+// shape. Going larger risks 413 responses we don't yet split on; going
+// smaller wastes coalescing opportunities. Bump together with `groupLimits.
+// concurrency` (see the load-bearing invariant below) and re-check Graph
+// payload size if rows grow.
+const BATCH_SIZE = 20
 
 //
 // This config sets up a per-app queue to serialize Excel actions by file, as
@@ -42,14 +54,43 @@ const queueSettings = {
   getGroupConfigForJob,
   groupLimits: {
     type: 'concurrency',
-    concurrency: 1,
+    // LOAD-BEARING INVARIANT: when batching is on, this MUST equal
+    // `batch.size`. BullMQ Pro increments the per-group active counter per
+    // job (see increaseGroupConcurrency.lua), so one batch of size N fills
+    // the budget and locks the group for the duration of the batch — which
+    // is what preserves Microsoft's per-file serialization. If this is
+    // raised ABOVE batch.size, two batches per file could run concurrently
+    // and break serialization; if lowered BELOW, batches under-fill and
+    // throughput drops. Move both values together when tuning.
+    concurrency: M365_EXCEL_BATCH_ENABLED ? BATCH_SIZE : 1,
   },
   isQueueDelayable: true,
-  queueRateLimit: {
-    max: 1,
-    duration: M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
-  },
+  // BullMQ Pro's rate limit is per-JOB at the lua-script level (see
+  // prepareJobForProcessing.lua — the counter increments once per job inside
+  // the batch fetch loop, not once per batch). So when batching is on, `max`
+  // must scale with `batch.size`, otherwise the limiter caps each fetch at 1
+  // job and batches silently never grow past size 1. Scaling `duration` by
+  // the same factor preserves the long-term throughput target
+  // (jobs-per-second = max/duration) while letting one full batch be
+  // dispensed per rate window.
+  queueRateLimit: M365_EXCEL_BATCH_ENABLED
+    ? {
+        max: BATCH_SIZE,
+        duration: BATCH_SIZE * M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
+      }
+    : {
+        max: 1,
+        duration: M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
+      },
   workerType: 'action',
+  ...(M365_EXCEL_BATCH_ENABLED
+    ? {
+        batch: {
+          size: BATCH_SIZE,
+          groupAffinity: true as const,
+        },
+      }
+    : {}),
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/config/app-env-vars/m365.ts
+++ b/packages/backend/src/config/app-env-vars/m365.ts
@@ -25,6 +25,15 @@ if (
   )
 }
 
+// Gates BullMQ Pro batching on the m365-excel action queue. When true, the
+// queue's worker fetches up to `batch.size` jobs at once and the action's
+// `runBatch` (if defined) coalesces per-job side effects. Off by default
+// because batching shifts the rate-limit unit from 1 job to 1 coalesced
+// batch and changes the failure mode (POST is now all-or-nothing across the
+// batch); requires explicit opt-in per environment.
+export const M365_EXCEL_BATCH_ENABLED =
+  process.env.M365_EXCEL_BATCH_ENABLED === 'true'
+
 const sensitivityLabelGuidsSchema = z
   .string()
   .trim()

--- a/packages/backend/src/workers/__tests__/action.batch.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.batch.itest.ts
@@ -1,0 +1,297 @@
+import { QueuePro, UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import m365ExcelQueueConfig from '@/apps/m365-excel/queue'
+import { M365_EXCEL_BATCH_ENABLED } from '@/config/app-env-vars/m365'
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import logger from '@/helpers/logger'
+import { makeActionQueue } from '@/queues/helpers/make-action-queue'
+import { makeActionWorker } from '@/workers/helpers/make-action-worker'
+
+import { backupWorker, flushQueue, restoreWorker } from './test-helpers'
+
+// processAction is the real entrypoint for single-item dispatch. We stub it
+// so the worker doesn't try to load real Step/Flow/Execution rows from the
+// DB in tests that exercise the single-item code path.
+const mocks = vi.hoisted(() => ({
+  processAction: vi.fn(async () => ({
+    executionStep: { isFailed: false },
+    nextStep: null,
+  })),
+}))
+
+vi.mock('@/services/action', () => ({ processAction: mocks.processAction }))
+
+describe('m365-excel queue config (flag off — the default in tests)', () => {
+  it('sanity: M365_EXCEL_BATCH_ENABLED is false in the test env', () => {
+    expect(M365_EXCEL_BATCH_ENABLED).toBe(false)
+  })
+
+  it('omits batch and keeps per-group concurrency at 1', () => {
+    expect(m365ExcelQueueConfig).not.toHaveProperty('batch')
+    expect(m365ExcelQueueConfig.groupLimits).toEqual({
+      type: 'concurrency',
+      concurrency: 1,
+    })
+  })
+})
+
+describe('makeActionWorker batch wiring', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+  const constructedWorkers: Array<ReturnType<typeof makeActionWorker>> = []
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation((() => {
+      // no-op
+    }) as unknown as typeof logger.warn)
+  })
+
+  afterEach(async () => {
+    warnSpy.mockRestore()
+    await Promise.all(constructedWorkers.splice(0).map((w) => w.close()))
+  })
+
+  it('warns when batch is configured but getGroupConfigForJob is missing', () => {
+    const queueName = '{batch-itest-warn}'
+    constructedWorkers.push(
+      makeActionWorker({
+        appKey: 'batch-itest-app',
+        queueName,
+        queueConfig: {
+          isQueueDelayable: false,
+          workerType: 'action',
+          batch: { size: 3, groupAffinity: true as const },
+        },
+      }),
+    )
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Queue '${queueName}' enables batch without getGroupConfigForJob`,
+      ),
+      expect.objectContaining({
+        event: 'action-worker-batch-without-group-config',
+      }),
+    )
+  })
+
+  it('does not warn when batch is configured with getGroupConfigForJob', () => {
+    constructedWorkers.push(
+      makeActionWorker({
+        appKey: 'batch-itest-app',
+        queueName: '{batch-itest-no-warn}',
+        queueConfig: {
+          isQueueDelayable: false,
+          workerType: 'action',
+          getGroupConfigForJob: async () => ({ id: 'g' }),
+          groupLimits: { type: 'concurrency', concurrency: 3 },
+          batch: { size: 3, groupAffinity: true as const },
+        },
+      }),
+    )
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when batch is not configured', () => {
+    constructedWorkers.push(
+      makeActionWorker({
+        appKey: 'batch-itest-app',
+        queueName: '{batch-itest-no-batch}',
+        queueConfig: {
+          isQueueDelayable: false,
+          workerType: 'action',
+        },
+      }),
+    )
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('batch dispatch stub (flag on locally)', () => {
+  // We build a fresh queue+worker pair here rather than using the m365-excel
+  // ones because the m365-excel queue's batch config is decided at module
+  // load time from M365_EXCEL_BATCH_ENABLED (which is off in tests).
+  const queueName = '{batch-itest-dispatch}'
+  let queue: QueuePro
+  let worker: ReturnType<typeof makeActionWorker>
+  let originalWorkerState: Awaited<ReturnType<typeof backupWorker>>
+
+  beforeAll(async () => {
+    queue = makeActionQueue({ queueName })
+    worker = makeActionWorker({
+      appKey: 'batch-itest-app',
+      queueName,
+      queueConfig: {
+        isQueueDelayable: false,
+        workerType: 'action',
+        getGroupConfigForJob: async () => ({ id: 'g1' }),
+        groupLimits: { type: 'concurrency', concurrency: 5 },
+        batch: { size: 5, groupAffinity: true as const },
+      },
+    })
+    originalWorkerState = await backupWorker(worker)
+    await worker.waitUntilReady()
+  })
+
+  afterEach(async () => {
+    await flushQueue(queue, worker)
+    await restoreWorker(worker, originalWorkerState)
+    mocks.processAction.mockClear()
+  })
+
+  afterAll(async () => {
+    await worker.close()
+    await queue.close()
+  })
+
+  it('throws UnrecoverableError when a multi-item batch is formed', async () => {
+    // BullMQ Pro emits ONE `failed` event per batch (for the representative
+    // job whose id is the comma-joined sibling ids — `'1,2,3'` in this test),
+    // not one per individual job. The underlying jobs all transition to the
+    // failed state, but the worker-level event fires once.
+    const failures: Array<{ err: Error; jobId?: string }> = []
+    const failurePromise = new Promise<void>((resolve) => {
+      worker.on('failed', (job, err) => {
+        failures.push({ err, jobId: job?.id })
+        resolve()
+      })
+    })
+
+    // Pause the worker BEFORE enqueueing so all three jobs land in the queue
+    // before any fetch happens; otherwise the worker may pull them one at a
+    // time and form batches of size 1, never tripping the stub.
+    await worker.pause()
+    await Promise.all(
+      [1, 2, 3].map((n) =>
+        queue.add(
+          `test-job-${n}`,
+          {
+            flowId: 'test-flow-id',
+            executionId: 'test-exec-id',
+            stepId: `test-step-${n}`,
+          },
+          { ...DEFAULT_JOB_OPTIONS, attempts: 1, group: { id: 'g1' } },
+        ),
+      ),
+    )
+    worker.resume()
+
+    await failurePromise
+
+    expect(failures).toHaveLength(1)
+    const [{ err, jobId }] = failures
+    expect(err.message).toContain('Batch dispatch not yet implemented')
+    expect(err.message).toContain('received 3 jobs')
+    // The representative job's id is the joined ids of all batched siblings.
+    expect(jobId?.split(',')).toHaveLength(3)
+    // The stub should fire BEFORE we delegate to processAction.
+    expect(mocks.processAction).not.toHaveBeenCalled()
+  }, 20000)
+
+  it('UnrecoverableError remains the chosen escape hatch', () => {
+    // Sanity that the symbol the worker throws actually exists in the bullmq
+    // contract we expect — guards against accidental import drift.
+    expect(typeof UnrecoverableError).toBe('function')
+  })
+})
+
+describe('queueRateLimit interplay with batch.size (regression for the per-job limiter footgun)', () => {
+  // BullMQ Pro's rate limit is per-JOB at the script level (the counter
+  // increments inside the batch-fetch loop), so `queueRateLimit.max` MUST
+  // scale with `batch.size`. The earlier in-flight version of the m365-excel
+  // config kept `max: 1`, which would have silently capped every batch at
+  // size 1 — coalescing-by-batch could never happen. This block mirrors the
+  // shape of the real m365-excel config (`max: BATCH, duration: BATCH * I`)
+  // and asserts a full batch actually forms; if anyone reverts `max` back to
+  // 1 (or otherwise lets it drift below `batch.size`), this test fails.
+  const queueName = '{batch-itest-ratelimit}'
+  const BATCH = 5
+  const INTERVAL_MS = 200
+  let queue: QueuePro
+  let worker: ReturnType<typeof makeActionWorker>
+  let originalWorkerState: Awaited<ReturnType<typeof backupWorker>>
+
+  beforeAll(async () => {
+    queue = makeActionQueue({ queueName })
+    worker = makeActionWorker({
+      appKey: 'batch-itest-app',
+      queueName,
+      queueConfig: {
+        isQueueDelayable: true,
+        workerType: 'action',
+        getGroupConfigForJob: async () => ({ id: 'g1' }),
+        groupLimits: { type: 'concurrency', concurrency: BATCH },
+        // Mirrors the m365-excel "batching on" shape exactly.
+        queueRateLimit: { max: BATCH, duration: BATCH * INTERVAL_MS },
+        batch: { size: BATCH, groupAffinity: true as const },
+      },
+    })
+    originalWorkerState = await backupWorker(worker)
+    await worker.waitUntilReady()
+  })
+
+  afterEach(async () => {
+    await flushQueue(queue, worker)
+    await restoreWorker(worker, originalWorkerState)
+    mocks.processAction.mockClear()
+  })
+
+  afterAll(async () => {
+    await worker.close()
+    await queue.close()
+  })
+
+  it('fills a batch to batch.size when max scales with BATCH_SIZE', async () => {
+    // The stub throws with "received N jobs in batch" — N is our proxy for
+    // actual batch size. With max: BATCH (correct) we expect N === BATCH;
+    // with max: 1 (the bug) we would see N === 1 on each of BATCH failures.
+    const failures: Array<{ err: Error; jobId?: string }> = []
+    const allFailuresSeen = new Promise<void>((resolve) => {
+      worker.on('failed', (job, err) => {
+        failures.push({ err, jobId: job?.id })
+        // Resolve once we see the first failure — under a correct config
+        // there's exactly one (a single batch of BATCH); under the bug
+        // there would be BATCH separate failures, so seeing >1 also lets
+        // us assert below.
+        resolve()
+      })
+    })
+
+    await worker.pause()
+    await Promise.all(
+      Array.from({ length: BATCH }, (_, i) => i + 1).map((n) =>
+        queue.add(
+          `test-job-${n}`,
+          {
+            flowId: 'test-flow-id',
+            executionId: 'test-exec-id',
+            stepId: `test-step-${n}`,
+          },
+          { ...DEFAULT_JOB_OPTIONS, attempts: 1, group: { id: 'g1' } },
+        ),
+      ),
+    )
+    worker.resume()
+
+    await allFailuresSeen
+    // Give the worker a beat to surface any additional (would-be) failures
+    // so we can catch the buggy max:1 case (BATCH separate failures).
+    await new Promise((r) => setTimeout(r, 250))
+
+    expect(failures).toHaveLength(1)
+    const [{ err, jobId }] = failures
+    expect(err.message).toContain(`received ${BATCH} jobs`)
+    expect(jobId?.split(',')).toHaveLength(BATCH)
+  }, 20000)
+})

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -13,6 +13,7 @@ import { handleFailedStepAndThrow } from '@/helpers/actions'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
+import logger from '@/helpers/logger'
 import tracer from '@/helpers/tracer'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
@@ -66,6 +67,21 @@ function convertParamsToBullMqOptions(
     workerOptions.group = groupSettings
   }
 
+  if (queueConfig.batch) {
+    // Without a group config the worker has no notion of "all jobs in this
+    // batch share the same unit of work", which is the only reason we ever
+    // turn batches on. Warn loudly instead of crashing — m365-excel (the
+    // only batched queue today) does set this, so this branch is purely
+    // future-proofing for the next caller who forgets.
+    if (!queueConfig.getGroupConfigForJob) {
+      logger.warn(
+        `[make-action-worker] Queue '${queueName}' enables batch without getGroupConfigForJob; batches will not respect grouping.`,
+        { event: 'action-worker-batch-without-group-config', queueName },
+      )
+    }
+    workerOptions.batch = queueConfig.batch
+  }
+
   return {
     queueName,
     workerOptions,
@@ -99,6 +115,17 @@ export function makeActionWorker(
       'workers.action',
       async (job) => {
         const span = tracer.scope().active()
+
+        // PR A stub: real batch dispatch lives in PR B. Today no caller has
+        // `batch` enabled in prod (m365-excel's flag is off by default), so
+        // this guard is unreachable at runtime — its purpose is to fail
+        // loudly the moment somebody flips the flag before PR B ships.
+        const batchSiblings = job.getBatch?.() ?? []
+        if (batchSiblings.length > 1) {
+          throw new UnrecoverableError(
+            `Batch dispatch not yet implemented (received ${batchSiblings.length} jobs in batch for queue '${queueName}')`,
+          )
+        }
 
         const jobData = job.data
         const jobId = makeActionJobId(queueName, job.id)

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -618,6 +618,25 @@ export interface IAppQueue {
    * The type of worker to use for this queue.
    */
   workerType: 'action' | 'sub-trigger'
+
+  /**
+   * Enables BullMQ Pro batches on this queue's worker. When set, the worker
+   * fetches up to `size` jobs at once and invokes the processor on the batch.
+   *
+   * Always pair with `getGroupConfigForJob` and `groupAffinity: true` so that
+   * every job in a batch belongs to the same group (e.g. same per-file
+   * serialization unit). Pairing batches with group affinity is what makes
+   * coalescing per-job side effects (e.g. one upstream API call per batch)
+   * correct.
+   *
+   * @see {@link WorkerProOptions.batch}
+   */
+  batch?: {
+    size: number
+    minSize?: number
+    timeout?: number
+    groupAffinity: true
+  }
 }
 
 export interface IApp {
@@ -932,6 +951,29 @@ export interface IBaseAction {
 
 export interface IRawAction extends IBaseAction {
   arguments?: IField[]
+
+  /**
+   * Opt-in batch processor. When defined, the action worker routes every
+   * dispatch through `runBatch` — including single-item dispatches — instead
+   * of `run`. This gives the action a chance to coalesce side effects (e.g.
+   * one API call covering N items in the batch) when its queue is configured
+   * with {@link IAppQueue.batch} and `groupAffinity: true`.
+   *
+   * Each item carries its own `$` (i.e. its own auth, step, parameters, etc)
+   * plus a `markFailed` callback that fails just that one item while letting
+   * the rest of the batch commit. `markFailed(err)` defaults to retryable
+   * (regular `Error` → BullMQ retries); pass `{ retryable: false }` after
+   * external state has already changed (e.g. a Graph POST succeeded for some
+   * sub-group), where a retry would duplicate. Items that `runBatch` does not
+   * `markFailed` are treated as succeeded; if `runBatch` itself throws, every
+   * un-`markFailed` item in the dispatched sub-batch fails with that error.
+   */
+  runBatch?(
+    items: Array<{
+      $: IGlobalVariable
+      markFailed: (err: Error, opts?: { retryable?: boolean }) => void
+    }>,
+  ): Promise<void>
 }
 
 export interface IAction extends IBaseAction {


### PR DESCRIPTION
## Summary

Pure-infra scaffolding for BullMQ Pro batches on the m365-excel action queue, gated behind a new `M365_EXCEL_BATCH_ENABLED` flag (**off by default**). Zero behavior change on the unflagged path; the flagged path is intentionally stubbed and fails loudly — real dispatch lands in PR B.

- **Types** — extend `IAppQueue` with optional `batch: { size; minSize?; timeout?; groupAffinity: true }` and `IRawAction` with opt-in `runBatch?(items)`. Each item carries `{ $, markFailed(err, { retryable? }) }` so a future `runBatch` can fail individual items / sub-groups while letting the rest commit (used by PR B to avoid duplicate Graph POSTs on retry across multi-table batches).
- **Env flag** — `M365_EXCEL_BATCH_ENABLED` (default `false`). Explicit opt-in per environment because batching shifts the rate-limit unit and changes failure modes.
- **m365-excel queue config** — when the flag is on:
    - `batch: { size: 20, groupAffinity: true }` so every job in a batch belongs to the same `fileId` group.
    - `groupLimits.concurrency = batch.size` — **load-bearing invariant** documented in-source: BullMQ Pro increments the per-group active counter per job (see `increaseGroupConcurrency.lua`), so one batch fills the budget and locks the group, preserving Microsoft's per-file serialization. `> batch.size` → two batches per file run concurrently and break serialization; `< batch.size` → batches under-fill.
    - `queueRateLimit: { max: BATCH_SIZE, duration: BATCH_SIZE * INTERVAL }` — BullMQ Pro's limiter is per-job at the script level (see `prepareJobForProcessing.lua`), so `max` must scale with `batch.size`; the prior `max: 1` would have silently capped batches at size 1.
    - `BATCH_SIZE = 20` rationale documented (Graph 4MB payload ceiling on `POST /tables/:tableId/rows` + empirical sweet-spot).
- **Worker wiring** — `convertParamsToBullMqOptions` forwards `queueConfig.batch` to the worker; warns (no crash) if `batch` is set without `getGroupConfigForJob`. Processor stub throws `UnrecoverableError("Batch dispatch not yet implemented")` on any multi-item batch — unreachable today (flag off), but proves the path before PR B.

## What's NOT in this PR

- Any real `runBatch` implementation (deferred to PR B → `create-table-row.runBatch`).
- `processAction` split into `prepareActionContext` / `finalizeActionStep` (deferred to PR B, where there's a concrete callsite to design against).
- Batching for any other action / queue.

## Test plan

- [ ] CI passes
- [ ] `npm run test:integration -- action.batch.itest.ts` → 8/8 green (covers: flag-off semantics, warn-log on missing group config, stub fires on multi-item batches, and a regression test asserting batches actually fill to `batch.size` under the scaled rate-limit config — would have caught the original `max: 1` bug)
- [ ] `tsc --noEmit` clean
- [ ] With flag unset (default everywhere), full m365-excel integration suite behaves byte-identically — no regression risk on the unflagged path
- [ ] Manual local check with `M365_EXCEL_BATCH_ENABLED=true`: enqueue ≥2 jobs against the same `fileId`, observe stub failure in worker logs (`received N jobs in batch`)

## Rollback

Unset `M365_EXCEL_BATCH_ENABLED` and restart workers. Config is read at module load.

## Follow-ups

- **PR B** — `processAction` split + real worker dispatch + `create-table-row.runBatch` (first real coalesce: N rows → 1 Graph POST per `(fileId, tableId)`).
- **PR C+** — one action per PR; sequencing by measured Graph call volume.
- **Pre-prod-flip checks** — confirm Graph rate-limit headroom with tenant owner; check Datadog dashboard impact (parent-batch + child-span model changes count semantics).