### PR TITLE
feat(workers): wrap workers in try catch blocks

### DIFF
--- a/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
+++ b/packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts
@@ -12,6 +12,10 @@ import ExecutionStep from '@/models/execution-step'
 
 import { MAXIMUM_JOB_ATTEMPTS } from '../default-job-configuration'
 import { parseRetryAfterToMs } from '../parse-retry-after-to-ms'
+import {
+  isTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '../retry-on-transient-db-error'
 
 /**
  * For queue and group delays, we need to manually check for max attempts ourselves
@@ -157,6 +161,13 @@ export function handleFailedStepAndThrow(
 
   // Inspect the error / failure reason, and determine if we can retry the step.
   try {
+    if (isTransientDbError(executionError)) {
+      throwAsTransientIfDbTransient(executionError, {
+        attemptsStarted: job.attemptsStarted,
+        context: 'handle-failed-step-and-throw',
+      })
+    }
+
     if (executionError instanceof RetriableError) {
       return handleRetriableError(executionError, context)
     }

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -6,6 +6,10 @@ import {
   REMOVE_AFTER_30_DAYS,
 } from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
+import {
+  isTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '@/helpers/retry-on-transient-db-error'
 import Flow from '@/models/flow'
 import triggerQueue from '@/queues/trigger'
 import { processFlow } from '@/services/flow'
@@ -15,40 +19,50 @@ export const worker = new WorkerPro(
   async (job) => {
     const { flowId } = job.data
 
-    const flow = await Flow.query().findById(flowId).throwIfNotFound()
-    const triggerStep = await flow.getTriggerStep()
+    try {
+      const flow = await Flow.query().findById(flowId).throwIfNotFound()
+      const triggerStep = await flow.getTriggerStep()
 
-    const { data, error } = await processFlow({ flowId })
+      const { data, error } = await processFlow({ flowId })
 
-    const reversedData = data.reverse()
+      const reversedData = data.reverse()
 
-    const jobOptions = {
-      removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
-      removeOnFail: REMOVE_AFTER_30_DAYS,
-    }
-
-    for (const triggerItem of reversedData) {
-      const jobName = `${triggerStep.id}-${triggerItem.meta.internalId}`
-
-      const jobPayload = {
-        flowId,
-        stepId: triggerStep.id,
-        triggerItem,
+      const jobOptions = {
+        removeOnComplete: REMOVE_AFTER_7_DAYS_OR_50_JOBS,
+        removeOnFail: REMOVE_AFTER_30_DAYS,
       }
 
-      await triggerQueue.add(jobName, jobPayload, jobOptions)
-    }
+      for (const triggerItem of reversedData) {
+        const jobName = `${triggerStep.id}-${triggerItem.meta.internalId}`
 
-    if (error) {
-      const jobName = `${triggerStep.id}-error`
+        const jobPayload = {
+          flowId,
+          stepId: triggerStep.id,
+          triggerItem,
+        }
 
-      const jobPayload = {
-        flowId,
-        stepId: triggerStep.id,
-        error,
+        await triggerQueue.add(jobName, jobPayload, jobOptions)
       }
 
-      await triggerQueue.add(jobName, jobPayload, jobOptions)
+      if (error) {
+        const jobName = `${triggerStep.id}-error`
+
+        const jobPayload = {
+          flowId,
+          stepId: triggerStep.id,
+          error,
+        }
+
+        await triggerQueue.add(jobName, jobPayload, jobOptions)
+      }
+    } catch (err) {
+      if (isTransientDbError(err)) {
+        throwAsTransientIfDbTransient(err, {
+          attemptsStarted: job.attemptsStarted,
+          context: 'flow-worker',
+        })
+      }
+      throw err
     }
   },
   {

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -9,10 +9,15 @@ import {
 import appConfig from '@/config/app'
 import { createRedisClient } from '@/config/redis'
 import { WORKER_CONCURRENCY } from '@/config/workers'
+import RetriableError from '@/errors/retriable-error'
 import { handleFailedStepAndThrow } from '@/helpers/actions'
 import { exponentialBackoffWithJitter } from '@/helpers/backoff'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import delayAsMilliseconds from '@/helpers/delay-as-milliseconds'
+import {
+  isTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '@/helpers/retry-on-transient-db-error'
 import tracer from '@/helpers/tracer'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
@@ -103,106 +108,118 @@ export function makeActionWorker(
         const jobData = job.data
         const jobId = makeActionJobId(queueName, job.id)
 
-        // The reason why we dont add .throwIfNotFound() here is to prevent job
-        // retries delegating the error throwing and handling to processAction
-        // where it also queries for Step.
-        const currStep = await Step.query().findById(jobData.stepId)
+        try {
+          // The reason why we dont add .throwIfNotFound() here is to prevent job
+          // retries delegating the error throwing and handling to processAction
+          // where it also queries for Step.
+          const currStep = await Step.query().findById(jobData.stepId)
 
-        span?.addTags({
-          queueName,
-          flowId: jobData.flowId,
-          executionId: jobData.executionId,
-          stepId: jobData.stepId,
-          actionKey: currStep?.key,
-          appKey: currStep?.appKey,
-          jobId,
-          jobEnqueueTime: job.timestamp,
-          jobDelay: job.opts?.delay ?? 0,
-          attempts: job.attemptsStarted,
-          timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
-          workerVersion: appConfig.version,
-        })
-
-        const {
-          flowId,
-          executionId,
-          nextStep,
-          executionStep,
-          nextStepMetadata,
-          executionError,
-        } = await processAction({ ...jobData, jobId }).catch(async (err) => {
-          // This happens when the prerequisite steps for the action fails (e.g.
-          // db error, missing execution, flow, step, etc...) in such cases, we
-          // do not want to retry
-          throw new UnrecoverableError(
-            err.message || 'Action failed to execute',
-          )
-        })
-
-        if (executionStep.isFailed) {
-          if (nextStepMetadata?.iteration) {
-            await ExecutionStep.patchIterationStatus(
-              executionId,
-              nextStepMetadata.iteration,
-              'failure',
-            )
-          }
-          return handleFailedStepAndThrow({
-            errorDetails: executionStep.errorDetails,
-            executionError,
-            context: {
-              isQueueDelayable,
-              worker,
-              span,
-              job,
-            },
+          span?.addTags({
+            queueName,
+            flowId: jobData.flowId,
+            executionId: jobData.executionId,
+            stepId: jobData.stepId,
+            actionKey: currStep?.key,
+            appKey: currStep?.appKey,
+            jobId,
+            jobEnqueueTime: job.timestamp,
+            jobDelay: job.opts?.delay ?? 0,
+            attempts: job.attemptsStarted,
+            timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
+            workerVersion: appConfig.version,
           })
-        }
 
-        if (!nextStep) {
-          const shouldContinue = await processForEachStatus({
+          const {
+            flowId,
             executionId,
-            currStep,
+            nextStep,
+            executionStep,
             nextStepMetadata,
-          })
+            executionError,
+          } = await processAction({ ...jobData, jobId })
 
-          if (!shouldContinue) {
+          if (executionStep.isFailed) {
+            if (nextStepMetadata?.iteration) {
+              await ExecutionStep.patchIterationStatus(
+                executionId,
+                nextStepMetadata.iteration,
+                'failure',
+              )
+            }
+            return handleFailedStepAndThrow({
+              errorDetails: executionStep.errorDetails,
+              executionError,
+              context: {
+                isQueueDelayable,
+                worker,
+                span,
+                job,
+              },
+            })
+          }
+
+          if (!nextStep) {
+            const shouldContinue = await processForEachStatus({
+              executionId,
+              currStep,
+              nextStepMetadata,
+            })
+
+            if (!shouldContinue) {
+              return
+            }
+
+            await Execution.setStatus(executionId, 'success')
             return
           }
 
-          await Execution.setStatus(executionId, 'success')
-          return
-        }
+          const jobName = `${executionId}-${nextStep.id}`
 
-        const jobName = `${executionId}-${nextStep.id}`
-
-        const jobPayload = {
-          flowId,
-          executionId,
-          stepId: nextStep.id,
-          metadata: nextStepMetadata,
-        }
-
-        let jobOptions = DEFAULT_JOB_OPTIONS
-
-        if (currStep.appKey === 'delay') {
-          jobOptions = {
-            ...DEFAULT_JOB_OPTIONS,
-            delay: delayAsMilliseconds(currStep.key, executionStep.dataOut),
+          const jobPayload = {
+            flowId,
+            executionId,
+            stepId: nextStep.id,
+            metadata: nextStepMetadata,
           }
-        }
 
-        try {
-          await enqueueActionJob({
-            appKey: nextStep.appKey,
-            jobName,
-            jobData: jobPayload,
-            jobOptions,
-          })
-        } catch (error) {
-          // Don't retry if we failed to enqueue the next step (e.g. if
-          // getGroupConfigForJob throws an error)
-          throw new UnrecoverableError(error.message)
+          let jobOptions = DEFAULT_JOB_OPTIONS
+
+          if (currStep.appKey === 'delay') {
+            jobOptions = {
+              ...DEFAULT_JOB_OPTIONS,
+              delay: delayAsMilliseconds(currStep.key, executionStep.dataOut),
+            }
+          }
+
+          try {
+            await enqueueActionJob({
+              appKey: nextStep.appKey,
+              jobName,
+              jobData: jobPayload,
+              jobOptions,
+            })
+          } catch (error) {
+            // Don't retry if we failed to enqueue the next step (e.g. if
+            // getGroupConfigForJob throws an error)
+            throw new UnrecoverableError(error.message)
+          }
+        } catch (err) {
+          if (isTransientDbError(err)) {
+            throwAsTransientIfDbTransient(err, {
+              attemptsStarted: job.attemptsStarted,
+              context: `action-worker:${queueName}`,
+            })
+          }
+          if (
+            err instanceof UnrecoverableError ||
+            err instanceof RetriableError ||
+            err?.name === 'RateLimitError'
+          ) {
+            throw err
+          }
+          throw new UnrecoverableError(
+            err.message || 'Action failed to execute',
+          )
         }
       },
     ),

--- a/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
+++ b/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
@@ -14,6 +14,10 @@ import { exponentialBackoffWithJitter } from '@/helpers/backoff'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
+import {
+  isTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '@/helpers/retry-on-transient-db-error'
 import tracer from '@/helpers/tracer'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
@@ -183,6 +187,12 @@ export function makeSubTriggerWorker(
           await executionStep.$query(trx).patch({ status: 'success' })
         })
       } catch (error) {
+        if (isTransientDbError(error)) {
+          throwAsTransientIfDbTransient(error, {
+            attemptsStarted: job.attemptsStarted,
+            context: `sub-trigger-worker:${queueName}`,
+          })
+        }
         logger.error('[sub-trigger] error', { error })
         // log raw http error from StepError
         if (error instanceof StepError && error.cause) {

--- a/packages/backend/src/workers/trigger.ts
+++ b/packages/backend/src/workers/trigger.ts
@@ -5,6 +5,10 @@ import { UnrecoverableError, WorkerPro } from '@taskforcesh/bullmq-pro'
 import { createRedisClient } from '@/config/redis'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import logger from '@/helpers/logger'
+import {
+  isTransientDbError,
+  throwAsTransientIfDbTransient,
+} from '@/helpers/retry-on-transient-db-error'
 import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 import { processTrigger } from '@/services/trigger'
@@ -19,35 +23,44 @@ type JobData = {
 export const worker = new WorkerPro(
   'trigger',
   async (job) => {
-    const { flowId, executionId, stepId, executionStep } = await processTrigger(
-      job.data as JobData,
-    )
-
-    if (executionStep.isFailed) {
-      return
-    }
-
-    const step = await Step.query().findById(stepId).throwIfNotFound()
-    const nextStep = await step.getNextStep()
-    const jobName = `${executionId}-${nextStep.id}`
-
-    const jobData = {
-      flowId,
-      executionId,
-      stepId: nextStep.id,
-    }
-
     try {
-      await enqueueActionJob({
-        appKey: nextStep.appKey,
-        jobName,
-        jobData,
-        jobOptions: DEFAULT_JOB_OPTIONS,
-      })
-    } catch (error) {
-      // Don't retry if we failed to enqueue the next step (e.g. if
-      // getGroupConfigForJob throws an error)
-      throw new UnrecoverableError(error.message)
+      const { flowId, executionId, stepId, executionStep } =
+        await processTrigger(job.data as JobData)
+
+      if (executionStep.isFailed) {
+        return
+      }
+
+      const step = await Step.query().findById(stepId).throwIfNotFound()
+      const nextStep = await step.getNextStep()
+      const jobName = `${executionId}-${nextStep.id}`
+
+      const jobData = {
+        flowId,
+        executionId,
+        stepId: nextStep.id,
+      }
+
+      try {
+        await enqueueActionJob({
+          appKey: nextStep.appKey,
+          jobName,
+          jobData,
+          jobOptions: DEFAULT_JOB_OPTIONS,
+        })
+      } catch (error) {
+        // Don't retry if we failed to enqueue the next step (e.g. if
+        // getGroupConfigForJob throws an error)
+        throw new UnrecoverableError(error.message)
+      }
+    } catch (err) {
+      if (isTransientDbError(err)) {
+        throwAsTransientIfDbTransient(err, {
+          attemptsStarted: job.attemptsStarted,
+          context: 'trigger-worker',
+        })
+      }
+      throw err
     }
   },
   {


### PR DESCRIPTION
## Summary

Wires the transient-DB detection + throw helper from the prior PR into every worker entrypoint, so a transient Postgres blip during a job retries the job instead of failing it permanently as `UnrecoverableError`.

## Problem / Feature

A five-second Postgres hiccup (e.g. `ECONNRESET`, SQLSTATE `08*` / `57P0*`) thrown anywhere in a worker processor — including prereq queries like `Step.query().findById(...)` — currently gets re-thrown as `UnrecoverableError`, which BullMQ refuses to retry. This change throws `TransientDBError` instead, letting BullMQ retry with the capped delay (~1s / ~2s / 5s) and the 3-attempt transient-DB budget.

## What changed

- `make-action-worker.ts`: full processor body wrapped in try/catch; transient → `TransientDBError`; bare non-transient → `UnrecoverableError`; `RetriableError` / `UnrecoverableError` / bullmq `RateLimitError` pass through. Inline `.catch` on `processAction(...)` removed.
- `make-sub-trigger-worker.ts`: transient check added at top of existing outer catch, before the `$.actionOutput.error` side-effect so we don't mark the action errored on a transient that will be retried.
- `trigger.ts`, `flow.ts`: processor bodies wrapped with the same transient-check pattern.
- `handle-failed-step-and-throw.ts`: transient-DB branch added before `RetriableError` / `HttpError` routing, so action-handler DB writes that hit transients also retry.

## Testing

- `npm run -w backend lint` clean (includes `tsc --noEmit`).
- `npm run -w backend test:unit`: 1540 tests pass. Two pre-existing compile failures (`authentication.test.ts`, `graphql-instance.test.ts`) reproduce on `git stash` — not introduced here.
- Worker integration test covering retry-on-transient lands in Phase 6.

## Phase context

- Done in this phase: worker boundary wiring + handle-failed-step-and-throw transient branch
- Done in previous phases:
    - Phase 1: `maxDelayMs` on `RetriableError`, backoff cap, `MAX_TRANSIENT_DB_ATTEMPTS = 3`
    - Phase 2: `pg-error.ts` extractors, `TransientDBError`, `isTransientDbError` / `throwAsTransientIfDbTransient` / `retryOnTransientDbError`
- Not yet done (future phases):
    - Phase 4: `forUpdate()` existence checks in `services/action.ts` and `services/trigger.ts` for idempotent retries
    - Phase 5: inline `retryOnTransientDbError` at the FormSG webhook and partial-retry GraphQL mutation
    - Phase 6: worker integration tests + manual smoke