### PR TITLE
chore: harden email preview iframe with explicit CSP

### DIFF
--- a/packages/frontend/src/components/ViewAsEmailModal/buildPreviewDocument.test.ts
+++ b/packages/frontend/src/components/ViewAsEmailModal/buildPreviewDocument.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPreviewDocument } from './buildPreviewDocument'
+
+// Runs in the default node environment (like RichTextEditor/utils.test.ts).
+// buildPreviewDocument is a pure string builder around @emailens/engine, so no
+// DOM / jsdom / testing-library is needed.
+
+describe('buildPreviewDocument', () => {
+  it('emits a full HTML document with exactly one document-shell body', () => {
+    const out = buildPreviewDocument('<p>hello</p>', 'gmail-web')
+
+    expect(out.startsWith('<!doctype html>')).toBe(true)
+
+    // The shell owns exactly one <body>. We pin it via the literal shell
+    // prefix/suffix rather than counting "<body>" substrings, because the
+    // engine returns a full document and nests its own <body> inside the
+    // shell's body. The shell is what guarantees a single outer body region.
+    expect(
+      out.startsWith(
+        '<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content=',
+      ),
+    ).toBe(true)
+    expect(out).toContain('<meta name="referrer" content="no-referrer">')
+    expect(out).toMatch(/"><\/head><body>/)
+    expect(out.endsWith('</body></html>')).toBe(true)
+  })
+
+  it('injects a Content-Security-Policy meta with the locked-down directives', () => {
+    const out = buildPreviewDocument('<p>hello</p>', 'gmail-web')
+
+    expect(out).toContain('<meta http-equiv="Content-Security-Policy"')
+    expect(out).toContain("default-src 'none'")
+    expect(out).toContain("script-src 'none'")
+    expect(out).toContain('img-src data:')
+  })
+
+  it('is never looser than the inherited Helmet CSP (only allowlisted hosts)', () => {
+    const out = buildPreviewDocument('<p>hello</p>', 'gmail-web')
+    const policy =
+      out.match(
+        /http-equiv="Content-Security-Policy" content="([^"]*)"/,
+      )?.[1] ?? ''
+
+    // The inherited Helmet policy uses narrow host allowlists, never a wildcard
+    // or a scheme-wide `https:`/`http:`. This meta may name a specific host
+    // (which must also be in the inherited policy) but must never grant a bare
+    // scheme or `*`, or it would be looser than the policy it reinforces.
+    expect(policy).not.toContain('*')
+    expect(policy).not.toMatch(/https?:(?!\/\/)/)
+    // Remote images limited to the gov file host (also in the inherited img-src).
+    expect(policy).toContain('img-src data: https://file.go.gov.sg')
+    expect(policy).toContain("default-src 'none'")
+    // base-uri / form-action have no default-src fallback - assert explicitly.
+    expect(policy).toContain("base-uri 'none'")
+    expect(policy).toContain("form-action 'none'")
+  })
+
+  it('preserves the transform output inside the body (incl. Outlook handling)', () => {
+    // Sentinel proves the transformed fragment is wrapped verbatim. The
+    // border-radius forces the engine down its Outlook-unsupported-CSS path.
+    const sentinel = 'PLUMBER_PREVIEW_SENTINEL_8f3a'
+    const out = buildPreviewDocument(
+      `<div style="border-radius: 12px"><p>${sentinel}</p></div>`,
+      'outlook-windows-legacy',
+    )
+
+    const body = out.slice(out.indexOf('<body>') + '<body>'.length)
+    expect(body).toContain(sentinel)
+    // NOTE: this engine version (@emailens/engine 0.9.2) does not emit an
+    // "[if mso]" conditional comment for this input, so we intentionally do
+    // not assert on it here (it would be flaky).
+  })
+
+  it('still applies the empty-<p> margin replacement', () => {
+    const out = buildPreviewDocument('<div><p></p></div>', 'gmail-web')
+
+    expect(out).toContain('<p style="margin: 0">&nbsp;</p>')
+  })
+
+  it('does NOT sanitize: a <script> survives as text but the CSP backstop is present', () => {
+    // We deliberately do not run a content sanitizer; the iframe sandbox="" +
+    // this CSP are the defense. So the script tag is expected to remain in the
+    // output - what we assert is that the script-src 'none' policy is present.
+    const out = buildPreviewDocument(
+      '<p>safe</p><script>alert(1)</script>',
+      'gmail-web',
+    )
+
+    expect(out).toContain('<script>alert(1)</script>')
+    expect(out).toContain('<meta http-equiv="Content-Security-Policy"')
+    expect(out).toContain("script-src 'none'")
+  })
+})

--- a/packages/frontend/src/components/ViewAsEmailModal/buildPreviewDocument.ts
+++ b/packages/frontend/src/components/ViewAsEmailModal/buildPreviewDocument.ts
@@ -1,0 +1,29 @@
+import { transformForClient } from '@emailens/engine'
+
+// Defense-in-depth CSP injected into the preview iframe's srcDoc document,
+// layered on top of the iframe's empty sandbox (see index.tsx). This is NOT a
+// content sanitizer - we deliberately do not strip attacker-controllable email
+// HTML.
+//
+// Some notes on the policy:
+// - [img-src]: We don't need anything other than GoGov files due to our existing
+//   CSP.
+// - [style-src]: We allow 'unsafe-inline' for email styling; we shouldn't need
+//   external sheets.
+// - [base-uri, form-action]: these don't fall back to default-src, so they're
+//   set explicitly
+// - [frame-ancestors]: is omitted: it's ignored in a meta CSP and is already
+//   enforced by the parent Helmet header.
+const CSP =
+  "default-src 'none'; script-src 'none'; object-src 'none'; frame-src 'none'; base-uri 'none'; form-action 'none'; img-src data: https://file.go.gov.sg; style-src 'unsafe-inline'"
+
+export function buildPreviewDocument(html: string, clientId: string): string {
+  const transformed = transformForClient(html, clientId).html.replace(
+    // Replicate logic in backend - see send-transactional-email/index.ts
+    /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
+    '<p style="margin: 0">&nbsp;</p>',
+  )
+
+  // NOTE: this also adds a no-referrer meta tag.
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="${CSP}"><meta name="referrer" content="no-referrer"></head><body>${transformed}</body></html>`
+}

--- a/packages/frontend/src/components/ViewAsEmailModal/index.tsx
+++ b/packages/frontend/src/components/ViewAsEmailModal/index.tsx
@@ -22,9 +22,10 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
-import { transformForClient } from '@emailens/engine'
 
 import { BrokenPipeIcon } from '@/components/Icons'
+
+import { buildPreviewDocument } from './buildPreviewDocument'
 
 interface ClientOption {
   id: string
@@ -56,21 +57,18 @@ interface PreviewPaneProps {
 }
 
 // Renders the transformed email. Extracted so the ErrorBoundary below sits
-// above the transformForClient() call, which is what can actually throw.
+// above the transformForClient() call (inside buildPreviewDocument), which is
+// what can actually throw.
 function PreviewPane({ html, clientId }: PreviewPaneProps) {
   const transformed = useMemo(() => {
-    return transformForClient(html, clientId).html.replace(
-      // Replicate logic in backend - see send-transactional-email/index.ts
-      /(<p\s?((style=")([a-zA-Z0-9:;.\s()\-,]*)("))?>)\s*(<\/p>)/g,
-      '<p style="margin: 0">&nbsp;</p>',
-    )
+    return buildPreviewDocument(html, clientId)
   }, [html, clientId])
 
   return (
     <iframe
       title="Email preview"
       srcDoc={transformed}
-      sandbox=""
+      sandbox="" // MUST stay empty.
       style={{ width: '100%', height: '100%', border: 0 }}
     />
   )


### PR DESCRIPTION
# Context

We're rendering user-provided variables in`ViewAsEmailModal`. While it already has a sandbox="" iframe for protection, we can do a little more hardening to protect the user against weird (e.g. phishy stuff like nested iframes from arcade) - while still not breaking the preview (e.g. we don't want to block images)

# This PR

Adds more defence-in-depth, non-visual-impacting hardening measures:

1. Apply an explicit, even more restrictive CSP to the iframe contents
2. Add no-referrer meta tag (cos why not...)

# Tests

- Check that things that the CSP blocks (like nested iframes) are blocked.
- Regression test: email preview still renders correctly