### PR TITLE
fix: ai builder chat stream missing usage stats

### DIFF
--- a/packages/backend/src/helpers/pair.ts
+++ b/packages/backend/src/helpers/pair.ts
@@ -8,6 +8,7 @@ const engineProvider = createOpenAICompatible({
   baseURL: 'https://engine.pair.gov.sg',
   apiKey: appConfig.pair.foundry.apiKey,
   supportsStructuredOutputs: true,
+  includeUsage: true,
 })
 const model = engineProvider.chatModel(MODEL_TYPE)
 


### PR DESCRIPTION
### TL;DR

Langfuse traces are missing usage stats for the AI Builder's chat stream such as the total tokens and cost.

### Fix

Add `includeUsage: true` when creating the engineProvider.

### Tests

- [ ]  Verify that you can still chat with the Ai Builder
- [ ]  Verify that traces in Langfuse contain the total tokens and cost details