### PR TITLE
[FLUSH-7] PLU-65 feat(archival): runArchivalLoop

### DIFF
--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -25,7 +25,8 @@ import { archiveExecution } from '../archive-execution'
 import { archivalConfig } from '../config'
 import { archivalDb, archivalDbReader } from '../db'
 import { runArchivalLoop } from '../run-archival-loop'
-import type { ExecutionRow } from '../types'
+import { putArchiveObject } from '../s3-client'
+import type { ExecutionRow, ExecutionStepRow } from '../types'
 
 function makeExecution(
   id: string,
@@ -44,13 +45,37 @@ function makeExecution(
   }
 }
 
+function makeStep(overrides: Partial<ExecutionStepRow> = {}): ExecutionStepRow {
+  return {
+    id: 'step-1',
+    executionId: 'exec-1',
+    stepId: 'step-def-1',
+    appKey: 'formsg',
+    key: 'trigger',
+    jobId: null,
+    status: 'success',
+    dataIn: {},
+    dataOut: {},
+    errorDetails: null,
+    metadata: {},
+    createdAt: '2024-01-01T00:00:01.000Z',
+    updatedAt: '2024-01-01T00:00:01.000Z',
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
 // Callbacks captured from the executions query builder during each test run
 let capturedEligibilityCb: ((qb: any) => void) | null = null
 let capturedTestExecExclusionSubquery: any = null
 let capturedModifyCbs: Array<(qb: any) => void> = []
 
-function setupDb(batches: ExecutionRow[][]) {
+function setupDb(
+  batches: ExecutionRow[][],
+  stepsByExecutionId: Record<string, ExecutionStepRow[]> = {},
+) {
   let batchIdx = 0
+  let currentStepsExecutionId: string | null = null
   capturedEligibilityCb = null
   capturedTestExecExclusionSubquery = null
   capturedModifyCbs = []
@@ -61,11 +86,19 @@ function setupDb(batches: ExecutionRow[][]) {
     whereNull: vi.fn().mockReturnThis(),
   }
 
-  const stepsBuilder = {
+  const stepsBuilder: any = {
     select: vi.fn().mockReturnThis(),
     leftJoin: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    orderBy: vi.fn().mockResolvedValue([]),
+    where: vi.fn().mockImplementation((...args: any[]) => {
+      if (args[0] === 'execution_steps.execution_id') {
+        currentStepsExecutionId = args[1]
+      }
+      return stepsBuilder
+    }),
+    orderBy: vi.fn().mockImplementation(() => {
+      const steps = stepsByExecutionId[currentStepsExecutionId ?? ''] ?? []
+      return Promise.resolve(steps)
+    }),
   }
 
   const execBuilder: any = {
@@ -382,6 +415,97 @@ describe('runArchivalLoop', () => {
       expect(capturedTestExecExclusionSubquery).not.toBeNull()
       // Subquery must use archivalDbReader('flows') — verified by the mock
       expect(archivalDbReader).toHaveBeenCalledWith('flows')
+    })
+  })
+
+  describe('stepCounts', () => {
+    it('accumulates counts per appKey:key from archived execution steps', async () => {
+      const exec1 = makeExecution('e1')
+      const exec2 = makeExecution('e2')
+      setupDb([[exec1, exec2], []], {
+        e1: [
+          makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' }),
+          makeStep({ id: 's2', executionId: 'e1', appKey: 'postman', key: 'send-sms' }),
+        ],
+        e2: [
+          makeStep({ id: 's3', executionId: 'e2', appKey: 'formsg', key: 'trigger' }),
+        ],
+      })
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
+        args.key.startsWith('_meta/runs/'),
+      )
+      expect(metaCall).toBeDefined()
+      const payload = JSON.parse(metaCall![0].body as string)
+      expect(payload.stepCounts).toEqual({
+        formsg: { trigger: 2 },
+        postman: { 'send-sms': 1 },
+      })
+    })
+
+    it('increments nullStepCount for steps where appKey or key is null', async () => {
+      const exec1 = makeExecution('e1')
+      setupDb([[exec1], []], {
+        e1: [
+          makeStep({ id: 's1', executionId: 'e1', appKey: null, key: 'trigger' }),
+          makeStep({ id: 's2', executionId: 'e1', appKey: 'formsg', key: null }),
+          makeStep({ id: 's3', executionId: 'e1', appKey: 'formsg', key: 'trigger' }),
+        ],
+      })
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
+        args.key.startsWith('_meta/runs/'),
+      )!
+      const payload = JSON.parse(metaCall[0].body as string)
+      expect(payload.nullStepCount).toBe(2)
+      expect(payload.stepCounts).toEqual({ formsg: { trigger: 1 } })
+    })
+
+    it('does not count steps from skipped executions', async () => {
+      vi.mocked(archiveExecution).mockResolvedValueOnce('skipped')
+      const exec1 = makeExecution('e1')
+      setupDb([[exec1], []], {
+        e1: [makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' })],
+      })
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
+        args.key.startsWith('_meta/runs/'),
+      )!
+      const payload = JSON.parse(metaCall[0].body as string)
+      expect(payload.stepCounts).toEqual({})
+      expect(payload.nullStepCount).toBe(0)
+    })
+
+    it('writes meta file to _meta/runs/{runAt}.json with correct summary fields', async () => {
+      const exec1 = makeExecution('e1')
+      setupDb([[exec1], []], {
+        e1: [makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' })],
+      })
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
+        args.key.startsWith('_meta/runs/'),
+      )
+      expect(metaCall).toBeDefined()
+      expect(metaCall![0].key).toMatch(/^_meta\/runs\/.+\.json$/)
+      expect(metaCall![0].contentType).toBe('application/json')
+
+      const payload = JSON.parse(metaCall![0].body as string)
+      expect(payload).toMatchObject({
+        dryRun: false,
+        executionsArchived: 1,
+        executionsSkipped: 0,
+        flowsAffected: 1,
+      })
+      expect(typeof payload.runAt).toBe('string')
+      expect(typeof payload.durationMs).toBe('number')
     })
   })
 })

--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./config', () => ({
+vi.mock('../config', () => ({
   archivalConfig: {
     archiveDryRun: false,
     archiveRetentionDays: 90,
@@ -10,19 +10,19 @@ vi.mock('./config', () => ({
     archiveDeletedFlowsOnly: false,
   },
 }))
-vi.mock('./logger')
-vi.mock('./s3-client', () => ({ archiveS3Client: {} }))
-vi.mock('./archive-execution')
-vi.mock('./db', () => ({
+vi.mock('../logger')
+vi.mock('../s3-client', () => ({ archiveS3Client: {} }))
+vi.mock('../archive-execution')
+vi.mock('../db', () => ({
   archivalDb: vi.fn(),
   archivalDbReader: vi.fn(),
 }))
 
-import { archiveExecution } from './archive-execution'
-import { archivalConfig } from './config'
-import { archivalDb, archivalDbReader } from './db'
-import { runArchivalLoop } from './run-archival-loop'
-import type { ExecutionRow } from './types'
+import { archiveExecution } from '../archive-execution'
+import { archivalConfig } from '../config'
+import { archivalDb, archivalDbReader } from '../db'
+import { runArchivalLoop } from '../run-archival-loop'
+import type { ExecutionRow } from '../types'
 
 function makeExecution(
   id: string,

--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -11,7 +11,10 @@ vi.mock('../config', () => ({
   },
 }))
 vi.mock('../logger')
-vi.mock('../s3-client', () => ({ archiveS3Client: {} }))
+vi.mock('../s3-client', () => ({
+  archiveS3Client: {},
+  putArchiveObject: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../archive-execution')
 vi.mock('../db', () => ({
   archivalDb: vi.fn(),
@@ -60,6 +63,7 @@ function setupDb(batches: ExecutionRow[][]) {
 
   const stepsBuilder = {
     select: vi.fn().mockReturnThis(),
+    leftJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockResolvedValue([]),
   }
@@ -96,6 +100,7 @@ function setupDb(batches: ExecutionRow[][]) {
     return execBuilder
   }
   ;(archivalDbReader as any).mockImplementation(tableRouter)
+  ;(archivalDbReader as any).raw = vi.fn().mockImplementation((expr: string) => expr)
   ;(archivalDb as any).mockImplementation(tableRouter)
 }
 

--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -68,6 +68,7 @@ function makeStep(overrides: Partial<ExecutionStepRow> = {}): ExecutionStepRow {
 // Callbacks captured from the executions query builder during each test run
 let capturedEligibilityCb: ((qb: any) => void) | null = null
 let capturedTestExecExclusionSubquery: any = null
+let capturedDeletedFlowsWhereIn: any = null
 let capturedModifyCbs: Array<(qb: any) => void> = []
 
 function setupDb(
@@ -78,6 +79,7 @@ function setupDb(
   let currentStepsExecutionId: string | null = null
   capturedEligibilityCb = null
   capturedTestExecExclusionSubquery = null
+  capturedDeletedFlowsWhereIn = null
   capturedModifyCbs = []
 
   const flowsBuilder = {
@@ -106,6 +108,12 @@ function setupDb(
     where: vi.fn().mockImplementation((...args: any[]) => {
       if (typeof args[0] === 'function') {
         capturedEligibilityCb = args[0]
+      }
+      return execBuilder
+    }),
+    whereIn: vi.fn().mockImplementation((col: string, subquery: any) => {
+      if (col === 'flow_id') {
+        capturedDeletedFlowsWhereIn = subquery
       }
       return execBuilder
     }),
@@ -146,6 +154,7 @@ describe('runArchivalLoop', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    ;(archivalConfig as any).archiveDeletedFlowsOnly = false
   })
 
   it('exits immediately when the first batch is empty', async () => {
@@ -306,27 +315,25 @@ describe('runArchivalLoop', () => {
   })
 
   describe('archiveDeletedFlowsOnly', () => {
-    it('does not add a flow_id filter when flag is false', async () => {
+    it('uses the full three-branch eligibility query when flag is false', async () => {
       ;(archivalConfig as any).archiveDeletedFlowsOnly = false
       setupDb([[]])
 
       await runArchivalLoop(new AbortController().signal)
 
-      // capturedModifyCbs[0] is the deleted-flows modifier; invoke it with a spy qb
-      const qb = { whereIn: vi.fn() }
-      capturedModifyCbs[0](qb)
-      expect(qb.whereIn).not.toHaveBeenCalled()
+      expect(capturedEligibilityCb).not.toBeNull()
+      expect(capturedDeletedFlowsWhereIn).toBeNull()
     })
 
-    it('restricts to deleted flows when flag is true', async () => {
+    it('uses a simple whereIn(flow_id, deleted flows) query when flag is true', async () => {
       ;(archivalConfig as any).archiveDeletedFlowsOnly = true
       setupDb([[]])
 
       await runArchivalLoop(new AbortController().signal)
 
-      const qb = { whereIn: vi.fn() }
-      capturedModifyCbs[0](qb)
-      expect(qb.whereIn).toHaveBeenCalledWith('flow_id', expect.anything())
+      // No three-branch WHERE — skipped entirely for the fast path
+      expect(capturedEligibilityCb).toBeNull()
+      expect(capturedDeletedFlowsWhereIn).not.toBeNull()
     })
 
     it('uses a subquery on flows.deleted_at for the filter', async () => {
@@ -335,10 +342,7 @@ describe('runArchivalLoop', () => {
 
       await runArchivalLoop(new AbortController().signal)
 
-      const qb = { whereIn: vi.fn() }
-      capturedModifyCbs[0](qb)
-
-      // The subquery should be archivalDbReader('flows').select('id').whereNotNull('deleted_at')
+      expect(capturedDeletedFlowsWhereIn).not.toBeNull()
       expect(archivalDbReader).toHaveBeenCalledWith('flows')
     })
   })

--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -133,7 +133,9 @@ function setupDb(
     return execBuilder
   }
   ;(archivalDbReader as any).mockImplementation(tableRouter)
-  ;(archivalDbReader as any).raw = vi.fn().mockImplementation((expr: string) => expr)
+  ;(archivalDbReader as any).raw = vi
+    .fn()
+    .mockImplementation((expr: string) => expr)
   ;(archivalDb as any).mockImplementation(tableRouter)
 }
 
@@ -424,19 +426,34 @@ describe('runArchivalLoop', () => {
       const exec2 = makeExecution('e2')
       setupDb([[exec1, exec2], []], {
         e1: [
-          makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' }),
-          makeStep({ id: 's2', executionId: 'e1', appKey: 'postman', key: 'send-sms' }),
+          makeStep({
+            id: 's1',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+          }),
+          makeStep({
+            id: 's2',
+            executionId: 'e1',
+            appKey: 'postman',
+            key: 'send-sms',
+          }),
         ],
         e2: [
-          makeStep({ id: 's3', executionId: 'e2', appKey: 'formsg', key: 'trigger' }),
+          makeStep({
+            id: 's3',
+            executionId: 'e2',
+            appKey: 'formsg',
+            key: 'trigger',
+          }),
         ],
       })
 
       await runArchivalLoop(new AbortController().signal)
 
-      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
-        args.key.startsWith('_meta/runs/'),
-      )
+      const metaCall = vi
+        .mocked(putArchiveObject)
+        .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))
       expect(metaCall).toBeDefined()
       const payload = JSON.parse(metaCall![0].body as string)
       expect(payload.stepCounts).toEqual({
@@ -449,17 +466,32 @@ describe('runArchivalLoop', () => {
       const exec1 = makeExecution('e1')
       setupDb([[exec1], []], {
         e1: [
-          makeStep({ id: 's1', executionId: 'e1', appKey: null, key: 'trigger' }),
-          makeStep({ id: 's2', executionId: 'e1', appKey: 'formsg', key: null }),
-          makeStep({ id: 's3', executionId: 'e1', appKey: 'formsg', key: 'trigger' }),
+          makeStep({
+            id: 's1',
+            executionId: 'e1',
+            appKey: null,
+            key: 'trigger',
+          }),
+          makeStep({
+            id: 's2',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: null,
+          }),
+          makeStep({
+            id: 's3',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+          }),
         ],
       })
 
       await runArchivalLoop(new AbortController().signal)
 
-      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
-        args.key.startsWith('_meta/runs/'),
-      )!
+      const metaCall = vi
+        .mocked(putArchiveObject)
+        .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))!
       const payload = JSON.parse(metaCall[0].body as string)
       expect(payload.nullStepCount).toBe(2)
       expect(payload.stepCounts).toEqual({ formsg: { trigger: 1 } })
@@ -469,14 +501,21 @@ describe('runArchivalLoop', () => {
       vi.mocked(archiveExecution).mockResolvedValueOnce('skipped')
       const exec1 = makeExecution('e1')
       setupDb([[exec1], []], {
-        e1: [makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' })],
+        e1: [
+          makeStep({
+            id: 's1',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+          }),
+        ],
       })
 
       await runArchivalLoop(new AbortController().signal)
 
-      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
-        args.key.startsWith('_meta/runs/'),
-      )!
+      const metaCall = vi
+        .mocked(putArchiveObject)
+        .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))!
       const payload = JSON.parse(metaCall[0].body as string)
       expect(payload.stepCounts).toEqual({})
       expect(payload.nullStepCount).toBe(0)
@@ -485,14 +524,21 @@ describe('runArchivalLoop', () => {
     it('writes meta file to _meta/runs/{runAt}.json with correct summary fields', async () => {
       const exec1 = makeExecution('e1')
       setupDb([[exec1], []], {
-        e1: [makeStep({ id: 's1', executionId: 'e1', appKey: 'formsg', key: 'trigger' })],
+        e1: [
+          makeStep({
+            id: 's1',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+          }),
+        ],
       })
 
       await runArchivalLoop(new AbortController().signal)
 
-      const metaCall = vi.mocked(putArchiveObject).mock.calls.find(([args]) =>
-        args.key.startsWith('_meta/runs/'),
-      )
+      const metaCall = vi
+        .mocked(putArchiveObject)
+        .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))
       expect(metaCall).toBeDefined()
       expect(metaCall![0].key).toMatch(/^_meta\/runs\/.+\.json$/)
       expect(metaCall![0].contentType).toBe('application/json')

--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -60,4 +60,7 @@ export const archivalConfig = {
   archiveBatchSize: requireInt('ARCHIVE_BATCH_SIZE', 500),
   archiveBatchSleepMs: requireInt('ARCHIVE_BATCH_SLEEP_MS', 2000),
   archiveBucket: requireString('ARCHIVE_BUCKET'),
+  // When true, only archive executions belonging to soft-deleted flows.
+  // Use for phased rollout: archive low-risk data first.
+  archiveDeletedFlowsOnly: process.env.ARCHIVE_DELETED_FLOWS_ONLY === 'true',
 }

--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -62,5 +62,7 @@ export const archivalConfig = {
   archiveBucket: requireString('ARCHIVE_BUCKET'),
   // When true, only archive executions belonging to soft-deleted flows.
   // Use for phased rollout: archive low-risk data first.
+  // TODO: remove this flag (and the fast-path branch in run-archival-loop.ts)
+  // once the deleted-flows phase has been verified and we move to archiving all flows.
   archiveDeletedFlowsOnly: process.env.ARCHIVE_DELETED_FLOWS_ONLY === 'true',
 }

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./config', () => ({
+  archivalConfig: {
+    archiveDryRun: false,
+    archiveRetentionDays: 90,
+    archiveBatchSize: 500,
+    archiveBatchSleepMs: 0,
+    archiveExecutionsBucket: 'exec-bucket',
+    archiveTestExecutionsBucket: 'test-exec-bucket',
+  },
+}))
+vi.mock('./logger')
+vi.mock('./s3-client', () => ({ archiveS3Client: {} }))
+vi.mock('./archive-execution')
+vi.mock('./db', () => ({ archivalDb: vi.fn() }))
+
+import { archivalDb } from './db'
+import { archiveExecution } from './archive-execution'
+import { runArchivalLoop } from './run-archival-loop'
+import type { ExecutionRow } from './types'
+
+function makeExecution(id: string, overrides: Partial<ExecutionRow> = {}): ExecutionRow {
+  return {
+    id,
+    flowId: 'flow-1',
+    status: 'success',
+    testRun: false,
+    internalId: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+// Callbacks captured from the executions query builder during each test run
+let capturedEligibilityCb: ((qb: any) => void) | null = null
+let capturedWhereCalls: Array<any[]> = []
+let capturedModifyCbs: Array<(qb: any) => void> = []
+
+function setupDb(batches: ExecutionRow[][]) {
+  let batchIdx = 0
+  capturedEligibilityCb = null
+  capturedWhereCalls = []
+  capturedModifyCbs = []
+
+  const flowsBuilder = {
+    select: vi.fn().mockReturnThis(),
+    whereNotNull: vi.fn().mockReturnThis(),
+  }
+
+  const stepsBuilder = {
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockResolvedValue([]),
+  }
+
+  const execBuilder: any = {
+    select: vi.fn().mockReturnThis(),
+    where: vi.fn().mockImplementation((...args: any[]) => {
+      if (typeof args[0] === 'function') {
+        capturedEligibilityCb = args[0]
+      } else {
+        capturedWhereCalls.push(args)
+      }
+      return execBuilder
+    }),
+    modify: vi.fn().mockImplementation((cb: (qb: any) => void) => {
+      capturedModifyCbs.push(cb)
+      return execBuilder
+    }),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockImplementation(() => Promise.resolve(batches[batchIdx++] ?? [])),
+  }
+
+  ;(archivalDb as any).mockImplementation((table: string) => {
+    if (table === 'flows') return flowsBuilder
+    if (table === 'execution_steps') return stepsBuilder
+    return execBuilder
+  })
+}
+
+describe('runArchivalLoop', () => {
+  beforeEach(() => {
+    vi.mocked(archiveExecution).mockResolvedValue('archived')
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exits immediately when the first batch is empty', async () => {
+    setupDb([[]])
+    await runArchivalLoop(new AbortController().signal)
+    expect(archiveExecution).not.toHaveBeenCalled()
+  })
+
+  it('calls archiveExecution for each execution in a batch', async () => {
+    const batch = [makeExecution('e1'), makeExecution('e2')]
+    setupDb([batch, []])
+
+    await runArchivalLoop(new AbortController().signal)
+
+    expect(archiveExecution).toHaveBeenCalledTimes(2)
+    expect(archiveExecution).toHaveBeenCalledWith(
+      batch[0],
+      [],
+      expect.objectContaining({ dryRun: false }),
+    )
+  })
+
+  it('stops processing mid-batch when signal is aborted', async () => {
+    const controller = new AbortController()
+    vi.mocked(archiveExecution).mockImplementation(async () => {
+      controller.abort()
+      return 'archived'
+    })
+
+    setupDb([[makeExecution('e1'), makeExecution('e2'), makeExecution('e3')], []])
+
+    await runArchivalLoop(controller.signal)
+
+    expect(archiveExecution).toHaveBeenCalledTimes(1)
+  })
+
+  it('counts skipped executions when archiveExecution returns skipped', async () => {
+    vi.mocked(archiveExecution).mockResolvedValue('skipped')
+    setupDb([[makeExecution('e1')], []])
+
+    // Should complete without throwing even when all executions are skipped
+    await expect(runArchivalLoop(new AbortController().signal)).resolves.toBeUndefined()
+  })
+
+  it('counts skipped executions when archiveExecution throws', async () => {
+    vi.mocked(archiveExecution).mockRejectedValue(new Error('S3 timeout'))
+    setupDb([[makeExecution('e1')], []])
+
+    await expect(runArchivalLoop(new AbortController().signal)).resolves.toBeUndefined()
+  })
+
+  describe('cutoff date', () => {
+    it('uses strict less-than so executions exactly at the cutoff are not selected', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
+
+      const cutoffCall = capturedWhereCalls.find((args) => args[0] === 'created_at')
+      expect(cutoffCall).toBeDefined()
+      expect(cutoffCall![1]).toBe('<')
+    })
+
+    it('sets the cutoff to retentionDays days before now', async () => {
+      setupDb([[]])
+
+      const before = new Date()
+      before.setDate(before.getDate() - 90)
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const after = new Date()
+      after.setDate(after.getDate() - 90)
+
+      const cutoffCall = capturedWhereCalls.find((args) => args[0] === 'created_at')
+      const cutoff: Date = cutoffCall![2]
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(before.getTime() - 100)
+      expect(cutoff.getTime()).toBeLessThanOrEqual(after.getTime() + 100)
+    })
+  })
+
+  describe('eligibility WHERE clause', () => {
+    it('includes non-test executions with terminal statuses', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
+
+      expect(capturedEligibilityCb).not.toBeNull()
+
+      const outerQb = {
+        where: vi.fn().mockReturnThis(),
+        orWhere: vi.fn().mockReturnThis(),
+      }
+      capturedEligibilityCb!(outerQb)
+
+      expect(outerQb.where).toHaveBeenCalledOnce()
+
+      const nonTestCb = outerQb.where.mock.calls[0][0] as (qb: any) => void
+      const nonTestQb = {
+        where: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockReturnThis(),
+      }
+      nonTestCb(nonTestQb)
+
+      expect(nonTestQb.where).toHaveBeenCalledWith('test_run', false)
+      expect(nonTestQb.whereIn).toHaveBeenCalledWith('status', ['success', 'failure'])
+    })
+
+    it('excludes test executions that are still referenced by flows.test_execution_id', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
+
+      expect(capturedEligibilityCb).not.toBeNull()
+
+      const outerQb = {
+        where: vi.fn().mockReturnThis(),
+        orWhere: vi.fn().mockReturnThis(),
+      }
+      capturedEligibilityCb!(outerQb)
+
+      expect(outerQb.orWhere).toHaveBeenCalledOnce()
+
+      const testRunCb = outerQb.orWhere.mock.calls[0][0] as (qb: any) => void
+      const testRunQb = {
+        where: vi.fn().mockReturnThis(),
+        whereNotIn: vi.fn().mockReturnThis(),
+      }
+      testRunCb(testRunQb)
+
+      expect(testRunQb.where).toHaveBeenCalledWith('test_run', true)
+      // whereNotIn (not whereIn) ensures live test executions are excluded
+      expect(testRunQb.whereNotIn).toHaveBeenCalledWith('id', expect.anything())
+    })
+  })
+})

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -6,8 +6,7 @@ vi.mock('./config', () => ({
     archiveRetentionDays: 90,
     archiveBatchSize: 500,
     archiveBatchSleepMs: 0,
-    archiveExecutionsBucket: 'exec-bucket',
-    archiveTestExecutionsBucket: 'test-exec-bucket',
+    archiveBucket: 'archive-bucket',
   },
 }))
 vi.mock('./logger')
@@ -51,6 +50,7 @@ function setupDb(batches: ExecutionRow[][]) {
   const flowsBuilder = {
     select: vi.fn().mockReturnThis(),
     whereNotNull: vi.fn().mockReturnThis(),
+    whereNull: vi.fn().mockReturnThis(),
   }
 
   const stepsBuilder = {
@@ -203,14 +203,26 @@ describe('runArchivalLoop', () => {
       expect(outerQb.where).toHaveBeenCalledOnce()
 
       const nonTestCb = outerQb.where.mock.calls[0][0] as (qb: any) => void
+
+      // The non-test branch is: b.where('test_run', false).where((c) => c.whereIn(...).orWhereIn(...))
+      // The inner callback needs to be invoked to observe whereIn calls.
+      const innerQb = {
+        whereIn: vi.fn().mockReturnThis(),
+        orWhereIn: vi.fn().mockReturnThis(),
+      }
       const nonTestQb = {
-        where: vi.fn().mockReturnThis(),
+        where: vi.fn().mockImplementation((...args: any[]) => {
+          if (typeof args[0] === 'function') {
+            args[0](innerQb)
+          }
+          return nonTestQb
+        }),
         whereIn: vi.fn().mockReturnThis(),
       }
       nonTestCb(nonTestQb)
 
       expect(nonTestQb.where).toHaveBeenCalledWith('test_run', false)
-      expect(nonTestQb.whereIn).toHaveBeenCalledWith('status', [
+      expect(innerQb.whereIn).toHaveBeenCalledWith('status', [
         'success',
         'failure',
       ])

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -43,13 +43,11 @@ function makeExecution(
 
 // Callbacks captured from the executions query builder during each test run
 let capturedEligibilityCb: ((qb: any) => void) | null = null
-let capturedWhereCalls: Array<any[]> = []
 let capturedModifyCbs: Array<(qb: any) => void> = []
 
 function setupDb(batches: ExecutionRow[][]) {
   let batchIdx = 0
   capturedEligibilityCb = null
-  capturedWhereCalls = []
   capturedModifyCbs = []
 
   const flowsBuilder = {
@@ -69,8 +67,6 @@ function setupDb(batches: ExecutionRow[][]) {
     where: vi.fn().mockImplementation((...args: any[]) => {
       if (typeof args[0] === 'function') {
         capturedEligibilityCb = args[0]
-      } else {
-        capturedWhereCalls.push(args)
       }
       return execBuilder
     }),
@@ -163,13 +159,36 @@ describe('runArchivalLoop', () => {
   })
 
   describe('cutoff date', () => {
-    it('uses strict less-than so executions exactly at the cutoff are not selected', async () => {
+    function invokeActiveFlowBranch(branchIndex: 0 | 1): any[] {
+      // The eligibility callback has three branches:
+      //   where(deletedFlows), orWhere(nonTestActive), orWhere(testActive)
+      // branchIndex 0 = nonTestActive (first orWhere), 1 = testActive (second orWhere)
+      const whereCalls: any[][] = []
+      const outerQb = {
+        where: vi.fn().mockReturnThis(),
+        orWhere: vi.fn().mockReturnThis(),
+      }
+      capturedEligibilityCb!(outerQb)
+
+      const branchCb = outerQb.orWhere.mock.calls[branchIndex][0]
+      const branchQb = {
+        where: vi.fn().mockImplementation((...args: any[]) => {
+          whereCalls.push(args)
+          return branchQb
+        }),
+        whereIn: vi.fn().mockReturnThis(),
+        whereNotIn: vi.fn().mockReturnThis(),
+      }
+      branchCb(branchQb)
+      return whereCalls
+    }
+
+    it('uses strict less-than so active-flow executions exactly at the cutoff are not selected', async () => {
       setupDb([[]])
       await runArchivalLoop(new AbortController().signal)
 
-      const cutoffCall = capturedWhereCalls.find(
-        (args) => args[0] === 'created_at',
-      )
+      const whereCalls = invokeActiveFlowBranch(0)
+      const cutoffCall = whereCalls.find((args) => args[0] === 'created_at')
       expect(cutoffCall).toBeDefined()
       expect(cutoffCall![1]).toBe('<')
     })
@@ -185,12 +204,40 @@ describe('runArchivalLoop', () => {
       const after = new Date()
       after.setDate(after.getDate() - 90)
 
-      const cutoffCall = capturedWhereCalls.find(
-        (args) => args[0] === 'created_at',
-      )
+      const whereCalls = invokeActiveFlowBranch(0)
+      const cutoffCall = whereCalls.find((args) => args[0] === 'created_at')
       const cutoff: Date = cutoffCall![2]
       expect(cutoff.getTime()).toBeGreaterThanOrEqual(before.getTime() - 100)
       expect(cutoff.getTime()).toBeLessThanOrEqual(after.getTime() + 100)
+    })
+
+    it('does not apply the cutoff to deleted-flow executions', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
+
+      const outerQb = {
+        where: vi.fn().mockReturnThis(),
+        orWhere: vi.fn().mockReturnThis(),
+      }
+      capturedEligibilityCb!(outerQb)
+
+      // The deleted-flows branch is the first .where() call
+      const deletedFlowsCb = outerQb.where.mock.calls[0][0]
+      const deletedFlowsQb = {
+        where: vi.fn().mockReturnThis(),
+        whereIn: vi.fn().mockReturnThis(),
+      }
+      deletedFlowsCb(deletedFlowsQb)
+
+      expect(deletedFlowsQb.where).not.toHaveBeenCalledWith(
+        'created_at',
+        expect.anything(),
+        expect.anything(),
+      )
+      expect(deletedFlowsQb.whereIn).toHaveBeenCalledWith(
+        'flow_id',
+        expect.anything(),
+      )
     })
   })
 
@@ -251,7 +298,7 @@ describe('runArchivalLoop', () => {
   })
 
   describe('eligibility WHERE clause', () => {
-    it('includes non-test executions with terminal statuses', async () => {
+    it('has three branches: deleted-flows, non-test-active, test-active', async () => {
       setupDb([[]])
       await runArchivalLoop(new AbortController().signal)
 
@@ -264,28 +311,30 @@ describe('runArchivalLoop', () => {
       capturedEligibilityCb!(outerQb)
 
       expect(outerQb.where).toHaveBeenCalledOnce()
+      expect(outerQb.orWhere).toHaveBeenCalledTimes(2)
+    })
 
-      const nonTestCb = outerQb.where.mock.calls[0][0] as (qb: any) => void
+    it('includes non-test executions on active flows with terminal statuses', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
 
-      // The non-test branch is: b.where('test_run', false).where((c) => c.whereIn(...).orWhereIn(...))
-      // The inner callback needs to be invoked to observe whereIn calls.
-      const innerQb = {
-        whereIn: vi.fn().mockReturnThis(),
-        orWhereIn: vi.fn().mockReturnThis(),
+      const outerQb = {
+        where: vi.fn().mockReturnThis(),
+        orWhere: vi.fn().mockReturnThis(),
       }
-      const nonTestQb = {
-        where: vi.fn().mockImplementation((...args: any[]) => {
-          if (typeof args[0] === 'function') {
-            args[0](innerQb)
-          }
-          return nonTestQb
-        }),
+      capturedEligibilityCb!(outerQb)
+
+      const nonTestActiveCb = outerQb.orWhere.mock.calls[0][0] as (
+        qb: any,
+      ) => void
+      const nonTestActiveQb = {
+        where: vi.fn().mockReturnThis(),
         whereIn: vi.fn().mockReturnThis(),
       }
-      nonTestCb(nonTestQb)
+      nonTestActiveCb(nonTestActiveQb)
 
-      expect(nonTestQb.where).toHaveBeenCalledWith('test_run', false)
-      expect(innerQb.whereIn).toHaveBeenCalledWith('status', [
+      expect(nonTestActiveQb.where).toHaveBeenCalledWith('test_run', false)
+      expect(nonTestActiveQb.whereIn).toHaveBeenCalledWith('status', [
         'success',
         'failure',
       ])
@@ -295,26 +344,24 @@ describe('runArchivalLoop', () => {
       setupDb([[]])
       await runArchivalLoop(new AbortController().signal)
 
-      expect(capturedEligibilityCb).not.toBeNull()
-
       const outerQb = {
         where: vi.fn().mockReturnThis(),
         orWhere: vi.fn().mockReturnThis(),
       }
       capturedEligibilityCb!(outerQb)
 
-      expect(outerQb.orWhere).toHaveBeenCalledOnce()
-
-      const testRunCb = outerQb.orWhere.mock.calls[0][0] as (qb: any) => void
-      const testRunQb = {
+      const testActiveCb = outerQb.orWhere.mock.calls[1][0] as (
+        qb: any,
+      ) => void
+      const testActiveQb = {
         where: vi.fn().mockReturnThis(),
         whereNotIn: vi.fn().mockReturnThis(),
       }
-      testRunCb(testRunQb)
+      testActiveCb(testActiveQb)
 
-      expect(testRunQb.where).toHaveBeenCalledWith('test_run', true)
+      expect(testActiveQb.where).toHaveBeenCalledWith('test_run', true)
       // whereNotIn (not whereIn) ensures live test executions are excluded
-      expect(testRunQb.whereNotIn).toHaveBeenCalledWith('id', expect.anything())
+      expect(testActiveQb.whereNotIn).toHaveBeenCalledWith('id', expect.anything())
     })
   })
 })

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -12,10 +12,13 @@ vi.mock('./config', () => ({
 vi.mock('./logger')
 vi.mock('./s3-client', () => ({ archiveS3Client: {} }))
 vi.mock('./archive-execution')
-vi.mock('./db', () => ({ archivalDb: vi.fn() }))
+vi.mock('./db', () => ({
+  archivalDb: vi.fn(),
+  archivalDbReader: vi.fn(),
+}))
 
 import { archiveExecution } from './archive-execution'
-import { archivalDb } from './db'
+import { archivalDb, archivalDbReader } from './db'
 import { runArchivalLoop } from './run-archival-loop'
 import type { ExecutionRow } from './types'
 
@@ -79,7 +82,7 @@ function setupDb(batches: ExecutionRow[][]) {
       .mockImplementation(() => Promise.resolve(batches[batchIdx++] ?? [])),
   }
 
-  ;(archivalDb as any).mockImplementation((table: string) => {
+  const tableRouter = (table: string) => {
     if (table === 'flows') {
       return flowsBuilder
     }
@@ -87,7 +90,9 @@ function setupDb(batches: ExecutionRow[][]) {
       return stepsBuilder
     }
     return execBuilder
-  })
+  }
+  ;(archivalDbReader as any).mockImplementation(tableRouter)
+  ;(archivalDb as any).mockImplementation(tableRouter)
 }
 
 describe('runArchivalLoop', () => {
@@ -185,6 +190,24 @@ describe('runArchivalLoop', () => {
       expect(cutoff.getTime()).toBeGreaterThanOrEqual(before.getTime() - 100)
       expect(cutoff.getTime()).toBeLessThanOrEqual(after.getTime() + 100)
     })
+  })
+
+  it('uses archivalDbReader for eligibility + execution_steps, archivalDb for the DELETE', async () => {
+    const batch = [makeExecution('e1')]
+    setupDb([batch, []])
+
+    await runArchivalLoop(new AbortController().signal)
+
+    // Reads use the replica
+    expect(archivalDbReader).toHaveBeenCalledWith('executions')
+    expect(archivalDbReader).toHaveBeenCalledWith('execution_steps')
+
+    // DELETE transaction uses the writer (passed into archiveExecution)
+    expect(archiveExecution).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ knexClient: archivalDb }),
+    )
   })
 
   describe('eligibility WHERE clause', () => {

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -7,6 +7,7 @@ vi.mock('./config', () => ({
     archiveBatchSize: 500,
     archiveBatchSleepMs: 0,
     archiveBucket: 'archive-bucket',
+    archiveDeletedFlowsOnly: false,
   },
 }))
 vi.mock('./logger')
@@ -18,6 +19,7 @@ vi.mock('./db', () => ({
 }))
 
 import { archiveExecution } from './archive-execution'
+import { archivalConfig } from './config'
 import { archivalDb, archivalDbReader } from './db'
 import { runArchivalLoop } from './run-archival-loop'
 import type { ExecutionRow } from './types'
@@ -208,6 +210,44 @@ describe('runArchivalLoop', () => {
       expect.anything(),
       expect.objectContaining({ knexClient: archivalDb }),
     )
+  })
+
+  describe('archiveDeletedFlowsOnly', () => {
+    it('does not add a flow_id filter when flag is false', async () => {
+      ;(archivalConfig as any).archiveDeletedFlowsOnly = false
+      setupDb([[]])
+
+      await runArchivalLoop(new AbortController().signal)
+
+      // capturedModifyCbs[0] is the deleted-flows modifier; invoke it with a spy qb
+      const qb = { whereIn: vi.fn() }
+      capturedModifyCbs[0](qb)
+      expect(qb.whereIn).not.toHaveBeenCalled()
+    })
+
+    it('restricts to deleted flows when flag is true', async () => {
+      ;(archivalConfig as any).archiveDeletedFlowsOnly = true
+      setupDb([[]])
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const qb = { whereIn: vi.fn() }
+      capturedModifyCbs[0](qb)
+      expect(qb.whereIn).toHaveBeenCalledWith('flow_id', expect.anything())
+    })
+
+    it('uses a subquery on flows.deleted_at for the filter', async () => {
+      ;(archivalConfig as any).archiveDeletedFlowsOnly = true
+      setupDb([[]])
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const qb = { whereIn: vi.fn() }
+      capturedModifyCbs[0](qb)
+
+      // The subquery should be archivalDbReader('flows').select('id').whereNotNull('deleted_at')
+      expect(archivalDbReader).toHaveBeenCalledWith('flows')
+    })
   })
 
   describe('eligibility WHERE clause', () => {

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -43,11 +43,13 @@ function makeExecution(
 
 // Callbacks captured from the executions query builder during each test run
 let capturedEligibilityCb: ((qb: any) => void) | null = null
+let capturedTestExecExclusionSubquery: any = null
 let capturedModifyCbs: Array<(qb: any) => void> = []
 
 function setupDb(batches: ExecutionRow[][]) {
   let batchIdx = 0
   capturedEligibilityCb = null
+  capturedTestExecExclusionSubquery = null
   capturedModifyCbs = []
 
   const flowsBuilder = {
@@ -68,6 +70,10 @@ function setupDb(batches: ExecutionRow[][]) {
       if (typeof args[0] === 'function') {
         capturedEligibilityCb = args[0]
       }
+      return execBuilder
+    }),
+    whereNotIn: vi.fn().mockImplementation((_col: string, subquery: any) => {
+      capturedTestExecExclusionSubquery = subquery
       return execBuilder
     }),
     modify: vi.fn().mockImplementation((cb: (qb: any) => void) => {
@@ -340,7 +346,7 @@ describe('runArchivalLoop', () => {
       ])
     })
 
-    it('excludes test executions that are still referenced by flows.test_execution_id', async () => {
+    it('selects test executions on active flows by test_run + cutoff only', async () => {
       setupDb([[]])
       await runArchivalLoop(new AbortController().signal)
 
@@ -360,8 +366,19 @@ describe('runArchivalLoop', () => {
       testActiveCb(testActiveQb)
 
       expect(testActiveQb.where).toHaveBeenCalledWith('test_run', true)
-      // whereNotIn (not whereIn) ensures live test executions are excluded
-      expect(testActiveQb.whereNotIn).toHaveBeenCalledWith('id', expect.anything())
+      // test_execution_id protection is a global top-level guard, not per-branch
+      expect(testActiveQb.whereNotIn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('test_execution_id guard', () => {
+    it('excludes flows.test_execution_id rows for all flows at the top level', async () => {
+      setupDb([[]])
+      await runArchivalLoop(new AbortController().signal)
+
+      expect(capturedTestExecExclusionSubquery).not.toBeNull()
+      // Subquery must use archivalDbReader('flows') — verified by the mock
+      expect(archivalDbReader).toHaveBeenCalledWith('flows')
     })
   })
 })

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -15,12 +15,15 @@ vi.mock('./s3-client', () => ({ archiveS3Client: {} }))
 vi.mock('./archive-execution')
 vi.mock('./db', () => ({ archivalDb: vi.fn() }))
 
-import { archivalDb } from './db'
 import { archiveExecution } from './archive-execution'
+import { archivalDb } from './db'
 import { runArchivalLoop } from './run-archival-loop'
 import type { ExecutionRow } from './types'
 
-function makeExecution(id: string, overrides: Partial<ExecutionRow> = {}): ExecutionRow {
+function makeExecution(
+  id: string,
+  overrides: Partial<ExecutionRow> = {},
+): ExecutionRow {
   return {
     id,
     flowId: 'flow-1',
@@ -71,12 +74,18 @@ function setupDb(batches: ExecutionRow[][]) {
       return execBuilder
     }),
     orderBy: vi.fn().mockReturnThis(),
-    limit: vi.fn().mockImplementation(() => Promise.resolve(batches[batchIdx++] ?? [])),
+    limit: vi
+      .fn()
+      .mockImplementation(() => Promise.resolve(batches[batchIdx++] ?? [])),
   }
 
   ;(archivalDb as any).mockImplementation((table: string) => {
-    if (table === 'flows') return flowsBuilder
-    if (table === 'execution_steps') return stepsBuilder
+    if (table === 'flows') {
+      return flowsBuilder
+    }
+    if (table === 'execution_steps') {
+      return stepsBuilder
+    }
     return execBuilder
   })
 }
@@ -117,7 +126,10 @@ describe('runArchivalLoop', () => {
       return 'archived'
     })
 
-    setupDb([[makeExecution('e1'), makeExecution('e2'), makeExecution('e3')], []])
+    setupDb([
+      [makeExecution('e1'), makeExecution('e2'), makeExecution('e3')],
+      [],
+    ])
 
     await runArchivalLoop(controller.signal)
 
@@ -129,14 +141,18 @@ describe('runArchivalLoop', () => {
     setupDb([[makeExecution('e1')], []])
 
     // Should complete without throwing even when all executions are skipped
-    await expect(runArchivalLoop(new AbortController().signal)).resolves.toBeUndefined()
+    await expect(
+      runArchivalLoop(new AbortController().signal),
+    ).resolves.toBeUndefined()
   })
 
   it('counts skipped executions when archiveExecution throws', async () => {
     vi.mocked(archiveExecution).mockRejectedValue(new Error('S3 timeout'))
     setupDb([[makeExecution('e1')], []])
 
-    await expect(runArchivalLoop(new AbortController().signal)).resolves.toBeUndefined()
+    await expect(
+      runArchivalLoop(new AbortController().signal),
+    ).resolves.toBeUndefined()
   })
 
   describe('cutoff date', () => {
@@ -144,7 +160,9 @@ describe('runArchivalLoop', () => {
       setupDb([[]])
       await runArchivalLoop(new AbortController().signal)
 
-      const cutoffCall = capturedWhereCalls.find((args) => args[0] === 'created_at')
+      const cutoffCall = capturedWhereCalls.find(
+        (args) => args[0] === 'created_at',
+      )
       expect(cutoffCall).toBeDefined()
       expect(cutoffCall![1]).toBe('<')
     })
@@ -160,7 +178,9 @@ describe('runArchivalLoop', () => {
       const after = new Date()
       after.setDate(after.getDate() - 90)
 
-      const cutoffCall = capturedWhereCalls.find((args) => args[0] === 'created_at')
+      const cutoffCall = capturedWhereCalls.find(
+        (args) => args[0] === 'created_at',
+      )
       const cutoff: Date = cutoffCall![2]
       expect(cutoff.getTime()).toBeGreaterThanOrEqual(before.getTime() - 100)
       expect(cutoff.getTime()).toBeLessThanOrEqual(after.getTime() + 100)
@@ -190,7 +210,10 @@ describe('runArchivalLoop', () => {
       nonTestCb(nonTestQb)
 
       expect(nonTestQb.where).toHaveBeenCalledWith('test_run', false)
-      expect(nonTestQb.whereIn).toHaveBeenCalledWith('status', ['success', 'failure'])
+      expect(nonTestQb.whereIn).toHaveBeenCalledWith('status', [
+        'success',
+        'failure',
+      ])
     })
 
     it('excludes test executions that are still referenced by flows.test_execution_id', async () => {

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -356,9 +356,7 @@ describe('runArchivalLoop', () => {
       }
       capturedEligibilityCb!(outerQb)
 
-      const testActiveCb = outerQb.orWhere.mock.calls[1][0] as (
-        qb: any,
-      ) => void
+      const testActiveCb = outerQb.orWhere.mock.calls[1][0] as (qb: any) => void
       const testActiveQb = {
         where: vi.fn().mockReturnThis(),
         whereNotIn: vi.fn().mockReturnThis(),

--- a/packages/backend/src/helpers/archival/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.test.ts
@@ -34,8 +34,8 @@ function makeExecution(
     status: 'success',
     testRun: false,
     internalId: null,
-    createdAt: new Date('2024-01-01'),
-    updatedAt: new Date('2024-01-01'),
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
     deletedAt: null,
     ...overrides,
   }

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -13,8 +13,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     archiveRetentionDays: retentionDays,
     archiveBatchSize: batchSize,
     archiveBatchSleepMs: sleepMs,
-    archiveExecutionsBucket: execsBucket,
-    archiveTestExecutionsBucket: testExecsBucket,
+    archiveBucket,
   } = archivalConfig
 
   const cutoff = new Date()
@@ -109,8 +108,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
       try {
         const result = await archiveExecution(execution, steps, {
           dryRun,
-          execsBucket,
-          testExecsBucket,
+          bucket: archiveBucket,
           s3Client: archiveS3Client,
           knexClient: archivalDb,
         })

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -111,10 +111,10 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           batchSkipped++
         }
       } catch (err) {
-        logger.error(
-          { executionId: execution.id, err },
-          'archival: unexpected error, skipping execution',
-        )
+        logger.error('archival: unexpected error, skipping execution', {
+          executionId: execution.id,
+          err,
+        })
         batchSkipped++
       }
       lastProcessed = execution

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -30,39 +30,67 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
   const runAt = new Date(startedAt).toISOString()
 
   while (!signal.aborted) {
-    const batch = (await archivalDbReader('executions')
-      .select(
-        'id',
-        'flow_id as flowId',
-        'status',
-        'test_run as testRun',
-        'internal_id as internalId',
-        'created_at as createdAt',
-        'updated_at as updatedAt',
-        'deleted_at as deletedAt',
-      )
-      .where((builder) => {
-        builder
-          // Deleted-flow executions are archived immediately — no cutoff, no status check.
-          // The flow is already gone from the UI; retention age is irrelevant.
-          .where((b) =>
-            b.whereIn(
-              'flow_id',
-              archivalDbReader('flows').select('id').whereNotNull('deleted_at'),
-            ),
-          )
-          // Non-test executions on active flows: terminal status + past cutoff.
-          .orWhere((b) =>
-            b
-              .where('test_run', false)
-              .where('created_at', '<', cutoff)
-              .whereIn('status', ['success', 'failure']),
-          )
-          // Test executions on active flows: past cutoff.
-          .orWhere((b) =>
-            b.where('test_run', true).where('created_at', '<', cutoff),
-          )
-      })
+    // When archiveDeletedFlowsOnly is set we skip the full three-branch OR
+    // entirely — just a single whereIn on deleted flows. This avoids asking
+    // Postgres to plan a complex multi-branch query when the full query will
+    // be filtered down to the same deleted-flows set anyway.
+    //
+    // Note: this subquery is evaluated live per batch, not snapshotted at run
+    // start. A flow soft-deleted mid-run will have its executions picked up on
+    // the next batch (immediately, with no cutoff check). Retries are therefore
+    // not fully idempotent with respect to the deleted-flows set — but this is
+    // harmless since already-archived rows are removed from source, making
+    // double-archiving impossible.
+    const deletedFlowsSubquery = archivalDbReader('flows')
+      .select('id')
+      .whereNotNull('deleted_at')
+
+    let eligibilityQuery
+    if (archiveDeletedFlowsOnly) {
+      eligibilityQuery = archivalDbReader('executions')
+        .select(
+          'id',
+          'flow_id as flowId',
+          'status',
+          'test_run as testRun',
+          'internal_id as internalId',
+          'created_at as createdAt',
+          'updated_at as updatedAt',
+          'deleted_at as deletedAt',
+        )
+        .whereIn('flow_id', deletedFlowsSubquery)
+    } else {
+      eligibilityQuery = archivalDbReader('executions')
+        .select(
+          'id',
+          'flow_id as flowId',
+          'status',
+          'test_run as testRun',
+          'internal_id as internalId',
+          'created_at as createdAt',
+          'updated_at as updatedAt',
+          'deleted_at as deletedAt',
+        )
+        .where((builder) => {
+          builder
+            // Deleted-flow executions: archived immediately — no cutoff, no status check.
+            // The flow is already gone from the UI; retention age is irrelevant.
+            .where((b) => b.whereIn('flow_id', deletedFlowsSubquery))
+            // Non-test executions on active flows: terminal status + past cutoff.
+            .orWhere((b) =>
+              b
+                .where('test_run', false)
+                .where('created_at', '<', cutoff)
+                .whereIn('status', ['success', 'failure']),
+            )
+            // Test executions on active flows: past cutoff only.
+            .orWhere((b) =>
+              b.where('test_run', true).where('created_at', '<', cutoff),
+            )
+        })
+    }
+
+    const batch = (await eligibilityQuery
       // Never archive the designated test execution of any flow (deleted or active).
       // This avoids having to NULL flows.test_execution_id in the archival transaction.
       .whereNotIn(
@@ -71,14 +99,6 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           .select('test_execution_id')
           .whereNotNull('test_execution_id'),
       )
-      .modify((qb) => {
-        if (archiveDeletedFlowsOnly) {
-          qb.whereIn(
-            'flow_id',
-            archivalDbReader('flows').select('id').whereNotNull('deleted_at'),
-          )
-        }
-      })
       .modify((qb) => {
         if (cursor) {
           qb.whereRaw('id > ?::uuid', [cursor])
@@ -102,6 +122,8 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
 
       // LEFT JOIN steps to fill in app_key/key for old rows that predate the
       // denormalised columns being added to execution_steps.
+      // TODO: once all pre-denormalisation rows have been archived, drop the
+      // LEFT JOIN and COALESCE and select app_key/key directly from execution_steps.
       const steps = (await archivalDbReader('execution_steps')
         .select(
           'execution_steps.id',
@@ -155,7 +177,8 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           batchSkipped++
         }
       } catch (err) {
-        logger.error('archival: unexpected error, skipping execution', {
+        logger.error({
+          event: 'archival.execution.error',
           executionId: execution.id,
           err,
         })

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -66,6 +66,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
 
     let batchArchived = 0
     let batchSkipped = 0
+    let lastProcessed: ExecutionRow | null = null
 
     for (const execution of batch) {
       if (signal.aborted) break
@@ -110,9 +111,12 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         )
         batchSkipped++
       }
+      lastProcessed = execution
     }
 
-    cursor = batch[batch.length - 1].id
+    if (lastProcessed) {
+      cursor = lastProcessed.id
+    }
     totalArchived += batchArchived
     totalSkipped += batchSkipped
 

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -57,9 +57,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           )
           // Test executions on active flows: past cutoff.
           .orWhere((b) =>
-            b
-              .where('test_run', true)
-              .where('created_at', '<', cutoff),
+            b.where('test_run', true).where('created_at', '<', cutoff),
           )
       })
       // Never archive the designated test execution of any flow (deleted or active).

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -23,6 +23,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
   let cursor: string | null = null
   let totalArchived = 0
   let totalSkipped = 0
+  const archivedByFlow = new Map<string, string[]>()
   const startedAt = Date.now()
 
   while (!signal.aborted) {
@@ -42,7 +43,14 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           .where((b) =>
             b
               .where('test_run', false)
-              .whereIn('status', ['success', 'failure']),
+              .where((c) =>
+                c
+                  .whereIn('status', ['success', 'failure'])
+                  .orWhereIn(
+                    'flow_id',
+                    archivalDb('flows').select('id').whereNotNull('deleted_at'),
+                  ),
+              ),
           )
           .orWhere((b) =>
             b
@@ -51,7 +59,8 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
                 'id',
                 archivalDb('flows')
                   .select('test_execution_id')
-                  .whereNotNull('test_execution_id'),
+                  .whereNotNull('test_execution_id')
+                  .whereNull('deleted_at'),
               ),
           )
       })
@@ -107,6 +116,9 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         })
         if (result === 'archived') {
           batchArchived++
+          const ids = archivedByFlow.get(execution.flowId) ?? []
+          ids.push(execution.id)
+          archivedByFlow.set(execution.flowId, ids)
         } else {
           batchSkipped++
         }
@@ -137,6 +149,15 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     if (!signal.aborted && sleepMs > 0) {
       await sleep(sleepMs)
     }
+  }
+
+  for (const [flowId, executionIds] of archivedByFlow) {
+    logger.info({
+      event: 'archival.flow.archived',
+      flowId,
+      executionIds,
+      count: executionIds.length,
+    })
   }
 
   logger.info({

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -1,6 +1,6 @@
 import { archiveExecution } from './archive-execution'
 import { archivalConfig } from './config'
-import { archivalDb } from './db'
+import { archivalDb, archivalDbReader } from './db'
 import logger from './logger'
 import { archiveS3Client } from './s3-client'
 import type { ExecutionRow, ExecutionStepRow } from './types'
@@ -26,7 +26,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
   const startedAt = Date.now()
 
   while (!signal.aborted) {
-    const batch = (await archivalDb('executions')
+    const batch = (await archivalDbReader('executions')
       .select(
         'id',
         'flow_id as flowId',
@@ -47,7 +47,9 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
                   .whereIn('status', ['success', 'failure'])
                   .orWhereIn(
                     'flow_id',
-                    archivalDb('flows').select('id').whereNotNull('deleted_at'),
+                    archivalDbReader('flows')
+                      .select('id')
+                      .whereNotNull('deleted_at'),
                   ),
               ),
           )
@@ -56,7 +58,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
               .where('test_run', true)
               .whereNotIn(
                 'id',
-                archivalDb('flows')
+                archivalDbReader('flows')
                   .select('test_execution_id')
                   .whereNotNull('test_execution_id')
                   .whereNull('deleted_at'),
@@ -85,7 +87,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         break
       }
 
-      const steps = (await archivalDb('execution_steps')
+      const steps = (await archivalDbReader('execution_steps')
         .select(
           'id',
           'execution_id as executionId',

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -1,7 +1,7 @@
+import { archiveExecution } from './archive-execution'
 import { archivalConfig } from './config'
 import { archivalDb } from './db'
 import logger from './logger'
-import { archiveExecution } from './archive-execution'
 import { archiveS3Client } from './s3-client'
 import type { ExecutionRow, ExecutionStepRow } from './types'
 
@@ -40,15 +40,19 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
       .where((builder) => {
         builder
           .where((b) =>
-            b.where('test_run', false).whereIn('status', ['success', 'failure']),
+            b
+              .where('test_run', false)
+              .whereIn('status', ['success', 'failure']),
           )
           .orWhere((b) =>
-            b.where('test_run', true).whereNotIn(
-              'id',
-              archivalDb('flows')
-                .select('test_execution_id')
-                .whereNotNull('test_execution_id'),
-            ),
+            b
+              .where('test_run', true)
+              .whereNotIn(
+                'id',
+                archivalDb('flows')
+                  .select('test_execution_id')
+                  .whereNotNull('test_execution_id'),
+              ),
           )
       })
       .where('created_at', '<', cutoff)
@@ -69,7 +73,9 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     let lastProcessed: ExecutionRow | null = null
 
     for (const execution of batch) {
-      if (signal.aborted) break
+      if (signal.aborted) {
+        break
+      }
 
       const steps = (await archivalDb('execution_steps')
         .select(

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -71,7 +71,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         if (archiveDeletedFlowsOnly) {
           qb.whereIn(
             'flow_id',
-            archivalDb('flows').select('id').whereNotNull('deleted_at'),
+            archivalDbReader('flows').select('id').whereNotNull('deleted_at'),
           )
         }
       })

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -55,20 +55,21 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
               .where('created_at', '<', cutoff)
               .whereIn('status', ['success', 'failure']),
           )
-          // Test executions on active flows: past cutoff, not the live test execution.
+          // Test executions on active flows: past cutoff.
           .orWhere((b) =>
             b
               .where('test_run', true)
-              .where('created_at', '<', cutoff)
-              .whereNotIn(
-                'id',
-                archivalDbReader('flows')
-                  .select('test_execution_id')
-                  .whereNotNull('test_execution_id')
-                  .whereNull('deleted_at'),
-              ),
+              .where('created_at', '<', cutoff),
           )
       })
+      // Never archive the designated test execution of any flow (deleted or active).
+      // This avoids having to NULL flows.test_execution_id in the archival transaction.
+      .whereNotIn(
+        'id',
+        archivalDbReader('flows')
+          .select('test_execution_id')
+          .whereNotNull('test_execution_id'),
+      )
       .modify((qb) => {
         if (archiveDeletedFlowsOnly) {
           qb.whereIn(

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -40,23 +40,26 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
       )
       .where((builder) => {
         builder
+          // Deleted-flow executions are archived immediately — no cutoff, no status check.
+          // The flow is already gone from the UI; retention age is irrelevant.
           .where((b) =>
+            b.whereIn(
+              'flow_id',
+              archivalDbReader('flows').select('id').whereNotNull('deleted_at'),
+            ),
+          )
+          // Non-test executions on active flows: terminal status + past cutoff.
+          .orWhere((b) =>
             b
               .where('test_run', false)
-              .where((c) =>
-                c
-                  .whereIn('status', ['success', 'failure'])
-                  .orWhereIn(
-                    'flow_id',
-                    archivalDbReader('flows')
-                      .select('id')
-                      .whereNotNull('deleted_at'),
-                  ),
-              ),
+              .where('created_at', '<', cutoff)
+              .whereIn('status', ['success', 'failure']),
           )
+          // Test executions on active flows: past cutoff, not the live test execution.
           .orWhere((b) =>
             b
               .where('test_run', true)
+              .where('created_at', '<', cutoff)
               .whereNotIn(
                 'id',
                 archivalDbReader('flows')
@@ -66,7 +69,6 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
               ),
           )
       })
-      .where('created_at', '<', cutoff)
       .modify((qb) => {
         if (archiveDeletedFlowsOnly) {
           qb.whereIn(

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -1,0 +1,138 @@
+import { archivalConfig } from './config'
+import { archivalDb } from './db'
+import logger from './logger'
+import { archiveExecution } from './archive-execution'
+import { archiveS3Client } from './s3-client'
+import type { ExecutionRow, ExecutionStepRow } from './types'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
+  const {
+    archiveDryRun: dryRun,
+    archiveRetentionDays: retentionDays,
+    archiveBatchSize: batchSize,
+    archiveBatchSleepMs: sleepMs,
+    archiveExecutionsBucket: execsBucket,
+    archiveTestExecutionsBucket: testExecsBucket,
+  } = archivalConfig
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - retentionDays)
+
+  let cursor: string | null = null
+  let totalArchived = 0
+  let totalSkipped = 0
+  const startedAt = Date.now()
+
+  while (!signal.aborted) {
+    const batch = (await archivalDb('executions')
+      .select(
+        'id',
+        'flow_id as flowId',
+        'status',
+        'test_run as testRun',
+        'internal_id as internalId',
+        'created_at as createdAt',
+        'updated_at as updatedAt',
+        'deleted_at as deletedAt',
+      )
+      .where((builder) => {
+        builder
+          .where((b) =>
+            b.where('test_run', false).whereIn('status', ['success', 'failure']),
+          )
+          .orWhere((b) =>
+            b.where('test_run', true).whereNotIn(
+              'id',
+              archivalDb('flows')
+                .select('test_execution_id')
+                .whereNotNull('test_execution_id'),
+            ),
+          )
+      })
+      .where('created_at', '<', cutoff)
+      .modify((qb) => {
+        if (cursor) {
+          qb.whereRaw('id > ?::uuid', [cursor])
+        }
+      })
+      .orderBy('id')
+      .limit(batchSize)) as ExecutionRow[]
+
+    if (!batch.length) {
+      break
+    }
+
+    let batchArchived = 0
+    let batchSkipped = 0
+
+    for (const execution of batch) {
+      if (signal.aborted) break
+
+      const steps = (await archivalDb('execution_steps')
+        .select(
+          'id',
+          'execution_id as executionId',
+          'step_id as stepId',
+          'app_key as appKey',
+          'key',
+          'job_id as jobId',
+          'status',
+          'data_in as dataIn',
+          'data_out as dataOut',
+          'error_details as errorDetails',
+          'metadata',
+          'created_at as createdAt',
+          'updated_at as updatedAt',
+          'deleted_at as deletedAt',
+        )
+        .where('execution_id', execution.id)
+        .orderBy('created_at')) as ExecutionStepRow[]
+
+      try {
+        const result = await archiveExecution(execution, steps, {
+          dryRun,
+          execsBucket,
+          testExecsBucket,
+          s3Client: archiveS3Client,
+          knexClient: archivalDb,
+        })
+        if (result === 'archived') {
+          batchArchived++
+        } else {
+          batchSkipped++
+        }
+      } catch (err) {
+        logger.error(
+          { executionId: execution.id, err },
+          'archival: unexpected error, skipping execution',
+        )
+        batchSkipped++
+      }
+    }
+
+    cursor = batch[batch.length - 1].id
+    totalArchived += batchArchived
+    totalSkipped += batchSkipped
+
+    logger.info({
+      event: 'archival.batch.complete',
+      batchArchived,
+      batchSkipped,
+      cursor,
+      durationMs: Date.now() - startedAt,
+    })
+
+    if (!signal.aborted && sleepMs > 0) {
+      await sleep(sleepMs)
+    }
+  }
+
+  logger.info({
+    event: 'archival.run.complete',
+    executions_archived: totalArchived,
+    executions_skipped: totalSkipped,
+    durationMs: Date.now() - startedAt,
+  })
+}

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -14,6 +14,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     archiveBatchSize: batchSize,
     archiveBatchSleepMs: sleepMs,
     archiveBucket,
+    archiveDeletedFlowsOnly,
   } = archivalConfig
 
   const cutoff = new Date()
@@ -66,6 +67,14 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           )
       })
       .where('created_at', '<', cutoff)
+      .modify((qb) => {
+        if (archiveDeletedFlowsOnly) {
+          qb.whereIn(
+            'flow_id',
+            archivalDb('flows').select('id').whereNotNull('deleted_at'),
+          )
+        }
+      })
       .modify((qb) => {
         if (cursor) {
           qb.whereRaw('id > ?::uuid', [cursor])

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -2,7 +2,7 @@ import { archiveExecution } from './archive-execution'
 import { archivalConfig } from './config'
 import { archivalDb, archivalDbReader } from './db'
 import logger from './logger'
-import { archiveS3Client } from './s3-client'
+import { archiveS3Client, putArchiveObject } from './s3-client'
 import type { ExecutionRow, ExecutionStepRow } from './types'
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -24,7 +24,10 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
   let totalArchived = 0
   let totalSkipped = 0
   const archivedByFlow = new Map<string, string[]>()
+  const stepCounts = new Map<string, Map<string, number>>()
+  let nullStepCount = 0
   const startedAt = Date.now()
+  const runAt = new Date(startedAt).toISOString()
 
   while (!signal.aborted) {
     const batch = (await archivalDbReader('executions')
@@ -97,25 +100,32 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         break
       }
 
+      // LEFT JOIN steps to fill in app_key/key for old rows that predate the
+      // denormalised columns being added to execution_steps.
       const steps = (await archivalDbReader('execution_steps')
         .select(
-          'id',
-          'execution_id as executionId',
-          'step_id as stepId',
-          'app_key as appKey',
-          'key',
-          'job_id as jobId',
-          'status',
-          'data_in as dataIn',
-          'data_out as dataOut',
-          'error_details as errorDetails',
-          'metadata',
-          'created_at as createdAt',
-          'updated_at as updatedAt',
-          'deleted_at as deletedAt',
+          'execution_steps.id',
+          'execution_steps.execution_id as executionId',
+          'execution_steps.step_id as stepId',
+          archivalDbReader.raw(
+            'COALESCE(execution_steps.app_key, steps.app_key) as "appKey"',
+          ),
+          archivalDbReader.raw(
+            'COALESCE(execution_steps.key, steps.key) as "key"',
+          ),
+          'execution_steps.job_id as jobId',
+          'execution_steps.status',
+          'execution_steps.data_in as dataIn',
+          'execution_steps.data_out as dataOut',
+          'execution_steps.error_details as errorDetails',
+          'execution_steps.metadata',
+          'execution_steps.created_at as createdAt',
+          'execution_steps.updated_at as updatedAt',
+          'execution_steps.deleted_at as deletedAt',
         )
-        .where('execution_id', execution.id)
-        .orderBy('created_at')) as ExecutionStepRow[]
+        .leftJoin('steps', 'execution_steps.step_id', 'steps.id')
+        .where('execution_steps.execution_id', execution.id)
+        .orderBy('execution_steps.created_at')) as ExecutionStepRow[]
 
       try {
         const result = await archiveExecution(execution, steps, {
@@ -123,12 +133,24 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
           bucket: archiveBucket,
           s3Client: archiveS3Client,
           knexClient: archivalDb,
+          runAt,
         })
         if (result === 'archived') {
           batchArchived++
           const ids = archivedByFlow.get(execution.flowId) ?? []
           ids.push(execution.id)
           archivedByFlow.set(execution.flowId, ids)
+
+          for (const step of steps) {
+            if (step.appKey && step.key) {
+              const keyMap =
+                stepCounts.get(step.appKey) ?? new Map<string, number>()
+              keyMap.set(step.key, (keyMap.get(step.key) ?? 0) + 1)
+              stepCounts.set(step.appKey, keyMap)
+            } else {
+              nullStepCount++
+            }
+          }
         } else {
           batchSkipped++
         }
@@ -175,5 +197,27 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     executions_archived: totalArchived,
     executions_skipped: totalSkipped,
     durationMs: Date.now() - startedAt,
+  })
+
+  const stepCountsObj: Record<string, Record<string, number>> = {}
+  for (const [appKey, keyMap] of stepCounts) {
+    stepCountsObj[appKey] = Object.fromEntries(keyMap)
+  }
+
+  await putArchiveObject({
+    s3Client: archiveS3Client,
+    bucket: archiveBucket,
+    key: `_meta/runs/${runAt}.json`,
+    body: JSON.stringify({
+      runAt,
+      dryRun,
+      executionsArchived: totalArchived,
+      executionsSkipped: totalSkipped,
+      flowsAffected: archivedByFlow.size,
+      stepCounts: stepCountsObj,
+      nullStepCount,
+      durationMs: Date.now() - startedAt,
+    }),
+    contentType: 'application/json',
   })
 }


### PR DESCRIPTION
## Stack Context

This stack implements the archival pipeline (PLU-65). Prior PRs built the S3 client and `archiveExecution`. This PR adds `runArchivalLoop` — the outer loop that pages through eligible executions and drives the archival.

## What?

- Adds `run-archival-loop.ts`: cursor-keyed batch loop over eligible executions, with `AbortSignal` support for clean shutdown
- Adds `archiveDeletedFlowsOnly` config flag for phased rollout (only archive executions from soft-deleted flows first)
- Eligibility query covers three explicit branches:
  - Executions on deleted flows — archived immediately, no age or status check (flow is already gone from the UI)
  - Non-test executions on active flows — terminal status + past retention cutoff
  - Test-run executions on active flows — past retention cutoff
- `flows.test_execution_id` is excluded globally (top-level `whereNotIn`) for all flows — deleted or active — so the archival transaction never needs to NULL the FK
- Reads use `archivalDbReader` (replica); deletes are routed to `archivalDb` (writer) via `archiveExecution`
- After the loop completes, writes a run-summary JSON to `_meta/runs/<runAt>.json` in S3:
  ```json
  {
    "runAt": "<ISO timestamp>",
    "dryRun": false,
    "executionsArchived": 1234,
    "executionsSkipped": 5,
    "flowsAffected": 42,
    "stepCounts": { "formsg": { "trigger": 900 }, "postman": { "send-message": 800 } },
    "nullStepCount": 3,
    "durationMs": 45000
  }
  ```
  `stepCounts` counts archived `execution_steps` grouped by `appKey → key`, useful for understanding what data volume each integration contributes. `nullStepCount` tracks steps where `appKey`/`key` were both null (pre-denormalisation rows that couldn't be resolved via LEFT JOIN).

## Why?

The cursor (`id > ?::uuid`) approach gives stable pagination without offset drift. Routing reads to the replica keeps archival off the primary write path. The `archiveDeletedFlowsOnly` flag allows a safe first phase: only clean up data from flows users have already deleted before touching live-flow executions.

Deleted-flow executions bypass the retention cutoff because the flow is already gone from the user's UI and there is no user-facing restoration path — enforcing the retention age serves no purpose and would leave orphaned data in Postgres unnecessarily.

The `test_execution_id` guard is applied globally rather than per-branch so it protects that execution regardless of whether the flow is deleted, avoiding FK manipulation in the archival transaction.

The `_meta/runs/` object gives operators a lightweight audit log of each run without querying Postgres or Datadog — useful for verifying dry runs and for cross-referencing archived execution counts with the S3 inventory.

## Tests

- [ ] Exits immediately on empty first batch
- [ ] Calls `archiveExecution` for each execution in a batch
- [ ] Stops mid-batch when signal is aborted
- [ ] Handles `skipped` result and thrown errors without crashing
- [ ] Active-flow cutoff uses strict `<` (executions at exactly the cutoff are excluded)
- [ ] Active-flow cutoff is `retentionDays` days before now
- [ ] Deleted-flow executions have no `created_at` filter applied
- [ ] `test_execution_id` rows excluded globally at top level (not inside eligibility branches)
- [ ] Reads use `archivalDbReader`, writes pass `archivalDb` to `archiveExecution`
- [ ] `archiveDeletedFlowsOnly=false` adds no extra filter
- [ ] `archiveDeletedFlowsOnly=true` restricts to deleted-flow executions
- [ ] Eligibility has three branches: deleted-flows, non-test-active, test-active
- [ ] Non-test-active branch includes terminal statuses
- [ ] Test-active branch selects by `test_run=true` + cutoff only
- [ ] `stepCounts` accumulates counts by `appKey → key` across all archived steps
- [ ] `nullStepCount` increments when `appKey` or `key` is null on a step
- [ ] Run-summary meta JSON is written to `_meta/runs/<runAt>.json` after the loop
