### PR TITLE
feat(formatter): date compare/calculate action + Excel serial & "Now" formats

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/compare-calculate.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/compare-calculate.test.ts
@@ -1,0 +1,160 @@
+import { DateTime } from 'luxon'
+import { describe, expect, it } from 'vitest'
+
+import type { IExecutionStep } from '@plumber/types'
+
+import getDataOutMetadata from '../actions/compare-calculate/get-data-out-metadata'
+import {
+  computeComparison,
+  computeDifference,
+  computeGap,
+  parseOperand,
+} from '../actions/compare-calculate/logic'
+
+const SG = 'Asia/Singapore'
+const sg = (iso: string): DateTime =>
+  DateTime.fromISO(iso, { zone: SG })
+
+describe('compare-calculate prototype', () => {
+  describe('parseOperand', () => {
+    it('converts an Excel serial number to a SG date', () => {
+      // 45292 is 1 Jan 2024 in Excel's 1900 date system.
+      const result = parseOperand('excelSerial', '45292')
+      expect(result.zoneName).toBe(SG)
+      expect(result.toFormat('yyyy-LL-dd')).toBe('2024-01-01')
+    })
+
+    it('reads the fractional part of an Excel serial as the time of day', () => {
+      const result = parseOperand('excelSerial', '45292.5')
+      expect(result.toFormat('yyyy-LL-dd HH:mm')).toBe('2024-01-01 12:00')
+    })
+
+    it('rejects non-positive / non-numeric Excel serials', () => {
+      expect(() => parseOperand('excelSerial', '0')).toThrow()
+      expect(() => parseOperand('excelSerial', '-5')).toThrow()
+      expect(() => parseOperand('excelSerial', 'abc')).toThrow()
+    })
+
+    it('parses zoneless formats as SG wall-clock time', () => {
+      const result = parseOperand('dd/LL/yyyy', '25/03/2024')
+      expect(result.zoneName).toBe(SG)
+      expect(result.toFormat('yyyy-LL-dd')).toBe('2024-03-25')
+    })
+
+    it('"now" ignores the value and returns the current SG time', () => {
+      const result = parseOperand('now', '')
+      expect(result.zoneName).toBe(SG)
+      expect(Math.abs(result.diffNow().as('seconds'))).toBeLessThan(5)
+    })
+  })
+
+  describe('computeComparison', () => {
+    const a = sg('2024-03-25T09:00')
+    const b = sg('2024-04-01T09:00')
+
+    it('before / after', () => {
+      expect(computeComparison(a, 'before', b).result).toBe('true')
+      expect(computeComparison(a, 'after', b).result).toBe('false')
+    })
+
+    it('same day ignores the time component', () => {
+      const morning = sg('2024-03-25T08:00')
+      const evening = sg('2024-03-25T20:00')
+      expect(computeComparison(morning, 'sameDay', evening).result).toBe('true')
+    })
+  })
+
+  describe('computeGap', () => {
+    it('"within 2 weeks" is true when the dates are 7 days apart', () => {
+      const submission = sg('2024-03-25')
+      const event = sg('2024-04-01')
+      expect(computeGap(submission, 'within', 2, 'weeks', event).result).toBe(
+        'true',
+      )
+    })
+
+    it('"more than 3 months after" reflects direction', () => {
+      const now = sg('2024-06-01')
+      const lastUpdate = sg('2024-01-01')
+      // now is ~5 months after lastUpdate -> true
+      expect(computeGap(now, 'moreAfter', 3, 'months', lastUpdate).result).toBe(
+        'true',
+      )
+      // now is not more than 3 months *before* lastUpdate -> false
+      expect(computeGap(now, 'moreBefore', 3, 'months', lastUpdate).result).toBe(
+        'false',
+      )
+    })
+  })
+
+  describe('computeDifference', () => {
+    it('returns a signed whole number from the first date to the second', () => {
+      const submission = sg('2024-03-25')
+      const today = sg('2024-04-04')
+      const diff = computeDifference(submission, today, 'days')
+      expect(diff.result).toBe(10)
+      expect(diff.absolute).toBe(10)
+      expect(diff.unit).toBe('days')
+    })
+
+    it('is negative when the second date is earlier', () => {
+      const today = sg('2024-04-04')
+      const submission = sg('2024-03-25')
+      const diff = computeDifference(today, submission, 'days')
+      expect(diff.result).toBe(-10)
+      expect(diff.absolute).toBe(10)
+    })
+  })
+
+  describe('readable summaries (output legibility)', () => {
+    it('compare summary reads as a plain sentence', () => {
+      const a = sg('2024-03-25')
+      const b = sg('2024-04-01')
+      expect(computeComparison(a, 'before', b).summary).toBe(
+        'The first date is before the second date: Yes',
+      )
+      expect(computeComparison(b, 'before', a).summary).toBe(
+        'The first date is before the second date: No',
+      )
+    })
+
+    it('gap summary spells out the period and direction', () => {
+      const a = sg('2024-06-01')
+      const b = sg('2024-01-01')
+      expect(computeGap(a, 'moreAfter', 3, 'months', b).summary).toBe(
+        'The first date is more than 3 months after the second date: Yes',
+      )
+    })
+
+    it('difference summary states magnitude and direction', () => {
+      const first = sg('2024-03-25')
+      const second = sg('2024-04-04')
+      expect(computeDifference(first, second, 'days').summary).toBe(
+        'The second date is 10 days after the first date',
+      )
+    })
+  })
+
+  describe('getDataOutMetadata (variable picker labels)', () => {
+    const fakeStep = (dataOut: Record<string, unknown>) =>
+      ({ dataOut } as unknown as IExecutionStep)
+
+    it('labels the boolean output for compare / gap', async () => {
+      const meta = await getDataOutMetadata(
+        fakeStep({ result: 'true', summary: 'x' }),
+      )
+      expect(meta?.result).toMatchObject({ label: 'Answer (true / false)' })
+      expect(meta?.summary).toMatchObject({ label: 'In words' })
+    })
+
+    it('labels the numeric outputs for calculate', async () => {
+      const meta = await getDataOutMetadata(
+        fakeStep({ result: 10, absolute: 10, unit: 'days', summary: 'x' }),
+      )
+      expect(meta?.absolute).toMatchObject({
+        label: 'Difference, ignoring direction',
+      })
+      expect(meta?.unit).toMatchObject({ label: 'Unit' })
+    })
+  })
+})

--- a/packages/backend/src/apps/formatter/actions/compare-calculate/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/compare-calculate/fields.ts
@@ -1,0 +1,258 @@
+import type { IField } from '@plumber/types'
+
+import z from 'zod'
+
+import { ensureZodObjectKey } from '@/helpers/zod-utils'
+
+import {
+  inputFormatOptions,
+  supportedFormats,
+} from '../date-time/common/date-time-format'
+import { timeUnitEnum, timeUnitOptions } from '../date-time/common/time-units'
+
+//
+// Enums (shared by fields + run logic)
+//
+
+export const operationEnum = z.enum(['compare', 'gap', 'calculate'])
+export const compareOpEnum = z.enum([
+  'before',
+  'after',
+  'onOrBefore',
+  'onOrAfter',
+  'sameDay',
+])
+export const gapOpEnum = z.enum(['within', 'moreBefore', 'moreAfter'])
+// One shared list of time units across all date actions. Re-exported so
+// logic.ts keeps importing `unitEnum` from here.
+export const unitEnum = timeUnitEnum
+
+// The amount + unit pair for the time-gap check, kept as a single row so they
+// render on one line (consistent with add/subtract's amount + unit columns).
+export const gapPeriodSchema = z.object({
+  gapAmount: z.string(),
+  gapUnit: unitEnum,
+})
+
+//
+// Parameter schema
+//
+
+export const paramsSchema = z.object({
+  operation: operationEnum,
+
+  firstDateFormat: supportedFormats,
+  firstDateValue: z.string().optional().default(''),
+  secondDateFormat: supportedFormats,
+  secondDateValue: z.string().optional().default(''),
+
+  // Compare ("Compare two dates")
+  compareOperator: compareOpEnum.optional(),
+
+  // Gap ("Check time gap between dates")
+  gapOperator: gapOpEnum.optional(),
+  gapPeriod: z.array(gapPeriodSchema).optional(),
+
+  // Calculate ("Calculate time between dates")
+  diffUnit: unitEnum.optional(),
+})
+
+const key = (k: keyof z.infer<typeof paramsSchema>): string =>
+  ensureZodObjectKey(paramsSchema, k)
+
+//
+// Field options
+//
+
+const operationOptions = [
+  {
+    label: 'Compare two dates',
+    description:
+      'Is one date before / after / the same as another? Gives a true / false answer to use in an "If... then" step',
+    value: operationEnum.enum.compare,
+  },
+  {
+    label: 'Check time gap between dates',
+    description:
+      'Are two dates within / more than a period apart? Gives a true / false answer to use in an "If... then" step',
+    value: operationEnum.enum.gap,
+  },
+  {
+    label: 'Calculate time between dates',
+    description:
+      'Get the number of days / weeks / months between two dates — a number you can use in messages or calculations',
+    value: operationEnum.enum.calculate,
+  },
+]
+
+const compareOperatorOptions = [
+  { label: 'before the second date', value: compareOpEnum.enum.before },
+  { label: 'after the second date', value: compareOpEnum.enum.after },
+  { label: 'on or before the second date', value: compareOpEnum.enum.onOrBefore },
+  { label: 'on or after the second date', value: compareOpEnum.enum.onOrAfter },
+  {
+    label: 'on the same day as the second date',
+    value: compareOpEnum.enum.sameDay,
+  },
+]
+
+const gapOperatorOptions = [
+  {
+    label: 'within a certain time of the second date',
+    value: gapOpEnum.enum.within,
+  },
+  {
+    label: 'more than a certain time before the second date',
+    value: gapOpEnum.enum.moreBefore,
+  },
+  {
+    label: 'more than a certain time after the second date',
+    value: gapOpEnum.enum.moreAfter,
+  },
+]
+
+//
+// Field definitions
+//
+// NOTE (prototype): `hiddenIf` currently supports only ONE condition, so:
+// - The two date operands are always shown (not gated on the operation), which
+//   lets each value field use its single condition to hide itself when its
+//   format is "Now".
+// - Each operation's extra fields are gated on the operation dropdown.
+// See prototype notes for the field-visibility constraint discussion.
+//
+
+const hiddenUnlessOperation = (op: string): IField['hiddenIf'] => ({
+  fieldKey: key('operation'),
+  op: 'not_equals',
+  fieldValue: op,
+})
+
+export const fields: IField[] = [
+  {
+    label: 'What do you want to do?',
+    key: key('operation'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: operationOptions,
+  },
+
+  // ---- First date (operand A) ----
+  // Value first, then format — matching the field order of the
+  // "Format date / time" action for consistency.
+  {
+    label: 'First date',
+    key: key('firstDateValue'),
+    type: 'string',
+    required: true,
+    variables: true,
+    hiddenIf: {
+      fieldKey: key('firstDateFormat'),
+      op: 'equals',
+      fieldValue: supportedFormats.enum.now,
+    },
+  },
+  {
+    label: 'Format of the first date',
+    key: key('firstDateFormat'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: inputFormatOptions,
+  },
+
+  // ---- Second date (operand B) ----
+  {
+    label: 'Second date',
+    key: key('secondDateValue'),
+    type: 'string',
+    required: true,
+    variables: true,
+    hiddenIf: {
+      fieldKey: key('secondDateFormat'),
+      op: 'equals',
+      fieldValue: supportedFormats.enum.now,
+    },
+  },
+  {
+    label: 'Format of the second date',
+    key: key('secondDateFormat'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: inputFormatOptions,
+  },
+
+  // ---- Compare ----
+  {
+    label: 'The first date is…',
+    key: key('compareOperator'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: compareOperatorOptions,
+    hiddenIf: hiddenUnlessOperation(operationEnum.enum.compare),
+  },
+
+  // ---- Gap ----
+  {
+    label: 'The first date is…',
+    key: key('gapOperator'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: gapOperatorOptions,
+    hiddenIf: hiddenUnlessOperation(operationEnum.enum.gap),
+  },
+  {
+    // Amount + unit on one row (multirow-multicol), mirroring add/subtract's
+    // amount + unit columns. The amount is a literal number (variables off), so
+    // no "No variables available" panel shows.
+    // PROTOTYPE LIMITATION: multirow-multicol always renders an "Add" button,
+    // so users can add extra (ignored) rows. Only the first row is used. The
+    // proper fix is a non-repeating / maxRows=1 variant of this field.
+    label: 'How much time?',
+    key: key('gapPeriod'),
+    type: 'multirow-multicol',
+    required: true,
+    subFields: [
+      {
+        placeholder: 'e.g. 2',
+        key: ensureZodObjectKey(gapPeriodSchema, 'gapAmount'),
+        type: 'string',
+        required: true,
+        variables: false,
+        customStyle: { flex: 2 },
+      },
+      {
+        placeholder: 'Unit of time',
+        key: ensureZodObjectKey(gapPeriodSchema, 'gapUnit'),
+        type: 'dropdown',
+        required: true,
+        variables: false,
+        showOptionValue: false,
+        options: timeUnitOptions,
+        customStyle: { flex: 3 },
+      },
+    ],
+    hiddenIf: hiddenUnlessOperation(operationEnum.enum.gap),
+  },
+
+  // ---- Calculate ----
+  {
+    label: 'Show the result in',
+    key: key('diffUnit'),
+    type: 'dropdown',
+    required: true,
+    variables: false,
+    showOptionValue: false,
+    options: timeUnitOptions,
+    hiddenIf: hiddenUnlessOperation(operationEnum.enum.calculate),
+  },
+]

--- a/packages/backend/src/apps/formatter/actions/compare-calculate/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/formatter/actions/compare-calculate/get-data-out-metadata.ts
@@ -1,0 +1,41 @@
+import type { IDataOutMetadata, IExecutionStep } from '@plumber/types'
+
+/**
+ * Friendly labels for this action's outputs, shown in the variable picker.
+ * Without this, users see raw keys like `result` / `summary`.
+ *
+ * The three operations share one action but emit different outputs:
+ * - compare / gap → a true/false `result` + a readable `summary`
+ * - calculate     → a numeric `result` + `absolute` + `unit` + `summary`
+ * We tell them apart by the presence of the `unit` key in `dataOut`.
+ */
+async function getDataOutMetadata(
+  executionStep: IExecutionStep,
+): Promise<IDataOutMetadata> {
+  const { dataOut } = executionStep
+  if (!dataOut) {
+    return null
+  }
+
+  const isCalculation = 'unit' in dataOut
+
+  if (isCalculation) {
+    return {
+      result: {
+        label: 'Difference (whole number; negative if the second date is earlier)',
+        order: 1,
+      },
+      absolute: { label: 'Difference, ignoring direction', order: 2 },
+      unit: { label: 'Unit', order: 3 },
+      summary: { label: 'In words', order: 4 },
+    }
+  }
+
+  return {
+    // true / false, designed to be used in an "If... then" step.
+    result: { label: 'Answer (true / false)', order: 1 },
+    summary: { label: 'In words', order: 2 },
+  }
+}
+
+export default getDataOutMetadata

--- a/packages/backend/src/apps/formatter/actions/compare-calculate/index.ts
+++ b/packages/backend/src/apps/formatter/actions/compare-calculate/index.ts
@@ -1,0 +1,130 @@
+import type { IRawAction } from '@plumber/types'
+
+import { ZodError } from 'zod'
+
+import StepError, { GenericSolution } from '@/errors/step'
+import { firstZodParseError } from '@/helpers/zod-utils'
+
+import { fields, paramsSchema } from './fields'
+import getDataOutMetadata from './get-data-out-metadata'
+import {
+  computeComparison,
+  computeDifference,
+  computeGap,
+  parseOperand,
+} from './logic'
+
+function getParams($: Parameters<IRawAction['run']>[0]) {
+  try {
+    return paramsSchema.parse($.step.parameters)
+  } catch (error) {
+    if (!(error instanceof ZodError)) {
+      throw error
+    }
+    throw new StepError(
+      `Configuration problem: '${firstZodParseError(error)}'`,
+      GenericSolution.ReconfigureInvalidField,
+    )
+  }
+}
+
+function parseAmount(raw: string | undefined): number {
+  const amount = Number(raw?.toString().trim())
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new StepError(
+      `'${raw}' is not a valid amount of time`,
+      'Enter a positive number for the amount of time.',
+    )
+  }
+  return amount
+}
+
+const action: IRawAction = {
+  name: 'Compare or calculate dates',
+  key: 'compareCalculateDates',
+  description:
+    'Compare two dates, check the gap between them, or calculate the time between them',
+  arguments: fields,
+
+  getDataOutMetadata,
+
+  async run($) {
+    const params = getParams($)
+
+    try {
+      const firstDate = parseOperand(
+        params.firstDateFormat,
+        params.firstDateValue,
+      )
+      const secondDate = parseOperand(
+        params.secondDateFormat,
+        params.secondDateValue,
+      )
+
+      switch (params.operation) {
+        case 'compare': {
+          if (!params.compareOperator) {
+            throw new StepError(
+              'No comparison selected',
+              GenericSolution.ReconfigureInvalidField,
+            )
+          }
+          $.setActionItem({
+            raw: computeComparison(
+              firstDate,
+              params.compareOperator,
+              secondDate,
+            ),
+          })
+          return
+        }
+
+        case 'gap': {
+          // Only the first row is used (the field is a multirow-multicol, but
+          // a time gap is a single threshold — see fields.ts).
+          const period = params.gapPeriod?.[0]
+          if (!params.gapOperator || !period?.gapUnit) {
+            throw new StepError(
+              'Incomplete time-gap configuration',
+              GenericSolution.ReconfigureInvalidField,
+            )
+          }
+          const amount = parseAmount(period.gapAmount)
+          $.setActionItem({
+            raw: computeGap(
+              firstDate,
+              params.gapOperator,
+              amount,
+              period.gapUnit,
+              secondDate,
+            ),
+          })
+          return
+        }
+
+        case 'calculate': {
+          if (!params.diffUnit) {
+            throw new StepError(
+              'No unit selected',
+              GenericSolution.ReconfigureInvalidField,
+            )
+          }
+          $.setActionItem({
+            raw: computeDifference(firstDate, secondDate, params.diffUnit),
+          })
+          return
+        }
+      }
+    } catch (error) {
+      if (error instanceof StepError) {
+        throw error
+      }
+      throw new StepError(
+        `Error processing dates: '${error.message}'`,
+        'Ensure that you have selected the correct format for each date.',
+      )
+    }
+  },
+}
+
+export default action

--- a/packages/backend/src/apps/formatter/actions/compare-calculate/logic.ts
+++ b/packages/backend/src/apps/formatter/actions/compare-calculate/logic.ts
@@ -1,0 +1,188 @@
+import { DateTime } from 'luxon'
+import type z from 'zod'
+
+import { commonDateFormats } from '../date-time/common/date-format-options'
+import {
+  parseDateTime,
+  SG_TIMEZONE,
+  type supportedFormats,
+} from '../date-time/common/date-time-format'
+
+import type { compareOpEnum, gapOpEnum, unitEnum } from './fields'
+
+type SupportedFormat = z.infer<typeof supportedFormats>
+type CompareOp = z.infer<typeof compareOpEnum>
+type GapOp = z.infer<typeof gapOpEnum>
+type Unit = z.infer<typeof unitEnum>
+
+// Formats that carry no timezone information. We re-interpret their wall-clock
+// time as Singapore time so that everything is compared in one consistent zone.
+//
+// PROTOTYPE NOTE: in the full implementation this SG pinning should live inside
+// the shared parser so that the existing convert / add-subtract transforms get
+// it too, rather than being applied here per-operand.
+const ZONELESS_FORMATS = new Set<SupportedFormat>([
+  ...commonDateFormats,
+  'formsgDateField',
+])
+
+/**
+ * Parses one of the two date operands into a Singapore-time DateTime.
+ *
+ * "Now" and "Excel serial" are already produced in SG time by the shared
+ * converters. Zoneless formats have their wall-clock time re-interpreted as SG
+ * time; zoned formats (ISO / FormSG submission time) are converted to the same
+ * instant expressed in SG time.
+ */
+export function parseOperand(
+  format: SupportedFormat,
+  value: string,
+): DateTime {
+  const parsed = parseDateTime(format, value)
+
+  if (ZONELESS_FORMATS.has(format)) {
+    return parsed.setZone(SG_TIMEZONE, { keepLocalTime: true })
+  }
+
+  return parsed.setZone(SG_TIMEZONE)
+}
+
+// NOTE: `type` (not `interface`) so these satisfy `IJSONObject`'s index
+// signature when passed to `$.setActionItem({ raw })`.
+export type CompareResult = {
+  result: 'true' | 'false'
+  summary: string
+}
+
+// Plain-language phrasing for each comparison, used in the readable summary.
+const COMPARE_PHRASE: Record<CompareOp, string> = {
+  before: 'before',
+  after: 'after',
+  onOrBefore: 'on or before',
+  onOrAfter: 'on or after',
+  sameDay: 'on the same day as',
+}
+
+export function computeComparison(
+  first: DateTime,
+  operator: CompareOp,
+  second: DateTime,
+): CompareResult {
+  let result: boolean
+
+  switch (operator) {
+    case 'before':
+      result = first < second
+      break
+    case 'after':
+      result = first > second
+      break
+    case 'onOrBefore':
+      result = first <= second
+      break
+    case 'onOrAfter':
+      result = first >= second
+      break
+    case 'sameDay':
+      result = first.hasSame(second, 'day')
+      break
+  }
+
+  return {
+    result: result ? 'true' : 'false',
+    summary: `The first date is ${COMPARE_PHRASE[operator]} the second date: ${
+      result ? 'Yes' : 'No'
+    }`,
+  }
+}
+
+export type GapResult = {
+  result: 'true' | 'false'
+  summary: string
+}
+
+/**
+ * Time-gap checks. "First" / "second" refer to the two operands A and B.
+ * - within:     |A − B| ≤ amount
+ * - moreBefore: A is earlier than B by more than amount  (B − A > amount)
+ * - moreAfter:  A is later than B by more than amount     (A − B > amount)
+ */
+export function computeGap(
+  first: DateTime,
+  operator: GapOp,
+  amount: number,
+  unit: Unit,
+  second: DateTime,
+): GapResult {
+  const aMinusB = first.diff(second, unit).as(unit)
+  const bMinusA = second.diff(first, unit).as(unit)
+
+  let result: boolean
+
+  switch (operator) {
+    case 'within':
+      result = Math.abs(aMinusB) <= amount
+      break
+    case 'moreBefore':
+      result = bMinusA > amount
+      break
+    case 'moreAfter':
+      result = aMinusB > amount
+      break
+  }
+
+  const yesNo = result ? 'Yes' : 'No'
+  let summary: string
+  switch (operator) {
+    case 'within':
+      summary = `The two dates are within ${amount} ${unit} of each other: ${yesNo}`
+      break
+    case 'moreBefore':
+      summary = `The first date is more than ${amount} ${unit} before the second date: ${yesNo}`
+      break
+    case 'moreAfter':
+      summary = `The first date is more than ${amount} ${unit} after the second date: ${yesNo}`
+      break
+  }
+
+  return {
+    result: result ? 'true' : 'false',
+    summary,
+  }
+}
+
+export type DifferenceResult = {
+  // Signed whole number, measured from the first date to the second (B − A).
+  // Positive means the second date is later.
+  result: number
+  // Magnitude, for users who just want "how many days since ...".
+  absolute: number
+  unit: Unit
+  // Plain-language version of the result.
+  summary: string
+}
+
+export function computeDifference(
+  first: DateTime,
+  second: DateTime,
+  unit: Unit,
+): DifferenceResult {
+  // Calendar-aware diff (Luxon handles varying month/year lengths).
+  const signedExact = second.diff(first, unit).as(unit)
+  const signed = Math.trunc(signedExact)
+  const absolute = Math.abs(signed)
+
+  const summary =
+    signed === 0
+      ? `The two dates are less than 1 ${unit.replace(/s$/, '')} apart`
+      : `The second date is ${absolute} ${unit} ${
+          signed > 0 ? 'after' : 'before'
+        } the first date`
+
+  return {
+    result: signed,
+    absolute,
+    unit,
+    summary,
+  }
+}

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -22,9 +22,23 @@ interface DateFormatConverter {
   stringify: (dateTime: DateTime) => string
 }
 
+// PROTOTYPE: all date parsing / "now" is pinned to Singapore time so that
+// comparisons and differences are not subject to off-by-one errors from a
+// differing server timezone. See prototype notes.
+export const SG_TIMEZONE = 'Asia/Singapore'
+
+// Excel's 1900 date system. Serial 1 = 1900-01-01, but Excel incorrectly
+// treats 1900 as a leap year, so the corrected epoch is 1899-12-30.
+const EXCEL_EPOCH = DateTime.fromObject(
+  { year: 1899, month: 12, day: 30 },
+  { zone: SG_TIMEZONE },
+)
+
 const supportedFormats = z.enum([
   'formsgSubmissionTime',
   'formsgDateField', // dd LLL yyyy; this is kept due to backwards compatibility
+  'now', // input-only: ignores the value field, uses current SG time
+  'excelSerial', // input-only: e.g. 45292 -> 1 Jan 2024
   ...commonDateFormats,
 ])
 
@@ -48,6 +62,34 @@ const formatConverters = Object.assign({
     description: 'FormSG submission time',
     parse: (input: string): DateTime => DateTime.fromISO(input),
     stringify: (dateTime: DateTime): string => dateTime.toISO(),
+  },
+  now: {
+    description: 'current date / time',
+    // Input-only: the value field is ignored (hidden in the UI). We always
+    // use the current time in Singapore.
+    parse: (_input: string): DateTime => DateTime.now().setZone(SG_TIMEZONE),
+    stringify: (): string => {
+      throw new Error('"Now" is an input-only format and cannot be output to')
+    },
+  },
+  excelSerial: {
+    description: 'Excel serial number',
+    parse: (input: string): DateTime => {
+      const serial = Number(input?.toString().trim())
+      // Reject non-numbers and <= 0 (the 0 / negative serials are the
+      // "1900-01-00" oddity we don't want to support).
+      if (!Number.isFinite(serial) || serial <= 0) {
+        return DateTime.invalid('Invalid Excel serial number')
+      }
+      // The fractional part of the serial is the time of day, so a plain
+      // `.plus({ days })` handles both date and time.
+      return EXCEL_EPOCH.plus({ days: serial })
+    },
+    stringify: (): string => {
+      throw new Error(
+        'Excel serial number is an input-only format and cannot be output to',
+      )
+    },
   },
   formsgDateField: {
     description: 'FormSG date field',
@@ -112,6 +154,10 @@ const formatConverters = Object.assign({
 // Field definitions and schema
 //
 
+// Exported so the schema can be reused by other actions (e.g. the
+// compare / calculate action's two date operands).
+export { supportedFormats }
+
 export const fieldSchema = z.object({
   // NOTE: Likely we will support arbitrary input in the future and this can no
   // longer be an enum. If that happens we can use a type guard to simulate
@@ -119,31 +165,50 @@ export const fieldSchema = z.object({
   dateTimeFormat: supportedFormats,
 })
 
+// The full list of input format options. Exported so any field that lets a
+// user declare the format of an incoming date (e.g. each operand of the
+// compare / calculate action) can reuse the exact same list.
+export const inputFormatOptions = [
+  {
+    label: 'Now (current date / time)',
+    description: 'Uses the current date and time in Singapore',
+    value: supportedFormats.enum.now,
+  },
+  {
+    label: 'FormSG Submission Time',
+    description: '2024-03-25T08:15:30.250+08:00',
+    value: supportedFormats.enum.formsgSubmissionTime,
+  },
+  {
+    // FormSG UI is a bit misleading; although the field shows dd/mm/yyyy,
+    // date fields are sent as dd MMM yyyy over webhooks.
+    label: 'FormSG Date Field - DD MMM YYYY',
+    description: '25 Mar 2024',
+    value: supportedFormats.enum.formsgDateField,
+  },
+  {
+    label: 'Excel serial number',
+    description: 'e.g. 45292 → 1 Jan 2024',
+    value: supportedFormats.enum.excelSerial,
+  },
+  // Exclude repeated option due to formsgDateField
+  ...commonDateFormatOptions.filter((option) => option.value !== 'dd LLL yyyy'),
+]
+
 export const field = {
-  label: 'Select the format of your value',
+  label: 'What format is your date / time in?',
   key: fieldSchema.keyof().enum.dateTimeFormat,
   type: 'dropdown' as const,
   required: true,
   variables: false,
   showOptionValue: false,
-  options: [
-    {
-      label: 'FormSG Submission Time',
-      description: '2024-03-25T08:15:30.250+08:00',
-      value: supportedFormats.enum.formsgSubmissionTime,
-    },
-    {
-      // FormSG UI is a bit misleading; although the field shows dd/mm/yyyy,
-      // date fields are sent as dd MMM yyyy over webhooks.
-      label: 'FormSG Date Field - DD MMM YYYY',
-      description: '25 Mar 2024',
-      value: supportedFormats.enum.formsgDateField,
-    },
-    // Exclude repeated option due to formsgDateField
-    ...commonDateFormatOptions.filter(
-      (option) => option.value !== 'dd LLL yyyy',
-    ),
-  ],
+  // "Now" is excluded here: it's a date *source*, not a format, and in this
+  // action the value field can't be hidden when it's picked (single-condition
+  // `hiddenIf`), so it would read confusingly. It stays available in the
+  // compare/calculate action, where the value field does hide.
+  options: inputFormatOptions.filter(
+    (option) => option.value !== supportedFormats.enum.now,
+  ),
 } satisfies IField
 
 //

--- a/packages/backend/src/apps/formatter/actions/date-time/common/time-units.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/time-units.ts
@@ -1,0 +1,27 @@
+import { type DurationLikeObject } from 'luxon'
+import z from 'zod'
+
+/**
+ * The single list of time units shared by every date action (add/subtract,
+ * compare, time gap, calculate between) so the options stay consistent.
+ *
+ * Keys match Luxon `Duration` keys so they can be passed straight to date math.
+ */
+export const timeUnitEnum = z.enum([
+  'seconds',
+  'minutes',
+  'hours',
+  'days',
+  'weeks',
+  'months',
+  'years',
+] as const satisfies ReadonlyArray<keyof DurationLikeObject>)
+
+function sentenceCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export const timeUnitOptions = timeUnitEnum.options.map((unit) => ({
+  label: sentenceCase(unit),
+  value: unit,
+}))

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
@@ -1,20 +1,11 @@
-import { type DurationLikeObject } from 'luxon'
 import z from 'zod'
 
 import { type TransformSpec } from '@/apps/formatter/common/transform-spec'
 import { ensureZodObjectKey } from '@/helpers/zod-utils'
 
-const opTypeEnum = z.enum(['add', 'subtract'])
+import { timeUnitEnum, timeUnitOptions } from '../../common/time-units'
 
-const timeUnitEnum = z.enum([
-  'seconds',
-  'minutes',
-  'hours',
-  'days',
-  'months',
-  // To simplify date math code, values have the same keys as luxton
-  // duration objects.
-] as const satisfies ReadonlyArray<keyof DurationLikeObject>)
+const opTypeEnum = z.enum(['add', 'subtract'])
 
 const opsSchema = z.object({
   opType: opTypeEnum,
@@ -47,7 +38,7 @@ function sentenceCase(s: string): string {
 
 export const fields: TransformSpec['fields'] = [
   {
-    label: 'Specify the amount of time you want to add or subtract',
+    label: 'How much time do you want to add or subtract?',
     key: ensureZodObjectKey(fieldSchema.sourceType(), 'addSubtractDateTimeOps'),
     type: 'multirow-multicol' as const,
     required: true,
@@ -80,10 +71,7 @@ export const fields: TransformSpec['fields'] = [
         required: true,
         variables: false,
         showOptionValue: false,
-        options: timeUnitEnum.options.map((unit) => ({
-          label: sentenceCase(unit),
-          value: unit,
-        })),
+        options: timeUnitOptions,
         customStyle: { flex: 3 },
       },
     ],

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -15,7 +15,7 @@ export const fieldSchema = z.object({
 
 export const field = {
   key: ensureZodObjectKey(fieldSchema, 'formatDateTimeToFormat'),
-  label: 'What format do you want to transform value to?',
+  label: 'What format do you want to convert to?',
   type: 'dropdown' as const,
   required: true,
   variables: false,

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -37,7 +37,7 @@ export const spec = {
   id: 'formatDateTime',
 
   dropdownConfig: {
-    label: 'Format',
+    label: 'Change the format',
     description: 'Change a date or time to a new format style',
   },
 

--- a/packages/backend/src/apps/formatter/actions/index.ts
+++ b/packages/backend/src/apps/formatter/actions/index.ts
@@ -1,3 +1,4 @@
+import compareCalculateDates from './compare-calculate'
 import dateTime from './date-time'
 
-export default [dateTime]
+export default [dateTime, compareCalculateDates]

--- a/packages/backend/src/apps/formatter/common/fixed-fields.ts
+++ b/packages/backend/src/apps/formatter/common/fixed-fields.ts
@@ -21,7 +21,7 @@ export const VALUE_TO_TRANSFORM_FIELD_KEY = ensureZodObjectKey(
 )
 
 export const VALUE_TO_TRANSFORM_FIELD = {
-  label: 'Value to transform',
+  label: 'Value to change',
   key: VALUE_TO_TRANSFORM_FIELD_KEY,
   type: 'string' as const,
   required: true,
@@ -36,7 +36,7 @@ export function createSelectTransformDropdown(
   transforms: TransformSpec[],
 ): IFieldDropdown {
   return {
-    label: 'Select how you want to transform your data',
+    label: 'What do you want to do?',
     key: SELECT_TRANSFORM_DROPDOWN_FIELD_KEY,
     type: 'dropdown' as const,
     required: true,

--- a/packages/backend/src/apps/formatter/index.ts
+++ b/packages/backend/src/apps/formatter/index.ts
@@ -5,8 +5,7 @@ import actions from './actions'
 const app: IApp = {
   name: 'Formatter',
   key: 'formatter',
-  description:
-    'Manipulate your data, such as changing date formats or adding days to a date',
+  description: 'Format, compare, and calculate dates and times',
   iconUrl: '{BASE_URL}/apps/formatter/assets/favicon.svg',
   authDocUrl: 'https://guide.plumber.gov.sg/user-guides/actions/formatter',
   baseUrl: '',


### PR DESCRIPTION
## Summary

Prototype for the new date utilities in the **Formatter** app, for engineering review. Adds a new **"Compare or calculate dates"** action and extends the input formats, plus a copy/UX cleanup across the app.

> ⚠️ **Prototype, not production-ready.** The field/config surface is faithful and most logic is real, but some cross-cutting concerns are deliberately scoped or stubbed — see **Known limitations** below.

### New action: "Compare or calculate dates"
Two date operands (each with its own format selector), one operation dropdown:
- **Compare two dates** → `true`/`false` (before / after / on-or-before / on-or-after / same day)
- **Check time gap between dates** → `true`/`false` (within / more-than-before / more-than-after + amount & unit)
- **Calculate time between dates** → number (signed `B − A`, plus `absolute`, plus `unit`)

All parsing + "Now" pinned to **Singapore time**; compare/diff use full-instant math. Outputs carry human-readable summaries and friendly variable-picker labels (`getDataOutMetadata`).

### Input formats
- **Excel serial number** (input-only) — 1900 system, epoch 1899-12-30, fractional time, rejects ≤ 0. Available everywhere a format dropdown appears.
- **"Now"** (current SG date/time) — available in the compare/calculate operands (excluded from Format date/time, where the value field can't be hidden — see limitations).
- One **shared time-unit list** (seconds…years) across all date actions.

### Copy / UX cleanup
- Plain-language field labels (e.g. transform picker → "What do you want to do?" in both actions; "Value to transform" → "Value to change"; operator options read as full sentences).
- Tightened the Formatter app description.

## Design decisions
- **Incremental**, not a redesign; app grouping/IA rethink deferred.
- Comparison **outputs a boolean** meant to feed a downstream **If… then** step; the existing conditional operators are left untouched (the conditional is the long-term "right home").
- Separate new action because comparison/difference need **two** operands, breaking the existing single-`valueToTransform` model.
- **No timezone picker** (SG-gov users) — hardcoded SGT.

## Known limitations / follow-ups
- **`hiddenIf` supports only one condition.** This is why compare vs time-gap are *two* operations (threshold fields can't be conditionally revealed within one), and why "Now" is excluded from Format date/time (its value field can't be hidden there). A compound-`hiddenIf` + validator relax would let these consolidate.
- **SGT pinning is per-operand** in the new action (`parseOperand`), not yet pushed into the shared parser used by convert/add-subtract.
- **Gap amount+unit uses `multirow-multicol`** (to sit on one line, matching add/subtract) — which always renders an "Add" button; only the first row is used. A non-repeating / `maxRows=1` variant is the proper fix.
- **Multi-date batch conversion deferred** (outputs are referenced by named key; arrays need For-each). Nothing here blocks a future labelled-rows mode.

## Test plan
- `npm run -w backend test:unit -- formatter` → **112 passing** (16 new, covering Excel-serial parsing, SGT, compare/gap/difference, readable summaries, and output metadata labels).
- Typecheck clean on changed files.
- Manually verified in the running app: new action renders, operation/format dropdowns (incl. Excel serial & "Now"), "Now" hides the value field, value→format ordering, gap amount+unit on one line, seconds present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)