### PR TITLE
[OG-ATTACHMENTS-3] PLU-769 (feat): file-api attachment upload helpers

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/common/attachment-upload.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/common/attachment-upload.test.ts
@@ -1,0 +1,160 @@
+import type { IGlobalVariable } from '@plumber/types'
+
+import axios from 'axios'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HttpError from '@/errors/http'
+import * as s3 from '@/helpers/s3'
+
+import {
+  generateUploadToken,
+  uploadCaseAttachments,
+  uploadFileToGather,
+} from '../../common/attachment'
+
+vi.mock('axios')
+
+const MOCK_CASE_UUID = '1234567890abcdefghijkl'
+const MOCK_S3_ID = 's3:plumber-bucket:flow-id-123/abc/photo.png'
+
+const mocks = vi.hoisted(() => ({
+  httpPost: vi.fn(),
+}))
+
+describe('gathersg attachment upload helpers', () => {
+  let $: IGlobalVariable
+
+  beforeEach(() => {
+    $ = {
+      flow: { id: 'flow-id-123' },
+      http: { post: mocks.httpPost } as unknown as IGlobalVariable['http'],
+    } as unknown as IGlobalVariable
+    mocks.httpPost.mockResolvedValue({ data: { data: { token: 'tok-123' } } })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('generateUploadToken', () => {
+    it('posts to /cases/upload/token and returns the token', async () => {
+      const token = await generateUploadToken($, {
+        field: 'photos',
+        type: 'attachment',
+        caseUuid: MOCK_CASE_UUID,
+      })
+
+      expect(mocks.httpPost).toHaveBeenCalledWith('/cases/upload/token', {
+        field: 'photos',
+        type: 'attachment',
+        uuid: MOCK_CASE_UUID,
+      })
+      expect(token).toBe('tok-123')
+    })
+  })
+
+  describe('uploadFileToGather', () => {
+    it('uploads with bearer token to the file-api and returns file data', async () => {
+      vi.mocked(axios.post).mockResolvedValue({
+        data: {
+          data: {
+            uuid: 'file-uuid-1',
+            name: 'photo.png',
+            mimeType: 'image/png',
+            size: 10,
+            expireAt: '2026-07-01',
+          },
+        },
+      })
+
+      const result = await uploadFileToGather('tok-123', {
+        name: 'photo.png',
+        data: new Uint8Array([1, 2, 3]),
+      })
+
+      expect(axios.post).toHaveBeenCalledWith(
+        'https://gather.gov.sg/file/api/upload',
+        expect.anything(),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer tok-123',
+          }),
+        }),
+      )
+      expect(result.uuid).toBe('file-uuid-1')
+    })
+
+    it('wraps a file-api error in HttpError', async () => {
+      const axiosError = {
+        isAxiosError: true,
+        message: 'Request failed',
+        response: { data: { error: { message: 'bad' } }, status: 400 },
+        config: {},
+      }
+      vi.mocked(axios.post).mockRejectedValue(axiosError)
+
+      await expect(
+        uploadFileToGather('tok-123', {
+          name: 'photo.png',
+          data: new Uint8Array([1]),
+        }),
+      ).rejects.toBeInstanceOf(HttpError)
+    })
+  })
+
+  describe('uploadCaseAttachments', () => {
+    it('fetches files from S3, mints one token, uploads each, returns uuids', async () => {
+      vi.spyOn(s3, 'getObjectFromS3Id').mockResolvedValue({
+        name: 'photo.png',
+        data: new Uint8Array([1, 2, 3]),
+      })
+      vi.mocked(axios.post)
+        .mockResolvedValueOnce({ data: { data: { uuid: 'u1' } } })
+        .mockResolvedValueOnce({ data: { data: { uuid: 'u2' } } })
+
+      const uuids = await uploadCaseAttachments({
+        $,
+        caseUuid: MOCK_CASE_UUID,
+        field: 'photos',
+        fieldType: 'attachment',
+        s3Ids: [MOCK_S3_ID, MOCK_S3_ID],
+      })
+
+      expect(s3.getObjectFromS3Id).toHaveBeenCalledWith(MOCK_S3_ID, {
+        flowId: 'flow-id-123',
+      })
+      expect(mocks.httpPost).toHaveBeenCalledTimes(1)
+      expect(axios.post).toHaveBeenCalledTimes(2)
+      expect(uuids).toEqual(['u1', 'u2'])
+    })
+
+    it('returns empty array when no s3 ids', async () => {
+      const uuids = await uploadCaseAttachments({
+        $,
+        caseUuid: MOCK_CASE_UUID,
+        field: 'photos',
+        fieldType: 'attachment',
+        s3Ids: [],
+      })
+      expect(uuids).toEqual([])
+      expect(mocks.httpPost).not.toHaveBeenCalled()
+    })
+
+    it('throws a StepError when a file exceeds MAX_FILE_SIZE', async () => {
+      vi.spyOn(s3, 'getObjectFromS3Id').mockResolvedValue({
+        name: 'big.png',
+        data: new Uint8Array(11 * 1024 * 1024),
+      })
+
+      await expect(
+        uploadCaseAttachments({
+          $,
+          caseUuid: MOCK_CASE_UUID,
+          field: 'photos',
+          fieldType: 'attachment',
+          s3Ids: [MOCK_S3_ID],
+        }),
+      ).rejects.toThrow('exceeds maximum size')
+    })
+  })
+})

--- a/packages/backend/src/apps/gathersg/common/attachment.ts
+++ b/packages/backend/src/apps/gathersg/common/attachment.ts
@@ -1,10 +1,20 @@
 import { IGlobalVariable, IJSONValue } from '@plumber/types'
 
+import axios from 'axios'
+import FormData from 'form-data'
 import { z } from 'zod'
 
+import HttpError from '@/errors/http'
 import StepError from '@/errors/step'
 import logger from '@/helpers/logger'
-import { COMMON_S3_BUCKET, MAX_FILE_SIZE, putObject } from '@/helpers/s3'
+import {
+  COMMON_S3_BUCKET,
+  getObjectFromS3Id,
+  MAX_FILE_SIZE,
+  putObject,
+} from '@/helpers/s3'
+
+import { GATHER_FILE_API_UPLOAD_URL } from './constants'
 
 export const attachmentsSchema = z.record(
   z.string(),
@@ -118,4 +128,116 @@ export async function processAttachments(
       },
     ),
   )
+}
+
+export interface GatherUploadedFile {
+  uuid: string
+  name: string
+  mimeType: string
+  size: number
+  expireAt: string
+}
+
+/**
+ * Step 1 of the upload handshake: mint a per-field upload token via the CMS API
+ * (x-api-key + CMS base through the addAuthHeader beforeRequest hook).
+ */
+export async function generateUploadToken(
+  $: IGlobalVariable,
+  { field, type, caseUuid }: { field: string; type: string; caseUuid: string },
+): Promise<string> {
+  const { data } = await $.http.post<{ data: { token: string } }>(
+    '/cases/upload/token',
+    { field, type, uuid: caseUuid },
+  )
+  return data.data.token
+}
+
+/**
+ * Step 2 of the upload handshake: upload one file to the File API with the
+ * bearer token. Uses a standalone axios call because the File API has a
+ * different base + Bearer auth than the app's $.http client.
+ */
+export async function uploadFileToGather(
+  token: string,
+  file: { name: string; data: Uint8Array },
+): Promise<GatherUploadedFile> {
+  const form = new FormData()
+  form.append('file', Buffer.from(file.data), file.name)
+
+  try {
+    const { data } = await axios.post<{ data: GatherUploadedFile }>(
+      GATHER_FILE_API_UPLOAD_URL,
+      form,
+      {
+        headers: {
+          ...form.getHeaders(),
+          Authorization: `Bearer ${token}`,
+        },
+        // Disable axios' default body-size guard; per-file size is already
+        // bounded by MAX_FILE_SIZE before we reach this point.
+        maxBodyLength: Infinity,
+        maxContentLength: Infinity,
+      },
+    )
+    return data.data
+  } catch (error) {
+    // Normalize to HttpError so the action's catch can map it consistently.
+    throw new HttpError(error)
+  }
+}
+
+/**
+ * Upload the files for one target attachment field: fetch each file from S3
+ * (flow-ownership + virus-scan enforced by getObjectFromS3Id), enforce the
+ * shared MAX_FILE_SIZE, mint a single token for the field, upload each file,
+ * and return the resulting file uuids in order.
+ */
+export async function uploadCaseAttachments({
+  $,
+  caseUuid,
+  field,
+  fieldType,
+  s3Ids,
+}: {
+  $: IGlobalVariable
+  caseUuid: string
+  field: string
+  fieldType: string
+  s3Ids: string[]
+}): Promise<string[]> {
+  if (!s3Ids.length) {
+    return []
+  }
+
+  const files = await Promise.all(
+    s3Ids.map(async (s3Id) => {
+      const obj = await getObjectFromS3Id(s3Id, { flowId: $.flow.id })
+      if (obj.data.byteLength > MAX_FILE_SIZE) {
+        const sizeText = MAX_FILE_SIZE / (1024 * 1024)
+        throw new StepError(
+          `Attachment ${obj.name} exceeds maximum size of ${sizeText}MB`,
+          `Please check that your case attachments do not exceed ${sizeText}MB.`,
+        )
+      }
+      return obj
+    }),
+  )
+
+  // One token is minted per field and reused for all of that field's files
+  // (the upload API accepts multiple files per token). Confirm against the
+  // live API if multi-file uploads to a single field ever start failing.
+  const token = await generateUploadToken($, {
+    field,
+    type: fieldType,
+    caseUuid,
+  })
+
+  const uuids: string[] = []
+  // Upload sequentially to avoid concurrent uploads racing on the same token.
+  for (const file of files) {
+    const uploaded = await uploadFileToGather(token, file)
+    uuids.push(uploaded.uuid)
+  }
+  return uuids
 }

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -16,3 +16,11 @@ export const UNSUPPORTED_FIELDS = [
 export const HEX_ENCODED_FIELD_PREFIX = '__HEX_ENCODED__'
 // Regex to match invalid characters in field names that need to be hex encoded
 export const INVALID_CHAR_REGEX = /[^a-zA-Z0-9-_ ]/
+
+/**
+ * The Ownself Gather File API lives on a different base (file-api) than the CMS
+ * API and uses Bearer-token auth, so attachment uploads cannot go through the
+ * app's $.http client (which is pinned to the CMS base + x-api-key).
+ */
+export const GATHER_FILE_API_UPLOAD_URL =
+  'https://gather.gov.sg/file/api/upload'


### PR DESCRIPTION
_Note_: this is independent of the attachment PRs for 'Get case details'.

## TL;DR

Foundation helpers for uploading a file to Ownself Gather's file API (token → upload → uuid). Backend only — not wired into any action yet (that happens in the PR above this in the stack).

## What changed?

- `gathersg/common/attachment.ts`: `generateUploadToken`, `uploadFileToGather` (standalone `axios` + `Authorization: Bearer` to the file API, because the app's `$.http` is pinned to the CMS base + `x-api-key`), and `uploadCaseAttachments` (fetch each file from S3 → guard against `MAX_FILE_SIZE` → mint one token per field → upload → return uuids).
- `gathersg/common/constants.ts`: `GATHER_FILE_API_UPLOAD_URL`.
- Unit tests for all three helpers.

## Tests (manual)

No user-facing surface in this PR; logic is covered by unit tests.

- [ ] CI is green (or `npm run test packages/backend/src/apps/gathersg` passes locally).

---

## Tradeoffs & decisions (stack-wide — reviewer input welcome)

> These cover the whole stack (#1712–#1715); collected here on the base PR so reviewers see them first. **Please weigh in** where flagged 👀.

**1\. Standalone** **`axios`** **for the file-API upload (bypasses** **`$.http`)**
The upload goes to a different base (`/file/api`) with `Authorization: Bearer`, but `addAuthHeader` unconditionally pins every `$.http` request to the CMS base + `x-api-key`. So we use a raw `axios.post` and re-implement `HttpError` normalization locally. This sits outside the shared interceptor (also skips `RetriableError` passthrough and the 401/403 refresh-token retry — both moot for gathersg's `x-api-key` auth).

- _Alternative:_ teach `addAuthHeader` to skip the override for absolute file-API URLs so the call could use `$.http`. Rejected to avoid complicating a shared hook for one caller.
- 👀 Prefer the shared-hook route instead?

**2\. Append = read-modify-write (one extra** **`GET`, only when uploading)**
Gather treats an attachment field as the _full_ uuid array, so to append we GET the case, read existing uuids, then PATCH the de-duped union. The GET runs **only when actually uploading attachments** (zero overhead for plain updates), and only once per run regardless of file count — including a first upload to an empty field (we can't know it's empty without asking).

- Orphaned-but-harmless uploads if the PATCH fails (file service has no OG-side effect; orphans expire); error still surfaces as a `StepError`.
- Concurrent updates to the same case are a **non-goal / out of scope** (last-writer-wins; no race handling).
- 👀 Aware of an additive endpoint that avoids sending the full array?

**3\. Per-file size guard reuses** **`MAX_FILE_SIZE`** **(10MB)**
For consistency with the download side **and** to protect our own worker memory (we buffer each file into memory before upload). Note this is Plumber's S3 limit, not a confirmed Gather file-API limit.

- 👀 OG: what's the real file-API cap? We'll align the friendly-error threshold to it.

**4\. Single attachment field per step**
One Attachment-field dropdown + one Attachments input; a step targets one attachment field. Multiple fields would be a dedicated multirow (confirmed feasible) but adds UI/schema/run complexity and weakens the auto-hide UX (#1715).

- Decision: **keep as-is until we discover otherwise** — revisit only if multi-attachment-field case types prove common.

**5\.** **`hideWhenNoOptions`** **is a shared** **`InputCreator`** **change (**#1715\*\*)**or '
A reusable flag so a source-backed dropdown hides when its dynamic data is empty (used to hide the attachment inputs for case types with no attachment fields). Flows via the JSON `/api/apps` path, so no GraphQL/codegen change — but it does alter the shared field renderer used by every app.

- **Known edge:** a hidden dropdown retains its form value (same as today's `hiddenIf` behavior), so switching to a case with no attachment fields _after_ configuring can leave a stale selection and keep the Attachments input visible. Left as-is for parity with `hiddenIf`.
- 👀 If you find a still-visible Attachments field confusing, we can clear the value in a follow-up PR.

**6\. Attachments kept separate from the "Case fields" multicol**
Not folded into the existing field/type/value multicol because: Case-fields values are built by a _synchronous_ Zod transform while attachments are _async_ (upload + append); they use a different field source (`getCaseFields` excludes attachment types); and have different value semantics (uuid array + file picker). Cost: a slightly larger action form vs. a tangled unified field.

- 👀 Input welcome on this split.