### PR TITLE
feat(m365-excel): add batch action worker (N>1 stubbed)

### DIFF
--- a/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-a.md
+++ b/docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-a.md
@@ -6,7 +6,7 @@
 
 ## Resume from here
 
-Phases 1–3 done. Phase 1: `batch?` on `IAppQueue` + `M365_EXCEL_BATCH_ENABLED`/`M365_EXCEL_BATCH_SIZE` (=20). Phase 2: flag-gated `batch` block in `packages/backend/src/apps/m365-excel/queue/index.ts` (actionKeys `['createTableRow']`, group `${fileId}-${tableId}-${step.key}`, `groupAffinity: true`). Phase 3: in `packages/backend/src/queues/action.ts` — new `appBatchActionQueues` record; registered `{app-actions-${appKey}-batch}` (added to `actionQueuesByName` so `getActionJob` resolves batch-queue retries) for apps with `queue.batch`; `enqueueActionJob` now fetches the `Step` and routes `actionKeys` to the batch queue with `batch.getGroupConfigForJob`, else the existing path. **Scope note:** the batch queue carries no rate limit — limiters are applied at the worker (`make-action-worker.ts:48`), so the scaled batch rate limit moves to Phase 5, not Phase 3 (the old resume note was wrong). Backend typecheck clean. **Next: Phase 4** — extract `makeActionWorker`'s processor body into exported `processSingleActionJob` and export `convertParamsToBullMqOptions` (behavior-preserving) in `packages/backend/src/workers/helpers/make-action-worker.ts`. Real dispatch is PR B (`docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-b.md`).
+Phases 1–5 done. Phases 1–3 as before (types/flags; flag-gated `batch` block; batch queue registration + enqueue routing in `queues/action.ts`). Phase 4 (combined into one PR with Phase 5 per user): extracted `makeActionWorker`'s processor body into exported `processSingleActionJob(job, ctx)` and exported `convertParamsToBullMqOptions` + `MakeActionWorkerParams` in `make-action-worker.ts` (pure refactor; existing worker/queue unit tests green). Phase 5: new `packages/backend/src/workers/helpers/make-batch-action-worker.ts` — sets `workerOptions.batch` (`size`/`groupAffinity`/optional `minSize`,`timeout`), scales the limiter to `{ max: max×size, duration: duration×size }`, tags the span with `batchSize`, processes N≤1 via `processSingleActionJob`, throws `UnrecoverableError` stub for N>1 (real dispatch = PR B). `workers/action.ts` now builds a flag-gated `makeBatchActionWorker` per app with a batch queue (new `appBatchActionWorkers` record; included in SIGTERM cleanup). Batch worker reuses the m365 `queueConfig`, so group concurrency stays 1 (per-table serialization). Backend typecheck clean; worker/queue unit tests pass. **Next: Phase 6** — unit tests (queue-config flag parity + enqueue routing) and `action.batch.itest.ts` (flag-on N=1 processes; N>1 throws stub with `batchSize` tagged). Real dispatch is PR B (`docs/plans/2026-05-29-bullmq-batch-m365-excel-pr-b.md`).
 
 ## Context
 
@@ -81,15 +81,15 @@ Verify: flag-on → a `createTableRow` job lands in the batch queue with group `
 
 ### Phase 4: Extract `processSingleActionJob` (behavior-preserving)
 
-- [ ] Lift `makeActionWorker`'s processor body into exported `processSingleActionJob`; export `convertParamsToBullMqOptions`.
+- [x] Lift `makeActionWorker`'s processor body into exported `processSingleActionJob`; export `convertParamsToBullMqOptions`.
 
 Files: `packages/backend/src/workers/helpers/make-action-worker.ts`
 Verify: existing `action.itest.ts` + worker unit tests pass unchanged (pure refactor).
 
 ### Phase 5: Batch worker + bootstrap wiring
 
-- [ ] Implement `make-batch-action-worker.ts` (batch options; `batchSize` tag; N=1 → `processSingleActionJob`; N>1 → stub throw).
-- [ ] In `workers/action.ts`, create the batch worker for apps with a batch queue (flag-gated).
+- [x] Implement `make-batch-action-worker.ts` (batch options; `batchSize` tag; N=1 → `processSingleActionJob`; N>1 → stub throw).
+- [x] In `workers/action.ts`, create the batch worker for apps with a batch queue (flag-gated).
 
 Files: `packages/backend/src/workers/helpers/make-batch-action-worker.ts`, `packages/backend/src/workers/action.ts`
 Verify: flag-off → no batch worker. Flag-on → batch worker on the batch queue; N=1 processes; N>1 throws stub.
@@ -128,6 +128,8 @@ Verify: scoped vitest passes; full m365-excel + worker/queue suites green.
 
 - **2026-05-29 (Phase 3):** The original "Resume from here" note claimed the scaled batch rate limit (`max: size, duration: size × interval`) is applied in `queues/action.ts`. It isn't — `makeActionQueue` carries no limiter; rate limits are applied at the **worker** level (`make-action-worker.ts:48`, `workerOptions.limiter`). Phase 3 is therefore queue-object creation + storage + routing only; the scaled batch limiter moves to Phase 5 (batch worker). Phase 3 code is otherwise as planned.
 - **2026-05-29 (Phase 3):** Decided to keep routing confined to `action.ts` and accept one redundant `Step` PK read (routing reads `step.key`; the group helper re-reads the Step). The plan's "single shared Step fetch" aspiration would require threading an optional `Step` through the public `IAppQueue` helper signatures — deferred as not worth the surface area. Mirrors the existing accepted double-read at `make-action-worker.ts:106-109`.
+
+- **2026-05-29 (Phases 4+5):** Combined into a single PR per user. The batch worker reuses the m365 `queueConfig` as-is, so `group.concurrency` stays 1 (per-`(fileId,tableId)` serialization). The Goals line "concurrency = BATCH_SIZE" is interpreted as `batch.size` (jobs coalesced per batch), not a worker/group concurrency override — overriding group concurrency would allow concurrent batches against the same table. The scaled limiter is derived in `make-batch-action-worker.ts` from the reused `queueRateLimit` (`{ max×size, duration×size }`).
 
 ## Open questions
 

--- a/packages/backend/src/apps/m365-excel/__tests__/queue.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/queue.test.ts
@@ -22,6 +22,11 @@ vi.mock('@/models/step', () => ({
 describe('Queue config', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    // The batch feature flag is read at import time, so flag-on tests below
+    // re-import the app module with a stubbed env. Reset both so later tests
+    // (and other files) see the default flag-off module.
+    vi.unstubAllEnvs()
+    vi.resetModules()
   })
 
   it('configures a delayable queue', () => {
@@ -53,5 +58,73 @@ describe('Queue config', () => {
 
   it('avoids bursting via a leaky bucket approach', () => {
     expect(m365ExcelApp.queue.queueRateLimit.max).toEqual(1)
+  })
+
+  describe('createTableRow batch config', () => {
+    it('does not expose a batch config when the flag is off', () => {
+      // Default in the test env: M365_EXCEL_BATCH_ENABLED is unset. Flag-off
+      // must leave the queue config byte-identical to today (no batch block).
+      expect(m365ExcelApp.queue.batch).toBeUndefined()
+    })
+
+    // Re-import the queue config module directly (not the app index) to pick up
+    // the flag-on env without dragging in the @/apps <-> app circular import.
+    const importBatchQueueConfig = async () => {
+      vi.stubEnv('M365_EXCEL_BATCH_ENABLED', 'true')
+      vi.resetModules()
+      return (await import('../queue')).default
+    }
+
+    it('exposes the batch config when the flag is on', async () => {
+      const queue = await importBatchQueueConfig()
+
+      expect(queue.batch).toMatchObject({
+        size: 20,
+        groupAffinity: true,
+        actionKeys: ['createTableRow'],
+      })
+      expect(typeof queue.batch?.getGroupConfigForJob).toBe('function')
+    })
+
+    it('groups batches by (fileId, tableId, stepKey)', async () => {
+      const queue = await importBatchQueueConfig()
+
+      mocks.stepQueryResult.mockResolvedValueOnce({
+        key: 'createTableRow',
+        parameters: {
+          fileId: 'mock-file-id',
+          tableId: 'mock-table-id',
+        },
+      })
+
+      const groupConfig = await queue.batch?.getGroupConfigForJob({
+        flowId: 'test-flow-id',
+        stepId: 'test-step-id',
+        executionId: 'test-exec-id',
+      })
+
+      expect(groupConfig).toEqual({
+        id: 'mock-file-id-mock-table-id-createTableRow',
+      })
+    })
+
+    it('throws when the batched step is missing a tableId', async () => {
+      const queue = await importBatchQueueConfig()
+
+      mocks.stepQueryResult.mockResolvedValueOnce({
+        key: 'createTableRow',
+        parameters: {
+          fileId: 'mock-file-id',
+        },
+      })
+
+      await expect(
+        queue.batch?.getGroupConfigForJob({
+          flowId: 'test-flow-id',
+          stepId: 'test-step-id',
+          executionId: 'test-exec-id',
+        }),
+      ).rejects.toThrow(/tableId/)
+    })
   })
 })

--- a/packages/backend/src/queues/__tests__/action.enqueue-routing.test.ts
+++ b/packages/backend/src/queues/__tests__/action.enqueue-routing.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  // Mutable holder for the step key the mocked Step returns, so each test can
+  // steer routing without re-mocking the module.
+  stepKey: { value: 'createTableRow' },
+}))
+
+// Capture every queue created at module load with an `add` spy keyed by name.
+vi.mock('@/queues/helpers/make-action-queue', () => ({
+  makeActionQueue: vi.fn(({ queueName }: { queueName: string }) => ({
+    name: queueName,
+    add: vi.fn(async (name: string, data: unknown, opts: unknown) => ({
+      id: '1',
+      queueName,
+      name,
+      data,
+      opts,
+    })),
+    // The action.ts SIGTERM handler calls q.close() on teardown.
+    close: vi.fn(async () => {}),
+  })),
+}))
+
+// One app with a batch config (so it gets a dedicated batch queue) and one
+// without (so it only ever uses its regular queue).
+vi.mock('@/apps', () => ({
+  default: {
+    'batch-app': {
+      queue: {
+        getGroupConfigForJob: async () => ({ id: 'file-grp' }),
+        batch: {
+          size: 20,
+          groupAffinity: true,
+          actionKeys: ['createTableRow'],
+          getGroupConfigForJob: async () => ({ id: 'batch-grp' }),
+        },
+      },
+    },
+    'plain-app': {
+      queue: {
+        getGroupConfigForJob: async () => ({ id: 'file-grp' }),
+      },
+    },
+  },
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: () => ({
+        throwIfNotFound: async () => ({ key: mocks.stepKey.value }),
+      }),
+    }),
+  },
+}))
+
+// Import after the mocks so module-load queue registration uses them.
+import {
+  appActionQueues,
+  appBatchActionQueues,
+  enqueueActionJob,
+  mainActionQueue,
+} from '@/queues/action'
+
+const JOB_DATA = {
+  flowId: 'test-flow-id',
+  executionId: 'test-exec-id',
+  stepId: 'test-step-id',
+}
+
+describe('enqueueActionJob routing', () => {
+  beforeEach(() => {
+    mocks.stepKey.value = 'createTableRow'
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes batchable action keys to the dedicated batch queue', async () => {
+    mocks.stepKey.value = 'createTableRow'
+
+    await enqueueActionJob({
+      appKey: 'batch-app',
+      jobName: 'test-job',
+      jobData: JOB_DATA,
+      jobOptions: {},
+    })
+
+    expect(appBatchActionQueues['batch-app'].add).toHaveBeenCalledTimes(1)
+    expect(appBatchActionQueues['batch-app'].add).toHaveBeenCalledWith(
+      'test-job',
+      JOB_DATA,
+      expect.objectContaining({ group: { id: 'batch-grp' } }),
+    )
+    expect(appActionQueues['batch-app'].add).not.toHaveBeenCalled()
+  })
+
+  it('routes non-batchable action keys to the existing app queue', async () => {
+    mocks.stepKey.value = 'writeCellValues'
+
+    await enqueueActionJob({
+      appKey: 'batch-app',
+      jobName: 'test-job',
+      jobData: JOB_DATA,
+      jobOptions: {},
+    })
+
+    expect(appActionQueues['batch-app'].add).toHaveBeenCalledTimes(1)
+    expect(appActionQueues['batch-app'].add).toHaveBeenCalledWith(
+      'test-job',
+      JOB_DATA,
+      expect.objectContaining({ group: { id: 'file-grp' } }),
+    )
+    expect(appBatchActionQueues['batch-app'].add).not.toHaveBeenCalled()
+  })
+
+  it('routes apps without a batch config to their existing queue', async () => {
+    mocks.stepKey.value = 'createTableRow'
+
+    await enqueueActionJob({
+      appKey: 'plain-app',
+      jobName: 'test-job',
+      jobData: JOB_DATA,
+      jobOptions: {},
+    })
+
+    expect(appActionQueues['plain-app'].add).toHaveBeenCalledTimes(1)
+    expect(appActionQueues['plain-app'].add).toHaveBeenCalledWith(
+      'test-job',
+      JOB_DATA,
+      expect.objectContaining({ group: { id: 'file-grp' } }),
+    )
+    // plain-app has no batch queue registered at all.
+    expect(appBatchActionQueues['plain-app']).toBeUndefined()
+  })
+
+  it('routes unknown apps to the main action queue', async () => {
+    await enqueueActionJob({
+      appKey: 'app-without-queue',
+      jobName: 'test-job',
+      jobData: JOB_DATA,
+      jobOptions: {},
+    })
+
+    expect(mainActionQueue.add).toHaveBeenCalledTimes(1)
+    expect(appActionQueues['batch-app'].add).not.toHaveBeenCalled()
+    expect(appActionQueues['plain-app'].add).not.toHaveBeenCalled()
+  })
+})

--- a/packages/backend/src/workers/__tests__/action.batch.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.batch.itest.ts
@@ -1,0 +1,265 @@
+import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+// The batch feature flag is read at import time. Force it on before any module
+// is evaluated; integration tests run with `isolate: true`, so this only
+// affects this file's module graph.
+vi.hoisted(() => {
+  process.env.M365_EXCEL_BATCH_ENABLED = 'true'
+})
+
+import { DEFAULT_JOB_OPTIONS } from '@/helpers/default-job-configuration'
+import {
+  actionQueuesByName,
+  appBatchActionQueues,
+  enqueueActionJob,
+  mainActionQueue,
+} from '@/queues/action'
+import {
+  appActionWorkers,
+  appBatchActionWorkers,
+  mainActionWorker,
+} from '@/workers/action'
+
+import {
+  backupWorker,
+  flushQueue,
+  restoreWorker,
+  type WorkerState,
+} from './test-helpers'
+
+const mocks = vi.hoisted(() => ({
+  processAction: vi.fn(async () => ({})),
+  exponentialBackoffWithJitter: vi.fn(() => 1),
+  handleFailedStepAndThrow: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+  addSpanTags: vi.fn(),
+  // Mutable step the mocked model returns; tests steer routing/grouping via it.
+  currentStep: {
+    value: {
+      key: 'createTableRow',
+      appKey: 'm365-excel',
+      parameters: { fileId: 'file-1', tableId: 'table-1' },
+    } as { key: string; appKey: string; parameters: Record<string, string> },
+  },
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    info: mocks.logInfo,
+    error: mocks.logError,
+  },
+}))
+
+vi.mock('@/helpers/tracer', () => ({
+  default: {
+    scope: vi.fn(() => ({
+      active: vi.fn(() => ({
+        addTags: mocks.addSpanTags,
+      })),
+    })),
+    wrap: vi.fn((_, callback) => callback),
+  },
+}))
+
+// findById must satisfy both fetch shapes: the routing/group helpers call
+// `.throwIfNotFound()`, while processSingleActionJob awaits findById directly.
+vi.mock('@/models/step', () => ({
+  default: {
+    query: () => ({
+      findById: () => ({
+        throwIfNotFound: async () => mocks.currentStep.value,
+        then: (
+          onFulfilled: (value: unknown) => unknown,
+          onRejected?: (reason: unknown) => unknown,
+        ) => Promise.resolve(mocks.currentStep.value).then(onFulfilled, onRejected),
+      }),
+    }),
+  },
+}))
+
+vi.mock('@/models/execution', () => ({
+  default: {
+    setStatus: vi.fn(),
+  },
+}))
+
+vi.mock('@/services/action', () => ({
+  processAction: mocks.processAction,
+}))
+
+vi.mock('@/helpers/actions', () => ({
+  handleFailedStepAndThrow: mocks.handleFailedStepAndThrow,
+}))
+
+vi.mock('@/helpers/backoff', () => ({
+  exponentialBackoffWithJitter: mocks.exponentialBackoffWithJitter,
+}))
+
+const BATCH_QUEUE_NAME = '{app-actions-m365-excel-batch}'
+const REGULAR_QUEUE_NAME = '{app-actions-m365-excel}'
+
+describe('Batch action worker', () => {
+  const batchQueue = appBatchActionQueues['m365-excel']
+  const batchWorker = appBatchActionWorkers['m365-excel']
+
+  let originalWorkerState: WorkerState | null = null
+
+  beforeAll(async () => {
+    // Wiring sanity: the flag-on path must have registered both.
+    expect(batchQueue).toBeDefined()
+    expect(batchWorker).toBeDefined()
+
+    originalWorkerState = await backupWorker(batchWorker)
+    await batchWorker.waitUntilReady()
+  })
+
+  beforeEach(() => {
+    mocks.currentStep.value = {
+      key: 'createTableRow',
+      appKey: 'm365-excel',
+      parameters: { fileId: 'file-1', tableId: 'table-1' },
+    }
+  })
+
+  afterEach(async () => {
+    await flushQueue(batchQueue, batchWorker)
+    await restoreWorker(batchWorker, originalWorkerState)
+    vi.clearAllMocks()
+  })
+
+  afterAll(async () => {
+    await Promise.all(
+      [
+        mainActionWorker,
+        ...Object.values(appActionWorkers),
+        ...Object.values(appBatchActionWorkers),
+      ].map((w) => w.close()),
+    )
+    await Promise.all(Object.values(actionQueuesByName).map((q) => q.close()))
+  })
+
+  describe('flag-on wiring', () => {
+    it('registers a dedicated batch queue and worker', () => {
+      expect(batchQueue.name).toBe(BATCH_QUEUE_NAME)
+      expect(batchQueue.name.endsWith('-batch}')).toBe(true)
+    })
+  })
+
+  describe('enqueue routing', () => {
+    // Pause so jobs stay queued and we can assert their destination queue.
+    beforeEach(async () => {
+      await batchWorker.pause()
+    })
+
+    it('routes createTableRow jobs to the batch queue', async () => {
+      mocks.currentStep.value.key = 'createTableRow'
+
+      const job = await enqueueActionJob({
+        appKey: 'm365-excel',
+        jobName: 'test-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: DEFAULT_JOB_OPTIONS,
+      })
+
+      expect(job.queueName).toBe(BATCH_QUEUE_NAME)
+    })
+
+    it('routes other m365-excel actions to the existing queue', async () => {
+      mocks.currentStep.value.key = 'writeCellValues'
+
+      const job = await enqueueActionJob({
+        appKey: 'm365-excel',
+        jobName: 'test-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: DEFAULT_JOB_OPTIONS,
+      })
+
+      expect(job.queueName).toBe(REGULAR_QUEUE_NAME)
+    })
+  })
+
+  describe('batch processing', () => {
+    it('processes a batch of 1 via the single-job path and tags batchSize 1', async () => {
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: false, nextStep: null },
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        batchWorker.on('completed', async () => resolve())
+      })
+
+      await enqueueActionJob({
+        appKey: 'm365-excel',
+        jobName: 'single-batch-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: DEFAULT_JOB_OPTIONS,
+      })
+
+      await jobProcessed
+
+      expect(mocks.processAction).toHaveBeenCalledTimes(1)
+      expect(mocks.addSpanTags).toHaveBeenCalledWith(
+        expect.objectContaining({ batchSize: 1 }),
+      )
+    })
+
+    it('throws the not-implemented stub for batches of >1 and tags batchSize', async () => {
+      // Pause, enqueue several same-group jobs so they coalesce, then resume so
+      // the worker fetches them as a single batch.
+      await batchWorker.pause()
+
+      const numJobs = 3
+      for (let i = 0; i < numJobs; i++) {
+        await enqueueActionJob({
+          appKey: 'm365-excel',
+          jobName: `multi-batch-job-${i}`,
+          jobData: {
+            flowId: 'test-flow-id',
+            executionId: 'test-exec-id',
+            stepId: 'test-step-id',
+          },
+          jobOptions: DEFAULT_JOB_OPTIONS,
+        })
+      }
+
+      const batchFailed = new Promise<Error>((resolve) => {
+        batchWorker.on('failed', async (_job, err) => resolve(err))
+      })
+
+      batchWorker.resume()
+
+      const err = await batchFailed
+
+      expect(err).toBeInstanceOf(UnrecoverableError)
+      expect(err.message).toMatch(/Batch dispatch not yet implemented/)
+      expect(mocks.addSpanTags).toHaveBeenCalledWith(
+        expect.objectContaining({ batchSize: numJobs }),
+      )
+      // The stub must not reach processAction.
+      expect(mocks.processAction).not.toHaveBeenCalled()
+    }, 20000)
+  })
+})

--- a/packages/backend/src/workers/action.ts
+++ b/packages/backend/src/workers/action.ts
@@ -2,10 +2,12 @@ import apps from '@/apps'
 import logger from '@/helpers/logger'
 import {
   appActionQueues,
+  appBatchActionQueues,
   MAIN_ACTION_QUEUE_NAME,
   MAIN_ACTION_QUEUE_REDIS_CONNECTION_PREFIX,
 } from '@/queues/action'
 import { makeActionWorker } from '@/workers/helpers/make-action-worker'
+import { makeBatchActionWorker } from '@/workers/helpers/make-batch-action-worker'
 
 import { makeSubTriggerWorker } from './helpers/make-sub-trigger-worker'
 
@@ -31,6 +33,14 @@ export const appActionWorkers: Record<
   keyof typeof apps,
   ReturnType<typeof makeActionWorker>
 > = Object.create(null)
+
+// Workers for app-specific batch action queues. Only populated for apps that
+// opt into batching (flag-gated); keyed by appKey.
+export const appBatchActionWorkers: Record<
+  string,
+  ReturnType<typeof makeBatchActionWorker>
+> = Object.create(null)
+
 for (const [appKey, app] of Object.entries(apps)) {
   if (!app.queue) {
     continue
@@ -48,11 +58,25 @@ for (const [appKey, app] of Object.entries(apps)) {
       queueConfig: app.queue,
     })
   }
+
+  // Flag-gated: a batch queue only exists when the app opts into batching, so a
+  // matching batch worker is created only then. Flag off => no batch worker.
+  if (app.queue.batch && appKey in appBatchActionQueues) {
+    appBatchActionWorkers[appKey] = makeBatchActionWorker({
+      appKey,
+      queueName: appBatchActionQueues[appKey].name,
+      queueConfig: app.queue,
+    })
+  }
 }
 
 process.on('SIGTERM', async () => {
   logger.info('SIGTERM: gracefully closing all action workers')
-  const allWorkers = [mainActionWorker, ...Object.values(appActionWorkers)]
+  const allWorkers = [
+    mainActionWorker,
+    ...Object.values(appActionWorkers),
+    ...Object.values(appBatchActionWorkers),
+  ]
   await Promise.all(allWorkers.map((w) => w?.close()))
   logger.info('SIGTERM: all action workers closed')
 })

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -1,6 +1,7 @@
 import type { IActionJobData, IAppQueue } from '@plumber/types'
 
 import {
+  type JobPro,
   UnrecoverableError,
   WorkerPro,
   type WorkerProOptions,
@@ -23,7 +24,7 @@ import { processAction } from '@/services/action'
 import processForEachStatus from './for-each-status-manager'
 import { registerWorkerEventHandlers } from './worker-event-handlers'
 
-function convertParamsToBullMqOptions(
+export function convertParamsToBullMqOptions(
   params: MakeActionWorkerParams,
 ) /* inferred type */ {
   const { appKey, queueName, redisConnectionPrefix, queueConfig } = params
@@ -73,11 +74,136 @@ function convertParamsToBullMqOptions(
   }
 }
 
-interface MakeActionWorkerParams {
+export interface MakeActionWorkerParams {
   appKey: string
   queueName: string
   redisConnectionPrefix?: string
   queueConfig: IAppQueue
+}
+
+/**
+ * Context the single-job processor needs from its enclosing worker.
+ */
+export interface ProcessSingleActionJobContext {
+  queueName: string
+  worker: WorkerPro<IActionJobData>
+  isQueueDelayable: boolean
+}
+
+/**
+ * Processes a single action job. Extracted verbatim from makeActionWorker's
+ * processor callback so it can be reused as the N=1 path of the batch worker.
+ * Must be invoked from within a `tracer.wrap('workers.action', ...)` callback so
+ * that `tracer.scope().active()` resolves the correct span.
+ */
+export async function processSingleActionJob(
+  job: JobPro<IActionJobData>,
+  { queueName, worker, isQueueDelayable }: ProcessSingleActionJobContext,
+) {
+  const span = tracer.scope().active()
+
+  const jobData = job.data
+  const jobId = makeActionJobId(queueName, job.id)
+
+  // The reason why we dont add .throwIfNotFound() here is to prevent job
+  // retries delegating the error throwing and handling to processAction
+  // where it also queries for Step.
+  const currStep = await Step.query().findById(jobData.stepId)
+
+  span?.addTags({
+    queueName,
+    flowId: jobData.flowId,
+    executionId: jobData.executionId,
+    stepId: jobData.stepId,
+    actionKey: currStep?.key,
+    appKey: currStep?.appKey,
+    jobId,
+    jobEnqueueTime: job.timestamp,
+    jobDelay: job.opts?.delay ?? 0,
+    attempts: job.attemptsStarted,
+    timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
+    workerVersion: appConfig.version,
+  })
+
+  const {
+    flowId,
+    executionId,
+    nextStep,
+    executionStep,
+    nextStepMetadata,
+    executionError,
+  } = await processAction({ ...jobData, jobId }).catch(async (err) => {
+    // This happens when the prerequisite steps for the action fails (e.g.
+    // db error, missing execution, flow, step, etc...) in such cases, we
+    // do not want to retry
+    throw new UnrecoverableError(err.message || 'Action failed to execute')
+  })
+
+  if (executionStep.isFailed) {
+    if (nextStepMetadata?.iteration) {
+      await ExecutionStep.patchIterationStatus(
+        executionId,
+        nextStepMetadata.iteration,
+        'failure',
+      )
+    }
+    return handleFailedStepAndThrow({
+      errorDetails: executionStep.errorDetails,
+      executionError,
+      context: {
+        isQueueDelayable,
+        worker,
+        span,
+        job,
+      },
+    })
+  }
+
+  if (!nextStep) {
+    const shouldContinue = await processForEachStatus({
+      executionId,
+      currStep,
+      nextStepMetadata,
+    })
+
+    if (!shouldContinue) {
+      return
+    }
+
+    await Execution.setStatus(executionId, 'success')
+    return
+  }
+
+  const jobName = `${executionId}-${nextStep.id}`
+
+  const jobPayload = {
+    flowId,
+    executionId,
+    stepId: nextStep.id,
+    metadata: nextStepMetadata,
+  }
+
+  let jobOptions = DEFAULT_JOB_OPTIONS
+
+  if (currStep.appKey === 'delay') {
+    jobOptions = {
+      ...DEFAULT_JOB_OPTIONS,
+      delay: delayAsMilliseconds(currStep.key, executionStep.dataOut),
+    }
+  }
+
+  try {
+    await enqueueActionJob({
+      appKey: nextStep.appKey,
+      jobName,
+      jobData: jobPayload,
+      jobOptions,
+    })
+  } catch (error) {
+    // Don't retry if we failed to enqueue the next step (e.g. if
+    // getGroupConfigForJob throws an error)
+    throw new UnrecoverableError(error.message)
+  }
 }
 
 /**
@@ -97,114 +223,8 @@ export function makeActionWorker(
       // Fix trace service name to workers.action regardless of queue name, so
       // that we can more easily monitor all actions.
       'workers.action',
-      async (job) => {
-        const span = tracer.scope().active()
-
-        const jobData = job.data
-        const jobId = makeActionJobId(queueName, job.id)
-
-        // The reason why we dont add .throwIfNotFound() here is to prevent job
-        // retries delegating the error throwing and handling to processAction
-        // where it also queries for Step.
-        const currStep = await Step.query().findById(jobData.stepId)
-
-        span?.addTags({
-          queueName,
-          flowId: jobData.flowId,
-          executionId: jobData.executionId,
-          stepId: jobData.stepId,
-          actionKey: currStep?.key,
-          appKey: currStep?.appKey,
-          jobId,
-          jobEnqueueTime: job.timestamp,
-          jobDelay: job.opts?.delay ?? 0,
-          attempts: job.attemptsStarted,
-          timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
-          workerVersion: appConfig.version,
-        })
-
-        const {
-          flowId,
-          executionId,
-          nextStep,
-          executionStep,
-          nextStepMetadata,
-          executionError,
-        } = await processAction({ ...jobData, jobId }).catch(async (err) => {
-          // This happens when the prerequisite steps for the action fails (e.g.
-          // db error, missing execution, flow, step, etc...) in such cases, we
-          // do not want to retry
-          throw new UnrecoverableError(
-            err.message || 'Action failed to execute',
-          )
-        })
-
-        if (executionStep.isFailed) {
-          if (nextStepMetadata?.iteration) {
-            await ExecutionStep.patchIterationStatus(
-              executionId,
-              nextStepMetadata.iteration,
-              'failure',
-            )
-          }
-          return handleFailedStepAndThrow({
-            errorDetails: executionStep.errorDetails,
-            executionError,
-            context: {
-              isQueueDelayable,
-              worker,
-              span,
-              job,
-            },
-          })
-        }
-
-        if (!nextStep) {
-          const shouldContinue = await processForEachStatus({
-            executionId,
-            currStep,
-            nextStepMetadata,
-          })
-
-          if (!shouldContinue) {
-            return
-          }
-
-          await Execution.setStatus(executionId, 'success')
-          return
-        }
-
-        const jobName = `${executionId}-${nextStep.id}`
-
-        const jobPayload = {
-          flowId,
-          executionId,
-          stepId: nextStep.id,
-          metadata: nextStepMetadata,
-        }
-
-        let jobOptions = DEFAULT_JOB_OPTIONS
-
-        if (currStep.appKey === 'delay') {
-          jobOptions = {
-            ...DEFAULT_JOB_OPTIONS,
-            delay: delayAsMilliseconds(currStep.key, executionStep.dataOut),
-          }
-        }
-
-        try {
-          await enqueueActionJob({
-            appKey: nextStep.appKey,
-            jobName,
-            jobData: jobPayload,
-            jobOptions,
-          })
-        } catch (error) {
-          // Don't retry if we failed to enqueue the next step (e.g. if
-          // getGroupConfigForJob throws an error)
-          throw new UnrecoverableError(error.message)
-        }
-      },
+      async (job) =>
+        processSingleActionJob(job, { queueName, worker, isQueueDelayable }),
     ),
     workerOptions,
   )

--- a/packages/backend/src/workers/helpers/make-batch-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-batch-action-worker.ts
@@ -1,0 +1,94 @@
+import type { IActionJobData } from '@plumber/types'
+
+import { UnrecoverableError, WorkerPro } from '@taskforcesh/bullmq-pro'
+
+import tracer from '@/helpers/tracer'
+
+import {
+  convertParamsToBullMqOptions,
+  type MakeActionWorkerParams,
+  processSingleActionJob,
+} from './make-action-worker'
+import { registerWorkerEventHandlers } from './worker-event-handlers'
+
+/**
+ * Creates a batch worker for an app's dedicated batch action queue (BullMQ Pro
+ * batches). Jobs are coalesced by group affinity so every batch belongs to a
+ * single group.
+ *
+ * For now this is a stub: a batch of 1 job is processed exactly like a regular
+ * single job (reusing {@link processSingleActionJob}); a batch of >1 tags the
+ * span with `batchSize` and throws - real multi-job dispatch is PR B.
+ */
+export function makeBatchActionWorker(
+  params: MakeActionWorkerParams,
+): WorkerPro<IActionJobData> {
+  const batchConfig = params.queueConfig.batch
+  if (!batchConfig) {
+    throw new Error(
+      `makeBatchActionWorker called for "${params.queueName}" without a batch config`,
+    )
+  }
+
+  const { queueName, workerOptions, isQueueDelayable } =
+    convertParamsToBullMqOptions(params)
+
+  // BullMQ Pro batch options. groupAffinity guarantees each batch belongs to a
+  // single (fileId, tableId, actionKey) group => exactly one Graph POST.
+  workerOptions.batch = {
+    size: batchConfig.size,
+    groupAffinity: batchConfig.groupAffinity,
+    ...(batchConfig.minSize !== undefined
+      ? { minSize: batchConfig.minSize }
+      : {}),
+    ...(batchConfig.timeout !== undefined
+      ? { timeout: batchConfig.timeout }
+      : {}),
+  }
+
+  // Scale the rate limit to the batch size. The per-job limiter (e.g.
+  // { max: 1, duration: interval }) would let only one job per batch through;
+  // multiplying both terms preserves the same per-file throughput while
+  // permitting a full batch to be dispatched at once.
+  if (workerOptions.limiter) {
+    workerOptions.limiter = {
+      max: workerOptions.limiter.max * batchConfig.size,
+      duration: workerOptions.limiter.duration * batchConfig.size,
+    }
+  }
+
+  const worker: WorkerPro<IActionJobData> = new WorkerPro<IActionJobData>(
+    queueName,
+    tracer.wrap(
+      // Fix trace service name to workers.action regardless of queue name, so
+      // that we can more easily monitor all actions.
+      'workers.action',
+      async (job) => {
+        const batch = job.getBatch()
+        const batchSize = batch.length
+
+        tracer.scope().active()?.addTags({ queueName, batchSize })
+
+        if (batchSize > 1) {
+          // Real multi-job dispatch is PR B. Tag batchSize first (above) so the
+          // distribution is visible on failing spans during staging.
+          throw new UnrecoverableError(
+            `Batch dispatch not yet implemented (${batchSize} jobs)`,
+          )
+        }
+
+        // N <= 1: behaves exactly like a regular single-job worker.
+        return processSingleActionJob(job, {
+          queueName,
+          worker,
+          isQueueDelayable,
+        })
+      },
+    ),
+    workerOptions,
+  )
+
+  registerWorkerEventHandlers(worker, queueName)
+
+  return worker
+}


### PR DESCRIPTION
## Summary

Adds a dedicated batch worker for app batch queues, reusing the existing single-job processor for N=1 and stubbing N>1 with a clear error. Real multi-job Graph dispatch is a follow-up PR.

## Problem / Feature

To coalesce m365-excel `createTableRow` jobs into one Graph POST, the diverted batch queue (added in the previous PR) needs its own worker. This PR builds that worker without yet implementing the actual batched write, so the wiring can ship and be observed in staging first.

## What changed

- **Refactor (behavior-preserving):** extracted `makeActionWorker`'s processor into exported `processSingleActionJob(job, ctx)`; exported `convertParamsToBullMqOptions` and `MakeActionWorkerParams`.
- **New** **`make-batch-action-worker.ts`:** sets `workerOptions.batch` (`size`, `groupAffinity`, optional `minSize`/`timeout`); scales the limiter to `{ max*size, duration*size }`; tags `batchSize` on the span; N≤1 → `processSingleActionJob`; N>1 → `UnrecoverableError` stub.
- **`workers/action.ts`:** flag-gated `makeBatchActionWorker` per app with a batch queue (new `appBatchActionWorkers` record, added to SIGTERM cleanup).

## Testing

- Backend `tsc --noEmit` clean.
- Existing worker + queue unit tests pass unchanged (14 passed) — confirms the refactor is behavior-preserving.
- Flag-off: no batch queue ⇒ no batch worker created.
- Flag-on (behavioral, covered by the itest in the next PR): N=1 processes like a single job; N>1 throws the stub with `batchSize` tagged.

## Deploy notes

- Batch worker only spins up when `M365_EXCEL_BATCH_ENABLED=true`. While the flag is off, behavior is byte-identical to today.

## Phase context

- Done in this phase: `processSingleActionJob` extraction (Phase 4) + batch worker & bootstrap wiring (Phase 5).
- Done in previous phases: `batch?` on `IAppQueue` + env flags (Phase 1); flag-gated `batch` queue config (Phase 2); batch queue registration + enqueue routing (Phase 3).
- Not yet done (future phases): unit + integration tests (Phase 6); real N>1 dispatch / per-item failure handling (PR B).