### PR TITLE
feat(db-retriable-error): add maxDelayMs cap and transient-db attempts budget

### DIFF
--- a/packages/backend/src/errors/retriable-error.ts
+++ b/packages/backend/src/errors/retriable-error.ts
@@ -6,6 +6,7 @@ interface RetriableErrorParams {
   error: ConstructorParameters<typeof BaseError>[0]
   delayInMs: number | 'default'
   delayType: 'step' | 'group' | 'queue'
+  maxDelayMs?: number
 }
 
 /**
@@ -35,11 +36,18 @@ interface RetriableErrorParams {
 export default class RetriableError extends BaseError {
   delayInMs: number
   delayType: RetriableErrorParams['delayType']
+  maxDelayMs?: number
 
-  constructor({ error, delayInMs, delayType }: RetriableErrorParams) {
+  constructor({
+    error,
+    delayInMs,
+    delayType,
+    maxDelayMs,
+  }: RetriableErrorParams) {
     super(error)
 
     this.delayInMs = delayInMs === 'default' ? DEFAULT_DELAY_MS : delayInMs
     this.delayType = delayType
+    this.maxDelayMs = maxDelayMs
   }
 }

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -87,6 +87,38 @@ describe('Backoff', () => {
     },
   )
 
+  it('caps the jittered delay at maxDelayMs when set', () => {
+    const err = new RetriableError({
+      error: 'test error',
+      delayInMs: 1000,
+      delayType: 'step',
+      maxDelayMs: 5000,
+    })
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    // Attempt 1: prevFullDelay = 1000, jittered = 1500 → uncapped.
+    expect(exponentialBackoffWithJitter(1, null, err)).toEqual(1500)
+    // Attempt 2: prevFullDelay = 2000, jittered = 3000 → uncapped.
+    expect(exponentialBackoffWithJitter(2, null, err)).toEqual(3000)
+    // Attempt 3: prevFullDelay = 4000, jittered = 6000 → capped at 5000.
+    expect(exponentialBackoffWithJitter(3, null, err)).toEqual(5000)
+    // Attempt 4: prevFullDelay = 8000, jittered = 12000 → capped at 5000.
+    expect(exponentialBackoffWithJitter(4, null, err)).toEqual(5000)
+  })
+
+  it('does not cap the delay when maxDelayMs is omitted', () => {
+    const err = new RetriableError({
+      error: 'test error',
+      delayInMs: 1000,
+      delayType: 'step',
+    })
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+
+    expect(exponentialBackoffWithJitter(10, null, err)).toEqual(
+      Math.pow(2, 9) * 1000 + Math.pow(2, 9) * 500,
+    )
+  })
+
   it("uses RetriableError's default delay and logs if error is not RetriableError", () => {
     const err = new Error('test error')
     vi.spyOn(Math, 'random').mockReturnValue(0)

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -39,5 +39,9 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   const initialDelay =
     err instanceof RetriableError ? err.delayInMs : DEFAULT_DELAY_MS
   const prevFullDelay = Math.pow(2, attemptsMade - 1) * initialDelay
-  return prevFullDelay + Math.round(Math.random() * prevFullDelay)
+  const jitteredDelay =
+    prevFullDelay + Math.round(Math.random() * prevFullDelay)
+  const maxDelayMs =
+    err instanceof RetriableError ? err.maxDelayMs ?? Infinity : Infinity
+  return Math.min(jitteredDelay, maxDelayMs)
 }

--- a/packages/backend/src/helpers/default-job-configuration.ts
+++ b/packages/backend/src/helpers/default-job-configuration.ts
@@ -27,6 +27,11 @@ export const DEFAULT_JOB_DELAY_DURATION = 0
 // - We round that up to 10 just in case.
 export const MAXIMUM_JOB_ATTEMPTS = appConfig.maxJobAttempts
 
+// Separate, smaller budget for transient DB errors so a flaky Postgres can't
+// burn the broader MAXIMUM_JOB_ATTEMPTS budget reserved for app-side
+// RetriableError causes (rate limits, etc.).
+export const MAX_TRANSIENT_DB_ATTEMPTS = 3
+
 export const DEFAULT_JOB_OPTIONS: JobsProOptions = {
   removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
   removeOnFail: REMOVE_AFTER_30_DAYS,


### PR DESCRIPTION
## Summary

Adds an optional per-error delay cap to `RetriableError` and a separate transient-DB attempts budget. Pure plumbing — no behavior change for any current call site.

## Problem

Foundation for treating transient Postgres / socket errors at worker boundaries as `TransientDBError` (a `RetriableError` subclass) so BullMQ retries the job instead of failing it as `UnrecoverableError`. That subclass needs (a) a tight per-attempt delay cap so user-visible latency stays small, and (b) its own attempts budget so transient DB causes can't exhaust the budget reserved for app-side `RetriableError` causes like rate limits.

## What changed

- `RetriableError` accepts an optional `maxDelayMs` field, plumbed through the constructor.
- `exponentialBackoffWithJitter` returns `Math.min(jitteredDelay, err.maxDelayMs ?? Infinity)`; existing sanity-check branches unchanged.
- Export `MAX_TRANSIENT_DB_ATTEMPTS = 3` from `default-job-configuration.ts`.
- Backoff tests cover the cap kicking in and the omitted-cap pass-through.

## Testing

- `npx vitest packages/backend/src/helpers/__tests__/backoff.test.ts` — 10/10 pass.
- `npm run -w backend lint` (eslint + `tsc --noEmit`) — clean.

## Phase context

- Done in this phase: foundations — `maxDelayMs` on `RetriableError`, cap in `exponentialBackoffWithJitter`, `MAX_TRANSIENT_DB_ATTEMPTS` export.
- Done in previous phases: none.
- Not yet done (future phases):
    - Phase 2: `pg-error.ts`, `TransientDBError`, `throwAsTransientIfDbTransient`, `retryOnTransientDbError` + tests.
    - Phase 3: wire boundary helper into action/sub-trigger/trigger/flow workers and `handleFailedStepAndThrow`.
    - Phase 4: service-side idempotency via `forUpdate()` existence checks in `services/action.ts` and `services/trigger.ts`.
    - Phase 5: inline `retryOnTransientDbError` at HTTP edges (webhook handler, partial-retry GraphQL mutation).
    - Phase 6: worker integration tests + manual smoke.