### PR TITLE
[FLUSH-4] PLU-65 feat(archival): add archive S3 client

### DIFF
--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -47,8 +47,12 @@ export const archivalConfig = {
   postgresReaderHost: requireString('ARCHIVE_POSTGRES_READER_HOST'),
   // S3 dev credentials (prod uses IAM role — no explicit credentials needed)
   s3Endpoint: process.env.S3_ENDPOINT,
-  s3AccessKey: process.env.S3_ACCESS_KEY,
-  s3SecretKey: process.env.S3_SECRET_KEY,
+  s3AccessKey: isDev
+    ? requireString('S3_ACCESS_KEY')
+    : process.env.S3_ACCESS_KEY,
+  s3SecretKey: isDev
+    ? requireString('S3_SECRET_KEY')
+    : process.env.S3_SECRET_KEY,
   // Archival job settings
   archiveEnabled: process.env.ARCHIVE_ENABLED === 'true',
   archiveDryRun: process.env.ARCHIVE_DRY_RUN === 'true',

--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -46,7 +46,7 @@ export const archivalConfig = {
   // reads never fall back to the writer. Use localhost for local dev.
   postgresReaderHost: requireString('ARCHIVE_POSTGRES_READER_HOST'),
   // S3 dev credentials (prod uses IAM role — no explicit credentials needed)
-  s3Endpoint: process.env.S3_ENDPOINT,
+  s3Endpoint: isDev ? requireString('S3_ENDPOINT') : process.env.S3_ENDPOINT,
   s3AccessKey: isDev
     ? requireString('S3_ACCESS_KEY')
     : process.env.S3_ACCESS_KEY,

--- a/packages/backend/src/helpers/archival/s3-client.ts
+++ b/packages/backend/src/helpers/archival/s3-client.ts
@@ -1,4 +1,4 @@
-import { S3Client } from '@aws-sdk/client-s3'
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
 
 import { archivalConfig } from './config'
 
@@ -13,3 +13,31 @@ export const archiveS3Client = new S3Client({
     forcePathStyle: true,
   }),
 })
+
+type PutArchiveObjectParams = {
+  s3Client: S3Client
+  bucket: string
+  key: string
+  body: Buffer | string
+  contentType: string
+  metadata?: Record<string, string>
+}
+
+export async function putArchiveObject({
+  s3Client,
+  bucket,
+  key,
+  body,
+  contentType,
+  metadata,
+}: PutArchiveObjectParams): Promise<void> {
+  await s3Client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      Metadata: metadata,
+    }),
+  )
+}

--- a/packages/backend/src/helpers/archival/s3-client.ts
+++ b/packages/backend/src/helpers/archival/s3-client.ts
@@ -6,8 +6,8 @@ export const archiveS3Client = new S3Client({
   region: 'ap-southeast-1',
   ...(archivalConfig.isDev && {
     credentials: {
-      accessKeyId: archivalConfig.s3AccessKey ?? '',
-      secretAccessKey: archivalConfig.s3SecretKey ?? '',
+      accessKeyId: archivalConfig.s3AccessKey!,
+      secretAccessKey: archivalConfig.s3SecretKey!,
     },
     endpoint: archivalConfig.s3Endpoint,
     forcePathStyle: true,

--- a/packages/backend/src/helpers/archival/s3-client.ts
+++ b/packages/backend/src/helpers/archival/s3-client.ts
@@ -1,0 +1,15 @@
+import { S3Client } from '@aws-sdk/client-s3'
+
+import { archivalConfig } from './config'
+
+export const archiveS3Client = new S3Client({
+  region: 'ap-southeast-1',
+  ...(archivalConfig.isDev && {
+    credentials: {
+      accessKeyId: archivalConfig.s3AccessKey ?? '',
+      secretAccessKey: archivalConfig.s3SecretKey ?? '',
+    },
+    endpoint: archivalConfig.s3Endpoint,
+    forcePathStyle: true,
+  }),
+})


### PR DESCRIPTION
## TL;DR

Adds the S3 client used by all archival upload operations. In dev it points at MinIO (local S3-compatible store); in prod it uses the default credential chain (IAM role, no hardcoded keys).

## What changed?

**`src/helpers/archival/s3-client.ts`** — exports `archiveS3Client`, a singleton `S3Client` configured for `ap-southeast-1`. In dev mode, injects MinIO credentials and `forcePathStyle: true`; in prod the client is bare so the AWS SDK picks up the ECS task role automatically.

**`src/helpers/archival/config.ts`** — hoisted `isDev` to a module-level const so it can guard `requireString` calls for `S3_ENDPOINT`, `S3_ACCESS_KEY`, and `S3_SECRET_KEY`. All three are now required at startup in dev (consistent with how `ARCHIVE_BUCKET` is validated), rather than silently producing an opaque AWS auth/endpoint error on the first upload. In prod, all three are optional (IAM role is used instead).

## Tests

This PR wires up the client — no upload logic runs yet. Sanity checks:

- [ ] No TypeScript errors: `npm run -w backend build` (or `tsc --noEmit`) succeeds
- [ ] In dev, starting with `S3_ACCESS_KEY` unset should throw `S3_ACCESS_KEY must be set` at startup
- [ ] In dev, starting with `S3_ENDPOINT` unset should throw `S3_ENDPOINT must be set` at startup