### PR TITLE
[BULLMQ-BATCH-3] PLU-524: add batch queue types, flag, and queue config

### DIFF
--- a/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-a.md
+++ b/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-a.md
@@ -1,0 +1,130 @@
+# BullMQ Pro batching for m365-excel — PR A (batch queue + routing + batch worker stub + metric)
+
+**Status:** In progress
+**Created:** 2026-05-29
+**Last updated:** 2026-05-29
+
+## Resume from here
+
+Phases 1 & 2 done (combined into one PR per user). Phase 1: added `batch?` to `IAppQueue` in `packages/types/index.d.ts` (size/minSize/timeout/groupAffinity/actionKeys/getGroupConfigForJob) and `M365_EXCEL_BATCH_ENABLED` (default false) + `M365_EXCEL_BATCH_SIZE` (=20, validated) to `packages/backend/src/config/app-env-vars/m365.ts`. Phase 2: added the flag-gated `batch` block to `packages/backend/src/apps/m365-excel/queue/index.ts` (actionKeys `['createTableRow']`, group key `${fileId}-${tableId}-${step.key}` via a new `getBatchGroupConfigForJob` that validates fileId+tableId, `size = M365_EXCEL_BATCH_SIZE`, `groupAffinity: true`). Existing config untouched; flag-off ⇒ `batch` undefined. Backend typecheck clean both phases. **Next: Phase 3** — register `{app-actions-${appKey}-batch}` queue + enqueue routing in `packages/backend/src/queues/action.ts` (this is where the scaled batch rate limit `max: size, duration: size × interval` gets applied). Real dispatch is PR B (`docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-b.md`).
+
+## Context
+
+The m365-excel queue serializes Excel writes per `fileId` and dispenses jobs via a leaky bucket (`max: 1, duration: 1000ms`). Every job makes one Graph call, so a burst of same-file writes becomes N sequential POSTs. We coalesce `createTableRow` jobs that share `(fileId, tableId)` into one Graph `POST /tables/:tableId/rows`, using BullMQ Pro 7.44's `batch` + `groupAffinity: true`.
+
+**Architecture (decided):** instead of batching inside the shared queue/worker, route `createTableRow` jobs to a **dedicated batch queue** with its own worker. Other actions stay on the existing queue, byte-identical. This keeps all batching code and risk in the new queue + worker, and makes the batch queue **homogeneous** (`createTableRow` only), grouped by `(fileId, tableId, actionKey)` so every batch is a single table → exactly one POST.
+
+**Serialization tradeoff (accepted — option a):** splitting `createTableRow` into its own queue means a `createTableRow` can run concurrently with another action on the same file (different queues), and two `createTableRow`s to different tables of the same file can run concurrently (group key includes `tableId`). This relaxes the previous per-file serialization. **Accepted.** A manual per-file lock (re-enqueue-with-delay if a file is busy) is a possible future addition — **out of scope here** (see Out of scope).
+
+**Verified against the installed code:** BullMQ Pro 7.44 batch API exists (`WorkerProOptions.batch`, `job.getBatch()`, `job.setAsFailed()`). `enqueueActionJob` (`queues/action.ts:69`) routes by `appKey` and applies `getGroupConfigForJob` (which already queries the `Step`). `makeActionJobId`/`getActionJob` encode the queue name into the `ExecutionStep.jobId`, so a second queue's jobs retry/resolve with no schema change.
+
+## Goals
+
+- A dedicated `createTableRow` batch queue (group key `(fileId, tableId, actionKey)`, `concurrency = BATCH_SIZE`, scaled rate limit) + a separate `makeBatchActionWorker`, both created only when the flag is on.
+- Enqueue-time routing: `createTableRow` (m365-excel) → batch queue; everything else → existing queue. One shared `Step` fetch for routing + grouping.
+- **Flag off = byte-identical to today** (no batch queue/worker; routing never diverts).
+- Batch worker: N=1 processes normally (reuses the existing single-job path); N>1 throws a clear stub error after tagging `batchSize` (real dispatch is PR B).
+- The existing m365-excel queue, `makeActionWorker`, and `processAction` are **unchanged in behavior** (only a shared extraction of the single-job processor, if needed for reuse).
+
+## Non-goals
+
+- Real N>1 dispatch / `create-table-row.runBatch` / per-item failure handling — PR B.
+- The manual per-file lock — out of scope (documented only).
+- Production flag flip; `minSize`/`timeout` tuning; Datadog dashboard refactor; batching other actions.
+
+## Decisions made
+
+- **Separate batch queue + worker for `createTableRow`** (not in-worker branching on the shared queue). The existing queue/worker/processAction path is untouched; other actions carry zero risk. Chosen per the serialization tradeoff (option a) the user accepted.
+- **Batch queue group key = `${fileId}-${tableId}-${stepKey}`.** Homogeneous `createTableRow` + per-table grouping ⇒ one POST per batch ⇒ the simplest possible failure model (PR B). The existing queue keeps group key = `fileId`.
+- **Route by step key at enqueue time.** In `enqueueActionJob`, fetch the `Step` once; if the app has a batch queue and `step.key` is batchable (`createTableRow`), enqueue to the batch queue with the batch group config; else the existing queue with `fileId` grouping. Reuse the single fetch for both routing and grouping.
+- **Flag gating = batch queue existence.** The queue config exposes `batch` only when the flag is on; the batch queue/worker are registered only then; routing checks for the batch queue's presence. Flag off ⇒ no divergence.
+- **Reuse the single-job processor for N=1.** Extract `makeActionWorker`'s processor body into a shared `processSingleActionJob` (behavior-preserving) so the batch worker uses it verbatim for N=1; only the N>1 path is new.
+- **Rate limits are per-queue.** Existing queue stays `max: 1, duration: interval`. Batch queue: `max: BATCH_SIZE, duration: BATCH_SIZE * M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS` (per-job `INCR` would otherwise cap batches at 1). Note: the two queues have independent rate budgets — combined Graph rate to a file can exceed today's single budget; revisit if it strains the tenant agreement.
+- **`BATCH_SIZE = 20`**, hardcoded with a rationale comment (well under Graph's ~4MB ceiling). Defer 413 handling. `minSize`/`timeout` supported in the type, unset for now.
+
+## Files touched
+
+- `packages/types/index.d.ts` (modify) — add `batch?: { size: number; minSize?: number; timeout?: number; groupAffinity: true; actionKeys: string[]; getGroupConfigForJob(jobData): Promise<JobsProOptions['group']> }` to `IAppQueue` (the batch-queue grouping + which action keys route to it).
+- `packages/backend/src/config/app-env-vars/m365.ts` (modify) — `M365_EXCEL_BATCH_ENABLED` (`=== 'true'`, default false) + `M365_EXCEL_BATCH_SIZE` (=20).
+- `packages/backend/src/apps/m365-excel/queue/index.ts` (modify) — when flag on, add `batch` (actionKeys: `['createTableRow']`, `getGroupConfigForJob` → `${fileId}-${tableId}-${stepKey}`, `size`, `groupAffinity: true`). Existing `getGroupConfigForJob`/`groupLimits`/`queueRateLimit` unchanged.
+- `packages/backend/src/queues/action.ts` (modify) — register a batch queue (`{app-actions-${appKey}-batch}`) for apps whose `queue.batch` is set; store in `actionQueuesByName` + a new `appBatchActionQueues` record. In `enqueueActionJob`, add routing: fetch `Step` once, route batchable keys to the batch queue with `batch.getGroupConfigForJob`, else existing behavior.
+- `packages/backend/src/workers/helpers/make-action-worker.ts` (modify) — extract the processor body into exported `processSingleActionJob(job, ctx)`; export `convertParamsToBullMqOptions`. Behavior unchanged.
+- `packages/backend/src/workers/helpers/make-batch-action-worker.ts` (create) — options incl. `workerOptions.batch`; processor tags span `batchSize`, then `getBatch().length > 1` → throw `UnrecoverableError('Batch dispatch not yet implemented (N jobs)')`, else → `processSingleActionJob`.
+- `packages/backend/src/workers/action.ts` (modify) — for apps with a batch queue, also create `makeBatchActionWorker` for it (new `appBatchActionWorkers` record), only when the flag is on.
+- `packages/backend/src/queues/__tests__/*`, `packages/backend/src/apps/m365-excel/__tests__/queue.test.ts` (modify) — routing + flag-off parity + flag-on wiring.
+- `packages/backend/src/workers/__tests__/action.batch.itest.ts` (create) — flag-on: `createTableRow` routes to batch queue; N=1 processes; N>1 throws stub with `batchSize` tagged; other actions still route to the existing queue.
+
+## Phases
+
+### Phase 1: Types + env flag
+
+- [x] Add `batch?` (with `actionKeys` + `getGroupConfigForJob`) to `IAppQueue`.
+- [x] Add `M365_EXCEL_BATCH_ENABLED` + `M365_EXCEL_BATCH_SIZE` (=20) to `m365.ts`.
+
+Files: `packages/types/index.d.ts`, `packages/backend/src/config/app-env-vars/m365.ts`
+Verify: typecheck clean.
+
+### Phase 2: Queue config (flag-gated)
+
+- [x] Add the flag-gated `batch` block to the m365-excel queue config (actionKeys `['createTableRow']`, group `${fileId}-${tableId}-${stepKey}`, `size = BATCH_SIZE`, scaled batch-queue rate limit). Existing config unchanged. NOTE: the `batch` type carries no rate-limit field; the scaled batch-queue rate limit is derived during queue/worker registration (Phase 3/5) from `queueRateLimit × size`.
+
+Files: `packages/backend/src/apps/m365-excel/queue/index.ts`
+Verify: flag-off → `batch` undefined, config identical to today; flag-on → `batch` populated correctly (Phase 6 test).
+
+### Phase 3: Batch queue registration + enqueue routing
+
+- [ ] Register `{app-actions-${appKey}-batch}` for apps with `queue.batch`; add to `actionQueuesByName` + `appBatchActionQueues`.
+- [ ] In `enqueueActionJob`, fetch the `Step` once and route batchable keys to the batch queue (batch group config), else existing behavior.
+
+Files: `packages/backend/src/queues/action.ts`
+Verify: flag-on → a `createTableRow` job lands in the batch queue with group `fileId-tableId-createTableRow`; a `writeCellValues` job lands in the existing queue with group `fileId`. Flag-off → both in the existing queue.
+
+### Phase 4: Extract `processSingleActionJob` (behavior-preserving)
+
+- [ ] Lift `makeActionWorker`'s processor body into exported `processSingleActionJob`; export `convertParamsToBullMqOptions`.
+
+Files: `packages/backend/src/workers/helpers/make-action-worker.ts`
+Verify: existing `action.itest.ts` + worker unit tests pass unchanged (pure refactor).
+
+### Phase 5: Batch worker + bootstrap wiring
+
+- [ ] Implement `make-batch-action-worker.ts` (batch options; `batchSize` tag; N=1 → `processSingleActionJob`; N>1 → stub throw).
+- [ ] In `workers/action.ts`, create the batch worker for apps with a batch queue (flag-gated).
+
+Files: `packages/backend/src/workers/helpers/make-batch-action-worker.ts`, `packages/backend/src/workers/action.ts`
+Verify: flag-off → no batch worker. Flag-on → batch worker on the batch queue; N=1 processes; N>1 throws stub.
+
+### Phase 6: Tests
+
+- [ ] Unit: queue config (flag-off parity + flag-on wiring); enqueue routing (createTableRow→batch, others→existing, flag-off→existing).
+- [ ] Itest: `action.batch.itest.ts` (flag-on N=1 processes; N>1 throws stub; `batchSize` tagged).
+
+Files: `packages/backend/src/apps/m365-excel/__tests__/queue.test.ts`, `packages/backend/src/queues/__tests__/*`, `packages/backend/src/workers/__tests__/action.batch.itest.ts`
+Verify: scoped vitest passes; full m365-excel + worker/queue suites green.
+
+## Out of scope (documented per user request — not planned)
+
+- **Manual per-file lock.** Because option (a) accepts concurrent same-file writes across the two queues / across tables, the user may later add a manual lock: before processing, check a per-`fileId` lock; if the file is busy, re-enqueue the job with a delay instead of writing. This would restore per-file serialization on top of the batch queue. Not designed or planned here.
+- **Cross-queue rate coordination.** The two queues have independent rate budgets; if the combined Graph rate to a file strains the tenant agreement, coordinate them. Not addressed here.
+
+## Edge cases considered
+
+- **Flag off** — no `batch` config → no batch queue/worker, routing never diverts → zero change for m365 and all other apps.
+- **Flag on, N=1** — batch worker routes to `processSingleActionJob` → identical to single-job behavior.
+- **Flag on, N>1** — `batchSize` tagged, then stub throw (visible in error rates; staging reads `batchSize` from failing spans).
+- **`createTableRow` with missing/variable `tableId`** — group key needs `tableId`; if absent the routing/group helper throws (mirror today's `fileId`-missing handling).
+- **Retry of a batch-queue job** — `jobId` encodes the batch queue name; `getActionJob` resolves it from `actionQueuesByName`. Confirm the batch queue is registered there.
+- **Mixed-version deploy** — flag stays off through PR A; no divergence.
+
+## Verification
+
+1. Typecheck/lint clean.
+2. Unit: queue config + routing tests.
+3. Itest: `action.batch.itest.ts` (testcontainers Redis/PG).
+4. Regression: existing `action.itest.ts` + m365-excel action itests green (existing queue/worker path untouched; flag off elsewhere).
+5. Staging: set `M365_EXCEL_BATCH_ENABLED=true`, drive concurrent `createTableRow` submissions to one file/table, read the `batchSize` Datadog distribution to size `minSize`/`timeout` before PR B.
+
+## Open questions
+
+1. **`minSize`/`timeout`** — unset; a small fill `timeout` may help batches form under moderate concurrency. Decide from staging `batchSize`.
+2. **Datadog span semantics** under batching — confirm with the dashboard owner before a prod flag flip (PR B concern).

--- a/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-b.md
+++ b/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-b.md
@@ -1,0 +1,124 @@
+# BullMQ Pro batching for m365-excel — PR B (batch dispatch + create-table-row.runBatch)
+
+**Status:** Not started
+**Created:** 2026-05-29
+**Last updated:** 2026-05-29
+
+## Resume from here
+
+Depends on PR A (`docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-a.md`): the dedicated `createTableRow` batch queue, enqueue-time routing, the separate `makeBatchActionWorker` (stub on N>1, `batchSize` metric, N=1 → shared `processSingleActionJob`), and the worker wiring. PR B replaces the stub with real dispatch and ships `create-table-row.runBatch`. The existing m365-excel queue, `makeActionWorker`, and the single-job path are **untouched** (only behavior-preserving extractions of shared helpers). Start at Phase 1.
+
+## Context
+
+PR A isolated all batching to a dedicated queue grouped by `(fileId, tableId, actionKey)`. Because that queue is **homogeneous `createTableRow`** and grouped per table, **every batch is one `(fileId, tableId)` → exactly one Graph POST.** That removes the hard parts of the original single-queue design: no partition-by-`step.key`, no sub-grouping by `tableId`, and no multi-write "duplicate-on-bail" risk (a batch makes one write — it either fully succeeds or fully fails, having written nothing).
+
+The batch worker gets one representative job; `job.getBatch()` returns all siblings (same `(fileId, tableId)` createTableRow). N=1 already delegates to `processSingleActionJob`. For N>1, PR B's `processActionBatch` prepares each item, calls `create-table-row.runBatch` once for the whole batch (one POST), finalizes each item, and completes/fails each job.
+
+**Defining constraint (verified in `@taskforcesh/bullmq-pro` `job-pro.js`):** `setAsFailed(err)` sets `job.failedError`; on processor return, `moveBatchToCompleted` fails those jobs via `moveToFailed(err, token, false)` (normal backoff; `UnrecoverableError` ⇒ no retry) and completes the rest. **A `throw` fails the entire batch.** Per-item failures (e.g. one schema-invalid item) must therefore be `setAsFailed`, not `throw` — that's the only reason per-item handling exists; the actual Graph write is a single all-or-nothing POST.
+
+## Goals
+
+- Replace the batch worker's N>1 stub with `processActionBatch`: parallel prepare → one `create-table-row.runBatch` call (one POST) → parallel finalize → per-item complete/`setAsFailed`.
+- Ship `create-table-row.runBatch`: validate each item, drop schema-invalid ones, build one multi-row `values` array, issue one POST, set each surviving item's `sheetRowNumber`.
+- **Single-job and test-run behavior byte-identical** — both paths call the same extracted helpers; the existing queue/worker are untouched.
+
+## Non-goals
+
+- Batching actions other than `createTableRow` (the batch queue only receives `createTableRow`).
+- The manual per-file lock and cross-queue rate coordination — out of scope (see PR A).
+- `minSize`/`timeout` tuning; Datadog refactor; Graph tenant sign-off (before prod flip).
+- Removing `RATE_LIMIT_FOR_RELEASE_ONLY_REMOVE_AFTER_JULY_2024` (preserve; flag for cleanup).
+
+## Decisions made
+
+- **Batch = one POST.** The homogeneous, per-table batch queue means `processActionBatch` calls `runBatch` once with the whole batch; `runBatch` issues a single `POST /tables/:tableId/rows`. No partitioning, no sub-grouping.
+- **Failure model (simplified):**
+  - Schema-invalid item → `markFailed(StepError, { retryable: false })`, dropped before the POST.
+  - POST success → finalize all surviving items (each gets its `sheetRowNumber` from the one response).
+  - POST failure → `markFailed(err, { retryable: true })` all surviving items (they share the one write, which wrote nothing). `processActionBatch` runs `classifyStepFailure(err)`: rate-limit kinds (429 `group` / 429-generic & 509 `queue`, from `request-error-handler.ts`) → apply `worker.rateLimitGroup`/`rateLimit` + `setAsFailed(retryable)`; step-retry → `setAsFailed(retryable)`; else → `setAsFailed(UnrecoverableError)`.
+  - The processor never `throw`s for per-item failures.
+- **`runBatch` contract:** `runBatch(items: { $: IGlobalVariable; markFailed: (err: Error, opts?: { retryable?: boolean }) => void }[]): Promise<void>`. `create-table-row.runBatch`: per-item `parametersSchema.safeParse` (invalid → `markFailed(_, { retryable: false })`, drop) → acquire one `WorkbookSession`, fetch header once, build one `values` array from survivors, one POST → per-item `sheetRowNumber` + `setActionItem`; on POST throw → `markFailed(err, { retryable: true })` every surviving item. (May defensively assert all items share `tableId`, guaranteed by the queue grouping.)
+- **`run` becomes a thin shim over `runBatch`** via `runSingleViaBatch`, preserving the test-run rate-limit and `metadata` (test runs reach `createTableRow` via `processAction → run`, N=1, synchronous, so `runBatch` must handle a `testRun` item).
+- **Sharing = extract pure pieces, reuse in both paths:** `prepareActionContext` + `finalizeActionStep` (from `processAction`), `classifyStepFailure` (from `handle-failed-step-and-throw.ts`, returns kind + finalError), `handleSuccessfulStepResult` (from `processSingleActionJob`'s success branch). All behavior-preserving; existing itests guard parity.
+- **Split PR B into B1 (Phases 1–2) + B2 (Phase 3)** optional, for smaller merges. B1 proves dispatch machinery; B2 adds the coalescing POST.
+- **Spike before building:** confirm (a) `setAsFailed(Error)` retries per backoff and `setAsFailed(UnrecoverableError)` doesn't; (b) `worker.rateLimitGroup`/`rateLimit` apply backpressure *without* throwing `RateLimitError` (so the batch can rate-limit + retry its items while completing nothing-committed cleanly).
+
+## Files touched
+
+- `packages/types/index.d.ts` (modify) — add `runBatch?` to `IBaseAction`.
+- `packages/backend/src/services/action.ts` (modify) — extract `prepareActionContext` + `finalizeActionStep`; `processAction` = `prepare → run → finalize` (unchanged behavior); export both.
+- `packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts` (modify) — extract `classifyStepFailure` (returns `{ kind: 'rate-limit-group'|'rate-limit-queue'|'retry-step'|'unrecoverable'; delayMs?; finalError }`); `handleFailedStepAndThrow` becomes a thin wrapper mapping kinds to its current throw / `worker.rateLimit` / `worker.rateLimitGroup` behavior.
+- `packages/backend/src/workers/helpers/process-single-action-job.ts` (modify) — extract `handleSuccessfulStepResult` from its success branch (behavior-preserving). *(PR A's extraction file, not `make-action-worker.ts`.)*
+- `packages/backend/src/workers/helpers/handle-successful-step-result.ts` (create) — shared success handler (enqueue-next / `processForEachStatus` / `setStatus`).
+- `packages/backend/src/workers/helpers/process-action-batch.ts` (create) — parallel prepare → one `runBatch` → parallel finalize → per-item `setAsFailed` (via `classifyStepFailure`, applying the limiter on rate-limit kinds) / `handleSuccessfulStepResult`. Always returns normally.
+- `packages/backend/src/workers/helpers/make-batch-action-worker.ts` (modify) — N>1 branch: replace the stub with `processActionBatch(...)`.
+- `packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts` (modify) — add `runBatch`; replace `run` with the `runSingleViaBatch` shim.
+- `packages/backend/src/apps/m365-excel/common/run-single-via-batch.ts` (create) — shim: single `$` → 1-item `runBatch`, captures `markFailed`, re-throws (`UnrecoverableError` when `retryable: false`).
+- `packages/backend/src/workers/__tests__/action.batch.itest.ts` (modify) — dispatch + failure-isolation matrix.
+- `packages/backend/src/apps/m365-excel/__tests__/actions/create-table-row.batch.itest.ts` (create) — coalescing + schema-drop + failure cases (Graph mocked).
+
+## Phases
+
+### Phase 1: Types + shared pure-helper extraction (no behavior change) — PR B1
+
+- [ ] Add `runBatch?` to `IBaseAction`.
+- [ ] Extract `prepareActionContext` + `finalizeActionStep` from `processAction`.
+- [ ] Extract `classifyStepFailure` from `handle-failed-step-and-throw.ts` (thin wrapper remains).
+- [ ] Extract `handleSuccessfulStepResult` from `processSingleActionJob`'s success branch.
+
+Files: `packages/types/index.d.ts`, `packages/backend/src/services/action.ts`, `packages/backend/src/helpers/actions/handle-failed-step-and-throw.ts`, `packages/backend/src/workers/helpers/process-single-action-job.ts`, `packages/backend/src/workers/helpers/handle-successful-step-result.ts`
+Verify: typecheck clean; all existing `action.itest.ts` + m365-excel action itests pass unchanged (pure refactor).
+
+### Phase 2: Real dispatch (`process-action-batch.ts`) — completes PR B1
+
+- [ ] Implement `process-action-batch.ts` (prepare → single `runBatch` → finalize → per-item `setAsFailed`/`handleSuccessfulStepResult`; limiter backpressure on rate-limit kinds; never throws per-item).
+- [ ] Point the batch worker's N>1 branch at `processActionBatch` (remove stub).
+- [ ] Spike: itest for (a)/(b) above.
+
+Files: `packages/backend/src/workers/helpers/process-action-batch.ts`, `packages/backend/src/workers/helpers/make-batch-action-worker.ts`, `packages/backend/src/workers/__tests__/action.batch.itest.ts`
+Verify: N>1 batch processes; per-item prepare failure isolated; for-each iteration status patched per item; N=1 identical to single path. (Coalescing POST itself is Phase 3.)
+
+### Phase 3: create-table-row.runBatch (the coalescing POST) — PR B2
+
+- [ ] Implement `runBatch` in `create-table-row/index.ts` (per-item schema → one session/header/POST → per-item `sheetRowNumber` + `setActionItem`; `markFailed` per the failure model; preserve test-run rate-limit).
+- [ ] Add `runSingleViaBatch`; make `run` a shim.
+
+Files: `packages/backend/src/apps/m365-excel/actions/create-table-row/index.ts`, `packages/backend/src/apps/m365-excel/common/run-single-via-batch.ts`
+Verify: 5 items same table → 1 POST, 5 rows; 1 of 5 schema-invalid → dropped non-retryably, other 4 in one POST; N=1 via shim identical to old `run`; test-run still rate-limited.
+
+### Phase 4: Failure-matrix tests
+
+- [ ] POST 500 → all surviving items retryable-fail, retry re-issues one POST (no duplicate rows, since the failed POST wrote nothing).
+- [ ] 429 → group rate-limit applied + items retryable-fail; processor does not throw.
+- [ ] `invalidSession` mid-call → items retryable-fail, session cleared from Redis, retry re-acquires.
+- [ ] Finalize/enqueue failure for one item → `setAsFailed(UnrecoverableError)`, others commit.
+
+Files: `packages/backend/src/workers/__tests__/action.batch.itest.ts`, `packages/backend/src/apps/m365-excel/__tests__/actions/create-table-row.batch.itest.ts`
+Verify: integration suite passes (testcontainers Redis/PG; Graph mocked).
+
+## Edge cases considered
+
+- **Processor never throws for a per-item failure** — all per-item errors → `setAsFailed`. (Verified `moveBatchToCompleted`.)
+- **Schema-invalid item** — dropped pre-POST via `markFailed(_, { retryable: false })`; the rest still POST.
+- **POST failure** — one write, nothing committed → all surviving items `setAsFailed(retryable)`; retry re-issues one POST, no duplicates. 429 also applies `rateLimitGroup`.
+- **Prepare failure** — `setAsFailed(UnrecoverableError)`, dropped pre-dispatch.
+- **Finalize/enqueue failure** — `setAsFailed(UnrecoverableError)`; siblings unaffected.
+- **For-each createTableRow** — routes to the batch queue; `finalizeActionStep` + `handleSuccessfulStepResult` run the for-each metadata/status per item. (Rarely co-batch due to the 2s stagger; correctness holds.)
+- **Test run (N=1)** — `processAction → run → runSingleViaBatch → runBatch`; rate-limit + real POST preserved; throws on failure (not `setAsFailed`).
+- **Concurrent same-(file,table) batches** — possible under partial batches at `concurrency = BATCH_SIZE` (accepted via option a; the future manual per-file lock would close it). Retry-safe because a failed POST writes nothing; the residual risk is two *successful* concurrent appends to one table.
+
+## Verification
+
+1. Typecheck/lint clean.
+2. Phase 1 regression: existing `action.itest.ts` + m365-excel action itests green (refactor is behavior-preserving; existing queue/worker untouched).
+3. Phase 2: dispatch itests + the setAsFailed/limiter spike.
+4. Phase 3: coalescing itests (one POST per batch; schema-drop; shim parity).
+5. Phase 4: failure-matrix itests.
+6. Staging: flag on, concurrent submissions to one file/table; Datadog shows Graph POSTs drop ~`batchSize`×; no duplicate rows under induced retries.
+7. Scope vitest to touched files during dev; run full batch + m365-excel suites before each PR.
+
+## Open questions
+
+1. **Ship B1 + B2 or one PR B?** Recommendation: optional split; the design is small enough that one PR B is also fine.
+2. **`minSize`/`timeout`** (from PR A) — set from staging `batchSize`.
+3. **Graph tenant rate-limit / burst sign-off** + **Datadog span semantics** — before prod flag flip.

--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.before-request.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.before-request.test.ts
@@ -51,6 +51,7 @@ vi.mock('@/helpers/logger', () => ({
 
 vi.mock('@/config/app-env-vars/m365', () => ({
   M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS: 1000,
+  M365_EXCEL_BATCH_ENABLED: false,
   isM365TenantKey: vi.fn(() => true),
 }))
 

--- a/packages/backend/src/apps/m365-excel/queue/index.ts
+++ b/packages/backend/src/apps/m365-excel/queue/index.ts
@@ -1,6 +1,10 @@
 import type { IAppQueue } from '@plumber/types'
 
-import { M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS } from '@/config/app-env-vars/m365'
+import {
+  M365_EXCEL_BATCH_ENABLED,
+  M365_EXCEL_BATCH_SIZE,
+  M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
+} from '@/config/app-env-vars/m365'
 import Step from '@/models/step'
 
 //
@@ -38,6 +42,34 @@ const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async (
   }
 }
 
+// Group key for the dedicated createTableRow batch queue. We group by
+// `(fileId, tableId, stepKey)` so every batch targets a single table on a
+// single file ⇒ exactly one Graph POST per batch. This is finer than the
+// existing per-file group key above.
+const getBatchGroupConfigForJob: NonNullable<
+  IAppQueue['batch']
+>['getGroupConfigForJob'] = async (jobData) => {
+  const step = await Step.query().findById(jobData.stepId).throwIfNotFound()
+  const fileId = step.parameters['fileId'] as string
+  const tableId = step.parameters['tableId'] as string
+
+  if (!fileId) {
+    throw new Error(
+      `Expected fileId to be non-empty for step ${jobData.stepId}`,
+    )
+  }
+
+  if (!tableId) {
+    throw new Error(
+      `Expected tableId to be non-empty for step ${jobData.stepId}`,
+    )
+  }
+
+  return {
+    id: `${fileId}-${tableId}-${step.key}`,
+  }
+}
+
 const queueSettings = {
   getGroupConfigForJob,
   groupLimits: {
@@ -50,6 +82,18 @@ const queueSettings = {
     duration: M365_EXCEL_INTERVAL_BETWEEN_ACTIONS_MS,
   },
   workerType: 'action',
+  // Flag-gated: when off, `batch` is undefined ⇒ no batch queue/worker is
+  // registered and enqueue routing never diverts (byte-identical to today).
+  ...(M365_EXCEL_BATCH_ENABLED
+    ? {
+        batch: {
+          size: M365_EXCEL_BATCH_SIZE,
+          groupAffinity: true,
+          actionKeys: ['createTableRow'],
+          getGroupConfigForJob: getBatchGroupConfigForJob,
+        },
+      }
+    : {}),
 } satisfies IAppQueue
 
 export default queueSettings

--- a/packages/backend/src/config/app-env-vars/m365.ts
+++ b/packages/backend/src/config/app-env-vars/m365.ts
@@ -25,6 +25,28 @@ if (
   )
 }
 
+// Feature flag for coalescing m365-excel createTableRow jobs into a dedicated
+// batch queue. Off by default; when off, m365-excel behaves byte-identically
+// to today (no batch queue/worker, no enqueue routing divergence).
+export const M365_EXCEL_BATCH_ENABLED =
+  process.env.M365_EXCEL_BATCH_ENABLED === 'true'
+
+// Max number of createTableRow jobs coalesced into a single Graph POST.
+// Hardcoded well under Graph's ~4MB request ceiling; 413 handling deferred.
+export const M365_EXCEL_BATCH_SIZE = Number(
+  process.env.M365_EXCEL_BATCH_SIZE ?? '20',
+)
+
+if (
+  isNaN(M365_EXCEL_BATCH_SIZE) ||
+  !Number.isInteger(M365_EXCEL_BATCH_SIZE) ||
+  M365_EXCEL_BATCH_SIZE < 1
+) {
+  throw new Error(
+    'M365_EXCEL_BATCH_SIZE environment variable is not a valid positive integer!',
+  )
+}
+
 const sensitivityLabelGuidsSchema = z
   .string()
   .trim()

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -597,6 +597,56 @@ export interface IAppQueue {
   queueRateLimit?: WorkerProOptions['limiter']
 
   /**
+   * Opt this app into a dedicated batch queue for a subset of its action
+   * keys. When set, jobs whose step key is in `actionKeys` are routed to a
+   * separate `{app-actions-${appKey}-batch}` queue and coalesced into batches
+   * via BullMQ Pro's batch worker option.
+   *
+   * Jobs whose step key is not in `actionKeys` continue to enqueue to the
+   * app's existing queue with `getGroupConfigForJob` grouping.
+   */
+  batch?: {
+    /**
+     * Maximum number of jobs per batch. Maps to `WorkerProOptions.batch.size`.
+     */
+    size: number
+
+    /**
+     * Minimum number of jobs to form a batch before `timeout` elapses. Maps to
+     * `WorkerProOptions.batch.minSize`.
+     */
+    minSize?: number
+
+    /**
+     * Max time (ms) to wait for a batch to fill to `minSize` before processing
+     * whatever has accumulated. Maps to `WorkerProOptions.batch.timeout`.
+     */
+    timeout?: number
+
+    /**
+     * Must be true: batches must respect group affinity so every batch belongs
+     * to a single group (one `(fileId, tableId, actionKey)` ⇒ one Graph POST).
+     */
+    groupAffinity: true
+
+    /**
+     * The step keys that route to the batch queue (e.g. `['createTableRow']`).
+     */
+    actionKeys: string[]
+
+    /**
+     * Obtains the group config for a job that is about to be enqueued to the
+     * batch queue. Distinct from {@link getGroupConfigForJob} because the batch
+     * queue groups by a finer key (e.g. `(fileId, tableId, actionKey)`).
+     *
+     * @see {@link JobsProOptions.group}
+     */
+    getGroupConfigForJob(
+      jobData: IActionJobData,
+    ): Promise<JobsProOptions['group']>
+  }
+
+  /**
    * Configures if we are allowed to delay or rate limit the entire queue.
    *
    * Concretely speaking, if this is true, RetriableErrors with delayType set


### PR DESCRIPTION
## Summary

Adds the type surface (`IAppQueue.batch`), env flags, and the m365-excel queue's flag-gated `batch` config block. Foundation only — no enqueue routing or batch worker yet, so behavior is unchanged.

## Problem / Feature

A burst of same-file `createTableRow` writes currently becomes N sequential Graph POSTs. We're building an opt-in batch queue that coalesces same-`(fileId, tableId)` writes into one POST. This PR lays the type/config groundwork.

## What changed

- `packages/types/index.d.ts`: optional `batch` block on `IAppQueue` — `size`, `minSize?`, `timeout?`, `groupAffinity: true`, `actionKeys: string[]`, and a batch-specific `getGroupConfigForJob`.
- `packages/backend/src/config/app-env-vars/m365.ts`: `M365_EXCEL_BATCH_ENABLED` (`=== 'true'`, default false) and `M365_EXCEL_BATCH_SIZE` (default 20, validated positive integer).
- `packages/backend/src/apps/m365-excel/queue/index.ts`: flag-gated `batch` block (actionKeys `['createTableRow']`, group key `${fileId}-${tableId}-${step.key}` with fileId+tableId validation, `size = M365_EXCEL_BATCH_SIZE`, `groupAffinity: true`). Existing per-file group config untouched.

## Testing

Backend typecheck (`tsc --noEmit`) passes clean. Flag defaults to off → `batch` undefined → config identical to today. Full unit coverage of flag-off parity + flag-on wiring lands in the Phase 6 test PR.

## Deploy notes

New env vars `M365_EXCEL_BATCH_ENABLED` (default false) and `M365_EXCEL_BATCH_SIZE` (default 20). Leave the flag off; no behavior change until enabled and later phases ship.

## Phase context

- Done in this PR: batch types + env flags (Phase 1) and m365-excel queue `batch` config block (Phase 2).
- Done in previous phases: none.
- Not yet done (future phases): batch queue registration + enqueue routing (+ scaled batch rate limit), `processSingleActionJob` extraction, batch worker stub + wiring, tests.