### PR TITLE
chore: fix mrf test breakage

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -126,10 +126,12 @@ function makeGlobalVariable(): IGlobalVariable {
     step: {
       id: '123',
       appKey: apps.formsg.key,
+      key: 'newSubmission',
       position: 0,
       parameters: {
         nricFilter: undefined,
       },
+      version: 1,
     },
     flow: {
       id: 'flowid',
@@ -144,7 +146,7 @@ function makeGlobalVariable(): IGlobalVariable {
       updatedAt: `${new Date().getTime()}`,
     },
     app: apps.formsg,
-  } as IGlobalVariable
+  }
 }
 
 describe('decrypt form response - MRF specific', () => {


### PR DESCRIPTION
sorry merged badly, mangled some test data because i refactored construction of `IGlobalVariable` in MRF test to a helper fncton.

Fixed by restoring previous test data from the SDK upgrade PR #1693

https://github.com/opengovsg/plumber/blob/ad6d960428e8394ec27d16b6c9e37e61ca7553f6/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts