### PR TITLE
[FLUSH-10] PLU-65 feat(archival): add ECS Fargate task definition (1 vCPU / 2 GB) with full SSM secret set

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,3 +206,22 @@ jobs:
           codedeploy-appspec: appspec.json
           codedeploy-application: ${{ inputs.codedeploy-application }}
           codedeploy-deployment-group: ${{ inputs.codedeploy-deployment-group }}
+
+      - name: (Archival) Replace variables in task definition
+        run: |
+          cp ecs/archival-task-definition.json ecs-archival-task-definition.json
+          sed -i 's/<AWS_ACCOUNT_ID>/${{ inputs.aws-account-id }}/g' ecs-archival-task-definition.json
+          sed -i 's/<ENVIRONMENT>/${{ inputs.environment }}/g' ecs-archival-task-definition.json
+
+      - name: (Archival) Fill in the new image ID in the Amazon ECS task definition
+        id: archival-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ecs-archival-task-definition.json
+          container-name: archival
+          image: ${{ steps.ecr-image-uri.outputs.image }}
+
+      - name: (Archival) Register task definition
+        run: |
+          aws ecs register-task-definition \
+            --cli-input-json file://${{ steps.archival-task-def.outputs.task-definition }}

--- a/ecs/archival-task-definition.json
+++ b/ecs/archival-task-definition.json
@@ -63,12 +63,8 @@
           "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-sleep-ms"
         },
         {
-          "name": "ARCHIVE_EXECUTIONS_BUCKET",
-          "valueFrom": "plumber-<ENVIRONMENT>-archive-executions-bucket"
-        },
-        {
-          "name": "ARCHIVE_TEST_EXECUTIONS_BUCKET",
-          "valueFrom": "plumber-<ENVIRONMENT>-archive-test-executions-bucket"
+          "name": "ARCHIVE_BUCKET",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-bucket"
         },
         {
           "name": "ARCHIVE_DELETED_FLOWS_ONLY",

--- a/ecs/archival-task-definition.json
+++ b/ecs/archival-task-definition.json
@@ -1,0 +1,43 @@
+{
+  "family": "plumber-<ENVIRONMENT>-archival",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/plumber-<ENVIRONMENT>-archival-task-exec-role",
+  "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/plumber-<ENVIRONMENT>-archival-task-role",
+  "containerDefinitions": [
+    {
+      "name": "archival",
+      "image": "plumber",
+      "command": ["node", "dist/scripts/archive-executions.js"],
+      "essential": true,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "plumber-<ENVIRONMENT>/ecs/archival",
+          "awslogs-region": "ap-southeast-1",
+          "awslogs-stream-prefix": "archival"
+        }
+      },
+      "environment": [
+        { "name": "APP_ENV",            "value": "<ENVIRONMENT>" },
+        { "name": "POSTGRES_PORT",      "value": "5432" },
+        { "name": "POSTGRES_ENABLE_SSL","value": "true" }
+      ],
+      "secrets": [
+        { "name": "RDS_PROXY_HOST",                  "valueFrom": "plumber-<ENVIRONMENT>-rds-proxy-host" },
+        { "name": "POSTGRES_DATABASE",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-database" },
+        { "name": "POSTGRES_USERNAME",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-username" },
+        { "name": "POSTGRES_PASSWORD",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-password" },
+        { "name": "ARCHIVE_ENABLED",                 "valueFrom": "plumber-<ENVIRONMENT>-archive-enabled" },
+        { "name": "ARCHIVE_DRY_RUN",                 "valueFrom": "plumber-<ENVIRONMENT>-archive-dry-run" },
+        { "name": "ARCHIVE_RETENTION_DAYS",          "valueFrom": "plumber-<ENVIRONMENT>-archive-retention-days" },
+        { "name": "ARCHIVE_BATCH_SIZE",              "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-size" },
+        { "name": "ARCHIVE_BATCH_SLEEP_MS",          "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-sleep-ms" },
+        { "name": "ARCHIVE_EXECUTIONS_BUCKET",       "valueFrom": "plumber-<ENVIRONMENT>-archive-executions-bucket" },
+        { "name": "ARCHIVE_TEST_EXECUTIONS_BUCKET",  "valueFrom": "plumber-<ENVIRONMENT>-archive-test-executions-bucket" }
+      ]
+    }
+  ]
+}

--- a/ecs/archival-task-definition.json
+++ b/ecs/archival-task-definition.json
@@ -21,22 +21,55 @@
         }
       },
       "environment": [
-        { "name": "APP_ENV",            "value": "<ENVIRONMENT>" },
-        { "name": "POSTGRES_PORT",      "value": "5432" },
-        { "name": "POSTGRES_ENABLE_SSL","value": "true" }
+        { "name": "APP_ENV", "value": "<ENVIRONMENT>" },
+        { "name": "POSTGRES_PORT", "value": "5432" },
+        { "name": "POSTGRES_ENABLE_SSL", "value": "true" }
       ],
       "secrets": [
-        { "name": "RDS_PROXY_HOST",                  "valueFrom": "plumber-<ENVIRONMENT>-rds-proxy-host" },
-        { "name": "POSTGRES_DATABASE",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-database" },
-        { "name": "POSTGRES_USERNAME",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-username" },
-        { "name": "POSTGRES_PASSWORD",               "valueFrom": "plumber-<ENVIRONMENT>-postgres-password" },
-        { "name": "ARCHIVE_ENABLED",                 "valueFrom": "plumber-<ENVIRONMENT>-archive-enabled" },
-        { "name": "ARCHIVE_DRY_RUN",                 "valueFrom": "plumber-<ENVIRONMENT>-archive-dry-run" },
-        { "name": "ARCHIVE_RETENTION_DAYS",          "valueFrom": "plumber-<ENVIRONMENT>-archive-retention-days" },
-        { "name": "ARCHIVE_BATCH_SIZE",              "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-size" },
-        { "name": "ARCHIVE_BATCH_SLEEP_MS",          "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-sleep-ms" },
-        { "name": "ARCHIVE_EXECUTIONS_BUCKET",       "valueFrom": "plumber-<ENVIRONMENT>-archive-executions-bucket" },
-        { "name": "ARCHIVE_TEST_EXECUTIONS_BUCKET",  "valueFrom": "plumber-<ENVIRONMENT>-archive-test-executions-bucket" }
+        {
+          "name": "RDS_PROXY_HOST",
+          "valueFrom": "plumber-<ENVIRONMENT>-rds-proxy-host"
+        },
+        {
+          "name": "POSTGRES_DATABASE",
+          "valueFrom": "plumber-<ENVIRONMENT>-postgres-database"
+        },
+        {
+          "name": "POSTGRES_USERNAME",
+          "valueFrom": "plumber-<ENVIRONMENT>-postgres-username"
+        },
+        {
+          "name": "POSTGRES_PASSWORD",
+          "valueFrom": "plumber-<ENVIRONMENT>-postgres-password"
+        },
+        {
+          "name": "ARCHIVE_ENABLED",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-enabled"
+        },
+        {
+          "name": "ARCHIVE_DRY_RUN",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-dry-run"
+        },
+        {
+          "name": "ARCHIVE_RETENTION_DAYS",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-retention-days"
+        },
+        {
+          "name": "ARCHIVE_BATCH_SIZE",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-size"
+        },
+        {
+          "name": "ARCHIVE_BATCH_SLEEP_MS",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-batch-sleep-ms"
+        },
+        {
+          "name": "ARCHIVE_EXECUTIONS_BUCKET",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-executions-bucket"
+        },
+        {
+          "name": "ARCHIVE_TEST_EXECUTIONS_BUCKET",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-test-executions-bucket"
+        }
       ]
     }
   ]

--- a/ecs/archival-task-definition.json
+++ b/ecs/archival-task-definition.json
@@ -2,8 +2,8 @@
   "family": "plumber-<ENVIRONMENT>-archival",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "512",
-  "memory": "1024",
+  "cpu": "1024",
+  "memory": "2048",
   "executionRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/plumber-<ENVIRONMENT>-archival-task-exec-role",
   "taskRoleArn": "arn:aws:iam::<AWS_ACCOUNT_ID>:role/plumber-<ENVIRONMENT>-archival-task-role",
   "containerDefinitions": [
@@ -69,6 +69,14 @@
         {
           "name": "ARCHIVE_DELETED_FLOWS_ONLY",
           "valueFrom": "plumber-<ENVIRONMENT>-archive-deleted-flows-only"
+        },
+        {
+          "name": "ARCHIVE_POSTGRES_READER_HOST",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-postgres-reader-host"
+        },
+        {
+          "name": "ARCHIVE_INTRA_BATCH_CONCURRENCY",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-intra-batch-concurrency"
         }
       ]
     }

--- a/ecs/archival-task-definition.json
+++ b/ecs/archival-task-definition.json
@@ -69,6 +69,10 @@
         {
           "name": "ARCHIVE_TEST_EXECUTIONS_BUCKET",
           "valueFrom": "plumber-<ENVIRONMENT>-archive-test-executions-bucket"
+        },
+        {
+          "name": "ARCHIVE_DELETED_FLOWS_ONLY",
+          "valueFrom": "plumber-<ENVIRONMENT>-archive-deleted-flows-only"
         }
       ]
     }

--- a/packages/backend/src/scripts/archive-executions.ts
+++ b/packages/backend/src/scripts/archive-executions.ts
@@ -16,6 +16,17 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
+  if (!archivalConfig.archiveExecutionsBucket || !archivalConfig.archiveTestExecutionsBucket) {
+    logger.error(
+      {
+        archiveExecutionsBucket: archivalConfig.archiveExecutionsBucket,
+        archiveTestExecutionsBucket: archivalConfig.archiveTestExecutionsBucket,
+      },
+      'archival: ARCHIVE_EXECUTIONS_BUCKET and ARCHIVE_TEST_EXECUTIONS_BUCKET must be set',
+    )
+    process.exit(1)
+  }
+
   logger.info({
     event: 'archival.run.start',
     dryRun: archivalConfig.archiveDryRun,

--- a/packages/backend/src/scripts/archive-executions.ts
+++ b/packages/backend/src/scripts/archive-executions.ts
@@ -16,17 +16,6 @@ async function main(): Promise<void> {
     process.exit(0)
   }
 
-  if (!archivalConfig.archiveExecutionsBucket || !archivalConfig.archiveTestExecutionsBucket) {
-    logger.error(
-      {
-        archiveExecutionsBucket: archivalConfig.archiveExecutionsBucket,
-        archiveTestExecutionsBucket: archivalConfig.archiveTestExecutionsBucket,
-      },
-      'archival: ARCHIVE_EXECUTIONS_BUCKET and ARCHIVE_TEST_EXECUTIONS_BUCKET must be set',
-    )
-    process.exit(1)
-  }
-
   logger.info({
     event: 'archival.run.start',
     dryRun: archivalConfig.archiveDryRun,


### PR DESCRIPTION
## Stack Context

This stack (PLU-65) builds the archival pipeline that moves old Plumber flow executions from Postgres to S3. This PR adds the infra side: the ECS Fargate task definition that runs the archival script, sized for Phase 1 concurrency.

## Why?

Without a task definition there's no way to schedule the archival job via ECS Scheduled Tasks. Sizing was kept at 512/1024 in earlier sketches when the loop was sequential; pulling concurrency=10 into Phase 1 means the task needs enough network bandwidth and memory headroom to handle 10 in-flight S3 uploads and reader queries at once. Fargate network bandwidth scales with vCPU, so 1 vCPU / 2 GB gives the bandwidth tier we need for Phase 1 and the backfill.

## What changed?

**`ecs/archival-task-definition.json`** — Fargate task definition for the `plumber-<ENVIRONMENT>-archival` family:
- `cpu: "1024"` (1 vCPU), `memory: "2048"` (2 GB)
- Container runs `node dist/scripts/archive-executions.js`
- All env vars documented: static (`APP_ENV`, `POSTGRES_PORT`, `POSTGRES_ENABLE_SSL`) + SSM secrets for Postgres creds, all archival tuning knobs, and the new `ARCHIVE_INTRA_BATCH_CONCURRENCY` secret
- IAM role ARN placeholders (`<AWS_ACCOUNT_ID>`, `<ENVIRONMENT>`) follow the existing task-definition convention

**`.github/workflows/deploy.yml`** — adds a `register-archival-task-definition` step that calls `aws ecs register-task-definition` with the rendered JSON on every deploy, keeping the task definition in sync with the application code.

## SSM secrets to provision (per environment)

| Secret name | Example value |
|---|---|
| `plumber-<env>-archive-enabled` | `"true"` |
| `plumber-<env>-archive-dry-run` | `"false"` |
| `plumber-<env>-archive-retention-days` | `"365"` |
| `plumber-<env>-archive-batch-size` | `"500"` |
| `plumber-<env>-archive-batch-sleep-ms` | `"2000"` |
| `plumber-<env>-archive-bucket` | `"plumber-<env>-archival"` |
| `plumber-<env>-archive-deleted-flows-only` | `"true"` (Phase 1), `"false"` (Phase 2+) |
| `plumber-<env>-archive-postgres-reader-host` | RDS read replica endpoint |
| `plumber-<env>-archive-intra-batch-concurrency` | `"1"` (Phase 1 initial), `"10"` (steady-state) |

## Manual testing

- [ ] **Task registers on deploy:** merge to staging triggers the CI step; `aws ecs describe-task-definition --task-definition plumber-staging-archival` returns the expected JSON with `cpu=1024`, `memory=2048`
- [ ] **All secrets resolve at startup:** ECS run-task with all SSM params configured; container exits 0 without `must be set` errors
- [ ] **`ARCHIVE_ENABLED=false` fast-exit:** container logs `archival.run.disabled` and exits 0 before fetching any batch