### PR TITLE
[SAFE-EMAIL-TEST-3] PLU-386: move formsg test step button to extension approach

### DIFF
--- a/packages/frontend/src/app-extensions/formsg/index.tsx
+++ b/packages/frontend/src/app-extensions/formsg/index.tsx
@@ -1,0 +1,14 @@
+import type { FrontEndAppExtension } from '@/app-extensions/types'
+
+import CheckStepButton from './triggers/check-step-button'
+
+const extensions = {
+  'formsg-newSubmission': {
+    CheckStepButton: CheckStepButton,
+  },
+  'formsg-mrfSubmission': {
+    CheckStepButton: CheckStepButton,
+  },
+} satisfies Record<string, FrontEndAppExtension>
+
+export default extensions

--- a/packages/frontend/src/app-extensions/formsg/triggers/check-step-button.tsx
+++ b/packages/frontend/src/app-extensions/formsg/triggers/check-step-button.tsx
@@ -1,6 +1,4 @@
-import { IExecutionStepMetadata, IStep } from '@plumber/types'
-
-import { forwardRef, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { IconType } from 'react-icons'
 import { BiChevronDown } from 'react-icons/bi'
 import { PiRobot, PiUser } from 'react-icons/pi'
@@ -15,63 +13,7 @@ import {
 } from '@chakra-ui/react'
 import { Button, IconButton, Menu } from '@opengovsg/design-system-react'
 
-import {
-  FORMSG_APP_KEY,
-  FORMSG_TRIGGER_KEY,
-  MRF_ACTION_KEY,
-} from '@/helpers/formsg'
-
-interface CheckAgainButtonProps {
-  isUnstyledInfobox: boolean
-  onClick: (testRunMetadata?: Record<string, unknown>) => void
-  isLoading: boolean
-  isDisabled: boolean
-  step: IStep
-  executionStepMetadata?: IExecutionStepMetadata
-}
-
-export const CheckAgainButton = forwardRef<
-  HTMLButtonElement,
-  CheckAgainButtonProps
->((props, ref) => {
-  const { isUnstyledInfobox, onClick, isLoading, isDisabled, step } = props
-  const isFormSgTrigger =
-    step.appKey === FORMSG_APP_KEY && step.key === FORMSG_TRIGGER_KEY
-  const isFormSgAction =
-    step.appKey === FORMSG_APP_KEY && step.key === MRF_ACTION_KEY
-
-  if (isFormSgTrigger) {
-    return <FormSGCheckAgainButton ref={ref} {...props} />
-  }
-  if (isFormSgAction) {
-    return <FormSGCheckAgainButton ref={ref} {...props} />
-  }
-  return (
-    <Button
-      ref={ref}
-      variant={isUnstyledInfobox ? 'solid' : 'outline'}
-      onClick={() => onClick()}
-      isLoading={isLoading}
-      colorScheme={isUnstyledInfobox ? 'primary' : 'black'}
-      size="sm"
-      isDisabled={isDisabled}
-      data-test="check-again-button"
-    >
-      Check step again
-    </Button>
-  )
-})
-
-/**
- * For UX reasons, we need to have a different button for FormSG.
- * The user flow goes like this:
- * - If user first connects the form, the button should be "Check step again"
- *   and display only mock data (no dropdown button)
- * - After the real submission is made, the button should be "Check again with submission"
- *   and display the dropdown button and real submission data
- * - If the user clicks on the dropdown button and select "Use mock data",
- *   the button should still show the dropdown and allow user to toggle between mock and real data
- */
+import type { CheckStepButtonExtensionProps } from '@/app-extensions/types'
 
 interface FormSGMenuItemProps {
   icon: IconType
@@ -108,19 +50,14 @@ function FormSGMenuItem({
   )
 }
 
-const FormSGCheckAgainButton = forwardRef<
-  HTMLButtonElement,
-  CheckAgainButtonProps
->((props, ref) => {
-  const {
-    isUnstyledInfobox: isTransparentInfobox,
-    onClick,
-    isLoading,
-    isDisabled,
-    executionStepMetadata,
-  } = props
-
+export default function FormSGCheckAgainButton({
+  buttonProps,
+  onClick,
+  executionStepMetadata,
+  children,
+}: CheckStepButtonExtensionProps) {
   const { isMock = false, lastTestSubmissionDate } = executionStepMetadata ?? {}
+  const { isLoading, isDisabled, size, variant, colorScheme } = buttonProps
 
   const buttonText = useMemo(() => {
     if (!lastTestSubmissionDate) {
@@ -133,14 +70,13 @@ const FormSGCheckAgainButton = forwardRef<
           <Text>Check with mock data</Text>
         </>
       )
-    } else {
-      return (
-        <>
-          <Icon as={PiUser} fontSize={20} mb={0.5} />
-          <Text>Check with last submission</Text>
-        </>
-      )
     }
+    return (
+      <>
+        <Icon as={PiUser} fontSize={20} mb={0.5} />
+        <Text>Check with last submission</Text>
+      </>
+    )
   }, [lastTestSubmissionDate, isMock])
 
   const onTestClick = useCallback(() => {
@@ -153,16 +89,19 @@ const FormSGCheckAgainButton = forwardRef<
     return onClick({ preferMock: false })
   }, [lastTestSubmissionDate, isMock, onClick])
 
+  if (!executionStepMetadata) {
+    return children
+  }
+
   return (
     <ButtonGroup
       isAttached
       isDisabled={isDisabled}
-      size="sm"
-      variant={isTransparentInfobox ? 'solid' : 'outline'}
-      colorScheme={isTransparentInfobox ? 'primary' : 'black'}
+      size={size}
+      variant={variant}
+      colorScheme={colorScheme}
     >
       <Button
-        ref={ref}
         onClick={onTestClick}
         isLoading={isLoading}
         gap={2}
@@ -198,4 +137,4 @@ const FormSGCheckAgainButton = forwardRef<
       )}
     </ButtonGroup>
   )
-})
+}

--- a/packages/frontend/src/app-extensions/index.ts
+++ b/packages/frontend/src/app-extensions/index.ts
@@ -1,3 +1,4 @@
+import formsgExtensions from './formsg'
 import postmanExtensions from './postman'
 import type { FrontEndAppExtension } from './types'
 
@@ -6,6 +7,7 @@ import type { FrontEndAppExtension } from './types'
  */
 const APP_EXTENSIONS: Record<string, FrontEndAppExtension> = {
   ...postmanExtensions,
+  ...formsgExtensions,
 }
 
 export function getExtension(

--- a/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
+++ b/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
@@ -2,7 +2,16 @@ import { Tooltip } from '@chakra-ui/react'
 
 import type { CheckStepButtonExtensionProps } from '@/app-extensions/types'
 
-function CheckStepButtonExtension({ children }: CheckStepButtonExtensionProps) {
+function CheckStepButtonExtension({
+  children,
+  buttonProps: { isDisabled },
+}: CheckStepButtonExtensionProps) {
+  // We don't have any special tooltips (yet) for if check step button is
+  // disabled.
+  if (isDisabled) {
+    return children
+  }
+
   return (
     <Tooltip
       label="Test email will only be sent to you."

--- a/packages/frontend/src/app-extensions/types.ts
+++ b/packages/frontend/src/app-extensions/types.ts
@@ -1,21 +1,39 @@
-import type { IStep } from '@plumber/types'
+import type { IExecutionStepMetadata, IStep } from '@plumber/types'
 
 import type { ComponentType, ReactNode } from 'react'
+import type { ButtonProps } from '@opengovsg/design-system-react'
 
 export interface CheckStepButtonExtensionProps {
   step: IStep
-  /** The Check Step / Check Step Again button itself. */
+  /**
+   * The Button props the parent applied to the default button. Spread these
+   * onto your own button (or ButtonGroup) when overriding so you inherit the
+   * variant/size/colour/loading/disabled state.
+   */
+  buttonProps: Omit<ButtonProps, 'onClick'>
+  /**
+   * Underlying handler. Accepts optional `testRunMetadata` for apps that need
+   * to vary the payload (e.g. FormSG's `{ preferMock: boolean }`).
+   */
+  onClick: (testRunMetadata?: Record<string, unknown>) => void
+  /**
+   * Defined at the "Check step again" site (after a test run).
+   * Undefined at the initial "Check step" site. Extensions use this to tell
+   * which site they're mounted on.
+   */
+  executionStepMetadata?: IExecutionStepMetadata
+  /**
+   * The default-rendered button. Render it to wrap (Postman tooltip), or
+   * ignore it and render your own using `buttonProps` + `onClick` (FormSG).
+   */
   children: ReactNode
 }
 
 export interface FrontEndAppExtension {
   /**
-   * Wraps the Check Step / Check Step Again button.
-   *
-   * Mounted ONLY WHEN the button is enabled.
-   * TBD: Allow extending when button is disabled (for showing custom failure
-   *      tooltip etc)
-   **/
+   * Customises the Check Step / Check Step Again button. Always mounted —
+   * extensions must handle `buttonProps.isDisabled` themselves.
+   */
   CheckStepButton?: ComponentType<CheckStepButtonExtensionProps>
 
   // Room to grow: ResultPanelWrapper, SubstepWrapper, etc.

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@chakra-ui/react'
 import {
   Button,
+  ButtonProps,
   BxsCheckCircle,
   BxsErrorCircle,
   BxsInfoCircle,
@@ -36,7 +37,6 @@ import { EDITOR_MARGIN_TOP_NUM } from '../Editor/constants'
 import ErrorResult from '../ErrorResult'
 import WebhookUrlInfo from '../WebhookUrlInfo'
 
-import { CheckAgainButton } from './CheckAgainButton'
 import { flowStepTestControllerStyles } from './styles'
 import TestResult from './TestResult'
 import { useTestDetails } from './useTestDetails'
@@ -265,9 +265,20 @@ export default function FlowStepTestController(
 
   const appExtension = getExtension(step.appKey, step.key)
   const CheckStepButtonExtension =
-    shouldAllowCheckStep && appExtension?.CheckStepButton != null
-      ? appExtension.CheckStepButton
-      : NoOpCheckStepButtonExtension
+    appExtension?.CheckStepButton ?? NoOpCheckStepButtonExtension
+
+  const checkAgainButtonProps: Omit<ButtonProps, 'onClick'> = {
+    variant: isStepUnchecked ? 'solid' : 'outline',
+    colorScheme: isStepUnchecked ? 'primary' : 'black',
+    size: 'sm',
+    isLoading: isTestExecuting,
+    isDisabled: !isValid || readOnly,
+  }
+
+  const checkStepButtonProps: Omit<ButtonProps, 'onClick'> = {
+    isLoading: isTestExecuting,
+    isDisabled: !shouldAllowCheckStep,
+  }
 
   return (
     <>
@@ -358,15 +369,19 @@ export default function FlowStepTestController(
                       {!isDirty ? 'Saved' : 'Save without checking'}
                     </Button>
                   )}
-                  <CheckStepButtonExtension step={step}>
-                    <CheckAgainButton
-                      isUnstyledInfobox={isStepUnchecked}
-                      onClick={handleSaveAndTest}
-                      isLoading={isTestExecuting}
-                      isDisabled={!isValid || readOnly}
-                      step={step}
-                      executionStepMetadata={currentTestExecutionStep?.metadata}
-                    />
+                  <CheckStepButtonExtension
+                    step={step}
+                    buttonProps={checkAgainButtonProps}
+                    onClick={handleSaveAndTest}
+                    executionStepMetadata={currentTestExecutionStep?.metadata}
+                  >
+                    <Button
+                      {...checkAgainButtonProps}
+                      onClick={() => handleSaveAndTest()}
+                      data-test="check-again-button"
+                    >
+                      Check step again
+                    </Button>
                   </CheckStepButtonExtension>
                 </Flex>
               </Flex>
@@ -402,17 +417,20 @@ export default function FlowStepTestController(
                   {isDirty ? 'Save' : 'Saved'}
                 </Button>
               )}
-              <CheckStepButtonExtension step={step}>
+              <CheckStepButtonExtension
+                step={step}
+                buttonProps={checkStepButtonProps}
+                onClick={handleSaveAndTest}
+              >
                 <CheckStepTooltip
                   hasDeletedVars={hasDeletedVars}
                   isDisabled={shouldAllowCheckStep}
                   isReadOnly={readOnly}
                 >
                   <Button
+                    {...checkStepButtonProps}
                     onClick={() => handleSaveAndTest()}
                     data-test="flow-substep-continue-button"
-                    isDisabled={!shouldAllowCheckStep}
-                    isLoading={isTestExecuting}
                   >
                     Check step
                   </Button>


### PR DESCRIPTION
# Problem

The `FormSGCheckAgainButton` is kinda edge-casey. I introduced a more generic app front-end extension approach in #1645, this migrates the FormSG button to use this new approach.

# Tests

- [ ]  Check that when creating a new FormSG trigger without mock data, the default "check step again" button is shown

![Screenshot 2026-05-28 at 2.40.03 PM.png](https://app.graphite.com/user-attachments/assets/7f526314-2dcb-4dff-94ef-fc22e777487f.png)

- [ ]  Check that when there is already true test data, the dropdown menu is shown

![Screenshot 2026-05-28 at 2.40.34 PM.png](https://app.graphite.com/user-attachments/assets/3480eb1b-9d9a-481d-b5d7-319fc20b31de.png)

![Screenshot 2026-05-28 at 2.43.45 PM.png](https://app.graphite.com/user-attachments/assets/edd4ad9d-8257-46b4-901c-1952176504df.png)

- [ ]  Test that the same behaviour above also applies for initial MRF form trigger

![Screenshot 2026-05-28 at 3.12.00 PM.png](https://app.graphite.com/user-attachments/assets/2e287897-d685-4e44-9bc9-95d6554344c0.png)

![Screenshot 2026-05-28 at 3.18.14 PM.png](https://app.graphite.com/user-attachments/assets/e28f904d-ea6d-4b9f-8292-3d23df16c4bc.png)

- [ ]  Test that same behaviour applies for MRF sub triggers

![Screenshot 2026-05-28 at 3.21.16 PM.png](https://app.graphite.com/user-attachments/assets/1da613eb-a188-450a-94d3-24964dcae54f.png)

![Screenshot 2026-05-28 at 3.21.37 PM.png](https://app.graphite.com/user-attachments/assets/9a6d265f-e6e7-4195-b73a-f3acd82e109c.png)

