### PR TITLE
feat(mcp): add create_step tool (4/9)

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -13,9 +13,13 @@ vi.mock('@/services/mcp/update-step-parameters', () => ({
     .fn()
     .mockResolvedValue({ id: 's1', parameters: {} }),
 }))
+vi.mock('@/services/mcp/create-step', () => ({
+  createStepService: vi.fn().mockResolvedValue({ id: 's2', appKey: 'slack' }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
+import { createStepService } from '@/services/mcp/create-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
@@ -29,6 +33,7 @@ describe('createMcpBridgeTools', () => {
       'list_apps',
       'create_pipe',
       'update_step_parameters',
+      'create_step',
     ])
   })
 
@@ -61,6 +66,26 @@ describe('createMcpBridgeTools', () => {
       pipeId: 'flow-1',
       stepId: 'step-1',
       parameters: { subject: 'Hello' },
+    })
+  })
+
+  it('create_step calls createStepService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.create_step.execute(
+      {
+        pipe_id: 'flow-1',
+        app_key: 'slack',
+        action_key: 'sendMessageToChannel',
+        previous_step_id: 'step-0',
+      },
+      { toolCallId: 'create_step', messages: [] },
+    )
+    expect(vi.mocked(createStepService)).toHaveBeenCalledWith({
+      user: mockUser,
+      pipeId: 'flow-1',
+      appKey: 'slack',
+      key: 'sendMessageToChannel',
+      previousStepId: 'step-0',
     })
   })
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -11,6 +11,7 @@ import {
   createFlowWithStepsService,
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
+import { createStepService } from '@/services/mcp/create-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
@@ -88,6 +89,38 @@ export function createMcpBridgeTools(user: User) {
           pipeId: pipe_id,
           stepId: step_id,
           parameters,
+        })
+      },
+    }),
+
+    create_step: tool({
+      description:
+        'Add a new action step to an existing pipe. Validates that the app key and action key exist. Inserts after previousStepId if given; otherwise appends at the end. Returns the created step.',
+      inputSchema: z.object({
+        pipe_id: z.string().describe('ID of the pipe to add the step to'),
+        app_key: z.string().describe('App key (e.g. "slack")'),
+        action_key: z
+          .string()
+          .describe('Action key (e.g. "sendMessageToChannel")'),
+        previous_step_id: z
+          .string()
+          .optional()
+          .describe(
+            'ID of the step after which to insert. Omit to append at the end.',
+          ),
+      }),
+      execute: async ({
+        pipe_id,
+        app_key,
+        action_key,
+        previous_step_id,
+      }): Promise<Step> => {
+        return createStepService({
+          user,
+          pipeId: pipe_id,
+          appKey: app_key,
+          key: action_key,
+          previousStepId: previous_step_id,
         })
       },
     }),

--- a/packages/backend/src/services/mcp/__tests__/create-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-step.itest.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { createStepService } from '../create-step'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('createStepService', () => {
+  beforeEach(() => {
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('appends a new action step at the end of the pipe', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-step-append-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Append Step Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-create-1',
+    })
+
+    const step = await createStepService({
+      user,
+      pipeId: flow.id,
+      appKey: 'slack',
+      key: 'sendMessageToChannel',
+    })
+
+    expect(step.appKey).toBe('slack')
+    expect(step.key).toBe('sendMessageToChannel')
+    expect(step.type).toBe('action')
+    expect(step.position).toBe(3)
+    expect(step.parameters).toEqual({})
+  })
+
+  it('inserts a step after a given previousStepId and shifts later steps', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-step-insert-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Insert Step Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+        {
+          appKey: 'slack',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 3,
+        },
+      ],
+      traceId: 'trace-create-2',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const triggerStep = loadedFlow.steps.find((s) => s.type === 'trigger')
+
+    const newStep = await createStepService({
+      user,
+      pipeId: flow.id,
+      appKey: 'postman',
+      key: 'sendTransactionalEmail',
+      previousStepId: triggerStep.id,
+    })
+
+    expect(newStep.position).toBe(2)
+
+    // The old position-2 step should have shifted to position 3
+    const loadedFlow2 = await flow.$fetchGraph('steps')
+    const positions = loadedFlow2.steps
+      .map((s) => s.position)
+      .sort((a, b) => a - b)
+    expect(positions).toEqual([1, 2, 3, 4])
+  })
+
+  it('throws if the trigger or action does not exist', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-step-notfound-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'NotFound Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+      ],
+      traceId: 'trace-create-3',
+    })
+
+    await expect(
+      createStepService({
+        user,
+        pipeId: flow.id,
+        appKey: 'slack',
+        key: 'nonExistentAction',
+      }),
+    ).rejects.toThrow('No such trigger or action')
+  })
+
+  it('throws if the pipe does not belong to the requesting user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-create-step-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-create-step-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+      ],
+      traceId: 'trace-create-4',
+    })
+
+    await expect(
+      createStepService({
+        user: intruder,
+        pipeId: flow.id,
+        appKey: 'slack',
+        key: 'sendMessageToChannel',
+      }),
+    ).rejects.toThrow('Pipe not found')
+  })
+})

--- a/packages/backend/src/services/mcp/create-step.ts
+++ b/packages/backend/src/services/mcp/create-step.ts
@@ -1,0 +1,89 @@
+import { raw } from 'objection'
+
+import { getStepVersion } from '@/helpers/get-step-version'
+import App from '@/models/app'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface CreateStepInput {
+  user: User
+  pipeId: string
+  appKey: string
+  key: string
+  previousStepId?: string
+}
+
+export async function createStepService({
+  user,
+  pipeId,
+  appKey,
+  key,
+  previousStepId,
+}: CreateStepInput): Promise<Step> {
+  const triggerOrAction = await App.findTriggerOrActionByKey(appKey, key)
+
+  if (!triggerOrAction) {
+    throw new Error('No such trigger or action')
+  }
+
+  if (triggerOrAction.hiddenFromUser) {
+    throw new Error('Action can only be created by system')
+  }
+
+  return Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    const flow = await user
+      .withAccessibleFlows({ requiredRole: 'editor', trx })
+      .findOne({ id: pipeId })
+
+    if (!flow) {
+      throw new Error('Pipe not found')
+    }
+
+    let newStepPosition: number
+
+    if (previousStepId) {
+      const previousStep = await flow
+        .$relatedQuery('steps', trx)
+        .findOne({ id: previousStepId })
+
+      if (!previousStep) {
+        throw new Error('Previous step not found')
+      }
+
+      newStepPosition = previousStep.position + 1
+    } else {
+      const lastStep = await flow
+        .$relatedQuery('steps', trx)
+        .orderBy('position', 'desc')
+        .first()
+
+      newStepPosition = lastStep ? lastStep.position + 1 : 2
+    }
+
+    await flow
+      .$relatedQuery('steps', trx)
+      .patch({ position: raw('position + 1') })
+      .where('position', '>=', newStepPosition)
+
+    const version = getStepVersion(appKey, key)
+
+    const step = await flow.$relatedQuery('steps', trx).insertAndFetch({
+      key,
+      appKey,
+      type: 'action',
+      position: newStepPosition,
+      parameters: {},
+      version,
+    })
+
+    await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: user.id,
+      trx,
+    })
+
+    return step
+  })
+}


### PR DESCRIPTION
- createStepService: validates app/key, appends or inserts by previousStepId, serializable txn
- Integration tests: append, insert-with-shift, not-found, access-control
- Wired into createMcpBridgeTools; unit test updated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>