### PR TITLE
PLU-821: modify LD flag for ses allowed domain

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   sendBlacklistEmail: vi.fn(),
   sendInvalidAttachmentsEmail: vi.fn(),
   createInvalidAttachmentsMessage: vi.fn(() => 'test invalid attachment body'),
-  getLdFlagValue: vi.fn(async () => [] as string[]),
+  getLdFlagValue: vi.fn(async (_flag: string, _email: string | null) => false),
   sesSend: vi.fn(async () => ({})),
   getSuppressedEmails: vi.fn(async () => [] as string[]),
 }))
@@ -133,6 +133,8 @@ describe('send transactional email', () => {
         name: 'file-2.png',
         data: '1111',
       })
+
+    mocks.getLdFlagValue.mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -841,9 +843,9 @@ describe('send transactional email', () => {
     })
   })
 
-  describe('SES routing via ses_enabled_domains flag', () => {
-    it('routes to SES when all recipients are in flagged domains', async () => {
-      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+  describe('SES routing via ses_enabled flag', () => {
+    it('routes to SES when ses_enabled is true for all recipients', async () => {
+      mocks.getLdFlagValue.mockResolvedValue(true)
       $.step.parameters.destinationEmail = 'a@open.gov.sg,b@open.gov.sg'
       $.step.parameters.attachments = []
 
@@ -863,7 +865,7 @@ describe('send transactional email', () => {
     })
 
     it('quotes a comma sender name for SES but keeps dataOut unquoted', async () => {
-      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+      mocks.getLdFlagValue.mockResolvedValue(true)
       $.step.parameters.destinationEmail = 'a@open.gov.sg'
       $.step.parameters.senderName = 'Acme, Inc'
       $.step.parameters.attachments = []
@@ -886,8 +888,11 @@ describe('send transactional email', () => {
       })
     })
 
-    it('falls back to Postman when any recipient is outside flagged domains', async () => {
-      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+    it('falls back to Postman when ses_enabled is false for any recipient', async () => {
+      mocks.getLdFlagValue.mockImplementation(
+        async (_flag: string, email: string | null) =>
+          !!email?.endsWith('@open.gov.sg'),
+      )
       $.step.parameters.destinationEmail = 'a@open.gov.sg,b@gmail.com'
       $.step.parameters.attachments = []
 
@@ -897,8 +902,8 @@ describe('send transactional email', () => {
       expect($.http.post).toHaveBeenCalledTimes(2)
     })
 
-    it('falls back to Postman when batch has attachments even if all domains qualify', async () => {
-      mocks.getLdFlagValue.mockImplementationOnce(async () => ['*'])
+    it('falls back to Postman when batch has attachments even if ses_enabled is true', async () => {
+      mocks.getLdFlagValue.mockResolvedValue(true)
       $.step.parameters.destinationEmail = 'a@open.gov.sg'
       mocks.filterAttachments.mockReturnValueOnce({
         attachmentFiles: [{ fileName: 'f.txt', data: new Uint8Array([0]) }],
@@ -912,7 +917,7 @@ describe('send transactional email', () => {
       expect($.http.post).toHaveBeenCalledTimes(1)
     })
 
-    it('uses Postman when ses_enabled_domains flag is empty (default kill switch)', async () => {
+    it('uses Postman when ses_enabled is false (default kill switch)', async () => {
       $.step.parameters.destinationEmail = 'a@open.gov.sg'
       $.step.parameters.attachments = []
 
@@ -923,7 +928,7 @@ describe('send transactional email', () => {
     })
 
     it('drops a suppressed CC from the SES call but keeps it in dataOut', async () => {
-      mocks.getLdFlagValue.mockImplementationOnce(async () => ['open.gov.sg'])
+      mocks.getLdFlagValue.mockResolvedValue(true)
       // Only the CC is suppressed — the To recipient still sends.
       mocks.getSuppressedEmails.mockResolvedValueOnce(['cc-bad@open.gov.sg'])
 

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -6,14 +6,13 @@ import { sortBy } from 'lodash'
 
 import appConfig from '@/config/app'
 import HttpError from '@/errors/http'
-import { getLdFlagValue } from '@/helpers/launch-darkly'
 import logger from '@/helpers/logger'
 import { incrementMetric } from '@/helpers/metrics'
 import { sanitizeEmailHtml } from '@/helpers/sanitize-email-html'
 import {
   formatFromAddress,
   getSesClient,
-  shouldUseSes,
+  isSesEnabledForRecipient,
 } from '@/helpers/ses-email-helper'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
@@ -214,18 +213,16 @@ export async function sendTransactionalEmails(
   errorStatus?: PostmanEmailSendStatus
   error?: HttpError
 }> {
-  const sesEnabledDomains = await getLdFlagValue<string[]>(
-    'ses_enabled_domains',
-    null,
-    [],
+  // Whether SES routing applies is a per-recipient boolean LaunchDarkly flag
+  // (`ses_enabled`); targeting is configured in LaunchDarkly. Use SES only when
+  // it is enabled for ALL recipients and there are no attachments — attachment
+  // support over SES lands in a later change. Otherwise send everything via
+  // Postman to avoid mixed error-handling paths.
+  const sesEnabledPerRecipient = await Promise.all(
+    recipients.map(isSesEnabledForRecipient),
   )
-
-  // Use SES only if ALL recipients are in SES-enabled domains and no
-  // attachments (SES Phase 1 does not support attachments). Otherwise,
-  // send everything via Postman to avoid mixed error-handling paths.
   const useSes =
-    !email.attachments?.length &&
-    recipients.every((r) => shouldUseSes(r, sesEnabledDomains))
+    !email.attachments?.length && sesEnabledPerRecipient.every(Boolean)
 
   // Pre-send suppression check (SES path only). CC addresses are included so a
   // blacklisted CC can be dropped from the SES call rather than re-sent to

--- a/packages/backend/src/helpers/send-email.ts
+++ b/packages/backend/src/helpers/send-email.ts
@@ -3,9 +3,8 @@ import axios from 'axios'
 import appConfig from '@/config/app'
 import HttpError from '@/errors/http'
 
-import { getLdFlagValue } from './launch-darkly'
 import logger from './logger'
-import { sendEmailViaSes, shouldUseSes } from './ses-email-helper'
+import { isSesEnabledForRecipient, sendEmailViaSes } from './ses-email-helper'
 
 export interface PostmanEmailRequestBody {
   subject: string
@@ -61,12 +60,7 @@ async function sendEmailViaPostman({
 export async function sendEmail(
   params: PostmanEmailRequestBody,
 ): Promise<void> {
-  const sesEnabledDomains = await getLdFlagValue<string[]>(
-    'ses_enabled_domains',
-    null,
-    [],
-  )
-  if (shouldUseSes(params.recipient, sesEnabledDomains)) {
+  if (await isSesEnabledForRecipient(params.recipient)) {
     return sendEmailViaSes(params)
   }
 

--- a/packages/backend/src/helpers/ses-email-helper.ts
+++ b/packages/backend/src/helpers/ses-email-helper.ts
@@ -4,6 +4,7 @@ import { fromTemporaryCredentials } from '@aws-sdk/credential-providers'
 import appConfig from '@/config/app'
 import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
+import { getLdFlagValue } from './launch-darkly'
 import logger from './logger'
 import { incrementMetric } from './metrics'
 import { sanitizeEmailHtml } from './sanitize-email-html'
@@ -25,24 +26,23 @@ export function getSesClient(): SESv2Client {
   return sesClient
 }
 
-export function shouldUseSes(
+/**
+ * Whether SES routing is enabled for a recipient. `ses_enabled` is a boolean
+ * flag; which recipients/domains/segments it applies to is configured in
+ * LaunchDarkly. The recipient email is passed as the `user` context key (the
+ * same kind {@link getLdFlagValue} uses), so LD rules can target by "user key
+ * ends with @domain", individual email targets, or segments. The email is
+ * lower-cased because LD string operators are case-sensitive. Defaults to false
+ * (routes via Postman) when the flag is off or unset.
+ */
+export function isSesEnabledForRecipient(
   recipientEmail: string,
-  sesEnabledDomains: string[],
-): boolean {
-  if (sesEnabledDomains.length === 0) {
-    return false
-  }
-
-  const normalizedEnabledDomains = sesEnabledDomains.map((d) =>
-    d.trim().toLowerCase(),
+): Promise<boolean> {
+  return getLdFlagValue<boolean>(
+    'ses_enabled',
+    recipientEmail.toLowerCase(),
+    false,
   )
-
-  if (normalizedEnabledDomains.includes('*')) {
-    return true
-  }
-
-  const domain = recipientEmail.split('@')[1]?.toLowerCase()
-  return domain ? normalizedEnabledDomains.includes(domain) : false
 }
 
 /**


### PR DESCRIPTION
### TL;DR

Replaces the `ses_enabled_domains` LaunchDarkly flag (a string array of allowed domains) with a per-recipient boolean flag `ses_enabled`, delegating targeting logic entirely to LaunchDarkly.

### What changed?

The `shouldUseSes` function, which previously checked whether a recipient's domain appeared in a `ses_enabled_domains` string array (including wildcard `*` support), has been replaced with `isSesEnabledForRecipient`. This new function calls `getLdFlagValue` with the `ses_enabled` boolean flag, passing the recipient's lowercased email as the LaunchDarkly user context key. LaunchDarkly rules then determine routing (e.g. by domain suffix, individual email, or segment) rather than application code.

Both `sendEmail` (single-recipient path) and `sendTransactionalEmails` (batch path) now call `isSesEnabledForRecipient` per recipient. The batch path uses `Promise.all` to resolve all recipients in parallel and only routes to SES if every recipient returns `true` and there are no attachments.

### How to test?

- Configure the `ses_enabled` flag in LaunchDarkly to return `true` for a specific email or domain and verify that sending an email to that recipient routes through SES.
- Confirm that a recipient not targeted by the flag falls back to Postman.
- In a batch send where only some recipients have `ses_enabled = true`, confirm the entire batch falls back to Postman.
- Confirm that a batch with attachments always routes to Postman regardless of flag value.
- Confirm that when the flag is off or unset (default `false`), all emails route through Postman.

### Why make this change?

Encoding domain-matching logic in application code (the old `ses_enabled_domains` array) is inflexible and requires a code change to adjust targeting. Moving to a per-recipient boolean flag lets LaunchDarkly handle all targeting rules — domain suffixes, individual addresses, segments — without any application changes, and makes the kill switch simpler: setting the flag to `false` globally disables SES routing immediately.