### PR TITLE
[OR condition 1/4] types + strict group evaluator

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/evaluate-condition-groups.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/evaluate-condition-groups.test.ts
@@ -1,0 +1,79 @@
+import type { IConditionRow, IMultiRowGroup } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import StepError from '@/errors/step'
+
+import { evaluateConditionGroups } from '../../common/evaluate-condition-groups'
+
+function row(overrides: Partial<IConditionRow>): IConditionRow {
+  return {
+    field: 'a',
+    is: 'is',
+    condition: 'equals',
+    text: 'a',
+    ...overrides,
+  }
+}
+
+function group(...rows: IConditionRow[]): IMultiRowGroup<IConditionRow> {
+  return { rows }
+}
+
+describe('evaluateConditionGroups', () => {
+  it('returns false for an empty group array', () => {
+    expect(evaluateConditionGroups([])).toBe(false)
+  })
+
+  it('passes a single group with a single satisfied row', () => {
+    expect(
+      evaluateConditionGroups([group(row({ field: 'a', text: 'a' }))]),
+    ).toBe(true)
+  })
+
+  it('AND-s rows within a group (all must pass)', () => {
+    const bothTrue = group(
+      row({ field: 'a', text: 'a' }),
+      row({ field: 'b', text: 'b' }),
+    )
+    const oneFalse = group(
+      row({ field: 'a', text: 'a' }),
+      row({ field: 'b', text: 'c' }),
+    )
+    expect(evaluateConditionGroups([bothTrue])).toBe(true)
+    expect(evaluateConditionGroups([oneFalse])).toBe(false)
+  })
+
+  it('OR-s across groups (any group passing is enough)', () => {
+    const failingGroup = group(row({ field: 'a', text: 'mismatch' }))
+    const passingGroup = group(row({ field: 'b', text: 'b' }))
+    expect(evaluateConditionGroups([failingGroup, passingGroup])).toBe(true)
+  })
+
+  it('returns false when no group passes', () => {
+    const groups = [
+      group(row({ field: 'a', text: 'x' })),
+      group(row({ field: 'b', text: 'y' })),
+    ]
+    expect(evaluateConditionGroups(groups)).toBe(false)
+  })
+
+  it('short-circuits: a malformed group after a matching one never throws', () => {
+    const matching = group(row({ field: 'a', text: 'a' }))
+    const malformed = group(row({ condition: 'not-a-real-operator' }))
+    expect(evaluateConditionGroups([matching, malformed])).toBe(true)
+  })
+
+  it('fail-fast: throws a StepError naming the offending group index', () => {
+    const failingGroup = group(row({ field: 'a', text: 'mismatch' }))
+    const malformedGroup = group(row({ condition: 'not-a-real-operator' }))
+
+    expect(() =>
+      evaluateConditionGroups([failingGroup, malformedGroup]),
+    ).toThrow(StepError)
+    // The malformed group is the 2nd one (1-indexed) in the array.
+    expect(() =>
+      evaluateConditionGroups([failingGroup, malformedGroup]),
+    ).toThrow(/condition group 2/)
+  })
+})

--- a/packages/backend/src/apps/toolbox/common/evaluate-condition-groups.ts
+++ b/packages/backend/src/apps/toolbox/common/evaluate-condition-groups.ts
@@ -1,0 +1,46 @@
+import type { IConditionRow, IJSONObject, IMultiRowGroup } from '@plumber/types'
+
+import StepError from '@/errors/step'
+
+import conditionIsTrue from './condition-is-true'
+
+/**
+ * Evaluates an OR-of-AND condition structure.
+ *
+ * The outer array is OR-ed; each group's inner `rows` are AND-ed. A step passes
+ * when **any** group passes; a group passes when **all** of its rows pass. The
+ * loop short-circuits on the first matching group.
+ *
+ * This evaluator is **strict** — it assumes the v2 grouped shape. It does not
+ * normalize legacy (flat) shapes; the toolbox `stepTransformer` migrates those
+ * upstream (on `$afterFind`) before `run()` is reached, so the worker always
+ * sees v2 here.
+ *
+ * Fail-fast: a malformed row throws a `StepError` that names the offending
+ * group so the user can find it. Because evaluation short-circuits, a config
+ * error in a group that is never reached (an earlier group already matched)
+ * will not surface at runtime — the frontend "Check step" validation covers
+ * completeness.
+ */
+export function evaluateConditionGroups(
+  groups: IMultiRowGroup<IConditionRow>[],
+): boolean {
+  for (let i = 0; i < groups.length; i++) {
+    try {
+      if (
+        groups[i].rows.every((row) =>
+          conditionIsTrue(row as unknown as IJSONObject),
+        )
+      ) {
+        return true
+      }
+    } catch (err) {
+      // Fail-fast, but name the offending group for the user.
+      throw new StepError(
+        `Error in condition group ${i + 1}: ${err.message}`,
+        'Check that the condition has been configured properly.',
+      )
+    }
+  }
+  return false
+}

--- a/packages/backend/src/helpers/__tests__/wrap-rows-into-single-group.test.ts
+++ b/packages/backend/src/helpers/__tests__/wrap-rows-into-single-group.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { wrapRowsIntoSingleGroup } from '../wrap-rows-into-single-group'
+
+describe('wrapRowsIntoSingleGroup', () => {
+  it('collapses a multi-row AND-list into exactly ONE group', () => {
+    const rows = [
+      { field: 'a', is: 'is', condition: 'equals', text: 'a' },
+      { field: 'b', is: 'is', condition: 'equals', text: 'b' },
+      { field: 'c', is: 'is', condition: 'equals', text: 'c' },
+    ]
+
+    const result = wrapRowsIntoSingleGroup(rows)
+
+    // The whole point: one group preserving AND — never one-group-per-row.
+    expect(result).toHaveLength(1)
+    expect(result[0].rows).toEqual(rows)
+  })
+
+  it('wraps a single row into one group', () => {
+    const rows = [{ field: 'a', is: 'is', condition: 'equals', text: 'a' }]
+    expect(wrapRowsIntoSingleGroup(rows)).toEqual([{ rows }])
+  })
+
+  it('wraps an empty list into one empty group', () => {
+    expect(wrapRowsIntoSingleGroup([])).toEqual([{ rows: [] }])
+  })
+
+  it('preserves row order and content', () => {
+    const rows = [{ id: 1 }, { id: 2 }, { id: 3 }]
+    expect(wrapRowsIntoSingleGroup(rows)[0].rows).toEqual([
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ])
+  })
+})

--- a/packages/backend/src/helpers/wrap-rows-into-single-group.ts
+++ b/packages/backend/src/helpers/wrap-rows-into-single-group.ts
@@ -1,0 +1,15 @@
+import type { IMultiRowGroup } from '@plumber/types'
+
+/**
+ * Collapses a flat list of rows (a legacy AND-list) into a **single** group,
+ * preserving AND semantics. Reusable by any app migrating a flat multirow field
+ * to the grouped `grouped-multirow` shape.
+ *
+ * Critically, this produces **exactly one** group — never one-group-per-row,
+ * which would flip AND → OR and silently break existing pipes. This is the
+ * single source of truth for the old → new collapse; the evaluator and frontend
+ * do not duplicate it.
+ */
+export function wrapRowsIntoSingleGroup<T>(rows: T[]): IMultiRowGroup<T>[] {
+  return [{ rows }]
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -552,6 +552,27 @@ export type IField =
   | IFieldBooleanRadio
   | IFieldDragDrop
 
+/**
+ * A single condition row, as evaluated by the toolbox `conditionIsTrue` helper.
+ * The row shape is unchanged from the original flat condition format; `text` is
+ * the legacy name for the comparison "value".
+ */
+export interface IConditionRow {
+  field: IJSONValue
+  is: 'is' | 'not'
+  condition: string // existing operator union
+  text: IJSONValue // legacy name for "value"
+}
+
+/**
+ * Generic group shape used by the `grouped-multirow` builder: an outer OR of
+ * inner AND-ed `rows`. Generic over the row type so the structure can be reused
+ * across apps (the inner key is always the neutral `rows`).
+ */
+export interface IMultiRowGroup<TRow = IJSONObject> {
+  rows: TRow[]
+}
+
 export interface IAuthenticationStepField {
   name: string
   value: string | null


### PR DESCRIPTION
## Stack Context

This 4-PR stack adds **OR-of-AND** condition support to the toolbox **If-then** and
**Only continue if** actions. A condition becomes an array of OR-groups, each holding
AND-ed rows — persisted as `{ conditions: [{ rows: [row, ...] }, ...] }` (outer = OR,
inner = AND). Built bottom-up so each PR is independently safe to merge:

1. **types + evaluator** ← _this PR_
2. grouped-multirow builder (frontend)
3. atomic backend cutover
4. validation + caps

Stacked on `feat/or-condition/trunk`.

## What

Pure additions, **no call sites yet** (zero runtime change):

- `@plumber/types`: `IConditionRow` and generic `IMultiRowGroup<TRow>` (inner key is the
  neutral `rows`).
- `evaluateConditionGroups()` — **strict** OR-of-AND evaluator: passes if *any* group
  passes; a group passes if *all* its rows pass. Short-circuits, and fail-fast — a
  malformed row throws a `StepError` that names the offending group (`Error in condition
  group N: …`).
- `wrapRowsIntoSingleGroup()` — collapses a flat AND-list into **exactly one** group.

## Why

Foundation for the cutover (PR 3). The evaluator is strict because `Step.$afterFind`
migrates legacy params to v2 before the worker runs. `wrapRowsIntoSingleGroup` is the
single source of truth for old→new collapse — one group, **never** one-group-per-row
(which would silently flip AND→OR and break existing pipes).

## Test plan

**Automated**

```
npm run -w backend test:unit
```

Key files / cases to eyeball:
- `src/apps/toolbox/__tests__/common/evaluate-condition-groups.test.ts` — AND within a
  group, OR across groups, short-circuit (a malformed *unreached* group never throws),
  and fail-fast naming the offending group index.
- `src/helpers/__tests__/wrap-rows-into-single-group.test.ts` — a multi-row list
  collapses to **one** group (not one-per-row).

**Manual:** none — no call sites, so nothing renders or executes differently yet.
