### PR TITLE
[AI-SETUP-1] PLU-810 feat(types): add MCP bridge API types

### DIFF
--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1293,7 +1293,7 @@ export interface IMcpAppField {
   type: string
   description?: string
   required: boolean
-  options?: Array<{ label: string; value: string }>
+  options?: IMcpFieldOption[]
 }
 
 export interface IMcpAppAction {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1284,3 +1284,55 @@ export interface IFlowSteps {
   actions: IFlowStepsAction[]
   traceId?: string
 }
+
+// ── MCP Bridge API types ────────────────────────────────────────────────────
+
+export interface IMcpAppAction {
+  key: string
+  name: string
+  description?: string
+}
+
+export interface IMcpApp {
+  key: string
+  name: string
+  triggers: IMcpAppAction[]
+  actions: IMcpAppAction[]
+}
+
+export interface IMcpStepDetail {
+  id: string
+  position: number
+  appKey: string
+  key: string
+  type: 'trigger' | 'action'
+  /** Configured parameter values — never contains connection credentials */
+  parameters: Record<string, unknown>
+}
+
+export interface IMcpPipeSummary {
+  id: string
+  name: string
+  active: boolean
+  stepCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface IMcpPipeDetail extends IMcpPipeSummary {
+  steps: IMcpStepDetail[]
+}
+
+export interface IMcpExecution {
+  id: string
+  pipeId: string
+  status: 'success' | 'failure' | null
+  testRun: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface IMcpVerifyResponse {
+  userId: string
+  email: string
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1287,10 +1287,20 @@ export interface IFlowSteps {
 
 // ── MCP Bridge API types ────────────────────────────────────────────────────
 
+export interface IMcpAppField {
+  key: string
+  label: string
+  type: string
+  description?: string
+  required: boolean
+  options?: Array<{ label: string; value: string }>
+}
+
 export interface IMcpAppAction {
   key: string
   name: string
   description?: string
+  fields: IMcpAppField[]
 }
 
 export interface IMcpApp {
@@ -1335,4 +1345,48 @@ export interface IMcpExecution {
 export interface IMcpVerifyResponse {
   userId: string
   email: string
+}
+
+export interface IMcpConnection {
+  id: string
+  appKey: string
+  label: string
+  verified: boolean
+}
+
+export interface IMcpFieldOption {
+  label: string
+  value: string
+}
+
+export interface IMcpCreatePipeStep {
+  appKey: string
+  triggerKey?: string
+  actionKey?: string
+}
+
+export interface IMcpCreatedStep {
+  stepId: string
+  appKey: string
+  triggerKey?: string
+  actionKey?: string
+  position: number
+}
+
+export interface IMcpCreatePipeResult {
+  pipeId: string
+  steps: IMcpCreatedStep[]
+}
+
+export interface IMcpIncompleteStep {
+  stepId: string
+  position: number
+  appKey: string | null
+  missingFields: Array<{ key: string; label: string }>
+  missingConnection: boolean
+}
+
+export interface IMcpActivateError {
+  isError: true
+  incompleteSteps: IMcpIncompleteStep[]
 }


### PR DESCRIPTION
## Stack context

This is the **foundation PR** for the MCP Bridge API stack. It sits at the bottom of the `trunk/mcp-tools` stack and introduces the shared TypeScript contracts that all subsequent MCP bridge PRs depend on. No runtime code is changed here — only type definitions in `packages/types`.

## TL;DR

Adds TypeScript interfaces for the MCP Bridge API to `@plumber/types`, covering the full lifecycle of pipes, steps, apps, connections, and executions. These types serve as the shared contract between the backend bridge routes and any consumer (frontend AI builder, external MCP clients).

## What changed?

**`packages/types/index.d.ts`** (+106 lines, no deletions)

New interfaces grouped by domain:

| Group | Interfaces |
|---|---|
| **App metadata** | `IMcpApp`, `IMcpAppAction`, `IMcpAppField` — app/action/trigger descriptors with field definitions and options |
| **Pipe & step shapes** | `IMcpPipeSummary`, `IMcpPipeDetail`, `IMcpStepDetail` — pipe listing and detailed step config (parameters only, no credentials) |
| **Execution records** | `IMcpExecution` — execution status and test-run flag |
| **Auth & connections** | `IMcpVerifyResponse`, `IMcpConnection` — identity verification and connection metadata |
| **Pipe creation** | `IMcpFieldOption`, `IMcpCreatePipeStep`, `IMcpCreatedStep`, `IMcpCreatePipeResult` — request/response shapes for the create-pipe flow |
| **Activation errors** | `IMcpIncompleteStep`, `IMcpActivateError` — structured error reporting when a pipe can't be activated due to unconfigured steps |

## Tests

This PR contains only type declarations — there is no runtime behaviour to regression-test. To verify:

- [ ] `npm run -w backend lint` passes with no errors
- [ ] TypeScript compiles cleanly across the monorepo: `npm run -w types build` (or equivalent)
- [ ] Later PRs in the stack that import these types compile correctly

## Deploy notes

None — types-only change, no migrations, no config, no feature flags needed.