### PR TITLE
feat(formsg): clarify MRF forms are read-only in the editor

### DIFF
--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -1,7 +1,24 @@
-import { useCallback, useContext } from 'react'
-import { Flex, Tab, TabList, TabProps, Tabs } from '@chakra-ui/react'
+import { useCallback, useContext, useState } from 'react'
+import {
+  Flex,
+  Popover,
+  PopoverAnchor,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  Tab,
+  TabList,
+  TabProps,
+  Tabs,
+  Text,
+} from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
 
 import { MrfContext } from '@/contexts/MrfContext'
+import {
+  dismissMrfApprovalHint,
+  hasSeenMrfApprovalHint,
+} from '@/helpers/formsg'
 
 const tabStyle = (primaryColor: string): TabProps => {
   return {
@@ -32,30 +49,82 @@ export function ApproveReject({ stepId }: { stepId: string }) {
 
   const isApproveBranch = approvalBranches[stepId] === 'approve'
 
+  const [isHintOpen, setIsHintOpen] = useState(false)
+
+  const dismissHint = useCallback(() => {
+    setIsHintOpen(false)
+    dismissMrfApprovalHint()
+  }, [])
+
   const onChange = useCallback(
     (index: number) => {
-      setApprovalBranch(stepId, index === 0 ? 'approve' : 'reject')
+      const branch = index === 0 ? 'approve' : 'reject'
+      setApprovalBranch(stepId, branch)
+      // Show the one-way reminder the first time a user reaches for "If rejected",
+      // the clearest signal they may think they're configuring the form itself.
+      if (branch === 'reject' && !hasSeenMrfApprovalHint()) {
+        setIsHintOpen(true)
+      } else {
+        // Close the hint if they switch back to "If approved" while it's open.
+        setIsHintOpen(false)
+      }
     },
     [stepId, setApprovalBranch],
   )
 
   return (
-    <Flex onClick={(e) => e.stopPropagation()} w="100%" maxW="600px" px={4}>
-      <Tabs
-        variant="enclosed-colored"
-        index={isApproveBranch ? 0 : 1}
-        backgroundColor="base.divider.medium"
-        py={1}
-        px={0.5}
-        borderRadius="md"
-        onChange={onChange}
-        flex={1}
+    <Flex
+      onClick={(e) => e.stopPropagation()}
+      flexDir="column"
+      w="100%"
+      maxW="600px"
+      px={4}
+      pb={3}
+      gap={1}
+    >
+      <Popover
+        isOpen={isHintOpen}
+        onClose={dismissHint}
+        placement="bottom"
+        closeOnBlur={false}
       >
-        <TabList gap={2} overflow="hidden">
-          <Tab {...tabStyle('green.500')}>If approved</Tab>
-          <Tab {...tabStyle('red.500')}>If rejected</Tab>
-        </TabList>
-      </Tabs>
+        <PopoverAnchor>
+          <Tabs
+            variant="enclosed-colored"
+            index={isApproveBranch ? 0 : 1}
+            backgroundColor="base.divider.medium"
+            py={1}
+            px={0.5}
+            borderRadius="md"
+            onChange={onChange}
+            flex={1}
+          >
+            <TabList gap={2} overflow="hidden">
+              <Tab {...tabStyle('green.500')}>If approved</Tab>
+              <Tab {...tabStyle('red.500')}>If rejected</Tab>
+            </TabList>
+          </Tabs>
+        </PopoverAnchor>
+        <PopoverContent>
+          <PopoverArrow />
+          <PopoverBody>
+            <Text textStyle="body-2" color="base.content.default" mb={3}>
+              To change who approves or the steps, edit your form in FormSG,
+              then click &ldquo;Check step&rdquo; to sync. Editing here
+              won&rsquo;t change your form.
+            </Text>
+            <Flex justifyContent="flex-end">
+              <Button size="xs" onClick={dismissHint}>
+                Okay
+              </Button>
+            </Flex>
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+      <Text textStyle="body-2" color="base.content.medium">
+        This approval comes from your form in FormSG. Choosing a branch here
+        only tells Plumber what to do next. It won&rsquo;t change your form.
+      </Text>
     </Flex>
   )
 }

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -74,15 +74,7 @@ export function ApproveReject({ stepId }: { stepId: string }) {
   )
 
   return (
-    <Flex
-      onClick={(e) => e.stopPropagation()}
-      flexDir="column"
-      w="100%"
-      maxW="600px"
-      px={4}
-      pb={3}
-      gap={1}
-    >
+    <Flex flexDir="column" w="100%" maxW="600px" px={4} pb={3} gap={1}>
       <Box onClick={(e) => e.stopPropagation()}>
         <Popover
           isOpen={isHintOpen}

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -84,7 +84,7 @@ export function ApproveReject({ stepId }: { stepId: string }) {
     >
       <Popover
         isOpen={isHintOpen}
-        onClose={dismissHint}
+        onClose={() => setIsHintOpen(false)}
         placement="bottom"
         closeOnBlur={false}
       >

--- a/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
+++ b/packages/frontend/src/components/FlowStep/components/ApproveReject.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useState } from 'react'
 import {
+  Box,
   Flex,
   Popover,
   PopoverAnchor,
@@ -82,45 +83,47 @@ export function ApproveReject({ stepId }: { stepId: string }) {
       pb={3}
       gap={1}
     >
-      <Popover
-        isOpen={isHintOpen}
-        onClose={() => setIsHintOpen(false)}
-        placement="bottom"
-        closeOnBlur={false}
-      >
-        <PopoverAnchor>
-          <Tabs
-            variant="enclosed-colored"
-            index={isApproveBranch ? 0 : 1}
-            backgroundColor="base.divider.medium"
-            py={1}
-            px={0.5}
-            borderRadius="md"
-            onChange={onChange}
-            flex={1}
-          >
-            <TabList gap={2} overflow="hidden">
-              <Tab {...tabStyle('green.500')}>If approved</Tab>
-              <Tab {...tabStyle('red.500')}>If rejected</Tab>
-            </TabList>
-          </Tabs>
-        </PopoverAnchor>
-        <PopoverContent>
-          <PopoverArrow />
-          <PopoverBody>
-            <Text textStyle="body-2" color="base.content.default" mb={3}>
-              To change who approves or the steps, edit your form in FormSG,
-              then click &ldquo;Check step&rdquo; to sync. Editing here
-              won&rsquo;t change your form.
-            </Text>
-            <Flex justifyContent="flex-end">
-              <Button size="xs" onClick={dismissHint}>
-                Okay
-              </Button>
-            </Flex>
-          </PopoverBody>
-        </PopoverContent>
-      </Popover>
+      <Box onClick={(e) => e.stopPropagation()}>
+        <Popover
+          isOpen={isHintOpen}
+          onClose={() => setIsHintOpen(false)}
+          placement="bottom"
+          closeOnBlur={false}
+        >
+          <PopoverAnchor>
+            <Tabs
+              variant="enclosed-colored"
+              index={isApproveBranch ? 0 : 1}
+              backgroundColor="base.divider.medium"
+              py={1}
+              px={0.5}
+              borderRadius="md"
+              onChange={onChange}
+              flex={1}
+            >
+              <TabList gap={2} overflow="hidden">
+                <Tab {...tabStyle('green.500')}>If approved</Tab>
+                <Tab {...tabStyle('red.500')}>If rejected</Tab>
+              </TabList>
+            </Tabs>
+          </PopoverAnchor>
+          <PopoverContent>
+            <PopoverArrow />
+            <PopoverBody>
+              <Text textStyle="body-2" color="base.content.default" mb={3}>
+                To change who approves for the steps, edit your form in FormSG,
+                then click &ldquo;Check step&rdquo; to sync. Editing here
+                won&rsquo;t change your form.
+              </Text>
+              <Flex justifyContent="flex-end">
+                <Button size="xs" onClick={dismissHint}>
+                  Okay
+                </Button>
+              </Flex>
+            </PopoverBody>
+          </PopoverContent>
+        </Popover>
+      </Box>
       <Text textStyle="body-2" color="base.content.medium">
         This approval comes from your form in FormSG. Choosing a branch here
         only tells Plumber what to do next. It won&rsquo;t change your form.

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -250,6 +250,7 @@ export default function FlowStep(
                 borderBottomRadius="none"
                 borderBottomWidth={0}
                 w={headerWidth}
+                overflow="hidden"
               >
                 <Infobox
                   icon={<BiSolidErrorCircle />}

--- a/packages/frontend/src/components/FlowStep/index.tsx
+++ b/packages/frontend/src/components/FlowStep/index.tsx
@@ -1,7 +1,7 @@
 import type { IStep } from '@plumber/types'
 
 import { useCallback, useContext, useMemo } from 'react'
-import { BiInfoCircle } from 'react-icons/bi'
+import { BiInfoCircle, BiSolidErrorCircle } from 'react-icons/bi'
 import { Box, CircularProgress, Flex, useDisclosure } from '@chakra-ui/react'
 import { Infobox } from '@opengovsg/design-system-react'
 
@@ -80,6 +80,8 @@ export default function FlowStep(
     shouldShowDragHandle,
     isDeletable,
     isApprovalStep,
+    isMrfStep,
+    warnsMrfNoGate,
   } = useStepMetadata(step, allowReorder)
 
   const {
@@ -172,10 +174,18 @@ export default function FlowStep(
       !!templateStepHelpMessage) ||
     !!step.config.templateConfig?.customTemplate
 
+  // Persistent reminder on the MRF trigger step that the FormSG connection is
+  // read-only: these steps are based on the form, Plumber never edits it.
+  const showMrfReadOnlyNote = isMrfStep && isTrigger
+
   // NOTE: there will only be 1 infobox shown at a time
   // there will not be a situation where both are shown as template messages
   // are removed once user executes a successful test
-  const hasInfoBox = shouldShowTemplateMsg || shouldTestStepAgain
+  const hasInfoBox =
+    shouldShowTemplateMsg ||
+    shouldTestStepAgain ||
+    showMrfReadOnlyNote ||
+    warnsMrfNoGate
 
   if (!allApps) {
     return <CircularProgress isIndeterminate my={2} />
@@ -206,6 +216,55 @@ export default function FlowStep(
             flex="1"
             minW="0"
           >
+            {showMrfReadOnlyNote && (
+              <Box
+                borderColor={
+                  shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
+                }
+                borderRadius="lg"
+                borderWidth="1px"
+                borderBottomRadius="none"
+                borderBottomWidth={0}
+                w={headerWidth}
+              >
+                <Infobox
+                  icon={<BiInfoCircle />}
+                  variant="secondary"
+                  style={{
+                    borderBottomLeftRadius: '0',
+                    borderBottomRightRadius: '0',
+                  }}
+                >
+                  These steps are based on your form in FormSG. Plumber only
+                  reads your form and never makes changes to it.
+                </Infobox>
+              </Box>
+            )}
+            {warnsMrfNoGate && (
+              <Box
+                borderColor={
+                  shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
+                }
+                borderRadius="lg"
+                borderWidth="1px"
+                borderBottomRadius="none"
+                borderBottomWidth={0}
+                w={headerWidth}
+              >
+                <Infobox
+                  icon={<BiSolidErrorCircle />}
+                  variant="warning"
+                  style={{
+                    borderBottomLeftRadius: '0',
+                    borderBottomRightRadius: '0',
+                  }}
+                >
+                  This won&rsquo;t stop the next respondent. FormSG still sends
+                  them the form. &ldquo;Only continue if&rdquo; only skips the
+                  Plumber steps below.
+                </Infobox>
+              </Box>
+            )}
             {shouldTestStepAgain && (
               <TestAgainInfobox
                 isNested={isNested}
@@ -248,7 +307,8 @@ export default function FlowStep(
                 shouldHighlight ? 'base.content.brand' : 'base.divider.medium'
               }
               borderTopRadius={hasInfoBox ? 'none' : 'lg'}
-              h={isNested ? '56px' : isApprovalStep ? '124px' : '64px'}
+              h={isNested ? '56px' : isApprovalStep ? undefined : '64px'}
+              minH={isApprovalStep && !isNested ? '124px' : undefined}
               w={headerWidth}
               onClick={handleClick}
             >

--- a/packages/frontend/src/helpers/__tests__/formsg.test.ts
+++ b/packages/frontend/src/helpers/__tests__/formsg.test.ts
@@ -1,0 +1,89 @@
+import { IStep } from '@plumber/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  dismissMrfApprovalHint,
+  hasSeenMrfApprovalHint,
+  MRF_APPROVAL_HINT_STORAGE_KEY,
+  shouldWarnMrfOnlyContinueIf,
+} from '@/helpers/formsg'
+import * as storage from '@/helpers/storage'
+
+describe('MRF approval hint dismissal', () => {
+  let store: Record<string, string>
+
+  beforeEach(() => {
+    store = {}
+    vi.spyOn(storage, 'getItem').mockImplementation((key) => store[key] ?? null)
+    vi.spyOn(storage, 'setItem').mockImplementation((key, value) => {
+      store[key] = value
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports the hint as unseen when nothing is stored', () => {
+    expect(hasSeenMrfApprovalHint()).toBe(false)
+  })
+
+  it('reports the hint as seen once it has been dismissed', () => {
+    dismissMrfApprovalHint()
+    expect(hasSeenMrfApprovalHint()).toBe(true)
+  })
+
+  it('persists dismissal under the namespaced storage key', () => {
+    dismissMrfApprovalHint()
+    expect(store[MRF_APPROVAL_HINT_STORAGE_KEY]).toBeDefined()
+  })
+})
+
+describe('shouldWarnMrfOnlyContinueIf', () => {
+  const onlyContinueIfStep = {
+    id: 'oci',
+    appKey: 'toolbox',
+    key: 'onlyContinueIf',
+    position: 3,
+  } as IStep
+
+  const subtriggerAt = (position: number) =>
+    ({
+      id: `mrf-${position}`,
+      appKey: 'formsg',
+      key: 'mrfSubmission',
+      position,
+    } as IStep)
+
+  it('is false when the step is not "Only continue if"', () => {
+    const step = { ...onlyContinueIfStep, key: 'ifThen' } as IStep
+    expect(
+      shouldWarnMrfOnlyContinueIf({ step, mrfSteps: [subtriggerAt(5)] }),
+    ).toBe(false)
+  })
+
+  it('is false when there are no MRF subtrigger steps', () => {
+    expect(
+      shouldWarnMrfOnlyContinueIf({ step: onlyContinueIfStep, mrfSteps: [] }),
+    ).toBe(false)
+  })
+
+  it('is false when every subtrigger is at or before the step position', () => {
+    expect(
+      shouldWarnMrfOnlyContinueIf({
+        step: onlyContinueIfStep,
+        mrfSteps: [subtriggerAt(1), subtriggerAt(3)],
+      }),
+    ).toBe(false)
+  })
+
+  it('is true when a subtrigger comes after the step', () => {
+    expect(
+      shouldWarnMrfOnlyContinueIf({
+        step: onlyContinueIfStep,
+        mrfSteps: [subtriggerAt(1), subtriggerAt(5)],
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/frontend/src/helpers/__tests__/toolbox.test.ts
+++ b/packages/frontend/src/helpers/__tests__/toolbox.test.ts
@@ -1,0 +1,36 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
+
+function makeStep(overrides: Partial<IStep> = {}): IStep {
+  return {
+    id: 'step-1',
+    type: 'action',
+    position: 2,
+    appKey: 'toolbox',
+    key: 'onlyContinueIf',
+    parameters: {},
+    config: {},
+    ...overrides,
+  } as IStep
+}
+
+describe('isOnlyContinueIfStep', () => {
+  it('is true for a toolbox "Only continue if" step', () => {
+    expect(isOnlyContinueIfStep(makeStep())).toBe(true)
+  })
+
+  it('is false for an if-then step', () => {
+    expect(isOnlyContinueIfStep(makeStep({ key: 'ifThen' }))).toBe(false)
+  })
+
+  it('is false for a for-each step', () => {
+    expect(isOnlyContinueIfStep(makeStep({ key: 'forEach' }))).toBe(false)
+  })
+
+  it('is false for a non-toolbox step with the same key', () => {
+    expect(isOnlyContinueIfStep(makeStep({ appKey: 'formsg' }))).toBe(false)
+  })
+})

--- a/packages/frontend/src/helpers/formsg.ts
+++ b/packages/frontend/src/helpers/formsg.ts
@@ -1,8 +1,46 @@
 import { IStep, IStepApprovalBranch, IStepApprovalConfig } from '@plumber/types'
 
+import { getItem, setItem } from '@/helpers/storage'
+import { isOnlyContinueIfStep } from '@/helpers/toolbox'
+
 export const MRF_ACTION_KEY = 'mrfSubmission'
 export const FORMSG_APP_KEY = 'formsg'
 export const FORMSG_TRIGGER_KEY = 'newSubmission'
+
+/**
+ * One-time hint shown the first time a user switches to the "If rejected" tab
+ * on an MRF approval step, clarifying that the approval is configured in FormSG
+ * and that the Plumber connection is read-only. Persisted per-browser.
+ */
+export const MRF_APPROVAL_HINT_STORAGE_KEY = 'mrf.approvalHint.dismissed'
+
+export function hasSeenMrfApprovalHint(): boolean {
+  return getItem(MRF_APPROVAL_HINT_STORAGE_KEY) === 'true'
+}
+
+export function dismissMrfApprovalHint(): void {
+  setItem(MRF_APPROVAL_HINT_STORAGE_KEY, 'true')
+}
+
+/**
+ * An "Only continue if" step cannot stop an MRF form's respondents: each
+ * respondent's submission is a separate FormSG webhook that enters its own
+ * subtrigger step, bypassing any halted execution. We warn when an "Only
+ * continue if" sits before a downstream subtrigger, where a user is most likely
+ * to assume it gates the rest of the workflow.
+ */
+export function shouldWarnMrfOnlyContinueIf({
+  step,
+  mrfSteps,
+}: {
+  step: IStep
+  mrfSteps: IStep[]
+}): boolean {
+  return (
+    isOnlyContinueIfStep(step) &&
+    mrfSteps.some((mrfStep) => mrfStep.position > step.position)
+  )
+}
 
 /**
  * Helper function to check if the step to be created is within an MRF approval branch

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -12,6 +12,14 @@ export const TOOLBOX_APP_KEY = 'toolbox'
 export enum TOOLBOX_ACTIONS {
   IfThen = 'ifThen',
   ForEach = 'forEach',
+  OnlyContinueIf = 'onlyContinueIf',
+}
+
+export function isOnlyContinueIfStep(step: IStep): boolean {
+  return (
+    step.appKey === TOOLBOX_APP_KEY &&
+    step.key === TOOLBOX_ACTIONS.OnlyContinueIf
+  )
 }
 
 //

--- a/packages/frontend/src/hooks/useStepMetadata.ts
+++ b/packages/frontend/src/hooks/useStepMetadata.ts
@@ -12,6 +12,7 @@ import { useContext, useMemo } from 'react'
 import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
+import { shouldWarnMrfOnlyContinueIf } from '@/helpers/formsg'
 import getStepName from '@/helpers/getStepName'
 import {
   isIfThenStep as checkIfThenStep,
@@ -41,6 +42,7 @@ interface UseStepMetadataResult {
   isApprovalStep: boolean
   approvalBranch: IStepApprovalBranch | null
   isAiStep: boolean
+  warnsMrfNoGate: boolean
 }
 
 function isAiStep(step: IStep): boolean {
@@ -183,6 +185,13 @@ export function useStepMetadata(
 
   const displayPosition = stepIdToOrder[step?.id ?? ''] ?? step?.position ?? 0
 
+  // Warn when an "Only continue if" sits before a downstream MRF subtrigger:
+  // it can't stop the form's respondents, only the Plumber steps below it.
+  const warnsMrfNoGate = useMemo(
+    () => (step ? shouldWarnMrfOnlyContinueIf({ step, mrfSteps }) : false),
+    [step, mrfSteps],
+  )
+
   return {
     app,
     selectedActionOrTrigger,
@@ -201,5 +210,6 @@ export function useStepMetadata(
     isApprovalStep,
     approvalBranch,
     isAiStep: step ? isAiStep(step) : false,
+    warnsMrfNoGate,
   }
 }


### PR DESCRIPTION
## Why?

Several users assumed the FormSG **multi-respondent form (MRF)** connection is two-way — e.g. that configuring an approval branch in Plumber would edit their form in FormSG, or that an "Only continue if" step could stop the form's respondents. It is **one-way**: Plumber reads the form's workflow and reacts to submissions; it never edits the form, and it can't control who FormSG asks next.

This PR adds editor messaging to fix that mental model.

## What?

Four surfaces, all shown only in MRF flows:

1. **Read-only note on the MRF trigger step** (grey info):
   > These steps are based on your form in FormSG. Plumber only reads your form and never makes changes to it.

2. **Caption under the approve/reject tabs** (grey):
   > This approval comes from your form in FormSG. Choosing a branch here only tells Plumber what to do next. It won't change your form.

3. **One-time dismissible hint** the first time a user switches to "If rejected" (persisted per-browser in localStorage):
   > To change who approves or the steps, edit your form in FormSG, then click "Check step" to sync. Editing here won't change your form.

4. **Warning when an "Only continue if" sits before a respondent subtrigger** (yellow):
   > This won't stop the next respondent. FormSG still sends them the form. "Only continue if" only skips the Plumber steps below.

## Notes

- **Non-breaking:** every surface is gated on MRF-specific state (`isMrfStep` / `isApprovalStep` / `warnsMrfNoGate`). Non-MRF flows render identically to before. Verified the full frontend test suite (102 tests) plus lint/typecheck pass.
- **No backend / GraphQL / schema changes** — frontend only.
- **Tests:** added unit tests for the new helpers — hint dismissal persistence, `isOnlyContinueIfStep` detection, and the downstream-subtrigger warn condition. Component rendering was verified manually in the running app (this repo has no component-test harness).
- Verified live in the editor against seeded MRF flows (screenshots below).

<img width="1280" height="720" alt="mrf-final-default" src="https://github.com/user-attachments/assets/9bf1388e-7b89-4988-adcd-49490c5f9c9d" />
<img width="1280" height="720" alt="mrf-shorter-copy" src="https://github.com/user-attachments/assets/aa43d611-8625-474c-ab78-37cd45bff963" />
<img width="1280" height="720" alt="mrf-oci-warning-v2" src="https://github.com/user-attachments/assets/0f7e18d1-3181-4798-b691-b0df1b1122df" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
