### PR TITLE
[SAFE-EMAIL-TEST-2] PLU-386: make postman email test step send only to the pipe owner

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -575,7 +575,7 @@ describe('send transactional email', () => {
     })
   })
 
-  it('should send to all recipients in test runs', async () => {
+  it('skips partial retry and sends only to the test runner in test runs', async () => {
     const recipients = [
       'recipient1@open.gov.sg',
       'recipient2@open.gov.sg',
@@ -600,11 +600,11 @@ describe('send transactional email', () => {
     })
     $.execution.testRun = true
     await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
-    expect($.http.post).toBeCalledTimes(5)
+    expect($.http.post).toBeCalledTimes(1)
     expect($.setActionItem).toHaveBeenCalledWith({
       raw: {
-        status: ['ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED', 'ACCEPTED'],
-        recipient: recipients,
+        status: ['ACCEPTED'],
+        recipient: [$.user.email],
         subject: 'test subject',
         body: 'test body',
         from: 'jack',
@@ -647,6 +647,70 @@ describe('send transactional email', () => {
         from: 'jack',
         reply_to: 'replyTo@open.gov.sg',
       },
+    })
+  })
+
+  describe('test-run recipient override', () => {
+    it("redirects email to the test runner's address and drops CCs when testRun is true", async () => {
+      $.step.parameters.destinationEmail = 'recipient@example.com'
+      $.step.parameters.destinationEmailCc = 'cc@example.com'
+      $.user.email = 'me@example.com'
+      $.execution.testRun = true
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.http.post).toBeCalledTimes(1)
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED'],
+          recipient: ['me@example.com'],
+          subject: 'test subject',
+          body: 'test body',
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
+    })
+
+    it('does not override recipients on a normal (non-test) run', async () => {
+      const recipients = ['recipient1@open.gov.sg', 'recipient2@open.gov.sg']
+      const ccRecipients = ['cc1@open.gov.sg', 'cc2@open.gov.sg']
+      $.step.parameters.destinationEmail = recipients.join(',')
+      $.step.parameters.destinationEmailCc = ccRecipients.join(',')
+      $.user.email = 'me@example.com'
+      $.execution.testRun = false
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED', 'ACCEPTED'],
+          recipient: recipients,
+          subject: 'test subject',
+          body: 'test body',
+          cc: ccRecipients,
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
+    })
+
+    it("collapses multiple configured recipients to the test runner's address in test mode", async () => {
+      $.step.parameters.destinationEmail = 'a@x.com, b@x.com, c@x.com'
+      $.step.parameters.destinationEmailCc = 'cc1@x.com, cc2@x.com'
+      $.user.email = 'me@example.com'
+      $.execution.testRun = true
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+      expect($.http.post).toBeCalledTimes(1)
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED'],
+          recipient: ['me@example.com'],
+          subject: 'test subject',
+          body: 'test body',
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
     })
   })
 

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -93,9 +93,18 @@ const action: IRawAction = {
       replyTo,
       attachments = [],
     } = $.step.parameters
+    // During test runs, redirect all recipients to the test runner's own
+    // email so test sends never spam unrelated addresses configured on the
+    // step.
+    const effectiveDestinationEmail = $.execution.testRun
+      ? $.user.email
+      : destinationEmail
+    const effectiveDestinationEmailCc = $.execution.testRun
+      ? undefined
+      : destinationEmailCc
     const result = transactionalEmailSchema.safeParse({
-      destinationEmail,
-      destinationEmailCc,
+      destinationEmail: effectiveDestinationEmail,
+      destinationEmailCc: effectiveDestinationEmailCc,
       senderName,
       subject,
       body,

--- a/packages/frontend/src/app-extensions/index.ts
+++ b/packages/frontend/src/app-extensions/index.ts
@@ -1,7 +1,12 @@
+import postmanExtensions from './postman'
 import type { FrontEndAppExtension } from './types'
 
-// Nothing for now
-const APP_EXTENSIONS: Record<string, FrontEndAppExtension> = {}
+/**
+ * Keys are `${appKey}-${stepKey}`.
+ */
+const APP_EXTENSIONS: Record<string, FrontEndAppExtension> = {
+  ...postmanExtensions,
+}
 
 export function getExtension(
   appKey?: string,

--- a/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
+++ b/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
@@ -1,0 +1,18 @@
+import { Tooltip } from '@chakra-ui/react'
+
+import type { CheckStepButtonExtensionProps } from '@/app-extensions/types'
+
+function CheckStepButtonExtension({ children }: CheckStepButtonExtensionProps) {
+  return (
+    <Tooltip
+      label="Test email will only be sent to you."
+      aria-label="Check step tooltip"
+      hasArrow
+      shouldWrapChildren
+    >
+      {children}
+    </Tooltip>
+  )
+}
+
+export default CheckStepButtonExtension

--- a/packages/frontend/src/app-extensions/postman/index.ts
+++ b/packages/frontend/src/app-extensions/postman/index.ts
@@ -1,0 +1,11 @@
+import type { FrontEndAppExtension } from '@/app-extensions/types'
+
+import CheckStepButton from './actions/send-transactional-email/check-step-button'
+
+const extensions = {
+  'postman-sendTransactionalEmail': {
+    CheckStepButton: CheckStepButton,
+  },
+} satisfies Record<string, FrontEndAppExtension>
+
+export default extensions


### PR DESCRIPTION
## Problem
When testing email, we want to always send the email only to the pipe owner. This prevents them from accidentally sending a real email to their target audience when testing.

## Solution
**High level**: when calling postman's API, clear CC list and force recipient to pipe owner if the run is a test run.

We want to add a UX signal to let the pipe owner know that when they click test step in postman, the email will be sent to them.

I decided on showing a tooltip. However, I'm not 100% sure if tooltip is good enough - we may want to do a NUX / first time modal instead.

### This PR
Adds a frontend extension for postman send email action to apply a new test step tooltip, and also updates the postman backend logic as described in the solution

<img width="1466" height="945" alt="Screenshot 2026-05-27 at 1 20 13 PM" src="https://github.com/user-attachments/assets/244430ed-48e0-4a3c-a8d9-927e546bf444" />
<img width="1453" height="944" alt="Screenshot 2026-05-27 at 1 20 25 PM" src="https://github.com/user-attachments/assets/9a472907-2164-433e-a374-5b7237dc1310" />


## Tests
- [x] Check that when sending a test email, the email is sent only to the pipe owner (Cc list and configured recipient is ignored)
- [x] Check that published pipes send the email to the configured recipients & CC list people.
- [x] Check that the postman test step tooltip shows up when configuring postman email step
- [x] Check that the postman test step tooltip does not show up for other apps & actions