### PR TITLE
feat(archival): add archivalDbReader Knex client + ARCHIVE_POSTGRES_READER_HOST config

### DIFF
--- a/packages/backend/src/helpers/archival/config.test.ts
+++ b/packages/backend/src/helpers/archival/config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+describe('archival/config — postgresReaderHost', () => {
+  it('is defined and string-typed', async () => {
+    const { archivalConfig } = await import('./config')
+    expect(typeof archivalConfig.postgresReaderHost).toBe('string')
+    expect(archivalConfig.postgresReaderHost.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -19,6 +19,15 @@ export const archivalConfig = {
   postgresUsername: process.env.POSTGRES_USERNAME ?? 'postgres',
   postgresPassword: process.env.POSTGRES_PASSWORD,
   postgresEnableSsl: process.env.POSTGRES_ENABLE_SSL === 'true',
+  // Postgres reader endpoint for archival read traffic (eligibility scan,
+  // execution_steps fetch, Phase 5 cleanup fetches). Falls back to the writer
+  // host if unset — safe for local dev and gradual rollout. Writes always go
+  // to postgresHost (the writer).
+  postgresReaderHost:
+    process.env.ARCHIVE_POSTGRES_READER_HOST ??
+    process.env.RDS_PROXY_HOST ??
+    process.env.POSTGRES_HOST ??
+    'localhost',
   // S3 dev credentials (prod uses IAM role — no explicit credentials needed)
   s3Endpoint: process.env.S3_ENDPOINT,
   s3AccessKey: process.env.S3_ACCESS_KEY,

--- a/packages/backend/src/helpers/archival/db.ts
+++ b/packages/backend/src/helpers/archival/db.ts
@@ -20,3 +20,25 @@ export const archivalDb: Knex = knex({
   } satisfies pg.ClientConfig,
   pool: { min: 0, max: 5 },
 })
+
+// Reader connection. Used for archival's eligibility scan, execution_steps
+// fetch, and Phase 5 cleanup-pass fetches. Falls back to the writer host if
+// ARCHIVE_POSTGRES_READER_HOST is unset.
+//
+// Pool sized smaller than the writer — the eligibility query is one-shot per
+// batch, and execution_steps fetches happen at most archiveIntraBatchConcurrency
+// at once. 10 is plenty of headroom at concurrency=10.
+export const archivalDbReader: Knex = knex({
+  client: 'pg',
+  connection: {
+    host: archivalConfig.postgresReaderHost,
+    port: archivalConfig.postgresPort,
+    user: archivalConfig.postgresUsername,
+    password: archivalConfig.postgresPassword,
+    database: archivalConfig.postgresDatabase,
+    ssl: archivalConfig.postgresEnableSsl
+      ? { rejectUnauthorized: false }
+      : false,
+  } satisfies pg.ClientConfig,
+  pool: { min: 0, max: 10 },
+})


### PR DESCRIPTION
Foundation for the read/write split. archivalDbReader points at the read
replica; falls back to the writer host if ARCHIVE_POSTGRES_READER_HOST is
unset. No call sites are updated yet — that happens in the existing
phase1/run-archival-loop and phase5/fk-closure-cleanup branches in
subsequent commits.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>