### PR TITLE
[PLU-790-2] extend attachment types

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -920,6 +920,26 @@ describe('send transactional email', () => {
       expect($.http.post).toHaveBeenCalledTimes(1)
     })
 
+    it('does not flip to SES when configured attachments are all filtered out', async () => {
+      // ses_enabled on, ses_attachments_enabled off. Attachments are configured
+      // (raw list non-empty) but filtering strips them all — the transport must
+      // stay on Postman rather than flip to SES on the now-empty attachment list.
+      mocks.getLdFlagValue.mockImplementation(
+        async (flag: string) => flag === 'ses_enabled',
+      )
+      $.step.parameters.destinationEmail = 'a@open.gov.sg'
+      mocks.filterAttachments.mockReturnValueOnce({
+        attachmentFiles: [],
+        invalidAttachments: [],
+        submissionId: null,
+      })
+
+      await expect(sendTransactionalEmail.run($)).resolves.not.toThrow()
+
+      expect(mocks.sesSend).not.toHaveBeenCalled()
+      expect($.http.post).toHaveBeenCalledTimes(1)
+    })
+
     it('sends attachments via SES as a raw MIME message when ses_attachments_enabled is on', async () => {
       // Both ses_enabled and ses_attachments_enabled true for all recipients.
       mocks.getLdFlagValue.mockResolvedValue(true)

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -12,12 +12,10 @@ import StepError from '@/errors/step'
 import { TableVariableMarker } from '@/helpers/compute-parameters'
 import { formatTable } from '@/helpers/format-table-variable'
 import logger from '@/helpers/logger'
+import { SES_BLOCKED_EXTENSIONS } from '@/helpers/s3'
 import Step from '@/models/step'
 
-import {
-  POSTMAN_ACCEPTED_EXTENSIONS,
-  SES_BLOCKED_EXTENSIONS,
-} from '../../common/constants'
+import { POSTMAN_ACCEPTED_EXTENSIONS } from '../../common/constants'
 import { dataOutSchema } from '../../common/data-out-validator'
 import {
   resolveSesRouting,

--- a/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
+++ b/packages/backend/src/apps/postman/actions/send-transactional-email/index.ts
@@ -14,13 +14,21 @@ import { formatTable } from '@/helpers/format-table-variable'
 import logger from '@/helpers/logger'
 import Step from '@/models/step'
 
+import {
+  POSTMAN_ACCEPTED_EXTENSIONS,
+  SES_BLOCKED_EXTENSIONS,
+} from '../../common/constants'
 import { dataOutSchema } from '../../common/data-out-validator'
-import { sendTransactionalEmails } from '../../common/email-helper'
+import {
+  resolveSesRouting,
+  sendTransactionalEmails,
+} from '../../common/email-helper'
 import {
   transactionalEmailFields,
   transactionalEmailSchema,
 } from '../../common/parameters'
 import {
+  AttachmentExtensionPolicy,
   filterAttachments,
   getDefaultReplyTo,
 } from '../../common/parameters-helper'
@@ -208,6 +216,24 @@ async function sendEmail(
     // Don't do partial retry in test runs! always send to all recipients
     !$.execution.testRun
 
+  if (isPartialRetry) {
+    const { status, recipient } = prevDataOutParseResult.data
+    recipientsToSend = recipient.filter((_, i) => status[i] !== 'ACCEPTED')
+  }
+
+  // Resolve the transport once, on the configured attachments and the actual
+  // send recipients. This single decision drives both the file-type policy (SES
+  // accepts everything except its executable block-list; Postman keeps its
+  // narrower allow-list) and the send itself, so the transport can't flip if
+  // filtering later strips every attachment.
+  const useSes = await resolveSesRouting(
+    recipientsToSend,
+    result.data.attachments.length > 0,
+  )
+  const extensionPolicy: AttachmentExtensionPolicy = useSes
+    ? { mode: 'block', extensions: SES_BLOCKED_EXTENSIONS }
+    : { mode: 'allow', extensions: POSTMAN_ACCEPTED_EXTENSIONS }
+
   const {
     attachmentFiles,
     invalidAttachments,
@@ -218,12 +244,8 @@ async function sendEmail(
     attachmentsList: result.data.attachments,
     isPartialRetry,
     lastExecutionStep,
+    extensionPolicy,
   })
-
-  if (isPartialRetry) {
-    const { status, recipient } = prevDataOutParseResult.data
-    recipientsToSend = recipient.filter((_, i) => status[i] !== 'ACCEPTED')
-  }
 
   const { dataOut, error, errorStatus } = await sendTransactionalEmails(
     $.http,
@@ -241,6 +263,7 @@ async function sendEmail(
       senderName: result.data.senderName,
       attachments: attachmentFiles,
     },
+    useSes,
   )
 
   /**

--- a/packages/backend/src/apps/postman/common/constants.ts
+++ b/packages/backend/src/apps/postman/common/constants.ts
@@ -34,5 +34,12 @@ export const POSTMAN_ACCEPTED_EXTENSIONS = [
   'xlsx',
 ]
 
+/**
+ * The block-list of executable/script extensions SES refuses now lives in the
+ * shared S3 helper because it also gates uploads (generatePresignedPost), not
+ * just SES sends; re-exported here so the send-time filter keeps its import.
+ */
+export { SES_BLOCKED_EXTENSIONS } from '@/helpers/s3'
+
 export const POSTMAN_SUPPORTED_ATTACHMENTS_GUIDE_URL =
   'https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types'

--- a/packages/backend/src/apps/postman/common/constants.ts
+++ b/packages/backend/src/apps/postman/common/constants.ts
@@ -34,12 +34,5 @@ export const POSTMAN_ACCEPTED_EXTENSIONS = [
   'xlsx',
 ]
 
-/**
- * The block-list of executable/script extensions SES refuses now lives in the
- * shared S3 helper because it also gates uploads (generatePresignedPost), not
- * just SES sends; re-exported here so the send-time filter keeps its import.
- */
-export { SES_BLOCKED_EXTENSIONS } from '@/helpers/s3'
-
 export const POSTMAN_SUPPORTED_ATTACHMENTS_GUIDE_URL =
   'https://postman-v1.guides.gov.sg/email-api-guide/programmatic-email-api/send-email-api/attachments#list-of-supported-attachment-file-types'

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -259,32 +259,44 @@ async function sendViaSes(
   }
 }
 
+/**
+ * Resolve whether to route via SES for the given recipients. SES is used only
+ * when `ses_enabled` is true for every recipient; if the email carries
+ * attachments, `ses_attachments_enabled` must also be true for every recipient.
+ * Otherwise the batch goes via Postman.
+ */
+export async function resolveSesRouting(
+  recipients: string[],
+  hasAttachments: boolean,
+): Promise<boolean> {
+  const sesEnabledPerRecipient = await Promise.all(
+    recipients.map(isSesEnabledForRecipient),
+  )
+  if (!sesEnabledPerRecipient.every(Boolean)) {
+    return false
+  }
+  if (!hasAttachments) {
+    return true
+  }
+  const attachmentsEnabledPerRecipient = await Promise.all(
+    recipients.map(isSesAttachmentsEnabledForRecipient),
+  )
+  return attachmentsEnabledPerRecipient.every(Boolean)
+}
+
 export async function sendTransactionalEmails(
   http: IHttpClient,
   recipients: string[],
   email: Email,
+  // Whether to route via SES. Resolved once by the caller (see resolveSesRouting)
+  // on the *configured* attachments rather than the post-filter list, so the
+  // transport can't flip between runs when filtering strips attachments to zero.
+  useSes: boolean,
 ): Promise<{
   dataOut: PostmanEmailDataOut
   errorStatus?: PostmanEmailSendStatus
   error?: HttpError
 }> {
-  // SES routing is gated by per-recipient boolean LaunchDarkly flags; targeting
-  // is configured in LaunchDarkly. Use SES only when `ses_enabled` is true for
-  // ALL recipients. When the email has attachments, additionally require
-  // `ses_attachments_enabled` for all recipients — otherwise fall back to
-  // Postman to avoid mixed error-handling paths.
-  const sesEnabledPerRecipient = await Promise.all(
-    recipients.map(isSesEnabledForRecipient),
-  )
-  let useSes = sesEnabledPerRecipient.every(Boolean)
-
-  if (useSes && email.attachments?.length) {
-    const attachmentsEnabledPerRecipient = await Promise.all(
-      recipients.map(isSesAttachmentsEnabledForRecipient),
-    )
-    useSes = attachmentsEnabledPerRecipient.every(Boolean)
-  }
-
   // Pre-send suppression check (SES path only). CC addresses are included so a
   // blacklisted CC can be dropped from the SES call rather than re-sent to
   // (which would re-bounce and inflate the bounce rate). CC suppression is

--- a/packages/backend/src/apps/postman/common/parameters-helper.ts
+++ b/packages/backend/src/apps/postman/common/parameters-helper.ts
@@ -3,7 +3,28 @@ import { IExecutionStep, IGlobalVariable, IJSONObject } from '@plumber/types'
 import { COMMON_S3_BUCKET, getObjectFromS3Id } from '@/helpers/s3'
 import Flow from '@/models/flow'
 
-import { POSTMAN_ACCEPTED_EXTENSIONS } from './constants'
+export type AttachmentExtensionPolicy =
+  | { mode: 'allow'; extensions: readonly string[] }
+  | { mode: 'block'; extensions: readonly string[] }
+
+/**
+ * Whether an attachment's extension is permitted under the given policy.
+ * `allow` mode (Postman): permitted only if the extension is in the list.
+ * `block` mode (SES): permitted unless the extension is in the list; a file with
+ * no extension is permitted (SES accepts it, and the malware scan still gates).
+ */
+function isExtensionAllowed(
+  fileType: string | undefined,
+  policy: AttachmentExtensionPolicy,
+): boolean {
+  if (!fileType) {
+    // No extension: allowed under a block-list (SES), rejected under an allow-list.
+    return policy.mode === 'block'
+  }
+  return policy.mode === 'allow'
+    ? policy.extensions.includes(fileType)
+    : !policy.extensions.includes(fileType)
+}
 
 export async function getDefaultReplyTo(flowId: string): Promise<string> {
   const flow = await Flow.query()
@@ -18,11 +39,13 @@ export async function filterAttachments({
   attachmentsList,
   isPartialRetry,
   lastExecutionStep,
+  extensionPolicy,
 }: {
   $: IGlobalVariable
   attachmentsList: string[]
   isPartialRetry: boolean
   lastExecutionStep: IExecutionStep | null
+  extensionPolicy: AttachmentExtensionPolicy
 }) {
   let submissionId: string | null = null
   const invalidAttachments: string[] = []
@@ -49,13 +72,20 @@ export async function filterAttachments({
    *    Upon retry, the execution runs without attachments, but the blacklisted recipient still exists.
    *    In such scenarios, we show the partial retry button with 'Resend to blacklisted recipients without attachments',
    *    and use this to tell the worker to remove all attachments.
+   *
+   * All of these are retry behaviours for real executions. Test runs (check
+   * step) must never auto-strip: `errorName` there comes from the *previous*
+   * check-step run, so without this guard re-clicking "check step" ping-pongs
+   * between stripping every attachment and re-including them. `isPartialRetry`
+   * is already gated on !testRun; gate the error-name conditions the same way.
    */
   const isRetryWithoutAttachments =
-    errorName === 'Password-protected attachment(s)' ||
-    errorName === 'Unsupported attachment file type' ||
-    (isPartialRetry &&
-      partialRetryButtonMessage ===
-        'Resend to blacklisted recipients without attachments')
+    !$.execution.testRun &&
+    (errorName === 'Password-protected attachment(s)' ||
+      errorName === 'Unsupported attachment file type' ||
+      (isPartialRetry &&
+        partialRetryButtonMessage ===
+          'Resend to blacklisted recipients without attachments'))
 
   await Promise.all(
     attachmentsList?.map(async (attachment) => {
@@ -70,7 +100,7 @@ export async function filterAttachments({
         return
       }
 
-      if (!fileType || !POSTMAN_ACCEPTED_EXTENSIONS.includes(fileType)) {
+      if (!isExtensionAllowed(fileType, extensionPolicy)) {
         invalidAttachments.push(fileName)
 
         if (submissionId === null) {

--- a/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
@@ -30,7 +30,7 @@ vi.mock('@/helpers/s3', () => ({
   COMMON_S3_MOCK_FOLDER_PREFIX: 's3:test-bucket:mock/',
   parseS3Id: vi.fn(),
   MAX_FILE_SIZE: 1024 * 1024 * 10,
-  ACCEPTED_FILE_TYPES: ['text/plain'],
+  SES_BLOCKED_EXTENSIONS: ['exe', 'bat', 'js', 'msi'],
   validateObjectKey: vi.fn((objectKey) => {
     const invalidCharacters = /[\\{}^`%~#<>|[\]]/
     if (invalidCharacters.test(objectKey)) {
@@ -153,14 +153,11 @@ describe('generatePresignedPost', () => {
     ).rejects.toThrow('Size of attachment exceeds 10MB')
   })
 
-  it.each([
-    'application/octet-stream',
-    'application/x-executable',
-    'application/x-shockwave-flash',
-    'application/x-msdownload',
-  ])(
-    'should throw an error if the file type is not supported: %s',
-    async (fileType) => {
+  // The gate is a block-list keyed on the filename's extension (executables /
+  // scripts); the reported MIME type no longer affects validation.
+  it.each(['virus.exe', 'script.bat', 'payload.js', 'setup.msi'])(
+    'should throw an error if the file extension is blocked: %s',
+    async (filename) => {
       await Flow.query().insert({
         id: VALID_PARAMS.flow.id,
         name: 'Test Flow',
@@ -169,12 +166,35 @@ describe('generatePresignedPost', () => {
 
       const unsupportedParams = {
         ...VALID_PARAMS,
-        fileType,
+        filename,
       }
 
       await expect(
         generatePresignedPost(null, { input: unsupportedParams }, context),
       ).rejects.toThrow('Unsupported file type')
+    },
+  )
+
+  // Types that the old MIME allow-list rejected are now accepted (SES supports
+  // them); only the executable block-list is refused.
+  it.each(['invite.ics', 'archive.zip', 'data.json', 'no-extension'])(
+    'should generate a presigned url for a non-blocked file: %s',
+    async (filename) => {
+      const mockFlow = await generateMockFlow(context, VALID_PARAMS.flow.id)
+
+      await generatePresignedPost(
+        null,
+        {
+          input: {
+            ...VALID_PARAMS,
+            filename,
+            flow: { id: mockFlow.id, updatedAt: mockFlow.updatedAt },
+          },
+        },
+        context,
+      )
+
+      expect(getPresignedPost).toHaveBeenCalled()
     },
   )
 })

--- a/packages/backend/src/graphql/mutations/generate-presigned-post.ts
+++ b/packages/backend/src/graphql/mutations/generate-presigned-post.ts
@@ -30,7 +30,9 @@ const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
     // actually filtered on send; the reported MIME type is unreliable and only
     // used for the S3 object's content type. Files with no extension are allowed
     // (consistent with filterAttachments); every object is malware-scanned.
-    const fileExtension = filename.split('.').pop()?.toLowerCase()
+    const parts = filename.split('.')
+    const fileExtension =
+      parts.length > 1 ? parts.pop()?.toLowerCase() : undefined
     if (fileExtension && SES_BLOCKED_EXTENSIONS.includes(fileExtension)) {
       throw new Error('Unsupported file type')
     }

--- a/packages/backend/src/graphql/mutations/generate-presigned-post.ts
+++ b/packages/backend/src/graphql/mutations/generate-presigned-post.ts
@@ -3,10 +3,10 @@ import { randomUUID } from 'crypto'
 
 import { ForbiddenError } from '@/errors/graphql-errors'
 import {
-  ACCEPTED_FILE_TYPES,
   COMMON_S3_BUCKET,
   getPresignedPost,
   MAX_FILE_SIZE,
+  SES_BLOCKED_EXTENSIONS,
   validateObjectKey,
 } from '@/helpers/s3'
 
@@ -25,7 +25,13 @@ const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
     if (size > MAX_FILE_SIZE) {
       throw new Error('Size of attachment exceeds 10MB')
     }
-    if (!ACCEPTED_FILE_TYPES.includes(fileType)) {
+    // Block-list gate: accept anything except executables/scripts (mirrors the
+    // SES send-time filter). Extension-based to match how attachments are
+    // actually filtered on send; the reported MIME type is unreliable and only
+    // used for the S3 object's content type. Files with no extension are allowed
+    // (consistent with filterAttachments); every object is malware-scanned.
+    const fileExtension = filename.split('.').pop()?.toLowerCase()
+    if (fileExtension && SES_BLOCKED_EXTENSIONS.includes(fileExtension)) {
       throw new Error('Unsupported file type')
     }
 

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -39,36 +39,105 @@ export const MALWARE_SCAN_FAILURE = [
   MALWARE_SCAN_STATUS.FAILED,
 ]
 
-export const ACCEPTED_FILE_TYPES = [
-  'text/plain', // .txt, .asc
-  'video/x-msvideo', // .avi
-  'image/bmp', // .bmp
-  'text/csv', // .csv
-  'application/x-dgn', // .dgn
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
-  'application/x-dwf', // .dwf
-  'application/x-dwg', // .dwg
-  'application/x-dxf', // .dxf
-  'application/x-ent', // .ent
-  'image/gif', // .gif
-  'image/jpeg', // .jpg, .jpeg
-  'video/mpeg', // .mpeg, .mpg
-  'application/vnd.ms-project', // .mpp
-  'application/vnd.oasis.opendocument.database', // .odb
-  'application/vnd.oasis.opendocument.formula', // .odf
-  'application/vnd.oasis.opendocument.graphics', // .odg
-  'application/vnd.oasis.opendocument.spreadsheet', // .ods
-  'application/pdf', // .pdf
-  'image/png', // .png
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
-  'application/rtf', // .rtf
-  'application/vnd.sun.xml.calc', // .sxc
-  'application/vnd.sun.xml.draw', // .sxd
-  'application/vnd.sun.xml.impress', // .sxi
-  'application/vnd.sun.xml.writer', // .sxw
-  'image/tiff', // .tif, .tiff
-  'video/x-ms-wmv', // .wmv
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+/**
+ * File extensions blocked from being uploaded/attached (executables/scripts).
+ * This mirrors the set SES refuses, so it is a block-list, not an allow-list:
+ * anything not listed here is accepted (subject to the malware scan). It is the
+ * single source of truth for both the upload gate (generatePresignedPost) and
+ * the SES send-time attachment filter (postman filterAttachments). Keep in sync
+ * with AWS's list: https://docs.aws.amazon.com/ses/latest/dg/attachments.html
+ */
+export const SES_BLOCKED_EXTENSIONS = [
+  'ade',
+  'adp',
+  'app',
+  'asp',
+  'bas',
+  'bat',
+  'cer',
+  'chm',
+  'cmd',
+  'com',
+  'cpl',
+  'crt',
+  'csh',
+  'der',
+  'exe',
+  'fxp',
+  'gadget',
+  'hlp',
+  'hta',
+  'inf',
+  'ins',
+  'isp',
+  'its',
+  'js',
+  'jse',
+  'ksh',
+  'lib',
+  'lnk',
+  'mad',
+  'maf',
+  'mag',
+  'mam',
+  'maq',
+  'mar',
+  'mas',
+  'mat',
+  'mau',
+  'mav',
+  'maw',
+  'mda',
+  'mdb',
+  'mde',
+  'mdt',
+  'mdw',
+  'mdz',
+  'msc',
+  'msh',
+  'msh1',
+  'msh2',
+  'mshxml',
+  'msh1xml',
+  'msh2xml',
+  'msi',
+  'msp',
+  'mst',
+  'ops',
+  'pcd',
+  'pif',
+  'plg',
+  'prf',
+  'prg',
+  'reg',
+  'scf',
+  'scr',
+  'sct',
+  'shb',
+  'shs',
+  'sys',
+  'ps1',
+  'ps1xml',
+  'ps2',
+  'ps2xml',
+  'psc1',
+  'psc2',
+  'tmp',
+  'url',
+  'vb',
+  'vbe',
+  'vbs',
+  'vps',
+  'vsmacros',
+  'vss',
+  'vst',
+  'vsw',
+  'vxd',
+  'ws',
+  'wsc',
+  'wsf',
+  'wsh',
+  'xnk',
 ]
 export const MAX_FILE_SIZE = 1024 * 1024 * 10 // 10MB
 

--- a/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/components/Suggestions.tsx
@@ -16,7 +16,7 @@ import { StepWithVariables, Variable } from '@/helpers/variables'
 import { POPOVER_MOTION_PROPS } from '@/theme/constants'
 
 import { boxStyles, divWrapperStyles, noVariablesTextStyles } from '../style'
-import { ACCEPTED_FILE_TYPES, AttachmentConfigInput } from '../utils'
+import { AttachmentConfigInput } from '../utils'
 
 import Checkbox, { type CheckboxVariable } from './Checkbox'
 import TagList from './TagList'
@@ -93,7 +93,7 @@ export default function Suggestions(props: SuggestionsProps) {
               >
                 {addNew && (
                   <FileUpload
-                    accept={ACCEPTED_FILE_TYPES.join(',')}
+                    accept="*/*"
                     buttonType="textButton"
                     disabled={isUploading || readOnly}
                     loading={isUploading}

--- a/packages/frontend/src/components/AttachmentSuggestions/index.tsx
+++ b/packages/frontend/src/components/AttachmentSuggestions/index.tsx
@@ -18,7 +18,7 @@ import MenuAlertDialog from '../MenuAlertDialog'
 import { CheckboxVariable } from './components/Checkbox'
 import Suggestions from './components/Suggestions'
 import { useAttachmentOptions } from './hooks/useAttachmentOptions'
-import { validateFiles, validateFileSize } from './utils'
+import { validateFileExtension, validateFiles, validateFileSize } from './utils'
 
 interface AttachmentSuggestionsProps {
   name: string
@@ -151,16 +151,25 @@ function AttachmentSuggestions(props: AttachmentSuggestionsProps) {
   const processFile = useCallback(
     async (file: File) => {
       /**
-       * when uploading the file, we only need to validate the file size.
-       * the total number of files and total size of files are validated when users make
-       * their selection via the suggestions component.
+       * when uploading the file, we only need to validate the file size and
+       * extension. the total number of files and total size of files are
+       * validated when users make their selection via the suggestions
+       * component.
        */
-      const { isValid, error } = validateFileSize(file)
-      if (!isValid) {
-        setError(name, { type: 'invalidFile', message: error })
-      } else {
-        await uploadToS3(file, flow.id, flow.updatedAt)
+      const { isValid: isValidExtension, error: extensionError } =
+        validateFileExtension(file)
+      if (!isValidExtension) {
+        setError(name, { type: 'invalidFile', message: extensionError })
+        return
       }
+
+      const { isValid: isValidSize, error: sizeError } = validateFileSize(file)
+      if (!isValidSize) {
+        setError(name, { type: 'invalidFile', message: sizeError })
+        return
+      }
+
+      await uploadToS3(file, flow.id, flow.updatedAt)
     },
     [flow.id, flow.updatedAt, name, setError, uploadToS3],
   )

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.test.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { type CheckboxVariable } from './components/Checkbox'
-import { validateFiles } from './utils'
+import { validateFileExtension, validateFiles } from './utils'
 
 const makeFile = (name: string): CheckboxVariable => ({
   name,
@@ -44,5 +44,28 @@ describe('validateFiles', () => {
     // This assertion documents that passing raw (stale) values to validateFiles
     // incorrectly blocks the selection — the fix passes filtered currentValues instead.
     expect(result.isValid).toBe(false)
+  })
+})
+
+describe('validateFileExtension', () => {
+  it('blocks a file with a blocked extension', () => {
+    const result = validateFileExtension(new File([''], 'blocked.exe'))
+    expect(result.isValid).toBe(false)
+    expect(result.error).toContain('.exe')
+  })
+
+  it('is case-insensitive when checking the extension', () => {
+    const result = validateFileExtension(new File([''], 'blocked.EXE'))
+    expect(result.isValid).toBe(false)
+  })
+
+  it('allows a file with an accepted extension', () => {
+    const result = validateFileExtension(new File([''], 'report.pdf'))
+    expect(result.isValid).toBe(true)
+  })
+
+  it('allows a file with no extension', () => {
+    const result = validateFileExtension(new File([''], 'README'))
+    expect(result.isValid).toBe(true)
   })
 })

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -10,38 +10,6 @@ export const MAX_NUM_FILES = 10
 const MAX_FILE_SIZE = 10 * MB // 10MB
 const MAX_TOTAL_FILE_SIZE = 10 * MB // 10MB
 
-export const ACCEPTED_FILE_TYPES = [
-  'text/plain', // .txt, .asc
-  'video/x-msvideo', // .avi
-  'image/bmp', // .bmp
-  'text/csv', // .csv
-  'application/x-dgn', // .dgn
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
-  'application/x-dwf', // .dwf
-  'application/x-dwg', // .dwg
-  'application/x-dxf', // .dxf
-  'application/x-ent', // .ent
-  'image/gif', // .gif
-  'image/jpeg', // .jpg, .jpeg
-  'video/mpeg', // .mpeg, .mpg
-  'application/vnd.ms-project', // .mpp
-  'application/vnd.oasis.opendocument.database', // .odb
-  'application/vnd.oasis.opendocument.formula', // .odf
-  'application/vnd.oasis.opendocument.graphics', // .odg
-  'application/vnd.oasis.opendocument.spreadsheet', // .ods
-  'application/pdf', // .pdf
-  'image/png', // .png
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
-  'application/rtf', // .rtf
-  'application/vnd.sun.xml.calc', // .sxc
-  'application/vnd.sun.xml.draw', // .sxd
-  'application/vnd.sun.xml.impress', // .sxi
-  'application/vnd.sun.xml.writer', // .sxw
-  'image/tiff', // .tif, .tiff
-  'video/x-ms-wmv', // .wmv
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
-]
-
 export interface AttachmentConfigInput {
   name: string
   displayedValue: string

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -10,6 +10,105 @@ export const MAX_NUM_FILES = 10
 const MAX_FILE_SIZE = 10 * MB // 10MB
 const MAX_TOTAL_FILE_SIZE = 10 * MB // 10MB
 
+/**
+ * Mirrors SES_BLOCKED_EXTENSIONS in packages/backend/src/helpers/s3.ts — keep
+ * in sync if that list changes. Duplicated here (rather than fetched) so the
+ * file picker can reject a blocked file immediately, before it's uploaded to
+ * S3 and generatePresignedPost rejects it server-side.
+ */
+const SES_BLOCKED_EXTENSIONS = new Set([
+  'ade',
+  'adp',
+  'app',
+  'asp',
+  'bas',
+  'bat',
+  'cer',
+  'chm',
+  'cmd',
+  'com',
+  'cpl',
+  'crt',
+  'csh',
+  'der',
+  'exe',
+  'fxp',
+  'gadget',
+  'hlp',
+  'hta',
+  'inf',
+  'ins',
+  'isp',
+  'its',
+  'js',
+  'jse',
+  'ksh',
+  'lib',
+  'lnk',
+  'mad',
+  'maf',
+  'mag',
+  'mam',
+  'maq',
+  'mar',
+  'mas',
+  'mat',
+  'mau',
+  'mav',
+  'maw',
+  'mda',
+  'mdb',
+  'mde',
+  'mdt',
+  'mdw',
+  'mdz',
+  'msc',
+  'msh',
+  'msh1',
+  'msh2',
+  'mshxml',
+  'msh1xml',
+  'msh2xml',
+  'msi',
+  'msp',
+  'mst',
+  'ops',
+  'pcd',
+  'pif',
+  'plg',
+  'prf',
+  'prg',
+  'reg',
+  'scf',
+  'scr',
+  'sct',
+  'shb',
+  'shs',
+  'sys',
+  'ps1',
+  'ps1xml',
+  'ps2',
+  'ps2xml',
+  'psc1',
+  'psc2',
+  'tmp',
+  'url',
+  'vb',
+  'vbe',
+  'vbs',
+  'vps',
+  'vsmacros',
+  'vss',
+  'vst',
+  'vsw',
+  'vxd',
+  'ws',
+  'wsc',
+  'wsf',
+  'wsh',
+  'xnk',
+])
+
 export interface AttachmentConfigInput {
   name: string
   displayedValue: string
@@ -179,6 +278,17 @@ export function validateFileSize(
   const fileSize = file.size ?? 0
   if (fileSize > MAX_FILE_SIZE) {
     return { isValid: false, error: 'Size of attachment exceeds 10MB' }
+  }
+  return { isValid: true }
+}
+
+export function validateFileExtension(file: File): FileSizeValidationResult {
+  const extension = file.name.split('.').pop()?.toLowerCase()
+  if (extension && SES_BLOCKED_EXTENSIONS.has(extension)) {
+    return {
+      isValid: false,
+      error: `Files with a .${extension} extension are not supported`,
+    }
   }
   return { isValid: true }
 }


### PR DESCRIPTION
### TL;DR

Replace the MIME-type allow-list for attachments with an extension-based block-list aligned with AWS SES, and fix a transport-flip bug where the SES/Postman routing decision could change after attachment filtering.

### What changed?

- `ACCEPTED_FILE_TYPES` (a MIME-type allow-list) has been removed from both the backend S3 helper and the frontend upload component. It is replaced by `SES_BLOCKED_EXTENSIONS`, an extension-based block-list that mirrors [AWS SES's blocked attachment list](https://docs.aws.amazon.com/ses/latest/dg/attachments.html). This is now the single source of truth for both the upload gate (`generatePresignedPost`) and the SES send-time attachment filter.
- The file upload input in the frontend now accepts `*/*` instead of the old MIME allow-list, so users can select any file; enforcement happens server-side via the block-list.
- `filterAttachments` now accepts an `AttachmentExtensionPolicy` (either `allow` with a list of permitted extensions for Postman, or `block` with a list of forbidden extensions for SES) instead of always applying the Postman allow-list.
- SES/Postman routing (`resolveSesRouting`) is now resolved once, upfront, based on the configured attachments before filtering. This prevents a bug where filtering all attachments down to zero could cause the transport to flip from SES to Postman mid-execution.
- The `isRetryWithoutAttachments` logic in `filterAttachments` is now gated on `!$.execution.testRun` to prevent ping-ponging between stripping and re-including attachments when re-clicking "check step".
- A new test covers the case where all configured attachments are filtered out but the transport correctly stays on Postman rather than flipping to SES.

### How to test?

1. Upload a file with a blocked extension (e.g. `.exe`, `.bat`, `.js`, `.msi`) via the attachment picker — it should be rejected with "Unsupported file type".
2. Upload a file type that was previously blocked by the old MIME allow-list (e.g. `.ics`, `.zip`, `.json`) — it should now be accepted and proceed to the malware scan.
3. Configure a Postman transactional email step with attachments for a recipient that has `ses_enabled` on but `ses_attachments_enabled` off. Verify the email is sent via Postman (not SES) even if all attachments are filtered out.
4. Run the existing and new unit/integration tests: `send-transactional-email.test.ts` and `generate-presigned-post.itest.ts`.

### Why make this change?

The old MIME-type allow-list was overly restrictive and inconsistent with what SES actually supports. Because MIME types are client-reported and unreliable, extension-based filtering is more accurate. Aligning the upload gate and the send-time filter to the same SES block-list means users can attach any file that SES will accept, while still blocking known executable/script types. The transport-flip fix ensures consistent routing behaviour when attachment filtering reduces the attachment list to zero between the routing decision and the actual send.