### PR TITLE
[OG-ATTACHMENTS-2] PLU-762 (feat): get attachments from case

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details-get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details-get-data-out-metadata.test.ts
@@ -1,0 +1,185 @@
+import { IExecutionStep } from '@plumber/types'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import getDataOutMetadata from '../../actions/get-case-details/get-data-out-metadata'
+
+const mockObjectName = 'invoice.pdf'
+
+const mocks = vi.hoisted(() => ({
+  parseS3Id: vi.fn(() => ({
+    bucket: 'common-bucket',
+    objectKey: `exec/gathersg/case/attach-1/${mockObjectName}`,
+    objectName: mockObjectName,
+  })),
+}))
+
+vi.mock('@/helpers/s3', () => ({
+  parseS3Id: mocks.parseS3Id,
+}))
+
+const minimalValidDataOut = {
+  traceId: 'trace-1',
+  data: {
+    type: { name: 'Case type', uuid: 'type-uuid-1' },
+    fields: {},
+    attachments: [
+      {
+        attachmentUuid: 'attach-1',
+        name: 'invoice.pdf',
+        mimeType: 'application/octet-stream',
+        size: 12,
+        s3Id: 's3:common-bucket:exec/gathersg/case/attach-1/invoice.pdf',
+      },
+    ],
+  },
+}
+
+describe('get-case-details getDataOutMetadata', () => {
+  it('returns null when dataOut is missing', async () => {
+    expect(await getDataOutMetadata({} as IExecutionStep)).toBeNull()
+  })
+
+  it('exposes attachment s3Id as file metadata like LetterSG', async () => {
+    const step = {
+      dataOut: minimalValidDataOut,
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(step)
+
+    expect(result?.data.attachments[0]).toEqual({
+      attachmentUuid: { isHidden: true },
+      name: { isHidden: true },
+      mimeType: { isHidden: true },
+      size: { isHidden: true },
+      s3Id: {
+        type: 'file',
+        label: 'invoice.pdf',
+        displayedValue: mockObjectName,
+      },
+    })
+    expect(mocks.parseS3Id).toHaveBeenCalledWith(
+      's3:common-bucket:exec/gathersg/case/attach-1/invoice.pdf',
+    )
+  })
+
+  it('omits file metadata when s3Id is absent', async () => {
+    const step = {
+      dataOut: {
+        traceId: 'trace-1',
+        data: {
+          type: { name: 'Case type', uuid: 'type-uuid-1' },
+          fields: {},
+          attachments: [
+            {
+              attachmentUuid: 'attach-1',
+              name: 'invoice.pdf',
+              mimeType: 'application/pdf',
+              size: 100,
+            },
+          ],
+        },
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(step)
+
+    expect(result?.data.attachments[0]).toEqual({
+      attachmentUuid: { isHidden: true },
+      name: { isHidden: true },
+      mimeType: { isHidden: true },
+      size: { isHidden: true },
+    })
+  })
+
+  it('returns empty attachments array when no attachments', async () => {
+    const step = {
+      dataOut: {
+        traceId: 'trace-1',
+        data: {
+          type: { name: 'Case type', uuid: 'type-uuid-1' },
+          fields: {},
+          attachments: [],
+        },
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(step)
+
+    expect(result?.data.attachments).toEqual([])
+  })
+
+  it('hides all fields for legacy record-shaped attachments', async () => {
+    const step = {
+      dataOut: {
+        traceId: 'trace-1',
+        data: {
+          type: { name: 'Case type', uuid: 'type-uuid-1' },
+          fields: {},
+          attachments: {
+            'attach-uuid-1': {
+              name: 'invoice.pdf',
+              mimeType: 'application/pdf',
+              size: 100,
+            },
+          },
+        },
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(step)
+
+    expect(result?.data.attachments['attach-uuid-1']).toEqual({
+      name: { isHidden: true },
+      mimeType: { isHidden: true },
+      size: { isHidden: true },
+    })
+  })
+
+  it('skips a malformed attachment and processes the rest', async () => {
+    mocks.parseS3Id.mockImplementationOnce(() => {
+      throw new Error('invalid s3Id')
+    })
+
+    const step = {
+      dataOut: {
+        traceId: 'trace-1',
+        data: {
+          type: { name: 'Case type', uuid: 'type-uuid-1' },
+          fields: {},
+          attachments: [
+            {
+              attachmentUuid: 'attach-bad',
+              name: 'bad.pdf',
+              mimeType: 'application/pdf',
+              size: 100,
+              s3Id: 'bad-s3-id',
+            },
+            {
+              attachmentUuid: 'attach-good',
+              name: mockObjectName,
+              mimeType: 'application/pdf',
+              size: 200,
+              s3Id: 's3:common-bucket:exec/gathersg/case/attach-good/invoice.pdf',
+            },
+          ],
+        },
+      },
+    } as unknown as IExecutionStep
+
+    const result = await getDataOutMetadata(step)
+
+    expect(result?.data.attachments).toHaveLength(1)
+    expect(result?.data.attachments[0]).toEqual({
+      attachmentUuid: { isHidden: true },
+      name: { isHidden: true },
+      mimeType: { isHidden: true },
+      size: { isHidden: true },
+      s3Id: {
+        type: 'file',
+        label: mockObjectName,
+        displayedValue: mockObjectName,
+      },
+    })
+  })
+})

--- a/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details.test.ts
@@ -1,0 +1,303 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import app from '../../..'
+import getCaseDetailsAction from '../../actions/get-case-details'
+
+const mocks = vi.hoisted(() => ({
+  putObject: vi.fn(),
+}))
+
+vi.mock('@/helpers/s3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/helpers/s3')>()
+  return {
+    ...actual,
+    COMMON_S3_BUCKET: 'common-bucket',
+    MAX_FILE_SIZE: 1024 * 1024, // 1MB, small enough to test the size guard
+    putObject: mocks.putObject,
+  }
+})
+
+const MOCK_CASE_UUID = 'case-uuid-123'
+const MOCK_EXECUTION_ID = 'execution-id-123'
+const MOCK_ATTACHMENT_UUID = 'attach-uuid-1'
+const MOCK_ATTACHMENT_NAME = 'invoice.pdf'
+
+describe('get case details', () => {
+  let $: IGlobalVariable
+  let httpGet: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mocks.putObject.mockReset()
+
+    httpGet = vi.fn(async (path: string) => {
+      if (path === '/cases/:caseUuid') {
+        return {
+          data: {
+            traceId: 'trace-1',
+            data: {
+              fields: {
+                'A/B': 'value',
+              },
+              attachments: {
+                [MOCK_ATTACHMENT_UUID]: {
+                  name: MOCK_ATTACHMENT_NAME,
+                  mimeType: 'application/octet-stream',
+                  size: 12,
+                },
+              },
+            },
+          },
+        }
+      }
+
+      if (path === '/cases/:caseUuid/attachments/:attachmentUuid') {
+        return {
+          data: Buffer.from('file-content'),
+        }
+      }
+
+      throw new Error(`Unexpected path: ${path}`)
+    })
+
+    mocks.putObject.mockResolvedValue(
+      `s3:common-bucket:${MOCK_EXECUTION_ID}/gathersg/${MOCK_CASE_UUID}/${MOCK_ATTACHMENT_UUID}/${MOCK_ATTACHMENT_NAME}`,
+    )
+
+    $ = {
+      app,
+      auth: {
+        set: vi.fn(),
+        data: { apiKey: 'sample-api-key' },
+      },
+      execution: {
+        id: MOCK_EXECUTION_ID,
+      },
+      flow: {
+        id: 'flow-id-123',
+      },
+      step: {
+        id: 'step-id-123',
+        appKey: 'gathersg',
+        position: 2,
+        parameters: {
+          caseUuid: MOCK_CASE_UUID,
+        },
+      },
+      http: {
+        get: httpGet,
+      } as unknown as IGlobalVariable['http'],
+      setActionItem: vi.fn(),
+    } as unknown as IGlobalVariable
+  })
+
+  it('downloads attachment, uploads to s3, and stores s3Id', async () => {
+    await getCaseDetailsAction.run($)
+
+    expect(httpGet).toHaveBeenCalledWith('/cases/:caseUuid', {
+      urlPathParams: { caseUuid: MOCK_CASE_UUID },
+    })
+    expect(httpGet).toHaveBeenCalledWith(
+      '/cases/:caseUuid/attachments/:attachmentUuid',
+      {
+        responseType: 'arraybuffer',
+        urlPathParams: {
+          caseUuid: MOCK_CASE_UUID,
+          attachmentUuid: MOCK_ATTACHMENT_UUID,
+        },
+      },
+    )
+
+    expect(mocks.putObject).toHaveBeenCalledWith({
+      bucket: 'common-bucket',
+      objectKey: `${MOCK_EXECUTION_ID}/gathersg/${MOCK_CASE_UUID}/${MOCK_ATTACHMENT_UUID}/${MOCK_ATTACHMENT_NAME}`,
+      body: Buffer.from('file-content'),
+      metadata: {
+        flowId: 'flow-id-123',
+        stepId: 'step-id-123',
+        executionId: MOCK_EXECUTION_ID,
+        caseUuid: MOCK_CASE_UUID,
+        attachmentUuid: MOCK_ATTACHMENT_UUID,
+        filename: MOCK_ATTACHMENT_NAME,
+      },
+    })
+
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        traceId: 'trace-1',
+        data: {
+          fields: {
+            __HEX_ENCODED__412f42: 'value',
+          },
+          attachments: [
+            {
+              attachmentUuid: MOCK_ATTACHMENT_UUID,
+              name: MOCK_ATTACHMENT_NAME,
+              mimeType: 'application/octet-stream',
+              size: 12,
+              s3Id: `s3:common-bucket:${MOCK_EXECUTION_ID}/gathersg/${MOCK_CASE_UUID}/${MOCK_ATTACHMENT_UUID}/${MOCK_ATTACHMENT_NAME}`,
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it('skips upload when there are no attachments', async () => {
+    httpGet.mockImplementationOnce(async () => ({
+      data: {
+        traceId: 'trace-1',
+        data: {
+          fields: { name: 'value' },
+        },
+      },
+    }))
+
+    await getCaseDetailsAction.run($)
+
+    expect(mocks.putObject).not.toHaveBeenCalled()
+    expect($.setActionItem).toHaveBeenCalledWith({
+      raw: {
+        traceId: 'trace-1',
+        data: {
+          fields: { name: 'value' },
+          attachments: [],
+        },
+      },
+    })
+  })
+
+  it('throws when attachment download fails', async () => {
+    httpGet.mockImplementation(async (path: string) => {
+      if (path === '/cases/:caseUuid') {
+        return {
+          data: {
+            traceId: 'trace-1',
+            data: {
+              fields: { name: 'value' },
+              attachments: {
+                [MOCK_ATTACHMENT_UUID]: {
+                  name: MOCK_ATTACHMENT_NAME,
+                  mimeType: 'application/octet-stream',
+                  size: 12,
+                },
+              },
+            },
+          },
+        }
+      }
+
+      throw new Error('attachment download failed')
+    })
+
+    await expect(getCaseDetailsAction.run($)).rejects.toThrow(
+      'Please check that you have configured your step correctly',
+    )
+  })
+
+  it('throws when attachment exceeds maximum size', async () => {
+    httpGet.mockImplementationOnce(async () => ({
+      data: {
+        traceId: 'trace-1',
+        data: {
+          fields: { name: 'value' },
+          attachments: {
+            [MOCK_ATTACHMENT_UUID]: {
+              name: MOCK_ATTACHMENT_NAME,
+              mimeType: 'application/octet-stream',
+              size: 1024 * 1024 * 2, // 2MB, exceeds mocked MAX_FILE_SIZE of 1MB
+            },
+          },
+        },
+      },
+    }))
+
+    await expect(getCaseDetailsAction.run($)).rejects.toThrow(
+      'exceeds maximum size',
+    )
+    expect(mocks.putObject).not.toHaveBeenCalled()
+  })
+
+  it('routes each attachment uuid to the correct download call and stores both', async () => {
+    const MOCK_ATTACHMENT_UUID_2 = 'attach-uuid-2'
+    const MOCK_ATTACHMENT_NAME_2 = 'receipt.png'
+
+    httpGet.mockImplementation(async (path: string, options?: any) => {
+      if (path === '/cases/:caseUuid') {
+        return {
+          data: {
+            traceId: 'trace-1',
+            data: {
+              fields: {},
+              attachments: {
+                [MOCK_ATTACHMENT_UUID]: {
+                  name: MOCK_ATTACHMENT_NAME,
+                  mimeType: 'application/pdf',
+                  size: 10,
+                },
+                [MOCK_ATTACHMENT_UUID_2]: {
+                  name: MOCK_ATTACHMENT_NAME_2,
+                  mimeType: 'image/png',
+                  size: 20,
+                },
+              },
+            },
+          },
+        }
+      }
+
+      if (path === '/cases/:caseUuid/attachments/:attachmentUuid') {
+        const uuid = options?.urlPathParams?.attachmentUuid
+        return { data: Buffer.from(`content-${uuid}`) }
+      }
+
+      throw new Error(`Unexpected path: ${path}`)
+    })
+
+    mocks.putObject
+      .mockResolvedValueOnce(
+        `s3:common-bucket:${MOCK_EXECUTION_ID}/gathersg/${MOCK_CASE_UUID}/${MOCK_ATTACHMENT_UUID}/${MOCK_ATTACHMENT_NAME}`,
+      )
+      .mockResolvedValueOnce(
+        `s3:common-bucket:${MOCK_EXECUTION_ID}/gathersg/${MOCK_CASE_UUID}/${MOCK_ATTACHMENT_UUID_2}/${MOCK_ATTACHMENT_NAME_2}`,
+      )
+
+    await getCaseDetailsAction.run($)
+
+    expect(httpGet).toHaveBeenCalledWith(
+      '/cases/:caseUuid/attachments/:attachmentUuid',
+      expect.objectContaining({
+        urlPathParams: expect.objectContaining({
+          attachmentUuid: MOCK_ATTACHMENT_UUID,
+        }),
+      }),
+    )
+    expect(httpGet).toHaveBeenCalledWith(
+      '/cases/:caseUuid/attachments/:attachmentUuid',
+      expect.objectContaining({
+        urlPathParams: expect.objectContaining({
+          attachmentUuid: MOCK_ATTACHMENT_UUID_2,
+        }),
+      }),
+    )
+
+    const call = ($.setActionItem as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    const attachments = call.raw.data.attachments
+    expect(attachments).toHaveLength(2)
+    expect(
+      attachments.find((a: any) => a.attachmentUuid === MOCK_ATTACHMENT_UUID),
+    ).toMatchObject({
+      attachmentUuid: MOCK_ATTACHMENT_UUID,
+      name: MOCK_ATTACHMENT_NAME,
+      mimeType: 'application/pdf',
+    })
+    expect(
+      attachments.find((a: any) => a.attachmentUuid === MOCK_ATTACHMENT_UUID_2),
+    ).toMatchObject({
+      attachmentUuid: MOCK_ATTACHMENT_UUID_2,
+      name: MOCK_ATTACHMENT_NAME_2,
+      mimeType: 'image/png',
+    })
+  })
+})

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/get-data-out-metadata.ts
@@ -1,8 +1,57 @@
 import { IDataOutMetadata, IExecutionStep, IJSONArray } from '@plumber/types'
 
+import { buildAttachmentMetadata } from '../../common/data-out-metadata-helpers'
 import { decodeFieldName } from '../../common/utils'
 
 import { dataOutSchema } from './schema'
+
+type Attachment = {
+  attachmentUuid?: string
+  name?: string
+  mimeType?: string
+  size?: number
+  s3Id?: string
+}
+
+function resolveAttachments(
+  attachments: Attachment[] | Record<string, unknown> | null | undefined,
+) {
+  // New format (array): each attachment has an s3Id and is surfaced as a
+  // downloadable file link via buildAttachmentMetadata.
+  if (Array.isArray(attachments)) {
+    const keys: string[] = []
+    const metadata: ReturnType<typeof buildAttachmentMetadata>[] = []
+    for (const attachment of attachments) {
+      if (attachment.attachmentUuid) {
+        keys.push(attachment.attachmentUuid)
+      }
+      try {
+        metadata.push(buildAttachmentMetadata(attachment))
+      } catch {
+        // skip malformed attachment without aborting the rest
+      }
+    }
+    return { metadata, keys }
+  }
+
+  // Legacy format (Record<attachmentUuid, {name,mimeType,size}>): no s3Id, so
+  // nothing useful to show — hide all fields but still track the UUIDs so the
+  // attachment ID arrays in fieldsMetadata are correctly hidden too.
+  if (attachments) {
+    const keys = Object.keys(attachments)
+    const metadata = Object.create(null)
+    for (const key of keys) {
+      metadata[key] = {
+        name: { isHidden: true },
+        mimeType: { isHidden: true },
+        size: { isHidden: true },
+      }
+    }
+    return { metadata, keys }
+  }
+
+  return { metadata: undefined, keys: [] as string[] }
+}
 
 async function getDataOutMetadata(
   step: IExecutionStep,
@@ -71,19 +120,8 @@ async function getDataOutMetadata(
     }
   }
 
-  const attachmentsMetadata = Object.create(null)
-  const attachmentKeys: string[] = []
-  if (dataOut.attachments) {
-    for (const key of Object.keys(dataOut.attachments)) {
-      attachmentsMetadata[key] = {
-        name: { isHidden: true },
-        mimeType: { isHidden: true },
-        size: { isHidden: true },
-      }
-
-      attachmentKeys.push(key)
-    }
-  }
+  const { metadata: attachmentsMetadata, keys: attachmentKeys } =
+    resolveAttachments(dataOut.attachments)
 
   // handle hex-encoded field names from dataOut
   const fieldsMetadata = Object.create(null)

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/index.ts
@@ -3,6 +3,7 @@ import { IRawAction } from '@plumber/types'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
 
+import { processAttachments } from '../../common/attachment'
 import { processFields } from '../../common/utils'
 
 import getDataOutMetadata from './get-data-out-metadata'
@@ -57,12 +58,20 @@ const action: IRawAction = {
       // hex encode the field names
       const processedFields = processFields(fields)
 
+      // process the attachments
+      const attachments = await processAttachments(
+        $,
+        caseUuid,
+        rawData.data?.attachments,
+      )
+
       $.setActionItem({
         raw: {
           ...rawData,
           data: {
             ...rawData.data,
             fields: processedFields,
+            attachments,
           },
         },
       })

--- a/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/get-case-details/schema.ts
@@ -29,14 +29,18 @@ export const dataOutSchema = z.object({
         .nullish(),
       tags: z.array(z.string()).nullish(),
       attachments: z
-        .record(
-          z.string(),
-          z.object({
-            name: z.string().min(1),
-            mimeType: z.string().min(1),
-            size: z.number(),
-          }),
-        )
+        .union([
+          z.array(
+            z.object({
+              attachmentUuid: z.string().min(1),
+              name: z.string().min(1),
+              mimeType: z.string().min(1),
+              size: z.number(),
+              s3Id: z.string().min(1).optional(),
+            }),
+          ),
+          z.record(z.string(), z.any()),
+        ])
         .nullish(),
       email: z.record(z.string(), z.any()).nullish(),
     })


### PR DESCRIPTION
### TL;DR

OG `get-case-details` action now downloads case attachments and uploads them to S3, storing the resulting `s3Id` alongside each attachment in the action output.

### What changed?

- The `get-case-details` action now calls `processAttachments`, which downloads each attachment from the OG API and uploads it to S3, enriching the attachment data with an `s3Id` field.
- The `dataOutSchema` was extended to include an optional `s3Id` field on attachments.
- `getDataOutMetadata` now delegates to a shared `buildAttachmentMetadata` helper, which exposes the `s3Id` as file metadata (similar to LetterSG) when present, hiding the raw `name`, `mimeType`, and `size` fields from the UI.
- Tests were added covering the full attachment download-upload flow, the no-attachments case, attachment download failures, and attachments that exceed the maximum allowed file size. Tests for `getDataOutMetadata` cover the file metadata exposure and the case where `s3Id` is absent.

### Tests

Create a Pipe with the `get-case-details` action pointing to a case that has attachments.

- [ ]  Verify that checking step retrieves the attachment and displays it properly in the data out
- [ ]  Verify that the attachment can be used properly in subsequent steps ie Postman email
- [ ]  Publish the Pipe and verify that it can fetch the attachments dynamically and send with the correct attachments
- [ ]  Verify that this works inside a for-each, i.e., loop through cases and send emails with the attachments and case details

Regresion tests

- [ ]  Verfiy that existing `get-case-details` actions still work as intended