### PR TITLE
feat(worker): log stalled jobs for Datadog tracking

### DIFF
--- a/packages/backend/docs/worker-monitoring.md
+++ b/packages/backend/docs/worker-monitoring.md
@@ -1,0 +1,61 @@
+# Worker monitoring
+
+Observability for the BullMQ workers: a **worker-uptime SLI** (are workers dequeuing jobs when there's work?) and **stalled-job tracking**. All metrics reach Datadog through the already-initialized `dd-trace` client — no new dependency or telemetry pipeline.
+
+## 1. Worker uptime SLI
+
+**Definition:** workers are "up" when they dequeue jobs whenever there is *eligible* ready work. The failure mode we catch is a **backlog that isn't draining** — jobs are ready but nothing is being processed (worker crashed, stalled, Redis-stuck, or deadlocked).
+
+dd-trace doesn't track queue depth, so a sampler reads each queue's state on an interval and emits gauges via `tracer.dogstatsd.gauge()`.
+
+- **Where:** the **server** process (`startQueueDepthMetrics()` called from `src/server.ts`), not the worker. Sampling from the server decouples the observer from worker health, so it catches both a *crashed* worker and a *stuck-but-alive* one. ("No data" then means the server itself is down — alert separately.)
+- **Cadence:** every 30s, across **all** queues (`flow`, `trigger`, main `action`, and every app-specific action queue).
+- **Code:** `src/helpers/queue-depth-metrics.ts` (sampler) + `src/helpers/queue-depth-metrics-verdict.ts` (pure decision logic, unit-tested).
+- **Local dev:** no-op when `APP_ENV=development` (no Datadog agent).
+
+### Metrics (tagged by `queue`; `env` added by dd-trace)
+
+| Metric | Type | Meaning |
+|---|---|---|
+| `plumber.worker.dequeuing_ok` | gauge (1/0) | **Primary SLI.** 1 = healthy (draining, or nothing eligible to do); 0 = eligible work exists but nothing is active. |
+| `plumber.queue.active` | gauge | Jobs currently processing. |
+| `plumber.queue.waiting` | gauge | Ready, unpicked jobs (excludes delayed/backoff). |
+| `plumber.queue.delayed` | gauge | Scheduled-later / retry-backoff jobs. |
+| `plumber.queue.rate_limit_ttl` | gauge (ms) | Queue-level throttle remaining. Emitted only for rate-limited queues (`postman`, `m365-excel`). |
+| `plumber.queue.groups.{waiting,limited,maxed,paused}` | gauge | Group state for grouped queues (`postman-sms`, `m365-excel`, `tiles`, `slack`, `telegram`). Explains *why* a grouped queue looks idle. |
+
+### How `dequeuing_ok` is computed
+
+```
+dequeuing_ok = 1  if active > 0                          // clearly draining
+             = 1  if no eligible ready work               // nothing to do (or all throttled)
+             = 0  if active == 0 AND eligible ready work  // OUTAGE
+
+eligible ready work = rateLimitTtl > 0 ? 0 : (ungrouped waiting + ready groups)
+```
+
+The key design choice is **subtracting throttling** so a healthy rate-limited worker is never flagged as down:
+
+- A positive queue-level `rateLimitTtl` throttles the whole queue → nothing eligible.
+- For grouped queues, only groups in `waiting` status count as eligible. Rate-limited groups sit in `limited` and at-concurrency groups in `maxed`, so neither is mistaken for a backlog.
+
+**Why not other signals:**
+- *Oldest-waiting-job age* — polluted by a single problem job retried with long exponential backoff (those live in `delayed`, not `waiting`, so `waiting` stays clean).
+- *BullMQ OpenTelemetry metrics* — would require standing up a second OTLP pipeline alongside dd-trace; the useful gauge still needs a polling loop. More plumbing for the same result.
+
+### Defining the SLO in Datadog (UI)
+
+- **Per-queue health:** `min:plumber.worker.dequeuing_ok{*} by {queue}` over a rolling 5-min window. `min == 0` ⇒ a sustained outage (a momentary handoff gap between jobs can't drag a 5-min `min` to 0).
+- **Monitor:** `min(last_5m): min:plumber.worker.dequeuing_ok{queue:action} < 1`.
+- **SLO:** metric-based, good = samples where `dequeuing_ok == 1`, target e.g. 99.9% / 30 days. Slice by `queue` or aggregate for an overall worker-uptime SLO.
+- Raw `plumber.queue.*` metrics power dashboards and root-cause (e.g. `dequeuing_ok == 1` with high `groups.limited` = healthy-but-throttled).
+
+## 2. Stalled-job tracking
+
+A job "stalls" when its lock expires and BullMQ moves it back to be reprocessed. We log every stall as a structured warning and derive the count in Datadog as a **log-based metric** (stalls are rare, auto-recover, and the log carries more context than a counter).
+
+- **Code:** `recordStalledJob(queueName, jobId)` in `src/workers/helpers/worker-event-handlers.ts`, called from a `worker.on('stalled', …)` handler on **every** worker — `registerWorkerEventHandlers` (action + sub-trigger), `src/workers/flow.ts`, and `src/workers/trigger.ts`.
+- **Log shape:** `logger.warn` at level `warn` (a stall is recoverable, not a failure) with structured fields `{ event: 'job-stalled', queueName, jobId, workerVersion }`.
+- **Not a span:** the `stalled` event fires from BullMQ's internal stall-checker, outside any job-processing span, so there's no active span to tag.
+
+**Datadog (UI):** create a log-based metric counting logs where `event:job-stalled`, tagged by `queueName`, to graph/alert on stall frequency.

--- a/packages/backend/src/helpers/__tests__/queue-depth-metrics-verdict.test.ts
+++ b/packages/backend/src/helpers/__tests__/queue-depth-metrics-verdict.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeDequeuingOk,
+  computeEligibleWaiting,
+} from '../queue-depth-metrics-verdict'
+
+describe('computeEligibleWaiting', () => {
+  it('counts ungrouped waiting jobs when not throttled', () => {
+    expect(
+      computeEligibleWaiting({
+        rateLimitTtlMs: -1,
+        waitingCount: 5,
+        readyGroupCount: 0,
+      }),
+    ).toBe(5)
+  })
+
+  it('counts ready groups on top of ungrouped waiting jobs', () => {
+    expect(
+      computeEligibleWaiting({
+        rateLimitTtlMs: -1,
+        waitingCount: 2,
+        readyGroupCount: 3,
+      }),
+    ).toBe(5)
+  })
+
+  it('returns 0 when the queue is throttled by a queue-level rate limit', () => {
+    expect(
+      computeEligibleWaiting({
+        rateLimitTtlMs: 1000,
+        waitingCount: 10,
+        readyGroupCount: 4,
+      }),
+    ).toBe(0)
+  })
+
+  it('returns 0 when nothing is waiting', () => {
+    expect(
+      computeEligibleWaiting({
+        rateLimitTtlMs: -1,
+        waitingCount: 0,
+        readyGroupCount: 0,
+      }),
+    ).toBe(0)
+  })
+})
+
+describe('computeDequeuingOk', () => {
+  it('is healthy when jobs are actively processing', () => {
+    expect(computeDequeuingOk(3, 10)).toBe(1)
+  })
+
+  it('is healthy when there is no eligible work to pick up', () => {
+    expect(computeDequeuingOk(0, 0)).toBe(1)
+  })
+
+  it('is an outage when eligible work exists but nothing is active', () => {
+    expect(computeDequeuingOk(0, 4)).toBe(0)
+  })
+
+  it('treats a throttled queue (no eligible work) as healthy even when idle', () => {
+    // e.g. rate-limited queue: eligibleWaiting collapses to 0, active is 0.
+    expect(computeDequeuingOk(0, 0)).toBe(1)
+  })
+})

--- a/packages/backend/src/helpers/queue-depth-metrics-verdict.ts
+++ b/packages/backend/src/helpers/queue-depth-metrics-verdict.ts
@@ -1,0 +1,35 @@
+//
+// Pure verdict logic for the worker uptime SLI. Kept free of queue/Redis
+// imports so it can be unit tested without touching infrastructure.
+//
+
+/**
+ * Number of jobs that are ready to run AND eligible to be picked up right now
+ * (i.e. not held back by throttling). If this is > 0 while nothing is active,
+ * the worker is not dequeuing - an outage.
+ *
+ * - A positive queue-level rate-limit TTL throttles the entire queue, so
+ *   nothing is eligible.
+ * - Otherwise eligible work = ungrouped waiting jobs + groups whose head job
+ *   is ready (`waiting` group status). Rate-limited groups sit in `limited`
+ *   and at-concurrency groups in `maxed`, so neither counts as eligible.
+ */
+export function computeEligibleWaiting(params: {
+  rateLimitTtlMs: number
+  waitingCount: number
+  readyGroupCount: number
+}): number {
+  const { rateLimitTtlMs, waitingCount, readyGroupCount } = params
+  if (rateLimitTtlMs > 0) {
+    return 0
+  }
+  return waitingCount + readyGroupCount
+}
+
+/** 1 = worker is dequeuing (or has nothing eligible to do), 0 = outage. */
+export function computeDequeuingOk(
+  activeCount: number,
+  eligibleWaiting: number,
+): 0 | 1 {
+  return activeCount > 0 || eligibleWaiting === 0 ? 1 : 0
+}

--- a/packages/backend/src/helpers/queue-depth-metrics.ts
+++ b/packages/backend/src/helpers/queue-depth-metrics.ts
@@ -1,0 +1,155 @@
+import apps from '@/apps'
+import appConfig from '@/config/app'
+import { appActionQueues, mainActionQueue } from '@/queues/action'
+import flowQueue from '@/queues/flow'
+import triggerQueue from '@/queues/trigger'
+
+import logger from './logger'
+import {
+  computeDequeuingOk,
+  computeEligibleWaiting,
+} from './queue-depth-metrics-verdict'
+import tracer from './tracer'
+
+//
+// Worker uptime SLI
+// ---
+// "Uptime" = workers are dequeuing jobs whenever there are jobs ready to run.
+// We sample every queue on an interval (from the server process, so the
+// observer is decoupled from worker health) and emit Datadog gauges via
+// dd-trace's built-in dogstatsd client - no extra dependency.
+//
+// The primary signal is `plumber.worker.dequeuing_ok` (1 healthy / 0 outage):
+// an outage is "there is eligible ready work but nothing is active". We
+// deliberately subtract throttling so a healthy rate-limited worker is not
+// flagged as down (see computeEligibleWaiting).
+//
+
+const SAMPLE_INTERVAL_MS = 30_000
+
+// Minimal structural type covering both QueuePro<IActionJobData> (action
+// queues) and the untyped flow/trigger QueuePro instances.
+interface SampleableQueue {
+  name: string
+  getActiveCount(): Promise<number>
+  getWaitingCount(): Promise<number>
+  getDelayedCount(): Promise<number>
+  getRateLimitTtl(): Promise<number>
+  getGroupsCountByStatus(): Promise<{
+    waiting: number
+    limited: number
+    maxed: number
+    paused: number
+  }>
+}
+
+interface QueueToSample {
+  queue: SampleableQueue
+  // Queue assigns jobs to groups (BullMQ-Pro groups) for some/all jobs.
+  hasGroups: boolean
+  // Queue declares a queue-level rate limiter (throttles the whole queue).
+  hasQueueRateLimit: boolean
+}
+
+function getQueuesToSample(): QueueToSample[] {
+  // Backbone queues - never grouped, never rate limited.
+  const queues: QueueToSample[] = [
+    { queue: flowQueue, hasGroups: false, hasQueueRateLimit: false },
+    { queue: triggerQueue, hasGroups: false, hasQueueRateLimit: false },
+    { queue: mainActionQueue, hasGroups: false, hasQueueRateLimit: false },
+  ]
+
+  // App-specific action queues - inspect each app's queue config to know
+  // whether it groups jobs and/or applies a queue-level rate limit.
+  for (const [appKey, queue] of Object.entries(appActionQueues)) {
+    const queueConfig = apps[appKey]?.queue
+    queues.push({
+      queue,
+      hasGroups: Boolean(queueConfig?.getGroupConfigForJob),
+      hasQueueRateLimit: Boolean(queueConfig?.queueRateLimit),
+    })
+  }
+
+  return queues
+}
+
+async function sampleQueue({
+  queue,
+  hasGroups,
+  hasQueueRateLimit,
+}: QueueToSample): Promise<void> {
+  const tags = { queue: queue.name }
+
+  const [activeCount, waitingCount, delayedCount] = await Promise.all([
+    queue.getActiveCount(),
+    queue.getWaitingCount(),
+    queue.getDelayedCount(),
+  ])
+
+  // Only query throttle/group state when the queue actually uses them - saves
+  // Redis round trips on the backbone queues and keeps custom metrics meaningful.
+  const rateLimitTtlMs = hasQueueRateLimit ? await queue.getRateLimitTtl() : -1
+  const groups = hasGroups ? await queue.getGroupsCountByStatus() : null
+
+  const eligibleWaiting = computeEligibleWaiting({
+    rateLimitTtlMs,
+    waitingCount,
+    readyGroupCount: groups?.waiting ?? 0,
+  })
+  const dequeuingOk = computeDequeuingOk(activeCount, eligibleWaiting)
+
+  // Primary SLI gauge.
+  tracer.dogstatsd.gauge('plumber.worker.dequeuing_ok', dequeuingOk, tags)
+
+  // Raw components for dashboards / root-cause.
+  tracer.dogstatsd.gauge('plumber.queue.active', activeCount, tags)
+  tracer.dogstatsd.gauge('plumber.queue.waiting', waitingCount, tags)
+  tracer.dogstatsd.gauge('plumber.queue.delayed', delayedCount, tags)
+
+  if (hasQueueRateLimit) {
+    tracer.dogstatsd.gauge(
+      'plumber.queue.rate_limit_ttl',
+      Math.max(rateLimitTtlMs, 0),
+      tags,
+    )
+  }
+
+  if (groups) {
+    tracer.dogstatsd.gauge('plumber.queue.groups.waiting', groups.waiting, tags)
+    tracer.dogstatsd.gauge('plumber.queue.groups.limited', groups.limited, tags)
+    tracer.dogstatsd.gauge('plumber.queue.groups.maxed', groups.maxed, tags)
+    tracer.dogstatsd.gauge('plumber.queue.groups.paused', groups.paused, tags)
+  }
+}
+
+export function startQueueDepthMetrics(): void {
+  // No Datadog agent locally; emitting is pointless noise.
+  if (appConfig.isDev) {
+    return
+  }
+
+  const queues = getQueuesToSample()
+
+  const interval = setInterval(() => {
+    void (async () => {
+      for (const queueToSample of queues) {
+        try {
+          await sampleQueue(queueToSample)
+        } catch (err) {
+          // A Redis hiccup on one queue must not crash the loop or skew the
+          // SLI - skip this queue for this tick rather than emitting a 0.
+          logger.error('Failed to sample queue depth', {
+            queue: queueToSample.queue.name,
+            err: (err as Error).stack,
+          })
+        }
+      }
+    })()
+  }, SAMPLE_INTERVAL_MS)
+
+  // Never let the sampler keep the process alive.
+  interval.unref()
+  process.on('SIGTERM', () => clearInterval(interval))
+
+  logger.info('Queue depth metrics sampler started')
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -7,6 +7,7 @@ import type { Server } from 'http'
 import app from '@/app'
 import appConfig from '@/config/app'
 import logger from '@/helpers/logger'
+import { startQueueDepthMetrics } from '@/helpers/queue-depth-metrics'
 
 const port = appConfig.port
 
@@ -15,6 +16,10 @@ const ALB_IDLE_TIMEOUT_SECONDS = 60
 const server: Server = app.listen(port, () => {
   logger.info(`Server is listening on ${port}`)
 })
+
+// Worker uptime SLI: sample queue depth from the server process (decoupled
+// from worker health) and emit gauges to Datadog.
+startQueueDepthMetrics()
 
 function shutdown(server: Server) {
   server.close()

--- a/packages/backend/src/workers/flow.ts
+++ b/packages/backend/src/workers/flow.ts
@@ -9,6 +9,7 @@ import logger from '@/helpers/logger'
 import Flow from '@/models/flow'
 import triggerQueue from '@/queues/trigger'
 import { processFlow } from '@/services/flow'
+import { recordStalledJob } from '@/workers/helpers/worker-event-handlers'
 
 export const worker = new WorkerPro(
   'flow',
@@ -65,6 +66,10 @@ worker.on('failed', (job, err) => {
   logger.error(
     `JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}`,
   )
+})
+
+worker.on('stalled', (jobId) => {
+  recordStalledJob('flow', jobId)
 })
 
 worker.on('ready', () => {

--- a/packages/backend/src/workers/helpers/worker-event-handlers.ts
+++ b/packages/backend/src/workers/helpers/worker-event-handlers.ts
@@ -13,6 +13,21 @@ import Execution from '@/models/execution'
 import Flow from '@/models/flow'
 
 /**
+ * Records a stalled job (lock expired and the job was moved back to be
+ * reprocessed). Logs a structured warning so Datadog can derive a log-based
+ * metric (filter `event:job-stalled`, tag by `queueName`). Shared across all
+ * workers - the `stalled` event only provides the job ID.
+ */
+export function recordStalledJob(queueName: string, jobId: string): void {
+  logger.warn(`[${queueName}] JOB ID: ${jobId} has stalled`, {
+    queueName,
+    jobId,
+    event: 'job-stalled',
+    workerVersion: appConfig.version,
+  })
+}
+
+/**
  * Attaches standard event listeners to a worker for logging and error handling.
  * Used by both action workers and sub-trigger workers.
  */
@@ -104,6 +119,10 @@ export function registerWorkerEventHandlers(
         },
       )
     }
+  })
+
+  worker.on('stalled', (jobId) => {
+    recordStalledJob(queueName, jobId)
   })
 
   worker.on('ready', () => {

--- a/packages/backend/src/workers/trigger.ts
+++ b/packages/backend/src/workers/trigger.ts
@@ -8,6 +8,7 @@ import logger from '@/helpers/logger'
 import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 import { processTrigger } from '@/services/trigger'
+import { recordStalledJob } from '@/workers/helpers/worker-event-handlers'
 
 type JobData = {
   flowId: string
@@ -64,6 +65,10 @@ worker.on('failed', (job, err) => {
   logger.error(
     `JOB ID: ${job.id} - FLOW ID: ${job.data.flowId} has failed to start with ${err.message}`,
   )
+})
+
+worker.on('stalled', (jobId) => {
+  recordStalledJob('trigger', jobId)
 })
 
 worker.on('ready', () => {


### PR DESCRIPTION
## Summary
Track how often BullMQ jobs stall (lock expired → requeued) by logging a structured warning on every worker's `stalled` event, surfaced in Datadog as a log-based metric.

## What changed
- `workers/helpers/worker-event-handlers.ts`: new `recordStalledJob(queueName, jobId)` (structured `logger.warn`, `event:job-stalled`); `worker.on('stalled', …)` added to `registerWorkerEventHandlers` (action + sub-trigger workers).
- `workers/flow.ts`, `workers/trigger.ts`: import the helper and wire their own `stalled` handlers.

## Testing
- `npm run -w backend lint:fix` (eslint + `tsc --noEmit`) clean.
- Staging smoke test: confirm a `event:job-stalled` warn appears with the correct `queueName` (stalls can't be forced deterministically locally).

## Deploy notes
- Build a Datadog log-based metric on `event:job-stalled`, tagged by `queueName`, to graph/alert on stall frequency.