### PR TITLE
fix: claude friction

### DIFF
--- a/.claude/hooks/bash-hook-for-nvm.jq
+++ b/.claude/hooks/bash-hook-for-nvm.jq
@@ -1,0 +1,25 @@
+# PreToolUse(Bash) rewrite: if the command invokes npm/npx/node, prepend an
+# `nvm use` so the repo's .nvmrc Node version is active. Other commands pass
+# through untouched (empty output = no modification). The \b...\b word boundary
+# means `node_modules` does NOT match (so e.g. `rm -rf node_modules` is left
+# alone), only `node` as a standalone word.
+#
+# Team-wide notes:
+#   * Requires `jq` on PATH (this filter runs via `jq -f`).
+#   * Requires nvm to be loaded in your shell (so the `nvm` function exists in
+#     Claude Code's shell snapshot). If nvm is NOT present, npm/npx commands are
+#     ABORTED with exit 1 — this repo requires nvm.
+#   * If nvm IS present but `nvm use` fails (no .nvmrc found, or the pinned Node
+#     isn't installed), the command is likewise ABORTED rather than running
+#     npm/npx on an unknown Node version.
+if (.tool_input.command | test("\\b(npm|npx|node)\\b"))
+then {
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    updatedInput: (.tool_input + {
+      command: ("command -v nvm >/dev/null 2>&1 || { echo \"nvm not found; this repo requires nvm (see .nvmrc). Aborting.\" >&2; exit 1; }; nvm use >/dev/null 2>&1 || { echo \"nvm use failed: no .nvmrc found or pinned Node not installed. Aborting.\" >&2; exit 1; }; " + .tool_input.command)
+    })
+  }
+}
+else empty
+end

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/bash-hook-for-nvm.jq\"",
+            "statusMessage": "nvm use"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gt create:*)",
+      "Bash(gt track:*)",
+      "Bash(gt parent:*)",
+      "Bash(npm run test:*)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run build:*)",
+      "Bash(npm run gqlc:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npx vitest run:*)",
+      "mcp__codegraph__codegraph_explore",
+      "mcp__codegraph__codegraph_search",
+      "mcp__codegraph__codegraph_node",
+      "mcp__codegraph__codegraph_callers",
+      "mcp__codegraph__codegraph_callees",
+      "mcp__codegraph__codegraph_impact",
+      "mcp__codegraph__codegraph_files",
+      "mcp__codegraph__codegraph_status"
+    ]
+  }
+}


### PR DESCRIPTION
# Problem

1. I keep getting "allow command" prompts, but I don't like `auto` mode.
2. If your .zshrc isn't setup to auto-use our nvm version, Claude will not switch versions correctly, this is mildly foot-gunny

# Fix

1. Allowlist some default safe commands
2. Add PreToolUse  hook to run `nvm use`automatically.

#### NOTE

I decided to use PreToolUse instead of SessionStart because SessionStart has some footguns:

1. If `nvm` itself or the `.nvmrc`node version we use isn't installed, it fails silently
2. `Bash` tool calls re-sources .zshrc which may clobber `nvm`'s PATH setup.