### PR TITLE
PLU-765 feat(ai-builder): add GitBook MCP tool call to chat handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,52 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-0.0.21.tgz",
+      "integrity": "sha512-DnS7JcHn9M1K9UEbmWF5UhGkZikgl5J3iHXKTyaA04ir9j2IWHfiapZDtFTk9taODNMH9fUQgmWXVFMrXXyhDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.27",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.27.tgz",
+      "integrity": "sha512-JFhJK5ynprll2FR3e+sHagJJIwvIagsNA0FLbLPq2Os4yLUK2/eiaCU0jXsADik73/hhvcPPLmD+Uo8eu5kFaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/openai": {
       "version": "2.0.88",
       "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.88.tgz",
@@ -26965,6 +27011,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -34386,6 +34441,7 @@
     "packages/backend": {
       "version": "1.70.4",
       "dependencies": {
+        "@ai-sdk/mcp": "0.0.21",
         "@ai-sdk/openai": "2.0.88",
         "@apollo/server": "5.5.0",
         "@as-integrations/express4": "1.1.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "copy-statics": "cpy '**/*.{graphql,json,svg}' ../dist --cwd=src"
   },
   "dependencies": {
+    "@ai-sdk/mcp": "0.0.21",
     "@ai-sdk/openai": "2.0.88",
     "@apollo/server": "5.5.0",
     "@as-integrations/express4": "1.1.2",

--- a/packages/backend/src/routes/api/__tests__/chat.itest.ts
+++ b/packages/backend/src/routes/api/__tests__/chat.itest.ts
@@ -35,9 +35,17 @@ vi.mock('@langfuse/tracing', () => ({
 vi.mock('ai', () => ({
   convertToModelMessages: vi.fn((msgs) => msgs),
   smoothStream: vi.fn(() => ({})),
+  stepCountIs: vi.fn(() => () => false),
   streamText: mocks.streamText,
   createUIMessageStream: mocks.createUIMessageStream,
   createUIMessageStreamResponse: mocks.createUIMessageStreamResponse,
+}))
+
+vi.mock('@ai-sdk/mcp', () => ({
+  experimental_createMCPClient: vi.fn().mockResolvedValue({
+    tools: vi.fn().mockResolvedValue({}),
+    close: vi.fn().mockResolvedValue(undefined),
+  }),
 }))
 
 vi.mock('@/helpers/stream', () => ({
@@ -257,6 +265,75 @@ describe('Chat Route Handler', () => {
           }),
         ]),
       })
+    })
+
+    it('should accept assistant messages with empty text parts from multi-step tool use', async () => {
+      // On turns after a tool call the frontend echoes the full assistant message
+      // back, including the empty text part the AI SDK emits when the LLM goes
+      // straight to calling a tool without generating any preamble first.
+      mockReq.body = {
+        messages: [
+          {
+            role: 'user',
+            parts: [
+              {
+                type: 'text',
+                text: 'what data classification can plumber handle?',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            parts: [
+              { type: 'step-start' },
+              { type: 'text', text: '' }, // empty — LLM went straight to tool call
+              {
+                type: 'dynamic-tool',
+                toolCallId: 'tool-123',
+                toolName: 'searchDocumentation',
+                state: 'output-available',
+                input: { query: 'data classification' },
+                output: {
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Plumber handles Restricted and Sensitive-Normal.',
+                    },
+                  ],
+                },
+              },
+              { type: 'step-start' },
+              {
+                type: 'text',
+                text: 'Plumber handles Restricted and Sensitive-Normal data.',
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [{ type: 'text', text: 'thanks' }],
+          },
+        ],
+      }
+
+      mocks.getAllLdFlags.mockResolvedValueOnce({
+        'ai-builder': {
+          enabled: true,
+          config: { chatPromptName: 'chat-v0', version: 'production' },
+        },
+      })
+      mocks.getRestrictedAppKeys.mockReturnValueOnce([])
+      mocks.getPrompt.mockResolvedValueOnce({
+        prompt: 'test prompt',
+        toJSON: vi.fn(),
+      })
+      mocks.getActiveTraceId.mockReturnValueOnce('test-trace-id')
+
+      await executeChatPostHandler(mockReq, mockRes)
+
+      // Schema accepted the payload — streaming was invoked, not a 400
+      expect(mockRes.status).not.toHaveBeenCalledWith(400)
+      expect(mocks.streamText).toHaveBeenCalled()
     })
 
     it('should throw error when AI Builder is not enabled', async () => {

--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -174,33 +174,32 @@ describe('chatRequestSchema', () => {
       )
     })
 
-    it('should reject more than 10 parts', () => {
-      const parts = Array(11).fill({ type: 'text', text: 'part' })
+    it('should reject more than 25 parts', () => {
+      const parts = Array(26).fill({ type: 'text', text: 'part' })
       const result = chatRequestSchema.safeParse({
         messages: [{ role: 'user', parts }],
       })
       expect(result.success).toBe(false)
       expect(result.error?.issues[0].message).toBe(
-        'Message cannot have more than 10 parts',
+        'Message cannot have more than 25 parts',
       )
     })
   })
 
   describe('text validation', () => {
-    it('should reject empty text', () => {
+    it('should accept empty text from assistant tool-call steps', () => {
+      // The AI SDK emits text: "" before each tool call when the LLM goes
+      // straight to calling a tool. This part is echoed back by the frontend
+      // on subsequent turns, so empty strings must be valid.
       const result = chatRequestSchema.safeParse({
-        messages: [{ role: 'user', parts: [{ type: 'text', text: '' }] }],
+        messages: [
+          {
+            role: 'assistant',
+            parts: [{ type: 'text', text: '' }],
+          },
+        ],
       })
-      expect(result.success).toBe(false)
-      expect(result.error?.issues[0].message).toBe('Text cannot be empty')
-    })
-
-    it('should reject whitespace-only text', () => {
-      const result = chatRequestSchema.safeParse({
-        messages: [{ role: 'user', parts: [{ type: 'text', text: '   ' }] }],
-      })
-      expect(result.success).toBe(false)
-      expect(result.error?.issues[0].message).toBe('Text cannot be empty')
+      expect(result.success).toBe(true)
     })
 
     it('should reject text exceeding 10000 characters', () => {

--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@ai-sdk/mcp', () => ({
+  experimental_createMCPClient: vi.fn(),
+}))
+
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ai')>()
+  return {
+    ...actual,
+    streamText: vi
+      .fn()
+      .mockImplementation(
+        ({
+          onFinish,
+        }: {
+          onFinish?: (event: { text: string }) => Promise<void>
+        }) => {
+          if (onFinish) {
+            void onFinish({ text: '' })
+          }
+          return { toUIMessageStream: vi.fn().mockReturnValue({}) }
+        },
+      ),
+    createUIMessageStream: vi
+      .fn()
+      .mockImplementation(
+        ({ execute }: { execute: (arg: { writer: unknown }) => unknown }) => {
+          void execute({ writer: { merge: vi.fn(), write: vi.fn() } })
+          return {}
+        },
+      ),
+    createUIMessageStreamResponse: vi.fn().mockReturnValue(new Response()),
+    convertToModelMessages: vi.fn((msgs) => msgs),
+  }
+})
+
+vi.mock('@/helpers/ai/get-prompt', () => ({
+  getPrompt: vi.fn().mockResolvedValue({
+    prompt: 'You are a helpful assistant.',
+    toJSON: () => ({}),
+  }),
+}))
+
+vi.mock('@/helpers/build-system-prompt', () => ({
+  buildSystemPrompt: vi.fn((prompt: string) => prompt),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: vi.fn().mockResolvedValue({}),
+  getRestrictedAppKeys: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('@/helpers/ai/get-ai-builder-flag', () => ({
+  getAiBuilderFlag: vi.fn().mockReturnValue({
+    enabled: true,
+    config: {
+      chatPromptName: 'chat',
+      chatSummaryPromptName: 'chat-summary',
+      version: 'production',
+    },
+  }),
+}))
+
+vi.mock('@/helpers/pair', () => ({
+  model: 'mock-model',
+  MODEL_TYPE: 'mock-model-type',
+  engineProvider: {
+    chat: vi.fn().mockReturnValue('mock-model'),
+  },
+}))
+
+vi.mock('@/helpers/stream', () => ({
+  pipeWebResponseToExpress: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@langfuse/tracing', () => ({
+  observe: vi.fn(
+    (fn: (...args: unknown[]) => unknown) =>
+      (...args: unknown[]) =>
+        fn(...args),
+  ),
+  getActiveTraceId: vi.fn().mockReturnValue('trace-123'),
+  updateActiveObservation: vi.fn(),
+  updateActiveTrace: vi.fn(),
+}))
+
+vi.mock('@opentelemetry/api', () => ({
+  trace: { getActiveSpan: vi.fn().mockReturnValue({ end: vi.fn() }) },
+}))
+
+import { experimental_createMCPClient } from '@ai-sdk/mcp'
+import { streamText } from 'ai'
+
+// @ts-expect-error top-level await is supported by Vitest's ESM runner
+const { default: router } = await import('./index')
+
+function makeReq(body = {}) {
+  return {
+    body: {
+      messages: [{ role: 'user', parts: [{ type: 'text', text: 'hello' }] }],
+      ...body,
+    },
+    context: {
+      currentUser: { email: 'test@example.com' },
+    },
+  }
+}
+
+function makeRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+    headersSent: false,
+    end: vi.fn(),
+  }
+}
+
+describe('chat handler — GitBook MCP integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes tools and stopWhen to streamText when MCP client connects', async () => {
+    const mockTools = { search_documentation: vi.fn(), get_page: vi.fn() }
+    const mockClose = vi.fn()
+    vi.mocked(experimental_createMCPClient).mockResolvedValue({
+      tools: vi.fn().mockResolvedValue(mockTools),
+      close: mockClose,
+    } as unknown as Awaited<ReturnType<typeof experimental_createMCPClient>>)
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: mockTools,
+        stopWhen: expect.anything(),
+      }),
+    )
+    expect(mockClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls streamText with empty tools and logs error when MCP client fails', async () => {
+    vi.mocked(experimental_createMCPClient).mockRejectedValue(
+      new Error('connection refused'),
+    )
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+
+    expect(streamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: {},
+      }),
+    )
+  })
+})

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -1,5 +1,6 @@
 import { IFlowSteps } from '@plumber/types'
 
+import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp'
 import {
   getActiveTraceId,
   observe,
@@ -12,6 +13,7 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   smoothStream,
+  stepCountIs,
   streamText,
 } from 'ai'
 import type { Response } from 'express'
@@ -108,6 +110,29 @@ const handleChatStream = observe(
         content: buildSystemPrompt(prompt.prompt, restrictedApps),
       }
       const allMessages = [systemMessage, ...messages]
+
+      let mcpClient: Awaited<ReturnType<typeof createMCPClient>> | null = null
+      let gitbookTools = {} as Parameters<typeof streamText>[0]['tools']
+
+      try {
+        mcpClient = await createMCPClient({
+          transport: {
+            type: 'http',
+            url: 'https://guide.plumber.gov.sg/~gitbook/mcp',
+          },
+        })
+        gitbookTools =
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (await mcpClient.tools()) as Parameters<typeof streamText>[0]['tools']
+      } catch (error) {
+        await mcpClient?.close()
+        mcpClient = null
+        logger.error('Failed to connect to GitBook MCP server', {
+          traceId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+
       let workflowError = 'Unable to generate the workflow.'
 
       const stream = createUIMessageStream({
@@ -115,6 +140,8 @@ const handleChatStream = observe(
           const result = streamText({
             model,
             messages: allMessages,
+            tools: gitbookTools,
+            stopWhen: stepCountIs(5),
             experimental_transform: smoothStream({
               chunking: 'word', // Stream word-by-word for typing effect
             }),
@@ -200,11 +227,25 @@ const handleChatStream = observe(
                   data: { isChatReady: false, error: workflowError },
                 })
               } finally {
+                try {
+                  await mcpClient?.close()
+                } catch (closeError) {
+                  logger.warn('Failed to close GitBook MCP client', {
+                    traceId,
+                    error:
+                      closeError instanceof Error
+                        ? closeError.message
+                        : String(closeError),
+                  })
+                }
+
                 // Manually end the span since we're streaming
                 trace.getActiveSpan()?.end()
               }
             },
             onError: (error) => {
+              void mcpClient?.close()
+              mcpClient = null
               const errorMessage =
                 error instanceof Error ? error.message : String(error)
 

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -8,7 +8,9 @@ const UUID_REGEX =
 // Limits to protect API and LLM costs
 const MAX_MESSAGES = 50
 const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
-const MAX_PARTS_PER_MESSAGE = 10
+// 5 steps × up to 4 parts each (step-start + empty-text + dynamic-tool + data-*)
+// plus headroom; must exceed stepCountIs(5) × parts-per-step
+const MAX_PARTS_PER_MESSAGE = 25
 
 const messagePartSchema = z.discriminatedUnion('type', [
   z.object({
@@ -16,7 +18,12 @@ const messagePartSchema = z.discriminatedUnion('type', [
     text: z
       .string()
       .trim()
-      .min(1, 'Text cannot be empty')
+      // No .min(1) here. When the LLM uses a tool, the AI SDK opens each
+      // generation step with a text part before emitting the tool call. If the
+      // model goes straight to calling a tool without generating any preamble,
+      // that part lands as text: "". The frontend echoes the full assistant
+      // message back on subsequent turns, so we must accept empty strings or
+      // every multi-step tool-use conversation breaks on the second turn.
       .max(MAX_TEXT_LENGTH, `Text cannot exceed ${MAX_TEXT_LENGTH} characters`),
   }),
   z.object({
@@ -44,6 +51,16 @@ const messagePartSchema = z.discriminatedUnion('type', [
         )
         .min(1),
     }),
+  }),
+  // Pair Foundry / AI SDK dynamic tool part — present in assistant messages when
+  // the LLM calls an MCP tool. The frontend echoes these parts back on subsequent turns.
+  z.object({
+    type: z.literal('dynamic-tool'),
+    toolCallId: z.string(),
+    toolName: z.string(),
+    state: z.string(),
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
   }),
 ])
 


### PR DESCRIPTION
## What

Wires the [Plumber GitBook MCP server](https://guide.plumber.gov.sg/~gitbook/mcp) into the AI Builder chat handler so the LLM can look up the Plumber guide when users ask configuration or usage questions (e.g. data classification, supported apps, connection setup).

## How

**`packages/backend/src/routes/api/chat/index.ts`**

Before each `streamText` call, an MCP client is created via `@ai-sdk/mcp` using the built-in HTTP transport. Its tools are passed directly to `streamText` alongside `stopWhen: stepCountIs(5)`, allowing up to 4 tool call/result cycles before the LLM must produce a final response. The client is closed in both `onFinish` and `onError`. If the MCP server is unreachable, the error is logged and the chat proceeds without tools (graceful degradation).

**`packages/backend/src/routes/api/chat/schema.ts`**

The frontend echoes the full assistant message back on subsequent turns, so the schema must accept the new part types the AI SDK introduces during multi-step tool use:

- Added `dynamic-tool` discriminant — how Pair Foundry serialises MCP tool invocations (`tool-call`/`tool-result` are not used)
- Removed `.min(1)` from text parts — the AI SDK emits `text: ""` before each tool call when the LLM goes straight to calling a tool without generating preamble; the frontend echoes this back verbatim
- Raised `MAX_PARTS_PER_MESSAGE` from 10 → 25 — with `stepCountIs(5)`, each tool-call step produces 3 parts (step-start + empty-text + dynamic-tool), so 3+ tool calls already exceed the old limit

**System prompt**

No code change — the Langfuse prompt has been updated directly to instruct the LLM to call the documentation tools when answering questions whose answer is likely in the guide, and to redirect only fully off-topic requests.

## Testing

- [ ] Manual: AI Builder still woks as intended and can generate a Pipe
- [ ] Manual: AI Builder still deflects irrelevant questions and redirects the user back to building a workflow
- [ ] Manual: ask the AI Builder a question where the answer is not in the prompt, but in the guide, and verify the LLM calls `searchDocumentation` and returns a guide-grounded answer