### PR TITLE
fix: add schema fallback defaults

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/common/generate-schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/common/generate-schema.test.ts
@@ -47,6 +47,23 @@ describe('generateSchemaFromFields', () => {
 
       expect(schemaShape.summary.description).toBe('Text field: summary')
     })
+
+    it('should use default value when text field is omitted', () => {
+      const fields = [
+        {
+          fieldName: 'description',
+          fieldType: 'text' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({})
+
+      assert(result.success === true)
+      expect(result.data.description).toBe(
+        'Sample text. Refine your prompt to generate different outputs!',
+      )
+    })
   })
 
   describe('number field type', () => {
@@ -106,6 +123,21 @@ describe('generateSchemaFromFields', () => {
       const schemaShape = schema._def.shape()
 
       expect(schemaShape.amount.description).toBe('Number field: amount')
+    })
+
+    it('should use default value 0 when number field is omitted', () => {
+      const fields = [
+        {
+          fieldName: 'count',
+          fieldType: 'number' as const,
+        },
+      ]
+
+      const schema = generateSchemaFromFields(fields)
+      const result = schema.safeParse({})
+
+      assert(result.success === true)
+      expect(result.data.count).toBe(0)
     })
   })
 
@@ -348,25 +380,25 @@ describe('generateSchemaFromFields', () => {
       assert(result.success === false)
     })
 
-    it('should require all defined fields', () => {
+    it('should accept all defined fields when explicitly provided', () => {
       const fields = [
         {
-          fieldName: 'required1',
+          fieldName: 'field1',
           fieldType: 'text' as const,
         },
         {
-          fieldName: 'required2',
+          fieldName: 'field2',
           fieldType: 'number' as const,
         },
       ]
 
       const schema = generateSchemaFromFields(fields)
       const result = schema.safeParse({
-        required1: 'value',
-        // missing required2
+        field1: 'value',
+        field2: 0,
       })
 
-      assert(result.success === false)
+      assert(result.success === true)
     })
   })
 

--- a/packages/backend/src/apps/pair/common/generate-schema.ts
+++ b/packages/backend/src/apps/pair/common/generate-schema.ts
@@ -18,12 +18,20 @@ export function generateSchemaFromFields(fields: ResponseField[]) {
 
     switch (fieldType) {
       case 'text':
-        schemaShape[fieldName] = z.string().describe(`Text field: ${fieldName}`)
+        schemaShape[fieldName] = z
+          .string()
+          .describe(`Text field: ${fieldName}`)
+          // Default value for text fields to avoid issues when the prompt is too vague or when the user is testing with presetss
+          .default(
+            'Sample text. Refine your prompt to generate different outputs!',
+          )
         break
       case 'number':
         schemaShape[fieldName] = z
           .number()
           .describe(`Number field: ${fieldName}`)
+          // Default value for number fields to avoid issues when the prompt is too vague or when the user is testing with presetss
+          .default(0)
         break
       case 'category':
         if (fieldCategories) {

--- a/packages/backend/src/apps/pair/common/generate-schema.ts
+++ b/packages/backend/src/apps/pair/common/generate-schema.ts
@@ -21,7 +21,7 @@ export function generateSchemaFromFields(fields: ResponseField[]) {
         schemaShape[fieldName] = z
           .string()
           .describe(`Text field: ${fieldName}`)
-          // Default value for text fields to avoid issues when the prompt is too vague or when the user is testing with presetss
+          // Default value for text fields to avoid issues when the prompt is too vague or when the user is testing with presets
           .default(
             'Sample text. Refine your prompt to generate different outputs!',
           )


### PR DESCRIPTION
### TL;DR

Text fields default to 'Sample text. Refine your prompt to generate different outputs!' and number fields default to 0, so that
LLM-omitted or unparseable values surface a readable placeholder rather than throwing an error.

### Tests

- [ ]  Enter vague prompt and 'Check step', you should see '\<UNKNOWN>' for Text fields and 0 for Number fields.