### PR TITLE
fix: render table variables in email preview

### DIFF
--- a/packages/backend/src/helpers/format-table-variable.ts
+++ b/packages/backend/src/helpers/format-table-variable.ts
@@ -56,6 +56,11 @@ function cellToString(value: unknown): string {
 /**
  * Formats table data as an HTML table with inline CSS for email compatibility
  * Simple black borders with background colors matching the preview
+ *
+ * NOTE: the frontend email preview mirrors this exact markup in
+ * `buildTableHtml` (packages/frontend/src/components/RichTextEditor/utils.ts).
+ * If you change the markup/styles here, update that mirror and its
+ * markup-pinning test so the preview keeps matching the sent email.
  */
 function formatAsHtml(rows: TableRow[], columns: TableColumn[]): string {
   const headerBg = '#F3F4F6' // gray.100

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -1,10 +1,13 @@
 import escapeHTML from 'escape-html'
 import { describe, expect, it } from 'vitest'
 
+import { hexEncode } from '@/helpers/hex-encoding'
+
 import {
   removeProblematicWhitespace,
   substituteForPreview,
   substituteOldTemplates,
+  type VariableInfoMap,
 } from './utils'
 
 const varInfo = new Map<
@@ -184,6 +187,108 @@ describe('substituteForPreview', () => {
     const input =
       '<div data-type="tableVariable" data-id="step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello|abcd" data-label="hello" data-value="world">{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.hello|abcd}}</div>'
     expect(substituteForPreview(input, varInfo)).toEqual('world')
+  })
+
+  // These assert the table markup byte-for-byte on purpose: the preview renderer
+  // mirrors the backend's email table renderer (formatAsHtml in
+  // packages/backend/src/helpers/format-table-variable.ts). If the backend markup
+  // changes, update buildTableHtml and these expectations so the preview keeps
+  // matching the sent email.
+  describe('table variables (real editor HTML, no data-value)', () => {
+    const TABLE_BASE_PATH = 'step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.data'
+    const tableVarInfo: VariableInfoMap = new Map([
+      [
+        `{{${TABLE_BASE_PATH}}}`,
+        {
+          label: 'My table',
+          testRunValue: '2 rows',
+          table: {
+            columns: [
+              { id: 'c1', name: 'Name' },
+              { id: 'c2', name: 'Email' },
+            ],
+            sampleRows: [
+              { c1: 'Alice', c2: 'alice@example.sg' },
+              { c1: 'Bob', c2: 'bob@example.sg' },
+            ],
+          },
+        },
+      ],
+    ])
+
+    const cell = 'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
+    const headerCell = (name: string) =>
+      `<td style="${cell} background-color: #F3F4F6; font-weight: 600;"><p style="margin: 0;">${name}</p></td>`
+    const dataCell = (value: string, bg: string) =>
+      `<td style="${cell} background-color: ${bg};"><p style="margin: 0;">${value}</p></td>`
+
+    const makeInput = (modifier: string) => {
+      const hex = hexEncode(modifier)
+      const id = `${TABLE_BASE_PATH}|${hex}`
+      return `<div data-type="tableVariable" data-id="${id}">{{${id}}}</div>`
+    }
+
+    it('renders the table variable as an HTML table from varInfo table data', () => {
+      const expected =
+        '<table style="border-collapse: collapse;"><tbody>' +
+        `<tr>${headerCell('Name')}${headerCell('Email')}</tr>` +
+        `<tr>${dataCell('Alice', '#FFFFFF')}${dataCell(
+          'alice@example.sg',
+          '#FFFFFF',
+        )}</tr>` +
+        `<tr>${dataCell('Bob', '#F9FAFB')}${dataCell(
+          'bob@example.sg',
+          '#F9FAFB',
+        )}</tr>` +
+        '</tbody></table>'
+      expect(
+        substituteForPreview(makeInput('table:c1,c2'), tableVarInfo),
+      ).toEqual(expected)
+    })
+
+    it('renders only the columns selected in the hex modifier', () => {
+      const expected =
+        '<table style="border-collapse: collapse;"><tbody>' +
+        `<tr>${headerCell('Email')}</tr>` +
+        `<tr>${dataCell('alice@example.sg', '#FFFFFF')}</tr>` +
+        `<tr>${dataCell('bob@example.sg', '#F9FAFB')}</tr>` +
+        '</tbody></table>'
+      expect(substituteForPreview(makeInput('table:c2'), tableVarInfo)).toEqual(
+        expected,
+      )
+    })
+
+    it('escapes HTML in cell values to prevent injection', () => {
+      const injectInfo: VariableInfoMap = new Map([
+        [
+          `{{${TABLE_BASE_PATH}}}`,
+          {
+            label: 'My table',
+            testRunValue: '1 row',
+            table: {
+              columns: [{ id: 'c1', name: 'Name' }],
+              sampleRows: [{ c1: '<script>alert(1)</script>' }],
+            },
+          },
+        ],
+      ])
+      const out = substituteForPreview(makeInput('table:c1'), injectInfo)
+      expect(out).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(out).not.toContain('<script>')
+    })
+
+    it('falls back to text value when the table cannot be rendered', () => {
+      // varInfo entry has no table data → cannot render a table
+      const noTableInfo: VariableInfoMap = new Map([
+        [
+          `{{${TABLE_BASE_PATH}}}`,
+          { label: 'My table', testRunValue: '2 rows' },
+        ],
+      ])
+      expect(substituteForPreview(makeInput('table:c1'), noTableInfo)).toEqual(
+        '2 rows',
+      )
+    })
   })
 
   it('substitutes legacy {{step.…}} patterns in plain text nodes', () => {

--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -2,8 +2,10 @@ import escapeHTML from 'escape-html'
 import { describe, expect, it } from 'vitest'
 
 import { hexEncode } from '@/helpers/hex-encoding'
+import type { StepWithVariables, TableVariable } from '@/helpers/variables'
 
 import {
+  genVariableInfoMap,
   removeProblematicWhitespace,
   substituteForPreview,
   substituteOldTemplates,
@@ -207,7 +209,7 @@ describe('substituteForPreview', () => {
               { id: 'c1', name: 'Name' },
               { id: 'c2', name: 'Email' },
             ],
-            sampleRows: [
+            rows: [
               { c1: 'Alice', c2: 'alice@example.sg' },
               { c1: 'Bob', c2: 'bob@example.sg' },
             ],
@@ -216,6 +218,8 @@ describe('substituteForPreview', () => {
       ],
     ])
 
+    // Rebuild the expected markup independently of buildTableHtml (don't import
+    // its constants) so these stay a byte-for-byte pin on the renderer's output.
     const cell = 'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
     const headerCell = (name: string) =>
       `<td style="${cell} background-color: #F3F4F6; font-weight: 600;"><p style="margin: 0;">${name}</p></td>`
@@ -267,7 +271,7 @@ describe('substituteForPreview', () => {
             testRunValue: '1 row',
             table: {
               columns: [{ id: 'c1', name: 'Name' }],
-              sampleRows: [{ c1: '<script>alert(1)</script>' }],
+              rows: [{ c1: '<script>alert(1)</script>' }],
             },
           },
         ],
@@ -316,6 +320,51 @@ describe('substituteForPreview', () => {
     for (const input of inputs) {
       expect(substituteForPreview(input, varInfo)).toEqual('')
     }
+  })
+})
+
+describe('genVariableInfoMap', () => {
+  it('carries all table rows (not the truncated pill sampleRows) for the preview', () => {
+    const allRows = [
+      { data: { c1: 'r1' } },
+      { data: { c1: 'r2' } },
+      { data: { c1: 'r3' } },
+      { data: { c1: 'r4' } },
+      { data: { c1: 'r5' } },
+    ]
+    const tableVar: TableVariable = {
+      name: 'step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.data',
+      type: 'table',
+      label: 'My table',
+      displayedValue: '5 rows',
+      // value is the full table data, exactly as the editor stores it
+      value: JSON.stringify({
+        columns: [{ id: 'c1', name: 'Name' }],
+        rows: allRows,
+      }),
+      columns: [{ id: 'c1', name: 'Name' }],
+      // sampleRows is intentionally truncated for the in-editor pill
+      sampleRows: allRows.slice(0, 3).map((r) => r.data),
+      totalRowCount: allRows.length,
+    }
+    const steps: StepWithVariables[] = [
+      {
+        id: 'ff5000f5-021c-4488-b6c2-c582c42ba3cf',
+        name: '1. Step',
+        output: [tableVar],
+      },
+    ]
+
+    const map = genVariableInfoMap(steps)
+    const entry = map.get('{{step.ff5000f5-021c-4488-b6c2-c582c42ba3cf.data}}')
+
+    expect(entry?.table?.rows).toEqual([
+      { c1: 'r1' },
+      { c1: 'r2' },
+      { c1: 'r3' },
+      { c1: 'r4' },
+      { c1: 'r5' },
+    ])
   })
 })
 

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -191,7 +191,9 @@ export function substituteOldTemplates(
   return substitutedDom.outerHTML
 }
 
-const HEX_MODIFIER_SUFFIX_REGEX = new RegExp(`\\|${HEX_MODIFIER_PATTERN}$`)
+// Matches a trailing `|<hexModifier>` suffix, capturing the hex in group 1.
+// Reused for both `.match` (read the modifier) and `.replace` (strip it).
+const HEX_MODIFIER_SUFFIX_REGEX = new RegExp(`\\|(${HEX_MODIFIER_PATTERN})$`)
 
 function cellToString(value: unknown): string {
   if (value === null || value === undefined) {
@@ -256,9 +258,7 @@ function renderTableVariableHtml(
   dataId: string,
   varInfo: VariableInfoMap,
 ): string | null {
-  const modifierMatch = dataId.match(
-    new RegExp(`\\|(${HEX_MODIFIER_PATTERN})$`),
-  )
+  const modifierMatch = dataId.match(HEX_MODIFIER_SUFFIX_REGEX)
   if (!modifierMatch) {
     return null
   }

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -14,7 +14,9 @@ import type { StepWithVariables, TableVariable } from '@/helpers/variables'
 
 interface TableVariablePreviewData {
   columns: Array<{ id: string; name: string }>
-  sampleRows: Array<Record<string, unknown>>
+  // All rows, so the preview matches the full table the email sends — not the
+  // truncated `sampleRows` used by the in-editor pill.
+  rows: Array<Record<string, unknown>>
 }
 
 export interface VariableInfo {
@@ -52,6 +54,24 @@ export function simpleSubstitute(
   })
 }
 
+/**
+ * Extracts every row's data from a table variable for the email preview.
+ *
+ * `tableVar.value` is the full table JSON (`{ columns, rows }`) the editor
+ * stores (set via `JSON.stringify` in helpers/variables.ts), so we parse it to
+ * get all rows — unlike the truncated `sampleRows` the in-editor pill uses. The
+ * value is always valid JSON from that single producer, so no parse guard is
+ * needed; a malformed value should surface loudly rather than silently degrade.
+ */
+function extractAllTableRows(
+  tableVar: TableVariable,
+): Array<Record<string, unknown>> {
+  const parsed = JSON.parse(tableVar.value as string) as {
+    rows?: Array<{ data?: Record<string, unknown> }>
+  }
+  return (parsed.rows ?? []).map((row) => row?.data ?? {})
+}
+
 export function genVariableInfoMap(
   stepsWithVariables: StepWithVariables[],
 ): VariableInfoMap {
@@ -72,7 +92,7 @@ export function genVariableInfoMap(
         const tableVar = variable as TableVariable
         entry.table = {
           columns: tableVar.columns,
-          sampleRows: tableVar.sampleRows,
+          rows: extractAllTableRows(tableVar),
         }
       }
       result.set(placeholderString, entry)
@@ -173,15 +193,6 @@ export function substituteOldTemplates(
 
 const HEX_MODIFIER_SUFFIX_REGEX = new RegExp(`\\|${HEX_MODIFIER_PATTERN}$`)
 
-// Inline styles mirror the backend's table renderer
-// (packages/backend/src/helpers/format-table-variable.ts) so the email preview
-// matches the table that actually gets sent.
-const TABLE_HEADER_BG = '#F3F4F6' // gray.100
-const TABLE_ROW_ODD_BG = '#FFFFFF' // white
-const TABLE_ROW_EVEN_BG = '#F9FAFB' // gray.50
-const TABLE_CELL_STYLE =
-  'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
-
 function cellToString(value: unknown): string {
   if (value === null || value === undefined) {
     return ''
@@ -193,17 +204,26 @@ function cellToString(value: unknown): string {
 }
 
 /**
- * Builds an email-safe HTML table string from the resolved table data, mirroring
- * the backend renderer. Cell content is escaped to prevent HTML injection.
+ * Builds an email-safe HTML table string from the resolved table data. Cell
+ * content is escaped to prevent HTML injection.
+ *
+ * The markup/styles mirror the backend's email table renderer (formatAsHtml in
+ * packages/backend/src/helpers/format-table-variable.ts) so the preview matches
+ * the table that actually gets sent — keep the two in sync.
  */
 function buildTableHtml(
   columns: Array<{ id: string; name: string }>,
   rows: Array<Record<string, unknown>>,
 ): string {
+  const headerBg = '#F3F4F6' // gray.100
+  const rowOddBg = '#FFFFFF' // white
+  const rowEvenBg = '#F9FAFB' // gray.50
+  const cell = 'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
+
   const headerCells = columns
     .map(
       (col) =>
-        `<td style="${TABLE_CELL_STYLE} background-color: ${TABLE_HEADER_BG}; font-weight: 600;"><p style="margin: 0;">${escapeHtml(
+        `<td style="${cell} background-color: ${headerBg}; font-weight: 600;"><p style="margin: 0;">${escapeHtml(
           col.name,
         )}</p></td>`,
     )
@@ -211,11 +231,11 @@ function buildTableHtml(
 
   const dataRows = rows
     .map((row, i) => {
-      const bg = i % 2 === 0 ? TABLE_ROW_ODD_BG : TABLE_ROW_EVEN_BG
+      const bg = i % 2 === 0 ? rowOddBg : rowEvenBg
       const cells = columns
         .map(
           (col) =>
-            `<td style="${TABLE_CELL_STYLE} background-color: ${bg};"><p style="margin: 0;">${escapeHtml(
+            `<td style="${cell} background-color: ${bg};"><p style="margin: 0;">${escapeHtml(
               cellToString(row[col.id]),
             )}</p></td>`,
         )
@@ -270,7 +290,7 @@ function renderTableVariableHtml(
     return null
   }
 
-  return buildTableHtml(selectedColumns, tableData.sampleRows)
+  return buildTableHtml(selectedColumns, tableData.rows)
 }
 
 /**

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -1,6 +1,7 @@
 import { FieldValues, UseFormGetValues } from 'react-hook-form'
 import { PlacementWithLogical } from '@chakra-ui/react'
 import { Editor } from '@tiptap/react'
+import escapeHtml from 'escape-html'
 import {
   HTMLElement as NodeHTMLElement,
   Node,
@@ -8,15 +9,26 @@ import {
   TextNode,
 } from 'node-html-parser'
 
-import type { StepWithVariables } from '@/helpers/variables'
+import { hexDecode } from '@/helpers/hex-encoding'
+import type { StepWithVariables, TableVariable } from '@/helpers/variables'
 
-export type VariableInfoMap = Map<
-  string,
-  {
-    label: string
-    testRunValue: string
-  }
->
+interface TableVariablePreviewData {
+  columns: Array<{ id: string; name: string }>
+  sampleRows: Array<Record<string, unknown>>
+}
+
+export interface VariableInfo {
+  label: string
+  testRunValue: string
+  /**
+   * Present only for table-type variables. Carries the structured data
+   * needed to render an HTML table in the email preview (see
+   * `substituteForPreview`), mirroring the backend's table rendering.
+   */
+  table?: TableVariablePreviewData
+}
+
+export type VariableInfoMap = Map<string, VariableInfo>
 
 const HEX_MODIFIER_PATTERN = '[a-fA-F0-9]+'
 
@@ -52,10 +64,18 @@ export function genVariableInfoMap(
         variable.label ??
         variable.name.replace(`step.${step.id}.`, `step${stepPosition + 1}.`)
       const testRunValue = variable.displayedValue ?? String(variable.value)
-      result.set(placeholderString, {
+      const entry: VariableInfo = {
         label,
         testRunValue,
-      })
+      }
+      if (variable.type === 'table') {
+        const tableVar = variable as TableVariable
+        entry.table = {
+          columns: tableVar.columns,
+          sampleRows: tableVar.sampleRows,
+        }
+      }
+      result.set(placeholderString, entry)
     }
   }
   return result
@@ -151,13 +171,118 @@ export function substituteOldTemplates(
   return substitutedDom.outerHTML
 }
 
+const HEX_MODIFIER_SUFFIX_REGEX = new RegExp(`\\|${HEX_MODIFIER_PATTERN}$`)
+
+// Inline styles mirror the backend's table renderer
+// (packages/backend/src/helpers/format-table-variable.ts) so the email preview
+// matches the table that actually gets sent.
+const TABLE_HEADER_BG = '#F3F4F6' // gray.100
+const TABLE_ROW_ODD_BG = '#FFFFFF' // white
+const TABLE_ROW_EVEN_BG = '#F9FAFB' // gray.50
+const TABLE_CELL_STYLE =
+  'border: 1px solid black; padding: 5px 10px; min-width: 100px;'
+
+function cellToString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return ''
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
+}
+
+/**
+ * Builds an email-safe HTML table string from the resolved table data, mirroring
+ * the backend renderer. Cell content is escaped to prevent HTML injection.
+ */
+function buildTableHtml(
+  columns: Array<{ id: string; name: string }>,
+  rows: Array<Record<string, unknown>>,
+): string {
+  const headerCells = columns
+    .map(
+      (col) =>
+        `<td style="${TABLE_CELL_STYLE} background-color: ${TABLE_HEADER_BG}; font-weight: 600;"><p style="margin: 0;">${escapeHtml(
+          col.name,
+        )}</p></td>`,
+    )
+    .join('')
+
+  const dataRows = rows
+    .map((row, i) => {
+      const bg = i % 2 === 0 ? TABLE_ROW_ODD_BG : TABLE_ROW_EVEN_BG
+      const cells = columns
+        .map(
+          (col) =>
+            `<td style="${TABLE_CELL_STYLE} background-color: ${bg};"><p style="margin: 0;">${escapeHtml(
+              cellToString(row[col.id]),
+            )}</p></td>`,
+        )
+        .join('')
+      return `<tr>${cells}</tr>`
+    })
+    .join('')
+
+  return `<table style="border-collapse: collapse;"><tbody><tr>${headerCells}</tr>${dataRows}</tbody></table>`
+}
+
+/**
+ * Renders a table-variable node's `data-id` (e.g. `step.uuid.path|hexModifier`)
+ * into an HTML table string, or returns null when it can't be rendered (no table
+ * data in varInfo, malformed modifier, or no valid selected columns).
+ */
+function renderTableVariableHtml(
+  dataId: string,
+  varInfo: VariableInfoMap,
+): string | null {
+  const modifierMatch = dataId.match(
+    new RegExp(`\\|(${HEX_MODIFIER_PATTERN})$`),
+  )
+  if (!modifierMatch) {
+    return null
+  }
+  const basePath = dataId.replace(HEX_MODIFIER_SUFFIX_REGEX, '')
+  const tableData = varInfo.get(`{{${basePath}}}`)?.table
+  if (!tableData) {
+    return null
+  }
+
+  let decodedModifier: string
+  try {
+    decodedModifier = hexDecode(modifierMatch[1])
+  } catch {
+    return null
+  }
+  if (!decodedModifier.startsWith('table:')) {
+    return null
+  }
+  const selectedColumnIds = decodedModifier
+    .slice('table:'.length)
+    .split(',')
+    .filter(Boolean)
+
+  const columnById = new Map(tableData.columns.map((col) => [col.id, col]))
+  const selectedColumns = selectedColumnIds
+    .map((id) => columnById.get(id))
+    .filter((col): col is { id: string; name: string } => col != null)
+  if (selectedColumns.length === 0) {
+    return null
+  }
+
+  return buildTableHtml(selectedColumns, tableData.sampleRows)
+}
+
 /**
  * Renders RichTextEditor HTML to plain final-form HTML, suitable for feeding
  * into an email preview pipeline.
  *
- * - Variable / table-variable spans are replaced with their resolved value:
- *   prefer the entry in `varInfo`, fall back to the node's own `data-value`
- *   attribute (kept current by `recursiveSubstitute`).
+ * - Variable spans are replaced with their resolved value: prefer the entry in
+ *   `varInfo`, fall back to the node's own `data-value` attribute (kept current
+ *   by `recursiveSubstitute`).
+ * - Table-variable nodes are rendered as an HTML table from the resolved table
+ *   data in `varInfo` (mirroring the email), falling back to the resolved text
+ *   value if the table can't be rendered.
  * - Legacy `{{step.…}}` patterns remaining in plain text nodes are resolved
  *   via `simpleSubstitute`.
  */
@@ -177,10 +302,20 @@ export function substituteForPreview(
       if (child instanceof NodeHTMLElement) {
         const dataType = child.getAttribute('data-type')
         const dataId = child.getAttribute('data-id')
-        if (
-          (dataType === 'variable' || dataType === 'tableVariable') &&
-          dataId != null
-        ) {
+        if (dataType === 'tableVariable' && dataId != null) {
+          const tableHtml = renderTableVariableHtml(dataId, varInfo)
+          if (tableHtml != null) {
+            newChildren.push(...parse(tableHtml).childNodes)
+            continue
+          }
+          // Couldn't render a table: fall back to the resolved text value.
+          const basePath = dataId.replace(HEX_MODIFIER_SUFFIX_REGEX, '')
+          const fromMap = varInfo.get(`{{${basePath}}}`)?.testRunValue
+          const fallback = child.getAttribute('data-value') ?? ''
+          newChildren.push(new TextNode(fromMap ?? fallback))
+          continue
+        }
+        if (dataType === 'variable' && dataId != null) {
           const fromMap = varInfo.get(`{{${dataId}}}`)?.testRunValue
           const fallback = child.getAttribute('data-value') ?? ''
           newChildren.push(new TextNode(fromMap ?? fallback))


### PR DESCRIPTION
## Problem

The email preview for table variables in the rich text editor did not match the actual HTML table rendered and sent by the backend. The preview was showing a plain text fallback value instead of a formatted HTML table, meaning users could not accurately see what their email would look like before sending.

## Solution

The frontend's `substituteForPreview` function now renders table variables as a proper HTML table, mirroring the backend's `formatAsHtml` function in `format-table-variable.ts`.

**Features**:

- Added `buildTableHtml` to the frontend utils, which produces email-safe HTML table markup with inline styles that exactly match the backend's table renderer (same colors, borders, padding, and alternating row backgrounds).
- `substituteForPreview` now handles `tableVariable` nodes separately from regular `variable` nodes: it attempts to render an HTML table from the structured table data in `varInfo`, and only falls back to the resolved text value if the table cannot be rendered (e.g. missing table data or malformed modifier).
- `VariableInfoMap` entries now carry an optional `table` field (`columns` + `rows`) populated from `TableVariable` data, giving the preview renderer the structured data it needs. All rows are sourced from the full table JSON rather than the truncated `sampleRows` used by the in-editor pill, so the preview reflects the complete data the email will send.
- `renderTableVariableHtml` decodes the hex modifier on a table variable's `data-id`, resolves the selected column IDs, and delegates to `buildTableHtml`.

**Improvements**:

- Cell values are HTML-escaped via `escape-html` to prevent injection in the preview.
- A comment was added to the backend's `formatAsHtml` function warning that the frontend mirror (`buildTableHtml`) and its pinning tests must be kept in sync whenever the markup or styles change.

## Tests

- New markup-pinning tests in `utils.test.ts` assert the exact HTML output of `substituteForPreview` for table variables byte-for-byte, covering:
    - Full table rendering with all columns.
    - Rendering only the columns selected via the hex modifier.
    - HTML escaping of cell values to prevent injection.
    - Fallback to the text value when no table data is available in `varInfo`.
- A `genVariableInfoMap` test verifies that all rows (not just the truncated `sampleRows`) are carried through to the preview map entry.

## How to test
- [ ] Table variable with filled rows
- [ ] Table variable with empty rows
- [ ] Normal variables

## Deploy Notes

**New dependencies**:

- `escape-html`: used in the frontend utils to escape cell content when building the preview table HTML.