### PR TITLE
fix(frontend): fire form watch on nested multirow row add/remove

### DIFF
--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -52,7 +52,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     ...forwardedInputCreatorProps
   } = props
 
-  const { control } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
 
   // react-hook-form requires a non-undefined default value for _every_
@@ -85,7 +85,15 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     } else {
       append(newRowDefaultValue)
     }
-  }, [append, newRowDefaultValue, subFields])
+    // A nested useFieldArray's `append` (like `remove`) updates the form value
+    // but does not fire the form's `watch` subject, so subscribers such as the
+    // step validator gating "Check step" never recompute. Re-assert the
+    // already-updated value through `setValue`, which does notify.
+    setValue(name, getValues(name), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [append, newRowDefaultValue, subFields, setValue, getValues, name])
 
   return (
     // Use Controller's defaultValue to introduce 1 blank row by default. We
@@ -108,9 +116,17 @@ function MultiRow(props: MultiRowProps): JSX.Element {
         const removeRow = (index: number) => {
           if (rowsToRender.length === 1 && onRequestRemoveLastRow) {
             onRequestRemoveLastRow()
-          } else {
-            remove(index)
+            return
           }
+          remove(index)
+          // A nested useFieldArray's `remove` updates the form value but does not
+          // fire the form's `watch` subject, so subscribers (e.g. the step
+          // validator that gates "Check step") never recompute. Re-assert the
+          // already-updated value through `setValue`, which does notify.
+          setValue(name, getValues(name), {
+            shouldDirty: true,
+            shouldValidate: true,
+          })
         }
 
         return (


### PR DESCRIPTION
# Problem

A user could get weird error in our pipe editor when using our Or condition. Repro steps:

1. Create a Only Continue If, fill in a valid 1st condition, check step.
2. Add a Or condition, don't fill in anything in the new condition, save without checking
    1. NOTE: observe that this makes the step invalid, so the step cannot be checked.
3. Remove that new (empty) condition

The user now sees an error and the step remains invalid (greyed check step), even though the step looks correct.

## Root cause

`useFieldArray` does not fire `watch` on updates, but we rely on `watch` to compute step validity, so our re-check never runs and the "Check Step" button remains disabled.

# Fix

Manually trigger `watch` via `setValue`.

# Tests

- Check that repo case no longer happens
- Regression test: check that I can still add and delete multi rows without OR in If-then, Find row in files, file row in excel