### PR TITLE
chore: enable Datadog continuous profiling via env var

### DIFF
--- a/ecs/env.json
+++ b/ecs/env.json
@@ -51,6 +51,10 @@
     {
       "name": "PAIR_ROME_BASE_URL",
       "value": "https://rome.pair.gov.sg"
+    },
+    {
+      "name": "DD_PROFILING_ENABLED",
+      "value": "true"
     }
   ],
   "secrets": [


### PR DESCRIPTION
# Problem

We want to root cause memory pressure more easily, let's add profilig.

# This PR

_UPDATE: Let's enable for all envs first to keep things simple. Old approach (fine-grained SSM) below_

Turns on DD profiling via the DD_PROFILING_ENABLED env var.

---

Enables us to turn on / off DD profiling for our tasks as needed, via the DD_PROFILING_ENABLED env var.  We likely won't need to turn it on in staging / UAT, but I want to use them to test first.

We will these via SSM: self explanatory:

- `plumber-<ENVIRONMENT>-server-datadog-profiling-enabled`
- `plumber-<ENVIRONMENT>-worker-datadog-profiling-enabled`

# Test, rollout & monitoring plan

1. Set staging env value to true, see that profiling shows up
2. Once I see the profiles, turn off for staging and on for prod.
3. Check in on datadog cost dashboard daily this week to ensure we dont bust the budget.

# Other notes

We will need to setup these vars in SSM:

Prod

- plumber-prod-server-datadog-profiling-enabled = true
- plumber-prod-worker-datadog-profiling-enabled = true

Staging

- plumber-staging-server-datadog-profiling-enabled = false (true only for testing)
- plumber-staging-worker-datadog-profiling-enabled= false (true only for testing)

UAT

- plumber-uat-server-datadog-profiling-enabled = false
- plumber-uat-worker-datadog-profiling-enabled = false