### PR TITLE
[DATE-UTILS-2] PLU-706 feat(formatter): add Excel serial & Now input formats, extract time-units module

### DIFF
--- a/packages/backend/src/apps/formatter/__tests__/date-time.add-subtract.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.add-subtract.test.ts
@@ -128,6 +128,26 @@ describe('add / subtract date time', () => {
       op: { opType: 'subtract', timeUnit: 'months', timeAmount: '-7' },
       expectedResult: '2024-11-01T12:05:10.000+08:00',
     },
+
+    // Weeks (= exactly 7 days in Luxon)
+    {
+      op: { opType: 'add', timeUnit: 'weeks', timeAmount: '2' },
+      expectedResult: '2024-04-15T12:05:10.000+08:00',
+    },
+    {
+      op: { opType: 'subtract', timeUnit: 'weeks', timeAmount: '1' },
+      expectedResult: '2024-03-25T12:05:10.000+08:00',
+    },
+
+    // Years
+    {
+      op: { opType: 'add', timeUnit: 'years', timeAmount: '1' },
+      expectedResult: '2025-04-01T12:05:10.000+08:00',
+    },
+    {
+      op: { opType: 'subtract', timeUnit: 'years', timeAmount: '1' },
+      expectedResult: '2023-04-01T12:05:10.000+08:00',
+    },
   ])(
     'can $op.opType $op.timeAmount $op.timeUnit (without overflow / underflow)',
     ({ op, expectedResult }) => {
@@ -297,6 +317,19 @@ describe('add / subtract date time', () => {
     transformData($, valueToTransform)
     expect(mocks.setActionItem).toBeCalledWith({
       raw: { result: expectedResult },
+    })
+  })
+
+  it('clamps to end of month when adding a year onto a leap day (Feb 29 → Feb 28)', () => {
+    $.step.parameters = {
+      dateTimeFormat: 'formsgSubmissionTime',
+      addSubtractDateTimeOps: [
+        { opType: 'add', timeUnit: 'years', timeAmount: '1' },
+      ],
+    }
+    transformData($, '2024-02-29T00:00:00.000+08:00')
+    expect(mocks.setActionItem).toBeCalledWith({
+      raw: { result: '2025-02-28T00:00:00.000+08:00' },
     })
   })
 })

--- a/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
+++ b/packages/backend/src/apps/formatter/__tests__/date-time.common.test.ts
@@ -1,7 +1,7 @@
 import '@/types/luxon-extensions'
 
 import { DateTime, Settings as LuxonSettings } from 'luxon'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   dateTimeToString,
@@ -75,6 +75,58 @@ describe('common date-time formatter functions', () => {
     it('supports parsing MyInfo Child date field', () => {
       const dateTime = parseDateTime('dd/LL/yyyy', '25/03/2024')
       expect(dateTime.toUnixInteger()).toEqual(1711296000)
+    })
+  })
+
+  describe('excelFormattedDate', () => {
+    // EXCEL_EPOCH = 1899-12-30 (SG time). This corrects for Excel's phantom
+    // Feb 29 1900 leap-year bug: serial 45292 = 2024-01-01T00:00:00+08:00.
+    it('parses a known serial to the correct SG date (45292 = 2024-01-01)', () => {
+      const dateTime = parseDateTime('excelFormattedDate', '45292')
+      // 2024-01-01T00:00:00+08:00 = 2023-12-31T16:00:00Z
+      expect(dateTime.toUnixInteger()).toEqual(1704038400)
+    })
+
+    it('converts fractional serials to time of day (0.5 = 12:00 noon)', () => {
+      const dateTime = parseDateTime('excelFormattedDate', '45292.5')
+      // 2024-01-01T12:00:00+08:00 = 2024-01-01T04:00:00Z
+      expect(dateTime.toUnixInteger()).toEqual(1704081600)
+    })
+
+    it('trims whitespace from input', () => {
+      const dateTime = parseDateTime('excelFormattedDate', '  45292  ')
+      expect(dateTime.toUnixInteger()).toEqual(1704038400)
+    })
+
+    it.each(['0', '-1', 'abc', ''])('throws for invalid serial %s', (input) => {
+      expect(() => parseDateTime('excelFormattedDate', input)).toThrowError()
+    })
+
+    it('stringify throws (input-only format)', () => {
+      expect(() =>
+        dateTimeToString('excelFormattedDate', DateTime.now()),
+      ).toThrowError()
+    })
+  })
+
+  describe('now', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(1718445600000) // 2024-06-15T10:00:00.000Z = 18:00 SG
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('ignores the input value and returns the current time in SG timezone', () => {
+      expect(parseDateTime('now', 'ignored').toISO()).toEqual(
+        '2024-06-15T18:00:00.000+08:00',
+      )
+    })
+
+    it('stringify throws (input-only format)', () => {
+      expect(() => dateTimeToString('now', DateTime.now())).toThrowError()
     })
   })
 })

--- a/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/date-time-format.ts
@@ -22,9 +22,16 @@ interface DateFormatConverter {
   stringify: (dateTime: DateTime) => string
 }
 
+// All date parsing is pinned to Singapore time so that comparisons and
+// differences are not subject to off-by-one errors from a differing server
+// timezone.
+export const SG_TIMEZONE = 'Asia/Singapore'
+
 const supportedFormats = z.enum([
   'formsgSubmissionTime',
   'formsgDateField', // dd LLL yyyy; this is kept due to backwards compatibility
+  'now', // input-only: ignores the value field, uses current SG time
+  'excelFormattedDate', // input-only: e.g. 45292 -> 1 Jan 2024
   ...commonDateFormats,
 ])
 
@@ -48,6 +55,40 @@ const formatConverters = Object.assign({
     description: 'FormSG submission time',
     parse: (input: string): DateTime => DateTime.fromISO(input),
     stringify: (dateTime: DateTime): string => dateTime.toISO(),
+  },
+  now: {
+    description: 'current date / time',
+    // Input-only: the value field is ignored (hidden in the UI). We always
+    // use the current time in Singapore.
+    parse: (_input: string): DateTime => DateTime.now().setZone(SG_TIMEZONE),
+    stringify: (): string => {
+      throw new Error('"Now" is an input-only format and cannot be output to')
+    },
+  },
+  excelFormattedDate: {
+    description: 'Excel formatted date',
+    parse: (input: string): DateTime => {
+      const serial = Number(input?.toString().trim())
+      // Reject non-numbers and <= 0 (the 0 / negative serials are the
+      // "1900-01-00" oddity we don't want to support).
+      if (!Number.isFinite(serial) || serial <= 0) {
+        return DateTime.invalid('Invalid Excel formatted date')
+      }
+      // Excel's 1900 date system. Serial 1 = 1900-01-01, but Excel incorrectly
+      // treats 1900 as a leap year, so the corrected epoch is 1899-12-30.
+      // The fractional part of the serial is the time of day, so a plain
+      // `.plus({ days })` handles both date and time.
+      const excelEpoch = DateTime.fromObject(
+        { year: 1899, month: 12, day: 30 },
+        { zone: SG_TIMEZONE },
+      )
+      return excelEpoch.plus({ days: serial })
+    },
+    stringify: (): string => {
+      throw new Error(
+        'Excel formatted date is an input-only format and cannot be output to',
+      )
+    },
   },
   formsgDateField: {
     description: 'FormSG date field',
@@ -112,6 +153,10 @@ const formatConverters = Object.assign({
 // Field definitions and schema
 //
 
+// Exported so the schema can be reused by other actions (e.g. the
+// compare / calculate action's two date operands).
+export { supportedFormats }
+
 export const fieldSchema = z.object({
   // NOTE: Likely we will support arbitrary input in the future and this can no
   // longer be an enum. If that happens we can use a type guard to simulate
@@ -119,31 +164,50 @@ export const fieldSchema = z.object({
   dateTimeFormat: supportedFormats,
 })
 
+// The full list of input format options. Exported so any field that lets a
+// user declare the format of an incoming date (e.g. each operand of the
+// compare / calculate action) can reuse the exact same list.
+export const inputFormatOptions = [
+  {
+    label: 'Now (current date / time)',
+    description: 'Uses the current date and time in Singapore',
+    value: supportedFormats.enum.now,
+  },
+  {
+    label: 'FormSG Submission Time',
+    description: '2024-03-25T08:15:30.250+08:00',
+    value: supportedFormats.enum.formsgSubmissionTime,
+  },
+  {
+    // FormSG UI is a bit misleading; although the field shows dd/mm/yyyy,
+    // date fields are sent as dd MMM yyyy over webhooks.
+    label: 'FormSG Date Field - DD MMM YYYY',
+    description: '25 Mar 2024',
+    value: supportedFormats.enum.formsgDateField,
+  },
+  {
+    label: 'Excel formatted date',
+    description: 'e.g. 45292 → 1 Jan 2024',
+    value: supportedFormats.enum.excelFormattedDate,
+  },
+  // Exclude repeated option due to formsgDateField
+  ...commonDateFormatOptions.filter((option) => option.value !== 'dd LLL yyyy'),
+]
+
 export const field = {
-  label: 'Select the format of your value',
+  label: 'What format is your date / time in?',
   key: fieldSchema.keyof().enum.dateTimeFormat,
   type: 'dropdown' as const,
   required: true,
   variables: false,
   showOptionValue: false,
-  options: [
-    {
-      label: 'FormSG Submission Time',
-      description: '2024-03-25T08:15:30.250+08:00',
-      value: supportedFormats.enum.formsgSubmissionTime,
-    },
-    {
-      // FormSG UI is a bit misleading; although the field shows dd/mm/yyyy,
-      // date fields are sent as dd MMM yyyy over webhooks.
-      label: 'FormSG Date Field - DD MMM YYYY',
-      description: '25 Mar 2024',
-      value: supportedFormats.enum.formsgDateField,
-    },
-    // Exclude repeated option due to formsgDateField
-    ...commonDateFormatOptions.filter(
-      (option) => option.value !== 'dd LLL yyyy',
-    ),
-  ],
+  // "Now" is excluded here: it's a date *source*, not a format, and in this
+  // action the value field can't be hidden when it's picked (single-condition
+  // `hiddenIf`), so it would read confusingly. It stays available in the
+  // compare/calculate action, where the value field does hide.
+  options: inputFormatOptions.filter(
+    (option) => option.value !== supportedFormats.enum.now,
+  ),
 } satisfies IField
 
 //

--- a/packages/backend/src/apps/formatter/actions/date-time/common/time-units.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/common/time-units.ts
@@ -1,0 +1,27 @@
+import { type DurationLikeObject } from 'luxon'
+import z from 'zod'
+
+/**
+ * The single list of time units shared by every date action (add/subtract,
+ * compare, time gap, calculate between) so the options stay consistent.
+ *
+ * Keys match Luxon `Duration` keys so they can be passed straight to date math.
+ */
+export const timeUnitEnum = z.enum([
+  'seconds',
+  'minutes',
+  'hours',
+  'days',
+  'weeks',
+  'months',
+  'years',
+] as const satisfies ReadonlyArray<keyof DurationLikeObject>)
+
+function sentenceCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export const timeUnitOptions = timeUnitEnum.options.map((unit) => ({
+  label: sentenceCase(unit),
+  value: unit,
+}))

--- a/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
+++ b/packages/backend/src/apps/formatter/actions/date-time/transforms/add-subtract-date-time/fields.ts
@@ -1,20 +1,11 @@
-import { type DurationLikeObject } from 'luxon'
 import z from 'zod'
 
 import { type TransformSpec } from '@/apps/formatter/common/transform-spec'
 import { ensureZodObjectKey } from '@/helpers/zod-utils'
 
-const opTypeEnum = z.enum(['add', 'subtract'])
+import { timeUnitEnum, timeUnitOptions } from '../../common/time-units'
 
-const timeUnitEnum = z.enum([
-  'seconds',
-  'minutes',
-  'hours',
-  'days',
-  'months',
-  // To simplify date math code, values have the same keys as luxton
-  // duration objects.
-] as const satisfies ReadonlyArray<keyof DurationLikeObject>)
+const opTypeEnum = z.enum(['add', 'subtract'])
 
 const opsSchema = z.object({
   opType: opTypeEnum,
@@ -47,7 +38,7 @@ function sentenceCase(s: string): string {
 
 export const fields: TransformSpec['fields'] = [
   {
-    label: 'Specify the amount of time you want to add or subtract',
+    label: 'How much time do you want to add or subtract?',
     key: ensureZodObjectKey(fieldSchema.sourceType(), 'addSubtractDateTimeOps'),
     type: 'multirow-multicol' as const,
     required: true,
@@ -80,10 +71,7 @@ export const fields: TransformSpec['fields'] = [
         required: true,
         variables: false,
         showOptionValue: false,
-        options: timeUnitEnum.options.map((unit) => ({
-          label: sentenceCase(unit),
-          value: unit,
-        })),
+        options: timeUnitOptions,
         customStyle: { flex: 3 },
       },
     ],


### PR DESCRIPTION
## TL;DR

Adds Excel serial number and "Now" as new date input formats to the Formatter's date-time actions, extracts a shared `timeUnitEnum` (adding `weeks` and `years` to the add/subtract action), and adds unit test coverage for all new behaviour.

## What changed?

- **`excelSerial` input format** — parses Excel 1900-system serial numbers (e.g. `45292` → 1 Jan 2024), including fractional serials for time-of-day. Uses the corrected epoch of 1899-12-30 to account for Excel's phantom Feb 29, 1900 leap-year bug. Input-only; `stringify` throws.
- **`now` input format** — ignores the value field and returns the current time in Singapore timezone. Intended for use in the upcoming compare/calculate action where the value field can be hidden; excluded from the existing convert-date-time dropdown for now.
- **`timeUnitEnum` extraction** — moved from `add-subtract-date-time/fields.ts` to a shared `common/time-units.ts` module. This also adds `weeks` and `years` as supported units in the add/subtract action (they were previously omitted without reason).
- **`inputFormatOptions` export** — the full input format list (including `now`) is exported for reuse by future date operand fields in the compare/calculate action.
- **Bug fix: module-level `DateTime.fromObject` call** — the Excel epoch was originally computed as a module-level constant, which crashed integration tests that mock `luxon` before the formatter module loads. Moved inside the `parse` function, consistent with how all other `DateTime` calls in the file are structured.

## Tests

- [ ] In a flow, add a Formatter → Format date/time step. Confirm the input format dropdown shows Excel serial number and the existing formats — but **not** "Now".
- [ ] Set input format to **Excel serial number**, enter `45292` as the value, and convert to `dd LLL yyyy`. Confirm output is `01 Jan 2024`.
- [ ] Enter a fractional serial (e.g. `45292.5`) and convert to `dd LLL yyyy hh:mm a`. Confirm output is `01 Jan 2024 12:00 pm`.
- [ ] Enter an invalid serial (`0`, `-1`, `abc`). Confirm the step errors with a clear message rather than silently producing a wrong date.
- [ ] In a Formatter → Add/subtract date-time step, confirm **Weeks** and **Years** now appear in the time unit dropdown.
- [ ] Add 2 weeks to a known date and verify the result is 14 days later.
- [ ] Add 1 year to 29 Feb 2024 — confirm the result is 28 Feb 2025 (Luxon leap-year clamping).
- [ ] Confirm existing date format conversions (FormSG submission time, FormSG date field, common formats) are unaffected.
