### PR TITLE
chore: use preset values as per-row placeholder hints instead of pre-filling

### DIFF
--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -86,14 +86,13 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: false,
-          dynamicPlaceholderKey: 'fieldNameHint',
         },
         {
           label: 'Categories',
           placeholder: 'Separated by commas',
           key: 'fieldCategories',
-          dynamicPlaceholderKey: 'fieldCategoriesHint',
           type: 'string' as const,
+          required: true,
           variables: true,
           hiddenIf: {
             fieldKey: 'fieldType',

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -86,11 +86,13 @@ const action: IRawAction = {
           type: 'string' as const,
           required: true,
           variables: false,
+          dynamicPlaceholderKey: 'fieldNameHint',
         },
         {
           label: 'Categories',
           placeholder: 'Separated by commas',
           key: 'fieldCategories',
+          dynamicPlaceholderKey: 'fieldCategoriesHint',
           type: 'string' as const,
           variables: true,
           hiddenIf: {

--- a/packages/backend/src/apps/pair/common/constants.ts
+++ b/packages/backend/src/apps/pair/common/constants.ts
@@ -113,54 +113,26 @@ export const DEFAULT_PROMPT_VALUES = {
 
 export const DEFAULT_RESPONSE_FIELDS_VALUES = {
   analyse: [
+    { fieldType: 'text', fieldNameHint: 'key patterns or trends' },
+    { fieldType: 'text', fieldNameHint: 'strength' },
+    { fieldType: 'text', fieldNameHint: 'weakness' },
+    { fieldType: 'text', fieldNameHint: 'implications or recommendations' },
     {
-      fieldName: 'key patterns or trends',
       fieldType: 'text',
-    },
-    {
-      fieldName: 'strength',
-      fieldType: 'text',
-    },
-    {
-      fieldName: 'weakness',
-      fieldType: 'text',
-    },
-    {
-      fieldName: 'implications or recommendations',
-      fieldType: 'text',
-    },
-    {
-      fieldName: 'supporting evidence for your conclusions',
-      fieldType: 'text',
+      fieldNameHint: 'supporting evidence for your conclusions',
     },
   ],
   categorise: [
     {
-      fieldName: 'sentiment',
       fieldType: 'category',
-      fieldCategories: 'Positive, Negative, Neutral',
+      fieldNameHint: 'sentiment',
+      fieldCategoriesHint: 'Positive, Negative, Neutral',
     },
   ],
-  summarise: [
-    {
-      fieldName: 'summary',
-      fieldType: 'text',
-    },
-  ],
+  summarise: [{ fieldType: 'text', fieldNameHint: 'summary' }],
   write: [
-    {
-      fieldName: 'title',
-      fieldType: 'text',
-    },
-    {
-      fieldName: 'content',
-      fieldType: 'text',
-    },
+    { fieldType: 'text', fieldNameHint: 'title' },
+    { fieldType: 'text', fieldNameHint: 'content' },
   ],
-  custom: [
-    {
-      fieldName: 'response',
-      fieldType: 'text',
-    },
-  ],
+  custom: [{ fieldType: 'text', fieldNameHint: 'response' }],
 }

--- a/packages/frontend/src/components/MultiCol.tsx/index.tsx
+++ b/packages/frontend/src/components/MultiCol.tsx/index.tsx
@@ -1,12 +1,15 @@
 import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 import React, { useContext } from 'react'
+import { useFormContext } from 'react-hook-form'
 import { BiTrash } from 'react-icons/bi'
 import { Divider, Flex } from '@chakra-ui/react'
 import { IconButton } from '@opengovsg/design-system-react'
 
 import InputCreator from '@/components/InputCreator'
 import { EditorContext } from '@/contexts/Editor'
+
+import { applyDynamicPlaceholder } from './utils'
 
 type MultiColProps = {
   name: string
@@ -29,6 +32,7 @@ export default function MultiCol(props: MultiColProps) {
   } = props
 
   const { isMobile } = useContext(EditorContext)
+  const { getValues } = useFormContext()
 
   const DeleteButton = () => {
     return (
@@ -50,7 +54,7 @@ export default function MultiCol(props: MultiColProps) {
     const { type, variables } = subF
 
     // Only show labels, descriptions, and tooltips on the first row
-    const schemaWithConditionalLabel =
+    let schemaWithConditionalLabel =
       index === 0
         ? subF
         : {
@@ -59,6 +63,11 @@ export default function MultiCol(props: MultiColProps) {
             description: undefined,
             tooltipText: undefined,
           }
+
+    schemaWithConditionalLabel = applyDynamicPlaceholder(
+      schemaWithConditionalLabel,
+      getValues(name),
+    )
 
     return (
       <InputCreator

--- a/packages/frontend/src/components/MultiCol.tsx/utils.test.ts
+++ b/packages/frontend/src/components/MultiCol.tsx/utils.test.ts
@@ -10,55 +10,48 @@ const baseSubField = {
 }
 
 describe('applyDynamicPlaceholder', () => {
-  it('returns the original schema when dynamicPlaceholderKey is not set', () => {
+  it('overrides placeholder with the `${key}Hint` value when present and non-empty', () => {
     const result = applyDynamicPlaceholder(baseSubField, {
       fieldNameHint: 'summary',
     })
-    expect(result).toBe(baseSubField)
-  })
-
-  it('overrides placeholder with the hint when key is present and non-empty', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
-    const result = applyDynamicPlaceholder(subF, { fieldNameHint: 'summary' })
     expect(result.placeholder).toBe('summary')
   })
 
   it('preserves all other schema properties when overriding placeholder', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
-    const result = applyDynamicPlaceholder(subF, { fieldNameHint: 'summary' })
+    const result = applyDynamicPlaceholder(baseSubField, {
+      fieldNameHint: 'summary',
+    })
     expect(result.key).toBe(baseSubField.key)
     expect(result.label).toBe(baseSubField.label)
     expect(result.type).toBe(baseSubField.type)
   })
 
-  it('returns original schema when hint key is absent from rowValues', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
-    const result = applyDynamicPlaceholder(subF, {})
-    expect(result).toBe(subF)
+  it('returns original schema when the `${key}Hint` key is absent from rowValues', () => {
+    const result = applyDynamicPlaceholder(baseSubField, {})
+    expect(result).toBe(baseSubField)
   })
 
   it('returns original schema when rowValues is undefined', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
-    const result = applyDynamicPlaceholder(subF, undefined)
-    expect(result).toBe(subF)
+    const result = applyDynamicPlaceholder(baseSubField, undefined)
+    expect(result).toBe(baseSubField)
   })
 
-  it('returns original schema when hint is an empty string', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
-    const result = applyDynamicPlaceholder(subF, { fieldNameHint: '' })
-    expect(result).toBe(subF)
+  it('returns original schema when the hint is an empty string', () => {
+    const result = applyDynamicPlaceholder(baseSubField, { fieldNameHint: '' })
+    expect(result).toBe(baseSubField)
   })
 
-  it('returns original schema when hint is a non-string value', () => {
-    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+  it('returns original schema when the hint is a non-string value', () => {
     expect(
-      applyDynamicPlaceholder(subF, { fieldNameHint: 42 }).placeholder,
+      applyDynamicPlaceholder(baseSubField, { fieldNameHint: 42 }).placeholder,
     ).toBe(baseSubField.placeholder)
     expect(
-      applyDynamicPlaceholder(subF, { fieldNameHint: true }).placeholder,
+      applyDynamicPlaceholder(baseSubField, { fieldNameHint: true })
+        .placeholder,
     ).toBe(baseSubField.placeholder)
     expect(
-      applyDynamicPlaceholder(subF, { fieldNameHint: null }).placeholder,
+      applyDynamicPlaceholder(baseSubField, { fieldNameHint: null })
+        .placeholder,
     ).toBe(baseSubField.placeholder)
   })
 })

--- a/packages/frontend/src/components/MultiCol.tsx/utils.test.ts
+++ b/packages/frontend/src/components/MultiCol.tsx/utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyDynamicPlaceholder } from './utils'
+
+const baseSubField = {
+  key: 'fieldName',
+  type: 'string' as const,
+  label: 'Output name',
+  placeholder: 'E.g., Summary',
+}
+
+describe('applyDynamicPlaceholder', () => {
+  it('returns the original schema when dynamicPlaceholderKey is not set', () => {
+    const result = applyDynamicPlaceholder(baseSubField, {
+      fieldNameHint: 'summary',
+    })
+    expect(result).toBe(baseSubField)
+  })
+
+  it('overrides placeholder with the hint when key is present and non-empty', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    const result = applyDynamicPlaceholder(subF, { fieldNameHint: 'summary' })
+    expect(result.placeholder).toBe('summary')
+  })
+
+  it('preserves all other schema properties when overriding placeholder', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    const result = applyDynamicPlaceholder(subF, { fieldNameHint: 'summary' })
+    expect(result.key).toBe(baseSubField.key)
+    expect(result.label).toBe(baseSubField.label)
+    expect(result.type).toBe(baseSubField.type)
+  })
+
+  it('returns original schema when hint key is absent from rowValues', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    const result = applyDynamicPlaceholder(subF, {})
+    expect(result).toBe(subF)
+  })
+
+  it('returns original schema when rowValues is undefined', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    const result = applyDynamicPlaceholder(subF, undefined)
+    expect(result).toBe(subF)
+  })
+
+  it('returns original schema when hint is an empty string', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    const result = applyDynamicPlaceholder(subF, { fieldNameHint: '' })
+    expect(result).toBe(subF)
+  })
+
+  it('returns original schema when hint is a non-string value', () => {
+    const subF = { ...baseSubField, dynamicPlaceholderKey: 'fieldNameHint' }
+    expect(
+      applyDynamicPlaceholder(subF, { fieldNameHint: 42 }).placeholder,
+    ).toBe(baseSubField.placeholder)
+    expect(
+      applyDynamicPlaceholder(subF, { fieldNameHint: true }).placeholder,
+    ).toBe(baseSubField.placeholder)
+    expect(
+      applyDynamicPlaceholder(subF, { fieldNameHint: null }).placeholder,
+    ).toBe(baseSubField.placeholder)
+  })
+})

--- a/packages/frontend/src/components/MultiCol.tsx/utils.ts
+++ b/packages/frontend/src/components/MultiCol.tsx/utils.ts
@@ -2,17 +2,14 @@ import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
 
 /**
  * Returns a copy of `subF` with `placeholder` overridden by the sibling row
- * value at `subF.dynamicPlaceholderKey`, if it exists and is a non-empty
- * string. Returns the original `subF` reference unchanged otherwise.
+ * value at the conventional `${subF.key}Hint` key, if it exists and is a
+ * non-empty string. Returns the original `subF` reference unchanged otherwise.
  */
 export function applyDynamicPlaceholder(
   subF: IFieldMultiRowMultiColSubField,
   rowValues: Record<string, unknown> | undefined,
 ): IFieldMultiRowMultiColSubField {
-  if (!subF.dynamicPlaceholderKey) {
-    return subF
-  }
-  const hint = rowValues?.[subF.dynamicPlaceholderKey]
+  const hint = rowValues?.[`${subF.key}Hint`]
   if (typeof hint === 'string' && hint) {
     return { ...subF, placeholder: hint }
   }

--- a/packages/frontend/src/components/MultiCol.tsx/utils.ts
+++ b/packages/frontend/src/components/MultiCol.tsx/utils.ts
@@ -1,0 +1,20 @@
+import type { IFieldMultiRowMultiColSubField } from '@plumber/types'
+
+/**
+ * Returns a copy of `subF` with `placeholder` overridden by the sibling row
+ * value at `subF.dynamicPlaceholderKey`, if it exists and is a non-empty
+ * string. Returns the original `subF` reference unchanged otherwise.
+ */
+export function applyDynamicPlaceholder(
+  subF: IFieldMultiRowMultiColSubField,
+  rowValues: Record<string, unknown> | undefined,
+): IFieldMultiRowMultiColSubField {
+  if (!subF.dynamicPlaceholderKey) {
+    return subF
+  }
+  const hint = rowValues?.[subF.dynamicPlaceholderKey]
+  if (typeof hint === 'string' && hint) {
+    return { ...subF, placeholder: hint }
+  }
+  return subF
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -478,6 +478,12 @@ export interface IFieldMultiSelect extends IBaseField {
 
 type IFieldMultiRowMultiColSubField = IField & {
   customStyle?: Record<string, string | number>
+  /**
+   * Key of a sibling field in the same row whose value is used as placeholder
+   * text. Evaluated at render time so each row can show a distinct hint.
+   * Only honoured by MultiCol for string-type subfields.
+   */
+  dynamicPlaceholderKey?: string
 }
 
 export interface IFieldMultiRowMultiCol extends IBaseField {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -478,12 +478,6 @@ export interface IFieldMultiSelect extends IBaseField {
 
 type IFieldMultiRowMultiColSubField = IField & {
   customStyle?: Record<string, string | number>
-  /**
-   * Key of a sibling field in the same row whose value is used as placeholder
-   * text. Evaluated at render time so each row can show a distinct hint.
-   * Only honoured by MultiCol for string-type subfields.
-   */
-  dynamicPlaceholderKey?: string
 }
 
 export interface IFieldMultiRowMultiCol extends IBaseField {


### PR DESCRIPTION
## TL;DR

When a preset is selected in the Pair "Use Pair" action, output names and category options are now shown as placeholder hints instead of pre-filled values — making it clear users need to fill them in themselves.

## What Changed

- **`IFieldMultiRowMultiColSubField`**: added `dynamicPlaceholderKey?` — a sibling field key whose runtime value is used as the placeholder for that row's input
- **`MultiCol`**: reads the current row's form data for `dynamicPlaceholderKey` and injects it as `placeholder` via the new `applyDynamicPlaceholder` util; extracted to `utils.ts` for testability
- **`send-prompt/index.ts`**: `fieldName` and `fieldCategories` subfields now declare `dynamicPlaceholderKey` pointing to `fieldNameHint` / `fieldCategoriesHint`
- **`constants.ts`**: `DEFAULT_RESPONSE_FIELDS_VALUES` entries no longer set `fieldName`/`fieldCategories`; the old values move to `fieldNameHint`/`fieldCategoriesHint` (Zod strips these unknown keys at execution time so they never reach the LLM)

## Tests

- [ ] Select the "Summarise" preset — the output name field should be empty with "summary" shown as grey placeholder text
- [ ] Select the "Categorise" preset — output name shows "sentiment" as placeholder, categories shows "Positive, Negative, Neutral" as placeholder
- [ ] Select the "Analyse" preset — five rows appear, each with a distinct output name hint (key patterns or trends, strength, weakness, etc.)
- [ ] Try to save the step without filling in output names — validation should fail requiring the user to fill them in
- [ ] Manually add a new output row ("Add output" button) — shows the generic placeholder "E.g., Summary, Sentiment..." with no hint, confirming hints only apply to preset-seeded rows