### PR TITLE
[PLU-790-3]: increase attachment file size limit

### DIFF
--- a/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/actions/send-transactional-email.test.ts
@@ -969,12 +969,12 @@ describe('send transactional email', () => {
       expect(mime).toContain('X-Plumber-Transport: ses')
     })
 
-    it('rejects with ATTACHMENT-SIZE-EXCEEDED when SES attachments exceed 10MB total', async () => {
+    it('rejects with ATTACHMENT-SIZE-EXCEEDED when SES attachments exceed 20MB total', async () => {
       mocks.getLdFlagValue.mockResolvedValue(true)
       $.step.parameters.destinationEmail = 'a@open.gov.sg'
       mocks.filterAttachments.mockReturnValueOnce({
         attachmentFiles: [
-          { fileName: 'big.pdf', data: new Uint8Array(10 * 1024 * 1024 + 1) },
+          { fileName: 'big.pdf', data: new Uint8Array(20 * 1024 * 1024 + 1) },
         ],
         invalidAttachments: [],
         submissionId: null,

--- a/packages/backend/src/apps/postman/__tests__/common/build-raw-mime.test.ts
+++ b/packages/backend/src/apps/postman/__tests__/common/build-raw-mime.test.ts
@@ -77,6 +77,21 @@ describe('buildRawEmail', () => {
 
     expect(raw).not.toMatch(/^To:/m)
   })
+
+  it('sends a .eml attachment as a downloadable file, not an inline nested message', async () => {
+    const raw = await build({
+      ...baseInput,
+      attachments: [
+        { fileName: 'original.eml', data: new Uint8Array([1, 2, 3]) },
+      ],
+    })
+
+    // nodemailer defaults message/* content types (which .eml resolves to)
+    // to Content-Disposition: inline unless overridden — assert we override it.
+    expect(raw).toContain('message/rfc822')
+    expect(raw).toMatch(/Content-Disposition: attachment/i)
+    expect(raw).not.toMatch(/Content-Disposition: inline/i)
+  })
 })
 
 describe('withRecipient', () => {

--- a/packages/backend/src/apps/postman/common/build-raw-mime.ts
+++ b/packages/backend/src/apps/postman/common/build-raw-mime.ts
@@ -40,6 +40,12 @@ export function buildRawEmail(input: RawEmailInput): Promise<Buffer> {
     attachments: input.attachments.map((attachment) => ({
       filename: attachment.fileName,
       content: Buffer.from(attachment.data),
+      // Force a real download. Without this, nodemailer defaults
+      // Content-Disposition to 'inline' for any content type it detects as
+      // message/* (e.g. .eml -> message/rfc822), which makes mail clients
+      // render the attachment as a nested email instead of a downloadable
+      // file. None of our attachments are ever inline/cid-embedded images.
+      contentDisposition: 'attachment' as const,
     })),
     ...(input.headers && { headers: input.headers }),
   })

--- a/packages/backend/src/apps/postman/common/email-helper.ts
+++ b/packages/backend/src/apps/postman/common/email-helper.ts
@@ -137,17 +137,17 @@ async function sendViaPostman(
   }
 }
 
-// Parity with Postman's server-side total-attachment limit (10MB), which the
-// SES path bypasses. Compared against raw (pre-base64) bytes — the same basis
-// Postman uses. SES itself allows up to 40MB, so this is the parity cap, not an
-// SES limit.
-const SES_MAX_TOTAL_ATTACHMENT_SIZE = 10 * 1024 * 1024
+// Total attachment cap for the SES path. SES accepts messages up to 40MB after
+// base64 encoding (~1.37x), so we cap raw attachments at 20MB (~27MB encoded) to
+// stay safely under that. Compared against raw (pre-base64) bytes. The Postman
+// route enforces its own (smaller) limit server-side.
+const SES_MAX_TOTAL_ATTACHMENT_SIZE = 20 * 1024 * 1024
 
-// Thrown by the SES path when attachments exceed the parity cap. Mapped to
+// Thrown by the SES path when attachments exceed the cap above. Mapped to
 // ATTACHMENT-SIZE-EXCEEDED by getSesErrorStatus (matched by name).
 class AttachmentSizeExceededError extends Error {
   constructor() {
-    super('Total attachment size exceeds 10MB')
+    super('Total attachment size exceeds 20MB')
     this.name = 'AttachmentSizeExceededError'
   }
 }

--- a/packages/backend/src/apps/postman/common/parameters.ts
+++ b/packages/backend/src/apps/postman/common/parameters.ts
@@ -94,7 +94,7 @@ export const transactionalEmailFields: IField[] = [
   {
     label: 'Attachments',
     key: 'attachments',
-    description: `Check supported file types [here](${POSTMAN_SUPPORTED_ATTACHMENTS_GUIDE_URL}).\nPlease note that the maximum file size for each file is 2MB, and the total size of all attachments cannot exceed 10MB.`,
+    description: `Check supported file types [here](${POSTMAN_SUPPORTED_ATTACHMENTS_GUIDE_URL}).\nPlease note that the total size of all attachments cannot exceed 20MB.`, // TODO: update the guide on the supported file types
     type: 'attachment' as const,
     required: false,
     variables: true,

--- a/packages/backend/src/apps/postman/common/throw-errors.ts
+++ b/packages/backend/src/apps/postman/common/throw-errors.ts
@@ -69,7 +69,7 @@ export function getSesErrorStatus(error: unknown): PostmanEmailSendStatus {
   }
 
   // Pre-send size guard on the SES path: SES has no structured size error, so we
-  // enforce the 10MB total ourselves and surface it like Postman's
+  // enforce the 20MB total ourselves and surface it like Postman's
   // `attachment_limit` → ATTACHMENT-SIZE-EXCEEDED.
   if (error.name === 'AttachmentSizeExceededError') {
     return 'ATTACHMENT-SIZE-EXCEEDED'
@@ -220,7 +220,7 @@ export function throwPostmanStepError({
     case 'ATTACHMENT-SIZE-EXCEEDED':
       throw new StepError(
         'Total attachment size exceeded',
-        'Check that the attachments do not exceed 10MB in total.',
+        'Check that the attachments do not exceed 20MB in total.',
         error,
       )
     case 'INTERMITTENT-ERROR':

--- a/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/generate-presigned-post.itest.ts
@@ -29,7 +29,7 @@ vi.mock('@/helpers/s3', () => ({
   COMMON_S3_BUCKET: 'test-bucket',
   COMMON_S3_MOCK_FOLDER_PREFIX: 's3:test-bucket:mock/',
   parseS3Id: vi.fn(),
-  MAX_FILE_SIZE: 1024 * 1024 * 10,
+  MAX_FILE_SIZE: 1024 * 1024 * 20,
   SES_BLOCKED_EXTENSIONS: ['exe', 'bat', 'js', 'msi'],
   validateObjectKey: vi.fn((objectKey) => {
     const invalidCharacters = /[\\{}^`%~#<>|[\]]/
@@ -147,10 +147,10 @@ describe('generatePresignedPost', () => {
       userId: context.currentUser.id,
     })
 
-    const tooLargeParams = { ...VALID_PARAMS, size: 10 * 1024 * 1024 + 1 }
+    const tooLargeParams = { ...VALID_PARAMS, size: 20 * 1024 * 1024 + 1 }
     await expect(
       generatePresignedPost(null, { input: tooLargeParams }, context),
-    ).rejects.toThrow('Size of attachment exceeds 10MB')
+    ).rejects.toThrow('Size of attachment exceeds 20MB')
   })
 
   // The gate is a block-list keyed on the filename's extension (executables /

--- a/packages/backend/src/graphql/mutations/generate-presigned-post.ts
+++ b/packages/backend/src/graphql/mutations/generate-presigned-post.ts
@@ -23,7 +23,7 @@ const generatePresignedPost: MutationResolvers['generatePresignedPost'] =
     } = params.input
 
     if (size > MAX_FILE_SIZE) {
-      throw new Error('Size of attachment exceeds 10MB')
+      throw new Error('Size of attachment exceeds 20MB')
     }
     // Block-list gate: accept anything except executables/scripts (mirrors the
     // SES send-time filter). Extension-based to match how attachments are

--- a/packages/backend/src/helpers/s3.ts
+++ b/packages/backend/src/helpers/s3.ts
@@ -139,7 +139,7 @@ export const SES_BLOCKED_EXTENSIONS = [
   'wsh',
   'xnk',
 ]
-export const MAX_FILE_SIZE = 1024 * 1024 * 10 // 10MB
+export const MAX_FILE_SIZE = 1024 * 1024 * 20 // 20MB
 
 function throwAttachmentError(
   errorType: string,

--- a/packages/frontend/src/components/AttachmentSuggestions/utils.ts
+++ b/packages/frontend/src/components/AttachmentSuggestions/utils.ts
@@ -7,8 +7,8 @@ import { type CheckboxVariable } from './components/Checkbox'
 const KB = 1024
 const MB = KB * KB
 export const MAX_NUM_FILES = 10
-const MAX_FILE_SIZE = 10 * MB // 10MB
-const MAX_TOTAL_FILE_SIZE = 10 * MB // 10MB
+const MAX_FILE_SIZE = 20 * MB // 20MB
+const MAX_TOTAL_FILE_SIZE = 20 * MB // 20MB
 
 /**
  * Mirrors SES_BLOCKED_EXTENSIONS in packages/backend/src/helpers/s3.ts — keep
@@ -266,7 +266,7 @@ export function validateFiles(
   if (totalSize > MAX_TOTAL_FILE_SIZE) {
     return {
       isValid: false,
-      error: 'Total size of attachments exceeds 10MB',
+      error: 'Total size of attachments exceeds 20MB',
     }
   }
   return { isValid: true }
@@ -277,7 +277,7 @@ export function validateFileSize(
 ): FileSizeValidationResult {
   const fileSize = file.size ?? 0
   if (fileSize > MAX_FILE_SIZE) {
-    return { isValid: false, error: 'Size of attachment exceeds 10MB' }
+    return { isValid: false, error: 'Size of attachment exceeds 20MB' }
   }
   return { isValid: true }
 }


### PR DESCRIPTION
### TL;DR

Increases the maximum attachment size limit from 10MB to 20MB across the entire email attachment flow.

### What changed?

- The per-file and total attachment size cap is raised from 10MB to 20MB in both frontend validation and backend enforcement.
- The SES path's internal attachment size guard is updated to reflect the new 20MB cap, with a revised comment explaining the rationale: SES accepts messages up to 40MB after base64 encoding (~1.37x overhead), so 20MB raw (~27MB encoded) stays safely under that limit.
- Error messages and field descriptions shown to users now reference 20MB instead of 10MB.
- The presigned S3 upload endpoint now allows files up to 20MB.
- The previous comment justifying the 10MB cap as parity with Postman's server-side limit has been removed, since the SES path is no longer constrained to match Postman's smaller limit.

### How to test?

- Attempt to upload an attachment between 10MB and 20MB — it should now be accepted rather than rejected.
- Attempt to upload an attachment exceeding 20MB — it should be rejected with the updated error message referencing 20MB.
- Verify the attachment field description in the email step UI reflects the new 20MB limit.

### Why make this change?

The previous 10MB cap was set to match Postman's server-side limit for parity, but emails sent via the SES path bypass Postman entirely. SES supports messages up to 40MB (post-encoding), so the 10MB cap was unnecessarily restrictive. Raising it to 20MB gives users more headroom while still staying well within SES's actual constraints.