### PR TITLE
feat(mcp): add create_pipe tool (2/9)

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
-vi.mock('@/services/mcp/create-pipe', () => ({
-  createPipeService: vi.fn().mockResolvedValue({ pipeId: 'p1', steps: [] }),
+vi.mock('@/services/mcp/create-flow-with-steps', () => ({
+  createFlowWithStepsService: vi
+    .fn()
+    .mockResolvedValue({ id: 'f1', name: 'My Pipe', steps: [] }),
 }))
 
 import { listAppsService } from '@/services/mcp/apps'
-import { createPipeService } from '@/services/mcp/create-pipe'
+import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
@@ -34,26 +36,37 @@ describe('createMcpBridgeTools', () => {
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
   })
 
-  it('create_pipe calls createPipeService with camelCase step keys', async () => {
+  it('create_pipe maps snake_case input to IStep-shaped steps', async () => {
     const tools = createMcpBridgeTools(mockUser)
-    await tools.create_pipe.execute({
+    await tools.create_pipe.execute(
+      {
+        name: 'My Pipe',
+        steps: [
+          { app_key: 'formsg', trigger_key: 'newSubmission' },
+          { app_key: 'slack', action_key: 'sendMessageToChannel' },
+        ],
+        traceId: 'trace-123',
+      },
+      { toolCallId: 'create_pipe', messages: [] },
+    )
+    expect(vi.mocked(createFlowWithStepsService)).toHaveBeenCalledWith({
+      user: mockUser,
       name: 'My Pipe',
       steps: [
-        { app_key: 'formsg', trigger_key: 'newSubmission' },
-        { app_key: 'slack', action_key: 'sendMessageToChannel' },
-      ],
-    })
-    expect(vi.mocked(createPipeService)).toHaveBeenCalledWith(
-      mockUser,
-      'My Pipe',
-      [
-        { appKey: 'formsg', triggerKey: 'newSubmission', actionKey: undefined },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'slack',
-          triggerKey: undefined,
-          actionKey: 'sendMessageToChannel',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 2,
         },
       ],
-    )
+      traceId: 'trace-123',
+    })
   })
 })

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,28 +3,57 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
+vi.mock('@/services/mcp/create-pipe', () => ({
+  createPipeService: vi.fn().mockResolvedValue({ pipeId: 'p1', steps: [] }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
+import { createPipeService } from '@/services/mcp/create-pipe'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
 const mockUser = { id: 'u1' } as any
 
 describe('createMcpBridgeTools', () => {
-  it('contains only list_apps tool', () => {
+  it('contains list_apps and create_pipe tools', () => {
     const tools = createMcpBridgeTools(mockUser)
-    expect(Object.keys(tools)).toEqual(['list_apps'])
+    expect(Object.keys(tools)).toEqual(['list_apps', 'create_pipe'])
   })
 
-  it('list_apps has description and execute function', () => {
+  it('each tool has description and execute function', () => {
     const tools = createMcpBridgeTools(mockUser)
-    expect(tools.list_apps).toHaveProperty('description')
-    expect(typeof tools.list_apps.execute).toBe('function')
+    for (const t of Object.values(tools)) {
+      expect(t).toHaveProperty('description')
+      expect(typeof t.execute).toBe('function')
+    }
   })
 
   it('list_apps calls listAppsService', async () => {
     const tools = createMcpBridgeTools(mockUser)
     await tools.list_apps.execute({}, { toolCallId: 'list_apps', messages: [] })
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
+  })
+
+  it('create_pipe calls createPipeService with camelCase step keys', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.create_pipe.execute({
+      name: 'My Pipe',
+      steps: [
+        { app_key: 'formsg', trigger_key: 'newSubmission' },
+        { app_key: 'slack', action_key: 'sendMessageToChannel' },
+      ],
+    })
+    expect(vi.mocked(createPipeService)).toHaveBeenCalledWith(
+      mockUser,
+      'My Pipe',
+      [
+        { appKey: 'formsg', triggerKey: 'newSubmission', actionKey: undefined },
+        {
+          appKey: 'slack',
+          triggerKey: undefined,
+          actionKey: 'sendMessageToChannel',
+        },
+      ],
+    )
   })
 })

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,10 +1,11 @@
-import type { IApp, IMcpApp } from '@plumber/types'
+import type { IApp, IMcpApp, IMcpCreatePipeResult } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
+import { createPipeService } from '@/services/mcp/create-pipe'
 
 type ListAppsInput = Record<string, IApp[]>
 
@@ -16,6 +17,45 @@ export function createMcpBridgeTools(user: User) {
       inputSchema: z.object({}),
       execute: async (): Promise<IMcpApp[]> => {
         return listAppsService(user)
+      },
+    }),
+
+    create_pipe: tool({
+      description:
+        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation.',
+      inputSchema: z.object({
+        name: z.string().describe('Human-readable name for the pipe'),
+        steps: z
+          .array(
+            z.object({
+              app_key: z.string().describe('App key (e.g. "formsg", "slack")'),
+              trigger_key: z
+                .string()
+                .optional()
+                .describe('Trigger key for step 0 (e.g. "newSubmission")'),
+              action_key: z
+                .string()
+                .optional()
+                .describe(
+                  'Action key for steps 1+ (e.g. "sendMessageToChannel")',
+                ),
+            }),
+          )
+          .min(1)
+          .describe(
+            'Ordered list of steps. First element must have trigger_key.',
+          ),
+      }),
+      execute: async ({ name, steps }): Promise<IMcpCreatePipeResult> => {
+        return createPipeService(
+          user,
+          name,
+          steps.map((s) => ({
+            appKey: s.app_key,
+            triggerKey: s.trigger_key,
+            actionKey: s.action_key,
+          })),
+        )
       },
     }),
   }

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,11 +1,15 @@
-import type { IApp, IMcpApp, IMcpCreatePipeResult } from '@plumber/types'
+import type { IApp, IMcpApp } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
 
+import type Flow from '@/models/flow'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
-import { createPipeService } from '@/services/mcp/create-pipe'
+import {
+  createFlowWithStepsService,
+  type McpStepInput,
+} from '@/services/mcp/create-flow-with-steps'
 
 type ListAppsInput = Record<string, IApp[]>
 
@@ -45,17 +49,22 @@ export function createMcpBridgeTools(user: User) {
           .describe(
             'Ordered list of steps. First element must have trigger_key.',
           ),
+        traceId: z.string().describe('Langfuse trace ID for this tool call'),
       }),
-      execute: async ({ name, steps }): Promise<IMcpCreatePipeResult> => {
-        return createPipeService(
+      execute: async ({ name, steps, traceId }): Promise<Flow> => {
+        return createFlowWithStepsService({
           user,
           name,
-          steps.map((s) => ({
-            appKey: s.app_key,
-            triggerKey: s.trigger_key,
-            actionKey: s.action_key,
-          })),
-        )
+          steps: steps.map(
+            (s, index): McpStepInput => ({
+              appKey: s.app_key,
+              key: s.trigger_key ?? s.action_key ?? null,
+              type: index === 0 ? 'trigger' : 'action',
+              position: index + 1,
+            }),
+          ),
+          traceId,
+        })
       },
     }),
   }

--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Flow from '@/models/flow'
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('createFlowWithStepsService', () => {
+  beforeEach(async () => {
+    mocks.getAllLdFlags.mockResolvedValue({
+      'ai-builder': {
+        enabled: true,
+        config: {
+          generateStepsPromptName: 'generate-steps',
+          version: 'production',
+        },
+      },
+    })
+  })
+
+  it('creates an inactive pipe and persists trigger/action steps in order', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: '  My Pipe  ',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+        { appKey: 'slack', key: 'sendMessage', type: 'action', position: 3 },
+      ],
+      traceId: 'trace-id-123',
+    })
+
+    expect(result).toBeInstanceOf(Flow)
+    expect(result.id).toBeDefined()
+    expect(result.name).toBe('My Pipe')
+    expect(result.userId).toBe(user.id)
+    expect(result.active).toBe(false)
+    expect(result.steps).toHaveLength(3)
+
+    const [triggerStep, firstActionStep, secondActionStep] = result.steps
+
+    expect(triggerStep.type).toBe('trigger')
+    expect(triggerStep.appKey).toBe('formsg')
+    expect(triggerStep.key).toBe('newSubmission')
+    expect(triggerStep.position).toBe(1)
+
+    expect(firstActionStep.type).toBe('action')
+    expect(firstActionStep.appKey).toBe('postman')
+    expect(firstActionStep.key).toBe('sendTransactionalEmail')
+    expect(firstActionStep.position).toBe(2)
+
+    expect(secondActionStep.type).toBe('action')
+    expect(secondActionStep.appKey).toBe('slack')
+    expect(secondActionStep.key).toBe('sendMessage')
+    expect(secondActionStep.position).toBe(3)
+  })
+
+  it('stores null keys when not provided', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-missing-keys-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: 'No Keys',
+      steps: [
+        { appKey: 'webhook', key: null, type: 'trigger', position: 1 },
+        { appKey: 'slack', key: null, type: 'action', position: 2 },
+      ],
+      traceId: 'trace-id-456',
+    })
+
+    expect(result.steps).toHaveLength(2)
+    expect(result.steps[0].key).toBeNull()
+    expect(result.steps[1].key).toBeNull()
+  })
+})

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -1,0 +1,103 @@
+import z from 'zod/v3'
+
+import { getActionStepsSchema } from '@/graphql/mutations/ai/schemas/action-steps-schema'
+import { generateSchema } from '@/graphql/mutations/ai/schemas/schema-generator'
+import { getStepVersion } from '@/helpers/get-step-version'
+import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import type User from '@/models/user'
+
+export interface McpStepInput {
+  appKey: string
+  key?: string | null
+  type: 'trigger' | 'action'
+  position: number
+}
+
+export async function createFlowWithStepsService({
+  user,
+  name,
+  steps,
+  traceId,
+}: {
+  user: User
+  name: string
+  steps: McpStepInput[]
+  traceId: string
+}): Promise<Flow> {
+  const trimmedName = name.trim()
+  if (!trimmedName) {
+    throw new Error('Pipe name needs to have at least 1 character.')
+  }
+
+  if (
+    !steps.every((step, index) => {
+      if (index === 0) {
+        return step.position === 1
+      }
+      return step.position === steps[index - 1].position + 1
+    })
+  ) {
+    throw new Error('Must be contiguous steps!')
+  }
+
+  const restrictedApps = getRestrictedAppKeys(await getAllLdFlags(user.email))
+
+  // Validate only when all steps have keys
+  const allKeysProvided = steps.every((s) => !!s.key)
+
+  if (allKeysProvided) {
+    const triggerSchema = generateSchema(
+      z.object({ type: z.literal('trigger') }),
+      'trigger',
+      restrictedApps,
+    )
+    const validatedTrigger = triggerSchema.safeParse(steps[0])
+    if (!validatedTrigger.success) {
+      logger.error(
+        'Failed to create flow with steps: Pipe must always start with a trigger',
+        { error: validatedTrigger.error.errors },
+      )
+      throw new Error('Pipe must always start with a trigger')
+    }
+
+    const actionSteps = steps.slice(1)
+    if (actionSteps.length > 0) {
+      const actionStepsSchema = getActionStepsSchema(restrictedApps)
+      const validatedActions = actionStepsSchema.safeParse(actionSteps)
+      if (!validatedActions.success) {
+        logger.error(
+          'Failed to create flow with steps: Pipe contains invalid action steps',
+          { error: validatedActions.error.errors },
+        )
+        throw new Error('Pipe contains invalid action steps')
+      }
+    }
+  }
+
+  const flow = await Flow.transaction(async (trx) => {
+    const createdFlow = await Flow.query(trx).insertAndFetch({
+      userId: user.id,
+      name: trimmedName,
+      active: false,
+      config: { aiBuilderConfig: { traceId } },
+    })
+
+    await createdFlow.$relatedQuery('steps', trx).insert(
+      steps.map((step) => ({
+        version: getStepVersion(step.appKey, step.key ?? undefined),
+        type: step.type,
+        appKey: step.appKey,
+        key: step.key ?? null,
+        config: {},
+        parameters: {},
+        position: step.position,
+      })),
+    )
+
+    return createdFlow
+  })
+
+  return flow.$fetchGraph('steps')
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1359,24 +1359,6 @@ export interface IMcpFieldOption {
   value: string
 }
 
-export interface IMcpCreatePipeStep {
-  appKey: string
-  triggerKey?: string
-  actionKey?: string
-}
-
-export interface IMcpCreatedStep {
-  stepId: string
-  appKey: string
-  triggerKey?: string
-  actionKey?: string
-  position: number
-}
-
-export interface IMcpCreatePipeResult {
-  pipeId: string
-  steps: IMcpCreatedStep[]
-}
 
 export interface IMcpIncompleteStep {
   stepId: string


### PR DESCRIPTION
feat(mcp): add create_pipe tool (2/9)

refactor(mcp): align create_pipe service with IStep/Flow types

- createFlowWithStepsService accepts McpStepInput (appKey, key, type,
  position) matching IStep shape and returns Flow with steps eager-loaded
- bridge tool maps LLM snake_case input → McpStepInput, inferring type
  and position from array index
- removed custom IMcpCreatePipeStep/IMcpCreatedStep/IMcpCreatePipeResult
  types from @plumber/types in favour of the shared Flow/IStep types
- fixed bridge tool unit test mock (was mocking wrong module) and
  updated assertions to new call signature
- validation skipped when steps have no keys (partial pipe creation)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>