### PR TITLE
[OR condition 2/4] grouped-multirow builder (frontend)

### DIFF
--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -10,7 +10,23 @@ const action: IRawAction = {
   name: 'Only continue if',
   key: 'onlyContinueIf',
   description: 'Only runs later actions if specified conditions are met',
-  arguments: getConditionArgs({ usePlaceholders: false }),
+  arguments: [
+    ...getConditionArgs({ usePlaceholders: false }),
+    // TEMPORARY (remove in feat/or-condition/cutover): renders the new generic
+    // `grouped-multirow` builder inside the real flow editor for manual QA.
+    // Uses a distinct key + `required: false` so it does not feed `run()` or
+    // affect step completeness — the real cutover replaces `arguments` wholesale.
+    {
+      label: 'OR condition groups (temporary QA — do not ship)',
+      key: 'groupedMultirowQa',
+      type: 'grouped-multirow' as const,
+      required: false,
+      variables: false,
+      maxGroups: 10,
+      maxRowsPerGroup: 10,
+      subFields: getConditionArgs({ usePlaceholders: true }),
+    },
+  ],
 
   async run($) {
     let result

--- a/packages/frontend/src/components/GroupedMultiRow/OrDivider.tsx
+++ b/packages/frontend/src/components/GroupedMultiRow/OrDivider.tsx
@@ -1,0 +1,16 @@
+import { Divider, Flex, Text } from '@chakra-ui/react'
+
+/**
+ * Divider shown between OR-groups (mirrors MultiRow's "And" RowDivider).
+ */
+export default function OrDivider() {
+  return (
+    <Flex alignItems="center" my={4}>
+      <Divider />
+      <Text textStyle="subhead-3" mx={2.5}>
+        OR
+      </Text>
+      <Divider />
+    </Flex>
+  )
+}

--- a/packages/frontend/src/components/GroupedMultiRow/helpers.test.ts
+++ b/packages/frontend/src/components/GroupedMultiRow/helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { canAddGroup, canAddRow, normalizeGroupsValue } from './helpers'
+
+describe('normalizeGroupsValue', () => {
+  it('returns a single empty group for missing/empty/non-array values', () => {
+    expect(normalizeGroupsValue(undefined)).toEqual([{ rows: [] }])
+    expect(normalizeGroupsValue(null)).toEqual([{ rows: [] }])
+    expect(normalizeGroupsValue([])).toEqual([{ rows: [] }])
+    expect(normalizeGroupsValue('nope')).toEqual([{ rows: [] }])
+  })
+
+  it('passes through an existing non-empty groups array unchanged', () => {
+    const groups = [{ rows: [{ field: 'a' }] }, { rows: [{ field: 'b' }] }]
+    expect(normalizeGroupsValue(groups)).toBe(groups)
+  })
+})
+
+describe('canAddGroup (group cap)', () => {
+  it('allows adding when no cap is set', () => {
+    expect(canAddGroup(99)).toBe(true)
+  })
+
+  it('allows adding below the cap and blocks at/above it', () => {
+    expect(canAddGroup(9, 10)).toBe(true)
+    expect(canAddGroup(10, 10)).toBe(false)
+    expect(canAddGroup(11, 10)).toBe(false)
+  })
+})
+
+describe('canAddRow (row cap)', () => {
+  it('allows adding when no cap is set', () => {
+    expect(canAddRow(99)).toBe(true)
+  })
+
+  it('allows adding below the cap and blocks at/above it', () => {
+    expect(canAddRow(9, 10)).toBe(true)
+    expect(canAddRow(10, 10)).toBe(false)
+  })
+})

--- a/packages/frontend/src/components/GroupedMultiRow/helpers.ts
+++ b/packages/frontend/src/components/GroupedMultiRow/helpers.ts
@@ -1,0 +1,43 @@
+import type { IJSONObject, IMultiRowGroup } from '@plumber/types'
+
+/**
+ * Pure, framework-free logic for the GroupedMultiRow builder. Extracted so the
+ * empty-state guard and caps can be unit tested without rendering React (the
+ * frontend has no component test harness).
+ */
+
+/**
+ * Empty-state guard: a grouped-multirow always renders at least one group so the
+ * builder never shows an empty/crashed state. Missing, non-array, or empty
+ * values normalize to a single empty group.
+ */
+export function normalizeGroupsValue(
+  value: unknown,
+): IMultiRowGroup<IJSONObject>[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    return [{ rows: [] }]
+  }
+  return value as IMultiRowGroup<IJSONObject>[]
+}
+
+/**
+ * Whether another OR-group may be added. `+ Or` is disabled at the cap.
+ */
+export function canAddGroup(numGroups: number, maxGroups?: number): boolean {
+  if (maxGroups == null) {
+    return true
+  }
+  return numGroups < maxGroups
+}
+
+/**
+ * Whether another AND-row may be added to a group. `+ And` is disabled at the
+ * cap. (The reused MultiRow enforces this via its `maxRows` prop; this mirrors
+ * the rule for testing.)
+ */
+export function canAddRow(numRows: number, maxRowsPerGroup?: number): boolean {
+  if (maxRowsPerGroup == null) {
+    return true
+  }
+  return numRows < maxRowsPerGroup
+}

--- a/packages/frontend/src/components/GroupedMultiRow/index.tsx
+++ b/packages/frontend/src/components/GroupedMultiRow/index.tsx
@@ -1,0 +1,132 @@
+import type { IField } from '@plumber/types'
+
+import { Fragment, useCallback, useContext } from 'react'
+import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
+import { BiPlus } from 'react-icons/bi'
+import Markdown from 'react-markdown'
+import { Flex } from '@chakra-ui/react'
+import { Button, FormLabel } from '@opengovsg/design-system-react'
+
+import { EditorContext } from '@/contexts/Editor'
+
+import { InputCreatorProps } from '../InputCreator'
+import MultiRow from '../MultiRow'
+
+import { canAddGroup } from './helpers'
+import OrDivider from './OrDivider'
+
+export type GroupedMultiRowProps = {
+  name: string
+  subFields: IField[]
+  required?: boolean
+  label?: string
+  description?: string
+  maxGroups?: number
+  maxRowsPerGroup?: number
+  addRowButtonText?: string
+  addGroupButtonText?: string
+} & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
+
+/**
+ * Generic "OR of AND" builder. It owns ONLY the group level — the array of
+ * groups, the `+ Or` button, the OR dividers, and cap-driven disabling of
+ * `+ Or`.
+ *
+ * Each group delegates its AND-rows to a reused `<MultiRow>` (rendered as
+ * `multirow-multicol`), so leaf inputs, the variable picker, the empty-operator
+ * `hiddenIf`, row add/delete, and the per-group row floor (>=1 row, via
+ * `required`) are reused untouched. The group-level `+ Or` control is rendered
+ * beside MultiRow's `+ And` via its `addButtonSuffix`. The persisted shape is
+ * `[{ rows: [row, ...] }, ...]`.
+ */
+function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
+  const {
+    name,
+    subFields,
+    label,
+    required,
+    description,
+    maxGroups,
+    maxRowsPerGroup,
+    addRowButtonText,
+    addGroupButtonText,
+    ...forwardedInputCreatorProps
+  } = props
+
+  const { control } = useFormContext()
+  const { readOnly: isEditorReadOnly } = useContext(EditorContext)
+
+  const { fields: groups, append } = useFieldArray({
+    name,
+    rules: { required },
+  })
+
+  const handleAddGroup = useCallback(() => {
+    // A new group starts empty; MultiRow renders one blank row by default.
+    append({ rows: [] })
+  }, [append])
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={(): JSX.Element => {
+        // Empty-state guard: always render at least one group.
+        const groupsToRender = groups.length
+          ? groups
+          : [{ id: `${name}-default-group` }]
+        const canAdd = canAddGroup(groupsToRender.length, maxGroups)
+
+        return (
+          <Flex flexDir="column">
+            <FormLabel
+              isRequired={required}
+              description={
+                description && (
+                  <Markdown linkTarget="_blank">{description}</Markdown>
+                )
+              }
+            >
+              {label}
+            </FormLabel>
+
+            {groupsToRender.map((group, index) => {
+              const isLastGroup = index === groupsToRender.length - 1
+              return (
+                <Fragment key={group.id}>
+                  <MultiRow
+                    name={`${name}.${index}.rows`}
+                    subFields={subFields}
+                    required
+                    type="multirow-multicol"
+                    showDivider={false}
+                    addRowButtonText={addRowButtonText ?? 'And'}
+                    maxRows={maxRowsPerGroup}
+                    addButtonSuffix={
+                      // `+ Or` lives next to the last group's `+ And`.
+                      isLastGroup && canAdd ? (
+                        <Button
+                          variant="outline"
+                          leftIcon={<BiPlus />}
+                          onClick={handleAddGroup}
+                          isDisabled={isEditorReadOnly}
+                          maxW="fit-content"
+                        >
+                          {addGroupButtonText ?? 'Or'}
+                        </Button>
+                      ) : undefined
+                    }
+                    {...forwardedInputCreatorProps}
+                  />
+                  {!isLastGroup && <OrDivider />}
+                </Fragment>
+              )
+            })}
+          </Flex>
+        )
+      }}
+    />
+  )
+}
+
+export default GroupedMultiRow

--- a/packages/frontend/src/components/GroupedMultiRow/index.tsx
+++ b/packages/frontend/src/components/GroupedMultiRow/index.tsx
@@ -1,6 +1,6 @@
 import type { IField } from '@plumber/types'
 
-import { Fragment, useCallback, useContext } from 'react'
+import { Fragment, useCallback, useContext, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { BiPlus } from 'react-icons/bi'
 import Markdown from 'react-markdown'
@@ -56,15 +56,39 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
   const { control } = useFormContext()
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
 
-  const { fields: groups, append } = useFieldArray({
+  const {
+    fields: groups,
+    append,
+    remove,
+  } = useFieldArray({
     name,
     rules: { required },
   })
 
+  // react-hook-form needs a non-undefined default for every subfield of a new
+  // row (mirrors MultiRow), otherwise it can repopulate it with deleted data.
+  const newRowDefaultValue = useMemo(() => {
+    const result: Record<string, unknown> = {}
+    for (const subField of subFields) {
+      result[subField.key] = subField.value ?? undefined
+    }
+    return result
+  }, [subFields])
+
   const handleAddGroup = useCallback(() => {
-    // A new group starts empty; MultiRow renders one blank row by default.
-    append({ rows: [] })
-  }, [append])
+    // Seed the new group with one row so focus lands on the first field. When
+    // that field is a variable-enabled RTE, flag the row `isNew` so it
+    // auto-focuses — same mechanism MultiRow uses for "+ And".
+    const firstColIsRte =
+      subFields?.[0]?.type === 'string' && subFields?.[0]?.variables
+    append({
+      rows: [
+        firstColIsRte
+          ? { ...newRowDefaultValue, isNew: true }
+          : newRowDefaultValue,
+      ],
+    })
+  }, [append, newRowDefaultValue, subFields])
 
   return (
     <Controller
@@ -76,6 +100,10 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
           ? groups
           : [{ id: `${name}-default-group` }]
         const canAdd = canAddGroup(groupsToRender.length, maxGroups)
+        // Floor: at least one group with at least one row must always remain.
+        // When more than one group exists, deleting a group's last row removes
+        // the whole group; otherwise the last group's last row is undeletable.
+        const canRemoveGroup = groupsToRender.length > 1
 
         return (
           <Flex flexDir="column">
@@ -102,6 +130,9 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
                     showDivider={false}
                     addRowButtonText={addRowButtonText ?? 'And'}
                     maxRows={maxRowsPerGroup}
+                    onRequestRemoveLastRow={
+                      canRemoveGroup ? () => remove(index) : undefined
+                    }
                     addButtonSuffix={
                       // `+ Or` lives next to the last group's `+ And`.
                       isLastGroup && canAdd ? (

--- a/packages/frontend/src/components/InputCreator/index.tsx
+++ b/packages/frontend/src/components/InputCreator/index.tsx
@@ -5,6 +5,7 @@ import { useContext } from 'react'
 import AttachmentSuggestions from '@/components/AttachmentSuggestions'
 import ControlledAutocomplete from '@/components/ControlledAutocomplete'
 import DragDropInput from '@/components/DragDropInput'
+import GroupedMultiRow from '@/components/GroupedMultiRow'
 import MultiRow from '@/components/MultiRow'
 import MultiSelect from '@/components/MultiSelect'
 import RichTextEditor from '@/components/RichTextEditor'
@@ -228,6 +229,24 @@ export default function InputCreator(props: InputCreatorProps): JSX.Element {
         // These are InputCreatorProps which MultiRow will forward.
         stepId={stepId}
         maxRows={schema.maxRows}
+      />
+    )
+  }
+
+  if (type === 'grouped-multirow') {
+    return (
+      <GroupedMultiRow
+        name={computedName}
+        label={label}
+        description={description}
+        subFields={schema.subFields}
+        required={required}
+        maxGroups={schema.maxGroups}
+        maxRowsPerGroup={schema.maxRowsPerGroup}
+        addRowButtonText={schema.addRowButtonText}
+        addGroupButtonText={schema.addGroupButtonText}
+        // Forwarded to the inner MultiRow / InputCreator.
+        stepId={stepId}
       />
     )
   }

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -28,6 +28,12 @@ export type MultiRowProps = {
   // Optional node rendered beside the "+ And" add-row button (e.g. a wrapper's
   // own controls). Renders even when the add-row button is hidden at maxRows.
   addButtonSuffix?: ReactNode
+  // Optional override for deleting the LAST remaining row. When provided, the
+  // last row's delete control is shown (even when `required`) and clicking it
+  // calls this instead of the internal remove — letting a wrapper (e.g.
+  // GroupedMultiRow) remove the whole containing group instead of leaving it
+  // empty. When omitted, `required` keeps the last row undeletable as before.
+  onRequestRemoveLastRow?: () => void
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
 function MultiRow(props: MultiRowProps): JSX.Element {
@@ -42,6 +48,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     type,
     maxRows,
     addButtonSuffix,
+    onRequestRemoveLastRow,
     ...forwardedInputCreatorProps
   } = props
 
@@ -91,8 +98,20 @@ function MultiRow(props: MultiRowProps): JSX.Element {
         // remaining.
         const rowsToRender =
           !rows.length && required ? [{ ...newRowDefaultValue }] : rows
-        const canRemoveRow = !required || rowsToRender.length > 1
+        const canRemoveRow =
+          !required || rowsToRender.length > 1 || !!onRequestRemoveLastRow
         const canAddRow = maxRows == null || rowsToRender.length < maxRows
+
+        // Deleting the last remaining row is delegated to the wrapper (e.g. to
+        // remove the whole group) when onRequestRemoveLastRow is provided;
+        // otherwise it's an internal row removal.
+        const removeRow = (index: number) => {
+          if (rowsToRender.length === 1 && onRequestRemoveLastRow) {
+            onRequestRemoveLastRow()
+          } else {
+            remove(index)
+          }
+        }
 
         return (
           <Flex flexDir="column">
@@ -123,7 +142,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                         subFields={subFields}
                         canRemoveRow={canRemoveRow}
                         isEditorReadOnly={isEditorReadOnly}
-                        remove={() => remove(index)}
+                        remove={() => removeRow(index)}
                         index={index}
                         {...forwardedInputCreatorProps}
                       />
@@ -154,7 +173,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
                             aria-label="Remove"
                             icon={<BiTrash />}
                             isDisabled={isEditorReadOnly}
-                            onClick={() => remove(index)}
+                            onClick={() => removeRow(index)}
                             colorScheme="secondary"
                           />
                         )}

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -1,6 +1,6 @@
 import type { IField } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
+import { ReactNode, useCallback, useContext, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { BiPlus, BiTrash } from 'react-icons/bi'
 import Markdown from 'react-markdown'
@@ -25,6 +25,9 @@ export type MultiRowProps = {
   addRowButtonText?: string
   type?: string
   maxRows?: number
+  // Optional node rendered beside the "+ And" add-row button (e.g. a wrapper's
+  // own controls). Renders even when the add-row button is hidden at maxRows.
+  addButtonSuffix?: ReactNode
 } & Omit<InputCreatorProps, 'schema' | 'namePrefix'>
 
 function MultiRow(props: MultiRowProps): JSX.Element {
@@ -38,6 +41,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     showDivider,
     type,
     maxRows,
+    addButtonSuffix,
     ...forwardedInputCreatorProps
   } = props
 
@@ -174,17 +178,20 @@ function MultiRow(props: MultiRowProps): JSX.Element {
               )
             })}
 
-            {canAddRow && (
-              <Button
-                variant="outline"
-                leftIcon={<BiPlus />}
-                onClick={handleAddRow}
-                isDisabled={isEditorReadOnly}
-                maxW="fit-content"
-              >
-                {addRowButtonText ?? 'And'}
-              </Button>
-            )}
+            <Flex gap={2} alignItems="center">
+              {canAddRow && (
+                <Button
+                  variant="outline"
+                  leftIcon={<BiPlus />}
+                  onClick={handleAddRow}
+                  isDisabled={isEditorReadOnly}
+                  maxW="fit-content"
+                >
+                  {addRowButtonText ?? 'And'}
+                </Button>
+              )}
+              {addButtonSuffix}
+            </Flex>
           </Flex>
         )
       }}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -466,6 +466,23 @@ export interface IFieldMultiRow extends IBaseField {
 }
 
 /**
+ * Generic "OR of AND" builder: an array of groups, each holding AND-ed rows.
+ * Persisted shape is `[{ rows: [row, ...] }, ...]` (outer = OR, inner = AND).
+ * It is agnostic to its rows — `subFields` describe a single row, exactly like
+ * `multirow-multicol`. `maxGroups` / `maxRowsPerGroup` are soft caps (the UI
+ * disables the add buttons at the limit; the backend re-checks them).
+ */
+export interface IFieldGroupedMultiRow extends IBaseField {
+  type: 'grouped-multirow'
+  value?: string
+  subFields: IField[]
+  maxGroups?: number
+  maxRowsPerGroup?: number
+  addRowButtonText?: string
+  addGroupButtonText?: string
+}
+
+/**
  * Marks a rich-text field as previewable in a kind-specific modal in
  * FlowStepTestController. Keep this union narrow; expand only as new preview
  * kinds (e.g. 'sms') ship.
@@ -548,6 +565,7 @@ export type IField =
   | IFieldMultiRowMultiCol
   | IFieldMultiSelect
   | IFieldMultiRow
+  | IFieldGroupedMultiRow
   | IFieldRichText
   | IFieldBooleanRadio
   | IFieldDragDrop


### PR DESCRIPTION
## Stack Context

PR 2 of 4 adding **OR-of-AND** conditions to toolbox **If-then** / **Only continue if**
(see PR 1 for the full picture). This PR adds the **frontend builder** for the new shape.
No real action consumes it yet — the cutover happens in PR 3.

## What

- `@plumber/types`: `IFieldGroupedMultiRow` (`type: 'grouped-multirow'`) — generic over
  `subFields`, with `maxGroups` / `maxRowsPerGroup` caps.
- `<GroupedMultiRow>` — owns the group level: the array of groups, `+ Or` (beside the
  last group's `+ And`), `OR` dividers, and cap-driven disabling of `+ Or`. Each group
  reuses an existing `<MultiRow>` (as `multirow-multicol`) for its AND-rows.
- Group lifecycle:
  - **Add** (`+ Or`) seeds the new group's first row and focuses the `Field` input.
  - **Delete** — a row is always deletable via its per-row trash, **except** the last
    row of the last remaining group (floor: ≥1 group with ≥1 row). When more than one
    group exists, deleting a group's only row removes the whole group.
- `MultiRow` gains two **optional, additive** props (`addButtonSuffix`,
  `onRequestRemoveLastRow`) — no behaviour change for any existing `multirow` /
  `multirow-multicol` user.
- `InputCreator` dispatch branch for `grouped-multirow`.
- Extracted pure builder helpers (`normalizeGroupsValue`, `canAddGroup`, `canAddRow`) with
  unit tests.
- **TEMPORARY QA arg** on `onlyContinueIf` (`OR condition groups (temporary QA — do not
  ship)`) so the builder renders in the real editor. Removed in PR 3.

## Why

Ship and verify the builder on its own before the atomic cutover. A dedicated field type
(rather than a flag on `multirow-multicol`) keeps **one type → one persisted shape**.

## Test plan

**Automated**

```
npm run -w frontend test      # or: cd packages/frontend && npx vitest run
```
- `src/components/GroupedMultiRow/helpers.test.ts` — empty-state guard, group cap, row cap.

**Manual (with `npm run dev`)** — add an **Only continue if** step; the temporary
*“OR condition groups”* field renders the builder:
1. `+ And` adds a row to a group; `+ Or` adds a new group — focus lands on the new
   group's **Field** input.
2. Rows within a group stack with no divider; groups are separated by an **OR** divider.
3. **Delete:** with one group, a single row can't be deleted (floor). Add a 2nd group →
   each group's single row can now be deleted, and deleting it removes that whole group;
   the last remaining group's last row stays undeletable.
4. **Caps:** `+ And` disables at 10 rows/group; `+ Or` disables at 10 groups.
5. Responsive: shrink to mobile width — rows stack and the `OR` divider still renders.

> ⚠️ **Known issue (tracked separately):** when the `Field` rich-text editor is focused
> and you scroll, its focus border can show as a thin line at the modal's left edge. This
> is a modal scroll/clipping interaction, not the builder logic — a follow-up fix.
