### PR TITLE
feat(mcp): add delete_step tool (5/9)

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -16,10 +16,14 @@ vi.mock('@/services/mcp/update-step-parameters', () => ({
 vi.mock('@/services/mcp/create-step', () => ({
   createStepService: vi.fn().mockResolvedValue({ id: 's2', appKey: 'slack' }),
 }))
+vi.mock('@/services/mcp/delete-step', () => ({
+  deleteStepService: vi.fn().mockResolvedValue({ id: 'f1', steps: [] }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import { deleteStepService } from '@/services/mcp/delete-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
@@ -34,6 +38,7 @@ describe('createMcpBridgeTools', () => {
       'create_pipe',
       'update_step_parameters',
       'create_step',
+      'delete_step',
     ])
   })
 
@@ -86,6 +91,19 @@ describe('createMcpBridgeTools', () => {
       appKey: 'slack',
       key: 'sendMessageToChannel',
       previousStepId: 'step-0',
+    })
+  })
+
+  it('delete_step calls deleteStepService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.delete_step.execute(
+      { pipe_id: 'flow-1', step_id: 'step-1' },
+      { toolCallId: 'delete_step', messages: [] },
+    )
+    expect(vi.mocked(deleteStepService)).toHaveBeenCalledWith({
+      user: mockUser,
+      pipeId: 'flow-1',
+      stepId: 'step-1',
     })
   })
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -12,6 +12,7 @@ import {
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import { deleteStepService } from '@/services/mcp/delete-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
@@ -121,6 +122,22 @@ export function createMcpBridgeTools(user: User) {
           appKey: app_key,
           key: action_key,
           previousStepId: previous_step_id,
+        })
+      },
+    }),
+
+    delete_step: tool({
+      description:
+        'Delete a single step from a pipe. Deleting a trigger replaces it with an empty trigger slot; deleting an action removes it and repositions the remaining steps. Steps that reference the deleted step are marked incomplete. Returns the updated pipe with all remaining steps.',
+      inputSchema: z.object({
+        pipe_id: z.string().describe('ID of the pipe that contains the step'),
+        step_id: z.string().describe('ID of the step to delete'),
+      }),
+      execute: async ({ pipe_id, step_id }): Promise<Flow> => {
+        return deleteStepService({
+          user,
+          pipeId: pipe_id,
+          stepId: step_id,
         })
       },
     }),

--- a/packages/backend/src/services/mcp/__tests__/delete-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/delete-step.itest.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { deleteStepService } from '../delete-step'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('deleteStepService', () => {
+  beforeEach(() => {
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('deletes an action step and repositions remaining steps', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `delete-step-reposition-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Reposition Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+        {
+          appKey: 'slack',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 3,
+        },
+      ],
+      traceId: 'trace-delete-1',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find(
+      (s) => s.type === 'action' && s.appKey === 'postman',
+    )
+    expect(actionStep).toBeDefined()
+
+    const result = await deleteStepService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+    })
+
+    expect(result.steps).toHaveLength(2)
+    const positions = result.steps.map((s) => s.position).sort((a, b) => a - b)
+    expect(positions).toEqual([1, 2])
+  })
+
+  it('deletes a trigger and replaces it with an empty trigger', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `delete-step-trigger-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Trigger Delete Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-2',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const triggerStep = loadedFlow.steps.find((s) => s.type === 'trigger')
+    expect(triggerStep).toBeDefined()
+
+    const result = await deleteStepService({
+      user,
+      pipeId: flow.id,
+      stepId: triggerStep.id,
+    })
+
+    expect(result.steps).toHaveLength(2)
+    const newTrigger = result.steps.find((s) => s.type === 'trigger')
+    expect(newTrigger).toBeDefined()
+    expect(newTrigger.appKey).toBeNull()
+    expect(newTrigger.key).toBeNull()
+    expect(newTrigger.id).not.toBe(triggerStep.id)
+  })
+
+  it('throws if the step does not belong to the requesting user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-delete-step-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-delete-step-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-3',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find((s) => s.type === 'action')
+
+    await expect(
+      deleteStepService({
+        user: intruder,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+
+  it('throws if the stepId does not belong to the given pipeId', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `mismatch-delete-step-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Mismatch Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-4',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find((s) => s.type === 'action')
+
+    await expect(
+      deleteStepService({
+        user,
+        pipeId: randomUUID(), // wrong pipe ID
+        stepId: actionStep.id,
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+})

--- a/packages/backend/src/services/mcp/delete-step.ts
+++ b/packages/backend/src/services/mcp/delete-step.ts
@@ -1,0 +1,107 @@
+import { raw } from 'objection'
+
+import { removeMrfSteps } from '@/apps/formsg/triggers/new-submission/remove-mrf-steps'
+import { hasStepReference } from '@/helpers/check-step-parameters'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface DeleteStepInput {
+  user: User
+  pipeId: string
+  stepId: string
+}
+
+export async function deleteStepService({
+  user,
+  pipeId,
+  stepId,
+}: DeleteStepInput): Promise<Flow> {
+  return Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    const step = await user
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
+      .withGraphFetched('flow')
+      .findOne({ 'steps.id': stepId, 'steps.flow_id': pipeId })
+
+    if (!step) {
+      throw new Error('Step not found')
+    }
+
+    const flow = step.flow
+
+    if (step.type === 'trigger') {
+      if (step.appKey === 'formsg' && step.key === 'newSubmission') {
+        await removeMrfSteps(flow.id, trx)
+      }
+
+      const allSteps = await flow
+        .$relatedQuery('steps', trx)
+        .where('id', '!=', stepId)
+        .orderBy('position', 'asc')
+
+      const stepsToInvalidate = getStepsToInvalidate(
+        allSteps,
+        new Set([stepId]),
+      )
+      await Step.query(trx)
+        .findByIds(stepsToInvalidate)
+        .patch({ status: 'incomplete' })
+
+      await step.$query(trx).delete()
+      await flow.$relatedQuery('steps', trx).insert({
+        key: null,
+        appKey: null,
+        type: 'trigger',
+        position: 1,
+        parameters: {},
+        connectionId: null,
+      })
+    } else {
+      const allSteps = await flow
+        .$relatedQuery('steps', trx)
+        .where('id', '!=', stepId)
+        .orderBy('position', 'asc')
+
+      const stepsToInvalidate = getStepsToInvalidate(
+        allSteps,
+        new Set([stepId]),
+      )
+      await Step.query(trx)
+        .findByIds(stepsToInvalidate)
+        .patch({ status: 'incomplete' })
+
+      await Step.query(trx).findById(stepId).delete()
+
+      await flow
+        .$relatedQuery('steps', trx)
+        .where('position', '>', step.position)
+        .patch({ position: raw('position - 1') })
+    }
+
+    await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: user.id,
+      trx,
+    })
+
+    return flow
+      .$query(trx)
+      .withGraphJoined('steps')
+      .orderBy('steps.position', 'asc')
+  })
+}
+
+function getStepsToInvalidate(
+  steps: Step[],
+  deletedIds: Set<string>,
+): string[] {
+  const stepsToInvalidate = []
+  for (const s of steps) {
+    if (hasStepReference(s.parameters, deletedIds)) {
+      stepsToInvalidate.push(s.id)
+    }
+  }
+  return stepsToInvalidate
+}


### PR DESCRIPTION
- deleteStepService: handles trigger replacement and action deletion with repositioning, invalidates referencing steps, serializable txn
- Integration tests: reposition, trigger-replace, access-control, pipe-mismatch
- Wired into createMcpBridgeTools; unit test updated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>