### PR TITLE
ai-builder: format clarification responses as Q&A pairs

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -94,7 +94,9 @@ export default function PromptInput({
 
     const isLast = currentQuestionIdx === clarification.length - 1
     if (isLast) {
-      const combined = clarification.map((_, i) => newAnswers[i]).join('\n')
+      const combined = clarification
+        .map((q, i) => `Q: ${q.question}\nA: ${newAnswers[i]}`)
+        .join('\n\n')
       sendMessage(combined)
       setSelectedAnswers({})
       setCurrentQuestionIdx(0)


### PR DESCRIPTION
## TL;DR

When users answer clarification questions in the AI Builder, responses were sent to the model as bare answers only (e.g. `Email notifications\nM365 Excel`). This formats them as Q&A pairs so the model has full context:

```
Q: What kind of notifications do you want to send?
A: Email notifications

Q: Where should data be stored?
A: M365 Excel
```

## Tests

- [ ] Open AI Builder and trigger a flow that prompts clarification questions via the ChoicePicker
- [ ] Answer all questions using the predefined options — verify the outgoing message in the chat shows each `Q:` / `A:` pair