### PR TITLE
feat(db-retry): retry worker-path inserts inline instead of forUpdate checks

### DIFF
--- a/packages/backend/src/helpers/retry-on-transient-db-error.ts
+++ b/packages/backend/src/helpers/retry-on-transient-db-error.ts
@@ -100,10 +100,15 @@ async function sleep(ms: number): Promise<void> {
 }
 
 /**
- * For HTTP-edge call sites (webhook handler, partial-retry mutation) where
- * there's no BullMQ to fall back on. Retries the function up to
- * `MAX_TRANSIENT_DB_ATTEMPTS` times on transient DB errors. Rethrows on
- * non-transient errors and on the final attempt.
+ * Retries `fn` up to `MAX_TRANSIENT_DB_ATTEMPTS` times on transient DB errors,
+ * with a capped jittered backoff. Rethrows on non-transient errors and on the
+ * final attempt.
+ *
+ * Used both at HTTP-edge call sites (webhook handler, partial-retry mutation),
+ * where there's no BullMQ to fall back on, and around worker-path inserts
+ * (`processAction` / `processTrigger`), so a transient blip during the write is
+ * absorbed in place rather than triggering a whole-job retry that could
+ * duplicate the row.
  */
 export async function retryOnTransientDbError<T>(
   fn: () => Promise<T>,

--- a/packages/backend/src/services/action.ts
+++ b/packages/backend/src/services/action.ts
@@ -17,6 +17,7 @@ import computeParameters from '@/helpers/compute-parameters'
 import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
 import globalVariable from '@/helpers/global-variable'
 import logger from '@/helpers/logger'
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Flow from '@/models/flow'
@@ -209,19 +210,24 @@ export const processAction = async (options: ProcessActionOptions) => {
     })
   }
 
-  const executionStep = await execution
-    .$relatedQuery('executionSteps')
-    .insertAndFetch({
-      stepId: $.step.id,
-      status,
-      dataIn: computedParameters,
-      dataOut: $.actionOutput.data?.raw ?? null,
-      errorDetails: $.actionOutput.error ?? null,
-      appKey: $.app.key,
-      jobId,
-      key: step.key,
-      metadata: { ...metadata, ...$.actionOutput.data?.meta },
-    })
+  // Retry the insert inline on a transient DB blip so the write succeeds in
+  // place, rather than letting it surface to the worker boundary and trigger a
+  // whole-job retry (which would re-run the processor and risk a duplicate row).
+  const executionStep = await retryOnTransientDbError(
+    async () =>
+      execution.$relatedQuery('executionSteps').insertAndFetch({
+        stepId: $.step.id,
+        status,
+        dataIn: computedParameters,
+        dataOut: $.actionOutput.data?.raw ?? null,
+        errorDetails: $.actionOutput.error ?? null,
+        appKey: $.app.key,
+        jobId,
+        key: step.key,
+        metadata: { ...metadata, ...$.actionOutput.data?.meta },
+      }),
+    'action-insert-execution-step',
+  )
 
   let nextStep = null
   switch (runResult.nextStep?.command) {

--- a/packages/backend/src/services/trigger.ts
+++ b/packages/backend/src/services/trigger.ts
@@ -2,6 +2,7 @@ import type { IJSONObject, ITriggerItem } from '@plumber/types'
 
 import { z } from 'zod'
 
+import { retryOnTransientDbError } from '@/helpers/retry-on-transient-db-error'
 import Execution from '@/models/execution'
 import ExecutionStep from '@/models/execution-step'
 import Step from '@/models/step'
@@ -67,29 +68,37 @@ export const processTrigger = async (
     }
   }
 
-  // non-FormSG triggers or test runs proceed without advisory lock
-  const execution = await Execution.query().insert({
-    flowId,
-    testRun,
-    internalId: triggerItem?.meta.internalId,
-    ...(error && { status: 'failure' }),
-  })
+  // Retry the inserts inline on a transient DB blip so the write succeeds in
+  // place, rather than letting it surface to the worker boundary and trigger a
+  // whole-job retry (which would re-run the processor and risk a duplicate row).
+  const execution = await retryOnTransientDbError(
+    async () =>
+      Execution.query().insert({
+        flowId,
+        testRun,
+        internalId: triggerItem?.meta.internalId,
+        ...(error && { status: 'failure' }),
+      }),
+    'trigger-insert-execution',
+  )
 
   // We store all metadata except internalId
   const { internalId: _, ...metadataToStore } = triggerItem?.meta ?? {}
 
-  const executionStep = await execution
-    .$relatedQuery('executionSteps')
-    .insertAndFetch({
-      stepId: step.id,
-      status: error ? 'failure' : 'success',
-      dataIn: step.parameters,
-      dataOut: !error ? triggerItem?.raw : null,
-      errorDetails: error,
-      appKey: step.appKey,
-      metadata: metadataToStore ?? {},
-      key: step.key,
-    })
+  const executionStep = await retryOnTransientDbError(
+    async () =>
+      execution.$relatedQuery('executionSteps').insertAndFetch({
+        stepId: step.id,
+        status: error ? 'failure' : 'success',
+        dataIn: step.parameters,
+        dataOut: !error ? triggerItem?.raw : null,
+        errorDetails: error,
+        appKey: step.appKey,
+        metadata: metadataToStore ?? {},
+        key: step.key,
+      }),
+    'trigger-insert-execution-step',
+  )
 
   const customWebhookResponse = getCustomWebhookResponse(step)
 


### PR DESCRIPTION
## Summary

Makes the worker-path inserts in `processAction` / `processTrigger` resilient to transient DB blips by retrying them inline, instead of guarding them with `forUpdate()` existence checks. Keeps the happy path a single plain `INSERT`.

## Problem / Feature

After Phase 3, a transient DB error retries the whole BullMQ job, which re-runs the processor and could create duplicate rows. The first idempotency cut used `SELECT … FOR UPDATE` before each insert — but that adds a transaction + extra round-trip + row lock to the hottest write in the engine, on every step, for a case that only happens on a rare retry.

## What changed

- `services/action.ts` — wrap the `executionSteps` insert in `retryOnTransientDbError(async () => …, 'action-insert-execution-step')`; removed the existence-check transaction.
- `services/trigger.ts` — wrap the `executions` insert (`'trigger-insert-execution'`) and the trigger `executionSteps` insert (`'trigger-insert-execution-step'`) in `retryOnTransientDbError`; removed the existence-check transaction.
- `helpers/retry-on-transient-db-error.ts` — broadened the doc comment (helper now also used worker-side).
- `services/__tests__/{action,trigger}.itest.ts` — reverted the mock edits the existence-check approach had required.
- `services/sub-trigger.ts` — unchanged.

## Testing

- `npx vitest -c packages/backend/vitest.config.integration.ts src/services/__tests__/{action,trigger,sub-trigger}.itest.ts` — 19 passing.
- `npm run -w backend lint` — clean.

## Phase context

- Done in this phase: inline insert retries on the worker-path services (replacing the reverted `forUpdate()` idempotency).
- Done in previous phases: `maxDelayMs` + transient-DB budget (Phase 1); `pg-error`/`TransientDBError`/`retry-on-transient-db-error` helpers (Phase 2); worker-boundary wiring to throw `TransientDBError` (Phase 3).
- Not yet done (future phases): HTTP-edge inline retry on the webhook handler + retry-partial-step mutation (Phase 5); worker integration tests + manual smoke (Phase 6).