### PR TITLE
[FORMSG-V4-2] PLU-767: Support v4 responses

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3-or-v4.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-attachments-v3-or-v4.test.ts
@@ -3,7 +3,7 @@ import { IGlobalVariable, IRequest } from '@plumber/types'
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { decryptFormAttachmentsV3 } from '../../auth/decrypt-form-attachments-v3'
+import { decryptFormAttachmentsV3OrV4 } from '../../auth/decrypt-form-attachments-v3-or-v4'
 import { getSdk } from '../../common/form-env'
 
 const mocks = vi.hoisted(() => {
@@ -94,7 +94,7 @@ describe('decrypt form attachments v3', () => {
 
   describe('decrypt attachments v3', () => {
     it('should return decrypted attachments when attachmentDownloadUrls is present', async () => {
-      const result = await decryptFormAttachmentsV3(
+      const result = await decryptFormAttachmentsV3OrV4(
         formSgSdk,
         SUBMISSION_SECRET_KEY,
         $.request.body.data.attachmentDownloadUrls,
@@ -108,7 +108,7 @@ describe('decrypt form attachments v3', () => {
     })
 
     it('should return empty object when attachmentDownloadUrls is empty', async () => {
-      const result = await decryptFormAttachmentsV3(
+      const result = await decryptFormAttachmentsV3OrV4(
         formSgSdk,
         SUBMISSION_SECRET_KEY,
         {},
@@ -118,7 +118,7 @@ describe('decrypt form attachments v3', () => {
     })
 
     it('should return all attachments even if form fields are not present', async () => {
-      const result = await decryptFormAttachmentsV3(
+      const result = await decryptFormAttachmentsV3OrV4(
         formSgSdk,
         SUBMISSION_SECRET_KEY,
         $.request.body.data.attachmentDownloadUrls,
@@ -129,7 +129,7 @@ describe('decrypt form attachments v3', () => {
 
     it('should throw an error if decryption fails', async () => {
       await expect(
-        decryptFormAttachmentsV3(
+        decryptFormAttachmentsV3OrV4(
           formSgSdk,
           'Lrw9HdnQwiCE5umnmrIkhff60WKmMGXrCgtLXgdZtzs=', // invalid
           $.request.body.data.attachmentDownloadUrls,
@@ -141,7 +141,7 @@ describe('decrypt form attachments v3', () => {
     it('should throw an error if downloading fails', async () => {
       mocks.axiosGet.mockRejectedValueOnce(new Error('Download failed'))
       await expect(
-        decryptFormAttachmentsV3(
+        decryptFormAttachmentsV3OrV4(
           formSgSdk,
           SUBMISSION_SECRET_KEY,
           $.request.body.data.attachmentDownloadUrls,

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -7,6 +7,11 @@ import apps from '@/apps'
 import { decryptFormResponse } from '../../auth/decrypt-form-response'
 import type { FormsgPayloadWorkflowContent } from '../../common/types'
 
+import {
+  exampleV4Submission,
+  makeExampleV4FormSchema,
+} from './v4-submission.mock'
+
 // mocks hoisted here so that they can be used in import mocks
 const mocks = vi.hoisted(() => {
   const webhooksAuthenticate = vi.fn()
@@ -29,7 +34,7 @@ const mocks = vi.hoisted(() => {
     parseFormEnv: vi.fn(),
     storeAttachmentInS3: vi.fn(() => 'mock-s3-id'),
     fetchFormSchema: vi.fn(() => null),
-    decryptFormAttachmentsV3: vi.fn(() => ({})),
+    decryptFormAttachmentsV3OrV4: vi.fn(() => ({})),
   }
 })
 
@@ -53,8 +58,8 @@ vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
   fetchFormSchema: mocks.fetchFormSchema,
 }))
 
-vi.mock('../../auth/decrypt-form-attachments-v3', () => ({
-  decryptFormAttachmentsV3: mocks.decryptFormAttachmentsV3,
+vi.mock('../../auth/decrypt-form-attachments-v3-or-v4', () => ({
+  decryptFormAttachmentsV3OrV4: mocks.decryptFormAttachmentsV3OrV4,
 }))
 
 const MOCK_WORKFLOW: FormsgPayloadWorkflowContent['workflow'] = [
@@ -93,58 +98,60 @@ function makeWorkflowContent(
   }
 }
 
+function makeGlobalVariable(): IGlobalVariable {
+  return {
+    request: {
+      query: {
+        formId: 'something',
+      } as Record<string, string>,
+      headers: {
+        'x-formsg-signature': 'signature',
+      } as Record<string, string>,
+      body: {
+        data: {
+          submissionId: 'submissionId',
+          formId: 'formId123',
+          created: '2023-07-06T10:26:27.505Z',
+          version: 3,
+        },
+      },
+    } as IRequest,
+    auth: {
+      set: vi.fn(),
+      data: {
+        formId: 'something',
+        privateKey: 'secretkey',
+      },
+    },
+    step: {
+      id: '123',
+      appKey: apps.formsg.key,
+      position: 0,
+      parameters: {
+        nricFilter: undefined,
+      },
+    },
+    flow: {
+      id: 'flowid',
+      userId: 'userid',
+      hasFileProcessingActions: false,
+      name: 'test flow',
+    },
+    user: {
+      id: 'userid',
+      email: 'test-email@open.gov.sg',
+      createdAt: `${new Date().getTime()}`,
+      updatedAt: `${new Date().getTime()}`,
+    },
+    app: apps.formsg,
+  } as IGlobalVariable
+}
+
 describe('decrypt form response - MRF specific', () => {
   let $: IGlobalVariable
 
   beforeEach(() => {
-    $ = {
-      request: {
-        query: {
-          formId: 'something',
-        } as Record<string, string>,
-        headers: {
-          'x-formsg-signature': 'signature',
-        } as Record<string, string>,
-        body: {
-          data: {
-            submissionId: 'submissionId',
-            formId: 'formId123',
-            created: '2023-07-06T10:26:27.505Z',
-            version: 3,
-          },
-        },
-      } as IRequest,
-      auth: {
-        set: vi.fn(),
-        data: {
-          formId: 'something',
-          privateKey: 'secretkey',
-        },
-      },
-      step: {
-        id: '123',
-        appKey: apps.formsg.key,
-        key: 'newSubmission',
-        position: 0,
-        parameters: {
-          nricFilter: undefined,
-        },
-        version: 1,
-      },
-      flow: {
-        id: 'flowid',
-        userId: 'userid',
-        hasFileProcessingActions: false,
-        name: 'test flow',
-      },
-      user: {
-        id: 'userid',
-        email: 'test-email@open.gov.sg',
-        createdAt: `${new Date().getTime()}`,
-        updatedAt: `${new Date().getTime()}`,
-      },
-      app: apps.formsg,
-    }
+    $ = makeGlobalVariable()
   })
 
   afterEach(() => {
@@ -171,7 +178,7 @@ describe('decrypt form response - MRF specific', () => {
       expect(mocks.fetchFormSchema).toHaveBeenCalledWith($, 'formId123')
     })
 
-    it('should pass the decrypted submissionSecretKey to decryptFormAttachmentsV3 for v3 attachments', async () => {
+    it('should pass the decrypted submissionSecretKey to decryptFormAttachmentsV3OrV4 for v3 attachments', async () => {
       $.flow.hasFileProcessingActions = true
       $.request.body.data.attachmentDownloadUrls = {
         attachField1:
@@ -188,7 +195,7 @@ describe('decrypt form response - MRF specific', () => {
         },
         verified: undefined,
       })
-      mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+      mocks.decryptFormAttachmentsV3OrV4.mockResolvedValueOnce({
         attachField1: {
           filename: 'myfile.pdf',
           content: Buffer.from('file content'),
@@ -197,7 +204,7 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptFormAttachmentsV3).toHaveBeenCalledWith(
+      expect(mocks.decryptFormAttachmentsV3OrV4).toHaveBeenCalledWith(
         mocks.getSdk(),
         'mock-secret-key',
         {
@@ -229,7 +236,7 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
+      expect(mocks.decryptFormAttachmentsV3OrV4).not.toHaveBeenCalled()
     })
 
     it('should not call v3 attachment decryption when hasFileProcessingActions is false', async () => {
@@ -247,7 +254,125 @@ describe('decrypt form response - MRF specific', () => {
 
       await decryptFormResponse($)
 
-      expect(mocks.decryptFormAttachmentsV3).not.toHaveBeenCalled()
+      expect(mocks.decryptFormAttachmentsV3OrV4).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('v4 decryption path', () => {
+    // v4-shaped content is detected via the per-response `provenance` object
+    const V4_PROVENANCE = { submittedAt: '2023-07-06T10:26:27.505Z' }
+
+    it('should route a real v4 submission through processResponsesV4', async () => {
+      // schema titles come from the shared fixture's schema, not the
+      // responses' inline "[Myinfo] "-prefixed questions
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeExampleV4FormSchema())
+      mocks.cryptoV3Decrypt.mockReturnValueOnce(exampleV4Submission)
+
+      const result = await decryptFormResponse($)
+
+      expect(result).toEqual({ verified: true, internalId: 'submissionId' })
+
+      const fields = $.request.body.fields
+      expect(Object.keys(fields)).toHaveLength(54)
+
+      // MyInfo-prefilled text field; the { value } unwrap proves the v4
+      // branch was taken (the v3 path would have kept the answer object)
+      expect(fields['69eedf3b2e18526ffea6335c']).toEqual({
+        order: 1,
+        fieldType: 'textfield',
+        question: 'Name',
+        answer: 'AH KOW, TAN',
+      })
+      // date is reformatted dd/MM/yyyy → dd MMM yyyy
+      expect(fields['69eedf4120948ed94fae09b9']).toMatchObject({
+        fieldType: 'date',
+        question: 'Date of birth',
+        answer: '12 Jan 1980',
+      })
+      // radiobutton: regular option and others input
+      expect(fields['69eeddcf8844a134ddbadc56'].answer).toBe('Option 2')
+      expect(fields['69eeddd53c9ffa7a2b464687'].answer).toBe('Others: adg')
+      // checkbox: FormSG's internal others marker becomes "Others: <input>"
+      expect(fields['69eedde76df93497297710b1'].answerArray).toEqual([
+        'Option 2',
+        'Others: adw',
+        'Option 1',
+      ])
+      // verified email keeps only the value, not the verification signature
+      expect(fields['69eede812e18526ffea60af3']).toMatchObject({
+        fieldType: 'email',
+        answer: 'ahkow@open.gov.local',
+      })
+      // address goes through processLocalAddress (empty level + unit numbers
+      // are combined into one empty slot)
+      expect(fields['69eede9f2f788da6393fbd91'].answerArray).toEqual([
+        '123',
+        'TAN AH MENG ROAD',
+        '',
+        '',
+        '123456',
+      ])
+      // signature is summarised downstream and its points dropped
+      expect(fields['69eedeb17cfa1c89fc419340'].answer).toBe(
+        'Signature captured',
+      )
+      expect(fields['69eedeb17cfa1c89fc419340'].answerArray).toBeUndefined()
+      // table becomes a matrix plus a serialised table object
+      const table = fields['69eedec5fd2757b0584e0be5']
+      expect(table.question).toBe('Table (Column 1, Column 2)')
+      expect(table.answerArray).toEqual([
+        ['a', 'Option 1'],
+        ['b', 'Option 2'],
+      ])
+      expect(JSON.parse(table.answer).rows).toHaveLength(2)
+      // attachment keeps the filename (no file-processing actions configured)
+      expect(fields['69eedecafd2757b0584e0c54']).toMatchObject({
+        order: 54,
+        fieldType: 'attachment',
+        answer: 'Screenshot.png',
+      })
+      // the MRF "uinFin (Step N)" verified key maps back to uinFin/sgidUinFin
+      expect($.request.body.verifiedSubmitterInfo).toEqual({
+        uinFin: 'S1234567D',
+        sgidUinFin: 'S1234567D',
+      })
+    })
+
+    it('should produce a request body identical to the v3 path for equivalent content', async () => {
+      const $v3 = makeGlobalVariable()
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        responses: {
+          field1: { fieldType: 'textfield', answer: 'hello' },
+          field2: { fieldType: 'checkbox', answer: { value: ['a', 'b'] } },
+        },
+        verified: undefined,
+      })
+      await decryptFormResponse($v3)
+
+      // the same submission content, v4-shaped
+      const $v4 = makeGlobalVariable()
+      mocks.cryptoV3Decrypt.mockReturnValueOnce({
+        submissionSecretKey: 'mock-secret-key',
+        responses: {
+          field1: {
+            fieldType: 'textfield',
+            answer: { value: 'hello' },
+            question: 'Your name',
+            provenance: V4_PROVENANCE,
+          },
+          field2: {
+            fieldType: 'checkbox',
+            answer: { value: ['a', 'b'] },
+            question: 'Hobbies',
+            provenance: V4_PROVENANCE,
+          },
+        },
+        verified: undefined,
+      })
+      await decryptFormResponse($v4)
+
+      expect($v4.request.body).toEqual($v3.request.body)
+      expect($v3.request.body.fields.field1.answer).toBe('hello')
     })
   })
 
@@ -367,7 +492,7 @@ describe('decrypt form response - MRF specific', () => {
           },
           verified: undefined,
         })
-        mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+        mocks.decryptFormAttachmentsV3OrV4.mockResolvedValueOnce({
           attachmentField1: {
             filename: 'myfile.pdf',
             content: Buffer.from('file content'),
@@ -400,7 +525,7 @@ describe('decrypt form response - MRF specific', () => {
           },
           verified: undefined,
         })
-        mocks.decryptFormAttachmentsV3.mockResolvedValueOnce({
+        mocks.decryptFormAttachmentsV3OrV4.mockResolvedValueOnce({
           attachmentField1: {
             filename: 'myfile.pdf',
             content: Buffer.from('file content'),

--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v4-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v4-responses.test.ts
@@ -1,0 +1,864 @@
+// you need to import this to make the toPlumberFormat method available
+import '@/types/luxon-extensions'
+
+import type { IGlobalVariable } from '@plumber/types'
+
+import type {
+  AnswerV4,
+  FieldResponseV4,
+  FieldType,
+  FormFieldsV3,
+} from '@opengovsg/formsg-sdk'
+// value imports from the SDK must use the adapters subpath — the package
+// root's CJS entry only exposes the default factory at runtime
+import { adaptV3ToV4 } from '@opengovsg/formsg-sdk/adapters'
+import { describe, expect, it, vi } from 'vitest'
+
+import { processResponsesV3 } from '../../auth/helpers/process-v3-responses'
+import { processResponsesV4 } from '../../auth/helpers/process-v4-responses'
+
+import {
+  exampleV4Submission,
+  makeExampleV4FormSchema,
+} from './v4-submission.mock'
+
+const mocks = vi.hoisted(() => ({
+  fetchFormSchema: vi.fn(),
+  loggerError: vi.fn(),
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.loggerError,
+  },
+}))
+
+vi.mock('../../triggers/new-submission/fetch-form-schema', () => ({
+  fetchFormSchema: mocks.fetchFormSchema,
+}))
+
+function makeFormSchema(
+  fields: Array<{
+    _id: string
+    title: string
+    fieldType: string
+    columns?: Array<{ title: string; _id: string }>
+  }>,
+) {
+  return {
+    form: {
+      form_fields: fields,
+    },
+  }
+}
+
+// question and provenance are part of every v4 response, but processResponsesV4
+// derives the question from the form schema instead
+function v4Response(fieldType: FieldType, answer: unknown): FieldResponseV4 {
+  return {
+    fieldType,
+    answer: answer as AnswerV4,
+    question: 'ignored - question comes from the form schema',
+    provenance: { submittedAt: '2026-03-29T00:00:00.000Z' },
+  }
+}
+
+describe('processResponsesV4', () => {
+  const $ = {} as IGlobalVariable
+
+  describe('field type mapping', () => {
+    it('maps a simple text field using catch-all', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'field1', title: 'Your name', fieldType: 'textfield' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        field1: v4Response('textfield', { value: 'John' }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'field1',
+          fieldType: 'textfield',
+          question: 'Your name',
+          answer: 'John',
+        },
+      ])
+    })
+
+    it('maps yes_no fields using catch-all', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'yn1', title: 'Agree?', fieldType: 'yes_no' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        yn1: v4Response('yes_no', { value: 'Yes' }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'yn1',
+          fieldType: 'yes_no',
+          question: 'Agree?',
+          answer: 'Yes',
+        },
+      ])
+    })
+
+    it('maps checkbox fields with answerArray from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'cb1', title: 'Hobbies', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        cb1: v4Response('checkbox', {
+          value: ['reading', 'gaming'],
+          othersInput: 'hiking',
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'cb1',
+          fieldType: 'checkbox',
+          question: 'Hobbies',
+          answerArray: ['reading', 'gaming'],
+        },
+      ])
+    })
+
+    it('replaces the internal others marker with "Others: <othersInput>"', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'cb1', title: 'Hobbies', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        cb1: v4Response('checkbox', {
+          value: ['reading', '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'],
+          othersInput: 'custom hobby',
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'cb1',
+          fieldType: 'checkbox',
+          question: 'Hobbies',
+          answerArray: ['reading', 'Others: custom hobby'],
+        },
+      ])
+    })
+
+    it.each([
+      ['email', { value: 'test-value', signature: 'some-signature' }],
+      ['mobile', { value: 'test-value' }],
+    ] as const)(
+      'maps %s fields with answer from answer.value',
+      async (fieldType, answer) => {
+        mocks.fetchFormSchema.mockResolvedValueOnce(
+          makeFormSchema([{ _id: 'f1', title: 'Field', fieldType }]),
+        )
+
+        const result = await processResponsesV4($, 'formId', {
+          f1: v4Response(fieldType, answer),
+        })
+
+        expect(result).toEqual([
+          {
+            _id: 'f1',
+            fieldType,
+            question: 'Field',
+            answer: 'test-value',
+          },
+        ])
+      },
+    )
+
+    it('maps radiobutton field with answer from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'f1', title: 'Choice', fieldType: 'radiobutton' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('radiobutton', {
+          value: 'Option 2',
+          isOthersInput: false,
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'radiobutton',
+          question: 'Choice',
+          answer: 'Option 2',
+        },
+      ])
+    })
+
+    it('maps radiobutton Others selection to "Others: <value>"', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'rb1', title: 'Pick one', fieldType: 'radiobutton' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        rb1: v4Response('radiobutton', {
+          value: 'Custom answer',
+          isOthersInput: true,
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'rb1',
+          fieldType: 'radiobutton',
+          question: 'Pick one',
+          answer: 'Others: Custom answer',
+        },
+      ])
+    })
+
+    it('maps signature fields with answerArray from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'sig1', title: 'Sign here', fieldType: 'signature' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        sig1: v4Response('signature', {
+          type: 'draw',
+          value: [
+            [
+              [1, 2, 0.5],
+              [3, 4, 0.5],
+            ],
+          ],
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'sig1',
+          fieldType: 'signature',
+          question: 'Sign here',
+          answerArray: [
+            [
+              [1, 2, 0.5],
+              [3, 4, 0.5],
+            ],
+          ],
+        },
+      ])
+    })
+
+    it('maps address fields into ordered answerArray', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'addr1', title: 'Address', fieldType: 'address' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        // deliberately listed in SDK key order (postalCode first) to verify
+        // the output uses Plumber's order instead
+        addr1: v4Response('address', {
+          postalCode: { value: '189554' },
+          blockNumber: { value: '51' },
+          streetName: { value: 'Bras Basah Road' },
+          buildingName: { value: 'Lazada One' },
+          levelNumber: { value: '08' },
+          unitNumber: { value: '888' },
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'addr1',
+          fieldType: 'address',
+          question: 'Address',
+          answerArray: [
+            '51',
+            'Bras Basah Road',
+            'Lazada One',
+            '08',
+            '888',
+            '189554',
+          ],
+        },
+      ])
+    })
+
+    it('handles address with missing subfields gracefully', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'addr1', title: 'Address', fieldType: 'address' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        addr1: v4Response('address', {}),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'addr1',
+          fieldType: 'address',
+          question: 'Address',
+          answerArray: [
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+          ],
+        },
+      ])
+    })
+
+    it('maps attachment fields with the filename as answer', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'att1', title: 'Upload file', fieldType: 'attachment' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        att1: v4Response('attachment', {
+          value: 'document.pdf',
+          hasBeenScanned: true,
+          md5Hash: 'abc123',
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'att1',
+          fieldType: 'attachment',
+          question: 'Upload file',
+          answer: 'document.pdf',
+        },
+      ])
+    })
+  })
+
+  describe('children fields', () => {
+    it('reconstructs the v3 { child, childFields } answer shape', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'ch1', title: 'Your children', fieldType: 'children' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        ch1: v4Response('children', {
+          child0: {
+            value: {
+              name: { value: 'Alice', myInfo: { attr: 'childname' } },
+              dateofbirth: {
+                value: '01/01/2020',
+                myInfo: { attr: 'childdateofbirth' },
+              },
+            },
+          },
+          child1: {
+            value: {
+              name: { value: 'Bob', myInfo: { attr: 'childname' } },
+              dateofbirth: {
+                value: '02/02/2022',
+                myInfo: { attr: 'childdateofbirth' },
+              },
+            },
+          },
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'ch1',
+          fieldType: 'children',
+          question: 'Your children',
+          answer: {
+            child: [
+              ['Alice', '01/01/2020'],
+              ['Bob', '02/02/2022'],
+            ],
+            childFields: ['name', 'dateofbirth'],
+          },
+        },
+      ])
+    })
+
+    it('handles an empty children answer', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'ch1', title: 'Your children', fieldType: 'children' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        ch1: v4Response('children', {}),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'ch1',
+          fieldType: 'children',
+          question: 'Your children',
+          answer: { child: [], childFields: [] },
+        },
+      ])
+    })
+
+    it('fills missing child sub-field values with empty strings', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'ch1', title: 'Your children', fieldType: 'children' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        ch1: v4Response('children', {
+          child0: {
+            value: {
+              name: { value: 'Alice' },
+              vaxxstatus: { value: 'Vaccinated' },
+            },
+          },
+          child1: {
+            value: {
+              name: { value: 'Bob' },
+            },
+          },
+        }),
+      })
+
+      expect(result[0].answer).toEqual({
+        child: [
+          ['Alice', 'Vaccinated'],
+          ['Bob', ''],
+        ],
+        childFields: ['name', 'vaxxstatus'],
+      })
+    })
+  })
+
+  describe('table fields', () => {
+    it('maps keyed rows to a matrix sorted by rowNum', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          {
+            _id: 'tbl1',
+            title: 'Items',
+            fieldType: 'table',
+            columns: [
+              { title: 'Name', _id: 'col1' },
+              { title: 'Qty', _id: 'col2' },
+            ],
+          },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        tbl1: v4Response('table', {
+          // deliberately out of order to verify rowNum sorting
+          'row-b': { rowNum: 1, value: { col1: 'Banana', col2: '5' } },
+          'row-a': { rowNum: 0, value: { col1: 'Apple', col2: '3' } },
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'tbl1',
+          fieldType: 'table',
+          question: 'Items (Name, Qty)',
+          answerArray: [
+            ['Apple', '3'],
+            ['Banana', '5'],
+          ],
+        },
+      ])
+    })
+
+    it('stringifies numeric cell values', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'tbl1', title: 'Items', fieldType: 'table' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        tbl1: v4Response('table', {
+          'row-a': { rowNum: 0, value: { col1: 'Apple', col2: 3 } },
+        }),
+      })
+
+      expect(result[0].answerArray).toEqual([['Apple', '3']])
+    })
+
+    it('escapes commas in column titles', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          {
+            _id: 'tbl1',
+            title: 'Data',
+            fieldType: 'table',
+            columns: [
+              { title: 'First, Last', _id: 'col1' },
+              { title: 'Age', _id: 'col2' },
+            ],
+          },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        tbl1: v4Response('table', {
+          'row-a': { rowNum: 0, value: { col1: 'John Doe', col2: '30' } },
+        }),
+      })
+
+      expect(result[0].question).toBe('Data (First  Last, Age)')
+    })
+
+    it('does not append columns to question if schema has no columns', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'tbl1', title: 'Items', fieldType: 'table' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        tbl1: v4Response('table', {
+          'row-a': { rowNum: 0, value: { col1: 'Apple' } },
+        }),
+      })
+
+      expect(result[0].question).toBe('Items')
+    })
+  })
+
+  describe('question fallback', () => {
+    it('falls back to "Question N" when form schema has no matching field', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeFormSchema([]))
+
+      const result = await processResponsesV4($, 'formId', {
+        unknown1: v4Response('textfield', { value: 'hello' }),
+        unknown2: v4Response('textfield', { value: 'world' }),
+      })
+
+      expect(result[0].question).toBe('Question 1')
+      expect(result[1].question).toBe('Question 2')
+    })
+  })
+
+  describe('form schema fetch failure', () => {
+    it('logs error and falls back to question numbers when schema fetch fails', async () => {
+      mocks.fetchFormSchema.mockRejectedValueOnce(new Error('Network error'))
+
+      const result = await processResponsesV4($, 'formId', {
+        field1: v4Response('textfield', { value: 'test' }),
+      })
+
+      expect(mocks.loggerError).toHaveBeenCalledWith(
+        'Unable to fetch form schema',
+        expect.objectContaining({
+          event: 'formsg-unable-to-fetch-form-schema',
+          formId: 'formId',
+        }),
+      )
+      expect(result).toEqual([
+        {
+          _id: 'field1',
+          fieldType: 'textfield',
+          question: 'Question 1',
+          answer: 'test',
+        },
+      ])
+    })
+  })
+
+  describe('date fields', () => {
+    it('converts DD/MM/YYYY to DD MMM YYYY format', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        dt1: v4Response('date', { value: '29/03/2026' }),
+      })
+
+      expect(result[0]).toMatchObject({
+        _id: 'dt1',
+        fieldType: 'date',
+        question: 'Date of birth',
+        answer: '29 Mar 2026',
+      })
+    })
+
+    it('should pad single digit dates with 0 in front', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        dt1: v4Response('date', { value: '01/03/2026' }),
+      })
+
+      expect(result[0]).toMatchObject({
+        answer: '01 Mar 2026',
+      })
+    })
+
+    it('should use Sep not Sept for September', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'dt1', title: 'Date of birth', fieldType: 'date' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        dt1: v4Response('date', { value: '01/09/2026' }),
+      })
+
+      expect(result[0]).toMatchObject({
+        answer: '01 Sep 2026',
+      })
+    })
+
+    it('uses Question N fallback when field not in schema', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeFormSchema([]))
+
+      const result = await processResponsesV4($, 'formId', {
+        dt1: v4Response('date', { value: '01/01/2025' }),
+      })
+
+      expect(result[0].question).toBe('Question 1')
+      expect(result[0].answer).toBe('01 Jan 2025')
+    })
+  })
+
+  describe('multiple fields', () => {
+    it('processes mixed field types in order', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([
+          { _id: 'f1', title: 'Name', fieldType: 'textfield' },
+          { _id: 'f2', title: 'Email', fieldType: 'email' },
+          { _id: 'f3', title: 'Agree?', fieldType: 'checkbox' },
+        ]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('textfield', { value: 'John' }),
+        f2: v4Response('email', { value: 'john@example.com' }),
+        f3: v4Response('checkbox', { value: ['Yes'] }),
+      })
+
+      expect(result).toHaveLength(3)
+      expect(result[0]).toMatchObject({ _id: 'f1', answer: 'John' })
+      expect(result[1]).toMatchObject({
+        _id: 'f2',
+        answer: 'john@example.com',
+      })
+      expect(result[2]).toMatchObject({
+        _id: 'f3',
+        answerArray: ['Yes'],
+      })
+    })
+  })
+
+  describe('parity with processResponsesV3', () => {
+    // The real SDK adaptV3ToV4 is used purely as a test-data generator here:
+    // it turns the proven v3 fixtures into their official v4 equivalents.
+    // Production code never calls it.
+    it('produces identical output to processResponsesV3 for every field type', async () => {
+      // Notably absent: address with missing subfields (adaptV3ToV4 fills
+      // empty strings where the v3 path keeps undefined).
+      const v3Responses: FormFieldsV3 = {
+        f1: { fieldType: 'textfield', answer: 'John' },
+        f2: { fieldType: 'checkbox', answer: { value: ['reading', 'gaming'] } },
+        f3: { fieldType: 'radiobutton', answer: { value: 'option-1' } },
+        f4: {
+          fieldType: 'email',
+          answer: { value: 'john@example.com', signature: 'some-signature' },
+        },
+        f5: { fieldType: 'mobile', answer: { value: '+6591234567' } },
+        f6: {
+          fieldType: 'attachment',
+          answer: {
+            hasBeenScanned: true,
+            answer: 'document.pdf',
+            md5Hash: 'abc123',
+          },
+        },
+        f7: {
+          fieldType: 'table',
+          answer: [
+            { col1: 'Apple', col2: '3' },
+            { col1: 'Banana', col2: '5' },
+          ],
+        },
+        f8: {
+          fieldType: 'address',
+          answer: {
+            addressSubFields: {
+              blockNumber: '51',
+              streetName: 'Bras Basah Road',
+              buildingName: 'Lazada One',
+              levelNumber: '08',
+              unitNumber: '888',
+              postalCode: '189554',
+            },
+          },
+        },
+        f9: {
+          fieldType: 'signature',
+          answer: { type: 'draw', value: [[[1, 2, 0.5]]] },
+        },
+        f10: { fieldType: 'yes_no', answer: 'Yes' },
+        f11: {
+          fieldType: 'children',
+          answer: {
+            child: [
+              ['Alice', '01/01/2020'],
+              ['Bob', '02/02/2022'],
+            ],
+            childFields: ['name', 'dateofbirth'],
+          },
+        },
+        f12: { fieldType: 'date', answer: '29/03/2026' },
+        f13: { fieldType: 'nric', answer: 'S1234567A' },
+        f14: {
+          fieldType: 'radiobutton',
+          answer: { othersInput: 'radio others' },
+        },
+        f15: {
+          fieldType: 'checkbox',
+          answer: {
+            value: ['reading', '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'],
+            othersInput: 'custom hobby',
+          },
+        },
+      }
+
+      const schema = makeFormSchema([
+        { _id: 'f1', title: 'Name', fieldType: 'textfield' },
+        { _id: 'f2', title: 'Hobbies', fieldType: 'checkbox' },
+        { _id: 'f3', title: 'Pick one', fieldType: 'radiobutton' },
+        { _id: 'f4', title: 'Email', fieldType: 'email' },
+        { _id: 'f5', title: 'Mobile', fieldType: 'mobile' },
+        { _id: 'f6', title: 'Upload file', fieldType: 'attachment' },
+        {
+          _id: 'f7',
+          title: 'Items',
+          fieldType: 'table',
+          columns: [
+            { title: 'Name', _id: 'col1' },
+            { title: 'Qty', _id: 'col2' },
+          ],
+        },
+        { _id: 'f8', title: 'Address', fieldType: 'address' },
+        { _id: 'f9', title: 'Sign here', fieldType: 'signature' },
+        { _id: 'f10', title: 'Agree?', fieldType: 'yes_no' },
+        { _id: 'f11', title: 'Your children', fieldType: 'children' },
+        // f12 deliberately missing to also cover the Question N fallback
+        { _id: 'f13', title: 'NRIC', fieldType: 'nric' },
+        { _id: 'f14', title: 'Pick one (others)', fieldType: 'radiobutton' },
+        { _id: 'f15', title: 'Hobbies (others)', fieldType: 'checkbox' },
+      ])
+      mocks.fetchFormSchema
+        .mockResolvedValueOnce(schema)
+        .mockResolvedValueOnce(schema)
+
+      const expected = await processResponsesV3($, 'formId', v3Responses)
+
+      const v4Responses = adaptV3ToV4(v3Responses, {
+        provenance: { submittedAt: '2026-03-29T00:00:00.000Z' },
+      })
+      const actual = await processResponsesV4($, 'formId', v4Responses)
+
+      expect(actual).toEqual(expected)
+    })
+  })
+  describe('real v4 submission', () => {
+    it('maps every field of the shared real submission', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(makeExampleV4FormSchema())
+
+      const result = await processResponsesV4(
+        $,
+        'formId',
+        exampleV4Submission.responses,
+      )
+
+      expect(result).toHaveLength(54)
+      // every question is resolved from the schema — no "[Myinfo] " prefixes
+      // from the inline questions and no "Question N" fallbacks
+      for (const field of result) {
+        expect(field.question).not.toContain('[Myinfo]')
+        expect(field.question).not.toMatch(/^Question \d+$/)
+      }
+
+      const byId = (id: string) => result.find((field) => field._id === id)
+
+      // MyInfo-prefilled text field
+      expect(byId('69eedf3b2e18526ffea6335c')).toEqual({
+        _id: '69eedf3b2e18526ffea6335c',
+        fieldType: 'textfield',
+        question: 'Name',
+        answer: 'AH KOW, TAN',
+      })
+      // date is reformatted dd/MM/yyyy → dd MMM yyyy
+      expect(byId('69eedf4120948ed94fae09b9')?.answer).toBe('12 Jan 1980')
+      // radiobutton: regular option and others input
+      expect(byId('69eeddcf8844a134ddbadc56')?.answer).toBe('Option 2')
+      expect(byId('69eeddd53c9ffa7a2b464687')?.answer).toBe('Others: adg')
+      // checkbox: FormSG's internal others marker becomes "Others: <input>"
+      expect(byId('69eedde76df93497297710b1')?.answerArray).toEqual([
+        'Option 2',
+        'Others: adw',
+        'Option 1',
+      ])
+      // verified email keeps only the value, not the verification signature
+      expect(byId('69eede812e18526ffea60af3')?.answer).toBe(
+        'ahkow@open.gov.local',
+      )
+      // address keeps all six subfields in Plumber order at this level
+      // (processLocalAddress only runs downstream in decrypt-form-response)
+      expect(byId('69eede9f2f788da6393fbd91')?.answerArray).toEqual([
+        '123',
+        'TAN AH MENG ROAD',
+        '',
+        '',
+        '',
+        '123456',
+      ])
+      // signature keeps its raw draw points at this level
+      expect(byId('69eedeb17cfa1c89fc419340')?.answerArray).toEqual([
+        [
+          [167.8428955078125, 74.453125, 0.5],
+          [179.0538330078125, 73.73698425292969, 0.5],
+        ],
+      ])
+      // table rows become a matrix and the question gains the column suffix
+      expect(byId('69eedec5fd2757b0584e0be5')).toMatchObject({
+        question: 'Table (Column 1, Column 2)',
+        answerArray: [
+          ['a', 'Option 1'],
+          ['b', 'Option 2'],
+        ],
+      })
+      // attachment maps the filename into answer
+      expect(byId('69eedecafd2757b0584e0c54')?.answer).toBe('Screenshot.png')
+    })
+  })
+})

--- a/packages/backend/src/apps/formsg/__tests__/auth/v4-submission.mock.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/v4-submission.mock.ts
@@ -1,0 +1,717 @@
+import type { DecryptedContentV4 } from '@opengovsg/formsg-sdk'
+
+/**
+ * Shared by the decrypt-form-response.mrf and process-v4-responses tests.
+ * Kept in a separate file while processResponsesV3 still exists; once the v3
+ * path is removed, this can be inlined into the remaining v4 tests.
+ */
+export const exampleV4Submission: DecryptedContentV4 = {
+  submissionSecretKey: '5TJG9xzu4PSzq2Ba9OvwFwtP9tpsychfakesecretKey',
+  responses: {
+    '69eedf3b2e18526ffea6335c': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Name',
+      answer: {
+        value: 'AH KOW, TAN',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'name',
+      },
+    },
+    '69eedf3ee69ec0227d5b44a1': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Sex',
+      answer: {
+        value: 'MALE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'sex',
+      },
+    },
+    '69eedf4120948ed94fae09b9': {
+      fieldType: 'date',
+      question: '[Myinfo] Date of birth',
+      answer: {
+        value: '12/01/1980',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'dob',
+      },
+    },
+    '69eedf448962b17f28b5d6d3': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Race',
+      answer: {
+        value: 'CHINESE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'race',
+      },
+    },
+    '69eedf472e18526ffea6359a': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Nationality',
+      answer: {
+        value: 'SINGAPORE CITIZEN',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'nationality',
+      },
+    },
+    '69eedf4a20948ed94fae0af9': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Birth country',
+      answer: {
+        value: 'SINGAPORE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'birthcountry',
+      },
+    },
+    '69eedf4e6df9349729779884': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Residential Status',
+      answer: {
+        value: 'CITIZEN',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'residentialstatus',
+      },
+    },
+    '69eedf508844a134ddbb4da2': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Dialect',
+      answer: {
+        value: 'HOKKIEN',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'dialect',
+      },
+    },
+    '69eedf55e83627c17770e283': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Housing type',
+      answer: {
+        value: 'CONDOMINIUM',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'housingtype',
+      },
+    },
+    '69eedf589ebc72ac95a1c146': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] HDB type',
+      answer: {
+        value: '4-ROOM FLAT (HDB)',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'hdbtype',
+      },
+    },
+    '69eedf5cfd2757b0584e30a7': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Passport number',
+      answer: {
+        value: 'K1234567A',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'passportnumber',
+      },
+    },
+    '69eedf60e83627c17770e4e2': {
+      fieldType: 'date',
+      question: '[Myinfo] Passport expiry date',
+      answer: {
+        value: '01/01/2099',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'passportexpirydate',
+      },
+    },
+    '69eedf646f410b5fe8efa650': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Vehicle number',
+      answer: {
+        value: 'SBS9999A',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'vehno',
+      },
+    },
+    '69eedf688962b17f28b5ddc1': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Registered address',
+      answer: {
+        value: '123 TAN AH MENG ROAD, #15-20, SINGAPORE 123456',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'regadd',
+      },
+    },
+    '69eedf6c4c4123822c147e79': {
+      fieldType: 'mobile',
+      question: '[Myinfo] Mobile number',
+      answer: {
+        value: '+6597654321',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'mobileno',
+      },
+    },
+    '69eedf739ebc72ac95a1c630': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Occupation',
+      answer: {
+        value: 'SOFTWARE TEST CASE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'occupation',
+      },
+    },
+    '69eedf77c50e6bea6bfcf0e9': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Name of employer',
+      answer: {
+        value: 'PLUMBER',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'employment',
+      },
+    },
+    '69eedf7c12e0ebead02e428b': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Workpass status',
+      answer: {
+        value: 'Live',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'workpassstatus',
+      },
+    },
+    '69eedf81426d1b5cb465d8df': {
+      fieldType: 'date',
+      question: '[Myinfo] Workpass expiry date',
+      answer: {
+        value: '02/09/2098',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'workpassexpirydate',
+      },
+    },
+    '69eedf89fd2757b0584e3a9b': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Vehicle number',
+      answer: {
+        value: 'SBS9999A',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'vehno',
+      },
+    },
+    '69eedf91ed3e04f8606c401c': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Registered address',
+      answer: {
+        value: '123 TAN AH MENG ROAD, #15-20, SINGAPORE 123456',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'regadd',
+      },
+    },
+    '69eedf97e69ec0227d5b54ed': {
+      fieldType: 'mobile',
+      question: '[Myinfo] Mobile number',
+      answer: {
+        value: '+6597654321',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'mobileno',
+      },
+    },
+    '69eedf9dc50e6bea6bfcf974': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Occupation',
+      answer: {
+        value: 'Test Case (Special)',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'occupation',
+      },
+    },
+    '69eedfa120948ed94fae1f9f': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Name of employer',
+      answer: {
+        value: 'PLUMBER',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'employment',
+      },
+    },
+    '69eedfa58844a134ddbb622b': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Workpass status',
+      answer: {
+        value: 'Live',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'workpassstatus',
+      },
+    },
+    '69eedfb120948ed94fae2422': {
+      fieldType: 'date',
+      question: '[Myinfo] Workpass expiry date',
+      answer: {
+        value: '02/09/2098',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'workpassexpirydate',
+      },
+    },
+    '69eedfb5426d1b5cb465e1a4': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Marital status',
+      answer: {
+        value: 'SINGLE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'marital',
+      },
+    },
+    '69eedfb9d19891b7776ee43f': {
+      fieldType: 'dropdown',
+      question: '[Myinfo] Country of marriage',
+      answer: {
+        value: 'SINGAPORE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'countryofmarriage',
+      },
+    },
+    '69eedfbed19891b7776ee5be': {
+      fieldType: 'textfield',
+      question: '[Myinfo] Marriage cert. no.',
+      answer: {
+        value: 'ASDF',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'marriagecertno',
+      },
+    },
+    '69eedfc1d19891b7776ee6f8': {
+      fieldType: 'date',
+      question: '[Myinfo] Marriage date',
+      answer: {
+        value: '02/09/2010',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+      myInfo: {
+        attr: 'marriagedate',
+      },
+    },
+    '69eeddc9e69ec0227d5ae7e0': {
+      fieldType: 'textfield',
+      question: 'Short answer',
+      answer: {
+        value: 'ASDF',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddcb77a3d021a8cdce44': {
+      fieldType: 'textarea',
+      question: 'Long answer',
+      answer: {
+        value: 'ASDF',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddcf8844a134ddbadc56': {
+      fieldType: 'radiobutton',
+      question: 'Radio',
+      answer: {
+        value: 'Option 2',
+        isOthersInput: false,
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddd53c9ffa7a2b464687': {
+      fieldType: 'radiobutton',
+      question: 'Radio',
+      answer: {
+        value: 'adg',
+        isOthersInput: true,
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedde26f410b5fe8ef4683': {
+      fieldType: 'checkbox',
+      question: 'Checkbox',
+      answer: {
+        value: ['Option 2'],
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedde76df93497297710b1': {
+      fieldType: 'checkbox',
+      question: 'Checkbox',
+      answer: {
+        value: [
+          'Option 2',
+          '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!',
+          'Option 1',
+        ],
+        othersInput: 'adw',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddec1b3ae67c084a5f1b': {
+      fieldType: 'dropdown',
+      question: 'Dropdown',
+      answer: {
+        value: 'Option 1',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddf02f788da6393f970f': {
+      fieldType: 'rating',
+      question: 'Rating',
+      answer: {
+        value: '5',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eeddf42f788da6393f982e': {
+      fieldType: 'yes_no',
+      question: 'Yes/No',
+      answer: {
+        value: 'Yes',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede378844a134ddbaf4e8': {
+      fieldType: 'number',
+      question: 'Number',
+      answer: {
+        value: '1',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede4704aec0d4bc3eda9e': {
+      fieldType: 'decimal',
+      question: 'Decimal',
+      answer: {
+        value: '0.5',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede7804aec0d4bc3ee296': {
+      fieldType: 'date',
+      question: 'Date',
+      answer: {
+        value: '02/01/2914',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede868c2bfbb8748c75d3': {
+      fieldType: 'email',
+      question: 'Email',
+      answer: {
+        value: 'ahkow@open.gov.local',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede812e18526ffea60af3': {
+      fieldType: 'email',
+      question: 'Email',
+      answer: {
+        value: 'ahkow@open.gov.local',
+        signature:
+          'f=99eedd9b7cfa2c89fc415899,v=69eee0b21b3ae67c084af5fe,t=1777262773570,s=aWf2CiOKzsgV2HPNwAbjo60Na1fdEfvwtJS41S47TOvP0Y+pOk2OnyqH/OLFHRQP13rQDMVbVHtKvdDK9jo7A',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede8a426d1b5cb465a369': {
+      fieldType: 'mobile',
+      question: 'Mobile number',
+      answer: {
+        value: '+6597654321',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede9304aec0d4bc3ee7c7': {
+      fieldType: 'mobile',
+      question: 'Mobile number',
+      answer: {
+        value: '+6597654321',
+        signature:
+          'f=99eedd9b7cfa1c09fc415899,v=69eee0b51g1ae67c084af5fe,t=1777262791314,s=4GUZQbkSFFyCZ8WCNOk0NKNyBc+ty2J0mJoyBSyTvw64AWDCU0GOFyhjx8zPQuuCnWXx4RncrwsMok+2duWrBC',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede9a9fae78f997888a57': {
+      fieldType: 'homeno',
+      question: 'Home number',
+      answer: {
+        value: '+14527178579',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eede9f2f788da6393fbd91': {
+      fieldType: 'address',
+      question: 'Local address',
+      answer: {
+        postalCode: {
+          value: '123456',
+        },
+        blockNumber: {
+          value: '123',
+        },
+        streetName: {
+          value: 'TAN AH MENG ROAD',
+        },
+        buildingName: {
+          value: '',
+        },
+        levelNumber: {
+          value: '',
+        },
+        unitNumber: {
+          value: '',
+        },
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedea3d19891b7776ea8bc': {
+      fieldType: 'nric',
+      question: 'NRIC/FIN',
+      answer: {
+        value: 'S1234567D',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedea8cd86908422560589': {
+      fieldType: 'uen',
+      question: 'UEN',
+      answer: {
+        value: '200700940A',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedead7cfa1c89fc419280': {
+      fieldType: 'country_region',
+      question: 'Country/Region',
+      answer: {
+        value: 'SINGAPORE',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedeb17cfa1c89fc419340': {
+      fieldType: 'signature',
+      question: 'Signature',
+      answer: {
+        value: [
+          [
+            [167.8428955078125, 74.453125, 0.5],
+            [179.0538330078125, 73.73698425292969, 0.5],
+          ],
+        ],
+        type: 'draw',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedec5fd2757b0584e0be5': {
+      fieldType: 'table',
+      question: 'Table',
+      answer: {
+        'ea3a9336-ae9c-46ee-a544-df0a0f911d41': {
+          rowNum: 0,
+          value: {
+            '69eedec5fd2757b0584e0be6': 'a',
+            '69eedec5fd2757b0584e0be7': 'Option 1',
+          },
+        },
+        '7d7bbee6-9f68-445e-878d-84904eaacdde': {
+          rowNum: 1,
+          value: {
+            '69eedec5fd2757b0584e0be6': 'b',
+            '69eedec5fd2757b0584e0be7': 'Option 2',
+          },
+        },
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+    '69eedecafd2757b0584e0c54': {
+      fieldType: 'attachment',
+      question: 'Attachment',
+      answer: {
+        value: 'Screenshot.png',
+        hasBeenScanned: true,
+        // real payloads carry the digest as raw (non-printable) bytes;
+        // replaced with a fake hex digest since nothing reads it
+        md5Hash: 'd41d8cd98f00b204e9800998ecf8427e',
+      },
+      provenance: {
+        submittedAt: '2026-06-02T05:00:53.879Z',
+      },
+    },
+  },
+  verified: {
+    'uinFin (Step 1)': 'S1234567D',
+  },
+}
+
+export function makeExampleV4FormSchema() {
+  return {
+    form: {
+      form_fields: Object.entries(exampleV4Submission.responses).map(
+        ([_id, response]) => ({
+          _id,
+          fieldType: response.fieldType,
+          // Schema API doesn't have the "[Myinfo] " prefix
+          title: response.question.replace(/^\[Myinfo\] /, ''),
+          ...(response.fieldType === 'table' && {
+            columns: [
+              { title: 'Column 1', _id: '69eedec5fd2757b0584e0be6' },
+              { title: 'Column 2', _id: '69eedec5fd2757b0584e0be7' },
+            ],
+          }),
+        }),
+      ),
+    },
+  }
+}

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-attachments-v3-or-v4.ts
@@ -7,14 +7,18 @@ import logger from '@/helpers/logger'
 import { getSdk } from '../common/form-env'
 
 /**
- * Decrypts V3 form attachments from presigned S3 download URLs.
+ * Decrypts form attachments from presigned S3 download URLs.
+ *
+ * Works for both v3- and v4-shaped MRF submissions: attachments are
+ * encrypted the same way in both, with only the decrypted response shape
+ * differing (and that is handled upstream by processResponsesV3/V4).
  *
  * @param formSgSdk - The FormSG SDK instance
  * @param submissionSecretKey - The decrypted submission secret key (base64)
  * @param attachmentDownloadUrls - Map of field ID to presigned S3 download URL
  * @param formFields - All decrypted form fields - it will be filtered to attachment fields only later
  */
-export async function decryptFormAttachmentsV3(
+export async function decryptFormAttachmentsV3OrV4(
   formSgSdk: ReturnType<typeof getSdk>,
   submissionSecretKey: string,
   attachmentDownloadUrls: Record<string, string>,

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -1,5 +1,6 @@
 import type { IAuth, IGlobalVariable } from '@plumber/types'
 
+import { isFieldResponsesV4 } from '@opengovsg/formsg-sdk/adapters'
 import {
   DecryptedAttachments,
   DecryptedContent,
@@ -15,8 +16,9 @@ import { NricFilter } from '../triggers/new-submission/index'
 
 import { computeSubmissionTime } from './helpers/compute-submission-time'
 import { processResponsesV3 } from './helpers/process-v3-responses'
+import { processResponsesV4 } from './helpers/process-v4-responses'
 import storeAttachmentInS3 from './helpers/store-attachment-in-s3'
-import { decryptFormAttachmentsV3 } from './decrypt-form-attachments-v3'
+import { decryptFormAttachmentsV3OrV4 } from './decrypt-form-attachments-v3-or-v4'
 
 const NRIC_VERIFIED_FIELDS = new Set(['sgidUinFin', 'uinFin'])
 
@@ -111,22 +113,21 @@ export async function decryptFormResponse(
       return { verified: false, internalId: null }
     }
 
-    const responsesV3 = decryptedSubmission?.responses
-    const mappedResponses = await processResponsesV3(
-      $,
-      data.formId,
-      responsesV3,
-    )
+    const rawResponses = decryptedSubmission.responses
+    const mappedResponses = isFieldResponsesV4(rawResponses)
+      ? await processResponsesV4($, data.formId, rawResponses)
+      : // NOTE: V3 will be deprecated soon (tm)
+        await processResponsesV3($, data.formId, rawResponses)
 
     submission = {
       responses: mappedResponses,
-      verified: decryptedSubmission?.verified,
+      verified: decryptedSubmission.verified,
     }
 
     // shouldStoreAttachments should only consider steps after the mrf step instead of the whole pipe
     // but leaving it as such for now to avoid complexity
     if (shouldStoreAttachments && data.attachmentDownloadUrls) {
-      attachments = await decryptFormAttachmentsV3(
+      attachments = await decryptFormAttachmentsV3OrV4(
         formSgSdk,
         decryptedSubmission.submissionSecretKey,
         data.attachmentDownloadUrls,

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -10,6 +10,11 @@ import { fetchFormSchema } from '../../triggers/new-submission/fetch-form-schema
 
 const CHECKBOX_OTHERS_MARKER = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
 
+/**
+ * Moving to v4 soon (tm)
+ * @see processResponsesV4
+ * @deprecated
+ **/
 export async function processResponsesV3(
   $: IGlobalVariable,
   formId: string,

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v4-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v4-responses.ts
@@ -1,0 +1,200 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import type {
+  AddressAnswerV4,
+  AttachmentAnswerV4,
+  CheckboxAnswerV4,
+  ChildrenAnswerV4,
+  FieldResponsesV4,
+  FormField,
+  RadioAnswerV4,
+  SignatureAnswerV4,
+  StringAnswerV4,
+  TableAnswerV4,
+  VerifiableAnswerV4,
+} from '@opengovsg/formsg-sdk'
+import { DateTime } from 'luxon'
+
+import logger from '@/helpers/logger'
+
+import type { FormSchemaField } from '../../common/types'
+import { fetchFormSchema } from '../../triggers/new-submission/fetch-form-schema'
+
+const CHECKBOX_OTHERS_MARKER = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
+
+export async function processResponsesV4(
+  $: IGlobalVariable,
+  formId: string,
+  responses: FieldResponsesV4,
+): Promise<FormField[]> {
+  const formSchemaFields: Record<string, FormSchemaField> = {}
+  try {
+    const formSchema = await fetchFormSchema($, formId)
+    if (formSchema?.form?.form_fields) {
+      for (const field of formSchema.form.form_fields) {
+        formSchemaFields[field._id] = field
+      }
+    }
+  } catch (e) {
+    logger.error('Unable to fetch form schema', {
+      event: 'formsg-unable-to-fetch-form-schema',
+      formId,
+      error: e,
+    })
+  }
+  const mappedResponses: FormField[] = []
+  let questionNumber = 0
+  for (const [key, value] of Object.entries(responses)) {
+    questionNumber++
+    // we fallback to Question # if the question is not found in the form schema
+    let question = formSchemaFields[key]?.title ?? `Question ${questionNumber}`
+    if (value.fieldType === 'table') {
+      const tableAnswer = value.answer as TableAnswerV4
+      // v4 table answers are keyed by row id ({ rowId: { rowNum, value } });
+      // map back to a matrix ordered by rowNum, like the v3 array of rows
+      const answerArray = Object.values(tableAnswer)
+        .sort((a, b) => a.rowNum - b.rowNum)
+        .map((row) => Object.values(row.value).map(String))
+      // we follow the same format as the old table field title schema
+      if (formSchemaFields[key]?.columns) {
+        question += ` (${formSchemaFields[key]?.columns
+          ?.map((column) => column.title.replaceAll(',', ' '))
+          .join(', ')})`
+      }
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'checkbox') {
+      const checkboxAnswer = value.answer as CheckboxAnswerV4
+      const answerArray = checkboxAnswer.value.map((v) =>
+        v === CHECKBOX_OTHERS_MARKER
+          ? `Others: ${checkboxAnswer.othersInput}`
+          : v,
+      )
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'radiobutton') {
+      const radioAnswer = value.answer as RadioAnswerV4
+      // When "Others" is selected, isOthersInput is true and value holds the
+      // free-text input
+      const answer = radioAnswer.isOthersInput
+        ? `Others: ${radioAnswer.value}`
+        : radioAnswer.value
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answer,
+      })
+      continue
+    }
+    if (['email', 'mobile'].includes(value.fieldType)) {
+      const answer = value.answer as VerifiableAnswerV4
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answer: answer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'signature') {
+      const signatureAnswer = value.answer as SignatureAnswerV4
+      // signature points are only length-checked downstream, never read
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answerArray: signatureAnswer.value as unknown as string[][],
+      })
+      continue
+    }
+    if (value.fieldType === 'address') {
+      const addressAnswer = (value.answer ?? {}) as Partial<AddressAnswerV4>
+      // we need to map to [block number, street name, building name, level number, unit number, postal code]
+      const answerArray = [
+        addressAnswer.blockNumber,
+        addressAnswer.streetName,
+        addressAnswer.buildingName,
+        addressAnswer.levelNumber,
+        addressAnswer.unitNumber,
+        addressAnswer.postalCode,
+      ].map((subField) => subField?.value) as string[]
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answerArray,
+      })
+      continue
+    }
+    if (value.fieldType === 'attachment') {
+      const attachmentAnswer = value.answer as AttachmentAnswerV4
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        // we temporarily store the filename in answer, it will subsequently be replaced with the S3 ID from storeAttachmentInS3
+        answer: attachmentAnswer.value,
+      })
+      continue
+    }
+    if (value.fieldType === 'date') {
+      // Currently, v4 responses return the date as DD/MM/YYYY (e.g. 29/03/2026)
+      // We need to convert it to the standard FormSG date format (e.g. 29 Mar 2026)
+      const originalDateString = (value.answer as StringAnswerV4).value
+      const originalDate = DateTime.fromFormat(originalDateString, 'dd/MM/yyyy')
+      const convertedDateString = originalDate.toPlumberFormat('dd MMM yyyy')
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answer: convertedDateString,
+      })
+      continue
+    }
+    if (value.fieldType === 'children') {
+      const childrenAnswer = value.answer as ChildrenAnswerV4
+      // downstream consumers expect the v3 { child, childFields } shape for
+      // MyInfo children, so reconstruct it from the keyed v4 answer
+      const childKeys = Object.keys(childrenAnswer)
+      const childFields =
+        childKeys.length === 0
+          ? []
+          : Object.keys(childrenAnswer[childKeys[0]].value)
+      const child = childKeys.map((childKey) =>
+        childFields.map(
+          (attr) => childrenAnswer[childKey].value[attr]?.value ?? '',
+        ),
+      )
+      mappedResponses.push({
+        _id: key,
+        fieldType: value.fieldType,
+        question,
+        answer: { child, childFields } as unknown as string,
+      })
+      continue
+    }
+    // catch-all: generic string answers ({ value }) and any future field
+    // types, e.g. yes_no, textfield, dropdown, nric
+    mappedResponses.push({
+      _id: key,
+      fieldType: value.fieldType,
+      question,
+      answer: String((value.answer as StringAnswerV4).value),
+    })
+    continue
+  }
+  return mappedResponses
+}


### PR DESCRIPTION
# Problem

We want to support FormSG v4 schema it will supersede v3 (which we use for MRF now).

# Approach

See #1693.

# This PR

Implements code to parse and convert v4 schema to our `dataOut` format.

# Tests

We still need to be careful as FormSG is a critical integration. On UAT, MRF forms are serving the v4 schema.

For v4 forms,

- Check that we can decode every single FormSG v4 MRF form field using my kitchen sink MRF form ([6a2a75cd805eb0584c034c5c](https://uat.form.gov.sg/6a2a75cd805eb0584c034c5c)).
- Check that MyInfo still works for MRF v4
- Check that attachments work for all respondents in MRF v4
- Check that optional fields and attachments still work as expected in our variable dropdown.
- Check that raw payload is stored in S3 bucket, under the `debug` root object

Regression test for storage mode form:

- Check that we can decode every single FormSG **_storage_** mode form field using my kitchen sink form in UAT ([6a2a70a5805eb0584c033e70](https://uat.form.gov.sg/6a2a70a5805eb0584c033e70)).
    - Note that this still uses v1 schema.
- Check that MyInfo still works for storage mode forms
- Check that attachments still work for storage mode form
- Check that optional fields and attachments still work as expected in our variable dropdown.
- Check that raw payload is stored in S3 bucket, under the `debug` root object
- Check that payments still work

Regression test for MRF v3 (on prod form env)

- Check that we can decode every single FormSG MRF form field using my kitchen sink MRF form ([6a29410c5868eecc68121e1f](https://form.gov.sg/6a29410c5868eecc68121e1f)).
- Check that MyInfo still works for MRF
- Check that attachments work for all respondents in MRF
- Check that optional fields and attachments still work as expected in our variable dropdown.
- Check that raw payload is stored in S3 bucket, under the `debug` root object

# Disaster Mitigation

See #1693.