### PR TITLE
fix: prevent multirow-multicol field overflow in Pair actions

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -47,7 +47,7 @@ const action: IRawAction = {
           placeholder: 'Whether the image contains a handwritten signature',
           type: 'string',
           required: true,
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '75%' },
         },
         {
           key: 'fieldName',

--- a/packages/backend/src/apps/pair/actions/send-prompt/index.ts
+++ b/packages/backend/src/apps/pair/actions/send-prompt/index.ts
@@ -100,7 +100,7 @@ const action: IRawAction = {
             fieldValue: 'category',
             op: 'not_equals',
           },
-          customStyle: { flex: 3 },
+          customStyle: { flex: 3, minWidth: 0, maxWidth: '60%' },
         },
       ],
     },


### PR DESCRIPTION
## Why?

In the \`multirow-multicol\` layout used by Pair actions (Send Prompt, Process Image), flex items have a default CSS \`min-width: auto\`, which prevents them from shrinking below their content's natural size. When a wide column (e.g. "Categories" with \`flex: 3\`) is present, long input values cause it to overflow the row and squish neighbouring columns.

This adds \`minWidth: 0\` to the wide column's \`customStyle\` to allow proper flex shrinkage, and \`maxWidth\` as a cap to prevent the column from consuming too much of the row.

## Tests

**Send Prompt — Categories overflow**
1. Open a flow with a **Pair → Send Prompt** action (or create a new one).
2. Set any prompt, then in **"Define how you want Pair to structure what it extracts"**, add a row and set **Type → Category**.
3. In the **Categories** field, paste a long comma-separated list, e.g. \`Very long category one, Very long category two, Very long category three, Very long category four\`.
4. Verify the Categories input scrolls horizontally instead of expanding the column.
5. Verify the **Type** and **Output name** columns are not squished or pushed off screen.

**Process Image — description overflow**
1. Open a flow with a **Pair → Process Image** action (or create a new one).
2. In **"What do you want to extract?"**, add a row.
3. In **What to look for**, type a very long description (e.g. repeat a sentence 3–4 times).
4. Verify the field scrolls horizontally and the **Output name** column remains visible and properly sized.

**Regression**
- Existing rows with normal-length inputs still render correctly (correct proportions, no layout shifts).
- Mobile view (narrow DevTools viewport) still stacks columns vertically without issues.