### PR TITLE
[SES-PHASE-1-9] - PLU-744: add suppression check for system email SES path

### DIFF
--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -51,8 +51,7 @@ async function sendEmailViaPostman({
 
       if (errorMsg.includes('blacklisted')) {
         logger.info('Blacklisted email', { email: recipient })
-        errorMsg =
-          'Your email may be blocked. Contact us at support@plumber.gov.sg'
+        errorMsg = 'Your email may be blocked.'
       }
     }
     throw new Error(errorMsg)

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -2,6 +2,7 @@ import { SendEmailCommand, SESv2Client } from '@aws-sdk/client-sesv2'
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers'
 
 import appConfig from '@/config/app'
+import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
 import logger from './logger'
 import { incrementMetric } from './metrics'
@@ -61,6 +62,20 @@ export async function sendEmailViaSes({
   const client = getSesClient()
   const fromAddress = `Plumber <${appConfig.ses.fromAddress}>`
 
+  // Pre-send suppression check: block sending to recipients that previously
+  // bounced/complained (mirrors Postman's blacklist rejection). Throwing here
+  // surfaces as an alert banner via the caller's error handling.
+  const suppressed = await EmailSuppressionEntry.getSuppressedEmails([
+    recipient,
+  ])
+  if (suppressed.length > 0) {
+    logger.info('Blacklisted email', { email: recipient })
+
+    throw new Error(
+      'Your email is on our suppression list (it previously bounced or reported spam).',
+    )
+  }
+
   try {
     await client.send(
       new SendEmailCommand({
@@ -85,7 +100,7 @@ export async function sendEmailViaSes({
     )
     incrementMetric('ses.email.sent')
   } catch (e) {
-    logger.error('Error sending email via SES', {
+    logger.error('Error sending email via SES, please try again later.', {
       error: e,
       recipient,
     })


### PR DESCRIPTION
### TL;DR

Added a pre-send suppression check for SES emails and updated blacklist error messages.

### What changed?

- Before sending via SES, the recipient is now checked against the `EmailSuppressionEntry` suppression list. If the recipient has previously bounced or reported spam, the send is blocked and a descriptive error is thrown.
- The blacklist error message in the Postman email helper was simplified to remove the support email address reference.
- The SES error log message was updated to include a "please try again later" prompt.

### How to test?

1. Attempt to send an email via SES to a recipient that exists in the `email_suppression_entries` table by changing the `appConfig.isDev` flow on `request-otp.ts`
2. Confirm that the email is not sent and the error message `"Your email is on our suppression list (it previously bounced or reported spam)."` is surfaced.
3. Attempt to send an email to a non-suppressed recipient and confirm it sends successfully.

### Why make this change?

SES does not automatically reject sends to suppressed addresses the same way Postman rejects blacklisted ones. This check ensures consistent behaviour across both email providers, preventing emails from being sent to addresses that have previously bounced or marked messages as spam, which protects sender reputation.