### PR TITLE
[FLUSH-6] PLU-65 feat(archival): track archived execution count per flow

### DIFF
--- a/packages/backend/src/db/migrations/20260618000000_add-archived-execution-count.ts
+++ b/packages/backend/src/db/migrations/20260618000000_add-archived-execution-count.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.table('flows', (table) => {
+    table.integer('archived_execution_count').notNullable().defaultTo(0)
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('flows', (table) => {
+    table.dropColumn('archived_execution_count')
+  })
+}

--- a/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
@@ -78,7 +78,8 @@ function makeMockKnex() {
           : table === 'executions'
           ? deleteExecFn
           : vi.fn().mockResolvedValue(0),
-      increment: table === 'flows' ? incrementFlowsFn : vi.fn().mockResolvedValue(0),
+      increment:
+        table === 'flows' ? incrementFlowsFn : vi.fn().mockResolvedValue(0),
     }
     return proxy
   }
@@ -293,11 +294,11 @@ describe('archiveExecution', () => {
     const s3 = makeMockS3()
     const knexClient = makeMockKnex()
 
-    await archiveExecution(
-      { ...mockExecution, testRun: true },
-      mockSteps,
-      { ...baseOpts, s3Client: s3, knexClient },
-    )
+    await archiveExecution({ ...mockExecution, testRun: true }, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
 
     expect((knexClient as any)._incrementFlowsFn).not.toHaveBeenCalled()
   })

--- a/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/archive-execution.test.ts
@@ -67,18 +67,34 @@ function makeMockS3(contentLength = 42) {
 function makeMockKnex() {
   const deleteStepsFn = vi.fn().mockResolvedValue(1)
   const deleteExecFn = vi.fn().mockResolvedValue(1)
-  const trx = (table: string) => ({
-    where: () => ({
-      delete: table === 'execution_steps' ? deleteStepsFn : deleteExecFn,
-    }),
-  })
+  const incrementFlowsFn = vi.fn().mockResolvedValue(1)
+
+  function makeTableProxy(table: string) {
+    const proxy: Record<string, unknown> = {
+      where: vi.fn(() => proxy),
+      delete:
+        table === 'execution_steps'
+          ? deleteStepsFn
+          : table === 'executions'
+          ? deleteExecFn
+          : vi.fn().mockResolvedValue(0),
+      increment: table === 'flows' ? incrementFlowsFn : vi.fn().mockResolvedValue(0),
+    }
+    return proxy
+  }
+
   const knexClient = {
-    transaction: vi.fn(async (cb: (trx: unknown) => Promise<void>) => cb(trx)),
+    transaction: vi.fn(
+      async (cb: (trx: (table: string) => unknown) => Promise<void>) =>
+        cb(makeTableProxy),
+    ),
     _deleteStepsFn: deleteStepsFn,
     _deleteExecFn: deleteExecFn,
+    _incrementFlowsFn: incrementFlowsFn,
   } as unknown as Knex & {
     _deleteStepsFn: ReturnType<typeof vi.fn>
     _deleteExecFn: ReturnType<typeof vi.fn>
+    _incrementFlowsFn: ReturnType<typeof vi.fn>
   }
   return knexClient
 }
@@ -258,5 +274,31 @@ describe('archiveExecution', () => {
     expect(putCall[0].input.Key).toBe(
       `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-1.json.gz`,
     )
+  })
+
+  it('increments archived_execution_count for non-test executions', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    await archiveExecution(mockExecution, mockSteps, {
+      ...baseOpts,
+      s3Client: s3,
+      knexClient,
+    })
+
+    expect((knexClient as any)._incrementFlowsFn).toHaveBeenCalledOnce()
+  })
+
+  it('does not increment archived_execution_count for test-run executions', async () => {
+    const s3 = makeMockS3()
+    const knexClient = makeMockKnex()
+
+    await archiveExecution(
+      { ...mockExecution, testRun: true },
+      mockSteps,
+      { ...baseOpts, s3Client: s3, knexClient },
+    )
+
+    expect((knexClient as any)._incrementFlowsFn).not.toHaveBeenCalled()
   })
 })

--- a/packages/backend/src/helpers/archival/archive-execution.ts
+++ b/packages/backend/src/helpers/archival/archive-execution.ts
@@ -72,6 +72,11 @@ export async function archiveExecution(
     await opts.knexClient.transaction(async (trx) => {
       await trx('execution_steps').where('execution_id', execution.id).delete()
       await trx('executions').where('id', execution.id).delete()
+      if (!execution.testRun) {
+        await trx('flows')
+          .where('id', execution.flowId)
+          .increment('archived_execution_count', 1)
+      }
     })
   }
 


### PR DESCRIPTION
## Stack Context

This stack (PLU-65) builds the archival pipeline that moves old Plumber flow executions from Postgres to S3 and deletes them from the DB. This PR adds a counter so flows accumulate a record of how many executions have been archived off them.

## Why?

Archived executions are deleted from Postgres, so the execution count visible on a flow would silently drop after archival runs. `archived_execution_count` lets the UI show the true lifetime count by summing the live count with the archived count.

The increment is inside the existing delete transaction — if the S3 upload or DB delete fails, the count stays consistent. Test executions are excluded (they are never shown in the UI's execution count).

## Tests

- [ ] `archive-execution.test.ts` — increments `archived_execution_count` for non-test executions
- [ ] `archive-execution.test.ts` — does not increment for test-run executions