### PR TITLE
[FORMSG-V4-1] PLU-767: Upgrade formsg sdk to 7.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6168,12 +6168,12 @@
       }
     },
     "node_modules/@opengovsg/formsg-sdk": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-0.16.1.tgz",
-      "integrity": "sha512-yfNTdN4vI7Gs8KTdpqnQPSQ4bkn0worRWeP9UJwcJ172MfvcP+lxHfHBk06FMDA0yJ6fEG/Z+kaGb20WZb4XTA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@opengovsg/formsg-sdk/-/formsg-sdk-7.2.0.tgz",
+      "integrity": "sha512-+TulEjgPVEmqtb0r24UX2v7OUMYLo/6cHa76Yasf1dh3lrlh33b+nptFqm9EySe+YJ2/0+U+rWehaAa51HdAng==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.4",
+        "axios": "^1.15.2",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       }
@@ -34112,7 +34112,7 @@
         "@langfuse/otel": "4.2.0",
         "@langfuse/tracing": "4.2.0",
         "@launchdarkly/node-server-sdk": "9.0.4",
-        "@opengovsg/formsg-sdk": "0.16.1",
+        "@opengovsg/formsg-sdk": "7.2.0",
         "@opengovsg/sgid-client": "2.3.0",
         "@opentelemetry/sdk-node": "0.219.0",
         "@plumber/types": "file:../types",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
     "@langfuse/otel": "4.2.0",
     "@langfuse/tracing": "4.2.0",
     "@launchdarkly/node-server-sdk": "9.0.4",
-    "@opengovsg/formsg-sdk": "0.16.1",
+    "@opengovsg/formsg-sdk": "7.2.0",
     "@opengovsg/sgid-client": "2.3.0",
     "@opentelemetry/sdk-node": "0.219.0",
     "@plumber/types": "file:../types",

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3.test.ts
@@ -3,10 +3,7 @@ import { IGlobalVariable, IRequest } from '@plumber/types'
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import {
-  decryptFormAttachmentsV3,
-  decryptSubmissionSecretKey,
-} from '../../auth/decrypt-form-attachments-v3'
+import { decryptFormAttachmentsV3 } from '../../auth/decrypt-form-attachments-v3'
 import { getSdk } from '../../common/form-env'
 
 const mocks = vi.hoisted(() => {
@@ -41,8 +38,8 @@ vi.mock('axios', () => ({
 
 const formSgSdk = getSdk('prod')
 
-// test form secret key - OK to commit
-const FORM_SECRET_KEY = 'Lrw8HdnQwiCE5umnmrIkhff60WKmMGXrCgtLXgdZtzs='
+// OK to commit - test data.
+const SUBMISSION_SECRET_KEY = 'UEHWr01L6Fura3bGYxCH22w9kocYhxOcfUuznnCL21I='
 const FORM_FIELDS: FormField[] = [
   {
     _id: '68f7ac5bd9b9803e70a2db61',
@@ -66,7 +63,6 @@ const FORM_FIELDS: FormField[] = [
 
 describe('decrypt form attachments v3', () => {
   let $: IGlobalVariable
-  let decryptedSubmissionSecretKey: string | null
   beforeEach(() => {
     $ = {
       request: {
@@ -90,35 +86,17 @@ describe('decrypt form attachments v3', () => {
         },
       } as IRequest,
     } as IGlobalVariable
-    decryptedSubmissionSecretKey = decryptSubmissionSecretKey(
-      FORM_SECRET_KEY,
-      $.request.body.data.encryptedSubmissionSecretKey,
-    )
   })
 
   afterEach(() => {
     vi.resetAllMocks()
   })
 
-  describe('decrypt submission secret key', () => {
-    it('should return null when encrypted submission secret key is invalid', () => {
-      const result = decryptSubmissionSecretKey(FORM_SECRET_KEY, 'invalid')
-      expect(result).toBeNull()
-    })
-    it('should return the decrypted submission secret key', () => {
-      const result = decryptSubmissionSecretKey(
-        FORM_SECRET_KEY,
-        $.request.body.data.encryptedSubmissionSecretKey,
-      )
-      expect(result).toBe('UEHWr01L6Fura3bGYxCH22w9kocYhxOcfUuznnCL21I=')
-    })
-  })
-
   describe('decrypt attachments v3', () => {
     it('should return decrypted attachments when attachmentDownloadUrls is present', async () => {
       const result = await decryptFormAttachmentsV3(
         formSgSdk,
-        decryptedSubmissionSecretKey,
+        SUBMISSION_SECRET_KEY,
         $.request.body.data.attachmentDownloadUrls,
         FORM_FIELDS,
       )
@@ -132,7 +110,7 @@ describe('decrypt form attachments v3', () => {
     it('should return empty object when attachmentDownloadUrls is empty', async () => {
       const result = await decryptFormAttachmentsV3(
         formSgSdk,
-        decryptedSubmissionSecretKey,
+        SUBMISSION_SECRET_KEY,
         {},
         FORM_FIELDS,
       )
@@ -142,7 +120,7 @@ describe('decrypt form attachments v3', () => {
     it('should return all attachments even if form fields are not present', async () => {
       const result = await decryptFormAttachmentsV3(
         formSgSdk,
-        decryptedSubmissionSecretKey,
+        SUBMISSION_SECRET_KEY,
         $.request.body.data.attachmentDownloadUrls,
         [],
       )
@@ -165,7 +143,7 @@ describe('decrypt form attachments v3', () => {
       await expect(
         decryptFormAttachmentsV3(
           formSgSdk,
-          decryptedSubmissionSecretKey,
+          SUBMISSION_SECRET_KEY,
           $.request.body.data.attachmentDownloadUrls,
           FORM_FIELDS,
         ),

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -29,7 +29,6 @@ const mocks = vi.hoisted(() => {
     parseFormEnv: vi.fn(),
     storeAttachmentInS3: vi.fn(() => 'mock-s3-id'),
     fetchFormSchema: vi.fn(() => null),
-    decryptSubmissionSecretKey: vi.fn(() => 'mock-secret-key'),
     decryptFormAttachmentsV3: vi.fn(() => ({})),
   }
 })
@@ -55,7 +54,6 @@ vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
 }))
 
 vi.mock('../../auth/decrypt-form-attachments-v3', () => ({
-  decryptSubmissionSecretKey: mocks.decryptSubmissionSecretKey,
   decryptFormAttachmentsV3: mocks.decryptFormAttachmentsV3,
 }))
 
@@ -173,15 +171,15 @@ describe('decrypt form response - MRF specific', () => {
       expect(mocks.fetchFormSchema).toHaveBeenCalledWith($, 'formId123')
     })
 
-    it('should call decryptSubmissionSecretKey and decryptFormAttachmentsV3 for v3 attachments', async () => {
+    it('should pass the decrypted submissionSecretKey to decryptFormAttachmentsV3 for v3 attachments', async () => {
       $.flow.hasFileProcessingActions = true
       $.request.body.data.attachmentDownloadUrls = {
         attachField1:
           'https://s3.ap-southeast-1.amazonaws.com/attachments.form.gov.sg/123',
       }
-      $.request.body.data.encryptedSubmissionSecretKey = 'encrypted-key'
 
       mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        submissionSecretKey: 'mock-secret-key',
         responses: {
           attachField1: {
             fieldType: 'attachment',
@@ -199,10 +197,6 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptSubmissionSecretKey).toHaveBeenCalledWith(
-        'secretkey',
-        'encrypted-key',
-      )
       expect(mocks.decryptFormAttachmentsV3).toHaveBeenCalledWith(
         mocks.getSdk(),
         'mock-secret-key',
@@ -235,7 +229,6 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptSubmissionSecretKey).not.toHaveBeenCalled()
       expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
     })
 
@@ -254,7 +247,6 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptSubmissionSecretKey).not.toHaveBeenCalled()
       expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
     })
   })

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3.ts
@@ -1,27 +1,10 @@
-import {
-  DecryptedAttachments,
-  FormField,
-} from '@opengovsg/formsg-sdk/dist/types'
-import {
-  convertEncryptedAttachmentToFileContent,
-  decryptContent,
-} from '@opengovsg/formsg-sdk/dist/util/crypto'
+import { FormField } from '@opengovsg/formsg-sdk'
+import { DecryptedAttachments } from '@opengovsg/formsg-sdk/dist/types'
 import axios from 'axios'
 
 import logger from '@/helpers/logger'
 
 import { getSdk } from '../common/form-env'
-
-export function decryptSubmissionSecretKey(
-  formSecretKey: string,
-  encryptedSubmissionSecretKey: string,
-): string | null {
-  const decrypted = decryptContent(formSecretKey, encryptedSubmissionSecretKey)
-  if (!decrypted) {
-    return null
-  }
-  return Buffer.from(decrypted).toString('base64')
-}
 
 /**
  * Decrypts V3 form attachments from presigned S3 download URLs.
@@ -53,15 +36,21 @@ export async function decryptFormAttachmentsV3(
   await Promise.all(
     Object.entries(attachmentDownloadUrls).map(async ([fieldId, url]) => {
       try {
-        const { data: downloadResponse } = await axios.get(url, {
+        const {
+          data: { encryptedFile },
+        } = await axios.get(url, {
           responseType: 'json',
         })
 
-        const encryptedFile =
-          convertEncryptedAttachmentToFileContent(downloadResponse)
         const decryptedBinary = await formSgSdk.cryptoV3.decryptFile(
           submissionSecretKey,
-          encryptedFile,
+          // Reverse engineered from convertEncryptedAttachmentToFileContent
+          // until the official SDK releases the decryptAttachmentV4 function.
+          {
+            submissionPublicKey: encryptedFile.submissionPublicKey,
+            nonce: encryptedFile.nonce,
+            binary: new Uint8Array(Buffer.from(encryptedFile.binary, 'base64')),
+          },
         )
 
         if (!decryptedBinary) {

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -16,10 +16,7 @@ import { NricFilter } from '../triggers/new-submission/index'
 import { computeSubmissionTime } from './helpers/compute-submission-time'
 import { processResponsesV3 } from './helpers/process-v3-responses'
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
-import {
-  decryptFormAttachmentsV3,
-  decryptSubmissionSecretKey,
-} from './decrypt-form-attachments-v3'
+import { decryptFormAttachmentsV3 } from './decrypt-form-attachments-v3'
 
 const NRIC_VERIFIED_FIELDS = new Set(['sgidUinFin', 'uinFin'])
 
@@ -129,13 +126,9 @@ export async function decryptFormResponse(
     // shouldStoreAttachments should only consider steps after the mrf step instead of the whole pipe
     // but leaving it as such for now to avoid complexity
     if (shouldStoreAttachments && data.attachmentDownloadUrls) {
-      const submissionSecretKey = decryptSubmissionSecretKey(
-        formSecretKey,
-        data.encryptedSubmissionSecretKey,
-      )
       attachments = await decryptFormAttachmentsV3(
         formSgSdk,
-        submissionSecretKey,
+        decryptedSubmission.submissionSecretKey,
         data.attachmentDownloadUrls,
         mappedResponses,
       )

--- a/packages/backend/src/apps/formsg/auth/helpers/store-attachment-in-s3.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/store-attachment-in-s3.ts
@@ -32,17 +32,17 @@ async function storeAttachmentInS3(
     return ''
   }
 
-  return await putObject(
-    COMMON_S3_BUCKET,
-    `${submissionId}/${formField._id}/${attachment.filename}`,
-    attachment.content,
-    {
+  return await putObject({
+    bucket: COMMON_S3_BUCKET,
+    objectKey: `${submissionId}/${formField._id}/${attachment.filename}`,
+    body: attachment.content,
+    metadata: {
       flowId: $.flow.id,
       stepId: $.step.id,
       executionId: $.execution.id ?? '', // Empty = test runs.
       formId: $.auth.data.formId as string,
     },
-  )
+  })
 }
 
 export default storeAttachmentInS3

--- a/packages/backend/src/apps/lettersg/helpers/attachment.ts
+++ b/packages/backend/src/apps/lettersg/helpers/attachment.ts
@@ -22,10 +22,15 @@ export async function downloadAndStoreAttachmentInS3(
   })
 
   const objectKey = `${$.execution.id}/${$.step.appKey}/${publicId}/${templateName}.pdf`
-  return await putObject(COMMON_S3_BUCKET, objectKey, pdfData, {
-    flowId: $.flow.id,
-    stepId: $.step.id,
-    executionId: $.execution.id ?? '', // Empty = test runs
-    publicId,
+  return await putObject({
+    bucket: COMMON_S3_BUCKET,
+    objectKey,
+    body: pdfData,
+    metadata: {
+      flowId: $.flow.id,
+      stepId: $.step.id,
+      executionId: $.execution.id ?? '', // Empty = test runs
+      publicId,
+    },
   })
 }

--- a/packages/backend/src/helpers/__tests__/s3.test.ts
+++ b/packages/backend/src/helpers/__tests__/s3.test.ts
@@ -82,22 +82,20 @@ describe('s3', () => {
 
   describe('putObject', () => {
     it("invokes AWS's s3-client's send", async () => {
-      await putObject(
-        COMMON_S3_BUCKET,
-        'abcd/my file.txt',
-        'file data bytes',
-        null,
-      )
+      await putObject({
+        bucket: COMMON_S3_BUCKET,
+        objectKey: 'abcd/my file.txt',
+        body: 'file data bytes',
+      })
       expect(mocks.s3Client.send).toHaveBeenCalledOnce()
     })
 
     it('returns a valid S3 ID', async () => {
-      const result = await putObject(
-        COMMON_S3_BUCKET,
-        'abcd/my file.txt',
-        '',
-        null,
-      )
+      const result = await putObject({
+        bucket: COMMON_S3_BUCKET,
+        objectKey: 'abcd/my file.txt',
+        body: '',
+      })
       expect(result).toEqual(`s3:${COMMON_S3_BUCKET}:abcd/my file.txt`)
     })
   })

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -252,18 +252,28 @@ export async function deleteObjects(
  * *Note 2:* This doesn't validate `objectKey`; the caller is expected to make
  * sure it's formatted correctly.
  */
-export async function putObject(
-  bucket: string,
-  objectKey: string,
-  body: PutObjectCommandInput['Body'],
-  metadata: PutObjectCommandInput['Metadata'] | null,
-): Promise<string> {
+export interface PutObjectParams {
+  bucket: string
+  objectKey: string
+  body: PutObjectCommandInput['Body']
+  metadata?: PutObjectCommandInput['Metadata']
+  tagging?: PutObjectCommandInput['Tagging']
+}
+
+export async function putObject({
+  bucket,
+  objectKey,
+  body,
+  metadata,
+  tagging,
+}: PutObjectParams): Promise<string> {
   await s3Client.send(
     new PutObjectCommand({
       Bucket: bucket,
       Key: objectKey,
       Body: body,
       Metadata: metadata,
+      Tagging: tagging,
     }),
   )
   return `s3:${bucket}:${objectKey}`


### PR DESCRIPTION
# Problem

We want to support FormSG v4 schema it will supersede v3 (which we use for MRF now).

# Approach

1. Upgrade to latest FormSG SDK which provides helpers to handle the new schema
2. Add a new codepath to decode v4.
3. [Later on] Deprecate v3 code path when cutover is 100% done.

# This PR

Upgrades to the latest FormSG SDK.

- This looks like jumping multiple major versions (0.16.1 -> 7.2.0), but that only because FormSG integrated SDK into their monorepo; it's synced with their version number.
- The actual change is not that big; mainly bumping internal libraries + adding v4 support (see changelog [here](https://github.com/opengovsg/FormSG/blob/develop/packages/sdk/CHANGELOG.md)).

# Tests

We still need to be careful as FormSG is a critical integration.

- Check that we can decode every single FormSG storage mode form field using my kitchen sink form ([6a290295724fe61771abb485](https://form.gov.sg/6a290295724fe61771abb485)).
- Check that we can decode every single FormSG MRF form field using my kitchen sink MRF form ([6a29410c5868eecc68121e1f](https://)).
- Check that MyInfo still works for storage mode forms
- Check that MyInfo still works for MRF
- Check that attachments still work for storage mode form
- Check that attachments work for all respondents in MRF
- Check that optional fields and attachments still work as expected in our variable dropdown.
- Check that raw payload is stored in S3 bucket, under the `debug` root object

# Disaster Mitigation

1. Cut this PR as a release by itself to enable easy rollback
2. Monitor error rate and 5xx form triggers during rollout.
3. In the event of silent failure (e.g. null result when decoding payload due to miscomms in data model) -  we will work with the user on recovery. This is more complex as the executions are in a metastable state.