### PR TITLE
[EMAIL-PREVIEW-5] nit stuff

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -551,6 +551,37 @@ SOFTWARE.
 -------------------------------------------------------------------------------
 
 ## Project
+@emailens/engine
+
+### Source
+https://github.com/emailens/engine
+
+### License
+MIT License
+
+Copyright (c) 2025 Emailens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+## Project
 @graphql-codegen/cli
 
 ### Source

--- a/packages/frontend/src/components/RichTextEditor/PreviewButton.tsx
+++ b/packages/frontend/src/components/RichTextEditor/PreviewButton.tsx
@@ -15,9 +15,7 @@ import { Editor } from '@tiptap/react'
 
 import { substituteForPreview, type VariableInfoMap } from './utils'
 
-const LazyEmailPreviewModal = lazy(
-  () => import('@/components/EmailPreviewModal'),
-)
+const LazyViewAsEmailModal = lazy(() => import('@/components/ViewAsEmailModal'))
 
 interface PreviewerProps {
   isOpen: boolean
@@ -29,7 +27,7 @@ function usePreviewer(previewType: TFieldPreviewType | undefined) {
   const preloadPreviewer = useCallback(() => {
     switch (previewType) {
       case 'email':
-        import('@/components/EmailPreviewModal')
+        import('@/components/ViewAsEmailModal')
         break
     }
   }, [previewType])
@@ -38,7 +36,7 @@ function usePreviewer(previewType: TFieldPreviewType | undefined) {
     (props: PreviewerProps): ReactNode => {
       switch (previewType) {
         case 'email':
-          return <LazyEmailPreviewModal {...props} title="Preview your email" />
+          return <LazyViewAsEmailModal {...props} title="Preview your email" />
       }
       return null
     },

--- a/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
+++ b/packages/frontend/src/components/VariablesList/VariableItemWithModal.tsx
@@ -9,7 +9,7 @@ import HtmlVariableModal from './HtmlVariableModal'
 import TableVariableModal from './TableVariableModal'
 import { VariableItem } from '.'
 
-const LazyEmailPreviewModal = lazy(() => import('../EmailPreviewModal'))
+const LazyViewAsEmailModal = lazy(() => import('../ViewAsEmailModal'))
 
 interface VariableItemWithModalProps {
   variable: Variable
@@ -42,7 +42,7 @@ export default function VariableItemWithModal(
 
   const preloadModal = useCallback(() => {
     if (variable.type === 'email') {
-      import('../EmailPreviewModal')
+      import('../ViewAsEmailModal')
     }
   }, [variable.type])
 
@@ -102,7 +102,7 @@ export default function VariableItemWithModal(
         return (
           <Suspense fallback={null}>
             {isModalOpen && (
-              <LazyEmailPreviewModal
+              <LazyViewAsEmailModal
                 isOpen={isModalOpen}
                 onClose={onModalClose}
                 html={(variable.value as string) ?? ''}

--- a/packages/frontend/src/components/ViewAsEmailModal/index.tsx
+++ b/packages/frontend/src/components/ViewAsEmailModal/index.tsx
@@ -59,7 +59,11 @@ interface PreviewPaneProps {
 // above the transformForClient() call, which is what can actually throw.
 function PreviewPane({ html, clientId }: PreviewPaneProps) {
   const transformed = useMemo(() => {
-    return transformForClient(html, clientId).html
+    return transformForClient(html, clientId).html.replace(
+      // Replicate logic in backend - see send-transactional-email/index.ts
+      /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
+      '<p style="margin: 0">&nbsp;</p>',
+    )
   }, [html, clientId])
 
   return (
@@ -129,19 +133,19 @@ function ClientOptionsList({
   )
 }
 
-interface EmailPreviewModalProps {
+interface ViewAsEmailModalProps {
   isOpen: boolean
   onClose: () => void
   html: string
   title: string
 }
 
-export default function EmailPreviewModal({
+export default function ViewAsEmailModal({
   isOpen,
   onClose,
   html,
   title,
-}: EmailPreviewModalProps) {
+}: ViewAsEmailModalProps) {
   const [selectedClientId, setSelectedClientId] = useState<string>(
     'outlook-windows-legacy',
   )


### PR DESCRIPTION
# Problem

We want pipe owners to be able to preview their email across a variety of email clients (Outlook, Yahoo etc).

# High-level Approach

See #1652 for more details.

# This PR

Does small nit stuf

- Renames `EmailPreviewModal` to `ViewAsEmailModal` (because it's no longer strictly only for previewing)
- Adds license for emailens
- [NEW] Fixes `nbsp` "bug" in preview that @kevinkim-ogp found, thanks!

# Tests

- [Regression test] Check that preview modal still works