### PR TITLE
[FLUSH-5] PLU-65 feat(archival): archiveExecution — write execution to S3 and delete from DB

### DIFF
--- a/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
@@ -4,7 +4,8 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3'
 import type { Knex } from 'knex'
-import { describe, expect, it, vi } from 'vitest'
+import { Settings as LuxonSettings } from 'luxon'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { archiveExecution } from '../archive-execution'
 import {
@@ -14,6 +15,13 @@ import {
 import type { ExecutionRow, ExecutionStepRow } from '../types'
 
 vi.mock('./logger')
+
+// TZ formatting replicated here (see appConfig) as tests don't load the app
+// config module.
+beforeAll(() => {
+  LuxonSettings.defaultZone = 'Asia/Singapore'
+  LuxonSettings.defaultLocale = 'en-SG'
+})
 
 const mockExecution: ExecutionRow = {
   id: 'exec-1',
@@ -182,6 +190,56 @@ describe('archiveExecution', () => {
 
     expect(result).toBe('skipped')
     expect(knexClient.transaction).not.toHaveBeenCalled()
+  })
+
+  describe('archived-at metadata', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('is stamped in SGT (UTC+8), not UTC', async () => {
+      // 2025-01-15T00:00:00Z UTC = 2025-01-15T08:00:00+08:00 SGT
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2025-01-15T00:00:00.000Z'))
+
+      const s3 = makeMockS3()
+      const knexClient = makeMockKnex()
+
+      await archiveExecution(mockExecution, mockSteps, {
+        ...baseOpts,
+        s3Client: s3,
+        knexClient,
+      })
+
+      const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
+        ([cmd]) => cmd instanceof PutObjectCommand,
+      )
+      expect(putCall[0].input.Metadata['archived-at']).toBe(
+        '2025-01-15T08:00:00.000+08:00',
+      )
+    })
+
+    it('correctly crosses midnight — UTC 16:00 is next SGT day', async () => {
+      // 2025-01-15T16:00:00Z UTC = 2025-01-16T00:00:00+08:00 SGT
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2025-01-15T16:00:00.000Z'))
+
+      const s3 = makeMockS3()
+      const knexClient = makeMockKnex()
+
+      await archiveExecution(mockExecution, mockSteps, {
+        ...baseOpts,
+        s3Client: s3,
+        knexClient,
+      })
+
+      const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
+        ([cmd]) => cmd instanceof PutObjectCommand,
+      )
+      expect(putCall[0].input.Metadata['archived-at']).toBe(
+        '2025-01-16T00:00:00.000+08:00',
+      )
+    })
   })
 
   it('builds the correct S3 key', async () => {

--- a/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
@@ -78,6 +78,7 @@ function makeMockKnex() {
 const baseOpts = {
   dryRun: false,
   bucket: 'plumber-archive-test',
+  runAt: '2025-01-15T00:00:00.000Z',
 }
 
 describe('archiveExecution', () => {

--- a/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
@@ -6,9 +6,12 @@ import {
 import type { Knex } from 'knex'
 import { describe, expect, it, vi } from 'vitest'
 
-import { archiveExecution } from './archive-execution'
-import { S3_PREFIX_EXECUTIONS, S3_PREFIX_TEST_EXECUTIONS } from './build-s3-key'
-import type { ExecutionRow, ExecutionStepRow } from './types'
+import { archiveExecution } from '../archive-execution'
+import {
+  S3_PREFIX_EXECUTIONS,
+  S3_PREFIX_TEST_EXECUTIONS,
+} from '../build-s3-key'
+import type { ExecutionRow, ExecutionStepRow } from '../types'
 
 vi.mock('./logger')
 

--- a/packages/backend/src/helpers/archival/__tests__/build-s3-key.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/build-s3-key.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { Settings as LuxonSettings } from 'luxon'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import {
   buildS3Key,
   S3_PREFIX_EXECUTIONS,
   S3_PREFIX_TEST_EXECUTIONS,
 } from '../build-s3-key'
+
+// TZ formatting replicated here (see appConfig) as tests don't load the app
+// config module.
+beforeAll(() => {
+  LuxonSettings.defaultZone = 'Asia/Singapore'
+  LuxonSettings.defaultLocale = 'en-SG'
+})
 
 describe('buildS3Key', () => {
   it('builds the correct key for non-test executions', () => {

--- a/packages/backend/src/helpers/archival/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.test.ts
@@ -7,6 +7,7 @@ import type { Knex } from 'knex'
 import { describe, expect, it, vi } from 'vitest'
 
 import { archiveExecution } from './archive-execution'
+import { S3_PREFIX_EXECUTIONS, S3_PREFIX_TEST_EXECUTIONS } from './build-s3-key'
 import type { ExecutionRow, ExecutionStepRow } from './types'
 
 vi.mock('./logger')
@@ -73,12 +74,11 @@ function makeMockKnex() {
 
 const baseOpts = {
   dryRun: false,
-  execsBucket: 'plumber-archive-executions-test',
-  testExecsBucket: 'plumber-archive-test-executions-test',
+  bucket: 'plumber-archive-test',
 }
 
 describe('archiveExecution', () => {
-  it('uploads to prod bucket for non-test-run executions', async () => {
+  it('non-test executions use executions/ key prefix', async () => {
     const s3 = makeMockS3()
     const knexClient = makeMockKnex()
 
@@ -91,10 +91,13 @@ describe('archiveExecution', () => {
     const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
       ([cmd]) => cmd instanceof PutObjectCommand,
     )
-    expect(putCall[0].input.Bucket).toBe('plumber-archive-executions-test')
+    expect(putCall[0].input.Bucket).toBe('plumber-archive-test')
+    expect(putCall[0].input.Key).toMatch(
+      new RegExp(`^${S3_PREFIX_EXECUTIONS}/`),
+    )
   })
 
-  it('uploads to test bucket for test-run executions', async () => {
+  it('test-run executions use test-executions/ key prefix', async () => {
     const s3 = makeMockS3()
     const knexClient = makeMockKnex()
 
@@ -107,7 +110,9 @@ describe('archiveExecution', () => {
     const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
       ([cmd]) => cmd instanceof PutObjectCommand,
     )
-    expect(putCall[0].input.Bucket).toBe('plumber-archive-test-executions-test')
+    expect(putCall[0].input.Key).toMatch(
+      new RegExp(`^${S3_PREFIX_TEST_EXECUTIONS}/`),
+    )
   })
 
   it('returns archived and deletes from DB on success', async () => {
@@ -189,7 +194,7 @@ describe('archiveExecution', () => {
       ([cmd]) => cmd instanceof PutObjectCommand,
     )
     expect(putCall[0].input.Key).toBe(
-      'archives/executions/flow_id=flow-1/year=2025/month=01/execution_id=exec-1.json.gz',
+      `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-1.json.gz`,
     )
   })
 })

--- a/packages/backend/src/helpers/archival/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.test.ts
@@ -150,6 +150,27 @@ describe('archiveExecution', () => {
     expect(knexClient.transaction).not.toHaveBeenCalled()
   })
 
+  it('returns skipped and does not delete when HeadObject throws', async () => {
+    const knexClient = makeMockKnex()
+    const s3 = {
+      send: vi.fn().mockImplementation((cmd) => {
+        if (cmd instanceof HeadObjectCommand) {
+          return Promise.reject(new Error('S3 503'))
+        }
+        return Promise.resolve({})
+      }),
+    } as unknown as S3Client
+
+    const result = await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    expect(result).toBe('skipped')
+    expect(knexClient.transaction).not.toHaveBeenCalled()
+  })
+
   it('builds the correct S3 key', async () => {
     const s3 = makeMockS3()
     const knexClient = makeMockKnex()

--- a/packages/backend/src/helpers/archival/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.test.ts
@@ -1,6 +1,10 @@
-import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
 import type { Knex } from 'knex'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { archiveExecution } from './archive-execution'
 import type { ExecutionRow, ExecutionStepRow } from './types'
@@ -94,11 +98,11 @@ describe('archiveExecution', () => {
     const s3 = makeMockS3()
     const knexClient = makeMockKnex()
 
-    await archiveExecution(
-      { ...mockExecution, testRun: true },
-      mockSteps,
-      { ...baseOpts, s3Client: s3, knexClient },
-    )
+    await archiveExecution({ ...mockExecution, testRun: true }, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
 
     const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
       ([cmd]) => cmd instanceof PutObjectCommand,

--- a/packages/backend/src/helpers/archival/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.test.ts
@@ -1,0 +1,170 @@
+import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import type { Knex } from 'knex'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { archiveExecution } from './archive-execution'
+import type { ExecutionRow, ExecutionStepRow } from './types'
+
+vi.mock('./logger')
+
+const mockExecution: ExecutionRow = {
+  id: 'exec-1',
+  flowId: 'flow-1',
+  status: 'success',
+  testRun: false,
+  internalId: null,
+  createdAt: new Date('2025-01-15T00:00:00.000Z'),
+  updatedAt: new Date('2025-01-15T00:00:00.000Z'),
+  deletedAt: null,
+}
+
+const mockSteps: ExecutionStepRow[] = [
+  {
+    id: 'step-1',
+    executionId: 'exec-1',
+    stepId: 'step-def-1',
+    appKey: 'formsg',
+    key: 'trigger',
+    jobId: null,
+    status: 'success',
+    dataIn: { foo: 'bar' },
+    dataOut: { result: 'ok' },
+    errorDetails: null,
+    metadata: {},
+    createdAt: new Date('2025-01-15T00:00:01.000Z'),
+    updatedAt: new Date('2025-01-15T00:00:01.000Z'),
+    deletedAt: null,
+  },
+]
+
+function makeMockS3(contentLength = 42) {
+  return {
+    send: vi.fn().mockImplementation((cmd) => {
+      if (cmd instanceof HeadObjectCommand) {
+        return Promise.resolve({ ContentLength: contentLength })
+      }
+      return Promise.resolve({})
+    }),
+  } as unknown as S3Client
+}
+
+function makeMockKnex() {
+  const deleteStepsFn = vi.fn().mockResolvedValue(1)
+  const deleteExecFn = vi.fn().mockResolvedValue(1)
+  const trx = (table: string) => ({
+    where: () => ({
+      delete: table === 'execution_steps' ? deleteStepsFn : deleteExecFn,
+    }),
+  })
+  const knexClient = {
+    transaction: vi.fn(async (cb: (trx: unknown) => Promise<void>) => cb(trx)),
+    _deleteStepsFn: deleteStepsFn,
+    _deleteExecFn: deleteExecFn,
+  } as unknown as Knex & {
+    _deleteStepsFn: ReturnType<typeof vi.fn>
+    _deleteExecFn: ReturnType<typeof vi.fn>
+  }
+  return knexClient
+}
+
+const baseOpts = {
+  dryRun: false,
+  execsBucket: 'plumber-archive-executions-test',
+  testExecsBucket: 'plumber-archive-test-executions-test',
+}
+
+describe('archiveExecution', () => {
+  it('uploads to prod bucket for non-test-run executions', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([cmd]) => cmd instanceof PutObjectCommand,
+    )
+    expect(putCall[0].input.Bucket).toBe('plumber-archive-executions-test')
+  })
+
+  it('uploads to test bucket for test-run executions', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    await archiveExecution(
+      { ...mockExecution, testRun: true },
+      mockSteps,
+      { ...baseOpts, s3Client: s3, knexClient },
+    )
+
+    const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([cmd]) => cmd instanceof PutObjectCommand,
+    )
+    expect(putCall[0].input.Bucket).toBe('plumber-archive-test-executions-test')
+  })
+
+  it('returns archived and deletes from DB on success', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    const result = await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    expect(result).toBe('archived')
+    expect((knexClient as any)._deleteStepsFn).toHaveBeenCalledOnce()
+    expect((knexClient as any)._deleteExecFn).toHaveBeenCalledOnce()
+  })
+
+  it('returns archived but skips DB delete when dryRun=true', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    const result = await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      dryRun: true,
+      s3Client: s3,
+      knexClient,
+    })
+
+    expect(result).toBe('archived')
+    expect(knexClient.transaction).not.toHaveBeenCalled()
+  })
+
+  it('returns skipped and does not delete when HeadObject ContentLength is 0', async () => {
+    const s3 = makeMockS3(0)
+    const knexClient = makeMockKnex()
+
+    const result = await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    expect(result).toBe('skipped')
+    expect(knexClient.transaction).not.toHaveBeenCalled()
+  })
+
+  it('builds the correct S3 key', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    const putCall = (s3.send as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([cmd]) => cmd instanceof PutObjectCommand,
+    )
+    expect(putCall[0].input.Key).toBe(
+      'archives/executions/flow_id=flow-1/year=2025/month=01/execution_id=exec-1.json.gz',
+    )
+  })
+})

--- a/packages/backend/src/helpers/archival/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.test.ts
@@ -18,8 +18,8 @@ const mockExecution: ExecutionRow = {
   status: 'success',
   testRun: false,
   internalId: null,
-  createdAt: new Date('2025-01-15T00:00:00.000Z'),
-  updatedAt: new Date('2025-01-15T00:00:00.000Z'),
+  createdAt: '2025-01-15T00:00:00.000Z',
+  updatedAt: '2025-01-15T00:00:00.000Z',
   deletedAt: null,
 }
 
@@ -36,8 +36,8 @@ const mockSteps: ExecutionStepRow[] = [
     dataOut: { result: 'ok' },
     errorDetails: null,
     metadata: {},
-    createdAt: new Date('2025-01-15T00:00:01.000Z'),
-    updatedAt: new Date('2025-01-15T00:00:01.000Z'),
+    createdAt: '2025-01-15T00:00:01.000Z',
+    updatedAt: '2025-01-15T00:00:01.000Z',
     deletedAt: null,
   },
 ]

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -45,14 +45,23 @@ export async function archiveExecution(
     }),
   )
 
-  const head = await opts.s3Client.send(
-    new HeadObjectCommand({ Bucket: bucket, Key: key }),
-  )
+  let head: { ContentLength?: number }
+  try {
+    head = await opts.s3Client.send(
+      new HeadObjectCommand({ Bucket: bucket, Key: key }),
+    )
+  } catch (err) {
+    logger.error(
+      { executionId: execution.id, key, err },
+      'archival: S3 verify threw, skipping',
+    )
+    return 'skipped'
+  }
 
   if (!head.ContentLength) {
     logger.error(
       { executionId: execution.id, key },
-      'archival: S3 verify failed, skipping',
+      'archival: S3 verify failed (zero ContentLength), skipping',
     )
     return 'skipped'
   }

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -1,5 +1,6 @@
 import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import type { Knex } from 'knex'
+import { DateTime } from 'luxon'
 import { promisify } from 'node:util'
 import { gzip } from 'node:zlib'
 
@@ -39,7 +40,7 @@ export async function archiveExecution(
       'flow-id': execution.flowId,
       'execution-id': execution.id,
       'execution-created-at': execution.createdAt,
-      'archived-at': new Date().toISOString(),
+      'archived-at': DateTime.now().toISO(),
       'step-count': String(steps.length),
       'archival-run-at': opts.runAt,
     },

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -1,0 +1,68 @@
+import { gzip } from 'node:zlib'
+import { promisify } from 'node:util'
+
+import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import type { Knex } from 'knex'
+
+import { buildS3Key } from './build-s3-key'
+import logger from './logger'
+import type { ExecutionRow, ExecutionStepRow } from './types'
+
+const gzipAsync = promisify(gzip)
+
+type ArchiveOpts = {
+  dryRun: boolean
+  execsBucket: string
+  testExecsBucket: string
+  s3Client: S3Client
+  knexClient: Knex
+}
+
+export async function archiveExecution(
+  execution: ExecutionRow,
+  steps: ExecutionStepRow[],
+  opts: ArchiveOpts,
+): Promise<'archived' | 'skipped'> {
+  const payload = JSON.stringify({ execution, steps })
+  const compressed = await gzipAsync(payload)
+
+  const bucket = execution.testRun ? opts.testExecsBucket : opts.execsBucket
+  const key = buildS3Key(execution)
+
+  await opts.s3Client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: compressed,
+      ContentType: 'application/gzip',
+      ContentEncoding: 'gzip',
+      Metadata: {
+        'flow-id': execution.flowId,
+        'execution-id': execution.id,
+        'archived-at': new Date().toISOString(),
+        'step-count': String(steps.length),
+      },
+    }),
+  )
+
+  const head = await opts.s3Client.send(
+    new HeadObjectCommand({ Bucket: bucket, Key: key }),
+  )
+
+  if (!head.ContentLength) {
+    logger.error(
+      { executionId: execution.id, key },
+      'archival: S3 verify failed, skipping',
+    )
+    return 'skipped'
+  }
+
+  if (!opts.dryRun) {
+    await opts.knexClient.transaction(async (trx) => {
+      await trx('execution_steps').where('execution_id', execution.id).delete()
+      await trx('executions').where('id', execution.id).delete()
+    })
+  }
+
+  return 'archived'
+}

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -18,6 +18,7 @@ type ArchiveOpts = {
   bucket: string
   s3Client: S3Client
   knexClient: Knex
+  runAt: string
 }
 
 export async function archiveExecution(
@@ -43,6 +44,7 @@ export async function archiveExecution(
         'execution-created-at': execution.createdAt,
         'archived-at': new Date().toISOString(),
         'step-count': String(steps.length),
+        'archival-run-at': opts.runAt,
       },
     }),
   )

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -1,14 +1,11 @@
-import {
-  HeadObjectCommand,
-  PutObjectCommand,
-  S3Client,
-} from '@aws-sdk/client-s3'
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3'
 import type { Knex } from 'knex'
 import { promisify } from 'node:util'
 import { gzip } from 'node:zlib'
 
 import { buildS3Key } from './build-s3-key'
 import logger from './logger'
+import { putArchiveObject } from './s3-client'
 import type { ExecutionRow, ExecutionStepRow } from './types'
 
 const gzipAsync = promisify(gzip)
@@ -32,22 +29,21 @@ export async function archiveExecution(
   const bucket = opts.bucket
   const key = buildS3Key(execution)
 
-  await opts.s3Client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: compressed,
-      ContentType: 'application/gzip',
-      Metadata: {
-        'flow-id': execution.flowId,
-        'execution-id': execution.id,
-        'execution-created-at': execution.createdAt,
-        'archived-at': new Date().toISOString(),
-        'step-count': String(steps.length),
-        'archival-run-at': opts.runAt,
-      },
-    }),
-  )
+  await putArchiveObject({
+    s3Client: opts.s3Client,
+    bucket,
+    key,
+    body: compressed,
+    contentType: 'application/gzip',
+    metadata: {
+      'flow-id': execution.flowId,
+      'execution-id': execution.id,
+      'execution-created-at': execution.createdAt,
+      'archived-at': new Date().toISOString(),
+      'step-count': String(steps.length),
+      'archival-run-at': opts.runAt,
+    },
+  })
 
   let head: { ContentLength?: number }
   try {

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -1,8 +1,11 @@
-import { gzip } from 'node:zlib'
-import { promisify } from 'node:util'
-
-import { HeadObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
 import type { Knex } from 'knex'
+import { promisify } from 'node:util'
+import { gzip } from 'node:zlib'
 
 import { buildS3Key } from './build-s3-key'
 import logger from './logger'
@@ -39,6 +42,7 @@ export async function archiveExecution(
       Metadata: {
         'flow-id': execution.flowId,
         'execution-id': execution.id,
+        'execution-created-at': new Date(execution.createdAt).toISOString(),
         'archived-at': new Date().toISOString(),
         'step-count': String(steps.length),
       },
@@ -51,18 +55,19 @@ export async function archiveExecution(
       new HeadObjectCommand({ Bucket: bucket, Key: key }),
     )
   } catch (err) {
-    logger.error(
-      { executionId: execution.id, key, err },
-      'archival: S3 verify threw, skipping',
-    )
+    logger.error('archival: S3 verify threw, skipping', {
+      executionId: execution.id,
+      key,
+      err,
+    })
     return 'skipped'
   }
 
   if (!head.ContentLength) {
-    logger.error(
-      { executionId: execution.id, key },
-      'archival: S3 verify failed (zero ContentLength), skipping',
-    )
+    logger.error('archival: S3 verify failed (zero ContentLength), skipping', {
+      executionId: execution.id,
+      key,
+    })
     return 'skipped'
   }
 

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -15,8 +15,7 @@ const gzipAsync = promisify(gzip)
 
 type ArchiveOpts = {
   dryRun: boolean
-  execsBucket: string
-  testExecsBucket: string
+  bucket: string
   s3Client: S3Client
   knexClient: Knex
 }
@@ -29,7 +28,7 @@ export async function archiveExecution(
   const payload = JSON.stringify({ execution, steps })
   const compressed = await gzipAsync(payload)
 
-  const bucket = execution.testRun ? opts.testExecsBucket : opts.execsBucket
+  const bucket = opts.bucket
   const key = buildS3Key(execution)
 
   await opts.s3Client.send(

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -37,11 +37,10 @@ export async function archiveExecution(
       Key: key,
       Body: compressed,
       ContentType: 'application/gzip',
-      ContentEncoding: 'gzip',
       Metadata: {
         'flow-id': execution.flowId,
         'execution-id': execution.id,
-        'execution-created-at': new Date(execution.createdAt).toISOString(),
+        'execution-created-at': execution.createdAt,
         'archived-at': new Date().toISOString(),
         'step-count': String(steps.length),
       },

--- a/packages/backend/src/helpers/archival/build-s3-key.ts
+++ b/packages/backend/src/helpers/archival/build-s3-key.ts
@@ -1,3 +1,7 @@
+import '@/types/luxon-extensions'
+
+import { DateTime } from 'luxon'
+
 export const S3_PREFIX_EXECUTIONS = 'executions'
 export const S3_PREFIX_TEST_EXECUTIONS = 'test-executions'
 
@@ -8,14 +12,9 @@ export function buildS3Key(execution: {
   testRun: boolean
 }): string {
   // Partition by SGT so re-hydration matches user-reported run times.
-  // formatToParts extracts named fields directly, avoiding locale-separator assumptions.
-  const sgtParts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Singapore',
-    year: 'numeric',
-    month: '2-digit',
-  }).formatToParts(new Date(execution.createdAt))
-  const year = sgtParts.find((p) => p.type === 'year')!.value
-  const month = sgtParts.find((p) => p.type === 'month')!.value
+  const sgt = DateTime.fromISO(execution.createdAt)
+  const year = sgt.toPlumberFormat('yyyy')
+  const month = sgt.toPlumberFormat('MM')
   const prefix = execution.testRun
     ? S3_PREFIX_TEST_EXECUTIONS
     : S3_PREFIX_EXECUTIONS


### PR DESCRIPTION
## Stack Context

This stack implements the archival pipeline (PLU-65): archiving old flow executions to S3 and deleting them from Postgres to keep the DB lean. Earlier PRs in the stack added primitives, types, S3 key builder, and S3 client. This PR adds `archiveExecution` — the core function that writes a single execution to S3 and removes it from the DB.

## What?

Adds `packages/backend/src/helpers/archival/archive-execution.ts`:
- Serialises `ExecutionRow` + `ExecutionStepRow[]` to JSON, gzips it
- Uploads to S3 via `PutObjectCommand`
- Verifies the upload via `HeadObjectCommand` (guards against silent S3 write failures)
- Deletes `execution_steps` then `executions` rows in a transaction (skipped when `dryRun: true`)
- Returns `'archived' | 'skipped'` (skipped if S3 verify fails — preserves DB rows as source of truth)

## Why?

The verify-before-delete pattern ensures we never lose data: if the S3 write appeared to succeed but the object didn't land (e.g. network hiccup between PUT and HEAD), we return `'skipped'` and leave the DB rows intact for the next archival run to retry.

`dryRun` mode lets operators test the archival loop against production data without deleting anything.

## Tests

- [ ] Non-test executions use `executions/` key prefix
- [ ] Test-run executions use `test-executions/` key prefix
- [ ] Returns `'archived'` and deletes from DB on success
- [ ] Returns `'archived'` but skips DB delete when `dryRun=true`
- [ ] Returns `'skipped'` and skips DB delete when HeadObject ContentLength is 0
- [ ] Returns `'skipped'` and skips DB delete when HeadObject throws
- [ ] Builds the correct S3 key