### PR TITLE
fix: sender and subject parsing for SES

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -862,6 +862,30 @@ describe('send transactional email', () => {
       })
     })
 
+    it('quotes a comma sender name for SES but keeps dataOut unquoted', async () => {
+      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+      $.step.parameters.destinationEmail = 'a@open.gov.sg'
+      $.step.parameters.senderName = 'Acme, Inc'
+      $.step.parameters.attachments = []
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+
+      // SES gets the RFC 5322-quoted display name...
+      const [sentCommand] = mocks.sesSend.mock.calls[0] as unknown as [
+        { input: { FromEmailAddress: string } },
+      ]
+      expect(sentCommand.input.FromEmailAddress).toBe(
+        '"Acme, Inc" <info@plumber.gov.sg>',
+      )
+
+      // ...but dataOut shows the clean, unquoted form.
+      expect($.setActionItem).toHaveBeenCalledWith({
+        raw: expect.objectContaining({
+          from: 'Acme, Inc <info@plumber.gov.sg>',
+        }),
+      })
+    })
+
     it('falls back to Postman when any recipient is outside flagged domains', async () => {
       mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
       $.step.parameters.destinationEmail = 'a@open.gov.sg,b@gmail.com'

--- a/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/parameters.test.ts
@@ -127,20 +127,31 @@ describe('postman transactional email schema zod validation', () => {
     expect(result.error?.errors[0].message).toEqual('Empty sender name')
   })
 
-  it('should strip display-name-breaking characters from sender name', () => {
-    // "Foo <x@y.com>" would otherwise yield a malformed "from" address that
-    // SES rejects (e.g. two angle-addrs).
+  it('preserves display-name specials in the sender name', () => {
+    // Display-name specials (angle brackets, commas, etc.) are no longer
+    // stripped at the schema layer — the From address is RFC 5322-quoted when
+    // sent via SES (see formatFromAddress in ses-email-helper), and the Postman
+    // API handles its own encoding.
     validPayload.senderName = 'Foo <x@y.com>'
     const result = transactionalEmailSchema.safeParse(validPayload)
     assert(result.success === true)
-    expect(result.data.senderName).toEqual('Foo x@y.com')
+    expect(result.data.senderName).toEqual('Foo <x@y.com>')
   })
 
-  it('should strip newlines from sender name', () => {
+  it('collapses whitespace (incl. newlines) in the sender name', () => {
+    // Newlines can't appear in an email header; collapsing them to spaces
+    // prevents header injection (e.g. a smuggled "Bcc:" line).
     validPayload.senderName = 'Foo\r\nBcc: evil@example.com'
     const result = transactionalEmailSchema.safeParse(validPayload)
     assert(result.success === true)
     expect(result.data.senderName).toEqual('Foo Bcc: evil@example.com')
+  })
+
+  it('collapses whitespace (incl. newlines) in the subject', () => {
+    validPayload.subject = 'Hello\r\n\tworld   again'
+    const result = transactionalEmailSchema.safeParse(validPayload)
+    assert(result.success === true)
+    expect(result.data.subject).toEqual('Hello world again')
   })
 
   it('should work with legacy body value', () => {

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -10,7 +10,11 @@ import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { incrementMetric } from '@/helpers/metrics'
 import { sanitizeEmailHtml } from '@/helpers/sanitize-email-html'
-import { getSesClient, shouldUseSes } from '@/helpers/ses-email-helper'
+import {
+  formatFromAddress,
+  getSesClient,
+  shouldUseSes,
+} from '@/helpers/ses-email-helper'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
 import {
@@ -142,7 +146,14 @@ async function sendViaSes(
   ccAddressesToSend: string[] | undefined,
 ): Promise<PostmanPromiseFulfilled> {
   const client = getSesClient()
-  const fromAddress = `${email.senderName} <${appConfig.ses.fromAddress}>`
+  // Address sent to SES: display name is RFC 5322-quoted when it contains
+  // specials (e.g. a comma) so the header isn't malformed.
+  const fromAddress = formatFromAddress(
+    email.senderName,
+    appConfig.ses.fromAddress,
+  )
+  // Human-readable form for dataOut — no quoting artifacts shown to the user.
+  const displayFrom = `${email.senderName} <${appConfig.ses.fromAddress}>`
 
   await client.send(
     new SendEmailCommand({
@@ -187,7 +198,7 @@ async function sendViaSes(
     params: {
       body: email.body,
       subject: email.subject,
-      from: fromAddress,
+      from: displayFrom,
       reply_to: email.replyTo,
       ...(email.ccList?.length && { cc: email.ccList }),
     },
@@ -254,6 +265,10 @@ export async function sendTransactionalEmails(
           event: 'postman-step-ses-email-failed',
           recipient: recipientEmail,
           errorName: e instanceof Error ? e.name : undefined,
+          // The AWS error message is the actual reason (e.g. unverified
+          // identity, malformed address/header). e.message is non-enumerable,
+          // so it must be logged explicitly — `error: e` alone drops it.
+          errorMessage: e instanceof Error ? e.message : String(e),
           httpStatus: (e as { $metadata?: { httpStatusCode?: number } })
             ?.$metadata?.httpStatusCode,
         })

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -103,7 +103,13 @@ export const transactionalEmailFields: IField[] = [
 ]
 
 export const transactionalEmailSchema = z.object({
-  subject: z.string().min(1, { message: 'Empty subject' }).trim(),
+  subject: z
+    .string()
+    .min(1, { message: 'Empty subject' })
+    .trim()
+    // Collapse whitespace so newlines (which can't appear in a header) become
+    // spaces — keeps the subject single-line and avoids header injection.
+    .transform((value) => value.replace(/\s+/g, ' ').trim()),
   body: z
     .string()
     .min(1, { message: 'Empty body' })
@@ -144,17 +150,11 @@ export const transactionalEmailSchema = z.object({
     .string()
     .min(1, { message: 'Empty sender name' })
     .trim()
-    // Strip characters that would break the RFC 5322 display name in the
-    // constructed "{senderName} <info@plumber.gov.sg>" address. A value like
-    // "Foo <x@y.com>" otherwise yields a malformed address that SES rejects
-    // (Postman happens to tolerate it). Collapse the resulting whitespace so
-    // stripped characters don't leave double spaces.
-    .transform((value) =>
-      value
-        .replace(/[\r\n<>"]/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim(),
-    )
+    // Collapse whitespace so newlines (which can't appear in an email header)
+    // become spaces — prevents header injection (e.g. "Foo\r\nBcc: evil@x.com").
+    // Display-name specials like commas/angle brackets are preserved; they're
+    // RFC 5322-quoted when the From address is built (see formatFromAddress).
+    .transform((value) => value.replace(/\s+/g, ' ').trim())
     // NOTE: we trim the sender name so that long sender names do not cause the email to fail.
     // Postman limits the sender name to 255 characters.
     // the API sends "{senderName} <info@plumber.gov.sg>" so it needs to be included in the calculation.

--- a/packages/backend/src/helpers/__tests__/ses-email-helper.test.ts
+++ b/packages/backend/src/helpers/__tests__/ses-email-helper.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatFromAddress } from '../ses-email-helper'
+
+describe('formatFromAddress', () => {
+  it('leaves a simple display name unquoted', () => {
+    expect(formatFromAddress('HR Department', 'info@plumber.gov.sg')).toBe(
+      'HR Department <info@plumber.gov.sg>',
+    )
+  })
+
+  it('quotes a display name containing a comma (the SES-breaking case)', () => {
+    expect(formatFromAddress('Acme, Inc', 'info@plumber.gov.sg')).toBe(
+      '"Acme, Inc" <info@plumber.gov.sg>',
+    )
+  })
+
+  it('quotes other RFC 5322 specials (semicolon, colon, parens)', () => {
+    expect(formatFromAddress('Dept; Unit', 'a@b.gov.sg')).toBe(
+      '"Dept; Unit" <a@b.gov.sg>',
+    )
+    expect(formatFromAddress('Team (Ops)', 'a@b.gov.sg')).toBe(
+      '"Team (Ops)" <a@b.gov.sg>',
+    )
+  })
+
+  it('escapes embedded quotes and backslashes when quoting', () => {
+    expect(formatFromAddress('A, "B" \\C', 'a@b.gov.sg')).toBe(
+      '"A, \\"B\\" \\\\C" <a@b.gov.sg>',
+    )
+  })
+})

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -45,6 +45,23 @@ export function shouldUseSes(
   return domain ? normalizedEnabledDomains.includes(domain) : false
 }
 
+/**
+ * Build an RFC 5322 From address (`Display Name <email>`).
+ *
+ * If the display name contains "specials" — most importantly a comma — it must
+ * be a quoted-string, otherwise the address is malformed (e.g. `Acme, Inc
+ * <x@y>` parses as two addresses) and SES rejects it with a BadRequestException
+ * while Postman silently tolerates it. We quote only when needed so simple
+ * names are unchanged, escaping any embedded `"`/`\`.
+ */
+export function formatFromAddress(displayName: string, email: string): string {
+  const needsQuoting = /[,;:<>@()[\]\\"]/.test(displayName)
+  const name = needsQuoting
+    ? `"${displayName.replace(/(["\\])/g, '\\$1')}"`
+    : displayName
+  return `${name} <${email}>`
+}
+
 interface SesEmailParams {
   subject: string
   body: string
@@ -116,8 +133,13 @@ export async function sendEmailViaSes({
   } catch (e) {
     logger.error('Error sending email via SES, please try again later.', {
       event: 'ses-email-failed',
-      error: e,
       recipient,
+      errorName: e instanceof Error ? e.name : undefined,
+      // e.message is non-enumerable, so `error: e` alone drops the actual
+      // reason — log it explicitly. Keep the full error for the stack too.
+      errorMessage: e instanceof Error ? e.message : String(e),
+      httpStatus: (e as { $metadata?: { httpStatusCode?: number } })?.$metadata
+        ?.httpStatusCode,
     })
     throw e
   }


### PR DESCRIPTION
## Summary

Fixes SES-direct email sends failing with `BadRequestException` when the **sender name** contains a comma (or other RFC 5322 special characters), hardens **sender name** and **subject** against newline/header injection, and makes SES send failures diagnosable in logs.

## Why

- **The bug:** SESv2 `SendEmail` takes `FromEmailAddress` verbatim and validates it strictly. A comma in the display name (`Acme, Inc <info@…>`) is parsed as an address-list separator → two addresses → malformed → `BadRequestException`. The Postman path never hit this because Postman is a higher-level API that re-encodes the `From` for you.
- **Why it was undiagnosable:** the failure log captured `errorName`/`httpStatus` but not `e.message` (it's a non-enumerable property, so `error: e` drops it). The actual AWS reason was invisible.
- **Injection hardening:** sender name and subject are user-controlled and flow into email headers; collapsing whitespace removes CR/LF, which can't appear in a header and is the classic header-injection vector.

## Changes

### `helpers/ses-email-helper.ts`
- Added **`formatFromAddress(displayName, email)`** — builds an RFC 5322 `Name <email>` address, wrapping the display name in a quoted-string when it contains specials (`,;:<>@()[]\"`) and escaping embedded `"`/`\`. Quotes only when needed, so simple names are unchanged.
- `sendEmailViaSes` failure log now logs structured `errorName` / `errorMessage` / `httpStatus` instead of an opaque `error: e`.

### `apps/postman/common/email-helper.ts`
- `sendViaSes` uses `formatFromAddress` for the SES `FromEmailAddress` (quoted when needed), and keeps a separate **unquoted** `displayFrom` for `dataOut.from` so users never see quoting artifacts.
- Added `errorMessage` to the `postman-step-ses-email-failed` log.

### `apps/postman/common/parameters.ts`
- `senderName` and `subject` now **collapse whitespace** (`\s+` → single space, then trim). Since `\s` matches CR/LF, this strips newlines on **both** the SES and Postman paths.
- Removed the previous `[\r\n<>"]` character-stripping on `senderName` — display-name specials are now **preserved** (commas, angle brackets, etc.) and quoted at send time instead of mangled.

### Tests
- New `helpers/__tests__/ses-email-helper.test.ts` — `formatFromAddress` (comma, other specials, escaping, simple names).
- `apps/postman/__tests__/common/parameters.test.ts` — whitespace collapse for sender name and subject; display-name specials preserved.
- `apps/postman/__tests__/actions/send-transactional-email.test.ts` — comma sender name is quoted in the SES call but unquoted in `dataOut`.

## How it works

| Input (sender name) | Sent to SES (`FromEmailAddress`) | Shown in `dataOut.from` |
|---|---|---|
| `HR Department` | `HR Department <info@…>` | `HR Department <info@…>` |
| `Acme, Inc` | `"Acme, Inc" <info@…>` | `Acme, Inc <info@…>` |
| `Foo⏎Bcc: x@y.com` | `"Foo Bcc: x@y.com" <info@…>` (newline collapsed) | `Foo Bcc: x@y.com <info@…>` |

## Test plan

**Automated** (green: lint, `tsc`, 59 tests across the three suites):
- `npm run -w backend test:unit`
- Recommended: run the `process-ses-event` / suppression **itests** (Docker) as a regression check.

**Manual / staging** (force SES via the `ses_enabled_domains` flag):
- [ ] Sender name `Acme, Inc` → sends OK, **no `BadRequestException`**; received `From:` renders "Acme, Inc"; step output `dataOut.from` = `Acme, Inc <info@plumber.gov.sg>` (no quotes).
- [ ] Other specials (`;`, `()`, `<>`) in sender name → sends OK.
- [ ] Simple sender name (`HR Department`) → unchanged, not quoted.
- [ ] Sender name containing a newline → collapses to one line, sends OK on **both** SES (flagged domain) and **Postman** (non-flagged domain) routing.
- [ ] Subject with newlines / runs of spaces → arrives as a single normalized line.
- [ ] Postman path (non-SES domain) with a comma sender name → still works.

## Notes for reviewers

- `formatFromAddress` is applied to the **SES path only** by design. The Postman path builds the `From` unquoted and relies on Postman's own re-encoding; newline safety for both paths comes from the schema-level whitespace collapse.
- The `subject`/`senderName` transforms live at the schema layer, so they apply to **both** send paths.