### PR TITLE
[FLUSH-2] PLU-65 feat(archival): add ExecutionRow and ExecutionStepRow types

### DIFF
--- a/packages/backend/src/helpers/archival/types.ts
+++ b/packages/backend/src/helpers/archival/types.ts
@@ -1,0 +1,27 @@
+export type ExecutionRow = {
+  id: string
+  flowId: string
+  status: 'success' | 'failure' | null
+  testRun: boolean
+  internalId: string | null
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date | null
+}
+
+export type ExecutionStepRow = {
+  id: string
+  executionId: string
+  stepId: string
+  appKey: string | null
+  key: string | null
+  jobId: string | null
+  status: 'success' | 'failure' | null
+  dataIn: Record<string, unknown> | null
+  dataOut: Record<string, unknown> | null
+  errorDetails: Record<string, unknown> | null
+  metadata: Record<string, unknown>
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date | null
+}

--- a/packages/backend/src/helpers/archival/types.ts
+++ b/packages/backend/src/helpers/archival/types.ts
@@ -4,9 +4,9 @@ export type ExecutionRow = {
   status: 'success' | 'failure' | null
   testRun: boolean
   internalId: string | null
-  createdAt: Date
-  updatedAt: Date
-  deletedAt: Date | null
+  createdAt: string
+  updatedAt: string
+  deletedAt: string | null
 }
 
 export type ExecutionStepRow = {
@@ -21,7 +21,7 @@ export type ExecutionStepRow = {
   dataOut: Record<string, unknown> | null
   errorDetails: Record<string, unknown> | null
   metadata: Record<string, unknown>
-  createdAt: Date
-  updatedAt: Date
-  deletedAt: Date | null
+  createdAt: string
+  updatedAt: string
+  deletedAt: string | null
 }


### PR DESCRIPTION
## TL;DR

Adds two plain TypeScript types — `ExecutionRow` and `ExecutionStepRow` — that describe the raw Knex row shapes for the `executions` and `execution_steps` tables. Used by the archival query layer in later PRs.

## What changed?

**`src/helpers/archival/types.ts`** — two new `type` declarations mirroring the DB schema:

- `ExecutionRow`: `id`, `flowId`, `status`, `testRun`, `internalId`, timestamps
- `ExecutionStepRow`: `id`, `executionId`, `stepId`, `appKey`, `key`, `jobId`, `status`, `dataIn`, `dataOut`, `errorDetails`, `metadata`, timestamps

All columns cross-checked against migrations. Timestamp fields are typed as `string` (not `Date`) — Knex/pg returns ISO strings, consistent with `src/models/base.ts`.

## Tests

This PR is types-only — no runtime behaviour. Sanity check:

- [ ] No TypeScript errors: `npm run -w backend build` (or `tsc --noEmit`) succeeds