### PR TITLE
[CHAT-ID-2] PLU-806 feat(ai-builder): send chatId per chat session to Langfuse

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -67,7 +67,7 @@ export function useChatStream(options: UseChatStreamOptions) {
   const toast = useToast()
   const navigate = useNavigate()
   const location = useLocation()
-  const { ddSessionId } = useAiBuilderContext()
+  const { ddSessionId, chatId } = useAiBuilderContext()
 
   // Track step readiness from data-isChatReady annotation
   // Initialize based on whether initialMessages contains a ready message.
@@ -88,6 +88,12 @@ export function useChatStream(options: UseChatStreamOptions) {
   // (e.g. the old 50 messages after clicking "New Chat").
   const initialMessagesRef = useRef(options?.initialMessages)
   initialMessagesRef.current = options?.initialMessages
+
+  // chatId is minted after mount and changes on "New Chat" (without a remount), so the
+  // transport closure captured on mount would otherwise send a stale/empty id. Read the
+  // latest value through a ref at send time.
+  const chatIdRef = useRef(chatId)
+  chatIdRef.current = chatId
 
   const {
     messages: aiMessages,
@@ -130,7 +136,10 @@ export function useChatStream(options: UseChatStreamOptions) {
 
         const body = {
           messages: allMessages,
-          sessionId: ddSessionId,
+          // chatId drives the Langfuse session; the RUM session id is sent as plain
+          // metadata for cross-referencing (no longer the session driver).
+          chatId: chatIdRef.current,
+          ddRumSessionId: ddSessionId,
         }
         return { body }
       },

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -17,6 +17,13 @@ export interface AIBuilderDraftState {
   // output can be populated (IStep values) or the initial empty state (empty strings)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   output: Record<string, any>
+  /**
+   * Unique id for this chat session, used as the Langfuse session id. Optional on the
+   * type because a draft persisted before this field existed may not have one; that
+   * case is left as-is rather than backfilled (see createNewChatDraft in new-chat.ts
+   * for where a fresh chatId is actually minted).
+   */
+  chatId?: string
 }
 
 interface AIBuilderSharedProps extends AIBuilderDraftState {
@@ -40,6 +47,8 @@ interface AIBuilderContextValue extends AIBuilderSharedProps {
   stepGroupCaption: string | null
   // DataDog RUM Session ID so we can associate the trace with the RUM
   ddSessionId: string
+  // Unique id for this chat session, used as the Langfuse session id
+  chatId: string
   isDrawerOpen: boolean
   setIsDrawerOpen: (open: boolean) => void
 }
@@ -68,6 +77,7 @@ export const AiBuilderContextProvider = ({
   chatInput,
   chatMessages,
   output,
+  chatId,
   clearPersistedState,
   setChatState,
 }: AiBuilderContextProviderProps) => {
@@ -144,6 +154,7 @@ export const AiBuilderContextProvider = ({
         stepGroupType,
         stepGroupCaption,
         ddSessionId,
+        chatId: chatId ?? '',
         clearPersistedState,
         setChatState,
         isDrawerOpen,

--- a/packages/frontend/src/pages/AiBuilder/__tests__/new-chat.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/__tests__/new-chat.test.ts
@@ -1,0 +1,56 @@
+import { webcrypto } from 'node:crypto'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { createNewChatDraft, extractContinuationPrompt } from '../new-chat'
+
+// The test environment doesn't expose `crypto` as a global (no jsdom/browser
+// shim). Wire it up from Node's built-in webcrypto so the tests can run.
+beforeAll(() => {
+  vi.stubGlobal('crypto', webcrypto)
+})
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('extractContinuationPrompt', () => {
+  it('extracts and trims the text inside a <code> block', () => {
+    expect(
+      extractContinuationPrompt(
+        'Sure, try this:\n<code>  Build a form  </code>',
+      ),
+    ).toBe('Build a form')
+  })
+
+  it('returns an empty string when there is no <code> block', () => {
+    expect(extractContinuationPrompt('No code here')).toBe('')
+  })
+
+  it('returns an empty string for undefined input', () => {
+    expect(extractContinuationPrompt(undefined)).toBe('')
+  })
+})
+
+describe('createNewChatDraft', () => {
+  it('mints a valid UUID chatId', () => {
+    expect(createNewChatDraft().chatId).toMatch(UUID_REGEX)
+  })
+
+  it('mints a new chatId on every call (a new chat is always a new session)', () => {
+    const ids = new Set(
+      Array.from({ length: 5 }, () => createNewChatDraft().chatId),
+    )
+    expect(ids.size).toBe(5)
+  })
+
+  it('seeds chatInput with the continuation prompt and starts with no messages', () => {
+    const draft = createNewChatDraft('<code>Send a Slack message</code>')
+    expect(draft.chatInput).toBe('Send a Slack message')
+    expect(draft.chatMessages).toEqual([])
+  })
+
+  it('called with no argument, produces the default empty draft (used for a fresh mount with nothing persisted)', () => {
+    const draft = createNewChatDraft()
+    expect(draft.chatInput).toBe('')
+    expect(draft.chatMessages).toEqual([])
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -8,6 +8,7 @@ import { Message } from '@/hooks/useChatStream'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import ChatMessages from '@/pages/AiBuilder/components/ChatMessages'
 import { PLACEHOLDER_MESSAGES } from '@/pages/AiBuilder/constants'
+import { createNewChatDraft } from '@/pages/AiBuilder/new-chat'
 
 import MessageLimitBanner from './MessageLimitBanner'
 import PromptInput from './PromptInput'
@@ -54,17 +55,11 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat()
     setIsDrawerOpen(false)
 
-    // Extract continuation prompt from the last assistant message (between <code> tags)
+    // Build the new draft from the last assistant message's continuation prompt.
+    // createNewChatDraft() always mints its own fresh chatId, so the new chat starts
+    // its own Langfuse session and never carries the old id forward.
     const lastMessage = messages[messages.length - 1]
-    const match = lastMessage?.text?.match(/<code[^>]*>([\s\S]*?)<\/code>/)
-    const continuationPrompt = match ? match[1].trim() : ''
-
-    const newState = {
-      flowName: 'Build with AI',
-      chatInput: continuationPrompt,
-      chatMessages: [],
-      output: { trigger: '', actions: '', name: 'Build with AI', traceId: '' },
-    }
+    const newState = createNewChatDraft(lastMessage?.text)
 
     // Synchronously update persisted state so the next render sees empty messages
     // immediately (avoids a stale intermediate render with old messages)

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -14,6 +14,7 @@ import {
   AiBuilderContextProvider,
   useAiBuilderContext,
 } from './AiBuilderContext'
+import { createNewChatDraft } from './new-chat'
 
 function AiBuilderContent() {
   const navigate = useNavigate()
@@ -125,30 +126,34 @@ function AiBuilderContent() {
 export default function AiBuilder() {
   const locationState = useLocation()?.state
 
-  // Persist state to sessionStorage so it survives refresh
+  // Persist state to sessionStorage so it survives refresh.
+  //
+  // locationState-carried drafts already have a chatId from wherever they were created ("New Chat", or a
+  // prior render of this same draft);
+  // createNewChatDraft() (no argument, so no continuation prompt) mints one for a genuinely fresh session.
+  //
+  // NOTE: any new navigate() call that passes `state` into this page needs a chatId
   const [persistedState, setPersistedState, clearPersistedState] =
     usePersistedState(
       'ai-builder-draft',
-      locationState || {
-        flowName: 'Build with AI',
-        chatInput: '',
-        chatMessages: [],
-        output: {
-          trigger: '',
-          actions: '',
-          name: 'Build with AI',
-        },
-      },
+      () => locationState || createNewChatDraft(),
     )
 
   // Sync location state updates (from useChatStream navigate calls) to persisted state
   useEffect(() => {
     if (locationState) {
-      setPersistedState(locationState)
+      setPersistedState((prev: typeof persistedState) => ({
+        ...locationState,
+        // Preserve the existing chatId when the navigation state doesn't carry one.
+        // onFinish navigates after every message; without this the minted chatId would
+        // be wiped and regenerated each message. "New Chat" sets a fresh chatId in
+        // locationState, so it still correctly starts a new session.
+        chatId: locationState.chatId ?? prev.chatId,
+      }))
     }
   }, [locationState, setPersistedState])
 
-  const { flowName, output, chatInput, chatMessages } = persistedState
+  const { flowName, output, chatInput, chatMessages, chatId } = persistedState
 
   return (
     <AiBuilderContextProvider
@@ -156,6 +161,7 @@ export default function AiBuilder() {
       chatInput={chatInput}
       chatMessages={chatMessages}
       output={output}
+      chatId={chatId}
       clearPersistedState={clearPersistedState}
       setChatState={setPersistedState}
     >

--- a/packages/frontend/src/pages/AiBuilder/new-chat.ts
+++ b/packages/frontend/src/pages/AiBuilder/new-chat.ts
@@ -1,0 +1,31 @@
+import type { AIBuilderDraftState } from './AiBuilderContext'
+
+// The assistant wraps a suggested continuation prompt in a <code> block; "New Chat"
+// pre-fills the input with it so the user can carry the idea into the new conversation.
+const CONTINUATION_PROMPT_REGEX = /<code[^>]*>([\s\S]*?)<\/code>/
+
+/**
+ * Extract the continuation prompt from an assistant message's <code> block, if present.
+ */
+export const extractContinuationPrompt = (lastMessageText?: string): string => {
+  const match = lastMessageText?.match(CONTINUATION_PROMPT_REGEX)
+  return match ? match[1].trim() : ''
+}
+
+/**
+ * Build the draft state for a brand-new chat. Always mints a fresh chatId so the new
+ * chat starts a new Langfuse session — never carrying the previous chat's id forward.
+ *
+ * Also doubles as the default draft for a fresh mount with nothing usable in
+ * sessionStorage (first-ever visit, or a session that expired): called with no
+ * argument, `extractContinuationPrompt` returns `''`, giving the same empty draft.
+ */
+export const createNewChatDraft = (
+  lastMessageText?: string,
+): AIBuilderDraftState => ({
+  flowName: 'Build with AI',
+  chatInput: extractContinuationPrompt(lastMessageText),
+  chatMessages: [],
+  output: { trigger: '', actions: '', name: 'Build with AI', traceId: '' },
+  chatId: crypto.randomUUID(),
+})


### PR DESCRIPTION
## TL;DR

The frontend now mints a unique `chatId` per chat session and sends it with every `/api/chat` request so each conversation becomes its own Langfuse session — enabling end-to-end trace grouping per chat.

## What changed?

- **`packages/frontend/src/pages/AiBuilder/new-chat.ts`** — `createNewChatDraft()` mints a fresh chatId and optionally extracts a continuation prompt from the last assistant message's `<code>` block. Called with no argument, it also serves as the default draft for a genuinely fresh mount (empty `chatInput`, fresh chatId) — used by `usePersistedState`'s lazy initializer in `index.tsx` — so there's a single function for "this is a new session" rather than two near-duplicates.
- **`packages/frontend/src/pages/AiBuilder/index.tsx`** — The default draft (nothing usable in `sessionStorage` yet) mints its chatId synchronously via `usePersistedState`'s lazy initializer, rather than via a `useEffect` after mount. The `useEffect` that syncs location state still preserves the existing `chatId` when navigation state doesn't carry one (prevents the id being wiped after each `onFinish` navigation).
- **`packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx`** — `chatId` is exposed on the provider state. `ddRumSessionId` from the Datadog RUM SDK is read and passed alongside it to the chat hook.
- **`packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx`** — "New Chat" calls `createNewChatDraft()`, ensuring a fresh chatId is always minted on each new conversation.
- **`packages/frontend/src/hooks/useChatStream.ts`** — `chatId` and `ddRumSessionId` forwarded in the POST body to `/api/chat`.
- **Tests** — `new-chat.test.ts` covers `createNewChatDraft()`, including the no-argument (default draft) path; test env polyfilled with Node's `webcrypto` for `crypto.randomUUID()`.

### Design note: why a `useEffect` isn't used to mint chatId

An earlier version of this PR minted `chatId` in a `useEffect` whenever it was missing — covering both a fresh session and a legacy draft (one persisted to `sessionStorage` before this field existed). That was removed in favor of minting only at the two points a session actually begins (the default-draft initializer, and `createNewChatDraft()` for "New Chat"), for two reasons: minting is non-deterministic (`crypto.randomUUID()`) and persists to `sessionStorage`, so doing it in render/effect timing risked wasted or duplicated writes; and, more importantly, a **legacy draft (already mid-conversation, no chatId) is deliberately left as-is rather than backfilled**. Backfilling it later would split that one conversation into two separate Langfuse sessions the moment a client picks up this change — whereas leaving it alone lets it keep falling back to the existing Datadog RUM session id on the backend, so it stays grouped as a single session throughout.

## Tests

**Manual verification:**

1. Open AI Builder, send a few messages — each message in the same tab session should share a `chatId` (same Langfuse session).
2. Click "New Chat" — the next conversation should have a *different* `chatId` (new Langfuse session). Verify in Langfuse that the two conversations appear as separate sessions.
3. Reload the page mid-conversation — the `chatId` should be preserved (persisted to session storage) so continuing the conversation stays in the same Langfuse session.
4. Verify no regressions: the continuation prompt still pre-fills the input on "New Chat" from the last assistant message's `<code>` block.