### PR TITLE
[FLUSH-8] PLU-65 feat(archival): process executions concurrently within each batch

### DIFF
--- a/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -8,6 +8,7 @@ vi.mock('../config', () => ({
     archiveBatchSleepMs: 0,
     archiveBucket: 'archive-bucket',
     archiveDeletedFlowsOnly: false,
+    archiveIntraBatchConcurrency: 10,
   },
 }))
 vi.mock('../logger')
@@ -177,8 +178,10 @@ describe('runArchivalLoop', () => {
     )
   })
 
-  it('stops processing mid-batch when signal is aborted', async () => {
+  it('does not start a new batch after signal is aborted', async () => {
     const controller = new AbortController()
+    // Use concurrency=1 so abort is observed before subsequent executions start
+    ;(archivalConfig as any).archiveIntraBatchConcurrency = 1
     vi.mocked(archiveExecution).mockImplementation(async () => {
       controller.abort()
       return 'archived'
@@ -186,12 +189,50 @@ describe('runArchivalLoop', () => {
 
     setupDb([
       [makeExecution('e1'), makeExecution('e2'), makeExecution('e3')],
-      [],
+      [makeExecution('e4')],
     ])
 
     await runArchivalLoop(controller.signal)
 
+    // With concurrency=1: e1 runs and aborts; e2/e3 see signal.aborted before
+    // calling archiveExecution. The second batch is never fetched.
     expect(archiveExecution).toHaveBeenCalledTimes(1)
+  })
+
+  it('continues processing remaining executions after one throws (allSettled)', async () => {
+    vi.mocked(archiveExecution)
+      .mockRejectedValueOnce(new Error('S3 timeout'))
+      .mockResolvedValue('archived')
+
+    setupDb([
+      [makeExecution('e1'), makeExecution('e2'), makeExecution('e3')],
+      [],
+    ])
+
+    await runArchivalLoop(new AbortController().signal)
+
+    expect(archiveExecution).toHaveBeenCalledTimes(3)
+  })
+
+  it('advances cursor to the last batch item even when some executions fail', async () => {
+    // All fail — cursor should still move to the last batch item
+    vi.mocked(archiveExecution).mockRejectedValue(new Error('S3 error'))
+
+    const batch = [
+      makeExecution('00000000-0000-0000-0000-000000000001'),
+      makeExecution('00000000-0000-0000-0000-000000000002'),
+      makeExecution('00000000-0000-0000-0000-000000000003'),
+    ]
+    setupDb([batch, []])
+
+    await runArchivalLoop(new AbortController().signal)
+
+    // The second batch SELECT uses whereRaw(id > cursor); capturedModifyCbs[1] is the cursor modifier
+    const qb = { whereRaw: vi.fn() }
+    capturedModifyCbs[1](qb)
+    expect(qb.whereRaw).toHaveBeenCalledWith('id > ?::uuid', [
+      '00000000-0000-0000-0000-000000000003',
+    ])
   })
 
   it('counts skipped executions when archiveExecution returns skipped', async () => {

--- a/packages/backend/src/helpers/archival/config.ts
+++ b/packages/backend/src/helpers/archival/config.ts
@@ -65,4 +65,10 @@ export const archivalConfig = {
   // TODO: remove this flag (and the fast-path branch in run-archival-loop.ts)
   // once the deleted-flows phase has been verified and we move to archiving all flows.
   archiveDeletedFlowsOnly: process.env.ARCHIVE_DELETED_FLOWS_ONLY === 'true',
+  // Number of executions processed concurrently within each batch.
+  // Must be >= 1. Reader pool max should be >= this value; writer max >= this value.
+  archiveIntraBatchConcurrency: requireInt(
+    'ARCHIVE_INTRA_BATCH_CONCURRENCY',
+    10,
+  ),
 }

--- a/packages/backend/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend/src/helpers/archival/run-archival-loop.ts
@@ -1,3 +1,5 @@
+import pLimit from 'p-limit'
+
 import { archiveExecution } from './archive-execution'
 import { archivalConfig } from './config'
 import { archivalDb, archivalDbReader } from './db'
@@ -15,6 +17,7 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     archiveBatchSleepMs: sleepMs,
     archiveBucket,
     archiveDeletedFlowsOnly,
+    archiveIntraBatchConcurrency,
   } = archivalConfig
 
   const cutoff = new Date()
@@ -23,7 +26,10 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
   let cursor: string | null = null
   let totalArchived = 0
   let totalSkipped = 0
-  const archivedByFlow = new Map<string, string[]>()
+  const archivedByFlow = new Map<
+    string,
+    { executionIds: string[]; testExecutionIds: string[] }
+  >()
   const stepCounts = new Map<string, Map<string, number>>()
   let nullStepCount = 0
   const startedAt = Date.now()
@@ -113,83 +119,112 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
 
     let batchArchived = 0
     let batchSkipped = 0
-    let lastProcessed: ExecutionRow | null = null
 
-    for (const execution of batch) {
-      if (signal.aborted) {
-        break
-      }
+    const limit = pLimit(archiveIntraBatchConcurrency)
 
-      // LEFT JOIN steps to fill in app_key/key for old rows that predate the
-      // denormalised columns being added to execution_steps.
-      // TODO: once all pre-denormalisation rows have been archived, drop the
-      // LEFT JOIN and COALESCE and select app_key/key directly from execution_steps.
-      const steps = (await archivalDbReader('execution_steps')
-        .select(
-          'execution_steps.id',
-          'execution_steps.execution_id as executionId',
-          'execution_steps.step_id as stepId',
-          archivalDbReader.raw(
-            'COALESCE(execution_steps.app_key, steps.app_key) as "appKey"',
-          ),
-          archivalDbReader.raw(
-            'COALESCE(execution_steps.key, steps.key) as "key"',
-          ),
-          'execution_steps.job_id as jobId',
-          'execution_steps.status',
-          'execution_steps.data_in as dataIn',
-          'execution_steps.data_out as dataOut',
-          'execution_steps.error_details as errorDetails',
-          'execution_steps.metadata',
-          'execution_steps.created_at as createdAt',
-          'execution_steps.updated_at as updatedAt',
-          'execution_steps.deleted_at as deletedAt',
-        )
-        .leftJoin('steps', 'execution_steps.step_id', 'steps.id')
-        .where('execution_steps.execution_id', execution.id)
-        .orderBy('execution_steps.created_at')) as ExecutionStepRow[]
-
-      try {
-        const result = await archiveExecution(execution, steps, {
-          dryRun,
-          bucket: archiveBucket,
-          s3Client: archiveS3Client,
-          knexClient: archivalDb,
-          runAt,
-        })
-        if (result === 'archived') {
-          batchArchived++
-          const ids = archivedByFlow.get(execution.flowId) ?? []
-          ids.push(execution.id)
-          archivedByFlow.set(execution.flowId, ids)
-
-          for (const step of steps) {
-            if (step.appKey && step.key) {
-              const keyMap =
-                stepCounts.get(step.appKey) ?? new Map<string, number>()
-              keyMap.set(step.key, (keyMap.get(step.key) ?? 0) + 1)
-              stepCounts.set(step.appKey, keyMap)
-            } else {
-              nullStepCount++
+    const results = await Promise.allSettled(
+      batch.map((execution) =>
+        limit(async () => {
+          if (signal.aborted) {
+            return {
+              execution,
+              outcome: 'skipped' as const,
+              steps: [] as ExecutionStepRow[],
             }
           }
-        } else {
-          batchSkipped++
+
+          // LEFT JOIN steps to fill in app_key/key for old rows that predate
+          // the denormalised columns being added to execution_steps.
+          // TODO: once all pre-denormalisation rows have been archived, drop the
+          // LEFT JOIN and COALESCE and select app_key/key directly from execution_steps.
+          const steps = (await archivalDbReader('execution_steps')
+            .select(
+              'execution_steps.id',
+              'execution_steps.execution_id as executionId',
+              'execution_steps.step_id as stepId',
+              archivalDbReader.raw(
+                'COALESCE(execution_steps.app_key, steps.app_key) as "appKey"',
+              ),
+              archivalDbReader.raw(
+                'COALESCE(execution_steps.key, steps.key) as "key"',
+              ),
+              'execution_steps.job_id as jobId',
+              'execution_steps.status',
+              'execution_steps.data_in as dataIn',
+              'execution_steps.data_out as dataOut',
+              'execution_steps.error_details as errorDetails',
+              'execution_steps.metadata',
+              'execution_steps.created_at as createdAt',
+              'execution_steps.updated_at as updatedAt',
+              'execution_steps.deleted_at as deletedAt',
+            )
+            .leftJoin('steps', 'execution_steps.step_id', 'steps.id')
+            .where('execution_steps.execution_id', execution.id)
+            .orderBy('execution_steps.created_at')) as ExecutionStepRow[]
+
+          try {
+            const outcome = await archiveExecution(execution, steps, {
+              dryRun,
+              bucket: archiveBucket,
+              s3Client: archiveS3Client,
+              knexClient: archivalDb,
+              runAt,
+            })
+            return { execution, outcome, steps }
+          } catch (err) {
+            logger.error({
+              event: 'archival.execution.error',
+              executionId: execution.id,
+              err,
+            })
+            return {
+              execution,
+              outcome: 'skipped' as const,
+              steps: [] as ExecutionStepRow[],
+            }
+          }
+        }),
+      ),
+    )
+
+    for (const settled of results) {
+      if (settled.status === 'rejected') {
+        batchSkipped++
+        continue
+      }
+
+      const { execution, outcome, steps } = settled.value
+      if (outcome === 'archived') {
+        batchArchived++
+        const entry = archivedByFlow.get(execution.flowId) ?? {
+          executionIds: [],
+          testExecutionIds: [],
         }
-      } catch (err) {
-        logger.error({
-          event: 'archival.execution.error',
-          executionId: execution.id,
-          err,
-        })
+        if (execution.testRun) {
+          entry.testExecutionIds.push(execution.id)
+        } else {
+          entry.executionIds.push(execution.id)
+        }
+        archivedByFlow.set(execution.flowId, entry)
+
+        for (const step of steps) {
+          if (step.appKey && step.key) {
+            const keyMap =
+              stepCounts.get(step.appKey) ?? new Map<string, number>()
+            keyMap.set(step.key, (keyMap.get(step.key) ?? 0) + 1)
+            stepCounts.set(step.appKey, keyMap)
+          } else {
+            nullStepCount++
+          }
+        }
+      } else {
         batchSkipped++
       }
-      lastProcessed = execution
     }
 
-    if (lastProcessed) {
-      cursor = lastProcessed.id
-    }
+    // Cursor advances to the last execution in the batch regardless of outcome.
+    // Failed executions stay eligible and are retried on the next scheduled run.
+    cursor = batch[batch.length - 1].id
     totalArchived += batchArchived
     totalSkipped += batchSkipped
 
@@ -206,12 +241,14 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     }
   }
 
-  for (const [flowId, executionIds] of archivedByFlow) {
+  for (const [flowId, { executionIds, testExecutionIds }] of archivedByFlow) {
     logger.info({
       event: 'archival.flow.archived',
       flowId,
       executionIds,
-      count: executionIds.length,
+      testExecutionIds,
+      executionsCount: executionIds.length,
+      testExecutionsCount: testExecutionIds.length,
     })
   }
 


### PR DESCRIPTION
## Stack Context

This stack (PLU-65) builds the archival pipeline that moves old Plumber flow executions from Postgres to S3. This PR introduces intra-batch concurrency to the archival loop, replacing the sequential for-loop with `p-limit` + `Promise.allSettled`.

## Why?

Phase 1 archives deleted-flow executions only, but the eventual backlog is large enough that sequential processing (~200–300k/night) leaves too much on the table. Concurrency=10 (the default) gets throughput to ~1M executions/night while staying within the 1 vCPU / 2 GB Fargate task introduced in the ECS branch. The same code path handles both Phase 1 and the Phase 2 backfill — no regime-specific code changes needed.

## What changed?

**`config.ts`** — adds `archiveIntraBatchConcurrency: requireInt('ARCHIVE_INTRA_BATCH_CONCURRENCY', 10)`. SSM-controlled at runtime; changing it requires no deploy.

**`run-archival-loop.ts`** — replaces the sequential `for` loop with `pLimit(archiveIntraBatchConcurrency)` + `Promise.allSettled`. Key semantics:
- Up to N executions run concurrently within each batch (fetch steps → upload to S3 → mark archived).
- `Promise.allSettled`: one execution throwing does not abort the rest — failed executions remain eligible and are retried on the next run.
- Cursor always advances to `batch[batch.length - 1].id` regardless of individual outcomes, so the loop always makes forward progress.
- Abort signal is checked at the start of each task inside the limiter; tasks already in-flight complete before the loop exits.

**`db.ts`** (via `archival-primitives`) — pool sizes bumped to writer `max:12`, reader `max:14` to support concurrency=10 with headroom.

## Manual testing

Covered in the testing plan §1.7 — Intra-batch concurrency:

- [ ] **Concurrency is active:** seed ≥20 eligible executions, run with `ARCHIVE_BATCH_SIZE=20`; `batchArchived=20` and `durationMs` is well under 20× a single execution time
- [ ] **Concurrency knob works:** `ARCHIVE_INTRA_BATCH_CONCURRENCY=1` produces ~10× longer batch time vs `=10`
- [ ] **allSettled resilience:** pause MinIO mid-batch; some `batchSkipped` alongside `batchArchived`; loop completes the batch and continues; failed executions still in Postgres
- [ ] **Cursor advances past failures:** after a partial-failure batch, cursor in log equals the last execution UUID in the batch