### PR TITLE
[CHAT-ID-1] PLU-806 feat(ai-builder): accept chatId and ddRumSessionId for chat tracing

### DIFF
--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -237,31 +237,54 @@ describe('chatRequestSchema', () => {
     })
   })
 
-  describe('sessionId validation', () => {
-    it('should reject invalid UUID format', () => {
+  describe('tracing id validation', () => {
+    const validUuid = '550e8400-e29b-41d4-a716-446655440000'
+
+    it('should accept a request with chatId and ddRumSessionId', () => {
       const result = chatRequestSchema.safeParse({
         messages: [validMessage],
-        sessionId: 'not-a-uuid',
+        chatId: validUuid,
+        ddRumSessionId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
       })
-      expect(result.success).toBe(false)
-      expect(result.error?.issues[0].message).toBe(
-        'Session ID must be a valid UUID',
-      )
+      expect(result.success).toBe(true)
     })
 
-    it('should accept missing sessionId', () => {
+    it('should accept a legacy request with only sessionId', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+        sessionId: validUuid,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept a request with all tracing ids missing', () => {
       const result = chatRequestSchema.safeParse({
         messages: [validMessage],
       })
       expect(result.success).toBe(true)
     })
 
-    it('should accept empty sessionId', () => {
-      const result = chatRequestSchema.safeParse({
-        messages: [validMessage],
-        sessionId: '',
-      })
-      expect(result.success).toBe(true)
-    })
+    it.each(['chatId', 'ddRumSessionId', 'sessionId'])(
+      'should accept an empty %s',
+      (field) => {
+        const result = chatRequestSchema.safeParse({
+          messages: [validMessage],
+          [field]: '',
+        })
+        expect(result.success).toBe(true)
+      },
+    )
+
+    it.each(['chatId', 'ddRumSessionId', 'sessionId'])(
+      'should reject a malformed %s',
+      (field) => {
+        const result = chatRequestSchema.safeParse({
+          messages: [validMessage],
+          [field]: 'not-a-uuid',
+        })
+        expect(result.success).toBe(false)
+        expect(result.error?.issues[0].message).toBe('Must be a valid UUID')
+      },
+    )
   })
 })

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -71,7 +71,16 @@ const handleChatStream = observe(
         return
       }
 
-      const { messages: rawMessages, sessionId } = validationResult.data
+      const {
+        messages: rawMessages,
+        chatId,
+        ddRumSessionId,
+        sessionId,
+      } = validationResult.data
+
+      // The RUM session id, preferring the new field but accepting the legacy
+      // `sessionId` from clients deployed before the chatId change.
+      const rumSessionId = ddRumSessionId || sessionId
 
       // Convert UIMessages to ModelMessages
       const messages = convertToModelMessages(
@@ -100,7 +109,8 @@ const handleChatStream = observe(
 
       logger.info('Starting AI chat stream', {
         traceId,
-        sessionId,
+        chatId,
+        ddRumSessionId: rumSessionId,
         userId: context.currentUser.email,
         model: MODEL_TYPE,
       })
@@ -150,7 +160,13 @@ const handleChatStream = observe(
               functionId: 'ai-chat-stream',
               metadata: {
                 name: 'ai-chat-stream',
-                sessionId: sessionId || 'unknown',
+                // Langfuse session = the chat session. Falls back to the RUM id for
+                // old clients during rollout, then 'unknown'. The fallbacks are
+                // removed in the cleanup release once old clients have drained.
+                sessionId: chatId || rumSessionId || 'unknown',
+                // Plain metadata (non-special key) so RUM traces can still be
+                // correlated with Langfuse without driving session grouping.
+                ddRumSessionId: rumSessionId || undefined,
                 userId: context.currentUser.email,
                 environment: appConfig.appEnv,
                 promptName: chatPromptName,

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -5,6 +5,19 @@ import { flowStepsSchema } from '@/helpers/ai/types'
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+/**
+ * Lenient schema for the tracing id fields (chatId, ddRumSessionId, and the
+ * legacy sessionId). Optional and allows an empty string (e.g. in dev) so a
+ * missing or malformed telemetry value never fails the chat request — we already
+ * have the user's email for correlation.
+ */
+const optionalTracingId = z
+  .string()
+  .refine((val) => val === '' || UUID_REGEX.test(val), {
+    message: 'Must be a valid UUID',
+  })
+  .optional()
+
 // Limits to protect API and LLM costs
 const MAX_MESSAGES = 50
 const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
@@ -89,15 +102,21 @@ export const chatRequestSchema = z.object({
     .min(1, 'Messages array must contain at least one message')
     .max(MAX_MESSAGES, `Cannot send more than ${MAX_MESSAGES} messages`),
   /**
-   * Datadog RUM session UUID for debugging. Optional and allows empty string
-   * (e.g., in dev) to avoid failing the API since we already have the user's email.
+   * Unique id for one AI Builder chat session, minted on the frontend. Used as the
+   * Langfuse session id so all traces from one conversation group together.
    */
-  sessionId: z
-    .string()
-    .refine((val) => val === '' || UUID_REGEX.test(val), {
-      message: 'Session ID must be a valid UUID',
-    })
-    .optional(),
+  chatId: optionalTracingId,
+  /**
+   * Datadog RUM session UUID, carried into Langfuse traces as plain metadata for
+   * cross-referencing. Does NOT define the chat session.
+   */
+  ddRumSessionId: optionalTracingId,
+  /**
+   * @deprecated Legacy alias for the Datadog RUM session id sent by clients before
+   * the chatId change. Treated as ddRumSessionId when the newer field is absent.
+   * Remove one release after rollout, once old clients have drained.
+   */
+  sessionId: optionalTracingId,
 })
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>


### PR DESCRIPTION
## TL;DR

Add two new optional fields (`chatId`, `ddRumSessionId`) to the AI Builder chat API, restructuring how tracing ids flow into Langfuse. The chat session is now driven by `chatId` (one per conversation), while the Datadog RUM session is recorded as plain metadata. Keeps the legacy `sessionId` field as a deprecated alias during rollout.

## What changed?

- **`packages/backend/src/routes/api/chat/schema.ts`** — Extracted a shared `optionalTracingId` Zod schema (UUID-or-empty, optional). Added `chatId` and `ddRumSessionId` fields. Deprecated `sessionId` with a JSDoc comment explaining it's a legacy RUM alias.
- **`packages/backend/src/routes/api/chat/index.ts`** — Reads all three fields; resolves `rumSessionId = ddRumSessionId || sessionId` for backward compat during rollout. Maps `chatId` as the Langfuse session id (falling back to `rumSessionId` then `'unknown'`). Records `ddRumSessionId` as plain Langfuse metadata.
- **Tests** — Updated `schema.test.ts` to cover `chatId`, `ddRumSessionId`, and the deprecated `sessionId` individually (empty/valid/malformed).

## Tests

**Manual verification:**

1. Open the AI Builder chat and send a message — confirm the request succeeds with no schema errors.
2. In Langfuse, verify the new trace has a `sessionId` set (not `'unknown'`) — this will only be populated once the frontend PR (`send-chat-session-id`) is also deployed.
3. Verify backward compat: send a request with only the legacy `sessionId` field and confirm it still works and maps to the RUM metadata in Langfuse.
4. Confirm a request with no tracing fields at all still succeeds (no 400 error).