### PR TITLE
PLU-770 (fix): handle MRF radiobutton Others value after v3 decryption

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
@@ -113,7 +113,52 @@ describe('processResponsesV3', () => {
       ])
     })
 
-    it.each(['radiobutton', 'email', 'mobile'])(
+    it('maps radiobutton field with answer from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'f1', title: 'Choice', fieldType: 'radiobutton' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        f1: { fieldType: 'radiobutton', answer: { value: 'Option 2' } },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'radiobutton',
+          question: 'Choice',
+          answer: 'Option 2',
+        },
+      ])
+    })
+
+    it('maps radiobutton Others selection to "Others: <othersInput>"', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'f1', title: 'Choice', fieldType: 'radiobutton' },
+        ]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        f1: {
+          fieldType: 'radiobutton',
+          answer: { othersInput: 'radio others' },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'radiobutton',
+          question: 'Choice',
+          answer: 'Others: radio others',
+        },
+      ])
+    })
+
+    it.each(['email', 'mobile'])(
       'maps %s fields with answer from answer.value',
       async (fieldType) => {
         mocks.fetchFormSchema.mockResolvedValueOnce(

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -3,12 +3,12 @@ import type { IGlobalVariable } from '@plumber/types'
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { DateTime } from 'luxon'
 
-const CHECKBOX_OTHERS_MARKER = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
-
 import logger from '@/helpers/logger'
 
 import type { FormSchemaField } from '../../common/types'
 import { fetchFormSchema } from '../../triggers/new-submission/fetch-form-schema'
+
+const CHECKBOX_OTHERS_MARKER = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
 
 export async function processResponsesV3(
   $: IGlobalVariable,
@@ -32,6 +32,7 @@ export async function processResponsesV3(
   }
   const mappedResponses: FormField[] = []
   let questionNumber = 0
+
   for (const [key, value] of Object.entries(responsesV3)) {
     questionNumber++
     if (value.fieldType === 'table') {
@@ -72,10 +73,25 @@ export async function processResponsesV3(
       })
       continue
     }
+    if (value.fieldType === 'radiobutton') {
+      // When "Others" is selected, the SDK returns { othersInput: '...' } with no value field
+      const answer =
+        value.answer.othersInput != null
+          ? `Others: ${value.answer.othersInput}`
+          : value.answer.value
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        // we fallback to Question # if the question is not found in the form schema
+        question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
+        answer,
+      })
+      continue
+    }
     /**
      * Similary, formv3 responses put these fields in value.answer.value
      */
-    if (['radiobutton', 'email', 'mobile'].includes(value.fieldType)) {
+    if (['email', 'mobile'].includes(value.fieldType)) {
       mappedResponses.push({
         _id: key,
         fieldType: value.fieldType,


### PR DESCRIPTION
## TL;DR

MRF radiobutton fields with "Others" selected were returning `undefined` as the answer. When "Others" is chosen, the v3 SDK returns `{ othersInput: '...' }` with no `value` field — unlike a normal selection which returns `{ value: 'Option X' }`. This fix handles both cases.

## What changed?

- **`process-v3-responses.ts`**: Split radiobutton out of the shared `['radiobutton', 'email', 'mobile']` handler into its own block. When `othersInput` is present, returns `Others: <othersInput>`; otherwise falls through to `value.answer.value`. Also cleans up two debug `console.log` statements and moves the `CHECKBOX_OTHERS_MARKER` constant to after all imports.
- **`process-v3-responses.test.ts`**: Added tests for radiobutton normal selection and radiobutton Others selection. Splits email/mobile into a separate `it.each`.

## Tests

- [ ] **Storage mode (v1/v2) — radiobutton with Others**: Submit a storage-mode FormSG form with a radiobutton field where "Others" is selected with custom text. Verify the Plumber trigger data shows `Others: <your text>` as the answer.
- [ ] **MRF (v3) — radiobutton normal selection**: Submit an MRF form with a radiobutton field where a regular option is selected. Verify the answer is the option label.
- [ ] **MRF (v3) — radiobutton with Others**: Submit an MRF form with a radiobutton field where "Others" is selected with custom text. Verify the Plumber trigger data shows `Others: <your text>` instead of `undefined`.