### PR TITLE
PLU-673 (feat): add clarification choice picker to chat

### DIFF
--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -33,6 +33,7 @@ import { pipeWebResponseToExpress } from '@/helpers/stream'
 import { AuthenticatedRequest } from '@/types/express/context'
 
 import { serializeMessagesForLangfuse } from './helpers'
+import { parseClarificationBlock } from './parse-clarification-block'
 import { chatRequestSchema } from './schema'
 
 const MAX_MESSAGES = 50
@@ -176,6 +177,16 @@ const handleChatStream = observe(
                       (flowSteps ? { flowSteps } : { error: workflowError })),
                   },
                 })
+
+                if (!hasWorkflowMetadata) {
+                  const questions = parseClarificationBlock(event.text)
+                  if (questions) {
+                    writer.write({
+                      type: 'data-clarification',
+                      data: { questions },
+                    })
+                  }
+                }
               } catch (error) {
                 logger.error('Error parsing workflow', {
                   traceId,

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -28,6 +28,7 @@ export interface Message {
    * only assistant messages should have this.
    */
   isChatReady: boolean
+  clarification?: ClarificationPart['data']['questions']
 }
 
 // Custom message type with metadata
@@ -42,6 +43,19 @@ export type IsChatReadyPart = {
     isChatReady: boolean
     flowSteps?: IFlowSteps
     error?: string
+  }
+}
+
+export interface ClarificationQuestion {
+  question: string
+  options: string[]
+}
+
+// Type for clarification questions data annotation
+export type ClarificationPart = {
+  type: 'data-clarification'
+  data: {
+    questions: ClarificationQuestion[]
   }
 }
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
@@ -1,0 +1,161 @@
+import { type FormEvent, type KeyboardEvent, useRef, useState } from 'react'
+import { FaArrowCircleUp } from 'react-icons/fa'
+import { FaCircleStop } from 'react-icons/fa6'
+import { Box, Button, Flex, Icon, Text, Textarea } from '@chakra-ui/react'
+import { Badge } from '@opengovsg/design-system-react'
+
+import { type ClarificationQuestion } from '@/hooks/useChatStream'
+
+interface ChoicePickerProps {
+  clarification: ClarificationQuestion[]
+  currentQuestionIdx: number
+  isStreaming: boolean
+  onOptionClick: (optionIdx: number) => void
+  onFreeTextSubmit: (text: string) => void
+  cancelStream: () => void
+}
+
+export default function ChoicePicker({
+  clarification,
+  currentQuestionIdx,
+  isStreaming,
+  onOptionClick,
+  onFreeTextSubmit,
+  cancelStream,
+}: ChoicePickerProps) {
+  const [input, setInput] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const currentQ = clarification[currentQuestionIdx] ?? clarification[0]
+  const isMulti = clarification.length > 1
+
+  const handleResize = (e?: FormEvent<HTMLTextAreaElement>) => {
+    const target = e?.currentTarget || textareaRef.current
+    if (!target) {
+      return
+    }
+    const maxHeight = window.innerHeight * 0.4 - 100
+    target.style.height = 'auto'
+    target.style.height = Math.min(target.scrollHeight, maxHeight) + 'px'
+  }
+
+  const handleSubmit = () => {
+    if (!input.trim() || isStreaming) {
+      return
+    }
+    onFreeTextSubmit(input)
+    setInput('')
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSubmit()
+    }
+  }
+
+  return (
+    <Box w="full" maxW="4xl">
+      <Box
+        bg="white"
+        border="1px"
+        borderColor="gray.200"
+        borderRadius="16px"
+        boxShadow="0 2px 4px rgba(0,0,0,0.1)"
+        p={4}
+        w="full"
+      >
+        <Flex justify="space-between" align="center" mb={2}>
+          <Text>{currentQ.question}</Text>
+          {isMulti && (
+            <Text fontSize="sm" color="gray.400" ml={3}>
+              {currentQuestionIdx + 1} / {clarification.length}
+            </Text>
+          )}
+        </Flex>
+
+        <Flex direction="column" gap={2}>
+          {currentQ.options.map((opt, optIdx) => (
+            <Button
+              key={optIdx}
+              variant="outline"
+              justifyContent="flex-start"
+              h="auto"
+              py={2}
+              isDisabled={isStreaming}
+              onClick={() => onOptionClick(optIdx)}
+              borderColor="gray.200"
+              bg="white"
+              color="gray.800"
+              _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
+              _active={{ bg: 'primary.100' }}
+              gap={2}
+            >
+              <Badge
+                colorScheme="secondary"
+                variant="subtle"
+                size="sm"
+                flexShrink={0}
+              >
+                {optIdx + 1}
+              </Badge>
+              <Text textAlign="left" whiteSpace="normal" color="gray.800">
+                {opt}
+              </Text>
+            </Button>
+          ))}
+        </Flex>
+
+        <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
+          <Flex gap={2} align="flex-end">
+            <Textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyPress}
+              placeholder="Or describe your answer..."
+              resize="none"
+              border="none"
+              bg="transparent"
+              p={0}
+              color="gray.900"
+              _placeholder={{ color: 'gray.400' }}
+              _focus={{ outline: 'none', boxShadow: 'none' }}
+              fontSize="md"
+              rows={1}
+              maxH="120px"
+              overflowY="auto"
+              onInput={handleResize}
+              isDisabled={isStreaming}
+            />
+            <Flex align="flex-end" gap={2} flexShrink={0} h="24px">
+              {isStreaming ? (
+                <Icon
+                  as={FaCircleStop}
+                  fontSize="24px"
+                  color="red.500"
+                  cursor="pointer"
+                  onClick={cancelStream}
+                  _hover={{ color: 'red.600' }}
+                />
+              ) : (
+                input.trim() && (
+                  <Icon
+                    as={FaArrowCircleUp}
+                    fontSize="24px"
+                    color="primary.500"
+                    onClick={handleSubmit}
+                    cursor="pointer"
+                  />
+                )
+              )}
+            </Flex>
+          </Flex>
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -10,6 +10,8 @@ import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
 import { Box, Flex, Icon, Textarea } from '@chakra-ui/react'
 
+import { type ClarificationQuestion } from '@/hooks/useChatStream'
+import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicker'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
 import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
 
@@ -20,6 +22,7 @@ interface PromptInputProps {
   initialValue?: string
   sendMessage: (message: string) => void
   cancelStream: () => void
+  clarification?: ClarificationQuestion[]
 }
 
 export default function PromptInput({
@@ -29,15 +32,27 @@ export default function PromptInput({
   initialValue = '',
   sendMessage,
   cancelStream,
+  clarification,
 }: PromptInputProps) {
   const [input, setInput] = useState<string>(initialValue)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [selectedAnswers, setSelectedAnswers] = useState<
+    Record<number, string>
+  >({})
+  const [currentQuestionIdx, setCurrentQuestionIdx] = useState(0)
 
-  const handleSubmit = async (e: SyntheticEvent) => {
+  // Reset state whenever a new clarification arrives
+  useEffect(() => {
+    setSelectedAnswers({})
+    setCurrentQuestionIdx(0)
+  }, [clarification])
+
+  const handleSubmit = (e: SyntheticEvent) => {
     e.preventDefault()
     if (input?.trim() && !isStreaming) {
       sendMessage(input)
       setInput('')
+      setSelectedAnswers({})
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto'
       }
@@ -56,7 +71,7 @@ export default function PromptInput({
     if (!target) {
       return
     }
-    const maxHeight = window.innerHeight * 0.4 - 100 // 40vh minus padding/margins
+    const maxHeight = window.innerHeight * 0.4 - 100
     target.style.height = 'auto'
     target.style.height = Math.min(target.scrollHeight, maxHeight) + 'px'
   }
@@ -69,8 +84,47 @@ export default function PromptInput({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const handleAnswer = (answer: string) => {
+    if (isStreaming || !clarification) {
+      return
+    }
+
+    const newAnswers = { ...selectedAnswers, [currentQuestionIdx]: answer }
+    setSelectedAnswers(newAnswers)
+
+    const isLast = currentQuestionIdx === clarification.length - 1
+    if (isLast) {
+      const combined = clarification.map((_, i) => newAnswers[i]).join('\n')
+      sendMessage(combined)
+      setSelectedAnswers({})
+      setCurrentQuestionIdx(0)
+    } else {
+      setCurrentQuestionIdx((prev) => prev + 1)
+    }
+  }
+
+  const handleOptionClick = (optionIdx: number) => {
+    if (!clarification) {
+      return
+    }
+    handleAnswer(clarification[currentQuestionIdx].options[optionIdx])
+  }
+
   // only show idea buttons if showIdeas is true and the user has not entered any text
   const shouldShowIdeas = showIdeas && !input?.trim()
+
+  if (clarification && clarification.length > 0) {
+    return (
+      <ChoicePicker
+        clarification={clarification}
+        currentQuestionIdx={currentQuestionIdx}
+        isStreaming={isStreaming}
+        onOptionClick={handleOptionClick}
+        onFreeTextSubmit={handleAnswer}
+        cancelStream={cancelStream}
+      />
+    )
+  }
 
   return (
     <Box w="full" maxW="4xl">

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -49,6 +49,12 @@ export default function ChatInterface(props: ChatInterfaceProps) {
 
   const hasMessages = messages.length > 0 || isStreaming
 
+  const lastMessage = messages[messages.length - 1]
+  const activeClarification =
+    lastMessage && !lastMessage.isUser && !isStreaming
+      ? lastMessage.clarification
+      : undefined
+
   const handleNewChat = useCallback(() => {
     cancelStream()
     resetChat()
@@ -194,6 +200,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   sendMessage={sendMessage}
                   isStreaming={isStreaming}
                   cancelStream={cancelStream}
+                  clarification={activeClarification}
                 />
               )}
               {!isMobile && (

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -1,6 +1,7 @@
 import { TextPart } from 'ai'
 
 import {
+  ClarificationPart,
   CustomUIMessage,
   IsChatReadyPart,
   Message,
@@ -27,7 +28,7 @@ export const extractTextContent = (msg: CustomUIMessage): string => {
     .join('')
 }
 
-export const transformMessages = (messages: CustomUIMessage[]) => {
+export const transformMessages = (messages: CustomUIMessage[]): Message[] => {
   let lastReadyIndex = -1
 
   const transformed = messages.map((msg, index) => {
@@ -39,12 +40,17 @@ export const transformMessages = (messages: CustomUIMessage[]) => {
       lastReadyIndex = index
     }
 
+    const clarificationPart = msg.parts.find(
+      (part): part is ClarificationPart => part.type === 'data-clarification',
+    )
+
     return {
       id: msg.id,
       text: extractTextContent(msg),
       isUser: msg.role === 'user',
       traceId: msg.metadata?.traceId,
-      isChatReady: false, // default to false
+      isChatReady: false,
+      clarification: clarificationPart?.data.questions,
     }
   })
 


### PR DESCRIPTION
### TL;DR

Adds a clarification question UI that prompts users to answer structured questions before the AI proceeds with building.

### What changed?

When the AI response contains a clarification block (parsed via `parseClarificationBlock`), a `data-clarification` annotation is emitted in the chat stream. This annotation is attached to the last assistant message and surfaced in the frontend as a `ChoicePicker` component that replaces the standard `PromptInput`.

The `ChoicePicker` displays one question at a time (with a progress indicator for multi-question flows), allowing users to either click a predefined option or type a free-text answer. Once all questions are answered, the combined responses are sent as a single message. The clarification state resets whenever a new clarification block arrives or a message is submitted.

### How to test?

_Set your prompt version to_ `test_clarifications` in `packages/backend/src/routes/api/chat/index.ts`

- [ ]  Verify that clarification questions use the `ChoicePicker`
    - [ ]  Click a predefined option and confirm the next question appears (if multi-question), or that the answers are submitted automatically on the last question.
- [ ]  Verify that typing an 'Others' answer does not send immediately, it should only send after all responses have been collected
- [ ]  Verify that after submission, the standard `PromptInput` is restored
- [ ]  Verify that if streaming is in progress, the stop button appears and options/inputs are disabled.

### Why make this change?

Improves the user experience, matching what users get from commercial products.

### Deploy notes

- [ ]  Promote `test_clarifications` prompt to production