### PR TITLE
feat(db-retriable-error): add transient-db detection, error type, and inline retry helper

### DIFF
--- a/packages/backend/src/errors/transient-db-error.ts
+++ b/packages/backend/src/errors/transient-db-error.ts
@@ -1,0 +1,35 @@
+import { extractErrorCode, extractErrorMessage } from '@/helpers/pg-error'
+
+import RetriableError from './retriable-error'
+
+/**
+ * Thrown at worker boundaries when a transient Postgres / socket error caused
+ * the failure. BullMQ retries the job with capped exponential backoff so a
+ * brief DB blip doesn't fail the execution permanently.
+ */
+export default class TransientDBError extends RetriableError {
+  errorCode: string | undefined
+  errorMessage: string | undefined
+
+  constructor(originalError: unknown, contextMessage?: string) {
+    const errorCode = extractErrorCode(originalError)
+    const errorMessage = extractErrorMessage(originalError)
+
+    const prefix = contextMessage
+      ? `Transient DB error (${contextMessage})`
+      : 'Transient DB error'
+    const formatted = `${prefix}: ${errorMessage ?? 'unknown'} (code=${
+      errorCode ?? 'unknown'
+    })`
+
+    super({
+      error: formatted,
+      delayInMs: 1000,
+      delayType: 'step',
+      maxDelayMs: 5000,
+    })
+
+    this.errorCode = errorCode
+    this.errorMessage = errorMessage
+  }
+}

--- a/packages/backend/src/helpers/__tests__/pg-error.test.ts
+++ b/packages/backend/src/helpers/__tests__/pg-error.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractErrorCode,
+  extractErrorMessage,
+  extractErrorMessages,
+  isUniqueViolation,
+} from '../pg-error'
+
+describe('pg-error extractors', () => {
+  describe('extractErrorCode', () => {
+    it('returns err.code when set directly', () => {
+      const err = Object.assign(new Error('boom'), { code: '08006' })
+      expect(extractErrorCode(err)).toBe('08006')
+    })
+
+    it('falls back to err.nativeError.code (Objection DBError wrapper)', () => {
+      const native = Object.assign(new Error('inner'), { code: '23505' })
+      const err = Object.assign(new Error('outer'), { nativeError: native })
+      expect(extractErrorCode(err)).toBe('23505')
+    })
+
+    it('prefers top-level code over nativeError.code', () => {
+      const native = Object.assign(new Error('inner'), { code: '23505' })
+      const err = Object.assign(new Error('outer'), {
+        code: '08006',
+        nativeError: native,
+      })
+      expect(extractErrorCode(err)).toBe('08006')
+    })
+
+    it('returns undefined for a plain Error', () => {
+      expect(extractErrorCode(new Error('plain'))).toBeUndefined()
+    })
+
+    it('returns undefined when code is not a string', () => {
+      const err = Object.assign(new Error('boom'), { code: 8006 })
+      expect(extractErrorCode(err)).toBeUndefined()
+    })
+
+    it('returns undefined for null / undefined / non-object', () => {
+      expect(extractErrorCode(null)).toBeUndefined()
+      expect(extractErrorCode(undefined)).toBeUndefined()
+      expect(extractErrorCode('error string')).toBeUndefined()
+      expect(extractErrorCode(42)).toBeUndefined()
+    })
+  })
+
+  describe('extractErrorMessages', () => {
+    it('returns [err.message] for a plain Error', () => {
+      expect(extractErrorMessages(new Error('boom'))).toEqual(['boom'])
+    })
+
+    it('includes both top-level and nativeError messages when present', () => {
+      const native = new Error('inner boom')
+      const err = Object.assign(new Error('outer boom'), {
+        nativeError: native,
+      })
+      expect(extractErrorMessages(err)).toEqual(['outer boom', 'inner boom'])
+    })
+
+    it('returns empty array for null / undefined', () => {
+      expect(extractErrorMessages(null)).toEqual([])
+      expect(extractErrorMessages(undefined)).toEqual([])
+    })
+
+    it('returns empty array when message is missing', () => {
+      expect(extractErrorMessages({})).toEqual([])
+    })
+  })
+
+  describe('extractErrorMessage', () => {
+    it('returns the first message', () => {
+      const native = new Error('inner')
+      const err = Object.assign(new Error('outer'), { nativeError: native })
+      expect(extractErrorMessage(err)).toBe('outer')
+    })
+
+    it('returns undefined when no messages are present', () => {
+      expect(extractErrorMessage(null)).toBeUndefined()
+      expect(extractErrorMessage({})).toBeUndefined()
+    })
+  })
+
+  describe('isUniqueViolation', () => {
+    it('is true for code 23505', () => {
+      const err = Object.assign(new Error('dup'), { code: '23505' })
+      expect(isUniqueViolation(err)).toBe(true)
+    })
+
+    it('is true when nativeError.code is 23505', () => {
+      const native = Object.assign(new Error('dup'), { code: '23505' })
+      const err = Object.assign(new Error('wrapped'), { nativeError: native })
+      expect(isUniqueViolation(err)).toBe(true)
+    })
+
+    it('is false for other codes and missing codes', () => {
+      expect(
+        isUniqueViolation(Object.assign(new Error('x'), { code: '08006' })),
+      ).toBe(false)
+      expect(isUniqueViolation(new Error('x'))).toBe(false)
+      expect(isUniqueViolation(null)).toBe(false)
+    })
+  })
+})

--- a/packages/backend/src/helpers/__tests__/retry-on-transient-db-error.test.ts
+++ b/packages/backend/src/helpers/__tests__/retry-on-transient-db-error.test.ts
@@ -1,0 +1,171 @@
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import TransientDBError from '@/errors/transient-db-error'
+
+import {
+  isTransientDbError,
+  retryOnTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '../retry-on-transient-db-error'
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+function pgError(overrides: Record<string, unknown> = {}): Error {
+  return Object.assign(new Error((overrides.message as string) ?? 'pg boom'), {
+    code: undefined,
+    ...overrides,
+  })
+}
+
+describe('isTransientDbError', () => {
+  it('is true for SQLSTATE class 08 (connection exception)', () => {
+    expect(isTransientDbError(pgError({ code: '08006' }))).toBe(true)
+    expect(isTransientDbError(pgError({ code: '08003' }))).toBe(true)
+    expect(isTransientDbError(pgError({ code: '08000' }))).toBe(true)
+  })
+
+  it('is true for SQLSTATE 57P0* (admin shutdown family)', () => {
+    expect(isTransientDbError(pgError({ code: '57P01' }))).toBe(true)
+    expect(isTransientDbError(pgError({ code: '57P02' }))).toBe(true)
+    expect(isTransientDbError(pgError({ code: '57P03' }))).toBe(true)
+  })
+
+  it('is true for transient message substrings', () => {
+    expect(isTransientDbError(new Error('read ECONNRESET'))).toBe(true)
+    expect(isTransientDbError(new Error('connect ETIMEDOUT 10.0.0.1'))).toBe(
+      true,
+    )
+    expect(isTransientDbError(new Error('Connection terminated'))).toBe(true)
+  })
+
+  it('honors nativeError.code on Objection-wrapped errors', () => {
+    const native = pgError({ code: '08006', message: 'inner' })
+    const err = Object.assign(new Error('wrapped'), { nativeError: native })
+    expect(isTransientDbError(err)).toBe(true)
+  })
+
+  it('honors nativeError.message for substring matching', () => {
+    const native = new Error('read ECONNRESET')
+    const err = Object.assign(new Error('Query failed'), {
+      nativeError: native,
+    })
+    expect(isTransientDbError(err)).toBe(true)
+  })
+
+  it('is false for unique violation (23505)', () => {
+    expect(isTransientDbError(pgError({ code: '23505' }))).toBe(false)
+  })
+
+  it('is false for a plain Error with no transient signal', () => {
+    expect(isTransientDbError(new Error('something else'))).toBe(false)
+  })
+
+  it('is false for null / undefined', () => {
+    expect(isTransientDbError(null)).toBe(false)
+    expect(isTransientDbError(undefined)).toBe(false)
+  })
+})
+
+describe('throwAsTransientIfDbTransient', () => {
+  it('throws TransientDBError when transient and within budget', () => {
+    const err = pgError({ code: '08006', message: 'lost connection' })
+    expect(() =>
+      throwAsTransientIfDbTransient(err, { attemptsStarted: 0 }),
+    ).toThrow(TransientDBError)
+  })
+
+  it('attaches errorCode + errorMessage on the thrown TransientDBError', () => {
+    const err = pgError({ code: '08006', message: 'lost connection' })
+    try {
+      throwAsTransientIfDbTransient(err, {
+        attemptsStarted: 1,
+        context: 'processAction',
+      })
+      expect.fail('expected throw')
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(TransientDBError)
+      const t = caught as TransientDBError
+      expect(t.errorCode).toBe('08006')
+      expect(t.errorMessage).toBe('lost connection')
+      expect(t.maxDelayMs).toBe(5000)
+      expect(t.delayInMs).toBe(1000)
+      expect(t.delayType).toBe('step')
+    }
+  })
+
+  it('throws UnrecoverableError once the transient-DB budget is exhausted', () => {
+    const err = pgError({ code: '08006' })
+    expect(() =>
+      throwAsTransientIfDbTransient(err, { attemptsStarted: 3 }),
+    ).toThrow(UnrecoverableError)
+  })
+
+  it('rethrows the original error when not transient', () => {
+    const original = new Error('not a db thing')
+    expect(() =>
+      throwAsTransientIfDbTransient(original, { attemptsStarted: 0 }),
+    ).toThrow(original)
+  })
+
+  it('rethrows a unique violation unchanged (not transient)', () => {
+    const err = pgError({ code: '23505' })
+    expect(() =>
+      throwAsTransientIfDbTransient(err, { attemptsStarted: 0 }),
+    ).toThrow(err)
+  })
+})
+
+describe('retryOnTransientDbError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the value on first success without retrying', async () => {
+    const fn = vi.fn().mockResolvedValue('ok')
+    await expect(retryOnTransientDbError(fn)).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on transient errors and succeeds within the budget', async () => {
+    vi.spyOn(global, 'setTimeout').mockImplementation(((cb: () => void) => {
+      cb()
+      return 0 as unknown as NodeJS.Timeout
+    }) as typeof setTimeout)
+
+    const transient = pgError({ code: '08006' })
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(transient)
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValue('ok')
+
+    await expect(retryOnTransientDbError(fn)).resolves.toBe('ok')
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('rethrows immediately on a non-transient error', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('nope'))
+    await expect(retryOnTransientDbError(fn)).rejects.toThrow('nope')
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows the transient error after the final attempt', async () => {
+    vi.spyOn(global, 'setTimeout').mockImplementation(((cb: () => void) => {
+      cb()
+      return 0 as unknown as NodeJS.Timeout
+    }) as typeof setTimeout)
+
+    const transient = pgError({ code: '08006' })
+    const fn = vi.fn().mockRejectedValue(transient)
+
+    await expect(retryOnTransientDbError(fn)).rejects.toBe(transient)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+})

--- a/packages/backend/src/helpers/pg-error.ts
+++ b/packages/backend/src/helpers/pg-error.ts
@@ -1,0 +1,59 @@
+/**
+ * Low-level extractors for pg / Objection (`DBError`) errors.
+ *
+ * Connection-level pg errors come through unwrapped (they don't satisfy
+ * Objection's `db-errors` shape requirement of having both `internalQuery` and
+ * `table`). Query-level errors come wrapped, with the original underneath at
+ * `err.nativeError`. So every extractor here checks both layers.
+ */
+
+type MaybeErr = unknown
+
+function asRecord(err: MaybeErr): Record<string, unknown> | undefined {
+  if (err === null || err === undefined) {
+    return undefined
+  }
+  if (typeof err !== 'object') {
+    return undefined
+  }
+  return err as Record<string, unknown>
+}
+
+export function extractErrorCode(err: MaybeErr): string | undefined {
+  const record = asRecord(err)
+  if (!record) {
+    return undefined
+  }
+  if (typeof record.code === 'string') {
+    return record.code
+  }
+  const nativeError = asRecord(record.nativeError)
+  if (nativeError && typeof nativeError.code === 'string') {
+    return nativeError.code
+  }
+  return undefined
+}
+
+export function extractErrorMessages(err: MaybeErr): string[] {
+  const record = asRecord(err)
+  if (!record) {
+    return []
+  }
+  const messages: string[] = []
+  if (typeof record.message === 'string') {
+    messages.push(record.message)
+  }
+  const nativeError = asRecord(record.nativeError)
+  if (nativeError && typeof nativeError.message === 'string') {
+    messages.push(nativeError.message)
+  }
+  return messages
+}
+
+export function extractErrorMessage(err: MaybeErr): string | undefined {
+  return extractErrorMessages(err)[0]
+}
+
+export function isUniqueViolation(err: MaybeErr): boolean {
+  return extractErrorCode(err) === '23505'
+}

--- a/packages/backend/src/helpers/retry-on-transient-db-error.ts
+++ b/packages/backend/src/helpers/retry-on-transient-db-error.ts
@@ -1,0 +1,131 @@
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+
+import TransientDBError from '@/errors/transient-db-error'
+
+import { MAX_TRANSIENT_DB_ATTEMPTS } from './default-job-configuration'
+import logger from './logger'
+import {
+  extractErrorCode,
+  extractErrorMessages,
+  isUniqueViolation,
+} from './pg-error'
+
+const TRANSIENT_MESSAGE_SUBSTRINGS = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'Connection terminated',
+]
+
+/**
+ * True for transient Postgres / socket errors that we expect to clear up on a
+ * retry. False for unique-violation (`23505`), which represents a successful
+ * prior insert that committed — the recovery path there is the in-transaction
+ * `forUpdate()` existence check, not retry.
+ */
+export function isTransientDbError(err: unknown): boolean {
+  if (err === null || err === undefined) {
+    return false
+  }
+
+  if (isUniqueViolation(err)) {
+    return false
+  }
+
+  const code = extractErrorCode(err)
+  if (code && (code.startsWith('08') || code.startsWith('57P0'))) {
+    return true
+  }
+
+  const messages = extractErrorMessages(err)
+  for (const message of messages) {
+    for (const substring of TRANSIENT_MESSAGE_SUBSTRINGS) {
+      if (message.includes(substring)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+interface ThrowAsTransientOptions {
+  attemptsStarted: number
+  context?: string
+}
+
+/**
+ * Called from worker catch blocks. If the error is a transient DB error and
+ * the transient-DB attempts budget isn't exhausted, throws a `TransientDBError`
+ * so BullMQ retries the job. If the budget is exhausted, throws an
+ * `UnrecoverableError` to fail the job fast rather than chewing through the
+ * broader `MAXIMUM_JOB_ATTEMPTS` budget. Otherwise rethrows the original error
+ * unchanged so existing catch logic can handle it.
+ */
+export function throwAsTransientIfDbTransient(
+  err: unknown,
+  { attemptsStarted, context }: ThrowAsTransientOptions,
+): void {
+  if (!isTransientDbError(err)) {
+    throw err
+  }
+
+  if (attemptsStarted < MAX_TRANSIENT_DB_ATTEMPTS) {
+    throw new TransientDBError(err, context)
+  }
+
+  logger.error('Transient DB retry budget exhausted', {
+    event: 'transient-db-retry-exhausted',
+    attemptsStarted,
+    context,
+    errorCode: extractErrorCode(err),
+  })
+
+  throw new UnrecoverableError(
+    `Transient DB retry budget exhausted: ${JSON.stringify({
+      context,
+      errorCode: extractErrorCode(err),
+      attemptsStarted,
+    })}`,
+  )
+}
+
+function jitteredDelay(attempt: number): number {
+  const base = 1000 * Math.pow(2, attempt)
+  const jitter = Math.random() * base * 0.5
+  return Math.min(base + jitter, 5000)
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * For HTTP-edge call sites (webhook handler, partial-retry mutation) where
+ * there's no BullMQ to fall back on. Retries the function up to
+ * `MAX_TRANSIENT_DB_ATTEMPTS` times on transient DB errors. Rethrows on
+ * non-transient errors and on the final attempt.
+ */
+export async function retryOnTransientDbError<T>(
+  fn: () => Promise<T>,
+  context?: string,
+): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fn()
+    } catch (err) {
+      const isLastAttempt = attempt >= MAX_TRANSIENT_DB_ATTEMPTS - 1
+      if (!isTransientDbError(err) || isLastAttempt) {
+        throw err
+      }
+      const delay = jitteredDelay(attempt)
+      logger.info('Retrying after transient DB error', {
+        event: 'db-retry',
+        context,
+        attempt,
+        delay,
+        errorCode: extractErrorCode(err),
+      })
+      await sleep(delay)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the foundations for retrying transient Postgres / socket errors as job-level BullMQ retries. Introduces `TransientDBError`, low-level `pg-error` extractors, and `retryOnTransientDbError` / `throwAsTransientIfDbTransient` helpers; nothing is wired into runtime yet.

## Problem / Feature

Today, transient errors thrown from worker code (`ECONNRESET`, `57P01` admin shutdown, `08006` connection failure) get caught and re-thrown as `UnrecoverableError`, so BullMQ refuses to retry the job and a five-second Postgres blip fails an execution permanently. The fix is to surface those as a `RetriableError` subclass with a tight delay cap and a separate, smaller attempts budget, plus an inline retry for HTTP-edge callers that don't have BullMQ behind them. This PR lands the building blocks; later phases wire them into the worker entrypoints and HTTP edges.

## What changed

- New `helpers/pg-error.ts` with `extractErrorCode`, `extractErrorMessages`, `extractErrorMessage`, `isUniqueViolation`; reads both `err.code` and `err.nativeError?.code` so it works against raw pg and Objection `DBError`.
- New `errors/transient-db-error.ts` — `RetriableError` subclass with `delayInMs: 1000`, `maxDelayMs: 5000`, `delayType: 'step'`, exposing `errorCode`/`errorMessage` for logging.
- New `helpers/retry-on-transient-db-error.ts` — `isTransientDbError`, `throwAsTransientIfDbTransient(err, { attemptsStarted, context? })` boundary helper that consults `MAX_TRANSIENT_DB_ATTEMPTS`, and `retryOnTransientDbError(fn, context?)` for HTTP-edge use.
- Unit tests for the extractors and the retry helpers (32 cases).

## Testing

- `npx vitest run packages/backend/src/helpers/__tests__/pg-error.test.ts packages/backend/src/helpers/__tests__/retry-on-transient-db-error.test.ts` — 32 passed.
- `npm run -w backend lint` — clean (covers `tsc --noEmit`).

## Phase context

- Done in this phase: foundational error type + detection + inline retry, untouched by runtime.
- Done in previous phases:
    - Phase 1: optional `maxDelayMs` on `RetriableError`, cap in `exponentialBackoffWithJitter`, `MAX_TRANSIENT_DB_ATTEMPTS = 3` exported.
- Not yet done (future phases):
    - Phase 3: wire `throwAsTransientIfDbTransient` into the worker entrypoints and `handle-failed-step-and-throw`.
    - Phase 4: service-side idempotency (`forUpdate()` existence checks in `services/action.ts`, `services/trigger.ts`).
    - Phase 5: inline `retryOnTransientDbError` around the webhook handler and partial-retry mutation.
    - Phase 6: worker integration tests + manual smoke.