### PR TITLE
[REHYDRATE-3] PLU-65 feat(archival): add listArchivedExecutions helper

### DIFF
--- a/packages/backend/src/helpers/archival/__tests__/list-archived-executions.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/list-archived-executions.test.ts
@@ -1,0 +1,83 @@
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { describe, expect, it, vi } from 'vitest'
+
+import { S3_PREFIX_EXECUTIONS } from '../build-s3-key'
+import { listArchivedExecutions } from '../list-archived-executions'
+
+const baseOpts = { bucket: 'plumber-archive-executions-test' }
+
+function makeMockS3(pages: Array<{ keys: string[]; hasMore: boolean }>) {
+  let pageIdx = 0
+  return {
+    send: vi.fn().mockImplementation(() => {
+      const page = pages[pageIdx++]
+      return Promise.resolve({
+        Contents: page.keys.map((key) => ({ Key: key })),
+        NextContinuationToken: page.hasMore ? `token-${pageIdx}` : undefined,
+      })
+    }),
+  } as unknown as S3Client
+}
+
+describe('listArchivedExecutions', () => {
+  it('returns execution IDs extracted from S3 keys', async () => {
+    const s3 = makeMockS3([
+      {
+        keys: [
+          `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-a.json.gz`,
+          `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-b.json.gz`,
+        ],
+        hasMore: false,
+      },
+    ])
+    const ids = await listArchivedExecutions('flow-1', {
+      ...baseOpts,
+      s3Client: s3,
+    })
+    expect(ids).toEqual(['exec-a', 'exec-b'])
+  })
+
+  it('uses the correct prefix and bucket', async () => {
+    const s3 = makeMockS3([{ keys: [], hasMore: false }])
+    await listArchivedExecutions('flow-1', {
+      ...baseOpts,
+      s3Client: s3,
+    })
+    const cmd = (s3.send as ReturnType<typeof vi.fn>).mock.calls[0][0]
+    expect(cmd).toBeInstanceOf(ListObjectsV2Command)
+    expect(cmd.input.Prefix).toBe(`${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/`)
+    expect(cmd.input.Bucket).toBe('plumber-archive-executions-test')
+  })
+
+  it('paginates until NextContinuationToken is absent', async () => {
+    const s3 = makeMockS3([
+      {
+        keys: [
+          `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-a.json.gz`,
+        ],
+        hasMore: true,
+      },
+      {
+        keys: [
+          `${S3_PREFIX_EXECUTIONS}/flow_id=flow-1/year=2025/month=01/execution_id=exec-b.json.gz`,
+        ],
+        hasMore: false,
+      },
+    ])
+    const ids = await listArchivedExecutions('flow-1', {
+      ...baseOpts,
+      s3Client: s3,
+    })
+    expect(ids).toEqual(['exec-a', 'exec-b'])
+    expect((s3.send as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2)
+  })
+
+  it('returns empty array when no objects exist', async () => {
+    const s3 = makeMockS3([{ keys: [], hasMore: false }])
+    const ids = await listArchivedExecutions('flow-1', {
+      ...baseOpts,
+      s3Client: s3,
+    })
+    expect(ids).toEqual([])
+  })
+})

--- a/packages/backend/src/helpers/archival/list-archived-executions.ts
+++ b/packages/backend/src/helpers/archival/list-archived-executions.ts
@@ -1,0 +1,40 @@
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+
+import { S3_PREFIX_EXECUTIONS } from './build-s3-key'
+
+type ListOpts = {
+  bucket: string
+  s3Client: S3Client
+}
+
+// Intentionally only lists production executions. Test-run executions are
+// archived under S3_PREFIX_TEST_EXECUTIONS but are never rehydrated.
+export async function listArchivedExecutions(
+  flowId: string,
+  opts: ListOpts,
+): Promise<string[]> {
+  const prefix = `${S3_PREFIX_EXECUTIONS}/flow_id=${flowId}/`
+  const executionIds: string[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const response = await opts.s3Client.send(
+      new ListObjectsV2Command({
+        Bucket: opts.bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    )
+
+    for (const obj of response.Contents ?? []) {
+      const match = obj.Key?.match(/execution_id=([^/]+)\.json\.gz$/)
+      if (match) {
+        executionIds.push(match[1])
+      }
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+
+  return executionIds
+}


### PR DESCRIPTION
## Stack Context

Phase 2 of the archival pipeline adds a rehydration path. This PR adds the list helper — used by the CLI when an operator wants to see all archived executions for a flow without knowing specific IDs.

## TL;DR

Add `listArchivedExecutions` to paginate S3 and return all archived execution IDs for a given flow.

## What changed?

- `list-archived-executions.ts`: new helper that paginates `ListObjectsV2` under the `S3_PREFIX_EXECUTIONS/flow_id=<flowId>/` prefix, extracts execution IDs from the Hive-partitioned key names, and returns them as a string array. Intentionally only lists production executions — test-run executions are never rehydrated.
- `__tests__/list-archived-executions.test.ts`: unit tests covering the happy path, correct prefix/bucket, pagination, and empty result.

## Tests

- [ ] Run `npm run -w backend archive:rehydrate -- --flow-id <id>` against a flow with archived data and confirm a JSON array of execution IDs is printed.
- [ ] Run against a flow with no archived data and confirm `[]` is returned.
- [ ] If a flow has more than one page of results (> 1000 S3 objects), confirm all IDs are returned.
