### PR TITLE
chore: add custom header for ses calls

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -851,6 +851,15 @@ describe('send transactional email', () => {
 
       expect($.http.post).not.toHaveBeenCalled()
       expect(mocks.sesSend).toHaveBeenCalledTimes(2)
+
+      // Every SES-direct message carries the transport marker header.
+      const [sentCommand] = mocks.sesSend.mock.calls[0] as unknown as [
+        { input: { Content: { Simple: { Headers?: unknown[] } } } },
+      ]
+      expect(sentCommand.input.Content.Simple.Headers).toContainEqual({
+        Name: 'X-Plumber-Transport',
+        Value: 'ses',
+      })
     })
 
     it('falls back to Postman when any recipient is outside flagged domains', async () => {

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -159,6 +159,9 @@ async function sendViaSes(
             // filtering the Postman path gets for free.
             Html: { Data: sanitizeEmailHtml(email.body), Charset: 'UTF-8' },
           },
+          // Marks the message as sent via the SES direct path (absent =>
+          // routed through Postman). Recipient-invisible; for triage only.
+          Headers: [{ Name: 'X-Plumber-Transport', Value: 'ses' }],
         },
       },
       ...(email.replyTo && { ReplyToAddresses: [email.replyTo] }),

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -93,6 +93,9 @@ export async function sendEmailViaSes({
               // filtering the Postman path gets for free.
               Html: { Data: sanitizeEmailHtml(body), Charset: 'UTF-8' },
             },
+            // Marks the message as sent via the SES direct path (absent =>
+            // routed through Postman). Recipient-invisible; for triage only.
+            Headers: [{ Name: 'X-Plumber-Transport', Value: 'ses' }],
           },
         },
         ...(replyTo && { ReplyToAddresses: [replyTo] }),


### PR DESCRIPTION
## Problem

Cannot tell quickly that an email sent from Plumber is by SES or postman

## Solution

Add a custom header called `X-Plumber-Transport`

## Tests
- Click on the email and show original to check for the header
<img width="365" height="136" alt="image" src="https://github.com/user-attachments/assets/eb3e1202-0b72-4de8-8bba-f5cd0a542c11" />
