### PR TITLE
chore: add setup-production-monitoring skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,7 @@ Do **not** run these yourself unless the user asks — the human runs the dev se
 - **Package manager**: only use `npm`. Never use `yarn`, `pnpm`, or other package managers.
 - **Installing packages**: always pass the `-E` (exact version) flag.
 - **Linting**: before committing, run `npm run lint:fix` (auto-fixes), then `npm run lint` and fix remaining errors. Scope to the workspace you touched: backend-only changes → `npm run -w backend lint:fix`; frontend-only → `npm run -w frontend lint:fix`; otherwise run the root command.
+- **Production monitoring**: after completing a backend/frontend feature, offer to run the `setup-production-monitoring` skill to plan Datadog monitoring for it.
 - **Branches & PRs**: managed via Graphite (`gt`); use the `graphite` skill.
   - **Before `gt submit`** (do both, in this order):
     1. **Fix the branch name.** If the current branch doesn't match `feat/<…>` or `chore/<…>` (e.g. an auto-generated `claude/<slug>` worktree branch), rename it first: `git branch -m <name>` (works on untracked branches) or `gt rename <name>` (if already tracked). You **MUST** ask the user for the branch name whenever it is at all possible to ask — never auto-pick a name unless asking is genuinely impossible.
@@ -44,6 +45,8 @@ There are two kinds of skills, distinguished by whether they are listed in the s
 
 - **Upstream skills** — listed in `skills-lock.json`, installed via `skills add <repo> --skill <name> --agent claude-code -y`. Do **not** edit their files (`SKILL.md`, etc.); upstream updates may be merged later and would clobber local changes. Per-repo overrides to their behavior go in the "Skill overrides" section below (or in the relevant `rules/*.md` for package-scoped ones).
 - **Plumber-specific skills** — anything in `.claude/skills/` that is **not** in `skills-lock.json`. These are authored in-repo and are freely editable. Create one with `skills init <name>` from the directory whose `.claude/skills/` should host it (repo root for cross-cutting skills, package root for package-scoped ones).
+
+In-repo skills: `setup-production-monitoring` — plan production monitoring for a feature (grills on failure modes, finds existing signals in the code, outputs a plan + Datadog monitor JSON in chat).
 
 ### Skill overrides
 

--- a/.claude/skills/setup-production-monitoring/SKILL.md
+++ b/.claude/skills/setup-production-monitoring/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: setup-production-monitoring
+description: >
+  Plan production monitoring (Datadog) for a feature that was just built or is
+  being reviewed. First grills the author about likely failure modes, then
+  inspects the codebase to find existing metrics/traces/logs to reuse,
+  recommends the minimal instrumentation changes needed, and outputs a
+  human-readable monitoring plan plus Datadog monitor definitions as JSON. Use
+  after building/reviewing a backend or frontend feature, or when asked what to
+  monitor or to set up Datadog monitors/alerts on traces, logs, or RUM.
+---
+
+# Setup production monitoring
+
+Plan Datadog monitoring for a feature that was just built (or is under review).
+The deliverable is **in chat only**: a readable monitoring plan plus Datadog
+monitor definitions as JSON that a human applies. Never write monitor files
+into the repo.
+
+Hard rules (non-negotiable):
+
+- **Grill first.** No monitor design before failure modes are agreed with the
+  author.
+- **Minimize instrumentation.** Reuse signals that already exist before
+  proposing any code change; a new span/metric/log is a last resort.
+- **JSON in chat, human applies.** Never create monitors yourself — not via
+  files, not via any API or MCP tool.
+- **Datadog MCP is optional and read-only.** Every MCP step is gated on the
+  tools actually being connected (see [references/datadog-mcp.md](references/datadog-mcp.md)).
+  When absent, work purely from the code.
+- **Notifications always go to `@slack-plumber-alerts`.** No per-run routing
+  decisions.
+
+## Workflow
+
+### 1. Gather the change
+
+Establish what was built:
+
+- On a feature branch, prefer the branch diff vs `develop-v2`:
+  `git diff develop-v2...HEAD --stat`, then per-file diffs for the interesting
+  files.
+- If currently **on `develop-v2` itself**, or the diff vs `develop-v2` is
+  empty, ask the author which commit/ref to use as the base (e.g. the commit
+  before the feature landed).
+- If there is no usable diff at all, ask which files/feature to plan for.
+
+Classify the touched areas: backend (worker / webhook / REST / GraphQL /
+app plugin) vs frontend (RUM-relevant). This drives which signals and monitor
+types are in play.
+
+### 2. Grill on failure modes — BEFORE any monitoring design
+
+Follow [references/failure-mode-grilling.md](references/failure-mode-grilling.md):
+
+- **Derive first**: propose a candidate failure-mode table from the diff
+  (external calls, queue jobs, DB writes, webhooks, frontend mutations, plus
+  the Plumber-domain probes listed there).
+- **Then grill one question at a time**, only on what the code cannot answer:
+  blast radius, silent vs loud, expected baseline/volume, and how urgently a
+  human must know (page / ticket / dashboard-only). If a question is
+  answerable from the codebase, investigate instead of asking.
+- **Stop** when every plausible failure mode has an agreed severity and
+  desired human signal.
+
+### 3. Find reusable signals in the code (live discovery)
+
+Run the discovery recipe in
+[references/observability-stack.md](references/observability-stack.md): search
+the instrumentation idiom patterns (`tracer.wrap(`, `.addTags(`,
+`setOperationName(`, `logger.error(`/`logger.warn(`, `datadogRum.`) starting
+from the feature diff's files, widening to areas relevant to the agreed
+failure modes. Read the hits to enumerate the *current* span op-names, span
+tags, and log fields — never trust a remembered or hardcoded catalog. Note the
+file path where each signal is emitted so a human can confirm it is flowing in
+Datadog.
+
+**If the Datadog MCP is connected** (capability check per
+[references/datadog-mcp.md](references/datadog-mcp.md)), additionally verify
+each discovered signal is actually flowing via read-only span/log/metric/RUM
+searches, and mark each signal **verified** vs **unverified**. With no MCP
+(the default today), mark every signal as code-derived and move on — make no
+attempt to query Datadog.
+
+### 4. Decide minimal instrumentation
+
+Apply this priority order, stopping at the first level that can detect each
+agreed failure mode:
+
+0. **Zero-code signals Datadog already derives**: auto-generated trace metrics
+   (`trace.<operation>.hits/errors/duration`) from spans that already flow,
+   RUM auto-collected errors/resources/actions, and logs already emitted.
+1. **Reuse an existing custom metric/trace/log as-is.**
+2. **Add an attribute/tag to an *existing* span, or a field to an *existing*
+   log line.**
+3. **Last resort: a new span/metric/log.**
+
+Output a short **"Instrumentation changes"** list: only what is strictly
+needed, each item ranked by minimality, tied to a failure mode, and pointing
+at the exact file + idiom (e.g. "add a tag to the existing `addTags({...})`
+call in make-action-worker.ts", not "add a new span"). This skill only
+*recommends* these changes — it does not apply them.
+
+### 5. Produce monitors
+
+For each failure mode that warrants a human signal, choose a monitor type via
+[references/monitor-types.md](references/monitor-types.md). Prefer
+auto-generated trace metrics over indexed-span (trace-analytics) queries —
+span-tag queries only work if a custom retention filter indexes those spans,
+which code alone cannot confirm; flag that dependency whenever proposed.
+
+Emit **in chat** (never written to the repo):
+
+- a readable plan following
+  [templates/monitoring-plan.md](templates/monitoring-plan.md), and
+- **JSON** monitor definitions per the verified examples in
+  [references/monitor-types.md](references/monitor-types.md) — Datadog Monitor
+  API shape: `type`, `query` (**always scoped to `env:prod`**), `name`
+  (convention: `[Plumber] <feature>: <condition>`), `message` (always
+  notifying `@slack-plumber-alerts`), `options` (thresholds, evaluation
+  window, `notify_no_data`, `renotify_interval`, priority per the severity
+  rubric), `tags` (`service:plumber`, `feature:<slug>`).
+
+Note in the output that these are artifacts for a human to apply, and that
+queries are derived from code and should be confirmed against live Datadog
+data.
+
+**If the Datadog MCP is connected**, first check existing monitors/coverage
+read-only to avoid duplicates, and validate each definition with
+`validate_datadog_monitor` before presenting it — never create monitors.
+
+### 6. Wrap up
+
+End with:
+
+- the instrumentation to add first (if any) before the monitors are
+  meaningful, and
+- the open human decisions: exact thresholds, whether span-indexing/retention
+  covers any proposed span-tag query, and any signals still unverified in
+  Datadog.

--- a/.claude/skills/setup-production-monitoring/references/datadog-mcp.md
+++ b/.claude/skills/setup-production-monitoring/references/datadog-mcp.md
@@ -1,0 +1,85 @@
+# Datadog MCP — read-only usage, capability-gated
+
+The org plans to enable Datadog's MCP server **around July 2026**. This file
+ships ahead of that so the skill upgrades itself the day the tools appear.
+Until then the gate below simply never opens and the skill is purely
+code-based.
+
+## Team policy (hard rule)
+
+> **The Datadog MCP is read-only for this skill. Never call any tool that
+> creates, modifies, deletes, or executes anything in Datadog.** The output
+> contract is monitor JSON in chat; a human applies it. In particular, never
+> call `create_datadog_monitor` — not even though it creates "in draft mode" —
+> nor `create_datadog_notebook`, `edit_datadog_notebook`,
+> `upsert_datadog_dashboard`, `delete_datadog_dashboard`,
+> `execute_datadog_workflow`, or anything else prefixed
+> `create_` / `update_` / `edit_` / `delete_` / `execute_` / `sync_`.
+>
+> Changing this (e.g. letting the skill create draft monitors) is a deliberate
+> edit to this file via a reviewed PR — not an ad-hoc decision mid-run.
+
+`validate_datadog_monitor` is allowed: it validates a definition without
+creating anything.
+
+## Capability check (run once, at step 3)
+
+Datadog MCP tools are deferred like any MCP tools — check whether they are
+connected with a ToolSearch for `datadog` (expect names like
+`search_datadog_spans`, `search_datadog_logs`, `validate_datadog_monitor`,
+typically `mcp__<server>__`-prefixed).
+
+- **No Datadog tools found** (the default today): skip the rest of this file
+  entirely. Mark every discovered signal "code-derived — confirm in Datadog",
+  and make **no** attempt to query Datadog by any other means.
+- **Tools found**: load only the read-only tools needed below and weave them
+  into the corresponding skill steps.
+
+## Read-only usage by skill step
+
+Tool names below are from the Datadog MCP docs snapshot of **2026-06-12**
+(`docs.datadoghq.com/mcp_server/tools`); the default "core" toolset covers all
+of them unless noted. Verify against the live tool list on first use (see
+true-up note).
+
+### Step 3 — verify discovered signals are actually flowing
+
+For each signal found in the code, run one cheap read-only search scoped to
+`env:prod` over a recent window, and mark the signal **verified** (data seen)
+or **unverified** (no data — maybe new code not yet deployed, maybe wrong
+assumption; say which you suspect):
+
+- Spans / op-names / span tags → `search_datadog_spans` (or the APM toolset's
+  `apm_search_spans`; `apm_discover_span_tags` lists available span tag keys).
+- Trace metrics (`trace.<op>.hits` etc.) → `search_datadog_metrics` to confirm
+  the metric exists, `get_datadog_metric` (and `get_datadog_metric_context`
+  for available tag values) to confirm it has recent data.
+- Log lines / fields → `search_datadog_logs`.
+- RUM events / facets → `search_datadog_rum_events`.
+
+### Step 5 — avoid duplicates, then validate
+
+Before proposing monitors:
+
+- `search_datadog_monitors` — look for existing monitors on the same
+  metric/query or with a `[Plumber]`-prefixed name / `service:plumber` tag
+  covering the same failure mode. Propose *changes to* an existing monitor
+  rather than a duplicate where one exists.
+- `get_monitor_coverage` (alerting toolset, if enabled) — check for stated
+  coverage gaps on the service.
+
+For each monitor JSON about to be presented:
+
+- `validate_datadog_monitor` — validate the definition (type/query/options).
+  Fix what it rejects before presenting; note in the plan that definitions
+  were validated. If validation is unavailable, present anyway with the usual
+  "confirm against live Datadog" caveat.
+
+## First-run true-up
+
+When the MCP actually lands, run this skill once with it connected and
+**true-up this file**: confirm the tool names, prefixes, and toolset
+groupings above match the real tool surface (the docs snapshot may have
+drifted), fix anything that differs, and note the new verification date at
+the top of [monitor-types.md](monitor-types.md)'s Sources section if monitor
+validation reveals grammar drift there too.

--- a/.claude/skills/setup-production-monitoring/references/failure-mode-grilling.md
+++ b/.claude/skills/setup-production-monitoring/references/failure-mode-grilling.md
@@ -1,0 +1,93 @@
+# Failure-mode grilling
+
+Interview technique for step 2 of the skill. The goal is a **shared, agreed
+list of failure modes, each with a severity and a desired human signal** —
+before any monitor or instrumentation is designed. This file is
+self-contained; it does not depend on any other skill being installed.
+
+The style is **hypothesis-led, not purely Socratic**: derive candidate failure
+modes from the code first, present them, then grill only on what the code
+cannot answer.
+
+## Phase 1 — Derive first
+
+Analyse the feature diff and *propose* a candidate failure-mode table before
+asking anything. Derive candidates mechanically from what the code does:
+
+| If the diff contains… | Candidate failure modes |
+| --- | --- |
+| External API call (FormSG, M365, Postman, LetterSG, etc.) | timeout, 429 rate-limit, 5xx, auth/token expiry, malformed response |
+| Queue job (BullMQ) | retry exhaustion, queue backlog, poison message, job stuck/delayed |
+| DB write (Postgres/DynamoDB) | constraint violation, partial write, lost update, migration mismatch |
+| Webhook / trigger ingestion | silent drop, duplicate delivery, payload schema drift, signature failure |
+| Frontend mutation / new UI flow | failed request, stuck UI state, RUM error spike, broken redirect |
+| Scheduled / delayed work | missed run, run at wrong time, double run |
+| Feature flag / config branch | wrong branch taken in prod, flag never enabled |
+
+Then probe the **Plumber domain** specifically — for each candidate, ask
+yourself (and check the code for):
+
+- Does this failure **stall an execution** (execution stuck in progress,
+  never reaching success/failure)?
+- Does it **back up a queue** (jobs accumulating, rate limits saturated)?
+- Does it **silently drop a trigger event** (webhook acknowledged but no flow
+  run)?
+- Does it **write wrong data** (e.g. to a tile, a connection, an execution
+  step's dataOut) rather than failing loudly?
+- Does it degrade **only one third-party app** (FormSG, M365, Postman…) while
+  everything else looks healthy?
+- Does it break **user-facing notifications** (error emails, Slack messages)
+  so failures stop being reported at all?
+
+Present the result as a proposed table: *failure mode → how it manifests →
+loud or silent (best guess) → proposed severity*. Make clear these are
+hypotheses for the author to confirm, not conclusions.
+
+## Phase 2 — The grill loop
+
+Now interview the author **relentlessly, one question at a time**, waiting for
+an answer before the next question. Resolve dependencies between decisions one
+by one — don't move to a dependent question until its prerequisite is settled.
+For each question, give your recommended answer.
+
+**If a question can be answered from the codebase, investigate instead of
+asking.** Only ask what the code cannot tell you. The code usually *can*
+answer "does this throw or swallow errors", "is there a retry", "what's
+upstream/downstream"; it usually *cannot* answer impact, volume, or urgency.
+
+Dimensions to cover for each candidate failure mode:
+
+- **Blast radius / impact** — who/what is affected: one flow, one user's
+  flows, one app integration, or everyone? Is data lost or merely delayed?
+- **Silent vs loud** — does it throw (caught by existing error handling,
+  worker `failed` events, RUM error tracking), or does it produce a
+  wrong-but-quiet outcome? Silent failures need the most scrutiny — they're
+  the ones existing signals likely miss.
+- **Partial failures** — can it half-succeed (some rows written, some steps
+  run)? What does the half-done state look like?
+- **Expected baseline / volume** — roughly how often does this code path run
+  in production (per minute/hour/day)? A monitor on a path that runs 5×/day
+  needs very different thresholds and windows from one running 100×/min.
+- **Retries** — is the failure retried (BullMQ retry, user retry)? Does a
+  retry mask it, or amplify it (duplicates)?
+- **Downstream / third-party dependencies** — whose failure is this really?
+  Can we distinguish "their outage" from "our bug"?
+- **Data correctness vs availability** — is the bad outcome "feature is
+  down" or "feature is up but wrong"? Wrong-data failures usually need a
+  different signal than error counts.
+- **Severity → desired human signal** — the crucial one. For each failure
+  mode, agree how urgently a human must know:
+  - **page** — wake someone / act within minutes,
+  - **ticket** — act within a day,
+  - **dashboard-only** — visible when someone looks, no notification.
+
+## Stop condition
+
+The grill is done when **every plausible failure mode has an agreed severity
+and a desired human signal** (page / ticket / dashboard-only). Failure modes
+the author explicitly rules out as implausible or not worth monitoring are
+recorded as such (they go in the plan's "Open decisions / explicitly not
+monitored" section, so the decision is visible).
+
+Carry the agreed table into step 3 (signal discovery) — the failure modes
+determine *where* to widen the code search and *which* signals matter.

--- a/.claude/skills/setup-production-monitoring/references/monitor-types.md
+++ b/.claude/skills/setup-production-monitoring/references/monitor-types.md
@@ -1,0 +1,264 @@
+# Datadog monitor types — choosing and emitting JSON
+
+How to pick a monitor type for each agreed failure mode, and the **verified**
+JSON shapes to emit. Everything here is the Datadog Monitor API body shape
+(`POST /api/v1/monitor`) — emitted **in chat** for a human to apply, never
+written to the repo, never created via API/MCP.
+
+Verified against Datadog sources on **2026-06-12** (see [Sources](#sources)).
+If a query is rejected when a human applies it, trust Datadog over this doc —
+and fix this doc.
+
+## Signal → monitor type cheat-sheet
+
+| To detect… | Use | `type` | Depends on |
+| --- | --- | --- | --- |
+| Errors / throughput / latency of an instrumented operation | **Auto-generated trace metrics** `trace.<op>.errors` / `.hits` / latency | `query alert` | A span with that op-name flowing (e.g. `tracer.wrap('workers.action', …)`). **No retention dependency — prefer this.** |
+| A log line or log-field threshold | Log monitor over indexed logs | `log alert` | The `logger.error/warn/info` call existing; logs being indexed (standard tier; max evaluation window 2 days) |
+| A condition on **span tags** (`flowId`, `appKey`, …) | Trace-analytics (indexed spans) | `trace-analytics alert` | Span tags exist **and** a custom retention filter indexes those spans — **code cannot confirm this; always flag it** |
+| Frontend errors / user impact | RUM monitor | `rum alert` | RUM auto-collection (already on in prod, 100% sampling, post-consent) |
+| Deviation from a seasonal/trending baseline | `anomalies()` wrapper on any metric query | `query alert` | Same as the underlying metric |
+| "It stopped happening" (heartbeat) | Low-threshold `below` condition or `notify_no_data` on the relevant metric/log count | (same as base type) | Expected baseline volume — confirm with the author |
+
+**Preference order: trace metrics → log monitor → trace-analytics.**
+Auto-generated trace metrics always exist for spans that flow and survive any
+retention config. Trace-analytics monitors "only evaluate spans retained by
+custom retention filters (not the intelligent retention filter)" — a span-tag
+query that looks right in code may silently match nothing.
+
+Anomaly monitors fit metrics with strong trends/recurring patterns where a
+static threshold goes stale; plain thresholds are easier to reason about —
+default to thresholds unless the author confirmed seasonality.
+
+## Conventions (bake into every monitor)
+
+- `query` — always scoped to `env:prod` (plus `service:plumber` where the
+  data source carries it).
+- `name` — `[Plumber] <feature>: <condition>`.
+- `message` — what broke + first-response hint, ending with
+  `@slack-plumber-alerts`. No other routing.
+- `tags` — `["service:plumber", "feature:<feature-slug>"]`.
+- `priority` — 1 (highest) to 5 (lowest), per the severity rubric below.
+
+## Severity rubric (from the grilled urgency)
+
+| Agreed urgency | `priority` | `renotify_interval` | Other options |
+| --- | --- | --- | --- |
+| **Page** — act within minutes | 1–2 | 10–30 (min; aggressive) | Consider `escalation_message`; `notify_no_data: true` *only if* absence of data is itself the failure |
+| **Ticket** — act within a day | 3 | omit (no renotify) | Sustained evaluation window (10–15m+) |
+| **Dashboard-only** | — | — | **No monitor.** Suggest a dashboard widget instead (or a muted monitor if the author insists) |
+
+Noise avoidance defaults:
+
+- Require a **sustained** breach: prefer 10–15m windows over 1–5m spikes
+  unless the failure mode is genuinely page-on-first-occurrence.
+- `notify_no_data: false` unless absence-of-data **is** the failure (then set
+  `no_data_timeframe`, in minutes, ≥ 2× the evaluation window).
+- For sparse/low-volume count metrics, set `require_full_window: false` so
+  evaluation doesn't stall waiting for a full window of data.
+- For counts, set `warning` below `critical` to give a pre-page signal.
+
+## Verified examples, per type
+
+The query grammars below are quoted from the Monitor API docs / Datadog-authored
+examples; placeholders are marked with `<…>`. Operation names like
+`workers.action` are illustrative — use the op-names/tags/fields actually
+discovered in step 3.
+
+### 1. Metric monitor on auto-generated trace metrics (`query alert`) — preferred
+
+Grammar: `time_aggr(time_window):space_aggr:metric{tags} [by {key}] operator #`
+— `time_aggr`: avg/sum/max/min/change/pct_change; `time_window`: `last_#m`
+(1–10080) / `last_#h` (1–168) / `last_1d` / `last_1w`; `space_aggr`:
+avg/sum/min/max; operators `<, <=, >, >=, ==, !=`.
+
+Trace metrics exist automatically per span op-name: `trace.<op>.hits` (count),
+`trace.<op>.errors` (count), `trace.<op>` (latency distribution; p50–p99
+available) and legacy `trace.<op>.duration` (gauge). Tags include `env`,
+`service`, `resource_name`, `version`. For count metrics use `.as_count()` so
+sums aggregate before any division.
+
+```json
+{
+  "name": "[Plumber] <feature>: workers.action errors elevated",
+  "type": "query alert",
+  "query": "sum(last_10m):sum:trace.workers.action.errors{env:prod,service:plumber}.as_count() > 5",
+  "message": "Action worker executions are failing for <feature>. Check the workers.action APM traces and correlated logs (trace IDs are injected). Value: {{value}}.\n\n@slack-plumber-alerts",
+  "tags": ["service:plumber", "feature:<feature-slug>"],
+  "priority": 3,
+  "options": {
+    "thresholds": { "critical": 5, "warning": 3 },
+    "notify_no_data": false,
+    "require_full_window": false,
+    "include_tags": true
+  }
+}
+```
+
+Error-**rate** variant (verified ratio form — aggregate before division):
+
+```
+sum(last_15m):sum:trace.workers.action.errors{env:prod,service:plumber}.as_count() / sum:trace.workers.action.hits{env:prod,service:plumber}.as_count() > 0.05
+```
+
+Latency variant: `avg(last_10m):avg:trace.workers.action{env:prod,service:plumber} > <seconds>`
+(percentile aggregations p50/p75/p90/p99 are available on the latency
+distribution; confirm the unit — seconds — against the metric summary before
+picking a threshold).
+
+### 2. Log monitor (`log alert`)
+
+Grammar: `logs(query).index(index_name).rollup(rollup_method[, measure]).last(time_window) operator #`
+— `query` uses Log Explorer search syntax; `rollup_method`:
+count/avg/cardinality; `time_window`: `#m` (1–2880) / `#h` (1–48). Winston
+levels surface as the `status` facet (`status:error`). Only **indexed** logs
+are evaluated; max window 2 days. To alert on "logs stopped", use a `below 1`
+condition instead of `notify_no_data`.
+
+```json
+{
+  "name": "[Plumber] <feature>: <error message> logged",
+  "type": "log alert",
+  "query": "logs(\"service:plumber env:prod status:error \\\"<distinctive message substring>\\\"\").index(\"*\").rollup(\"count\").last(\"10m\") > 5",
+  "message": "The <feature> code path at <file.ts> is logging errors. Inspect the log attributes (e.g. @queueName, @err) and the correlated trace.\n\n@slack-plumber-alerts",
+  "tags": ["service:plumber", "feature:<feature-slug>"],
+  "priority": 3,
+  "options": {
+    "thresholds": { "critical": 5 },
+    "enable_logs_sample": true,
+    "notify_no_data": false
+  }
+}
+```
+
+Note: the verified Datadog examples pin a named index (`.index("main")` /
+`.index("default")`); `.index("*")` queries all indexes. If validation rejects
+`"*"`, set the org's actual index name. Confirm facet names (`service`, `env`,
+custom `@…` attributes) in Log Explorer — log facets depend on pipeline
+config, which code cannot see.
+
+### 3. Trace-analytics monitor (`trace-analytics alert`) — span-tag queries; retention-gated
+
+Verified query shape (Datadog-authored example):
+`trace-analytics("env:prod operation_name:pylons.request").rollup("count").by("*").last("5m") > 100`.
+Custom span tags (added via `.addTags({…})`) are queried as `@<tag>` facets.
+
+> **Retention dependency — always flag this.** Trace-analytics monitors only
+> evaluate spans retained by **custom retention filters** (not the intelligent
+> retention filter). A human must confirm a retention filter indexes the
+> relevant spans, or this monitor evaluates nothing. If unconfirmed, prefer a
+> trace-metric monitor (type 1) plus a log monitor (type 2).
+
+```json
+{
+  "name": "[Plumber] <feature>: errors for appKey <app>",
+  "type": "trace-analytics alert",
+  "query": "trace-analytics(\"env:prod service:plumber operation_name:workers.action @appKey:<app> status:error\").rollup(\"count\").last(\"10m\") > 5",
+  "message": "workers.action spans tagged @appKey:<app> are erroring — likely <feature> / third-party degradation. NOTE: this monitor requires a retention filter indexing these spans.\n\n@slack-plumber-alerts",
+  "tags": ["service:plumber", "feature:<feature-slug>"],
+  "priority": 3,
+  "options": {
+    "thresholds": { "critical": 5 },
+    "notify_no_data": false
+  }
+}
+```
+
+### 4. RUM monitor (`rum alert`)
+
+Verified query shape (Datadog-authored example):
+`rum("*").rollup("count").by("@type").last("5m") >= 5`. The search query uses
+RUM Explorer syntax; `@type` selects the event type (e.g. `@type:error`).
+
+```json
+{
+  "name": "[Plumber] <feature>: frontend error spike",
+  "type": "rum alert",
+  "query": "rum(\"@type:error service:plumber env:prod <view/action filter>\").rollup(\"count\").last(\"15m\") > 10",
+  "message": "RUM errors spiking on the <feature> UI. Check RUM error tracking for the offending view/action; session replay is on.\n\n@slack-plumber-alerts",
+  "tags": ["service:plumber", "feature:<feature-slug>"],
+  "priority": 3,
+  "options": {
+    "thresholds": { "critical": 10 },
+    "notify_no_data": false
+  }
+}
+```
+
+Confirm facet names in the RUM Explorer (e.g. `@view.name`, `@action.name`)
+before applying. RUM only records sessions after tracking consent (login), so
+baselines exclude pre-login traffic.
+
+### 5. Anomaly monitor (`query alert` + `anomalies()`)
+
+Verified signature:
+`avg(<query_window>):anomalies(<metric_query>, '<algorithm>', <deviations>, direction='<direction>', alert_window='<alert_window>', interval=<interval>, count_default_zero='true') >= 1`
+— algorithm: `basic` / `agile` / `robust`; direction: `above` / `below` /
+`both`. Verified docs example:
+`avg(last_1h):anomalies(avg:system.cpu.system{name:cassandra}, 'basic', 3, direction='above', alert_window='last_5m', interval=20, count_default_zero='true') >= 1`.
+
+Use for e.g. "throughput dropped below its normal pattern" when the author
+confirmed seasonality (weekday/weekend cycles):
+
+```json
+{
+  "name": "[Plumber] <feature>: workers.action throughput anomalously low",
+  "type": "query alert",
+  "query": "avg(last_1h):anomalies(sum:trace.workers.action.hits{env:prod,service:plumber}.as_count(), 'basic', 3, direction='below', alert_window='last_15m', interval=60, count_default_zero='true') >= 1",
+  "message": "Action executions dropped below the expected pattern — possible silent trigger/webhook drop upstream of <feature>.\n\n@slack-plumber-alerts",
+  "tags": ["service:plumber", "feature:<feature-slug>"],
+  "priority": 3,
+  "options": {
+    "thresholds": { "critical": 1.0 },
+    "notify_no_data": false,
+    "renotify_interval": 0
+  }
+}
+```
+
+Datadog recommends building anomaly monitors in the UI (preview graphs +
+auto-tuning) and exporting JSON — say so in the plan when proposing one.
+
+## Common `options` fields (verified meanings)
+
+| Field | Meaning |
+| --- | --- |
+| `thresholds.critical` / `.warning` | Alert / warn values; `critical` must match the threshold in the query string |
+| `notify_no_data` (default false) | Alert when data stops reporting — only where absence is itself the failure |
+| `no_data_timeframe` | Minutes before a no-data alert (default ~10; use ≥ 2× evaluation window) |
+| `renotify_interval` | Minutes between re-notifications while unresolved; omit/0 = no renotify |
+| `evaluation_delay` | Metric alerts only; seconds to delay evaluation for late-arriving data |
+| `new_group_delay` | Seconds to skip evaluation for newly-appearing groups (multi-alert) |
+| `require_full_window` (default true) | Set false for sparse metrics |
+| `include_tags` (default true) | Put triggering tags in the alert title |
+| `timeout_h` | Hours until a triggered state auto-resolves |
+
+## Monitor `type` values (verified enum, for reference)
+
+`query alert` (metric, anomaly, outlier, forecast), `log alert`,
+`trace-analytics alert` (APM can also use `query alert` for trace metrics),
+`rum alert`, `error-tracking alert`, `event-v2 alert`, `service check`,
+`process alert`, `composite`, `slo alert`, `audit alert`, plus CI/cost/DBM/
+network variants not relevant here. `metric alert` is a legacy synonym of
+`query alert` — emit `query alert`.
+
+## Sources
+
+Authored 2026-06-12 from:
+
+- Monitor API v1 OpenAPI spec (`DataDog/datadog-api-client-python`,
+  `.generator/schemas/v1/openapi.yaml`) — type mapping, metric & log query
+  grammars, options, full create example.
+- `DataDog/datadog-api-client-python` `examples/v1/monitors/CreateMonitor*.py`
+  — verbatim log-alert and RUM (formula) create bodies.
+- `DataDog/datadog-operator` `examples/datadogmonitor/*.yaml` — verbatim
+  trace-analytics, rum, and log alert queries.
+- `docs.datadoghq.com/monitors/types/{metric,log,apm,real_user_monitoring,anomaly}` —
+  aggregations, log/trace-analytics constraints, retention-filter dependency,
+  `anomalies()` signature.
+- `docs.datadoghq.com/monitors/guide/as-count-in-monitor-evaluations` —
+  `.as_count()` ratio form.
+- `docs.datadoghq.com/tracing/metrics/metrics_namespace` — trace metric names
+  and tags.
+- `DataDog/terraform-provider-datadog` `docs/resources/monitor.md` — options
+  defaults and full type enum.

--- a/.claude/skills/setup-production-monitoring/references/observability-stack.md
+++ b/.claude/skills/setup-production-monitoring/references/observability-stack.md
@@ -1,0 +1,84 @@
+# Plumber observability stack — discovery recipe
+
+How to enumerate the signals (spans, span tags, log lines/fields, RUM events)
+that *currently* exist in the code. This file deliberately contains **no
+catalog of individual spans/tags/log-fields and no list of entry-point
+files** — both drift as code is added. The only stable anchor is the
+instrumentation **idiom/API surface**; everything else is discovered live at
+planning time by grepping for the idioms and reading the hits.
+
+## Idiom patterns (the stable contract)
+
+Grepping for these finds all current call sites in any file, including files
+that didn't exist when this doc was written:
+
+| Idiom | What it produces in Datadog |
+| --- | --- |
+| `tracer.wrap('<op.name>', …)` | A span named `<op.name>` → Datadog auto-generates trace metrics `trace.<op.name>.hits` / `.errors` and a latency distribution, with zero extra code and no retention dependency |
+| `tracer.scope().active()` + `span?.addTags({…})` | Tags on the active span → only queryable in monitors via indexed spans (trace-analytics), which needs a custom retention filter |
+| `span?.setOperationName('<op.name>')` | Renames the active span's operation (same effect as `tracer.wrap` for metric naming) |
+| `tracer.setUser({…})` | User attribution on the trace |
+| `logger.error('msg', {…})` / `logger.warn(…)` / `logger.info(…)` / `logger.http(…)` | A winston log line; in prod it is JSON, the metadata object's keys become log attributes, the level becomes the `status` facet |
+| `datadogRum.<anything>` | Frontend RUM usage beyond the auto-collected events |
+
+## Discovery procedure
+
+1. **Search for the idioms, starting from the feature diff's files** (known
+   from step 1 of the skill), then **widen** to the areas implicated by the
+   agreed failure modes (e.g. the worker/queue helpers if a failure mode is
+   "retry exhaustion", the relevant `apps/<key>/` dir if it is scoped to one
+   app). Note that not every app under `apps/` is a third-party integration —
+   some (e.g. `toolbox`, `delay`) are core Plumber features packaged as apps
+   for UX. "Third-party degradation" failure modes only apply to apps whose
+   triggers/actions call an external service; read the app's code to tell
+   which kind it is. Exclude worktree copies and tests:
+
+   ```sh
+   rg -n "tracer\.wrap\(|setOperationName\(|\.addTags\(|tracer\.setUser\(" \
+     packages/backend/src -g '!**/*.test.ts' -g '!**/*.itest.ts'
+
+   rg -n "logger\.(error|warn|info|http)\(" <relevant dirs/files> \
+     -g '!**/*.test.ts' -g '!**/*.itest.ts'
+
+   rg -n "datadogRum\." packages/frontend/src
+   ```
+
+   When searching from the repo root, also pass `-g '!.claude/worktrees/**'` —
+   worktree copies under `.claude/worktrees/` duplicate every hit.
+
+2. **Read the matching files** to extract the live signal inventory:
+   span op-names, the exact keys passed to `.addTags({…})`, the message +
+   metadata fields of relevant `logger.*` calls, and any custom RUM calls.
+   Record **where each signal is emitted (file path)** so a human can confirm
+   it is actually flowing in Datadog — code proves the signal is *emitted*,
+   not that it is *retained or indexed*.
+
+3. Optional accelerator: `codegraph` MCP tools can speed up "who calls X"
+   questions, with two caveats — it indexes `.claude/worktrees/*` copies
+   (duplicate/noisy hits), and it cannot resolve dynamic method calls like
+   `span.addTags(...)`. Prefer `rg` for enumerating call sites; query
+   codegraph by explicit filename if used.
+
+## Fixed facts (change rarely — verify in `helpers/tracer.ts` / `helpers/logger.ts` if in doubt)
+
+- **Service name is `plumber`** for both backend APM (`dd-trace` init in
+  `packages/backend/src/helpers/tracer.ts`) and frontend RUM
+  (`packages/frontend/src/index.tsx`).
+- **Env tag comes from `APP_ENV`** (backend) / build env (frontend):
+  production is `env:prod`, staging is `env:staging`. Scope every monitor
+  query to `env:prod`.
+- **Winston levels**: `error` > `warn` > `info` > `http` > `debug`. In prod
+  the level is `http`, so `logger.debug(...)` lines are **not emitted in
+  prod** — never propose monitoring a debug log.
+- **Logs are JSON in prod with trace correlation**: `logInjection: true`
+  injects trace IDs into log records, so logs and APM traces cross-link.
+- **HTTP access logs** are emitted at the `http` level via morgan
+  (`packages/backend/src/helpers/morgan.ts`).
+- **Frontend RUM** is initialised only in `prod`/`staging`, with
+  `trackingConsent: 'not-granted'` until the user is authenticated — RUM only
+  captures sessions after consent is granted. Errors, resources, actions and
+  long tasks are auto-collected.
+- **No StatsD / custom-metric helper exists today.** There is no code path
+  for emitting custom metrics — proposing a new custom metric means adding
+  that plumbing, so it is a **last-resort** change. Prefer reusing spans
+  (auto trace metrics) and logs.

--- a/.claude/skills/setup-production-monitoring/templates/monitoring-plan.md
+++ b/.claude/skills/setup-production-monitoring/templates/monitoring-plan.md
@@ -1,0 +1,70 @@
+# Monitoring plan template
+
+Render the final deliverable **in chat** following this structure. Do not
+write it (or the monitor JSON) anywhere in the repo.
+
+---
+
+## Monitoring plan: \<feature\>
+
+### Feature summary
+
+Two or three sentences: what was built, which surfaces it touches (worker /
+webhook / GraphQL / REST / frontend), and the branch/diff the plan was derived
+from.
+
+### Failure modes (agreed during grilling)
+
+| # | Failure mode | Loud or silent | Severity → signal | Detected by |
+| --- | --- | --- | --- | --- |
+| 1 | \<what goes wrong\> | loud (throws) / silent (wrong-but-quiet) | page / ticket / dashboard-only | monitor #N / existing signal / explicitly not monitored |
+
+Include the failure modes the author explicitly ruled out, marked
+"not monitored (agreed)" — the decision should be visible.
+
+### Existing signals found (code-derived)
+
+| Signal | Kind | Emitted at | Status |
+| --- | --- | --- | --- |
+| `workers.action` span (`trace.workers.action.*` metrics) | span / trace metric | `packages/backend/src/workers/helpers/make-action-worker.ts` | verified in Datadog / unverified — confirm it is flowing |
+
+With no Datadog MCP connected, every row is "unverified (code-derived)" — a
+human confirms in Datadog. With the MCP, mark per the read-only checks.
+
+### Instrumentation changes (minimal, ranked)
+
+Only what is strictly needed for the agreed failure modes. Most-minimal first;
+each item names the failure mode it serves and the exact file + idiom:
+
+1. **[reuse — no change]** Failure mode #1 is covered by the existing
+   \<signal\> as-is.
+2. **[add tag to existing span]** For failure mode #2, add `<tag>` to the
+   existing `span?.addTags({…})` call in `<file>` — enables \<query\>.
+3. **[new signal — last resort]** For failure mode #3, a new
+   `logger.error(…)` in `<file>` because \<why nothing existing can detect it\>.
+
+If none are needed, say "No instrumentation changes needed — all agreed
+failure modes are detectable from existing signals."
+
+### Proposed monitors
+
+| # | Monitor | Type | Failure mode | Severity | Needs first |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `[Plumber] <feature>: <condition>` | query alert | #1 | ticket (P3) | — |
+| 2 | `[Plumber] <feature>: <condition>` | trace-analytics alert | #2 | page (P2) | retention filter indexing `workers.action` spans; instrumentation change 2 |
+
+Then one fenced `json` block per monitor (Monitor API shape, per
+[references/monitor-types.md](../references/monitor-types.md)), in the same
+order as the table.
+
+> These definitions are artifacts for a human to apply (Datadog → Monitors →
+> New Monitor → Import, or `POST /api/v1/monitor`). Queries are derived from
+> code; confirm the underlying signals are flowing before relying on them.
+
+### Open decisions
+
+- Exact thresholds/windows to tune after observing baselines (list each).
+- Whether a custom retention filter indexes the spans behind any
+  trace-analytics monitor proposed (list them).
+- Signals still unverified in Datadog (list them).
+- Anything the author deferred during grilling.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3309,6 +3309,38 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------------------------------------------------------------------------
 
 ## Project
+mattpocock/skills
+(Used by our /setup-production-monitoring skill)
+
+### Source
+https://github.com/mattpocock/skills
+
+### License
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+## Project
 notistack
 
 ### Source


### PR DESCRIPTION
# Problem

We want another brain in the box for coming up with monitoring plans when we release stuff. Lets have AI help!

# Approach

We'll create a /setup-production-monitoring claude skill to help us do this. It will analyze changes against develop-v2, grill with you for potential failure modes and suggest instrumentation + monitors to watch for these.

Monitors are generated in JSON so that we can easily import them into DD.

# Tests

Try it out on @m0nggh 's SES stack and validate that its findings + suggestions make sense