### PR TITLE
chore: validate and trim send-prompt schema inputs

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/send-prompt/schema.test.ts
@@ -25,6 +25,43 @@ describe('call-pair schema', () => {
       assert(result.success === false)
     })
 
+    it('should reject whitespace-only prompts', () => {
+      const result = schema.safeParse({
+        prompt: '   ',
+      })
+      assert(result.success === false)
+    })
+
+    it('should trim leading and trailing whitespace from prompts', () => {
+      const result = schema.safeParse({
+        prompt: '  Analyze this document  ',
+        responseFields: [{ fieldName: 'summary', fieldType: 'text' }],
+      })
+      assert(result.success === true)
+      assert(result.data.prompt === 'Analyze this document')
+    })
+
+    it('should reject prompts longer than 10,000 characters', () => {
+      const result = schema.safeParse({
+        prompt: 'a'.repeat(10001),
+        responseFields: [{ fieldName: 'summary', fieldType: 'text' }],
+      })
+      assert(result.success === false)
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'Prompt cannot exceed 10,000 characters',
+        )
+      }
+    })
+
+    it('should accept prompts exactly 10,000 characters long', () => {
+      const result = schema.safeParse({
+        prompt: 'a'.repeat(10000),
+        responseFields: [{ fieldName: 'summary', fieldType: 'text' }],
+      })
+      assert(result.success === true)
+    })
+
     it('should require prompt field', () => {
       const result = schema.safeParse({})
       assert(result.success === false)
@@ -89,6 +126,24 @@ describe('call-pair schema', () => {
           ],
         })
         assert(result.success === false)
+      })
+
+      it('should reject whitespace-only field names', () => {
+        const result = schema.safeParse({
+          prompt: 'test prompt',
+          responseFields: [{ fieldName: '   ', fieldType: 'text' }],
+        })
+        assert(result.success === false)
+      })
+
+      it('should trim leading and trailing whitespace from field names', () => {
+        const result = schema.safeParse({
+          prompt: 'test prompt',
+          responseFields: [{ fieldName: '  summary  ', fieldType: 'text' }],
+        })
+        assert(result.success === true)
+        assert(result.data.responseFields[0].fieldName === 'summary')
+        assert(result.data.responseFields[0].originalFieldName === 'summary')
       })
 
       it('should reject field names longer than 64 characters', () => {

--- a/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/schema.ts
@@ -6,7 +6,11 @@ import {
 } from '../../common/schema'
 
 export const schema = z.object({
-  prompt: z.string().min(1),
+  prompt: z
+    .string()
+    .trim()
+    .min(1)
+    .max(10000, { message: 'Prompt cannot exceed 10,000 characters' }),
   responseFields: z
     .array(
       z

--- a/packages/backend/src/apps/pair/common/schema.ts
+++ b/packages/backend/src/apps/pair/common/schema.ts
@@ -7,6 +7,7 @@ export const optionalFlowIdSchema = z.string().uuid().nullish()
 
 export const outputFieldNameSchema = z
   .string()
+  .trim()
   .min(1, { message: 'Output name is required' })
   .max(64, {
     message: 'Output name cannot be more than 64 characters',


### PR DESCRIPTION
## TL;DR

Tighten validation on the send-prompt schema: trim whitespace from the prompt and field names, and cap the prompt at 10,000 characters.

## What Changed

- `prompt`: added `.trim()` (rejects whitespace-only prompts) and `.max(10000)`
- `outputFieldNameSchema` (shared by send-prompt and process-image): added `.trim()` so leading/trailing whitespace is stripped before regex/length checks
- Added schema test cases covering: whitespace-only prompt and field name rejection, trimming behaviour, and max-length boundary for the prompt

## Tests

- [ ] Open the Pair "Use Pair" action, enter a prompt that is only spaces — the step should fail validation
- [ ] Enter a field name that is only spaces — the step should fail validation
- [ ] Enter a prompt with leading/trailing whitespace — it should be accepted (Tiptap strips this in practice, but schema handles it defensively)