### PR TITLE
[REHYDRATE-4] PLU-65 feat(archival): add restoreExecution helper, set archiveDisabled on restore

### DIFF
--- a/packages/backend/src/helpers/archival/__tests__/restore-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/restore-execution.test.ts
@@ -35,22 +35,24 @@ const mockPayload: ArchivedPayload = {
   ],
 }
 
+function makeInsertChain(returning: object[]) {
+  return {
+    onConflict: vi.fn().mockReturnThis(),
+    ignore: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue(returning),
+  }
+}
+
 function makeMockKnex({ executionExists = false, stepExists = false } = {}) {
-  const insertExecFn = vi.fn().mockResolvedValue([])
-  const insertStepFn = vi.fn().mockResolvedValue([])
   const rawFn = vi.fn().mockResolvedValue([])
 
+  const execChain = makeInsertChain(executionExists ? [] : [{ id: 'exec-1' }])
+  const stepChain = makeInsertChain(stepExists ? [] : [{ id: 'step-1' }])
+
+  const insertExecFn = vi.fn().mockReturnValue(execChain)
+  const insertStepFn = vi.fn().mockReturnValue(stepChain)
+
   const trx = (table: string) => ({
-    where: (_col: string, _val: string) => ({
-      first: () =>
-        Promise.resolve(
-          (table === 'executions' && executionExists) ||
-            (table === 'execution_steps' && stepExists)
-            ? { id: 'existing' }
-            : undefined,
-        ),
-      insert: table === 'executions' ? insertExecFn : insertStepFn,
-    }),
     insert: table === 'executions' ? insertExecFn : insertStepFn,
   })
   const trxWithRaw = Object.assign(trx, { raw: rawFn })
@@ -80,18 +82,18 @@ describe('restoreExecution', () => {
     expect((knex as any)._insertStepFn).toHaveBeenCalledOnce()
   })
 
-  it('skips execution insert when it already exists', async () => {
+  it('reports executionInserted=false when execution already exists', async () => {
     const knex = makeMockKnex({ executionExists: true })
     const result = await restoreExecution(mockPayload, knex)
     expect(result.executionInserted).toBe(false)
-    expect((knex as any)._insertExecFn).not.toHaveBeenCalled()
+    expect((knex as any)._insertExecFn).toHaveBeenCalledOnce()
   })
 
-  it('skips step insert when it already exists', async () => {
+  it('reports stepsInserted=0 when steps already exist', async () => {
     const knex = makeMockKnex({ stepExists: true })
     const result = await restoreExecution(mockPayload, knex)
     expect(result.stepsInserted).toBe(0)
-    expect((knex as any)._insertStepFn).not.toHaveBeenCalled()
+    expect((knex as any)._insertStepFn).toHaveBeenCalledOnce()
   })
 
   it('runs inside a transaction', async () => {
@@ -100,12 +102,22 @@ describe('restoreExecution', () => {
     expect(knex.transaction).toHaveBeenCalledOnce()
   })
 
-  it('sets archiveDisabled on the flow config after restoring', async () => {
+  it('sets archiveDisabled on the flow config before restoring', async () => {
     const knex = makeMockKnex()
     await restoreExecution(mockPayload, knex)
     const rawCall = (knex as any)._rawFn.mock.calls[0]
     expect(rawCall[0]).toContain('UPDATE flows')
     expect(rawCall[1][0]).toBe(JSON.stringify({ archiveDisabled: true }))
     expect(rawCall[1][1]).toBe('flow-1')
+    expect((knex as any)._rawFn).toHaveBeenCalledBefore(
+      (knex as any)._insertExecFn,
+    )
+  })
+
+  it('handles empty steps array', async () => {
+    const knex = makeMockKnex()
+    const result = await restoreExecution({ ...mockPayload, steps: [] }, knex)
+    expect(result.stepsInserted).toBe(0)
+    expect((knex as any)._insertStepFn).not.toHaveBeenCalled()
   })
 })

--- a/packages/backend/src/helpers/archival/__tests__/restore-execution.test.ts
+++ b/packages/backend/src/helpers/archival/__tests__/restore-execution.test.ts
@@ -1,0 +1,111 @@
+import type { Knex } from 'knex'
+import { describe, expect, it, vi } from 'vitest'
+
+import { restoreExecution } from '../restore-execution'
+import type { ArchivedPayload } from '../types'
+
+const mockPayload: ArchivedPayload = {
+  execution: {
+    id: 'exec-1',
+    flowId: 'flow-1',
+    status: 'success',
+    testRun: false,
+    internalId: null,
+    createdAt: '2025-01-15T00:00:00.000Z',
+    updatedAt: '2025-01-15T00:00:00.000Z',
+    deletedAt: null,
+  },
+  steps: [
+    {
+      id: 'step-1',
+      executionId: 'exec-1',
+      stepId: 'step-def-1',
+      appKey: 'formsg',
+      key: 'trigger',
+      jobId: null,
+      status: 'success',
+      dataIn: { foo: 'bar' },
+      dataOut: { result: 'ok' },
+      errorDetails: null,
+      metadata: {},
+      createdAt: '2025-01-15T00:00:01.000Z',
+      updatedAt: '2025-01-15T00:00:01.000Z',
+      deletedAt: null,
+    },
+  ],
+}
+
+function makeMockKnex({ executionExists = false, stepExists = false } = {}) {
+  const insertExecFn = vi.fn().mockResolvedValue([])
+  const insertStepFn = vi.fn().mockResolvedValue([])
+  const rawFn = vi.fn().mockResolvedValue([])
+
+  const trx = (table: string) => ({
+    where: (_col: string, _val: string) => ({
+      first: () =>
+        Promise.resolve(
+          (table === 'executions' && executionExists) ||
+            (table === 'execution_steps' && stepExists)
+            ? { id: 'existing' }
+            : undefined,
+        ),
+      insert: table === 'executions' ? insertExecFn : insertStepFn,
+    }),
+    insert: table === 'executions' ? insertExecFn : insertStepFn,
+  })
+  const trxWithRaw = Object.assign(trx, { raw: rawFn })
+
+  const knexClient = {
+    transaction: vi.fn(async (cb: (trx: unknown) => Promise<void>) =>
+      cb(trxWithRaw),
+    ),
+    _insertExecFn: insertExecFn,
+    _insertStepFn: insertStepFn,
+    _rawFn: rawFn,
+  } as unknown as Knex & {
+    _insertExecFn: ReturnType<typeof vi.fn>
+    _insertStepFn: ReturnType<typeof vi.fn>
+    _rawFn: ReturnType<typeof vi.fn>
+  }
+  return knexClient
+}
+
+describe('restoreExecution', () => {
+  it('inserts execution and steps when neither exist', async () => {
+    const knex = makeMockKnex()
+    const result = await restoreExecution(mockPayload, knex)
+    expect(result.executionInserted).toBe(true)
+    expect(result.stepsInserted).toBe(1)
+    expect((knex as any)._insertExecFn).toHaveBeenCalledOnce()
+    expect((knex as any)._insertStepFn).toHaveBeenCalledOnce()
+  })
+
+  it('skips execution insert when it already exists', async () => {
+    const knex = makeMockKnex({ executionExists: true })
+    const result = await restoreExecution(mockPayload, knex)
+    expect(result.executionInserted).toBe(false)
+    expect((knex as any)._insertExecFn).not.toHaveBeenCalled()
+  })
+
+  it('skips step insert when it already exists', async () => {
+    const knex = makeMockKnex({ stepExists: true })
+    const result = await restoreExecution(mockPayload, knex)
+    expect(result.stepsInserted).toBe(0)
+    expect((knex as any)._insertStepFn).not.toHaveBeenCalled()
+  })
+
+  it('runs inside a transaction', async () => {
+    const knex = makeMockKnex()
+    await restoreExecution(mockPayload, knex)
+    expect(knex.transaction).toHaveBeenCalledOnce()
+  })
+
+  it('sets archiveDisabled on the flow config after restoring', async () => {
+    const knex = makeMockKnex()
+    await restoreExecution(mockPayload, knex)
+    const rawCall = (knex as any)._rawFn.mock.calls[0]
+    expect(rawCall[0]).toContain('UPDATE flows')
+    expect(rawCall[1][0]).toBe(JSON.stringify({ archiveDisabled: true }))
+    expect(rawCall[1][1]).toBe('flow-1')
+  })
+})

--- a/packages/backend/src/helpers/archival/restore-execution.ts
+++ b/packages/backend/src/helpers/archival/restore-execution.ts
@@ -16,12 +16,18 @@ export async function restoreExecution(
   let stepsInserted = 0
 
   await knexClient.transaction(async (trx) => {
-    const existing = await trx('executions')
-      .where('id', execution.id)
-      .first('id')
+    // Protect the flow from same-night re-archival before we start restoring,
+    // so there is no race window with the archival routine. Sets archiveDisabled
+    // in the flow's config JSONB so the eligibility query skips it until the
+    // operator clears the flag:
+    //   UPDATE flows SET config = config - 'archiveDisabled' WHERE id = '<id>';
+    await trx.raw(
+      `UPDATE flows SET config = COALESCE(config, '{}') || ?::jsonb WHERE id = ?`,
+      [JSON.stringify({ archiveDisabled: true }), execution.flowId],
+    )
 
-    if (!existing) {
-      await trx('executions').insert({
+    const insertedExecution = await trx('executions')
+      .insert({
         id: execution.id,
         flow_id: execution.flowId,
         status: execution.status,
@@ -31,43 +37,36 @@ export async function restoreExecution(
         updated_at: execution.updatedAt,
         deleted_at: execution.deletedAt,
       })
-      executionInserted = true
+      .onConflict('id')
+      .ignore()
+      .returning('id')
+    executionInserted = insertedExecution.length > 0
+
+    if (steps.length > 0) {
+      const insertedSteps = await trx('execution_steps')
+        .insert(
+          steps.map((step) => ({
+            id: step.id,
+            execution_id: step.executionId,
+            step_id: step.stepId,
+            app_key: step.appKey,
+            key: step.key,
+            job_id: step.jobId,
+            status: step.status,
+            data_in: step.dataIn,
+            data_out: step.dataOut,
+            error_details: step.errorDetails,
+            metadata: step.metadata,
+            created_at: step.createdAt,
+            updated_at: step.updatedAt,
+            deleted_at: step.deletedAt,
+          })),
+        )
+        .onConflict('id')
+        .ignore()
+        .returning('id')
+      stepsInserted = insertedSteps.length
     }
-
-    for (const step of steps) {
-      const existingStep = await trx('execution_steps')
-        .where('id', step.id)
-        .first('id')
-
-      if (!existingStep) {
-        await trx('execution_steps').insert({
-          id: step.id,
-          execution_id: step.executionId,
-          step_id: step.stepId,
-          app_key: step.appKey,
-          key: step.key,
-          job_id: step.jobId,
-          status: step.status,
-          data_in: step.dataIn,
-          data_out: step.dataOut,
-          error_details: step.errorDetails,
-          metadata: step.metadata,
-          created_at: step.createdAt,
-          updated_at: step.updatedAt,
-          deleted_at: step.deletedAt,
-        })
-        stepsInserted++
-      }
-    }
-
-    // Protect the flow from same-night re-archival. Sets archiveDisabled in the
-    // flow's config JSONB so the eligibility query skips it until the operator
-    // clears the flag:
-    //   UPDATE flows SET config = config - 'archiveDisabled' WHERE id = '<id>';
-    await trx.raw(
-      `UPDATE flows SET config = COALESCE(config, '{}') || ?::jsonb WHERE id = ?`,
-      [JSON.stringify({ archiveDisabled: true }), execution.flowId],
-    )
   })
 
   return { executionInserted, stepsInserted }

--- a/packages/backend/src/helpers/archival/restore-execution.ts
+++ b/packages/backend/src/helpers/archival/restore-execution.ts
@@ -1,0 +1,74 @@
+import type { Knex } from 'knex'
+
+import type { ArchivedPayload } from './types'
+
+export type RestoreResult = {
+  executionInserted: boolean
+  stepsInserted: number
+}
+
+export async function restoreExecution(
+  payload: ArchivedPayload,
+  knexClient: Knex,
+): Promise<RestoreResult> {
+  const { execution, steps } = payload
+  let executionInserted = false
+  let stepsInserted = 0
+
+  await knexClient.transaction(async (trx) => {
+    const existing = await trx('executions')
+      .where('id', execution.id)
+      .first('id')
+
+    if (!existing) {
+      await trx('executions').insert({
+        id: execution.id,
+        flow_id: execution.flowId,
+        status: execution.status,
+        test_run: execution.testRun,
+        internal_id: execution.internalId,
+        created_at: execution.createdAt,
+        updated_at: execution.updatedAt,
+        deleted_at: execution.deletedAt,
+      })
+      executionInserted = true
+    }
+
+    for (const step of steps) {
+      const existingStep = await trx('execution_steps')
+        .where('id', step.id)
+        .first('id')
+
+      if (!existingStep) {
+        await trx('execution_steps').insert({
+          id: step.id,
+          execution_id: step.executionId,
+          step_id: step.stepId,
+          app_key: step.appKey,
+          key: step.key,
+          job_id: step.jobId,
+          status: step.status,
+          data_in: step.dataIn,
+          data_out: step.dataOut,
+          error_details: step.errorDetails,
+          metadata: step.metadata,
+          created_at: step.createdAt,
+          updated_at: step.updatedAt,
+          deleted_at: step.deletedAt,
+        })
+        stepsInserted++
+      }
+    }
+
+    // Protect the flow from same-night re-archival. Sets archiveDisabled in the
+    // flow's config JSONB so the eligibility query skips it until the operator
+    // clears the flag:
+    //   UPDATE flows SET config = config - 'archiveDisabled' WHERE id = '<id>';
+    await trx.raw(
+      `UPDATE flows SET config = COALESCE(config, '{}') || ?::jsonb WHERE id = ?`,
+      [JSON.stringify({ archiveDisabled: true }), execution.flowId],
+    )
+  })
+
+  return { executionInserted, stepsInserted }
+}


### PR DESCRIPTION
## Stack Context

Phase 2 of the archival pipeline adds a rehydration path. This PR adds the restore helper — the write-path that inserts an archived execution back into Postgres so it's visible in the Plumber UI again.

## TL;DR

Add `restoreExecution` to write an archived execution and its steps back to Postgres, then protect the flow from same-night re-archival.

## What changed?

- `restore-execution.ts`: new helper that runs a single transaction to:
  1. Insert the execution row into `executions` (skips if already exists — idempotent).
  2. Insert each step row into `execution_steps` (skips existing rows).
  3. Set `archiveDisabled: true` in the flow's `config` JSONB so the archival eligibility guard (PR #1778) skips the flow until an operator clears the flag.
- `__tests__/restore-execution.test.ts`: unit tests covering insert, skip-on-exists for both execution and steps, transaction wrapping, and the `archiveDisabled` update.

## Tests

- [ ] Run `npm run -w backend archive:rehydrate -- --flow-id <id> --execution-id <id> --restore` and confirm `{"executionInserted":true,"stepsInserted":<N>}` is printed.
- [ ] Re-run the same command and confirm `{"executionInserted":false,"stepsInserted":0}` — idempotency check.
- [ ] Confirm the restored execution is visible in the Plumber execution history UI for the flow.
- [ ] Confirm `SELECT config FROM flows WHERE id = '<id>'` shows `{"archiveDisabled":true,...}` after restore.
