### PR TITLE
fix: table variable test step data mismatch

### DIFF
--- a/packages/frontend/src/components/RichTextEditor/utils.test.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.test.ts
@@ -7,6 +7,7 @@ import type { StepWithVariables, TableVariable } from '@/helpers/variables'
 import {
   genVariableInfoMap,
   removeProblematicWhitespace,
+  simpleSubstitute,
   substituteForPreview,
   substituteOldTemplates,
   type VariableInfoMap,
@@ -292,6 +293,45 @@ describe('substituteForPreview', () => {
       expect(substituteForPreview(makeInput('table:c1'), noTableInfo)).toEqual(
         '2 rows',
       )
+    })
+
+    // simpleSubstitute powers the "has anything changed since the last test?"
+    // check (matchParamsToDataIn). For the comparison to match the backend's
+    // computed dataIn.body, it must swap only the {{token}} for the rendered
+    // table HTML and leave the surrounding wrapper untouched — exactly what the
+    // backend's computeParameters does.
+    it('simpleSubstitute renders a table token to HTML, keeping the surrounding wrapper', () => {
+      const expectedTable =
+        '<table style="border-collapse: collapse;"><tbody>' +
+        `<tr>${headerCell('Name')}${headerCell('Email')}</tr>` +
+        `<tr>${dataCell('Alice', '#FFFFFF')}${dataCell(
+          'alice@example.sg',
+          '#FFFFFF',
+        )}</tr>` +
+        `<tr>${dataCell('Bob', '#F9FAFB')}${dataCell(
+          'bob@example.sg',
+          '#F9FAFB',
+        )}</tr>` +
+        '</tbody></table>'
+      const hex = hexEncode('table:c1,c2')
+      const id = `${TABLE_BASE_PATH}|${hex}`
+      const input = `<div data-type="tableVariable" data-id="${id}">{{${id}}}</div>`
+      expect(simpleSubstitute(input, tableVarInfo)).toEqual(
+        `<div data-type="tableVariable" data-id="${id}">${expectedTable}</div>`,
+      )
+    })
+
+    it('simpleSubstitute leaves a table token as empty when there is no table data', () => {
+      const noTableInfo: VariableInfoMap = new Map([
+        [
+          `{{${TABLE_BASE_PATH}}}`,
+          { label: 'My table', testRunValue: '2 rows' },
+        ],
+      ])
+      const hex = hexEncode('table:c1')
+      const id = `${TABLE_BASE_PATH}|${hex}`
+      const input = `{{${id}}}`
+      expect(simpleSubstitute(input, noTableInfo)).toEqual('')
     })
   })
 

--- a/packages/frontend/src/components/RichTextEditor/utils.ts
+++ b/packages/frontend/src/components/RichTextEditor/utils.ts
@@ -49,6 +49,14 @@ export function simpleSubstitute(
 ): string {
   return original.replaceAll(GLOBAL_VARIABLE_REGEX, (match) => {
     const id = match.replace('{{', '').replace('}}', '')
+    // Table variables (id ends with a `|hexModifier`) resolve to the rendered
+    // HTML table, mirroring the backend's computeParameters. This keeps the
+    // substituted body in sync with the test execution's dataIn so the step's
+    // "set up successfully" check (matchParamsToDataIn) matches.
+    const tableHtml = renderTableVariableHtml(id, varInfo)
+    if (tableHtml != null) {
+      return tableHtml
+    }
     const varInfoForNode = varInfo.get(`{{${id}}}`)
     return varInfoForNode?.testRunValue || ''
   })


### PR DESCRIPTION
## Problem

When a pipe step contains a table variable, the frontend's `simpleSubstitute` function was not rendering table tokens to HTML. This caused a mismatch between the frontend's computed `dataIn.body` and the backend's `computeParameters` output, which in turn caused the "has anything changed since the last test?" check (`matchParamsToDataIn`) to incorrectly report that the step had not been set up successfully.

## Solution

`simpleSubstitute` now calls `renderTableVariableHtml` when it encounters a table variable token (identified by a `|hexModifier` suffix in the id). If the function returns HTML, that HTML is used as the substitution — mirroring what the backend's `computeParameters` does. If no table data is available, the token resolves to an empty string, consistent with prior behaviour for unknown variables.

**Bug Fixes**:

- Table variable tokens in `simpleSubstitute` are now replaced with their rendered HTML table, keeping the frontend's substituted body in sync with the backend's `dataIn` so the step's "set up successfully" check passes correctly.

## Tests

Two new unit tests cover the fix:

- `simpleSubstitute renders a table token to HTML, keeping the surrounding wrapper` — verifies that a `tableVariable` node's inner `{{token}}` is replaced with the expected HTML table while the outer `<div>` wrapper is preserved.
- `simpleSubstitute leaves a table token as empty when there is no table data` — verifies that a token with no matching table data resolves to an empty string.