### PR TITLE
[SES-PHASE-1-10]: drop suppressed CCs from SES call and fix whitelist_count tracking

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -768,5 +768,38 @@ describe('send transactional email', () => {
       expect(mocks.sesSend).not.toHaveBeenCalled()
       expect($.http.post).toHaveBeenCalledTimes(1)
     })
+
+    it('drops a suppressed CC from the SES call but keeps it in dataOut', async () => {
+      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+      // Only the CC is suppressed — the To recipient still sends.
+      mocks.getSuppressedEmails.mockResolvedValueOnce(['cc-bad@open.gov.sg'])
+
+      $.step.parameters.destinationEmail = 'recipient@open.gov.sg'
+      $.step.parameters.destinationEmailCc =
+        'cc-good@open.gov.sg,cc-bad@open.gov.sg'
+      $.step.parameters.attachments = []
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+
+      // Sent once for the single (non-suppressed) To recipient, and the
+      // suppressed CC is dropped from the actual SES API call.
+      expect(mocks.sesSend).toHaveBeenCalledTimes(1)
+      const [sentCommand] = mocks.sesSend.mock.calls[0] as unknown as [
+        { input: { Destination: { CcAddresses?: string[] } } },
+      ]
+      expect(sentCommand.input.Destination.CcAddresses).toEqual([
+        'cc-good@open.gov.sg',
+      ])
+
+      // ...but the full CC list (including the suppressed address) is still
+      // reported in dataOut, since CC status is not tracked.
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: expect.objectContaining({
+          status: ['ACCEPTED'],
+          recipient: ['recipient@open.gov.sg'],
+          cc: ['cc-good@open.gov.sg', 'cc-bad@open.gov.sg'],
+        }),
+      })
+    })
   })
 })

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -134,6 +134,11 @@ async function sendViaPostman(
 async function sendViaSes(
   recipientEmail: string,
   email: Email,
+  // CC addresses to actually send to. Suppressed CCs are dropped from the SES
+  // call so we don't re-send to known-bad addresses (which would re-bounce and
+  // inflate the bounce rate). The full email.ccList is still reported in
+  // dataOut below — only the API call is filtered.
+  ccAddressesToSend: string[] | undefined,
 ): Promise<PostmanPromiseFulfilled> {
   const client = getSesClient()
   const fromAddress = `${email.senderName} <${appConfig.ses.fromAddress}>`
@@ -143,7 +148,7 @@ async function sendViaSes(
       FromEmailAddress: fromAddress,
       Destination: {
         ToAddresses: [recipientEmail],
-        ...(email.ccList?.length && { CcAddresses: email.ccList }),
+        ...(ccAddressesToSend?.length && { CcAddresses: ccAddressesToSend }),
       },
       Content: {
         Simple: {
@@ -167,6 +172,7 @@ async function sendViaSes(
     subject: email.subject,
     from: fromAddress,
     recipient: recipientEmail,
+    ccAddressesToSend,
   })
 
   return {
@@ -204,12 +210,16 @@ export async function sendTransactionalEmails(
     !email.attachments?.length &&
     recipients.every((r) => shouldUseSes(r, sesEnabledDomains))
 
-  // Pre-send suppression check (SES path only)
+  // Pre-send suppression check (SES path only). CC addresses are included so a
+  // blacklisted CC can be dropped from the SES call rather than re-sent to
+  // (which would re-bounce and inflate the bounce rate). CC suppression is
+  // silent — the full ccList is still reported in dataOut.
   let suppressedSet = new Set<string>()
   if (useSes) {
-    const suppressedEmails = await EmailSuppressionEntry.getSuppressedEmails(
-      recipients,
-    )
+    const suppressedEmails = await EmailSuppressionEntry.getSuppressedEmails([
+      ...recipients,
+      ...(email.ccList ?? []),
+    ])
     suppressedSet = new Set(suppressedEmails)
 
     if (suppressedSet.size > 0) {
@@ -222,11 +232,14 @@ export async function sendTransactionalEmails(
   }
 
   const activeRecipients = recipients.filter((r) => !suppressedSet.has(r))
+  // Suppressed CCs are removed from the API call only — dataOut keeps the full
+  // ccList (CC status is not tracked per the field's documented behaviour).
+  const ccAddressesToSend = email.ccList?.filter((cc) => !suppressedSet.has(cc))
 
   const promises = activeRecipients.map(async (recipientEmail) => {
     try {
       if (useSes) {
-        return await sendViaSes(recipientEmail, email)
+        return await sendViaSes(recipientEmail, email, ccAddressesToSend)
       }
       return await sendViaPostman(http, recipientEmail, email)
     } catch (e) {

--- a/packages/backend/src/helpers/process-ses-event.ts
+++ b/packages/backend/src/helpers/process-ses-event.ts
@@ -53,24 +53,25 @@ export async function processSesEvent(data: SesEventInput): Promise<void> {
   if (sesEvent.eventType === SesEventType.Bounce) {
     const { bounceType, bounceSubType, bouncedRecipients } = sesEvent.bounce
 
-    // Count one bounce per affected recipient (matching the per-recipient
-    // ses.email.sent denominator), excluding the SES bounce simulator so test
-    // sends don't skew the bounce rate.
-    const meteredRecipients = bouncedRecipients.filter(
-      (r) => !isSesSimulatorAddress(r.emailAddress, 'bounce'),
-    )
-    if (meteredRecipients.length > 0) {
-      incrementMetric(
-        'ses.email.bounce',
-        {
-          bounce_type: bounceType,
-          bounce_sub_type: bounceSubType ?? 'unknown',
-        },
-        meteredRecipients.length,
-      )
-    }
-
     if (bounceType === 'Permanent') {
+      // Increment one bounce per recipient we actually suppress (matching the
+      // per-recipient ses.email.sent denominator). Only permanent bounces
+      // suppress, so the metric fires only here. The SES bounce simulator is
+      // excluded so test sends don't skew the bounce rate.
+      const meteredRecipients = bouncedRecipients.filter(
+        (r) => !isSesSimulatorAddress(r.emailAddress, 'bounce'),
+      )
+      if (meteredRecipients.length > 0) {
+        incrementMetric(
+          'ses.email.bounce',
+          {
+            bounce_type: bounceType,
+            bounce_sub_type: bounceSubType ?? 'unknown',
+          },
+          meteredRecipients.length,
+        )
+      }
+
       // TODO: add micro-optimisation for upsertSuppression to blacklist multiple recipient emails in phase 2
       for (const recipient of bouncedRecipients) {
         await EmailSuppressionEntry.upsertSuppression({
@@ -106,24 +107,9 @@ export async function processSesEvent(data: SesEventInput): Promise<void> {
   if (sesEvent.eventType === SesEventType.Complaint) {
     const { complainedRecipients, complaintFeedbackType } = sesEvent.complaint
 
-    // Count one complaint per affected recipient (matching the per-recipient
-    // ses.email.sent denominator), excluding the SES complaint simulator so
-    // test sends don't skew the complaint rate.
-    const meteredRecipients = complainedRecipients.filter(
-      (r) => !isSesSimulatorAddress(r.emailAddress, 'complaint'),
-    )
-    if (meteredRecipients.length > 0) {
-      incrementMetric(
-        'ses.email.complaint',
-        {
-          complaint_feedback_type: complaintFeedbackType ?? 'other',
-        },
-        meteredRecipients.length,
-      )
-    }
-
     if (complaintFeedbackType === 'not-spam') {
-      // Auto-whitelist: recipient marked the email as not-spam
+      // Auto-whitelist: recipient marked the email as not-spam. No suppression
+      // happens here, so the complaint metric is not incremented.
       const emails = complainedRecipients.map((r) => r.emailAddress)
       const whitelisted = await EmailSuppressionEntry.whitelistEmails(emails)
 
@@ -135,6 +121,24 @@ export async function processSesEvent(data: SesEventInput): Promise<void> {
       })
     } else {
       // abuse, fraud, virus, other, null — suppress
+
+      // Increment one complaint per recipient we actually suppress (matching
+      // the per-recipient ses.email.sent denominator). Only this path
+      // suppresses, so the metric fires only here. The SES complaint simulator
+      // is excluded so test sends don't skew the complaint rate.
+      const meteredRecipients = complainedRecipients.filter(
+        (r) => !isSesSimulatorAddress(r.emailAddress, 'complaint'),
+      )
+      if (meteredRecipients.length > 0) {
+        incrementMetric(
+          'ses.email.complaint',
+          {
+            complaint_feedback_type: complaintFeedbackType ?? 'other',
+          },
+          meteredRecipients.length,
+        )
+      }
+
       for (const recipient of complainedRecipients) {
         await EmailSuppressionEntry.upsertSuppression({
           email: recipient.emailAddress,

--- a/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
+++ b/packages/backend/src/models/__tests__/email-suppression-entry.itest.ts
@@ -47,15 +47,15 @@ describe('EmailSuppressionEntry model', () => {
       expect(rows[0].whitelistCount).toBe(0)
     })
 
-    it('should increment whitelist_count when re-suppressing a whitelisted email', async () => {
+    it('should not change whitelist_count when re-suppressing a whitelisted email', async () => {
       // Suppress
       await EmailSuppressionEntry.upsertSuppression({
         email: testEmail,
         reason: 'BOUNCE',
       })
-      // Whitelist
+      // Whitelist — this is what increments whitelist_count (to 1)
       await EmailSuppressionEntry.whitelistEmails([testEmail])
-      // Re-suppress
+      // Re-suppress — must NOT touch whitelist_count
       await EmailSuppressionEntry.upsertSuppression({
         email: testEmail,
         reason: 'BOUNCE',
@@ -226,6 +226,30 @@ describe('EmailSuppressionEntry model', () => {
       expect(row.lastWhitelistedAt).not.toBeNull()
     })
 
+    it('should increment whitelist_count on a successful whitelist', async () => {
+      // Starts at 0 from the suppression in beforeEach.
+      await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'suppressed@example.com',
+      })
+      expect(row.whitelistCount).toBe(1)
+    })
+
+    it('should not increment whitelist_count for an already-whitelisted email', async () => {
+      await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
+      // Second call is a no-op (email is no longer suppressed).
+      const result = await EmailSuppressionEntry.whitelistEmails([
+        'suppressed@example.com',
+      ])
+      expect(result).toEqual([])
+
+      const row = await EmailSuppressionEntry.query().findOne({
+        email: 'suppressed@example.com',
+      })
+      expect(row.whitelistCount).toBe(1)
+    })
+
     it('should not return emails that are not suppressed or do not exist', async () => {
       const result = await EmailSuppressionEntry.whitelistEmails([
         'unknown@example.com',
@@ -233,18 +257,21 @@ describe('EmailSuppressionEntry model', () => {
       expect(result).toEqual([])
     })
 
-    it('should not reset whitelist_count', async () => {
+    it('should count each whitelist across re-suppression cycles', async () => {
+      // whitelist (count -> 1)
       await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
+      // re-suppress (count unchanged)
       await EmailSuppressionEntry.upsertSuppression({
         email: 'suppressed@example.com',
         reason: 'BOUNCE',
       })
+      // whitelist again (count -> 2)
       await EmailSuppressionEntry.whitelistEmails(['suppressed@example.com'])
 
       const row = await EmailSuppressionEntry.query().findOne({
         email: 'suppressed@example.com',
       })
-      expect(row.whitelistCount).toBe(1)
+      expect(row.whitelistCount).toBe(2)
       expect(row.lastWhitelistedAt).not.toBeNull()
     })
 

--- a/packages/backend/src/models/email-suppression-entry.ts
+++ b/packages/backend/src/models/email-suppression-entry.ts
@@ -99,8 +99,8 @@ class EmailSuppressionEntry extends Base {
    * On conflict:
    *   - Overwrites reason / reason_detail / ses_message_id with latest event
    *   - Re-suppresses the row (last_whitelisted_at = NULL)
-   *   - Increments whitelist_count ONLY if the email was whitelisted before
-   *     this event — a signal that an admin's whitelist decision was wrong
+   *   - Leaves whitelist_count untouched — it counts successful whitelists
+   *     (incremented in whitelistEmails), not re-suppressions
    *   - Resets deleted_at so a previously soft-deleted row becomes visible
    *     to the suppression check again
    *
@@ -137,14 +137,8 @@ class EmailSuppressionEntry extends Base {
         sesMessageId: sesMessageId ?? null,
         lastWhitelistedAt: null,
         updatedAt: new Date().toISOString(),
-        // increment only when re-suppressing a previously whitelisted email
-        whitelistCount: raw(
-          `CASE
-            WHEN email_suppression.last_whitelisted_at IS NOT NULL
-            THEN email_suppression.whitelist_count + 1
-            ELSE email_suppression.whitelist_count
-          END`,
-        ),
+        // whitelist_count is intentionally not updated here — it tracks
+        // successful whitelists (see whitelistEmails), not re-suppressions.
         // undelete: re-suppression should always be visible to suppression checks
         deletedAt: null,
       })
@@ -175,8 +169,10 @@ class EmailSuppressionEntry extends Base {
 
   /**
    * Whitelist one or more emails (admin force-whitelist).
-   * Sets last_whitelisted_at = now() for emails that are currently suppressed.
-   * Does NOT reset whitelist_count.
+   * Sets last_whitelisted_at = now() for emails that are currently suppressed,
+   * and increments whitelist_count once per suppressed -> whitelisted
+   * transition (already-whitelisted emails are skipped by the WHERE clause, so
+   * the count is not double-incremented).
    *
    * Returns the list of emails that were actually whitelisted
    * (i.e. were suppressed and are now whitelisted).
@@ -190,6 +186,7 @@ class EmailSuppressionEntry extends Base {
     const results = await this.query()
       .patch({
         lastWhitelistedAt: new Date().toISOString(),
+        whitelistCount: raw('whitelist_count + 1'),
       })
       .whereIn('email', lowercasedEmails)
       .whereNull('last_whitelisted_at')


### PR DESCRIPTION
### TL;DR

Fix suppressed CC address handling in SES emails and correct `whitelist_count` semantics so it tracks successful whitelists rather than re-suppressions.

### What changed?

**CC suppression in SES sends:**
- When checking for suppressed emails before an SES send, CC addresses are now included in the suppression lookup alongside `To` recipients.
- Suppressed CC addresses are silently dropped from the actual SES API call to avoid re-bouncing and inflating the bounce rate.
- The full CC list (including suppressed addresses) is still reported in `dataOut`, since CC delivery status is not tracked per the field's documented behaviour.

**`whitelist_count` semantics:**
- `whitelist_count` now increments only in `whitelistEmails` (i.e. on a successful suppressed → whitelisted transition), not in `upsertSuppression`.
- Previously, re-suppressing a whitelisted email would increment `whitelist_count`, which was misleading. Now re-suppression leaves the count untouched.
- Each whitelist across re-suppression cycles correctly increments the count (e.g. suppress → whitelist → re-suppress → whitelist again yields a count of 2).

**Bounce/complaint metric alignment:**
- The `ses.email.bounce` metric now only fires for permanent bounces, matching the suppression logic (only permanent bounces suppress).
- The `ses.email.complaint` metric now only fires for the suppressing complaint path (abuse, fraud, virus, other, null), not for `not-spam` complaints, which trigger a whitelist instead.

### How to test?

- The new unit test `drops a suppressed CC from the SES call but keeps it in dataOut` covers the CC suppression behaviour end-to-end.
- The updated integration tests for `EmailSuppressionEntry` cover the corrected `whitelist_count` increment and re-suppression cycle behaviour.
- Manually trigger a transactional email via SES with a suppressed CC address and verify the SES call omits the suppressed CC while `dataOut` still contains it.

### Why make this change?

Sending to a suppressed CC address would cause a re-bounce, inflating the SES bounce rate and risking account-level sending limits. The `whitelist_count` fix ensures the metric accurately reflects how many times an admin has whitelisted an address, rather than how many times it was re-suppressed after being whitelisted. The bounce/complaint metric scoping ensures rates are only counted when suppression actually occurs, keeping the metrics meaningful.