### PR TITLE
[OG-ATTACHMENTS-1] PLU-762 (feat): common utils for og attachments

### DIFF
--- a/packages/backend/src/apps/gathersg/common/attachment.ts
+++ b/packages/backend/src/apps/gathersg/common/attachment.ts
@@ -1,0 +1,131 @@
+import { IGlobalVariable, IJSONValue } from '@plumber/types'
+
+import { z } from 'zod'
+
+import StepError from '@/errors/step'
+import logger from '@/helpers/logger'
+import { COMMON_S3_BUCKET, MAX_FILE_SIZE, putObject } from '@/helpers/s3'
+
+export const attachmentsSchema = z.record(
+  z.string(),
+  z.object({
+    name: z.string().min(1),
+    mimeType: z.string().min(1),
+    size: z.number(),
+    s3Id: z.string().min(1).optional(),
+  }),
+)
+type ParsedAttachment = z.infer<typeof attachmentsSchema>[string]
+type EnrichedAttachment = ParsedAttachment & { s3Id: string }
+export type ProcessedAttachment = EnrichedAttachment & {
+  attachmentUuid: string
+}
+
+async function downloadAndStoreAttachmentInS3(
+  $: IGlobalVariable,
+  caseUuid: IJSONValue,
+  attachmentUuid: string,
+  attachment: ParsedAttachment,
+): Promise<string> {
+  try {
+    // NOTE: there should not be any instance where there is no execution id
+    // we skip saving attachments if there is no execution id as it becomes useless
+    if (!$.execution.id) {
+      logger.error(
+        `Failed to process attachment ${attachmentUuid} for case ${caseUuid}:`,
+        'Missing execution id',
+      )
+      throw new Error('Failed to store attachments')
+    }
+
+    const filename = attachment.name
+
+    if (attachment.size > MAX_FILE_SIZE) {
+      const sizeText = MAX_FILE_SIZE / (1024 * 1024)
+      throw new StepError(
+        `Attachment ${filename} exceeds maximum size of ${sizeText}MB`,
+        `Please check that your case attachments do not exceed ${sizeText}MB.`,
+      )
+    }
+
+    const { data: attachmentBinary } = await $.http.get(
+      '/cases/:caseUuid/attachments/:attachmentUuid',
+      {
+        responseType: 'arraybuffer',
+        urlPathParams: {
+          caseUuid,
+          attachmentUuid,
+        },
+      },
+    )
+
+    const objectKey = `${$.execution.id}/${$.step.appKey}/${String(
+      caseUuid,
+    )}/${attachmentUuid}/${filename}`
+
+    const s3Id = await putObject({
+      bucket: COMMON_S3_BUCKET,
+      objectKey,
+      body: attachmentBinary,
+      metadata: {
+        flowId: String($.flow.id),
+        stepId: String($.step.id),
+        executionId: String($.execution.id),
+        caseUuid: String(caseUuid),
+        attachmentUuid,
+        filename,
+      },
+    })
+
+    return s3Id
+  } catch (error) {
+    logger.error(
+      `Failed to process attachment ${attachmentUuid} for case ${caseUuid}:`,
+      error,
+    )
+
+    if (error instanceof StepError) {
+      throw error
+    }
+
+    throw new StepError(
+      `Failed to process attachment ${attachmentUuid} for case ${caseUuid}`,
+      'Please check that your case attachments are accessible and try again.',
+      error,
+    )
+  }
+}
+
+export async function processAttachments(
+  $: IGlobalVariable,
+  caseUuid: IJSONValue,
+  attachments: Record<string, unknown>,
+): Promise<ProcessedAttachment[]> {
+  if (!attachments) {
+    return []
+  }
+
+  const parsedAttachments = attachmentsSchema.safeParse(attachments)
+
+  if (!parsedAttachments.success) {
+    throw new StepError(
+      `Invalid attachments: ${parsedAttachments.error.message}`,
+      'Please check that your case attachments are accessible and try again.',
+    )
+  }
+
+  return Promise.all(
+    Object.entries(parsedAttachments.data).map(
+      async ([attachmentUuid, attachment]) => {
+        const s3Id = await downloadAndStoreAttachmentInS3(
+          $,
+          caseUuid,
+          attachmentUuid,
+          attachment,
+        )
+
+        return { attachmentUuid, ...attachment, s3Id }
+      },
+    ),
+  )
+}

--- a/packages/backend/src/apps/gathersg/common/data-out-metadata-helpers.ts
+++ b/packages/backend/src/apps/gathersg/common/data-out-metadata-helpers.ts
@@ -1,6 +1,37 @@
 import { IJSONArray } from '@plumber/types'
 
+import { parseS3Id } from '@/helpers/s3'
+
 import { HEX_ENCODED_FIELD_PREFIX } from './constants'
+
+// Helper function to build metadata for a single attachment entry
+export function buildAttachmentMetadata(attachment: {
+  attachmentUuid?: string | null
+  name?: string | null
+  s3Id?: string | null
+}) {
+  const name = attachment.name ?? ''
+  const s3Id =
+    typeof attachment.s3Id === 'string' && attachment.s3Id.length > 0
+      ? attachment.s3Id
+      : undefined
+
+  return {
+    attachmentUuid: { isHidden: true },
+    name: { isHidden: true },
+    mimeType: { isHidden: true },
+    size: { isHidden: true },
+    ...(s3Id
+      ? {
+          s3Id: {
+            type: 'file' as const,
+            label: name,
+            displayedValue: parseS3Id(s3Id)?.objectName ?? name,
+          },
+        }
+      : {}),
+  }
+}
 
 // Helper function to decode hex-encoded field keys
 export function decodeFieldKey(key: string): string {


### PR DESCRIPTION
### TL;DR

Prepares for attachment processing support for OG by adding utility functions and metadata helper.

### What changed?

- Added a new `attachment.ts` module that handles downloading OG case attachments and uploading them to S3. It validates attachment size against a maximum file limit, fetches the binary content via the OG API, and stores it using a structured S3 key path. Appropriate `StepError`s are thrown for oversized files or failed downloads.
- Added a `buildAttachmentMetadata` helper in `data-out-metadata-helpers.ts` that constructs the data-out metadata shape for a single attachment, hiding raw fields like `name`, `mimeType`, and `size`, while exposing the S3 object as a `file` type with a human-readable label when an `s3Id` is present.

### Tests

Regression tests only, as the function has not been added to any OG action.

- [ ]  OG actions still work as intended
- [ ]  Data out is still displayed properly