### PR TITLE
PLU-728 (fix): handle MRF checkbox Others value after v3 decryption

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
@@ -86,6 +86,33 @@ describe('processResponsesV3', () => {
       ])
     })
 
+    it('replaces the internal others marker with "Others: <othersInput>"', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'cb1', title: 'Hobbies', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        cb1: {
+          fieldType: 'checkbox',
+          answer: {
+            value: ['reading', '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'],
+            othersInput: 'custom hobby',
+          },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'cb1',
+          fieldType: 'checkbox',
+          question: 'Hobbies',
+          answerArray: ['reading', 'Others: custom hobby'],
+        },
+      ])
+    })
+
     it.each(['radiobutton', 'email', 'mobile'])(
       'maps %s fields with answer from answer.value',
       async (fieldType) => {

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -3,6 +3,8 @@ import type { IGlobalVariable } from '@plumber/types'
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { DateTime } from 'luxon'
 
+const CHECKBOX_OTHERS_MARKER = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
+
 import logger from '@/helpers/logger'
 
 import type { FormSchemaField } from '../../common/types'
@@ -56,13 +58,17 @@ export async function processResponsesV3(
       continue
     }
     if (value.fieldType === 'checkbox') {
+      const answerArray = (value.answer.value as string[]).map((v) =>
+        v === CHECKBOX_OTHERS_MARKER
+          ? `Others: ${value.answer.othersInput}`
+          : v,
+      )
       mappedResponses.push({
         _id: key,
         fieldType: value.fieldType,
         // we fallback to Question # if the question is not found in the form schema
         question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
-        // this is kinda weird, but it's the way formsg returns the answer for checkbox fields
-        answerArray: value.answer.value,
+        answerArray,
       })
       continue
     }


### PR DESCRIPTION
## TL;DR

MRF checkbox fields with "Others" selected were passing through `!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!` (an internal SDK marker) instead of the actual user input. This fix replaces the marker with `Others: <othersInput>` after v3 decryption.

## What changed?

- **`process-v3-responses.ts`**: In the checkbox handler, map over `value.answer.value` and replace any occurrence of `!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!` with `Others: ${value.answer.othersInput}`, matching the format already used by storage-mode forms.
- **`process-v3-responses.test.ts`**: Added a test case for the Others marker replacement.

## Tests

- [ ] **Storage mode (v1/v2) — checkbox with Others**: Submit a storage-mode FormSG form with a checkbox field that has "Others" selected with custom text. Verify the Plumber trigger data shows `Others: <your text>` in the checkbox answer array.
- [ ] **MRF (v3) — checkbox without Others**: Submit an MRF form with a checkbox field where only regular options are selected. Verify the answer array contains only the selected option labels.
- [ ] **MRF (v3) — checkbox with Others**: Submit an MRF form with a checkbox field where "Others" is selected with custom text. Verify the Plumber trigger data shows `Others: <your text>` instead of `!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!`.
- [ ] **MRF (v3) — checkbox with Others + other options**: Submit an MRF form with both regular options and "Others" selected. Verify the full answer array is correct.