### PR TITLE
[DATE-UTILS-1] PLU-706 feat(formatter): update copy in date-time and formatter actions

### DIFF
--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/fields.ts
@@ -15,7 +15,7 @@ export const fieldSchema = z.object({
 
 export const field = {
   key: ensureZodObjectKey(fieldSchema, 'formatDateTimeToFormat'),
-  label: 'What format do you want to transform value to?',
+  label: 'What format do you want to convert to?',
   type: 'dropdown' as const,
   required: true,
   variables: false,

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/convert-date-time/index.ts
@@ -37,7 +37,7 @@ export const spec = {
   id: 'formatDateTime',
 
   dropdownConfig: {
-    label: 'Format',
+    label: 'Change the format',
     description: 'Change a date or time to a new format style',
   },
 

--- a/packages/backend/src/apps/formatter/common/fixed-fields.ts
+++ b/packages/backend/src/apps/formatter/common/fixed-fields.ts
@@ -21,7 +21,7 @@ export const VALUE_TO_TRANSFORM_FIELD_KEY = ensureZodObjectKey(
 )
 
 export const VALUE_TO_TRANSFORM_FIELD = {
-  label: 'Value to transform',
+  label: 'Value to change',
   key: VALUE_TO_TRANSFORM_FIELD_KEY,
   type: 'string' as const,
   required: true,
@@ -36,7 +36,7 @@ export function createSelectTransformDropdown(
   transforms: TransformSpec[],
 ): IFieldDropdown {
   return {
-    label: 'Select how you want to transform your data',
+    label: 'What do you want to do?',
     key: SELECT_TRANSFORM_DROPDOWN_FIELD_KEY,
     type: 'dropdown' as const,
     required: true,


### PR DESCRIPTION
## TL;DR

Minor copy updates to field labels across the Formatter app — no logic changes.

## What changed?

Four label strings updated for clearer, more conversational language:

| Location | Before | After |
|---|---|---|
| All formatter actions — input field | `Value to transform` | `Value to change` |
| All formatter actions — transform picker | `Select how you want to transform your data` | `What do you want to do?` |
| Date / Time → "Change the format" — dropdown option | `Format` | `Change the format` |
| Date / Time → "Change the format" — format picker | `What format do you want to transform value to?` | `What format do you want to convert to?` |

`fixed-fields.ts` changes apply to every action in the Formatter app (Text, Number, Date / Time, etc.).

## Tests

- [ ] Open any **Formatter** action (e.g. Text → Capitalise). Confirm the input field reads **"Value to change"** and the transform picker reads **"What do you want to do?"**.
- [ ] Open **Formatter → Date / Time**. Confirm the same two shared labels appear as above.
- [ ] Select **"Change the format"** from the Date / Time transform dropdown. Confirm the dropdown option label reads **"Change the format"** (not "Format").
- [ ] Inside the "Change the format" step, confirm the format picker reads **"What format do you want to convert to?"**.
- [ ] Save and run a flow using the "Change the format" transform end-to-end — confirm output is unchanged.