### PR TITLE
fix: add doesFileProcessing to process image

### DIFF
--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -63,7 +63,9 @@ const action: IRawAction = {
   ],
 
   doesFileProcessing: (step: Step) => {
-    return step.parameters.image && step.parameters.image !== ''
+    return (
+      Array.isArray(step.parameters.image) && step.parameters.image.length > 0
+    )
   },
 
   getDataOutMetadata,

--- a/packages/backend/src/apps/pair/actions/process-image/index.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/index.ts
@@ -8,6 +8,7 @@ import appConfig from '@/config/app'
 import StepError, { GenericSolution } from '@/errors/step'
 import logger from '@/helpers/logger'
 import { engineProvider } from '@/helpers/pair'
+import Step from '@/models/step'
 
 import getDataOutMetadata from '../../common/get-data-out-metadata'
 import { getImageContent } from '../../common/get-image-content'
@@ -60,6 +61,10 @@ const action: IRawAction = {
       ],
     },
   ],
+
+  doesFileProcessing: (step: Step) => {
+    return step.parameters.image && step.parameters.image !== ''
+  },
 
   getDataOutMetadata,
 


### PR DESCRIPTION
## Problem
Process image action was missing `doesFileProcessing` so users were not able to use the attachment from FormSG in the Pair action.

## Tests
- [ ] Verify that Process image action works when checking step.
- [ ] Verify that Process image action works in a published Pipe.

