### PR TITLE
chore: add infobox to link to guide

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -20,6 +20,7 @@ const action: IRawAction = {
   name: 'Process an image',
   key: 'processImage',
   description: 'Extract information from an image or PDF',
+  linkToGuide: 'https://guide.plumber.gov.sg/user-guides/actions/pair',
   arguments: [
     {
       label: 'Image',

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -23,6 +23,7 @@ const action: IRawAction = {
   key: 'sendPrompt',
   description:
     'Enter a custom prompt to summarise, categorise or analyse data with Pair',
+  linkToGuide: 'https://guide.plumber.gov.sg/user-guides/actions/pair',
   arguments: [
     {
       label: 'Describe what you want Pair to do',


### PR DESCRIPTION
### TL;DR

These actions are not the easiest to use/understand for a new user. Use the existing`LearnFromGuideInfobox` to link them out to the link (similar to what we did for For each)

### Tests

- [ ] Verify that the action fields are rendered properly
- [ ] Verify that the link opens to the guide properly