### PR TITLE
feat(types): add MCP bridge API types

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1284,3 +1284,55 @@ export interface IFlowSteps {
   actions: IFlowStepsAction[]
   traceId?: string
 }
+
+// ── MCP Bridge API types ────────────────────────────────────────────────────
+
+export interface IMcpAppAction {
+  key: string
+  name: string
+  description?: string
+}
+
+export interface IMcpApp {
+  key: string
+  name: string
+  triggers: IMcpAppAction[]
+  actions: IMcpAppAction[]
+}
+
+export interface IMcpStepDetail {
+  id: string
+  position: number
+  appKey: string
+  key: string
+  type: 'trigger' | 'action'
+  /** Configured parameter values — never contains connection credentials */
+  parameters: Record<string, unknown>
+}
+
+export interface IMcpPipeSummary {
+  id: string
+  name: string
+  active: boolean
+  stepCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface IMcpPipeDetail extends IMcpPipeSummary {
+  steps: IMcpStepDetail[]
+}
+
+export interface IMcpExecution {
+  id: string
+  pipeId: string
+  status: 'success' | 'failure' | null
+  testRun: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface IMcpVerifyResponse {
+  userId: string
+  email: string
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1287,10 +1287,20 @@ export interface IFlowSteps {
 
 // ── MCP Bridge API types ────────────────────────────────────────────────────
 
+export interface IMcpAppField {
+  key: string
+  label: string
+  type: string
+  description?: string
+  required: boolean
+  options?: Array<{ label: string; value: string }>
+}
+
 export interface IMcpAppAction {
   key: string
   name: string
   description?: string
+  fields: IMcpAppField[]
 }
 
 export interface IMcpApp {
@@ -1335,4 +1345,48 @@ export interface IMcpExecution {
 export interface IMcpVerifyResponse {
   userId: string
   email: string
+}
+
+export interface IMcpConnection {
+  id: string
+  appKey: string
+  label: string
+  verified: boolean
+}
+
+export interface IMcpFieldOption {
+  label: string
+  value: string
+}
+
+export interface IMcpCreatePipeStep {
+  appKey: string
+  triggerKey?: string
+  actionKey?: string
+}
+
+export interface IMcpCreatedStep {
+  stepId: string
+  appKey: string
+  triggerKey?: string
+  actionKey?: string
+  position: number
+}
+
+export interface IMcpCreatePipeResult {
+  pipeId: string
+  steps: IMcpCreatedStep[]
+}
+
+export interface IMcpIncompleteStep {
+  stepId: string
+  position: number
+  appKey: string | null
+  missingFields: Array<{ key: string; label: string }>
+  missingConnection: boolean
+}
+
+export interface IMcpActivateError {
+  isError: true
+  incompleteSteps: IMcpIncompleteStep[]
 }


### PR DESCRIPTION
feat(types): add MCP bridge API types

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(types): add IMcpConnection, IMcpFieldOption, IMcpCreatePipe*, IMcpActivateError interfaces