### PR TITLE
chore: bump axios 1.15.2→1.17.0 and shell-quote 1.8.3→1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11490,13 +11490,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -11514,6 +11515,18 @@
         "axios": ">= 0.17.0"
       }
     },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -11525,6 +11538,19 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"
@@ -29531,9 +29557,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -34013,7 +34039,7 @@
         "ai": "5.0.81",
         "ajv-formats": "2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.15.2",
+        "axios": "1.17.0",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.7",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "overrides": {
-    "axios": "1.15.2",
+    "axios": "1.17.0",
     "graphql-rate-limit": {
       "@graphql-tools/utils": {
         "graphql": "16.11.0"
@@ -47,7 +47,8 @@
     "lodash-es": "4.18.1",
     "vite": "6.4.2",
     "immutable": "4.3.8",
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "shell-quote": "1.8.4"
   },
   "devDependencies": {
     "@eddeee888/gcg-typescript-resolver-files": "0.7.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,7 +51,7 @@
     "ai": "5.0.81",
     "ajv-formats": "2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.15.2",
+    "axios": "1.17.0",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
## What changed

| Package | From | To | Location |
|---|---|---|---|
| `axios` | `1.15.2` | `1.17.0` | `packages/backend/package.json` + root `overrides` |
| `shell-quote` | `1.8.3` | `1.8.4` | Root `overrides` (lockfile only) |

**axios** fixes 7 high-severity CVEs: SSRF via IPv4-mapped IPv6 addresses, MITM via prototype pollution in proxy config, proxy-auth credential leak across redirects, ReDoS via cookie name injection, and resource allocation DoS. The bump also transitively resolves the audit findings on `@opengovsg/formsg-sdk`, `wait-on`, and `axios-mock-adapter`, which all use the hoisted axios.

**shell-quote** fixes a critical CVE (GHSA-w7jw-789q-3m8p) — shell injection via unescaped newlines in `quote()`. Used transitively by `concurrently` and `dd-trace` (child_process plugin). Note: `dd-trace` only calls `shell-quote/parse`, not `quote`, so it was not directly exposed.

## Tests

- [ ] **Custom API — HTTP Request action**: run a pipe with both GET and POST steps with custom headers; verify success and error responses are handled correctly
- [ ] **M365 Excel — any action (e.g. Get Rows / Add Row)**: exercises request + response interceptor chain and workbook session management
- [ ] **FormSG — trigger with file attachment**: submit a form with a file attachment and verify it decrypts and passes through the pipe
- [ ] **Postman SMS — Send SMS action**: verify a message is delivered successfully
- [ ] **Postman (email) — Send Transactional Email action**: verify email is sent and error handling works on failure path
- [ ] **OAuth reconnect (any app)**: disconnect and reconnect an OAuth-based integration to verify auth URL validation still works