### PR TITLE
[OR condition 3/4] atomic backend cutover

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
@@ -1,11 +1,14 @@
-import { type IGlobalVariable } from '@plumber/types'
+import { type IGlobalVariable, type IJSONObject } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import StepError from '@/errors/step'
-
 import toolboxApp from '../..'
 import ifThenAction from '../../actions/if-then'
+
+// Wraps a single condition row into the v2 grouped shape (one OR-group).
+function singleGroup(row: IJSONObject) {
+  return [{ rows: [row] }]
+}
 
 /**
  * [T = trigger S = normal step, B = branch]
@@ -239,13 +242,24 @@ describe('If-then', () => {
     })
 
     it('runs the branch and returns void if branch condition passes', async () => {
+      $.step.parameters.conditions = singleGroup({
+        field: 1,
+        is: 'is',
+        condition: 'equals',
+        text: 1,
+      })
+      const result = await ifThenAction.run($)
+
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isConditionMet: true },
+      })
+    })
+
+    it('takes the branch when any OR-group passes', async () => {
       $.step.parameters.conditions = [
-        {
-          field: 1,
-          is: 'is',
-          condition: 'equals',
-          text: 1,
-        },
+        { rows: [{ field: 1, is: 'is', condition: 'equals', text: 9999 }] },
+        { rows: [{ field: 1, is: 'is', condition: 'equals', text: 1 }] },
       ]
       const result = await ifThenAction.run($)
 
@@ -255,13 +269,13 @@ describe('If-then', () => {
       })
     })
 
-    it('skips to the next branch if branch condition fails and there is a next branch', async () => {
+    it('AND-s rows within a group (all rows must pass)', async () => {
       $.step.parameters.conditions = [
         {
-          field: 1,
-          is: 'is',
-          condition: 'equals',
-          text: 9999,
+          rows: [
+            { field: 1, is: 'is', condition: 'equals', text: 1 },
+            { field: 'a', is: 'is', condition: 'equals', text: 'b' },
+          ],
         },
       ]
       const result = await ifThenAction.run($)
@@ -274,15 +288,30 @@ describe('If-then', () => {
       })
     })
 
+    it('skips to the next branch if branch condition fails and there is a next branch', async () => {
+      $.step.parameters.conditions = singleGroup({
+        field: 1,
+        is: 'is',
+        condition: 'equals',
+        text: 9999,
+      })
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'jump-to-step', stepId: 'branch-2' },
+      })
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isConditionMet: false },
+      })
+    })
+
     it('ends the pipe if branch condition fails and there is no next branch', async () => {
-      $.step.parameters.conditions = [
-        {
-          field: 1,
-          is: 'is',
-          condition: 'equals',
-          text: 9999,
-        },
-      ]
+      $.step.parameters.conditions = singleGroup({
+        field: 1,
+        is: 'is',
+        condition: 'equals',
+        text: 9999,
+      })
       // Exclude all of branch-2 from pipe for this test.
       mocks.stepQueryResult.mockResolvedValueOnce(FLAT_PIPE_STEPS.slice(0, 3))
       const result = await ifThenAction.run($)
@@ -295,21 +324,29 @@ describe('If-then', () => {
       })
     })
 
-    it('should throw step error if no condition is configured', async () => {
+    it('treats missing conditions as not met and skips to the next branch', async () => {
+      // The evaluator is strict but defensive: missing conditions evaluate to
+      // false rather than throwing (empty conditions are caught by frontend
+      // "Check step" validation and the incomplete-step activation guard).
       $.step.parameters.conditions = undefined
-      await expect(ifThenAction.run($)).rejects.toThrowError(StepError)
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'jump-to-step', stepId: 'branch-2' },
+      })
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isConditionMet: false },
+      })
     })
 
     it('should throw step error if invalid condition is configured', async () => {
       const invalidCondition = '==='
-      $.step.parameters.conditions = [
-        {
-          field: 1,
-          is: 'is',
-          condition: invalidCondition,
-          text: 9999,
-        },
-      ]
+      $.step.parameters.conditions = singleGroup({
+        field: 1,
+        is: 'is',
+        condition: invalidCondition,
+        text: 9999,
+      })
 
       // throw partial step error message
       await expect(ifThenAction.run($)).rejects.toThrowError(
@@ -341,14 +378,12 @@ describe('If-then', () => {
     ])(
       'runs the branch and returns void if the branch condition passes',
       async () => {
-        $.step.parameters.conditions = [
-          {
-            field: 1,
-            is: 'is',
-            condition: 'equals',
-            text: 1,
-          },
-        ]
+        $.step.parameters.conditions = singleGroup({
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          text: 1,
+        })
         const result = await ifThenAction.run($)
 
         expect(result).toBeFalsy()
@@ -369,14 +404,12 @@ describe('If-then', () => {
         $.step = {
           ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
         } as unknown as IGlobalVariable['step']
-        $.step.parameters.conditions = [
-          {
-            field: 1,
-            is: 'is',
-            condition: 'equals',
-            text: 9999,
-          },
-        ]
+        $.step.parameters.conditions = singleGroup({
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          text: 9999,
+        })
 
         const result = await ifThenAction.run($)
 
@@ -399,14 +432,12 @@ describe('If-then', () => {
         $.step = {
           ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
         } as unknown as IGlobalVariable['step']
-        $.step.parameters.conditions = [
-          {
-            field: 1,
-            is: 'is',
-            condition: 'equals',
-            text: 9999,
-          },
-        ]
+        $.step.parameters.conditions = singleGroup({
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          text: 9999,
+        })
 
         const result = await ifThenAction.run($)
 
@@ -430,14 +461,12 @@ describe('If-then', () => {
         $.step = {
           ...NESTED_BRANCH_PIPE_STEPS.find((step) => step.id === stepId),
         } as unknown as IGlobalVariable['step']
-        $.step.parameters.conditions = [
-          {
-            field: 1,
-            is: 'is',
-            condition: 'equals',
-            text: 9999,
-          },
-        ]
+        $.step.parameters.conditions = singleGroup({
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          text: 9999,
+        })
 
         const result = await ifThenAction.run($)
 
@@ -458,14 +487,12 @@ describe('If-then', () => {
     ])(
       'should handle begins with condition',
       async ({ field, text, expectedResult }) => {
-        $.step.parameters.conditions = [
-          {
-            field,
-            is: 'is',
-            condition: 'begins',
-            text,
-          },
-        ]
+        $.step.parameters.conditions = singleGroup({
+          field,
+          is: 'is',
+          condition: 'begins',
+          text,
+        })
 
         await ifThenAction.run($)
         expect(mocks.setActionItem).toBeCalledWith({

--- a/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/only-continue-if.test.ts
@@ -1,4 +1,4 @@
-import { type IGlobalVariable } from '@plumber/types'
+import { type IGlobalVariable, type IJSONObject } from '@plumber/types'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -22,6 +22,11 @@ vi.mock('@/models/step', () => ({
     })),
   },
 }))
+
+// Wraps a single condition row into the v2 grouped shape (one OR-group).
+function singleGroup(row: IJSONObject) {
+  return { conditions: [{ rows: [row] }] }
+}
 
 const MOCK_FLOW = [
   {
@@ -111,11 +116,26 @@ describe('Only continue if', () => {
   })
 
   it('returns void if condition passes', async () => {
-    $.step.parameters = {
+    $.step.parameters = singleGroup({
       field: 1,
       is: 'is',
       condition: 'equals',
       text: 1,
+    })
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toBeFalsy()
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: true },
+    })
+  })
+
+  it('passes when any OR-group passes (first group fails, second passes)', async () => {
+    $.step.parameters = {
+      conditions: [
+        { rows: [{ field: 1, is: 'is', condition: 'equals', text: 2 }] },
+        { rows: [{ field: 1, is: 'is', condition: 'equals', text: 1 }] },
+      ],
     }
 
     const result = await onlyContinueIfAction.run($)
@@ -125,13 +145,36 @@ describe('Only continue if', () => {
     })
   })
 
-  it('stops execution if condition fails before branches', async () => {
+  it('AND-s rows within a group (all rows must pass)', async () => {
     $.step.parameters = {
+      conditions: [
+        {
+          rows: [
+            { field: 1, is: 'is', condition: 'equals', text: 1 },
+            { field: 'a', is: 'is', condition: 'equals', text: 'b' },
+          ],
+        },
+      ],
+    }
+
+    mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
+
+    const result = await onlyContinueIfAction.run($)
+    expect(result).toEqual({
+      nextStep: { command: 'stop-execution' },
+    })
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: false },
+    })
+  })
+
+  it('stops execution if condition fails before branches', async () => {
+    $.step.parameters = singleGroup({
       field: 1,
       is: 'is',
       condition: 'contains',
       text: 0,
-    }
+    })
 
     mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
 
@@ -148,13 +191,13 @@ describe('Only continue if', () => {
     // update only continue if to step 4
     $.step = {
       ...MOCK_FLOW[3],
-      parameters: {
+      parameters: singleGroup({
         field: 1,
         is: 'not',
         condition: 'equals',
         text: 1,
-      },
-      version: 1,
+      }),
+      version: 2,
     }
 
     mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
@@ -172,13 +215,13 @@ describe('Only continue if', () => {
     // update only continue if to step 7
     $.step = {
       ...MOCK_FLOW[6],
-      parameters: {
+      parameters: singleGroup({
         field: 1,
         is: 'not',
         condition: 'equals',
         text: 1,
-      },
-      version: 1,
+      }),
+      version: 2,
     }
 
     mocks.stepQueryResult.mockResolvedValueOnce(MOCK_FLOW)
@@ -194,12 +237,12 @@ describe('Only continue if', () => {
 
   it('should throw step error if invalid condition is configured', async () => {
     const invalidCondition = '==='
-    $.step.parameters = {
+    $.step.parameters = singleGroup({
       field: 1,
       is: 'is',
       condition: invalidCondition,
       text: 0,
-    }
+    })
 
     // throw partial step error message
     await expect(onlyContinueIfAction.run($)).rejects.toThrowError(
@@ -208,11 +251,11 @@ describe('Only continue if', () => {
   })
 
   it('returns void if field is empty', async () => {
-    $.step.parameters = {
+    $.step.parameters = singleGroup({
       field: '',
       is: 'is',
       condition: 'empty',
-    }
+    })
 
     const result = await onlyContinueIfAction.run($)
     expect(result).toBeFalsy()
@@ -230,12 +273,12 @@ describe('Only continue if', () => {
   ])(
     'returns void if numbers are used for operator comparison',
     async ({ field, is, condition, text }) => {
-      $.step.parameters = {
+      $.step.parameters = singleGroup({
         field,
         is,
         condition,
         text,
-      }
+      })
 
       const result = await onlyContinueIfAction.run($)
       expect(result).toBeFalsy()
@@ -246,12 +289,12 @@ describe('Only continue if', () => {
   )
 
   it('should throw step error if a non-number is used for operator comparison', async () => {
-    $.step.parameters = {
+    $.step.parameters = singleGroup({
       field: 123,
       is: 'is',
       condition: 'gte',
       text: '19 Nov 2021',
-    }
+    })
 
     await expect(onlyContinueIfAction.run($)).rejects.toThrowError(StepError)
   })

--- a/packages/backend/src/apps/toolbox/__tests__/common/transform-step-parameters.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/transform-step-parameters.test.ts
@@ -1,0 +1,130 @@
+import { type IJSONObject } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  stepTransformer,
+  transformIfThenConditions,
+  transformOnlyContinueIfConditions,
+} from '../../common/transform-step-parameters'
+
+const { transformStepParameters, getLatestStepVersion } = stepTransformer
+
+describe('transformIfThenConditions', () => {
+  it('collapses a flat AND-list into exactly ONE group (never one-per-row)', () => {
+    const oldRows = [
+      { field: 'a', is: 'is', condition: 'equals', text: 'a' },
+      { field: 'b', is: 'is', condition: 'equals', text: 'b' },
+    ]
+    const result = transformIfThenConditions({
+      branchName: 'Branch 2',
+      depth: 0,
+      conditions: oldRows,
+    })
+
+    // The whole point: AND-ed rows stay together in one OR-group.
+    expect(result.conditions).toEqual([{ rows: oldRows }])
+    expect((result.conditions as unknown[]).length).toBe(1)
+    // branchName / depth preserved.
+    expect(result.branchName).toBe('Branch 2')
+    expect(result.depth).toBe(0)
+  })
+
+  it('is idempotent: already-migrated grouped conditions are unchanged', () => {
+    const migrated = {
+      branchName: 'Branch 2',
+      depth: 0,
+      conditions: [
+        { rows: [{ field: 'a', is: 'is', condition: 'equals', text: 'a' }] },
+      ],
+    }
+    expect(transformIfThenConditions(migrated)).toEqual(migrated)
+  })
+
+  it('leaves parameters untouched when conditions is not an array', () => {
+    const params = { branchName: 'Branch 2', depth: 0 }
+    expect(transformIfThenConditions(params)).toBe(params)
+  })
+
+  it('treats an empty conditions array as already-migrated (no wrapping)', () => {
+    const params: IJSONObject = {
+      branchName: 'Branch 2',
+      depth: 0,
+      conditions: [],
+    }
+    expect(transformIfThenConditions(params)).toEqual(params)
+  })
+})
+
+describe('transformOnlyContinueIfConditions', () => {
+  it('wraps the root condition into one group with one row', () => {
+    const result = transformOnlyContinueIfConditions({
+      field: '1',
+      is: 'is',
+      condition: 'equals',
+      text: '1',
+    })
+
+    expect(result).toEqual({
+      conditions: [
+        { rows: [{ field: '1', is: 'is', condition: 'equals', text: '1' }] },
+      ],
+    })
+    // Root-level condition keys are moved out.
+    expect(result).not.toHaveProperty('field')
+    expect(result).not.toHaveProperty('condition')
+  })
+
+  it('preserves unrelated root keys (e.g. depth) while wrapping', () => {
+    const result = transformOnlyContinueIfConditions({
+      depth: 2,
+      field: '1',
+      is: 'is',
+      condition: 'equals',
+      text: '1',
+    })
+    expect(result.depth).toBe(2)
+    expect(result.conditions).toEqual([
+      { rows: [{ field: '1', is: 'is', condition: 'equals', text: '1' }] },
+    ])
+  })
+
+  it('is idempotent: parameters with a conditions array are unchanged', () => {
+    const migrated = {
+      conditions: [
+        { rows: [{ field: '1', is: 'is', condition: 'equals', text: '1' }] },
+      ],
+    }
+    expect(transformOnlyContinueIfConditions(migrated)).toBe(migrated)
+  })
+
+  it('leaves unconfigured parameters (no field, no condition) untouched', () => {
+    const params = { depth: 0 }
+    expect(transformOnlyContinueIfConditions(params)).toBe(params)
+  })
+})
+
+describe('stepTransformer wiring', () => {
+  it('reports latest version 2 for both toolbox condition actions', () => {
+    expect(getLatestStepVersion('ifThen')).toBe(2)
+    expect(getLatestStepVersion('onlyContinueIf')).toBe(2)
+  })
+
+  it('defaults to version 1 for actions without a transformer', () => {
+    expect(getLatestStepVersion('forEach')).toBe(1)
+  })
+
+  it('applies the v1→v2 transform at version 1 and is a no-op at version 2', () => {
+    const v1 = {
+      branchName: 'Branch 2',
+      depth: 0,
+      conditions: [{ field: 'a', is: 'is', condition: 'equals', text: 'a' }],
+    }
+    const migrated = transformStepParameters('ifThen', v1, 1)
+    expect(migrated.conditions).toEqual([
+      { rows: [{ field: 'a', is: 'is', condition: 'equals', text: 'a' }] },
+    ])
+
+    expect(transformStepParameters('ifThen', migrated, 2)).toEqual(migrated)
+  })
+})

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -1,20 +1,10 @@
-import type { IGlobalVariable, IJSONObject, IRawAction } from '@plumber/types'
+import type { IConditionRow, IMultiRowGroup, IRawAction } from '@plumber/types'
 
-import StepError from '@/errors/step'
-
-import conditionIsTrue from '../../common/condition-is-true'
+import { evaluateConditionGroups } from '../../common/evaluate-condition-groups'
 import { getBranchStepIdToSkipTo } from '../../common/get-branch-step-id-to-skip-to'
 import getConditionArgs from '../../common/get-condition-args'
 
 const ACTION_KEY = 'ifThen'
-
-function shouldTakeBranch($: IGlobalVariable): boolean {
-  const conditions = $.step.parameters.conditions as IJSONObject[]
-  if (!Array.isArray(conditions)) {
-    throw new Error('No conditions found')
-  }
-  return conditions.every((condition) => conditionIsTrue(condition))
-}
 
 const action: IRawAction = {
   name: 'If-then',
@@ -45,24 +35,21 @@ const action: IRawAction = {
     {
       label: 'Conditions',
       key: 'conditions',
-      type: 'multirow-multicol' as const,
+      type: 'grouped-multirow' as const,
       required: true,
       description:
         'Every condition has to be satisfied for this branch to be taken.',
+      maxGroups: 10,
+      maxRowsPerGroup: 10,
       subFields: getConditionArgs({ usePlaceholders: true }),
     },
   ],
 
   async run($) {
-    let isConditionMet
-    try {
-      isConditionMet = shouldTakeBranch($)
-    } catch (err) {
-      throw new StepError(
-        err.message,
-        'Check that the condition has been configured properly.',
-      )
-    }
+    // Strict v2 shape: Step.$afterFind has already migrated legacy params.
+    const groups = ($.step.parameters.conditions ??
+      []) as unknown as IMultiRowGroup<IConditionRow>[]
+    const isConditionMet = evaluateConditionGroups(groups)
     $.setActionItem({
       raw: { isConditionMet },
     })

--- a/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/only-continue-if/index.ts
@@ -1,8 +1,6 @@
-import type { IRawAction } from '@plumber/types'
+import type { IConditionRow, IMultiRowGroup, IRawAction } from '@plumber/types'
 
-import StepError from '@/errors/step'
-
-import conditionIsTrue from '../../common/condition-is-true'
+import { evaluateConditionGroups } from '../../common/evaluate-condition-groups'
 import { getBranchStepIdToSkipTo } from '../../common/get-branch-step-id-to-skip-to'
 import getConditionArgs from '../../common/get-condition-args'
 
@@ -11,17 +9,11 @@ const action: IRawAction = {
   key: 'onlyContinueIf',
   description: 'Only runs later actions if specified conditions are met',
   arguments: [
-    ...getConditionArgs({ usePlaceholders: false }),
-    // TEMPORARY (remove in feat/or-condition/cutover): renders the new generic
-    // `grouped-multirow` builder inside the real flow editor for manual QA.
-    // Uses a distinct key + `required: false` so it does not feed `run()` or
-    // affect step completeness — the real cutover replaces `arguments` wholesale.
     {
-      label: 'OR condition groups (temporary QA — do not ship)',
-      key: 'groupedMultirowQa',
+      label: 'Conditions',
+      key: 'conditions',
       type: 'grouped-multirow' as const,
-      required: false,
-      variables: false,
+      required: true,
       maxGroups: 10,
       maxRowsPerGroup: 10,
       subFields: getConditionArgs({ usePlaceholders: true }),
@@ -29,15 +21,10 @@ const action: IRawAction = {
   ],
 
   async run($) {
-    let result
-    try {
-      result = conditionIsTrue($.step.parameters)
-    } catch (err) {
-      throw new StepError(
-        err.message,
-        'Check that one of valid options in the condition dropdown is being selected.',
-      )
-    }
+    // Strict v2 shape: Step.$afterFind has already migrated legacy params.
+    const groups = ($.step.parameters.conditions ??
+      []) as unknown as IMultiRowGroup<IConditionRow>[]
+    const result = evaluateConditionGroups(groups)
     $.setActionItem({
       raw: { result },
     })

--- a/packages/backend/src/apps/toolbox/common/get-condition-args.ts
+++ b/packages/backend/src/apps/toolbox/common/get-condition-args.ts
@@ -4,8 +4,6 @@ interface GetConditionArgsOptions {
   usePlaceholders: boolean
 }
 
-// FIXME (ogp-weeloong): migrate to multi-row for both ifThen and
-// onlyContinueIf.
 export default function getConditionArgs({
   usePlaceholders,
 }: GetConditionArgsOptions): IFieldMultiRowMultiColSubField[] {

--- a/packages/backend/src/apps/toolbox/common/transform-step-parameters.ts
+++ b/packages/backend/src/apps/toolbox/common/transform-step-parameters.ts
@@ -1,0 +1,67 @@
+import type { IJSONObject, IJSONValue } from '@plumber/types'
+
+import { createVersionedStepTransformer } from '@/helpers/transform-step-parameters'
+import { wrapRowsIntoSingleGroup } from '@/helpers/wrap-rows-into-single-group'
+
+/**
+ * ifThen (v1 → v2): collapse to a single group.
+ *
+ * Old rows were all AND-ed, so they must stay AND-ed inside ONE OR-group.
+ * Wrapping each old row in its own group would flip AND → OR and break existing
+ * pipes. `branchName` / `depth` (and any other keys) are preserved. Idempotent.
+ */
+export function transformIfThenConditions(
+  parameters: IJSONObject,
+): IJSONObject {
+  const { conditions, ...rest } = parameters
+  if (!Array.isArray(conditions)) {
+    return parameters
+  }
+  const alreadyMigrated = conditions.every(
+    (condition) =>
+      !!condition && typeof condition === 'object' && 'rows' in condition,
+  )
+  if (alreadyMigrated) {
+    return parameters
+  }
+  return {
+    ...rest,
+    conditions: wrapRowsIntoSingleGroup(conditions) as unknown as IJSONValue,
+  }
+}
+
+/**
+ * onlyContinueIf (v1 → v2): wrap the root condition.
+ *
+ * The single root-level condition (`field` / `is` / `condition` / `text`) moves
+ * into a `conditions` array holding one group with one row. Idempotent;
+ * unconfigured steps (no field and no condition) are left untouched.
+ */
+export function transformOnlyContinueIfConditions(
+  parameters: IJSONObject,
+): IJSONObject {
+  if (Array.isArray(parameters.conditions)) {
+    return parameters
+  }
+  const { field, is, condition, text, ...rest } = parameters
+  if (field === undefined && condition === undefined) {
+    return parameters
+  }
+  return {
+    ...rest,
+    conditions: wrapRowsIntoSingleGroup([
+      { field, is, condition, text },
+    ]) as unknown as IJSONValue,
+  }
+}
+
+const ACTION_TRANSFORMERS: Record<
+  string,
+  ((parameters: IJSONObject) => IJSONObject)[]
+> = {
+  ifThen: [transformIfThenConditions],
+  onlyContinueIf: [transformOnlyContinueIfConditions],
+}
+
+export const stepTransformer =
+  createVersionedStepTransformer(ACTION_TRANSFORMERS)

--- a/packages/backend/src/apps/toolbox/index.ts
+++ b/packages/backend/src/apps/toolbox/index.ts
@@ -1,5 +1,6 @@
 import { IApp } from '@plumber/types'
 
+import { stepTransformer } from './common/transform-step-parameters'
 import actions from './actions'
 
 const app: IApp = {
@@ -11,6 +12,7 @@ const app: IApp = {
   apiBaseUrl: '',
   primaryColor: '000000',
   actions,
+  stepTransformer,
   description:
     "Use Plumber's built in tools like If-then and Only continue if to add more functionality to your pipes",
   category: 'logic',


### PR DESCRIPTION
## Stack Context

PR 3 of 4 adding **OR-of-AND** conditions to toolbox **If-then** / **Only continue if**
(see PR 1). This is the **atomic cutover**: it flips both actions to the new shape.

## Why this PR is atomic

Registering the toolbox `stepTransformer` flips the `$afterFind` wire shape for **both**
the worker *and* the editor at once (`getFlow` loads steps through the same Objection
model). So the transformer, both `run()`s, and both `arguments` schemas must all be ready
for v2 the instant the transformer is on — that flip is one irreducible PR.

## What

- Register the toolbox `stepTransformer` with two **idempotent** v1→v2 transforms:
  - **ifThen** — collapse the flat AND-rows into **one** group (never one-per-row, which
    would flip AND→OR); `branchName` / `depth` preserved.
  - **onlyContinueIf** — wrap the root-level condition into `conditions: [{ rows: [row] }]`.
  - Both via the shared `wrapRowsIntoSingleGroup` (PR 1).
- Rewire both `run()`s to the strict `evaluateConditionGroups` (PR 1).
- Flip both actions' `arguments` to `grouped-multirow` (with `maxGroups` /
  `maxRowsPerGroup`).
- **Remove** the temporary QA arg added in PR 2, and the resolved `get-condition-args`
  FIXME.
- Update both actions' `run()` unit tests to the v2 grouped shape (+ OR/AND cases). Note:
  missing conditions now evaluate to `false` instead of throwing.

## Backwards compatibility

No DB backfill — un-edited v1 steps are migrated lazily on every read by `$afterFind`;
`create-step`/`update-step` stamp/persist v2. The transform functions are **permanent**.

## Test plan

**Automated**

```
npm run -w backend test:unit
```
- `src/apps/toolbox/__tests__/common/transform-step-parameters.test.ts` — single-group
  collapse, idempotency, unconfigured/no-op, and version routing (latest = 2).
- `src/apps/toolbox/__tests__/actions/if-then.test.ts` &
  `only-continue-if.test.ts` — `run()` over the v2 shape, incl. OR-across-groups and
  AND-within-group.

**Manual (with `npm run dev`)** — the cutover end-to-end:
1. **New step:** add an **If-then** (and an **Only continue if**) — both now show the OR
   builder (`+ And` / `+ Or` / `OR` dividers). The temp QA field from PR 2 is gone.
2. Build `(A AND B) OR (C)`, save, and **Check step** / run — confirm it passes when
   either the `A AND B` group or the `C` group matches, and fails when neither does.
3. **Legacy migration (no backfill):** open a flow with a **pre-existing** If-then
   (multi-row AND) or Only continue if (single condition) created before this change —
   it should load into the builder as a single group preserving its original AND meaning
   (an old 2-row If-then still requires **both**, never becomes OR).
4. Edit + save a legacy step → it persists in the v2 shape.
