### PR TITLE
PLU-788 (fix): clear stale attachment when upstream form changes

### DIFF
--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -103,7 +103,7 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
         const { isValid, error } = validateFiles(
           variable,
           options,
-          getValues(name),
+          currentValues,
           maxFiles,
         )
         if (!isValid) {

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.test.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { type CheckboxVariable } from './components/Checkbox'
+import { validateFiles } from './utils'
+
+const makeFile = (name: string): CheckboxVariable => ({
+  name,
+  value: name,
+  label: name,
+  displayedValue: name,
+  type: 'file',
+  order: 1,
+  isCollapsedByDefault: false,
+  size: 100,
+})
+
+describe('validateFiles', () => {
+  const newFile = makeFile('step.newStep.attachment')
+  const availableOptions = [newFile]
+
+  it('allows selecting a file when current selection is empty', () => {
+    const result = validateFiles(newFile, availableOptions, [], 1)
+    expect(result.isValid).toBe(true)
+  })
+
+  it('blocks selecting a file when maxFiles is already reached with valid current selections', () => {
+    const existing = makeFile('step.existingStep.attachment')
+    const result = validateFiles(
+      newFile,
+      [existing, newFile],
+      [`{{${existing.name}}}`],
+      1,
+    )
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('1')
+  })
+
+  it('blocks selecting a file when stale (out-of-options) values occupy the maxFiles limit', () => {
+    // Simulates the pre-fix bug: user changed the upstream form, stale variable remains
+    // in raw form values but is absent from current options. validateFiles was called with
+    // the raw values, causing a false "max files exceeded" error.
+    const staleValue = '{{step.oldStep.oldAttachment}}'
+    const result = validateFiles(newFile, availableOptions, [staleValue], 1)
+    // This assertion documents that passing raw (stale) values to validateFiles
+    // incorrectly blocks the selection — the fix passes filtered currentValues instead.
+    expect(result.isValid).toBe(false)
+  })
+})


### PR DESCRIPTION
## What?

Fix a bug where the attachment field blocks new selections after the upstream form is changed.

## Why?

When a user selects an attachment from Form A, then changes the trigger to Form B, the attachment tag display correctly empties (the stale variable is no longer in the available options). However, the underlying form state still held the old variable value.

When the user then tried to select a new attachment, `validateFiles` was called with the raw form values (including the stale variable), causing it to count 2 files against a `maxFiles: 1` limit — producing the error _"Total number of files cannot exceed 1"_ even though visually nothing was selected.

**Fix:** pass the already-filtered `currentValues` (stale entries stripped) to `validateFiles` instead of `getValues(name)`. The filtering logic already existed in `onSuggestionClick`; it just wasn't being used for the validation check.

## Manual Testing

Two actions use the `attachment` field type. Test both.

### 1. Pair — Process an image

1. Create a flow with a **FormSG** trigger connected to a form that has an attachment field (Form A).
2. Add a **Pair → Process an image** action.
3. In the Image field, open the suggestions and select the attachment variable from Form A. Confirm the tag appears.
4. Go back to the FormSG trigger and switch to a **different form** (Form B) with a different attachment field.
5. Return to the Pair step.
6. **Before fix:** the tag is gone but clicking any new attachment shows _"Total number of files cannot exceed 1"_.
7. **After fix:** the stale tag is gone and selecting a new attachment from Form B succeeds without error.
8. Save and confirm the step saves with the new attachment variable.

### 2. Postman — Send transactional email

1. Create a flow with a **FormSG** trigger connected to Form A (with an attachment field).
2. Add a **Postman → Send transactional email** action and select the Form A attachment in the **Attachments** field.
3. Change the FormSG trigger to Form B (different attachment field).
4. Return to the Postman step.
5. **After fix:** selecting a new attachment from Form B succeeds — no false "max files exceeded" error.
6. Also verify the happy path: selecting, deselecting, and re-selecting attachments within the **same** form still behaves correctly.