### PR TITLE
feat(mcp): add mcpStepConfig field to ai-builder LD flag fallback

### DIFF
--- a/packages/backend/src/config/flags.ts
+++ b/packages/backend/src/config/flags.ts
@@ -18,5 +18,6 @@ export const AI_BUILDER_FEATURE_FLAG_FALLBACK = {
     chatSummaryPromptName: 'chat-summary',
     generateStepsPromptName: 'generate-steps',
     version: 'production',
+    mcpStepConfig: false,
   },
 }

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
+vi.mock('@/services/mcp/list-connections', () => ({
+  listConnectionsService: vi.fn().mockResolvedValue([]),
+}))
 vi.mock('@/services/mcp/create-flow-with-steps', () => ({
   createFlowWithStepsService: vi
     .fn()
@@ -41,6 +44,7 @@ describe('createMcpBridgeTools', () => {
     const tools = createMcpBridgeTools(mockUser)
     expect(Object.keys(tools)).toEqual([
       'list_apps',
+      'list_connections',
       'create_pipe',
       'update_step_parameters',
       'create_step',
@@ -163,6 +167,70 @@ describe('createMcpBridgeTools', () => {
         },
       ],
       traceId: 'trace-123',
+    })
+  })
+
+  describe('onPipeChange callback', () => {
+    it('is called with pipeId after create_pipe succeeds', async () => {
+      const onPipeChange = vi.fn()
+      const tools = createMcpBridgeTools(mockUser, onPipeChange)
+      await tools.create_pipe.execute(
+        {
+          name: 'My Pipe',
+          steps: [{ app_key: 'formsg', trigger_key: 'newSubmission' }],
+          traceId: 'trace-1',
+        },
+        { toolCallId: 'create_pipe', messages: [] },
+      )
+      expect(onPipeChange).toHaveBeenCalledWith('f1')
+    })
+
+    it('is called with pipe_id after update_step_parameters succeeds', async () => {
+      const onPipeChange = vi.fn()
+      const tools = createMcpBridgeTools(mockUser, onPipeChange)
+      await tools.update_step_parameters.execute(
+        { pipe_id: 'flow-1', step_id: 's1', parameters: {} },
+        { toolCallId: 'update_step_parameters', messages: [] },
+      )
+      expect(onPipeChange).toHaveBeenCalledWith('flow-1')
+    })
+
+    it('is called with pipe_id after create_step succeeds', async () => {
+      const onPipeChange = vi.fn()
+      const tools = createMcpBridgeTools(mockUser, onPipeChange)
+      await tools.create_step.execute(
+        {
+          pipe_id: 'flow-1',
+          app_key: 'slack',
+          action_key: 'sendMessageToChannel',
+        },
+        { toolCallId: 'create_step', messages: [] },
+      )
+      expect(onPipeChange).toHaveBeenCalledWith('flow-1')
+    })
+
+    it('is called with pipe_id after delete_step succeeds', async () => {
+      const onPipeChange = vi.fn()
+      const tools = createMcpBridgeTools(mockUser, onPipeChange)
+      await tools.delete_step.execute(
+        { pipe_id: 'flow-1', step_id: 's1' },
+        { toolCallId: 'delete_step', messages: [] },
+      )
+      expect(onPipeChange).toHaveBeenCalledWith('flow-1')
+    })
+
+    it('does not throw when onPipeChange is not provided', async () => {
+      const tools = createMcpBridgeTools(mockUser)
+      await expect(
+        tools.create_pipe.execute(
+          {
+            name: 'My Pipe',
+            steps: [{ app_key: 'formsg', trigger_key: 'newSubmission' }],
+            traceId: 'trace-1',
+          },
+          { toolCallId: 'create_pipe', messages: [] },
+        ),
+      ).resolves.not.toThrow()
     })
   })
 })

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -22,7 +22,10 @@ import { updateStepParametersService } from '@/services/mcp/update-step-paramete
 
 type ListAppsInput = Record<string, IApp[]>
 
-export function createMcpBridgeTools(user: User) {
+export function createMcpBridgeTools(
+  user: User,
+  onPipeChange?: (pipeId: string) => void,
+) {
   return {
     list_apps: tool<ListAppsInput, IMcpApp[]>({
       description:
@@ -70,7 +73,7 @@ export function createMcpBridgeTools(user: User) {
         traceId: z.string().describe('Langfuse trace ID for this tool call'),
       }),
       execute: async ({ name, steps, traceId }): Promise<Flow> => {
-        return createFlowWithStepsService({
+        const flow = await createFlowWithStepsService({
           user,
           name,
           steps: steps.map(
@@ -83,6 +86,8 @@ export function createMcpBridgeTools(user: User) {
           ),
           traceId,
         })
+        onPipeChange?.(flow.id)
+        return flow
       },
     }),
 
@@ -110,13 +115,15 @@ export function createMcpBridgeTools(user: User) {
         parameters,
         connection_id,
       }): Promise<Step> => {
-        return updateStepParametersService({
+        const step = await updateStepParametersService({
           user,
           pipeId: pipe_id,
           stepId: step_id,
           parameters,
           connectionId: connection_id,
         })
+        onPipeChange?.(pipe_id)
+        return step
       },
     }),
 
@@ -142,13 +149,15 @@ export function createMcpBridgeTools(user: User) {
         action_key,
         previous_step_id,
       }): Promise<Step> => {
-        return createStepService({
+        const step = await createStepService({
           user,
           pipeId: pipe_id,
           appKey: app_key,
           key: action_key,
           previousStepId: previous_step_id,
         })
+        onPipeChange?.(pipe_id)
+        return step
       },
     }),
 
@@ -160,11 +169,13 @@ export function createMcpBridgeTools(user: User) {
         step_id: z.string().describe('ID of the step to delete'),
       }),
       execute: async ({ pipe_id, step_id }): Promise<Flow> => {
-        return deleteStepService({
+        const flow = await deleteStepService({
           user,
           pipeId: pipe_id,
           stepId: step_id,
         })
+        onPipeChange?.(pipe_id)
+        return flow
       },
     }),
 

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -32,6 +32,7 @@ import logger from '@/helpers/logger'
 import { createMcpBridgeTools } from '@/helpers/mcp-bridge-tools'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import { pipeWebResponseToExpress } from '@/helpers/stream'
+import Flow from '@/models/flow'
 import { AuthenticatedRequest } from '@/types/express/context'
 
 import { serializeMessagesForLangfuse } from './helpers'
@@ -112,7 +113,10 @@ const handleChatStream = observe(
       const allMessages = [systemMessage, ...messages]
       let workflowError = 'Unable to generate the workflow.'
 
-      const mcpTools = createMcpBridgeTools(context.currentUser)
+      let activePipeId: string | null = null
+      const mcpTools = createMcpBridgeTools(context.currentUser, (pipeId) => {
+        activePipeId = pipeId
+      })
 
       const stream = createUIMessageStream({
         execute: async ({ writer }) => {
@@ -153,46 +157,119 @@ const handleChatStream = observe(
                 updateActiveObservation({ output: event })
                 updateActiveTrace({ output: event })
 
-                const hasWorkflowMetadata = WORKFLOW_METADATA_REGEX.test(
-                  event.text,
-                )
+                const mcpStepConfig =
+                  aiBuilderFlag.config.mcpStepConfig ?? false
 
-                let flowSteps: IFlowSteps | undefined = undefined
-
-                if (hasWorkflowMetadata) {
-                  try {
-                    const parsedWorkflowMetadata = parseWorkflowMetadata(
-                      event.text,
-                      restrictedApps,
-                    )
-                    flowSteps = { ...parsedWorkflowMetadata, traceId }
-                  } catch (error) {
-                    workflowError =
-                      error instanceof BadUserInputError
-                        ? error.message
-                        : 'Unable to generate the workflow.'
+                if (mcpStepConfig) {
+                  // Phase 2a: LLM proposed a workflow (WORKFLOW_METADATA present, no tools ran)
+                  const hasWorkflowMetadata = WORKFLOW_METADATA_REGEX.test(
+                    event.text,
+                  )
+                  if (hasWorkflowMetadata) {
+                    try {
+                      const parsedWorkflowMetadata = parseWorkflowMetadata(
+                        event.text,
+                        restrictedApps,
+                      )
+                      const flowSteps = { ...parsedWorkflowMetadata, traceId }
+                      writer.write({
+                        type: 'data-isChatReady',
+                        data: { isChatReady: true, flowSteps, mcpMode: true },
+                      })
+                    } catch (error) {
+                      const msg =
+                        error instanceof BadUserInputError
+                          ? error.message
+                          : 'Unable to generate the workflow.'
+                      writer.write({
+                        type: 'data-isChatReady',
+                        data: {
+                          isChatReady: true,
+                          error: msg,
+                          mcpMode: true,
+                        },
+                      })
+                    }
                   }
-                }
 
-                // isChatReady: true whenever WORKFLOW_METADATA is present (success or error)
-                // isChatReady: false only when there is no WORKFLOW_METADATA block
-                // NOTE: type MUST start with "data-" - SDK enforces this
-                writer.write({
-                  type: 'data-isChatReady',
-                  data: {
-                    isChatReady: hasWorkflowMetadata,
-                    ...(hasWorkflowMetadata &&
-                      (flowSteps ? { flowSteps } : { error: workflowError })),
-                  },
-                })
+                  // Phase 2b+: MCP tools ran this turn — emit fresh pipe state from DB
+                  if (activePipeId) {
+                    const flow = await Flow.query().findById(activePipeId)
+                    const steps = flow
+                      ? await flow
+                          .$relatedQuery('steps')
+                          .orderBy('position', 'asc')
+                      : []
 
-                if (!hasWorkflowMetadata) {
+                    writer.write({
+                      type: 'data-pipeState',
+                      data: {
+                        pipeId: activePipeId,
+                        steps: steps.map((step) => ({
+                          id: step.id,
+                          appKey: step.appKey,
+                          key: step.key,
+                          type: step.type,
+                          position: step.position,
+                          status: step.status,
+                          parameters: step.parameters,
+                          connectionId: step.connectionId ?? null,
+                        })),
+                      },
+                    })
+                  }
+
+                  // Clarification blocks on both phases
                   const questions = parseClarificationBlock(event.text)
                   if (questions) {
                     writer.write({
                       type: 'data-clarification',
                       data: { questions },
                     })
+                  }
+                } else {
+                  // Old YAML path — unchanged
+                  const hasWorkflowMetadata = WORKFLOW_METADATA_REGEX.test(
+                    event.text,
+                  )
+
+                  let flowSteps: IFlowSteps | undefined = undefined
+
+                  if (hasWorkflowMetadata) {
+                    try {
+                      const parsedWorkflowMetadata = parseWorkflowMetadata(
+                        event.text,
+                        restrictedApps,
+                      )
+                      flowSteps = { ...parsedWorkflowMetadata, traceId }
+                    } catch (error) {
+                      workflowError =
+                        error instanceof BadUserInputError
+                          ? error.message
+                          : 'Unable to generate the workflow.'
+                    }
+                  }
+
+                  // isChatReady: true whenever WORKFLOW_METADATA is present (success or error)
+                  // isChatReady: false only when there is no WORKFLOW_METADATA block
+                  // NOTE: type MUST start with "data-" - SDK enforces this
+                  writer.write({
+                    type: 'data-isChatReady',
+                    data: {
+                      isChatReady: hasWorkflowMetadata,
+                      ...(hasWorkflowMetadata &&
+                        (flowSteps ? { flowSteps } : { error: workflowError })),
+                    },
+                  })
+
+                  if (!hasWorkflowMetadata) {
+                    const questions = parseClarificationBlock(event.text)
+                    if (questions) {
+                      writer.write({
+                        type: 'data-clarification',
+                        data: { questions },
+                      })
+                    }
                   }
                 }
               } catch (error) {

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -12,6 +12,19 @@ const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
 // so allow enough headroom for up to ~10 tool calls per assistant turn.
 const MAX_PARTS_PER_MESSAGE = 50
 
+// Tool invocation part shape — shared by all MCP bridge tool entries below.
+// The backend does not process these parts; it only needs to accept them when
+// the AI SDK echoes the full assistant message back on subsequent turns.
+const toolPart = <T extends string>(toolType: T) =>
+  z.object({
+    type: z.literal(toolType),
+    toolCallId: z.string().optional(),
+    toolName: z.string().optional(),
+    state: z.string().optional(),
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
+  })
+
 const messagePartSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('text'),
@@ -53,13 +66,31 @@ const messagePartSchema = z.discriminatedUnion('type', [
     }),
   }),
   z.object({
-    type: z.literal('tool-list_apps'),
-    toolCallId: z.string(),
-    toolName: z.string(),
-    state: z.string(),
-    input: z.unknown().optional(),
-    output: z.unknown().optional(),
+    type: z.literal('data-pipeState'),
+    data: z.object({
+      pipeId: z.string(),
+      steps: z.array(
+        z.object({
+          id: z.string(),
+          appKey: z.string(),
+          key: z.string(),
+          type: z.string(),
+          position: z.number(),
+          status: z.string(),
+          parameters: z.record(z.string(), z.unknown()),
+          connectionId: z.string().nullable(),
+        }),
+      ),
+    }),
   }),
+  // One entry per MCP bridge tool — keeps discriminatedUnion error quality intact.
+  toolPart('tool-list_apps'),
+  toolPart('tool-list_connections'),
+  toolPart('tool-create_pipe'),
+  toolPart('tool-update_step_parameters'),
+  toolPart('tool-create_step'),
+  toolPart('tool-delete_step'),
+  toolPart('tool-get_dynamic_data'),
 ])
 
 const messageSchema = z.object({

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -43,6 +43,26 @@ export type IsChatReadyPart = {
     isChatReady: boolean
     flowSteps?: IFlowSteps
     error?: string
+    mcpMode?: boolean // true when mcpStepConfig LD flag is on — suppresses the create-pipe mutation button
+  }
+}
+
+export type PipeStateStep = {
+  id: string
+  appKey: string
+  key: string
+  type: 'trigger' | 'action'
+  position: number
+  status: 'incomplete' | 'completed'
+  parameters: Record<string, unknown>
+  connectionId: string | null
+}
+
+export type PipeStatePart = {
+  type: 'data-pipeState'
+  data: {
+    pipeId: string
+    steps: PipeStateStep[]
   }
 }
 
@@ -161,13 +181,21 @@ export function useChatStream(options: UseChatStreamOptions) {
       ])
 
       const lastMessage = messages[messages.length - 1]
+
+      // Phase 2b+: DB-backed pipe state from data-pipeState event
+      const pipeStatePart = lastMessage.parts.find(
+        (part): part is PipeStatePart => part.type === 'data-pipeState',
+      )
+
+      // Phase 2a or old path: workflow proposal from data-isChatReady event
       const isChatReadyPart = lastMessage.parts.find(
         (part): part is IsChatReadyPart => part.type === 'data-isChatReady',
       )
 
-      const { isChatReady, flowSteps, error } = isChatReadyPart?.data ?? {}
+      const { isChatReady, flowSteps, error, mcpMode } =
+        isChatReadyPart?.data ?? {}
 
-      if (isChatReady) {
+      if (pipeStatePart || isChatReady) {
         setIsReady(true)
       }
 
@@ -179,11 +207,17 @@ export function useChatStream(options: UseChatStreamOptions) {
           ...locationRef.current.state,
           chatInput: allMessages[allMessages.length - 1].text,
           chatMessages: allMessages,
+          // pipeStatePart: replace output with DB pipe state (Phase 2b+)
           // isChatReady: populate output from stream (steps or error), drawer opens
-          // !isChatReady: preserve current output
-          ...(isChatReady
+          // neither: preserve current output
+          ...(pipeStatePart
+            ? { output: pipeStatePart.data }
+            : isChatReady
             ? {
-                output: flowSteps ?? { error },
+                output: {
+                  ...(flowSteps ?? { error }),
+                  mcpMode: mcpMode ?? false,
+                },
                 ...(flowSteps?.name ? { flowName: flowSteps.name } : {}),
               }
             : currentOutput

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -78,8 +78,10 @@ export const AiBuilderContextProvider = ({
 
   // Update drawer state when isMobile or output changes (handles async isMobile hook)
   useEffect(() => {
-    const shouldOpen =
-      !isMobile && Boolean(output?.trigger || output?.actions?.length)
+    const hasSteps = output?.pipeId
+      ? Array.isArray(output?.steps) && output.steps.length > 0
+      : Boolean(output?.trigger || output?.actions?.length)
+    const shouldOpen = !isMobile && hasSteps
 
     if (shouldOpen !== isDrawerOpen) {
       setIsDrawerOpen(shouldOpen)
@@ -98,17 +100,21 @@ export const AiBuilderContextProvider = ({
    * NOTE: process the steps that have been returned by Pair
    * as if its in the Editor, but a lot simpler
    */
-  const steps = useMemo(
-    () =>
-      [
-        ...(output?.trigger ? [output.trigger] : []),
-        ...(output?.actions || []),
-      ].map((step, index) => ({
-        ...step,
-        position: index + 1,
-      })),
-    [output?.trigger, output?.actions],
-  )
+  const steps = useMemo(() => {
+    // Phase 2b+: DB-backed pipe state — steps already have correct positions
+    if (output?.pipeId && Array.isArray(output?.steps)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return output.steps as any as AiBuilderStep[]
+    }
+    // Phase 2a (proposal) and legacy path
+    return [
+      ...(output?.trigger ? [output.trigger] : []),
+      ...(output?.actions || []),
+    ].map((step, index) => ({
+      ...step,
+      position: index + 1,
+    }))
+  }, [output?.pipeId, output?.steps, output?.trigger, output?.actions])
   const [triggerStep, stepsBeforeGroup, groupedSteps] = useMemo(
     () => getStepStructure(appsWithActions, steps),
     [appsWithActions, steps],
@@ -138,7 +144,11 @@ export const AiBuilderContextProvider = ({
         isMobile,
         steps,
         triggerStep,
-        actionSteps: output?.actions || [],
+        actionSteps: output?.pipeId
+          ? (output?.steps || []).filter(
+              (s: { type: string }) => s.type === 'action',
+            )
+          : output?.actions || [],
         stepsBeforeGroup,
         groupedSteps,
         stepGroupType,

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -43,6 +43,9 @@ export default function StepsPreview() {
 
   const isMobile = useIsMobile()
 
+  const isMcpPipeMode = Boolean(output?.pipeId) // Phase 2b+: DB pipe exists
+  const isMcpProposalMode = !isMcpPipeMode && Boolean(output?.mcpMode) // Phase 2a: proposal, no DB
+
   const [createFlowWithSteps, { loading: isCreatingFlow }] = useMutation(
     CREATE_FLOW_WITH_STEPS,
   )
@@ -107,11 +110,11 @@ export default function StepsPreview() {
     clearPersistedState,
   ])
 
-  if (
-    output?.error ||
-    !steps ||
-    !(output?.trigger && output?.actions?.length)
-  ) {
+  const hasNoContent = isMcpPipeMode
+    ? !output?.steps?.length
+    : output?.error || !steps || !(output?.trigger && output?.actions?.length)
+
+  if (hasNoContent) {
     return (
       <Center h="80%">
         <Flex
@@ -126,7 +129,7 @@ export default function StepsPreview() {
           <Text textStyle="h4" fontWeight="normal">
             Something went wrong.
           </Text>
-          {output?.error && <Text>{output.error}</Text>}
+          {!isMcpPipeMode && output?.error && <Text>{output.error}</Text>}
           <Text>Modify your prompt and try again.</Text>
           <Text>
             If this issue persists,{' '}
@@ -142,7 +145,13 @@ export default function StepsPreview() {
 
   return (
     <>
-      <Box opacity={isCreatingFlow ? 0.4 : 1} pos="relative" w="100%">
+      <Box
+        opacity={
+          !isMcpPipeMode && !isMcpProposalMode && isCreatingFlow ? 0.4 : 1
+        }
+        pos="relative"
+        w="100%"
+      >
         <Step step={triggerStep} />
         {stepsBeforeGroup.map((action) => (
           <Fragment key={`${action.position}-${action.appKey}`}>
@@ -210,13 +219,30 @@ export default function StepsPreview() {
         <VStack mt={10} gap={2}>
           <Text textStyle="body-1">Looks good?</Text>
           <HStack alignItems="center" justifyContent="center" gap={2}>
-            <Button variant="solid" onClick={onCreateFlowWithSteps} size="sm">
-              Create this workflow
-            </Button>
+            {isMcpPipeMode ? (
+              <Button
+                variant="solid"
+                size="sm"
+                onClick={() => {
+                  clearPersistedState()
+                  navigate(URLS.FLOW_EDITOR(output.pipeId), { replace: true })
+                }}
+              >
+                Open in editor
+              </Button>
+            ) : isMcpProposalMode ? (
+              <Text textStyle="body-2" color="base.content.medium">
+                Reply in chat to confirm and build this pipe
+              </Text>
+            ) : (
+              <Button variant="solid" onClick={onCreateFlowWithSteps} size="sm">
+                Create this workflow
+              </Button>
+            )}
           </HStack>
         </VStack>
       </Box>
-      {isCreatingFlow && (
+      {!isMcpPipeMode && !isMcpProposalMode && isCreatingFlow && (
         <Flex
           pos="absolute"
           top="50%"


### PR DESCRIPTION
feat(mcp): add mcpStepConfig field to ai-builder LD flag fallback

feat(mcp): add onPipeChange callback to createMcpBridgeTools

feat(mcp): restructure onFinish to emit data-isChatReady+mcpMode for proposals and data-pipeState for tool calls

feat(mcp): update useChatStream to handle mcpMode proposals and data-pipeState events

feat(mcp): AiBuilderContext handles DB-backed pipeId+steps output shape

feat(mcp): StepsPreview three-mode rendering — proposal hint, DB pipe open-in-editor, legacy create

fix(chat): accept MCP tool parts and data-pipeState in request schema

Adds all MCP bridge tool-invocation part types and the new data-pipeState
part to the chat request discriminated union so multi-turn tool-use
conversations don't fail validation when the AI SDK echoes assistant
message history back on subsequent turns.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>