### PR TITLE
fix(frontend): handle config-matches-last-test edge cases in step test controller

### DIFF
--- a/packages/frontend/src/components/FlowStepTestController/index.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/index.tsx
@@ -119,6 +119,7 @@ export default function FlowStepTestController(
 
   const {
     isTestSuccessful,
+    isLastTestExecutionSuccessful,
     lastErrorDetails,
     isWebhookSubstep,
     testVariables,
@@ -145,6 +146,7 @@ export default function FlowStepTestController(
     isDirty,
     isIfThenStep,
     isLastTestExecutionCurrent,
+    isLastTestExecutionSuccessful,
     isTestSuccessful,
     isTestExecuting,
     stepId: step.id,
@@ -186,7 +188,34 @@ export default function FlowStepTestController(
   const shouldAllowCheckStep = isValid && !readOnly && !isSaving
 
   const shouldShowSaveButton =
-    !readOnly && (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty))
+    !readOnly &&
+    // Users may exit and continue configuring their step in a different
+    // session. As long as the config differs from the last test execution,
+    // show the save button to let them split their work across multiple
+    // sessions (note: save button is disabled unless it's dirty, but that's ok
+    // as we also use it to signal "saved-or-not" status to users)
+    (!isLastTestExecutionCurrent ||
+      // Edge case: Users may update the step config to a state where it's
+      // exactly the same as the previous test execution, even if the persisted
+      // database state is not. Example (via OR condition):
+      //   1. Add Only-Continue-If, configure the initial condition and test
+      //      successfully
+      //   2. Add a new OR group, do NOT configure anything.
+      //   3. Save the step (this updates the DB and inserts a new empty array
+      //      for the OR-ed condition. It also makes the step incomplete)
+      //   4. Delete the OR group from step 2. This makes the data in match the
+      //      test execution, but we still need to show the "Save" button as the
+      //      config differs from DB state.
+      // Some more notes:
+      // - We require at least one successful test execution; otherwise, we
+      //   should show "Check step" instead of "Save + Check step again".
+      // - We also show the "Save" button when the status is incomplete;
+      //   otherwise, it becomes not dirty after saving and the button will
+      //   disappear. This is inconsistent with other user journeys (current
+      //   config differs from last tested config) where the button stays on
+      //   screen.
+      (isLastTestExecutionSuccessful &&
+        (isDirty || step.status !== 'completed')))
   const shouldShowTestResults =
     isSameAppAndAppKey(step, currentTestExecutionStep) &&
     !lastErrorDetails &&

--- a/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
+++ b/packages/frontend/src/components/FlowStepTestController/useTestDetails.ts
@@ -6,6 +6,9 @@ import { isSameAppAndAppKey } from './utils'
 
 interface UseTestDetailsResult {
   isTestSuccessful: boolean
+  // Whether the last execution itself succeeded, independent of the persisted
+  // step.status (which only executeStep promotes to 'completed').
+  isLastTestExecutionSuccessful: boolean
   isWebhookSubstep: boolean
   lastErrorDetails?: IJSONObject | null
   testVariables: Variable[] | null
@@ -23,15 +26,18 @@ export function useTestDetails(
   if (!isSameAppAndAppKey(step, currentTestExecutionStep)) {
     return {
       isTestSuccessful: false,
+      isLastTestExecutionSuccessful: false,
       isWebhookSubstep,
       lastErrorDetails: null,
       testVariables: null,
     }
   }
 
-  const isTestSuccessful =
-    step.status === 'completed' &&
+  const isLastTestExecutionSuccessful =
     currentTestExecutionStep?.status === 'success'
+
+  const isTestSuccessful =
+    step.status === 'completed' && isLastTestExecutionSuccessful
 
   const lastErrorDetails = currentTestExecutionStep?.errorDetails
 
@@ -42,6 +48,7 @@ export function useTestDetails(
 
   return {
     isTestSuccessful,
+    isLastTestExecutionSuccessful,
     isWebhookSubstep,
     lastErrorDetails,
     testVariables,

--- a/packages/frontend/src/components/FlowStepTestController/utils.tsx
+++ b/packages/frontend/src/components/FlowStepTestController/utils.tsx
@@ -267,6 +267,7 @@ export function getInfoBoxDetails({
   isDirty,
   isIfThenStep,
   isLastTestExecutionCurrent,
+  isLastTestExecutionSuccessful,
   isTestSuccessful,
   isTestExecuting,
   stepId,
@@ -276,6 +277,9 @@ export function getInfoBoxDetails({
   isDirty: boolean
   isIfThenStep: boolean
   isLastTestExecutionCurrent: boolean
+  // Whether the last execution step itself succeeded, independent of the
+  // persisted step.status (which only `executeStep` promotes to 'completed').
+  isLastTestExecutionSuccessful: boolean
   isTestSuccessful: boolean
   isTestExecuting: boolean
   stepId: string
@@ -296,7 +300,21 @@ export function getInfoBoxDetails({
     ]
   }
 
-  if (!isLastTestExecutionCurrent || (isTestSuccessful && isDirty)) {
+  // Show a neutral "Previous result" (prompting a re-check rather than
+  // asserting failure) whenever the shown result no longer describes the step
+  // as it now stands:
+  //   - the current params no longer match the last test's input,
+  //   - there are unsaved edits (also signalled by the "Save without checking"
+  //     button), or
+  //   - the last execution succeeded but the step isn't marked completed yet
+  //     (invalidated after a successful test, or saved without re-checking).
+  //     `isLastTestExecutionSuccessful && !isTestSuccessful` is equivalent to
+  //     "last execution succeeded but step.status !== 'completed'".
+  if (
+    !isLastTestExecutionCurrent ||
+    isDirty ||
+    (isLastTestExecutionSuccessful && !isTestSuccessful)
+  ) {
     return ['unstyled', 'Previous result']
   }
 
@@ -309,6 +327,9 @@ export function getInfoBoxDetails({
     return ['success', 'Step was set up successfully!']
   }
 
+  // Only reached when the last execution did not succeed (and carried no
+  // errorDetails, so it wasn't rendered via ErrorResult) — the step isn't set
+  // up.
   return ['error', 'Failed to set up step']
 }
 

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -52,7 +52,7 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     ...forwardedInputCreatorProps
   } = props
 
-  const { control } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
 
   // react-hook-form requires a non-undefined default value for _every_
@@ -85,7 +85,15 @@ function MultiRow(props: MultiRowProps): JSX.Element {
     } else {
       append(newRowDefaultValue)
     }
-  }, [append, newRowDefaultValue, subFields])
+    // A nested useFieldArray's `append` (like `remove`) updates the form value
+    // but does not fire the form's `watch` subject, so subscribers such as the
+    // step validator gating "Check step" never recompute. Re-assert the
+    // already-updated value through `setValue`, which does notify.
+    setValue(name, getValues(name), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [append, newRowDefaultValue, subFields, setValue, getValues, name])
 
   return (
     // Use Controller's defaultValue to introduce 1 blank row by default. We
@@ -108,9 +116,17 @@ function MultiRow(props: MultiRowProps): JSX.Element {
         const removeRow = (index: number) => {
           if (rowsToRender.length === 1 && onRequestRemoveLastRow) {
             onRequestRemoveLastRow()
-          } else {
-            remove(index)
+            return
           }
+          remove(index)
+          // A nested useFieldArray's `remove` updates the form value but does not
+          // fire the form's `watch` subject, so subscribers (e.g. the step
+          // validator that gates "Check step") never recompute. Re-assert the
+          // already-updated value through `setValue`, which does notify.
+          setValue(name, getValues(name), {
+            shouldDirty: true,
+            shouldValidate: true,
+          })
         }
 
         return (


### PR DESCRIPTION
# Problem

A user could get weird error in our pipe editor when using our Or condition. Repro steps:

1. Create a Only Continue If, fill in a valid 1st condition, check step.
2. Add a Or condition, don't fill in anything in the new condition, save without checking
3. Remove that new (empty) condition

The user now sees an error ("Failed to set up step") and the step remains invalid, even though the step looks correct.

## Root cause

`FlowTestStepController` was falling back to our catch-all case in `getInfoBoxDetails`. This was because to show the "Previous Result" message, we require that the current step config matches 2 conditions:

1. The test step dataIn matches the frontend params
2. The step is complete.

For the repo case, condition (1) is satisfied, but (2) is not because the step is incomplete (due to adding the empty row).

# Fix

Relax `getInfoBoxDetails` to show the "previous result" state as long as:

1. [EXISTING] The last test execution's dataIn doesn't match the current params
2. [NEW] The last test execution was successful _and_ (the form is dirty _or_ the step is incomplete)

NOTE: We don't want to show the save button if user has just loaded an invalid step config (i.e. has not changed the config yet); we only want a single "Check step" primary button for this scenario.

# Tests

- Check that repo case no longer happens
- Regression test: check that I still see "step set up successfuly" when I have a successful check step.
- Regression test: check that i still see "previous result" message when changing my step params to be different from the test step's dataIn.