### PR TITLE
chore: bump vite from 6.4.2 to 6.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33411,9 +33411,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34533,7 +34533,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "prettier": "^2.5.1",
         "type-fest": "4.10.3",
-        "vite": "^6.4.2",
+        "vite": "^6.4.3",
         "vite-plugin-dts": "^4.5.4",
         "vite-plugin-package-version": "1.1.0",
         "vite-tsconfig-paths": "^5.1.4"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "lodash": "4.18.1",
     "lodash-es": "4.18.1",
-    "vite": "6.4.2",
+    "vite": "6.4.3",
     "immutable": "4.3.8",
     "picomatch": "4.0.4",
     "shell-quote": "1.8.4",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.5.1",
     "type-fest": "4.10.3",
-    "vite": "^6.4.2",
+    "vite": "^6.4.3",
     "vite-plugin-dts": "^4.5.4",
     "vite-plugin-package-version": "1.1.0",
     "vite-tsconfig-paths": "^5.1.4"


### PR DESCRIPTION
### TL;DR
Bump `vite` from v6.4.2 to v.6.4.3

### Tests
- [ ] `npm run build` builds the app properly
- [ ] `npm run test` and test suite passes
- [ ] `npm run dev` starts without errors and hot-reload works
- [ ] Click around and make sure the app still works, can still execute Pipes