### PR TITLE
PLU-673 (feat): helpers to parse clarifications

### DIFF
--- a/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseClarificationBlock } from './parse-clarification-block'
+
+describe('parseClarificationBlock', () => {
+  it('returns null when no block is present', () => {
+    expect(parseClarificationBlock('Just some conversational text.')).toBeNull()
+  })
+
+  it('returns null for an empty block', () => {
+    expect(parseClarificationBlock('<!-- CLARIFICATION_DATA\n-->')).toBeNull()
+  })
+
+  it('ignores a Q line with no question text', () => {
+    const text = `<!-- CLARIFICATION_DATA\nQ:\n- A\n- B\n-->`.trim()
+    expect(parseClarificationBlock(text)).toBeNull()
+  })
+
+  it('returns null when a question has fewer than 2 options', () => {
+    const text = `
+Some response.
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- Form submission
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toBeNull()
+  })
+
+  it('parses a single question with 2 options', () => {
+    const text = `
+Understanding of workflow: ...
+
+<!-- CLARIFICATION_DATA
+Q: What kind of notifications do you want to send?
+- Email notifications
+- Slack messages
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'What kind of notifications do you want to send?',
+        options: ['Email notifications', 'Slack messages'],
+      },
+    ])
+  })
+
+  it('parses a single question with 3 options', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: Where should data be stored?
+- Tiles
+- M365 Excel
+- Both
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'Where should data be stored?',
+        options: ['Tiles', 'M365 Excel', 'Both'],
+      },
+    ])
+  })
+
+  it('parses multiple questions', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- Form submission
+- Scheduled
+Q: Where to store?
+- Tiles
+- M365 Excel
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission', 'Scheduled'] },
+      { question: 'Where to store?', options: ['Tiles', 'M365 Excel'] },
+    ])
+  })
+
+  it('appends a wrapped option line to the preceding option, mid-list', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- FormSG
+- a new trigger
+that runs to the next line
+- Webhook
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'What trigger?',
+        options: [
+          'FormSG',
+          'a new trigger that runs to the next line',
+          'Webhook',
+        ],
+      },
+    ])
+  })
+
+  it('appends a continuation line to the last option', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- Form submission
+- Scheduled
+continuation of scheduled
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'What trigger?',
+        options: ['Form submission', 'Scheduled continuation of scheduled'],
+      },
+    ])
+  })
+
+  it('appends wrapped question lines to the question text', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger? For example, the
+continuation of the question
+- FormSG
+- Webhook
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'What trigger? For example, the continuation of the question',
+        options: ['FormSG', 'Webhook'],
+      },
+    ])
+  })
+
+  it('appends a hyphenated continuation line to the question rather than treating it as an option', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger? For example, the postman
+-transactional-email action is usually used with FormSG Trigger
+- FormSG
+- Webhook
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question:
+          'What trigger? For example, the postman -transactional-email action is usually used with FormSG Trigger',
+        options: ['FormSG', 'Webhook'],
+      },
+    ])
+  })
+
+  it('does not bleed a wrapped option into the next question at a Q boundary', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- Form submission
+- Scheduled
+continuation of scheduled
+Q: Where to store?
+- Tiles
+- M365 Excel
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      {
+        question: 'What trigger?',
+        options: ['Form submission', 'Scheduled continuation of scheduled'],
+      },
+      { question: 'Where to store?', options: ['Tiles', 'M365 Excel'] },
+    ])
+  })
+
+  it('handles surrounding whitespace in the block', () => {
+    const text = `
+<!--  CLARIFICATION_DATA
+
+Q:  What trigger?
+  -  Form submission
+  -  Scheduled
+
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission', 'Scheduled'] },
+    ])
+  })
+
+  it('returns null when block is present but all questions have < 2 options', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What trigger?
+- Form submission
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toBeNull()
+  })
+})

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.ts
@@ -1,0 +1,60 @@
+export interface ClarificationQuestion {
+  question: string
+  options: string[]
+}
+
+/**
+ * Extracts structured clarification questions from a CLARIFICATION_DATA HTML
+ * comment block embedded in the LLM response text.
+ *
+ * Returns null when no valid block is found (most responses).
+ * @remarks Only the first CLARIFICATION_DATA block in the text is parsed.
+ */
+export function parseClarificationBlock(
+  text: string,
+): ClarificationQuestion[] | null {
+  const match = text.match(/<!--\s*CLARIFICATION_DATA\s*([\s\S]*?)\s*-->/)
+  if (!match) {
+    return null
+  }
+
+  const lines = match[1]
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+
+  const questions: ClarificationQuestion[] = []
+  let current: ClarificationQuestion | null = null
+
+  for (const line of lines) {
+    if (line.startsWith('Q:')) {
+      if (current) {
+        questions.push(current)
+      }
+      const question = line.slice(2).trim()
+      if (!question) {
+        current = null
+        continue
+      }
+      current = { question, options: [] }
+    } else if (line.startsWith('- ') && current) {
+      const option = line.slice(2).trim()
+      if (option) {
+        current.options.push(option)
+      }
+    } else if (current) {
+      if (current.options.length === 0) {
+        current.question += ' ' + line
+      } else {
+        current.options[current.options.length - 1] += ' ' + line
+      }
+    }
+  }
+
+  if (current) {
+    questions.push(current)
+  }
+
+  const valid = questions.filter((q) => q.options.length >= 2)
+  return valid.length > 0 ? valid : null
+}

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -32,6 +32,19 @@ const messagePartSchema = z.discriminatedUnion('type', [
       z.object({ isChatReady: z.boolean() }),
     ]),
   }),
+  z.object({
+    type: z.literal('data-clarification'),
+    data: z.object({
+      questions: z
+        .array(
+          z.object({
+            question: z.string(),
+            options: z.array(z.string()).min(2),
+          }),
+        )
+        .min(1),
+    }),
+  }),
 ])
 
 const messageSchema = z.object({


### PR DESCRIPTION
### **TL;DR**

Adds a parser for extracting structured clarification questions from LLM responses, along with a new `data-clarification` message part type in the chat schema.

### **What changed?**

- Introduced `parseClarificationBlock`, which extracts `ClarificationQuestion` objects (each with a `question` string and at least two `options`) from a `CLARIFICATION_DATA` HTML comment block embedded in LLM response text. Returns `null` when no valid block is found.
- Added a `data-clarification` discriminated union variant to the chat message part schema, carrying an array of questions with their options.
- Added comprehensive unit tests covering empty blocks, missing questions, single/multiple questions, stray lines, whitespace handling, and insufficient options.

### **How to test?**

- [ ] Sanity check that the parsers make sense
- [ ] Verify all test cases pass, including edge cases such as blocks with fewer than 2 options per question (should return `null`) and blocks with surrounding whitespace (should parse correctly).

### **Why make this change?**

When the LLM needs more information before generating a workflow, it should be able to surface structured clarification questions to the user. This parser provides a reliable way to extract those questions from the raw LLM response text, and the new schema type ensures the clarification data can be properly validated and transmitted through the chat message pipeline.

This is in preparation for the next PR, which introduces a new frontend component to collect the responses to the clarifications.