### PR TITLE
[EMAIL-PREVIEW-3] PLU-386: Add "Preview" button to TipTap toolbar

### DIFF
--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -52,6 +52,7 @@ export const transactionalEmailFields: IField[] = [
       'table',
     ],
     supportTableDisplay: true,
+    previewType: 'email' as const,
   },
   {
     label: 'Recipient email(s)',

--- a/packages/frontend/src/components/EmailPreviewModal/index.tsx
+++ b/packages/frontend/src/components/EmailPreviewModal/index.tsx
@@ -1,17 +1,25 @@
 import { useMemo, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
+import { RiArrowDownSLine } from 'react-icons/ri'
 import {
   Box,
   Flex,
   Heading,
   Icon,
+  List,
+  ListItem,
   Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
   Text,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
 import { transformForClient } from '@emailens/engine'
@@ -21,29 +29,24 @@ import { BrokenPipeIcon } from '@/components/Icons'
 interface ClientOption {
   id: string
   label: string
-  subtitle: string
 }
 
 const CLIENT_OPTIONS: ClientOption[] = [
   {
     id: 'outlook-windows-legacy',
-    label: 'Outlook Classic',
-    subtitle: 'Microsoft Word engine',
+    label: 'Microsoft Outlook',
   },
   {
     id: 'gmail-web',
     label: 'Gmail',
-    subtitle: 'Gmail Web',
   },
   {
     id: 'apple-mail-macos',
     label: 'Apple Mail',
-    subtitle: 'WebKit on macOS',
   },
   {
     id: 'yahoo-mail',
     label: 'Yahoo Mail',
-    subtitle: 'Yahoo webmail',
   },
 ]
 
@@ -89,6 +92,42 @@ function PreviewErrorFallback() {
     </Flex>
   )
 }
+interface ClientOptionsListProps {
+  selectedClientId: string
+  onSelect: (id: string) => void
+}
+
+function ClientOptionsList({
+  selectedClientId,
+  onSelect,
+}: ClientOptionsListProps) {
+  return (
+    <List spacing={1}>
+      {CLIENT_OPTIONS.map((option) => {
+        const isSelected = option.id === selectedClientId
+        return (
+          <ListItem key={option.id}>
+            <Box
+              as="button"
+              type="button"
+              w="100%"
+              textAlign="left"
+              px={5}
+              py={2}
+              borderRadius="md"
+              bg={isSelected ? 'primary.100' : undefined}
+              _hover={{ bg: isSelected ? undefined : 'grey.100' }}
+              aria-current={isSelected || undefined}
+              onClick={() => onSelect(option.id)}
+            >
+              <Text textStyle="body-1">{option.label}</Text>
+            </Box>
+          </ListItem>
+        )
+      })}
+    </List>
+  )
+}
 
 interface EmailPreviewModalProps {
   isOpen: boolean
@@ -105,6 +144,12 @@ export default function EmailPreviewModal({
     'outlook-windows-legacy',
   )
 
+  const selectedClient =
+    CLIENT_OPTIONS.find((option) => option.id === selectedClientId) ??
+    CLIENT_OPTIONS[0]
+
+  const clientPopover = useDisclosure()
+
   return (
     <Modal
       isOpen={isOpen}
@@ -115,51 +160,62 @@ export default function EmailPreviewModal({
     >
       <ModalOverlay />
       <ModalContent maxH="85vh" overflow="hidden" borderRadius="lg">
-        <ModalHeader
-          position="sticky"
-          top={0}
-          bg="white"
-          zIndex={1}
-          borderBottom="1px solid"
-          borderColor="base.divider.medium"
-        >
-          <Flex direction="column">Email preview</Flex>
+        <ModalHeader borderBottom="1px solid" borderColor="base.divider.medium">
+          <Flex direction="column">Preview your email</Flex>
           <ModalCloseButton />
         </ModalHeader>
         <ModalBody p={4}>
-          <Flex direction="row" gap={4} h="70vh">
-            <Flex
-              direction="column"
-              flex="0 0 220px"
+          <Flex direction={{ base: 'column', sm: 'row' }} gap={4} h="70vh">
+            <Box
+              display={{ base: 'none', sm: 'block' }}
               borderRight="1px solid"
               borderColor="base.divider.medium"
               pr={2}
-              gap={1}
-              overflowY="auto"
             >
-              {CLIENT_OPTIONS.map((option) => {
-                const isSelected = option.id === selectedClientId
-                return (
+              <ClientOptionsList
+                selectedClientId={selectedClientId}
+                onSelect={setSelectedClientId}
+              />
+            </Box>
+            <Box display={{ base: 'block', sm: 'none' }}>
+              <Popover
+                isOpen={clientPopover.isOpen}
+                onOpen={clientPopover.onOpen}
+                onClose={clientPopover.onClose}
+                matchWidth
+                placement="bottom-start"
+              >
+                <PopoverTrigger>
                   <Box
-                    key={option.id}
                     as="button"
                     type="button"
-                    textAlign="left"
+                    w="100%"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="space-between"
                     px={3}
                     py={2}
                     borderRadius="md"
-                    bg={isSelected ? 'primary.50' : undefined}
-                    _hover={{ bg: isSelected ? 'primary.50' : 'grey.100' }}
-                    onClick={() => setSelectedClientId(option.id)}
+                    borderWidth="1px"
+                    borderColor="base.divider.medium"
                   >
-                    <Text textStyle="body-1">{option.label}</Text>
-                    <Text textStyle="body-2" mt={1} color="secondary.500">
-                      {option.subtitle}
-                    </Text>
+                    <Text textStyle="body-1">{selectedClient.label}</Text>
+                    <RiArrowDownSLine />
                   </Box>
-                )
-              })}
-            </Flex>
+                </PopoverTrigger>
+                <PopoverContent w="100%" minW={0}>
+                  <PopoverBody p={2}>
+                    <ClientOptionsList
+                      selectedClientId={selectedClientId}
+                      onSelect={(id) => {
+                        setSelectedClientId(id)
+                        clientPopover.onClose()
+                      }}
+                    />
+                  </PopoverBody>
+                </PopoverContent>
+              </Popover>
+            </Box>
             <Box flex="1" minW={0}>
               <ErrorBoundary
                 fallback={<PreviewErrorFallback />}

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -150,6 +150,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         customRteMenuOptions={schema?.customRteMenuOptions}
         variableTypes={schema.variableTypes}
         supportTableDisplay={schema.supportTableDisplay}
+        previewType={schema.previewType}
       />
     )
   }

--- a/packages/frontend/src/components/RichTextEditor/MenuBar.scss
+++ b/packages/frontend/src/components/RichTextEditor/MenuBar.scss
@@ -1,5 +1,14 @@
 .editor__header {
+  display: flex;
+  align-items: center;
   padding: 0.5rem;
+}
+
+.editor__formatting {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .divider {
@@ -30,5 +39,17 @@
   &:hover,
   &.is-active {
     background-color: #303030;
+  }
+}
+
+.menu-item.menu-item--preview {
+  align-self: stretch;
+  color: var(--chakra-colors-primary-500);
+  height: auto;
+  margin-right: 0;
+  min-height: 1.75rem;
+
+  &:hover {
+    background-color: var(--chakra-colors-primary-50);
   }
 }

--- a/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
+++ b/packages/frontend/src/components/RichTextEditor/MenuBar.tsx
@@ -1,6 +1,6 @@
 import './MenuBar.scss'
 
-import type { TRteMenuOption } from '@plumber/types'
+import type { TFieldPreviewType, TRteMenuOption } from '@plumber/types'
 
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { LuHeading1, LuHeading2, LuHeading3, LuHeading4 } from 'react-icons/lu'
@@ -41,6 +41,7 @@ import Form from '@/components/Form'
 import { RteMenuOption } from '@/graphql/__generated__/graphql'
 import { makeExternalLink } from '@/helpers/urls'
 
+import { PreviewButton } from './PreviewButton'
 import { simpleSubstitute, type VariableInfoMap } from './utils'
 import { BareEditor } from '.'
 
@@ -234,6 +235,7 @@ interface MenuBarProps {
   variableMap: VariableInfoMap
   editable: boolean
   customMenuOptions?: TRteMenuOption[]
+  previewType?: TFieldPreviewType
 }
 
 export const MenuBar = ({
@@ -241,6 +243,7 @@ export const MenuBar = ({
   variableMap,
   editable,
   customMenuOptions,
+  previewType,
 }: MenuBarProps) => {
   const {
     isOpen: isDialogOpen,
@@ -356,52 +359,59 @@ export const MenuBar = ({
   return (
     <>
       <div className="editor__header">
-        {menuButtons.map(({ onClick, label, icon, isActive }, index) => {
-          if (!onClick) {
-            return (
-              <div
-                className="divider"
-                style={{
-                  opacity: editable ? 1 : 0.5,
-                }}
-                key={`${label}${index}`}
-              />
-            )
-          }
-          const isDisabled =
-            !editable ||
-            (selectionContainsTableVariable &&
-              FORMATTING_BUTTONS_DISABLED_FOR_TABLE_VARIABLE.has(label))
+        <div className="editor__formatting">
+          {menuButtons.map(({ onClick, label, icon, isActive }, index) => {
+            if (!onClick) {
+              return (
+                <div
+                  className="divider"
+                  style={{
+                    opacity: editable ? 1 : 0.5,
+                  }}
+                  key={`${label}${index}`}
+                />
+              )
+            }
+            const isDisabled =
+              !editable ||
+              (selectionContainsTableVariable &&
+                FORMATTING_BUTTONS_DISABLED_FOR_TABLE_VARIABLE.has(label))
 
-          return (
-            <button
-              key={`${label}${index}`}
-              title={label}
-              disabled={isDisabled}
-              style={{
-                borderRadius: '0.25rem',
-                width: 'auto',
-                minWidth: 0,
-                backgroundColor: isActive?.(editor)
-                  ? 'rgba(0,0,0,0.1)'
-                  : 'transparent',
-                opacity: isDisabled ? 0.5 : 1,
-                cursor: isDisabled ? 'default' : 'pointer',
-              }}
-              className={`menu-item${isActive?.(editor) ? ' is-active' : ''}`}
-              onClick={() => {
-                const clickOverride = onClickOverrides[label]
-                if (clickOverride) {
-                  clickOverride()
-                  return
-                }
-                onClick(editor)
-              }}
-            >
-              {icon}
-            </button>
-          )
-        })}
+            return (
+              <button
+                key={`${label}${index}`}
+                title={label}
+                disabled={isDisabled}
+                style={{
+                  borderRadius: '0.25rem',
+                  width: 'auto',
+                  minWidth: 0,
+                  backgroundColor: isActive?.(editor)
+                    ? 'rgba(0,0,0,0.1)'
+                    : 'transparent',
+                  opacity: isDisabled ? 0.5 : 1,
+                  cursor: isDisabled ? 'default' : 'pointer',
+                }}
+                className={`menu-item${isActive?.(editor) ? ' is-active' : ''}`}
+                onClick={() => {
+                  const clickOverride = onClickOverrides[label]
+                  if (clickOverride) {
+                    clickOverride()
+                    return
+                  }
+                  onClick(editor)
+                }}
+              >
+                {icon}
+              </button>
+            )
+          })}
+        </div>
+        <PreviewButton
+          previewType={previewType}
+          editor={editor}
+          variableMap={variableMap}
+        />
       </div>
       {isDialogOpen && dialogLabel && (
         <AlertDialog

--- a/packages/frontend/src/components/RichTextEditor/PreviewButton.tsx
+++ b/packages/frontend/src/components/RichTextEditor/PreviewButton.tsx
@@ -1,0 +1,112 @@
+import type { TFieldPreviewType } from '@plumber/types'
+
+import {
+  lazy,
+  type MouseEvent,
+  type ReactNode,
+  Suspense,
+  useCallback,
+  useState,
+  useTransition,
+} from 'react'
+import { RiEyeLine } from 'react-icons/ri'
+import { Box, Spinner, Tooltip, useDisclosure } from '@chakra-ui/react'
+import { Editor } from '@tiptap/react'
+
+import { substituteForPreview, type VariableInfoMap } from './utils'
+
+const LazyEmailPreviewModal = lazy(
+  () => import('@/components/EmailPreviewModal'),
+)
+
+interface PreviewerProps {
+  isOpen: boolean
+  onClose: () => void
+  html: string
+}
+
+function usePreviewer(previewType: TFieldPreviewType | undefined) {
+  const preloadPreviewer = useCallback(() => {
+    switch (previewType) {
+      case 'email':
+        import('@/components/EmailPreviewModal')
+        break
+    }
+  }, [previewType])
+
+  const renderPreviewer = useCallback(
+    (props: PreviewerProps): ReactNode => {
+      switch (previewType) {
+        case 'email':
+          return <LazyEmailPreviewModal {...props} />
+      }
+      return null
+    },
+    [previewType],
+  )
+
+  return { preloadPreviewer, renderPreviewer }
+}
+
+interface PreviewButtonProps {
+  previewType: TFieldPreviewType | undefined
+  editor: Editor
+  variableMap: VariableInfoMap
+}
+
+export const PreviewButton = ({
+  previewType,
+  editor,
+  variableMap,
+}: PreviewButtonProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [html, setHtml] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const { preloadPreviewer, renderPreviewer } = usePreviewer(previewType)
+
+  if (!previewType) {
+    return null
+  }
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    const newHtml = substituteForPreview(editor.getHTML(), variableMap)
+    startTransition(() => {
+      setHtml(newHtml)
+      onOpen()
+    })
+  }
+
+  return (
+    <>
+      <Box
+        borderLeftWidth="2px"
+        borderLeftStyle="dotted"
+        borderColor="grey.300"
+        alignSelf="stretch"
+        mx={2}
+        aria-hidden
+      />
+      <Tooltip label="Preview" hasArrow>
+        <button
+          type="button"
+          aria-label="Preview"
+          className="menu-item menu-item--preview"
+          disabled={isPending}
+          onMouseEnter={preloadPreviewer}
+          onFocus={preloadPreviewer}
+          onPointerDown={preloadPreviewer}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onClick}
+        >
+          {isPending ? <Spinner size="sm" /> : <RiEyeLine />}
+        </button>
+      </Tooltip>
+      <Suspense fallback={null}>
+        {isOpen && renderPreviewer({ isOpen, onClose, html })}
+      </Suspense>
+    </>
+  )
+}
+
+export default PreviewButton

--- a/packages/frontend/src/components/RichTextEditor/index.tsx
+++ b/packages/frontend/src/components/RichTextEditor/index.tsx
@@ -1,6 +1,6 @@
 import './RichTextEditor.scss'
 
-import type { TRteMenuOption } from '@plumber/types'
+import type { TFieldPreviewType, TRteMenuOption } from '@plumber/types'
 import { TDataOutMetadatumType } from '@plumber/types'
 
 import { useCallback, useContext, useEffect, useMemo } from 'react'
@@ -104,6 +104,7 @@ interface EditorProps {
   customRteMenuOptions?: TRteMenuOption[]
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
+  previewType?: TFieldPreviewType
 }
 const Editor = ({
   onChange,
@@ -121,6 +122,7 @@ const Editor = ({
   customRteMenuOptions,
   isDisplayOnly = false,
   supportTableDisplay,
+  previewType,
 }: EditorProps) => {
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
@@ -320,6 +322,7 @@ const Editor = ({
                   variableMap={varInfo}
                   editable={editable ?? false}
                   customMenuOptions={customRteMenuOptions}
+                  previewType={previewType}
                 />
               )}
               <EditorContent
@@ -384,6 +387,7 @@ interface RichTextEditorProps {
   customRteMenuOptions?: TRteMenuOption[]
   isDisplayOnly?: boolean
   supportTableDisplay?: boolean
+  previewType?: TFieldPreviewType
 }
 const RichTextEditor = ({
   required,
@@ -404,6 +408,7 @@ const RichTextEditor = ({
   customRteMenuOptions,
   isDisplayOnly = false,
   supportTableDisplay,
+  previewType,
 }: RichTextEditorProps) => {
   const { readOnly } = useContext(EditorContext)
   const { control, getValues } = useFormContext()
@@ -455,6 +460,7 @@ const RichTextEditor = ({
             customRteMenuOptions={customRteMenuOptions}
             isDisplayOnly={isDisplayOnly}
             supportTableDisplay={supportTableDisplay}
+            previewType={previewType}
           />
         )}
       />

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -506,8 +506,8 @@ export interface IFieldRichText extends IBaseField {
   customRteMenuOptions?: TRteMenuOption[]
 
   /**
-   * If set, FlowStepTestController renders a kind-specific "Preview" button
-   * next to "Check step" and feeds it the live form value of this field.
+   * If set, renders a kind-specific Preview button at the end of the
+   * RichTextEditor toolbar that previews the editor's live HTML.
    */
   previewType?: TFieldPreviewType
 }


### PR DESCRIPTION
# Problem

We want pipe owners to be able to preview their email across a variety of email clients (Outlook, Yahoo etc).

# High-level Approach

See #1652 for more details.

# This PR

- Adds a right-aligned preview button to the tiptap editor top bar.
- Enables email preview for postman's email action

#### IMPORTANT

Feel free to comment on the best UX treatment for the preview button. I had a few ideas in mind:

1. In editortop bar, as a right aligned button with a minimum left margin to keep it visually separate from the text formatting controls.
2. In editor bottom bar or FAB in the editor - Rejected as bottom bar is wasting real estate, while FAB might be irritating if it floats over the users' content.
3. As a split button in the "test step" button (like formsg) - Rejected as I worry about discoverability; its unlikely users will try this out.

### Beedios

Desktop

[Screen Recording 2026-06-02 at 2.34.05 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e58136dc-1ca3-4c4b-95fd-8f78d621c4c0.mov" />](https://app.graphite.com/user-attachments/video/e58136dc-1ca3-4c4b-95fd-8f78d621c4c0.mov)

Mobile  
_NOTE: Our mobile UX needs some love..._

[Screen Recording 2026-06-02 at 2.51.19 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/809aa472-d9ee-4d12-bd9f-1575de615689.mov" />](https://app.graphite.com/user-attachments/video/809aa472-d9ee-4d12-bd9f-1575de615689.mov)

# Tests

- [x]  Check that i can preview emails in a variety of clients via the preview button
- [x]  Check that preview is accurate (_tested on outlook and gmail_)
- [x]  Check that I can still view email with actual values past executions
- [x]  [Regression test] Check that emails from published pipes have variables substituted correctly