### PR TITLE
PLU-772 (feat): Pair action template

### DIFF
--- a/packages/backend/src/db/storage/index.ts
+++ b/packages/backend/src/db/storage/index.ts
@@ -4,6 +4,7 @@ import { ATTENDANCE_TAKING_TEMPLATE } from './attendance-taking-v2'
 import { FOR_EACH_REMINDER_TEMPLATE } from './for-each-reminder'
 import { GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE } from './get-live-updates-through-telegram'
 import { ROUTE_SUPPORT_ENQUIRIES_TEMPLATE } from './route-support-enquiries'
+import { ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_TEMPLATE } from './route-support-enquiries-with-pair'
 import { SEND_A_COPY_OF_FORM_RESPONSE_TEMPLATE } from './send-a-copy-of-form-response'
 import { SEND_FOLLOW_UPS_TEMPLATE } from './send-follow-ups'
 import { SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE } from './send-message-to-a-slack-channel'
@@ -40,6 +41,7 @@ export const TEMPLATES: ITemplate[] = deepFreeze<ITemplate[]>([
   ATTENDANCE_TAKING_TEMPLATE,
   UPDATE_MAILING_LISTS_TEMPLATE,
   ROUTE_SUPPORT_ENQUIRIES_TEMPLATE,
+  ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_TEMPLATE,
   GET_LIVE_UPDATES_THROUGH_TELEGRAM_TEMPLATE,
   SEND_MESSAGE_TO_A_SLACK_CHANNEL_TEMPLATE,
 ])

--- a/packages/backend/src/db/storage/route-support-enquiries-with-pair.ts
+++ b/packages/backend/src/db/storage/route-support-enquiries-with-pair.ts
@@ -1,0 +1,130 @@
+import type { ITemplate, ITemplateStep } from '@plumber/types'
+
+import {
+  CREATE_TEMPLATE_STEP_VARIABLE,
+  FORMSG_SAMPLE_URL_DESCRIPTION,
+  USER_EMAIL_PLACEHOLDER,
+} from './constants'
+
+const ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_ID =
+  '8f0a3052-db94-45de-b984-29647f2b09c9'
+
+/**
+ * The divisions Pair classifies each enquiry into. Each one becomes a Pair
+ * category, an if-then branch, and a routing email, so they must stay in sync.
+ */
+const DIVISIONS = ['Finance', 'IT', 'HR', 'Facilities'] as const
+
+/**
+ * Pair prompt (stored as HTML, since the prompt field is a rich-text editor).
+ * References the form submission from step 1 via a variable placeholder that
+ * the user re-points after copying the template.
+ */
+const PAIR_PROMPT = [
+  '<p>You are a support officer for a government agency. Read the enquiry below and decide which division should handle it:</p>',
+  '<p></p>',
+  '<p>',
+  '<span ',
+  'data-type="variable" ',
+  'data-id="step.00000000-0000-0000-0000-000000000000.Replace this with the enquiry from step 1" ',
+  'data-label="Replace this with the enquiry from step 1" ',
+  'data-value>',
+  '{{step.00000000-0000-0000-0000-000000000000.Replace this with the enquiry from step 1}}',
+  '</span>',
+  '</p>',
+  '<p></p>',
+  '<p>Pick the single division best suited to handle this enquiry, then write a one to two sentence summary of what the enquirer needs.</p>',
+].join('')
+
+// If-then branch that fires when Pair classifies the enquiry as `division`.
+function createDivisionBranch(
+  division: string,
+  position: number,
+): ITemplateStep {
+  return {
+    position,
+    appKey: 'toolbox',
+    eventKey: 'ifThen',
+    parameters: {
+      depth: 0,
+      branchName: division,
+      conditions: [
+        {
+          is: 'is',
+          text: division,
+          field: CREATE_TEMPLATE_STEP_VARIABLE(
+            'Replace with department from step 2',
+          ),
+          condition: 'equals',
+        },
+      ],
+    },
+  }
+}
+
+// Routing email sent to a division when its branch is taken.
+function createDivisionEmail(
+  division: string,
+  position: number,
+): ITemplateStep {
+  return {
+    position,
+    appKey: 'postman',
+    eventKey: 'sendTransactionalEmail',
+    parameters: {
+      body: `<p style="margin: 0">A new enquiry has been routed to the ${division} division.</p><p style="margin: 0"></p><p style="margin: 0">From: ${CREATE_TEMPLATE_STEP_VARIABLE(
+        'Replace with the enquirer from step 1',
+      )}</p><p style="margin: 0"></p><p style="margin: 0">What they need: ${CREATE_TEMPLATE_STEP_VARIABLE(
+        'Replace with the summary from step 2',
+      )}</p><p style="margin: 0"></p><p style="margin: 0">Please follow up within 3 working days. Thank you!</p>`,
+      subject: `New ${division} enquiry received`,
+      senderName: 'Enquiry routing',
+      destinationEmail: USER_EMAIL_PLACEHOLDER,
+    },
+  }
+}
+
+export const ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_TEMPLATE: ITemplate = {
+  id: ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_ID,
+  name: 'Route support enquiries with Pair',
+  description:
+    'Use Pair to read incoming form enquiries and route to the right division',
+  iconName: 'BiDirections',
+  tags: ['new'],
+  // Steps: formsg --> Pair (classify) --> one if-then + email per division
+  steps: [
+    {
+      position: 1,
+      appKey: 'formsg',
+      eventKey: 'newSubmission',
+      sampleUrl: 'https://form.gov.sg/6a32a65e000886c246640e50',
+      sampleUrlDescription: FORMSG_SAMPLE_URL_DESCRIPTION,
+    },
+    {
+      position: 2,
+      appKey: 'pair',
+      eventKey: 'sendPrompt',
+      parameters: {
+        prompt: PAIR_PROMPT,
+        responseFields: [
+          {
+            fieldType: 'category',
+            fieldName: 'Department',
+            fieldCategories: DIVISIONS.join(', '),
+          },
+          {
+            fieldType: 'text',
+            fieldName: 'Summary',
+          },
+        ],
+      },
+    },
+    ...DIVISIONS.flatMap((division, index): ITemplateStep[] => {
+      const branchPosition = 3 + index * 2
+      return [
+        createDivisionBranch(division, branchPosition),
+        createDivisionEmail(division, branchPosition + 1),
+      ]
+    }),
+  ],
+}

--- a/packages/frontend/src/pages/Templates/index.tsx
+++ b/packages/frontend/src/pages/Templates/index.tsx
@@ -1,5 +1,6 @@
 import type { ITemplate } from '@plumber/types'
 
+import { useContext } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { Flex, Grid, Text } from '@chakra-ui/react'
@@ -8,6 +9,7 @@ import { Link } from '@opengovsg/design-system-react'
 import Container from '@/components/Container'
 import PageTitle from '@/components/PageTitle'
 import * as URLS from '@/config/urls'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { GET_TEMPLATES } from '@/graphql/queries/get-templates'
 import { useApps } from '@/hooks/useApps'
 
@@ -22,7 +24,19 @@ const TEMPLATES_COUNT = 9
 export default function Templates(): JSX.Element {
   const { data, loading: templatesLoading } = useQuery(GET_TEMPLATES)
 
-  const templates: ITemplate[] = data?.getTemplates
+  // TODO (kevinkim-ogp): remove this when Pair is released to all users
+  // we do this to avoid adding extra flags or parameters into the query
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const isPairEnabled = getFlagValue('app_pair') as boolean
+  const templates: ITemplate[] =
+    data?.getTemplates?.filter((template: ITemplate) => {
+      if (isPairEnabled) {
+        return template.id !== '2a84e2f6-4806-46a2-890a-0dba1411b12f' // ROUTE_SUPPORT_ENQUIRIES_TEMPLATE
+      } else if (!isPairEnabled) {
+        return template.id !== '8f0a3052-db94-45de-b984-29647f2b09c9' // ROUTE_SUPPORT_ENQUIRIES_WITH_PAIR_TEMPLATE
+      }
+      return true
+    }) ?? []
   const { templateId } = useParams()
   const template = templates?.find((template) => template.id === templateId)
 


### PR DESCRIPTION
## TL;DR

Adds a new "Route support enquiries with Pair" flow template that demonstrates using Pair (our LLM action) to classify incoming FormSG enquiries and route each one to the right division via if-then branches. The template is gated behind the `app_pair` LaunchDarkly flag and swaps in for the existing non-Pair "Route support enquiries" template when the flag is on, so the templates count stays the same for every user.

## What changed?

- **New template** `route-support-enquiries-with-pair.ts`: `FormSG (new submission)` → `Pair (classify)` → one `if-then` branch + routing email per division.
  - Pair step classifies each enquiry into a `Department` category (`Finance`, `IT`, `HR`, `Facilities`) plus a `Summary` text field.
  - Divisions are defined once in a `DIVISIONS` constant; branches and routing emails are generated from it via helpers (`createDivisionBranch`, `createDivisionEmail`) to avoid copy-paste.
  - Each branch fires when `Department` equals its division and sends a routing email containing the enquirer + Pair summary (variable placeholders the user re-points after copying).
- **Registered** the template in `db/storage/index.ts`.
- **Flag-gated display** in `Templates/index.tsx`: when `app_pair` is on, the Pair template is shown and the old `ROUTE_SUPPORT_ENQUIRIES_TEMPLATE` is hidden; when off, the reverse. Mutually exclusive, so `TEMPLATES_COUNT` stays at 9.

## Tests

Reviewer checklist:

- [ ] **Flag ON (`app_pair` enabled):** the templates page shows "Route support enquiries with Pair" and does **not** show the old "Route support enquiries"; total count is still 9.
- [ ] **Flag OFF (`app_pair` disabled):** the page shows the old "Route support enquiries" and does **not** show the Pair template; total count is still 9.
- [ ] **Create flow from template:** clicking the Pair template creates a flow with FormSG → Pair → 4 if-then branches, each with its own routing email (10 steps total).
- [ ] **Pair step config loads:** the Pair step opens with the prompt populated and the `responseFields` showing a `Department` category (Finance, IT, HR, Facilities) and a `Summary` text field — no validation errors on open.
- [ ] **If-then branches:** each branch's condition reads `Department equals <division>` and each branch name matches its division.
- [ ] **Routing emails:** each branch's Postman email has the right subject (`New <division> enquiry received`) and the placeholder variables for enquirer/summary are present.
- [ ] **No regressions:** other existing templates still render and are creatable as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)