### PR TITLE
feat(mcp): add updateStepParametersService with field filtering

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -8,9 +8,15 @@ vi.mock('@/services/mcp/create-flow-with-steps', () => ({
     .fn()
     .mockResolvedValue({ id: 'f1', name: 'My Pipe', steps: [] }),
 }))
+vi.mock('@/services/mcp/update-step-parameters', () => ({
+  updateStepParametersService: vi
+    .fn()
+    .mockResolvedValue({ id: 's1', parameters: {} }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
+import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
@@ -19,7 +25,11 @@ const mockUser = { id: 'u1' } as any
 describe('createMcpBridgeTools', () => {
   it('contains list_apps and create_pipe tools', () => {
     const tools = createMcpBridgeTools(mockUser)
-    expect(Object.keys(tools)).toEqual(['list_apps', 'create_pipe'])
+    expect(Object.keys(tools)).toEqual([
+      'list_apps',
+      'create_pipe',
+      'update_step_parameters',
+    ])
   })
 
   it('each tool has description and execute function', () => {
@@ -34,6 +44,24 @@ describe('createMcpBridgeTools', () => {
     const tools = createMcpBridgeTools(mockUser)
     await tools.list_apps.execute({}, { toolCallId: 'list_apps', messages: [] })
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
+  })
+
+  it('update_step_parameters calls updateStepParametersService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.update_step_parameters.execute(
+      {
+        pipe_id: 'flow-1',
+        step_id: 'step-1',
+        parameters: { subject: 'Hello' },
+      },
+      { toolCallId: 'update_step_parameters', messages: [] },
+    )
+    expect(vi.mocked(updateStepParametersService)).toHaveBeenCalledWith({
+      user: mockUser,
+      pipeId: 'flow-1',
+      stepId: 'step-1',
+      parameters: { subject: 'Hello' },
+    })
   })
 
   it('create_pipe maps snake_case input to IStep-shaped steps', async () => {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -4,7 +4,7 @@ import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type Flow from '@/models/flow'
-import Step from '@/models/step'
+import type Step from '@/models/step'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
 import {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -4,12 +4,14 @@ import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type Flow from '@/models/flow'
+import Step from '@/models/step'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
 import {
   createFlowWithStepsService,
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
+import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
 
@@ -64,6 +66,28 @@ export function createMcpBridgeTools(user: User) {
             }),
           ),
           traceId,
+        })
+      },
+    }),
+
+    update_step_parameters: tool({
+      description:
+        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.",
+      inputSchema: z.object({
+        pipe_id: z.string().describe('ID of the pipe that contains the step'),
+        step_id: z.string().describe('ID of the step to update'),
+        parameters: z
+          .record(z.string(), z.unknown())
+          .describe(
+            "Parameter key/value pairs to save. Only keys matching the step's field schema are kept.",
+          ),
+      }),
+      execute: async ({ pipe_id, step_id, parameters }): Promise<Step> => {
+        return updateStepParametersService({
+          user,
+          pipeId: pipe_id,
+          stepId: step_id,
+          parameters,
         })
       },
     }),

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { updateStepParametersService } from '../update-step-parameters'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('updateStepParametersService', () => {
+  beforeEach(() => {
+    // Return no LD flags so no apps are restricted
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('saves only field keys defined in the action schema, silently dropping unknown keys', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `update-params-filter-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Filter Test Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-filter-1',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: {
+        subject: 'Hello world',            // valid — in postman sendTransactionalEmail schema
+        destinationEmail: ['a@b.com'],      // valid — in postman sendTransactionalEmail schema
+        unknownHallucinatedField: 'drop',  // invalid — not in schema, must be dropped
+      },
+    })
+
+    expect(result.parameters).toMatchObject({
+      subject: 'Hello world',
+      destinationEmail: ['a@b.com'],
+    })
+    expect(result.parameters).not.toHaveProperty('unknownHallucinatedField')
+  })
+
+  it('sets status to incomplete after parameter update', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `update-params-status-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Status Test Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-status-2',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: { subject: 'Test' },
+    })
+
+    expect(result.status).toBe('incomplete')
+  })
+
+  it('throws if the step does not belong to the requesting user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-access-3',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    await expect(
+      updateStepParametersService({
+        user: intruder,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: { subject: 'Hack' },
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+
+  it('throws if the stepId does not belong to the given pipeId', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `mismatch-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Mismatch Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+      ],
+      traceId: 'trace-mismatch-4',
+    })
+
+    const triggerStep = flow.steps[0]
+    expect(triggerStep).toBeDefined()
+
+    await expect(
+      updateStepParametersService({
+        user,
+        pipeId: randomUUID(), // wrong pipe ID
+        stepId: triggerStep.id,
+        parameters: {},
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+})

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -33,7 +33,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Filter Test Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -52,9 +57,9 @@ describe('updateStepParametersService', () => {
       pipeId: flow.id,
       stepId: actionStep.id,
       parameters: {
-        subject: 'Hello world',            // valid — in postman sendTransactionalEmail schema
-        destinationEmail: ['a@b.com'],      // valid — in postman sendTransactionalEmail schema
-        unknownHallucinatedField: 'drop',  // invalid — not in schema, must be dropped
+        subject: 'Hello world', // valid — in postman sendTransactionalEmail schema
+        destinationEmail: ['a@b.com'], // valid — in postman sendTransactionalEmail schema
+        unknownHallucinatedField: 'drop', // invalid — not in schema, must be dropped
       },
     })
 
@@ -75,7 +80,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Status Test Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -113,7 +123,12 @@ describe('updateStepParametersService', () => {
       user: owner,
       name: 'Owned Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -147,7 +162,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Mismatch Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
       ],
       traceId: 'trace-mismatch-4',
     })

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -1,0 +1,93 @@
+import type {
+  IAction,
+  IJSONObject,
+  IRawAction,
+  IRawTrigger,
+} from '@plumber/types'
+
+import apps from '@/apps'
+import App from '@/models/app'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface UpdateStepParametersInput {
+  user: User
+  pipeId: string
+  stepId: string
+  parameters: Record<string, unknown>
+}
+
+export async function updateStepParametersService({
+  user,
+  pipeId,
+  stepId,
+  parameters,
+}: UpdateStepParametersInput): Promise<Step> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'editor' })
+    .findOne({
+      'steps.id': stepId,
+      'steps.flow_id': pipeId,
+    })
+
+  if (!step) {
+    throw new Error('Step not found')
+  }
+
+  // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)
+  const triggerOrAction = await App.findTriggerOrActionByKey(
+    step.appKey,
+    step.key,
+  )
+
+  if (!triggerOrAction) {
+    throw new Error('No such trigger or action')
+  }
+
+  if (step.type === 'action') {
+    const action = triggerOrAction as IAction
+    if (action.hiddenFromUser) {
+      throw new Error('Action can only be updated by system')
+    }
+  }
+
+  // Get arguments from the raw app registry (before getApp transforms them into substeps)
+  const rawApp = apps[step.appKey]
+  const rawTriggerOrAction = (
+    step.type === 'trigger'
+      ? rawApp?.triggers?.find((t) => t.key === step.key)
+      : rawApp?.actions?.find((a) => a.key === step.key)
+  ) as IRawAction | IRawTrigger | undefined
+
+  // Silently drop any keys not in this action/trigger's declared argument schema
+  const allowedKeys = new Set(
+    (rawTriggerOrAction?.arguments ?? []).map((f) => f.key),
+  )
+  const filteredParameters = Object.fromEntries(
+    Object.entries(parameters).filter(([k]) => allowedKeys.has(k)),
+  ) as IJSONObject
+
+  let patchedParameters = filteredParameters
+  let version = step.version
+
+  const transformer = apps[step.appKey]?.stepTransformer
+  if (transformer) {
+    patchedParameters = transformer.transformStepParameters(
+      step.key,
+      filteredParameters,
+      version,
+    ) as IJSONObject
+    version = transformer.getLatestStepVersion(step.key)
+  }
+
+  if (step.type === 'action') {
+    const action = triggerOrAction as IAction
+    action.validateStepParameters?.(patchedParameters)
+  }
+
+  return Step.query().patchAndFetchById(stepId, {
+    parameters: patchedParameters,
+    version,
+    status: 'incomplete',
+  })
+}


### PR DESCRIPTION
feat(mcp): add updateStepParametersService with field filtering

feat(mcp): wire update_step_parameters tool into createMcpBridgeTools (3/9)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

fix(mcp): import type Step and clean up itest formatting

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>