### PR TITLE
fix(ai-builder): fix pipe name defaulting to 'Build with AI'

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -182,7 +182,10 @@ export function useChatStream(options: UseChatStreamOptions) {
           // isChatReady: populate output from stream (steps or error), drawer opens
           // !isChatReady: preserve current output
           ...(isChatReady
-            ? { output: flowSteps ?? { error } }
+            ? {
+                output: flowSteps ?? { error },
+                ...(flowSteps?.name ? { flowName: flowSteps.name } : {}),
+              }
             : currentOutput
             ? { output: currentOutput }
             : {}),

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -38,14 +38,8 @@ export default function ChatInterface(props: ChatInterfaceProps) {
   } = props
   const navigate = useNavigate()
   const location = useLocation()
-  const {
-    flowName,
-    chatInput,
-    isMobile,
-    isDrawerOpen,
-    setIsDrawerOpen,
-    setChatState,
-  } = useAiBuilderContext()
+  const { chatInput, isMobile, isDrawerOpen, setIsDrawerOpen, setChatState } =
+    useAiBuilderContext()
 
   const hasMessages = messages.length > 0 || isStreaming
 
@@ -91,7 +85,6 @@ export default function ChatInterface(props: ChatInterfaceProps) {
       navigate(`${URLS.EDITOR}/ai`, {
         state: {
           ...location.state,
-          flowName,
           chatInput: messages[messages.length - 1].text,
           chatMessages: messages,
         },
@@ -102,15 +95,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     if (!isMobile) {
       setIsDrawerOpen(true)
     }
-  }, [
-    chatInput,
-    messages,
-    setIsDrawerOpen,
-    navigate,
-    location.state,
-    flowName,
-    isMobile,
-  ])
+  }, [chatInput, messages, setIsDrawerOpen, navigate, location.state, isMobile])
 
   // Auto-open preview when streaming completes and result is ready
   useEffect(() => {


### PR DESCRIPTION
## TL;DR

Bug fixes for the AI Builder pipe name header display.

## Why?

Two bugs caused the pipe name to always show "Build with AI" instead of the AI-suggested name:

**Bug 1 —** **`useChatStream.ts`**: When the stream finished with `isChatReady: true`, `onFinish` was writing `flowSteps` into `output` in location state but never extracting `flowSteps.name` into the top-level `flowName` field. Added `flowName: flowSteps.name` to the navigate state when present.

**Bug 2 —** **`ChatInterface/index.tsx`**: Race condition — `handleOpenPreview` fires (triggered by `isReadyForPreview` becoming true) in the same effects flush as the location state → `persistedState` sync. At that point context's `flowName` is still stale (`"Build with AI"`), and the callback was explicitly passing it into the navigate state, overwriting the correct value `onFinish` had just set in `location.state`. Fix: remove the explicit `flowName` override — `...location.state` already carries the freshly-set name.

## Tests

- [ ]   Manual: ensure you can still chat with the AI Builder and create a workflow
- [ ]  Manual: verify that the suggested Pipe name is displayed in the header and applies when you create the Pipe
- [ ]  Manual: ensure that exiting the chat and starting a new chat resets the Pipe name