### PR TITLE
[REHYDRATE-5] PLU-65 feat(archival): add archive:rehydrate CLI script

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,7 +27,8 @@
     "readme:dynamodb:setup": "echo 'Run this function to create the required tile table in dynamodb locally.'",
     "dynamodb:setup": "ts-node src/db/dynamodb_seeds/create_table.ts",
     "copy-statics": "cpy '**/*.{graphql,json,svg}' ../dist --cwd=src",
-    "archive:backfill": "ts-node --swc src/scripts/archive-executions.ts"
+    "archive:backfill": "ts-node --swc src/scripts/archive-executions.ts",
+    "archive:rehydrate": "ts-node --swc src/scripts/rehydrate-execution.ts"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "1.0.23",

--- a/packages/backend/src/scripts/rehydrate-execution.ts
+++ b/packages/backend/src/scripts/rehydrate-execution.ts
@@ -1,0 +1,82 @@
+/* eslint-disable no-console */
+import { archivalConfig } from '@/helpers/archival/config'
+import { archivalDb } from '@/helpers/archival/db'
+import { fetchArchivedExecution } from '@/helpers/archival/fetch-archived-execution'
+import { listArchivedExecutions } from '@/helpers/archival/list-archived-executions'
+import { restoreExecution } from '@/helpers/archival/restore-execution'
+import { archiveS3Client } from '@/helpers/archival/s3-client'
+
+function parseArgs(): {
+  flowId: string
+  executionId: string | null
+  restore: boolean
+  bucket: string
+} {
+  const args = process.argv.slice(2)
+  const get = (flag: string) => {
+    const idx = args.indexOf(flag)
+    return idx !== -1 ? args[idx + 1] : null
+  }
+
+  const flowId = get('--flow-id')
+  if (!flowId) {
+    console.error(
+      'Usage: rehydrate-execution --flow-id <id> [--execution-id <id>] [--restore]',
+    )
+    process.exit(1)
+  }
+
+  return {
+    flowId,
+    executionId: get('--execution-id'),
+    restore: args.includes('--restore'),
+    bucket: archivalConfig.archiveBucket,
+  }
+}
+
+async function main(): Promise<void> {
+  const { flowId, executionId, restore, bucket } = parseArgs()
+  const opts = { bucket, s3Client: archiveS3Client }
+
+  if (executionId) {
+    const payload = await fetchArchivedExecution(flowId, executionId, opts)
+
+    if (restore) {
+      const result = await restoreExecution(payload, archivalDb)
+      console.log(
+        JSON.stringify({
+          executionId,
+          executionInserted: result.executionInserted,
+          stepsInserted: result.stepsInserted,
+        }),
+      )
+    } else {
+      console.log(JSON.stringify(payload, null, 2))
+    }
+  } else {
+    const executionIds = await listArchivedExecutions(flowId, opts)
+
+    if (restore) {
+      for (const id of executionIds) {
+        const payload = await fetchArchivedExecution(flowId, id, opts)
+        const result = await restoreExecution(payload, archivalDb)
+        console.log(
+          JSON.stringify({
+            executionId: id,
+            executionInserted: result.executionInserted,
+            stepsInserted: result.stepsInserted,
+          }),
+        )
+      }
+    } else {
+      console.log(JSON.stringify(executionIds, null, 2))
+    }
+  }
+
+  await archivalDb.destroy()
+}
+
+main().catch((err) => {
+  console.error('rehydrate-execution failed:', err)
+  process.exit(1)
+})

--- a/packages/backend/src/scripts/rehydrate-execution.ts
+++ b/packages/backend/src/scripts/rehydrate-execution.ts
@@ -57,6 +57,7 @@ async function main(): Promise<void> {
     const executionIds = await listArchivedExecutions(flowId, opts)
 
     if (restore) {
+      // TODO: if restoring large flows is too slow, consider a bulk COPY-from-S3 strategy
       for (const id of executionIds) {
         const payload = await fetchArchivedExecution(flowId, id, opts)
         const result = await restoreExecution(payload, archivalDb)


### PR DESCRIPTION
## Stack Context

Phase 2 of the archival pipeline adds a rehydration path. This PR wires together all the helpers (list, fetch, restore) into a runnable CLI script that operators use to inspect or restore archived executions.

## TL;DR

Add `archive:rehydrate` npm script — a CLI for operator-driven execution rehydration from S3.

## What changed?

- `scripts/rehydrate-execution.ts`: new script with three modes driven by flags:
  - `--flow-id <id>` only → print JSON array of archived execution IDs for the flow.
  - `--flow-id <id> --execution-id <id>` → pretty-print the full `ArchivedPayload` JSON.
  - `--flow-id <id> --execution-id <id> --restore` → restore to Postgres and print a result summary.
  - `--flow-id <id> --restore` → bulk-restore all archived executions for the flow.
- `package.json`: added `archive:rehydrate` npm script entry.

## Tests

- [ ] `npm run -w backend archive:rehydrate -- --flow-id <id>` → prints execution ID array.
- [ ] `npm run -w backend archive:rehydrate -- --flow-id <id> --execution-id <id>` → pretty-prints the full payload (execution + steps).
- [ ] `npm run -w backend archive:rehydrate -- --flow-id <id> --execution-id <id> --restore` → prints `{"executionInserted":true,...}` and execution appears in Plumber UI.
- [ ] Run `--restore` a second time → prints `{"executionInserted":false,"stepsInserted":0}` (idempotent).
- [ ] Run without `--flow-id` → prints usage error and exits non-zero.
