### PR TITLE
chore: disable manual attachment upload for process-image action

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -23,13 +23,14 @@ const action: IRawAction = {
   arguments: [
     {
       label: 'Image',
-      description: 'Select an image from a previous step or upload one',
+      description: 'Select an image from a previous step',
       key: 'image',
       type: 'attachment' as const,
       required: true,
       variableTypes: ['file'],
       // TODO(kevinkim-ogp): restrict the supported file types
       maxFiles: 1,
+      disableUpload: true,
     },
     {
       label: 'What do you want to extract?',

--- a/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
@@ -72,7 +72,7 @@ export default function Suggestions(props: SuggestionsProps) {
 
   const SuggestionsRightPanel = ({ values }: { values: any }) => {
     if (suggestions.length === 0) {
-      return <Text style={noVariablesTextStyles}>No variables available</Text>
+      return <Text {...noVariablesTextStyles}>No attachments available</Text>
     }
 
     return (

--- a/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
@@ -162,7 +162,11 @@ export default function Suggestions(props: SuggestionsProps) {
               }}
               tags={tags}
             />
-            <PopoverContent w="100%" motionProps={POPOVER_MOTION_PROPS}>
+            <PopoverContent
+              w="100%"
+              cursor="default"
+              motionProps={POPOVER_MOTION_PROPS}
+            >
               {loading ? (
                 <PrimarySpinner margin="auto" fontSize="4xl" p="5" />
               ) : (

--- a/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/hooks/useAttachmentOptions.ts
@@ -19,6 +19,7 @@ export function useAttachmentOptions(
   flowConfig: Flow['config'],
   priorExecutionSteps: IExecutionStep[],
   variableTypes: TDataOutMetadatumType[] | null,
+  disableUpload?: boolean,
 ) {
   const { allApps } = useContext(EditorContext)
   const { stepIdToOrder } = useContext(StepsToDisplayContext)
@@ -53,12 +54,14 @@ export function useAttachmentOptions(
 
     return [
       ...filteredVars,
-      {
-        id: 'uploaded',
-        name: 'Uploaded attachments',
-        output: uploadedItems,
-        addNew: true,
-      },
+      disableUpload
+        ? null
+        : {
+            id: 'uploaded',
+            name: 'Uploaded attachments',
+            output: uploadedItems,
+            addNew: true,
+          },
     ].filter(Boolean) as StepWithVariables[]
   }, [
     priorExecutionSteps,
@@ -66,6 +69,7 @@ export function useAttachmentOptions(
     allApps,
     uploadedItems,
     variableTypes,
+    disableUpload,
   ])
 
   return {

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -28,6 +28,7 @@ interface AttachmentSuggestionsProps {
   required?: boolean
   variableTypes?: TDataOutMetadatumType[]
   maxFiles?: number
+  disableUpload?: boolean
 }
 
 function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
@@ -39,6 +40,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     variableTypes = null,
     defaultValue = [],
     maxFiles,
+    disableUpload,
   } = props
   const { priorExecutionSteps } = useContext(StepExecutionsContext)
   const cancelRef = useRef<HTMLButtonElement>(null)
@@ -72,6 +74,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
     flowData?.getFlow?.config,
     priorExecutionSteps,
     variableTypes,
+    disableUpload,
   )
 
   const onSuggestionClick = useCallback(

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -223,6 +223,7 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         variableTypes={schema.variableTypes}
         required={required}
         maxFiles={schema.maxFiles}
+        disableUpload={schema.disableUpload}
       />
     )
   }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -454,6 +454,7 @@ export interface IFieldAttachment extends IBaseField {
 
   // Only for attachments
   maxFiles?: number
+  disableUpload?: boolean
 }
 
 export interface IFieldMultiline extends IBaseField {


### PR DESCRIPTION
## TL;DR

The `processImage` action should only accept files piped in from a previous step — not manually uploaded ones. This PR disables the upload tab for that action and fixes two minor bugs in the empty-state display of the attachments picker.

## What changed

**`pair/process-image` action (`backend`)**
- Added `disableUpload: true` to the `image` argument, hiding the "Uploaded attachments" tab for this action specifically.
- Updated the field description from "Select an image from a previous step or upload one" → "Select an image from a previous step" to match.

**`IFieldAttachment` type (`packages/types`)**
- Added optional `disableUpload?: boolean` to the attachment field interface so any action can opt in.

**`AttachmentSuggestions` + `useAttachmentOptions` + `InputCreator` (`frontend`)**
- Threaded `disableUpload` from `IFieldAttachment` → `InputCreator` → `AttachmentSuggestions` → `useAttachmentOptions`.
- When `disableUpload` is true, the "Uploaded attachments" entry (with `addNew: true`) is omitted from the suggestions list, hiding the file upload button entirely.

**`Suggestions.tsx` (`frontend`)**
- Fixed empty-state text from "No variables available" → "No attachments available" (this component is attachments-only).
- Fixed alignment bug: `noVariablesTextStyles` was passed via `style={}` (plain CSS, resolves `p: 4` as 4px) instead of spread as Chakra props (resolves `p: 4` as 1rem, matching the "Choose attachments" header).

## Tests

- [ ] Open a flow with the **Pair → Process Image** action. Click the Image field and open the attachment picker — confirm the "Uploaded attachments" tab is **not present** and there is no file upload button.
- [ ] With no prior steps that output a file, open the same picker — confirm it shows "No attachments available" with correct left-aligned padding (matching the "Choose attachments" header).
- [ ] Open a flow with the **Postman → Send Email** action. Open the attachment field picker, confirm the "Uploaded attachments" tab is present and that uploading a file still works normally.