### PR TITLE
feat(mcp): allow free-text parameter collection via clarification UI

### DIFF
--- a/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
@@ -16,7 +16,7 @@ describe('parseClarificationBlock', () => {
     expect(parseClarificationBlock(text)).toBeNull()
   })
 
-  it('returns null when a question has fewer than 2 options', () => {
+  it('returns a question with a single option', () => {
     const text = `
 Some response.
 <!-- CLARIFICATION_DATA
@@ -24,7 +24,35 @@ Q: What trigger?
 - Form submission
 -->
     `.trim()
-    expect(parseClarificationBlock(text)).toBeNull()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission'] },
+    ])
+  })
+
+  it('returns a free-text question with no options', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What is the row ID to update?
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What is the row ID to update?', options: [] },
+    ])
+  })
+
+  it('returns a mix of option-based and free-text questions', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: Which trigger?
+- FormSG
+- Webhook
+Q: What is your table ID?
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'Which trigger?', options: ['FormSG', 'Webhook'] },
+      { question: 'What is your table ID?', options: [] },
+    ])
   })
 
   it('parses a single question with 2 options', () => {
@@ -189,13 +217,15 @@ Q:  What trigger?
     ])
   })
 
-  it('returns null when block is present but all questions have < 2 options', () => {
+  it('returns a question with exactly 1 option (no longer requires min 2)', () => {
     const text = `
 <!-- CLARIFICATION_DATA
 Q: What trigger?
 - Form submission
 -->
     `.trim()
-    expect(parseClarificationBlock(text)).toBeNull()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission'] },
+    ])
   })
 })

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.ts
@@ -55,6 +55,6 @@ export function parseClarificationBlock(
     questions.push(current)
   }
 
-  const valid = questions.filter((q) => q.options.length >= 2)
+  const valid = questions.filter((q) => q.question.length > 0)
   return valid.length > 0 ? valid : null
 }

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -59,7 +59,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
         .array(
           z.object({
             question: z.string(),
-            options: z.array(z.string()).min(2),
+            options: z.array(z.string()),
           }),
         )
         .min(1),

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
@@ -77,37 +77,39 @@ export default function ChoicePicker({
           )}
         </Flex>
 
-        <Flex direction="column" gap={2}>
-          {currentQ.options.map((opt, optIdx) => (
-            <Button
-              key={optIdx}
-              variant="outline"
-              justifyContent="flex-start"
-              h="auto"
-              py={2}
-              isDisabled={isStreaming}
-              onClick={() => onOptionClick(optIdx)}
-              borderColor="gray.200"
-              bg="white"
-              color="gray.800"
-              _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
-              _active={{ bg: 'primary.100' }}
-              gap={2}
-            >
-              <Badge
-                colorScheme="secondary"
-                variant="subtle"
-                size="sm"
-                flexShrink={0}
+        {currentQ.options.length > 0 && (
+          <Flex direction="column" gap={2}>
+            {currentQ.options.map((opt, optIdx) => (
+              <Button
+                key={optIdx}
+                variant="outline"
+                justifyContent="flex-start"
+                h="auto"
+                py={2}
+                isDisabled={isStreaming}
+                onClick={() => onOptionClick(optIdx)}
+                borderColor="gray.200"
+                bg="white"
+                color="gray.800"
+                _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
+                _active={{ bg: 'primary.100' }}
+                gap={2}
               >
-                {optIdx + 1}
-              </Badge>
-              <Text textAlign="left" whiteSpace="normal" color="gray.800">
-                {opt}
-              </Text>
-            </Button>
-          ))}
-        </Flex>
+                <Badge
+                  colorScheme="secondary"
+                  variant="subtle"
+                  size="sm"
+                  flexShrink={0}
+                >
+                  {optIdx + 1}
+                </Badge>
+                <Text textAlign="left" whiteSpace="normal" color="gray.800">
+                  {opt}
+                </Text>
+              </Button>
+            ))}
+          </Flex>
+        )}
 
         <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
           <Flex gap={2} align="flex-end">
@@ -116,7 +118,11 @@ export default function ChoicePicker({
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyPress}
-              placeholder="Or describe your answer..."
+              placeholder={
+                currentQ.options.length > 0
+                  ? 'Or describe your answer...'
+                  : 'Enter your answer...'
+              }
               resize="none"
               border="none"
               bg="transparent"


### PR DESCRIPTION
## Stack Context

This stack builds the MCP AI Builder — an LLM-powered pipe builder that lets users describe their workflow in natural language and have it built via a set of MCP bridge tools (`list_apps`, `get_dynamic_data`, `create_pipe`, `update_step_parameters`, etc.).

## What?

- Relaxes `CLARIFICATION_DATA` block schema to allow questions with zero options (free-text only)
- Updates `ChoicePicker` to hide option buttons when none are present, using "Enter your answer..." placeholder

## Why?

The clarification UI (`ChoicePicker`) was designed for multiple-choice questions (min 2 options). Parameter collection often needs free-text input only — e.g. "What is the row ID to update?" has no fixed set of options. Previously, such questions were silently discarded by the parser (`options.length >= 2` filter) and the Zod schema rejected `options: []`. This PR removes those constraints so the LLM can ask for step parameters using the same clarification block format, showing a textarea-only UI when there are no options to choose from.
