### PR TITLE
chore: make "continue edit" the primary action in unsaved changes modal 

### DIFF
--- a/packages/frontend/src/components/Editor/components/UnsavedChangesAlert.tsx
+++ b/packages/frontend/src/components/Editor/components/UnsavedChangesAlert.tsx
@@ -42,15 +42,14 @@ export default function UnsavedChangesAlert({
 
           <AlertDialogFooter>
             <Button
-              ref={cancelRef}
-              onClick={onClose}
+              onClick={handleLeave}
               variant="clear"
               colorScheme="secondary"
             >
-              Continue editing
-            </Button>
-            <Button colorScheme="critical" onClick={handleLeave} ml={3}>
               Discard changes
+            </Button>
+            <Button ref={cancelRef} onClick={onClose} ml={3}>
+              Continue editing
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
# Context

Primary button in our "Unsaved Changes" modal is set to "discard changes", which might be confusing for users; primary actions should not be destructive unless its a confirmation for an intentionally destructive action.

# Fix

Make the primary action "Continue Editing"

### NOTE

I removed `colorScheme` critical - having "Discard Changes" be red feels weird.

# Tests

- Continue editing and discard changes button still works
- Looks good

![Screenshot 2026-06-18 at 5.41.01 PM.png](https://app.graphite.com/user-attachments/assets/ddfe621c-177f-4cb8-b8c1-3915af534c20.png)