### PR TITLE
chore: add .worktreeinclude for worktree env syncing

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+# .worktreeinclude
+.env


### PR DESCRIPTION
## Why?

Adds a `.worktreeinclude` file so that when git worktrees are created (e.g. via `gt worktree`), the `.env` file at the repo root is automatically copied into each worktree. Without this, worktrees start without any environment config and local dev breaks silently.