### PR TITLE
chore: refine graphite instructions in claude

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,7 +31,10 @@ Do **not** run these yourself unless the user asks — the human runs the dev se
 - **Package manager**: only use `npm`. Never use `yarn`, `pnpm`, or other package managers.
 - **Installing packages**: always pass the `-E` (exact version) flag.
 - **Linting**: before committing, run `npm run lint:fix` (auto-fixes), then `npm run lint` and fix remaining errors. Scope to the workspace you touched: backend-only changes → `npm run -w backend lint:fix`; frontend-only → `npm run -w frontend lint:fix`; otherwise run the root command.
-- **Branches & PRs**: managed via Graphite (`gt`); use the `graphite` skill. Before creating a new branch, ask the user what to name it. Naming: `feat/<feature>[/<subfeature>]` or `chore/<chore>[/<subchore>]`.
+- **Branches & PRs**: managed via Graphite (`gt`); use the `graphite` skill.
+  - **Before `gt submit`** (do both, in this order):
+    1. **Fix the branch name.** If the current branch doesn't match `feat/<…>` or `chore/<…>` (e.g. an auto-generated `claude/<slug>` worktree branch), rename it first: `git branch -m <name>` (works on untracked branches) or `gt rename <name>` (if already tracked). You **MUST** ask the user for the branch name whenever it is at all possible to ask — never auto-pick a name unless asking is genuinely impossible.
+    2. **Track the branch.** Ensure it is tracked onto the branch directly below it in the stack: `gt track --parent <branch-below>`. The parent is the branch immediately beneath it, or the trunk if it sits at the bottom of the stack (note: the trunk is not necessarily named `main`).
 
 ## Skills
 


### PR DESCRIPTION
# Problem

Sometimes I use claude desktop, which generates a random branch name that I commit

# Fix

Tell claude to ask me for appropriate name before submitting a PR.

# Tests

Try to create a commit and check that claude desktop asks me for a branch name before submitting a PR.