### PR TITLE
[SAFE-EMAIL-TEST-REDUX-2] update postman backend to support useConfiguredEmails test step flag

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -712,6 +712,62 @@ describe('send transactional email', () => {
         },
       })
     })
+
+    it('sends to the configured recipients and CC when testRun is invoked with useConfiguredEmails: true', async () => {
+      const recipients = ['recipient1@open.gov.sg', 'recipient2@open.gov.sg']
+      const ccRecipients = ['cc1@open.gov.sg', 'cc2@open.gov.sg']
+      $.step.parameters.destinationEmail = recipients.join(',')
+      $.step.parameters.destinationEmailCc = ccRecipients.join(',')
+      $.user.email = 'me@example.com'
+      $.execution.testRun = true
+
+      await expect(
+        sendTransactionalEmail.testRun($, { useConfiguredEmails: true }),
+      ).resolves.not.toThrow()
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: {
+          status: ['ACCEPTED', 'ACCEPTED'],
+          recipient: recipients,
+          subject: 'test subject',
+          body: 'test body',
+          cc: ccRecipients,
+          from: 'jack',
+          reply_to: 'replyTo@open.gov.sg',
+        },
+      })
+    })
+
+    it.each([
+      {
+        label: 'useConfiguredEmails: false',
+        metadata: { useConfiguredEmails: false },
+      },
+      { label: 'undefined metadata', metadata: undefined },
+      { label: 'empty object metadata', metadata: {} },
+    ])(
+      "redirects to the pipe owner's address and drops CCs when testRun is invoked with $label",
+      async ({ metadata }) => {
+        $.step.parameters.destinationEmail = 'recipient@example.com'
+        $.step.parameters.destinationEmailCc = 'cc@example.com'
+        $.user.email = 'me@example.com'
+        $.execution.testRun = true
+
+        await expect(
+          sendTransactionalEmail.testRun($, metadata),
+        ).resolves.not.toThrow()
+        expect($.http.post).toBeCalledTimes(1)
+        expect($.setActionItem).toHaveBeenCalledWith({
+          raw: {
+            status: ['ACCEPTED'],
+            recipient: ['me@example.com'],
+            subject: 'test subject',
+            body: 'test body',
+            from: 'jack',
+            reply_to: 'replyTo@open.gov.sg',
+          },
+        })
+      },
+    )
   })
 
   it('should send two emails if there are blacklisted recipients and invalid attachments', async () => {

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -1,6 +1,11 @@
-import { IJSONArray, IRawAction } from '@plumber/types'
+import {
+  IGlobalVariable,
+  IJSONArray,
+  IRawAction,
+  TestRunStepMetadata,
+} from '@plumber/types'
 
-import { SafeParseError } from 'zod'
+import { SafeParseError, z } from 'zod'
 import { fromZodError } from 'zod-validation-error'
 
 import StepError from '@/errors/step'
@@ -24,6 +29,10 @@ import { sendInvalidAttachmentsEmail } from '../../common/send-invalid-attachmen
 import { throwPostmanStepError } from '../../common/throw-errors'
 
 import getDataOutMetadata from './get-data-out-metadata'
+
+const sendEmailTestRunMetadataSchema = z
+  .object({ useConfiguredEmails: z.boolean().optional() })
+  .default({ useConfiguredEmails: false })
 /**
  * Type guard to check if a value is a TableVariableMarker
  */
@@ -84,217 +93,263 @@ const action: IRawAction = {
   getDataOutMetadata,
 
   async run($) {
-    const {
+    return sendEmail($)
+  },
+
+  async testRun($, testRunMetadata) {
+    return sendEmail($, testRunMetadata)
+  },
+}
+
+function getSendEmailParams(
+  $: IGlobalVariable,
+  testRunMetadata?: TestRunStepMetadata,
+) {
+  const {
+    subject,
+    body,
+    destinationEmail,
+    destinationEmailCc,
+    senderName,
+    replyTo,
+    attachments = [],
+  } = $.step.parameters
+
+  // Production runs must always use the configured recipients. `useConfiguredEmails`
+  // is only consulted on test runs, where the default is to redirect to the test
+  // runner's own email so test sends never spam unrelated configured addresses.
+  if (!$.execution.testRun) {
+    return {
       subject,
       body,
       destinationEmail,
       destinationEmailCc,
       senderName,
       replyTo,
-      attachments = [],
-    } = $.step.parameters
-    // During test runs, redirect all recipients to the test runner's own
-    // email so test sends never spam unrelated addresses configured on the
-    // step.
-    const effectiveDestinationEmail = $.execution.testRun
-      ? $.user.email
-      : destinationEmail
-    const effectiveDestinationEmailCc = $.execution.testRun
-      ? undefined
-      : destinationEmailCc
-    const result = transactionalEmailSchema.safeParse({
-      destinationEmail: effectiveDestinationEmail,
-      destinationEmailCc: effectiveDestinationEmailCc,
-      senderName,
-      subject,
-      body,
-      replyTo: replyTo || (await getDefaultReplyTo($.flow.id)),
       attachments,
-    })
-
-    if (!result.success) {
-      const validationError = fromZodError(
-        (result as SafeParseError<unknown>).error,
-      )
-
-      const fieldName = validationError.details[0].path[0]
-      const stepErrorName = validationError.details[0].message
-      const isAttachmentNotStoredError =
-        fieldName === 'attachments' && stepErrorName.includes('not a S3 ID')
-      const stepErrorSolution = isAttachmentNotStoredError
-        ? 'This attachment was not stored in the last submission. Please make a new submission with attachments to successfully configure this pipe.'
-        : 'Reconfigure the invalid field and try again.'
-
-      throw new StepError(stepErrorName, stepErrorSolution)
     }
+  }
 
-    let recipientsToSend = result.data.destinationEmail
-    /**
-     * Logic to handle retries here:
-     * We dont want to send the email to the same recipient again if it has been sent before
-     */
-    const lastExecutionStep = await $.getLastExecutionStep({
-      sameExecution: true,
-      iteration: Number($.metadata?.iteration) || undefined,
-    })
+  const parsed = sendEmailTestRunMetadataSchema.safeParse(testRunMetadata)
+  const useConfiguredEmails = parsed.success
+    ? parsed.data.useConfiguredEmails ?? false
+    : false
 
-    /**
-     * If dataOut is set and valid, it means the last step was at least successful for one recipient
-     */
-    const prevDataOutParseResult = dataOutSchema.safeParse(
-      lastExecutionStep?.dataOut,
-    )
-    const isPartialRetry =
-      prevDataOutParseResult.success &&
-      lastExecutionStep.errorDetails &&
-      // Don't do partial retry in test runs! always send to all recipients
-      !$.execution.testRun
+  return {
+    subject,
+    body,
+    destinationEmail: useConfiguredEmails ? destinationEmail : $.user.email,
+    destinationEmailCc: useConfiguredEmails ? destinationEmailCc : undefined,
+    senderName,
+    replyTo,
+    attachments,
+  }
+}
 
-    const {
-      attachmentFiles,
-      invalidAttachments,
-      submissionId,
-      isRetryWithoutAttachments,
-    } = await filterAttachments({
-      $,
-      attachmentsList: result.data.attachments,
-      isPartialRetry,
-      lastExecutionStep,
-    })
+async function sendEmail(
+  $: IGlobalVariable,
+  testRunMetadata?: TestRunStepMetadata,
+) {
+  const {
+    subject,
+    body,
+    destinationEmail,
+    destinationEmailCc,
+    senderName,
+    replyTo,
+    attachments,
+  } = getSendEmailParams($, testRunMetadata)
 
-    if (isPartialRetry) {
-      const { status, recipient } = prevDataOutParseResult.data
-      recipientsToSend = recipient.filter((_, i) => status[i] !== 'ACCEPTED')
-    }
+  const result = transactionalEmailSchema.safeParse({
+    destinationEmail,
+    destinationEmailCc,
+    senderName,
+    subject,
+    body,
+    replyTo: replyTo || (await getDefaultReplyTo($.flow.id)),
+    attachments,
+  })
 
-    const { dataOut, error, errorStatus } = await sendTransactionalEmails(
-      $.http,
-      recipientsToSend,
-      {
-        subject: result.data.subject,
-        // this is to make sure there's at least some content for every new line
-        // so on the email client the new line will have some height and show up
-        body: result.data.body.replace(
-          /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
-          '<p style="margin: 0">&nbsp;</p>',
-        ),
-        ccList: result.data.destinationEmailCc,
-        replyTo: result.data.replyTo,
-        senderName: result.data.senderName,
-        attachments: attachmentFiles,
-      },
+  if (!result.success) {
+    const validationError = fromZodError(
+      (result as SafeParseError<unknown>).error,
     )
 
-    /**
-     * Patch the status of the recipients that were sent in the previous execution
-     */
-    if (isPartialRetry) {
-      const prevDataOut = prevDataOutParseResult.data
-      const updatedStatus = prevDataOut.status.map((oldStatus, i) => {
-        const correspondingRecipient = prevDataOut.recipient[i]
-        if (recipientsToSend.includes(correspondingRecipient)) {
-          return dataOut.status[
-            recipientsToSend.indexOf(correspondingRecipient)
-          ]
-        }
-        return oldStatus
-      })
-      dataOut.status = updatedStatus
-      dataOut.recipient = prevDataOut.recipient
-    }
+    const fieldName = validationError.details[0].path[0]
+    const stepErrorName = validationError.details[0].message
+    const isAttachmentNotStoredError =
+      fieldName === 'attachments' && stepErrorName.includes('not a S3 ID')
+    const stepErrorSolution = isAttachmentNotStoredError
+      ? 'This attachment was not stored in the last submission. Please make a new submission with attachments to successfully configure this pipe.'
+      : 'Reconfigure the invalid field and try again.'
 
-    /**
-     * If at least one succeeds, we will allow the execution step to succeed and execution to continue.
-     */
-    const hasAtLeastOneSuccess = dataOut.status.some(
-      (status) => status === 'ACCEPTED',
-    )
-    if (hasAtLeastOneSuccess) {
-      $.setActionItem({
-        raw: {
-          ...dataOut,
-        },
-      })
-    }
+    throw new StepError(stepErrorName, stepErrorSolution)
+  }
 
-    const blacklistedRecipients = dataOut.recipient.filter(
-      (_, i) => dataOut.status[i] === 'BLACKLISTED',
-    )
+  let recipientsToSend = result.data.destinationEmail
+  /**
+   * Logic to handle retries here:
+   * We dont want to send the email to the same recipient again if it has been sent before
+   */
+  const lastExecutionStep = await $.getLastExecutionStep({
+    sameExecution: true,
+    iteration: Number($.metadata?.iteration) || undefined,
+  })
 
-    const defaultSendEmailParams = {
-      flowId: $.flow.id,
-      flowName: $.flow.name,
-      userEmail: $.user.email,
-      executionId: $.execution.id,
-    }
-    const hasInvalidAttachments = invalidAttachments.length > 0
-    const invalidAttachmentParams = {
-      hasInvalidAttachments,
-      submissionId,
-      invalidAttachments,
-    }
+  /**
+   * If dataOut is set and valid, it means the last step was at least successful for one recipient
+   */
+  const prevDataOutParseResult = dataOutSchema.safeParse(
+    lastExecutionStep?.dataOut,
+  )
+  const isPartialRetry =
+    prevDataOutParseResult.success &&
+    lastExecutionStep.errorDetails &&
+    // Don't do partial retry in test runs! always send to all recipients
+    !$.execution.testRun
 
-    /**
-     * Send blacklist notification email if any
-     * If there are any invalid attachments, it will be included in this email
-     */
-    if (blacklistedRecipients.length > 0 && !$.execution.testRun) {
-      try {
-        await sendBlacklistEmail({
-          ...defaultSendEmailParams,
-          blacklistedRecipients,
-        })
-      } catch (e) {
-        logger.error(e)
-        logger.error({
-          message: 'Error sending blacklist email',
-          flowId: $.flow.id,
-          executionId: $.execution.id,
-          blacklistedRecipients,
-          error: e,
-        })
+  const {
+    attachmentFiles,
+    invalidAttachments,
+    submissionId,
+    isRetryWithoutAttachments,
+  } = await filterAttachments({
+    $,
+    attachmentsList: result.data.attachments,
+    isPartialRetry,
+    lastExecutionStep,
+  })
+
+  if (isPartialRetry) {
+    const { status, recipient } = prevDataOutParseResult.data
+    recipientsToSend = recipient.filter((_, i) => status[i] !== 'ACCEPTED')
+  }
+
+  const { dataOut, error, errorStatus } = await sendTransactionalEmails(
+    $.http,
+    recipientsToSend,
+    {
+      subject: result.data.subject,
+      // this is to make sure there's at least some content for every new line
+      // so on the email client the new line will have some height and show up
+      body: result.data.body.replace(
+        /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
+        '<p style="margin: 0">&nbsp;</p>',
+      ),
+      ccList: result.data.destinationEmailCc,
+      replyTo: result.data.replyTo,
+      senderName: result.data.senderName,
+      attachments: attachmentFiles,
+    },
+  )
+
+  /**
+   * Patch the status of the recipients that were sent in the previous execution
+   */
+  if (isPartialRetry) {
+    const prevDataOut = prevDataOutParseResult.data
+    const updatedStatus = prevDataOut.status.map((oldStatus, i) => {
+      const correspondingRecipient = prevDataOut.recipient[i]
+      if (recipientsToSend.includes(correspondingRecipient)) {
+        return dataOut.status[recipientsToSend.indexOf(correspondingRecipient)]
       }
-    }
+      return oldStatus
+    })
+    dataOut.status = updatedStatus
+    dataOut.recipient = prevDataOut.recipient
+  }
 
-    /**
-     * Send invalid attachments notification email
-     * Do not send on partial retry as we would have already sent this once with the blacklist email
-     * Do not send on retry when removing all attachments
-     */
-    if (
-      hasInvalidAttachments &&
-      !isPartialRetry &&
-      !$.execution.testRun &&
-      !isRetryWithoutAttachments
-    ) {
-      await sendInvalidAttachmentsEmail({
+  /**
+   * If at least one succeeds, we will allow the execution step to succeed and execution to continue.
+   */
+  const hasAtLeastOneSuccess = dataOut.status.some(
+    (status) => status === 'ACCEPTED',
+  )
+  if (hasAtLeastOneSuccess) {
+    $.setActionItem({
+      raw: {
+        ...dataOut,
+      },
+    })
+  }
+
+  const blacklistedRecipients = dataOut.recipient.filter(
+    (_, i) => dataOut.status[i] === 'BLACKLISTED',
+  )
+
+  const defaultSendEmailParams = {
+    flowId: $.flow.id,
+    flowName: $.flow.name,
+    userEmail: $.user.email,
+    executionId: $.execution.id,
+  }
+  const hasInvalidAttachments = invalidAttachments.length > 0
+  const invalidAttachmentParams = {
+    hasInvalidAttachments,
+    submissionId,
+    invalidAttachments,
+  }
+
+  /**
+   * Send blacklist notification email if any
+   * If there are any invalid attachments, it will be included in this email
+   */
+  if (blacklistedRecipients.length > 0 && !$.execution.testRun) {
+    try {
+      await sendBlacklistEmail({
         ...defaultSendEmailParams,
-        ...invalidAttachmentParams,
+        blacklistedRecipients,
       })
-
-      logger.warn({
-        message: 'Invalid attachments',
+    } catch (e) {
+      logger.error(e)
+      logger.error({
+        message: 'Error sending blacklist email',
         flowId: $.flow.id,
         executionId: $.execution.id,
-        invalidAttachments: invalidAttachments.join(', '),
-      })
-    }
-    /**
-     * If there's any rate-limit error, we will throw the rate-limit error
-     * else we just throw the first error we encounter
-     */
-    if ((error && errorStatus) || invalidAttachments.length > 0) {
-      throwPostmanStepError({
-        $,
-        status: errorStatus,
-        error,
-        isPartialSuccess: hasAtLeastOneSuccess || invalidAttachments.length > 0,
         blacklistedRecipients,
-        invalidAttachments,
-        isRetryWithoutAttachments,
+        error: e,
       })
     }
-  },
+  }
+
+  /**
+   * Send invalid attachments notification email
+   * Do not send on partial retry as we would have already sent this once with the blacklist email
+   * Do not send on retry when removing all attachments
+   */
+  if (
+    hasInvalidAttachments &&
+    !isPartialRetry &&
+    !$.execution.testRun &&
+    !isRetryWithoutAttachments
+  ) {
+    await sendInvalidAttachmentsEmail({
+      ...defaultSendEmailParams,
+      ...invalidAttachmentParams,
+    })
+
+    logger.warn({
+      message: 'Invalid attachments',
+      flowId: $.flow.id,
+      executionId: $.execution.id,
+      invalidAttachments: invalidAttachments.join(', '),
+    })
+  }
+  /**
+   * If there's any rate-limit error, we will throw the rate-limit error
+   * else we just throw the first error we encounter
+   */
+  if ((error && errorStatus) || invalidAttachments.length > 0) {
+    throwPostmanStepError({
+      $,
+      status: errorStatus,
+      error,
+      isPartialSuccess: hasAtLeastOneSuccess || invalidAttachments.length > 0,
+      blacklistedRecipients,
+      invalidAttachments,
+      isRetryWithoutAttachments,
+    })
+  }
 }
 
 export default action


### PR DESCRIPTION
## Problem

We always send test email to the pipe owner. However, they may have valid use case to send a test email to the configured recipient (e.g. people with multiple emails). We should support this.

# Approach

We will reuse FormSG's approach to pass test run metadata to the backend.

1. Postman will pass a new `useConfiguredEmails` test step metadata to backend. This defaults to `false`.
2. If `useConfiguredEmails === true`, the test run handler will send test email To/Cc configured in the pipe. Otherwise it always sends to the pipe owner.

# This PR

Updates the postman backend to support this flag. Currently it's a no-op until the frontend is updated.

# Tests

- Check that postman test step still works
- [Regression test] Check that published pipes with postman still work