### PR TITLE
[SAFE-EMAIL-TEST-REDUX-3] update postman frontend to use the new useConfiguredEmails flag

### DIFF
--- a/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
+++ b/packages/frontend/src/app-extensions/postman/actions/send-transactional-email/check-step-button.tsx
@@ -1,27 +1,91 @@
-import { Tooltip } from '@chakra-ui/react'
+import { IconType } from 'react-icons'
+import { BiChevronDown } from 'react-icons/bi'
+import { PiAddressBook } from 'react-icons/pi'
+import {
+  ButtonGroup,
+  Flex,
+  Icon,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+} from '@chakra-ui/react'
+import { Button, IconButton, Menu } from '@opengovsg/design-system-react'
 
 import type { CheckStepButtonExtensionProps } from '@/app-extensions/types'
 
-function CheckStepButtonExtension({
-  children,
-  buttonProps: { isDisabled },
-}: CheckStepButtonExtensionProps) {
-  // We don't have any special tooltips (yet) for if check step button is
-  // disabled.
-  if (isDisabled) {
-    return children
-  }
+interface PostmanMenuItemProps {
+  icon: IconType
+  title: string
+  description: string
+  onClick: () => void
+}
 
+function PostmanMenuItem({
+  icon,
+  title,
+  description,
+  onClick,
+}: PostmanMenuItemProps) {
   return (
-    <Tooltip
-      label="Test email will only be sent to you."
-      aria-label="Check step tooltip"
-      hasArrow
-      shouldWrapChildren
+    <MenuItem
+      display="block"
+      _hover={{
+        bg: 'grey.100',
+      }}
+      onClick={onClick}
     >
-      {children}
-    </Tooltip>
+      <Flex alignItems="center" gap={2}>
+        <Icon as={icon} fontSize={20} mb={0.5} />
+        <Text textStyle="body-1">{title}</Text>
+      </Flex>
+      <Text textStyle="body-2" mt={1} color="secondary.500">
+        {description}
+      </Text>
+    </MenuItem>
   )
 }
 
-export default CheckStepButtonExtension
+export default function PostmanCheckStepButton({
+  buttonProps,
+  onClick,
+  executionStepMetadata,
+}: CheckStepButtonExtensionProps) {
+  const { isLoading, isDisabled, size, variant, colorScheme } = buttonProps
+  const buttonText = executionStepMetadata
+    ? 'Check step again with my email'
+    : 'Check step with my email'
+
+  return (
+    <ButtonGroup
+      isAttached
+      isDisabled={isDisabled || isLoading}
+      size={size}
+      variant={variant}
+      colorScheme={colorScheme}
+    >
+      <Button
+        onClick={() => onClick({ useConfiguredEmails: false })}
+        isLoading={isLoading}
+        data-test="postman-check-step-button"
+      >
+        {buttonText}
+      </Button>
+      <Menu gutter={0} colorScheme="grey" autoSelect={false}>
+        <MenuButton
+          as={IconButton}
+          icon={<BiChevronDown />}
+          data-test="postman-check-step-button-dropdown"
+        />
+        <MenuList maxW="350px" py={0}>
+          <PostmanMenuItem
+            onClick={() => onClick({ useConfiguredEmails: true })}
+            icon={PiAddressBook}
+            title="Check step with configured emails"
+            description="Recipients and CCs in this step will receive the email."
+          />
+        </MenuList>
+      </Menu>
+    </ButtonGroup>
+  )
+}

--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -87,6 +87,7 @@ const CheckStepTooltip = forwardRef<HTMLDivElement, CheckStepTooltipProps>(
         aria-label="check step tooltip"
         isDisabled={isDisabled}
         hasArrow
+        shouldWrapChildren
       >
         {children}
       </Tooltip>
@@ -417,15 +418,15 @@ export default function FlowStepTestController(
                   {isDirty ? 'Save' : 'Saved'}
                 </Button>
               )}
-              <CheckStepButtonExtension
-                step={step}
-                buttonProps={checkStepButtonProps}
-                onClick={handleSaveAndTest}
+              <CheckStepTooltip
+                hasDeletedVars={hasDeletedVars}
+                isDisabled={shouldAllowCheckStep}
+                isReadOnly={readOnly}
               >
-                <CheckStepTooltip
-                  hasDeletedVars={hasDeletedVars}
-                  isDisabled={shouldAllowCheckStep}
-                  isReadOnly={readOnly}
+                <CheckStepButtonExtension
+                  step={step}
+                  buttonProps={checkStepButtonProps}
+                  onClick={handleSaveAndTest}
                 >
                   <Button
                     {...checkStepButtonProps}
@@ -434,8 +435,8 @@ export default function FlowStepTestController(
                   >
                     Check step
                   </Button>
-                </CheckStepTooltip>
-              </CheckStepButtonExtension>
+                </CheckStepButtonExtension>
+              </CheckStepTooltip>
             </HStack>
           </VStack>
         )}


### PR DESCRIPTION
## Problem

We always send test email to the pipe owner. However, they may have valid use case to send a test email to the configured recipient (e.g. people with multiple emails). We should support this.

# Approach

We will reuse FormSG's approach to pass test run metadata to the backend.

1. Postman will pass a new `useConfiguredEmails` test step metadata to backend. This defaults to `false`.
2. If `useConfiguredEmails === true`, the test run handler will send test email To/Cc configured in the pipe. Otherwise it always sends to the pipe owner.

# This PR

Updates the postman frontend to populate the `useConfiguredEmails` flag.

**!!! The UX for this mirrors the FormSG trigger, but... the "Check step" button always defaults to "Test via my email" rather than defaulting to the last used one. I think defaulting to last used one is risky - if the user tested for real and then added an important recipient,** **things** **will** **blow** **up.**

Feel free to suggest better UX treatment!

# [Screen Recording 2026-06-04 at 9.45.15 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/1ad677ed-a75b-47aa-b31b-3b74d60894a3.mov" />](https://app.graphite.com/user-attachments/video/1ad677ed-a75b-47aa-b31b-3b74d60894a3.mov)



# Tests

- Check that postman test step still works
- [Regression test] Check that published pipes with postman still work
- [Regression test] Check that other test step button (especially FormSG trigger) still work