### PR TITLE
[IF-THEN-THEN-1] PLU-743: (backend) introduce stepIdToJumpTo

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/triggers/create-mrf-steps.itest.ts
+++ b/packages/backend/src/apps/formsg/__tests__/triggers/create-mrf-steps.itest.ts
@@ -975,4 +975,185 @@ describe('createMrfSteps', () => {
       expect(rejectSteps).toHaveLength(0)
     })
   })
+
+  describe('if-then jump targets', () => {
+    function jumpTarget(step: Step): unknown {
+      return (step.parameters as Record<string, unknown>)?.stepIdToJumpTo
+    }
+
+    async function assertNoDanglingJumpTargets(flowId: string): Promise<void> {
+      const steps = await Step.query().where('flow_id', flowId)
+      const ids = new Set(steps.map((step) => step.id))
+      for (const step of steps) {
+        const target = jumpTarget(step)
+        if (typeof target === 'string') {
+          expect(ids.has(target)).toBe(true)
+        }
+      }
+    }
+
+    /**
+     * Appends, after the existing steps, an if-then block chained into a second
+     * if-then block plus a single step after it, wiring the chain of steps to
+     * jump to (target-first so the forward-pointing ids exist):
+     *
+     *   ifThenA   (startPosition)      stepIdToJumpTo -> ifThenB
+     *   actionA   (startPosition + 1)
+     *   ifThenB   (startPosition + 2)  stepIdToJumpTo -> afterStep
+     *   actionB   (startPosition + 3)
+     *   afterStep (startPosition + 4)
+     */
+    async function appendIfThenBlock(startPosition: number) {
+      const afterStep = await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        mockFlowId,
+        startPosition + 4,
+      )
+      const ifThenB = await generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        mockFlowId,
+        startPosition + 2,
+        { depth: 0, branchName: 'B', stepIdToJumpTo: afterStep.id },
+      )
+      const ifThenA = await generateMockStep(
+        context,
+        'ifThen',
+        'toolbox',
+        'action',
+        mockFlowId,
+        startPosition,
+        { depth: 0, branchName: 'A', stepIdToJumpTo: ifThenB.id },
+      )
+      await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        mockFlowId,
+        startPosition + 1,
+      )
+      await generateMockStep(
+        context,
+        'sendTransactionalEmail',
+        'postman',
+        'action',
+        mockFlowId,
+        startPosition + 3,
+      )
+      return { afterStep, ifThenB, ifThenA }
+    }
+
+    it('keeps stepIdToJumpTo pointers valid when a new MRF step shifts positions', async () => {
+      await createMrfSteps($, {
+        trigger: {
+          defaultStepName: 'Trigger',
+          formWorkflowStepId: 'trigger-001',
+          type: 'static',
+        },
+        actions: [
+          {
+            defaultStepName: 'Action 1',
+            formWorkflowStepId: 'action-001',
+            type: 'static',
+            fields: [],
+          },
+        ],
+      })
+      // trigger(1) + MRF-001(2); block occupies positions 3..7.
+      const { afterStep, ifThenB, ifThenA } = await appendIfThenBlock(3)
+
+      // Add a second MRF step: inserted at the front, shifting the block down.
+      await createMrfSteps($, {
+        trigger: {
+          defaultStepName: 'Trigger',
+          formWorkflowStepId: 'trigger-001',
+          type: 'static',
+        },
+        actions: [
+          {
+            defaultStepName: 'Action 1',
+            formWorkflowStepId: 'action-001',
+            type: 'static',
+            fields: [],
+          },
+          {
+            defaultStepName: 'Action 2',
+            formWorkflowStepId: 'action-002',
+            type: 'static',
+            fields: [],
+          },
+        ],
+      })
+
+      const reloadedA = await Step.query().findById(ifThenA.id)
+      const reloadedB = await Step.query().findById(ifThenB.id)
+
+      // ids are stable across the position shift, so the pointers still resolve.
+      expect(jumpTarget(reloadedA)).toBe(ifThenB.id)
+      expect(jumpTarget(reloadedB)).toBe(afterStep.id)
+      expect(reloadedA.position).toBeGreaterThan(3)
+      await assertNoDanglingJumpTargets(mockFlowId)
+    })
+
+    it('removes an if-then block and its after-steps together on a trailing MRF delete', async () => {
+      await createMrfSteps($, {
+        trigger: {
+          defaultStepName: 'Trigger',
+          formWorkflowStepId: 'trigger-001',
+          type: 'static',
+        },
+        actions: [
+          {
+            defaultStepName: 'Action 1',
+            formWorkflowStepId: 'action-001',
+            type: 'static',
+            fields: [],
+          },
+          {
+            defaultStepName: 'Action 2',
+            formWorkflowStepId: 'action-002',
+            type: 'static',
+            fields: [],
+          },
+        ],
+      })
+      // trigger(1) + MRF-001(2) + MRF-002(3); block occupies positions 4..8.
+      await appendIfThenBlock(4)
+
+      // Delete the trailing MRF step (action-002); its whole branch — the block
+      // and its after-steps — is removed together.
+      await createMrfSteps($, {
+        trigger: {
+          defaultStepName: 'Trigger',
+          formWorkflowStepId: 'trigger-001',
+          type: 'static',
+        },
+        actions: [
+          {
+            defaultStepName: 'Action 1',
+            formWorkflowStepId: 'action-001',
+            type: 'static',
+            fields: [],
+          },
+        ],
+      })
+
+      const remaining = await Step.query()
+        .where('flow_id', mockFlowId)
+        .orderBy('position', 'asc')
+
+      // Only trigger + the surviving MRF-001 remain; no if-then steps linger.
+      expect(remaining.map((step) => step.key)).toEqual([
+        'newSubmission',
+        'mrfSubmission',
+      ])
+      await assertNoDanglingJumpTargets(mockFlowId)
+    })
+  })
 })

--- a/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/actions/if-then.test.ts
@@ -318,6 +318,195 @@ describe('If-then', () => {
     })
   })
 
+  describe('pipes with a stored stepIdToJumpTo (after-block / chained blocks)', () => {
+    /**
+     * [T = trigger, S = single step, B = branch]
+     *
+     *   T
+     *   |
+     *   B1 (branch-1)  stepIdToJumpTo -> branch-2 (next if-then)
+     *     \
+     *      S1 (branch-1-action-1)
+     *     /
+     *   B2 (branch-2)  stepIdToJumpTo -> after-step (single step after block)
+     *     \
+     *      S2 (branch-2-action-1)
+     *     /
+     *   S3 (after-step) // runs after the block via position+1
+     */
+    const AFTER_BLOCK_PIPE_STEPS = [
+      {
+        id: 'trigger',
+        appKey: 'fakeTrigger',
+        key: 'nom-nom-nom',
+        position: 1,
+      },
+      {
+        id: 'branch-1',
+        appKey: toolboxApp.key,
+        key: ifThenAction.key,
+        position: 2,
+        parameters: {
+          depth: 0,
+          stepIdToJumpTo: 'branch-2',
+        },
+      },
+      {
+        id: 'branch-1-action-1',
+        appKey: 'coffeeMaker',
+        key: 'makeEspresso',
+        position: 3,
+      },
+      {
+        id: 'branch-2',
+        appKey: toolboxApp.key,
+        key: ifThenAction.key,
+        position: 4,
+        parameters: {
+          depth: 0,
+          stepIdToJumpTo: 'after-step',
+        },
+      },
+      {
+        id: 'branch-2-action-1',
+        appKey: 'coffeeMaker',
+        key: 'makeEspresso',
+        position: 5,
+      },
+      {
+        id: 'after-step',
+        appKey: 'coffeeMaker',
+        key: 'makeEspresso',
+        position: 6,
+      },
+    ]
+
+    const failingCondition = [
+      {
+        field: 1,
+        is: 'is',
+        condition: 'equals',
+        text: 9999,
+      },
+    ]
+
+    beforeEach(() => {
+      mocks.stepQueryResult.mockResolvedValue(AFTER_BLOCK_PIPE_STEPS)
+
+      $ = {
+        flow: {
+          id: 'fake-pipe',
+        },
+        step: {
+          ...AFTER_BLOCK_PIPE_STEPS[1],
+        },
+        setActionItem: mocks.setActionItem,
+      } as unknown as IGlobalVariable
+    })
+
+    it.each([
+      // Non-last branch: the stored target is the next if-then.
+      { stepId: 'branch-1', expectedNextStepId: 'branch-2' },
+      // Last branch: the stored target is the single step after the block.
+      // The scan would return null here, so this proves the pointer is used.
+      { stepId: 'branch-2', expectedNextStepId: 'after-step' },
+    ])(
+      'returns the stored stepIdToJumpTo verbatim when a branch condition fails',
+      async ({ stepId, expectedNextStepId }) => {
+        $.step = {
+          ...AFTER_BLOCK_PIPE_STEPS.find((step) => step.id === stepId),
+        } as unknown as IGlobalVariable['step']
+        $.step.parameters.conditions = failingCondition
+
+        const result = await ifThenAction.run($)
+
+        expect(result).toEqual({
+          nextStep: { command: 'jump-to-step', stepId: expectedNextStepId },
+        })
+        expect(mocks.setActionItem).toBeCalledWith({
+          raw: { isConditionMet: false },
+        })
+      },
+    )
+
+    it('returns the stored target verbatim even when it differs from the scan result', async () => {
+      // branch-1's stored target deliberately differs from what the scan would
+      // return for this non-last branch (the next if-then 'branch-2'), proving
+      // the pointer is read verbatim rather than recomputed by the scan.
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        AFTER_BLOCK_PIPE_STEPS.map((step) =>
+          step.id === 'branch-1'
+            ? {
+                ...step,
+                parameters: {
+                  ...step.parameters,
+                  stepIdToJumpTo: 'after-step',
+                },
+              }
+            : step,
+        ),
+      )
+      $.step = {
+        ...AFTER_BLOCK_PIPE_STEPS.find((step) => step.id === 'branch-1'),
+      } as unknown as IGlobalVariable['step']
+      $.step.parameters.conditions = failingCondition
+
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'jump-to-step', stepId: 'after-step' },
+      })
+    })
+
+    it('stops execution when the stored target is null, without falling back to the scan', async () => {
+      // branch-1 stores null (the "stop" sentinel) even though a next sibling
+      // (branch-2) exists — the scan would jump there, so returning stop proves
+      // the stored null is honoured instead of the legacy scan.
+      mocks.stepQueryResult.mockResolvedValueOnce(
+        AFTER_BLOCK_PIPE_STEPS.map((step) =>
+          step.id === 'branch-1'
+            ? {
+                ...step,
+                parameters: { ...step.parameters, stepIdToJumpTo: null },
+              }
+            : step,
+        ),
+      )
+      $.step = {
+        ...AFTER_BLOCK_PIPE_STEPS.find((step) => step.id === 'branch-1'),
+      } as unknown as IGlobalVariable['step']
+      $.step.parameters.conditions = failingCondition
+
+      const result = await ifThenAction.run($)
+
+      expect(result).toEqual({
+        nextStep: { command: 'stop-execution' },
+      })
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isConditionMet: false },
+      })
+    })
+
+    it('runs the branch and returns void if the branch condition passes', async () => {
+      $.step.parameters.conditions = [
+        {
+          field: 1,
+          is: 'is',
+          condition: 'equals',
+          text: 1,
+        },
+      ]
+
+      const result = await ifThenAction.run($)
+
+      // A true branch ignores stepIdToJumpTo and falls through via position+1.
+      expect(result).toBeFalsy()
+      expect(mocks.setActionItem).toBeCalledWith({
+        raw: { isConditionMet: true },
+      })
+    })
+  })
+
   describe('pipes with nested branches', () => {
     beforeEach(() => {
       mocks.stepQueryResult.mockResolvedValue(NESTED_BRANCH_PIPE_STEPS)

--- a/packages/backend/src/apps/toolbox/actions/if-then/index.ts
+++ b/packages/backend/src/apps/toolbox/actions/if-then/index.ts
@@ -43,6 +43,21 @@ const action: IRawAction = {
       variables: false,
     },
     {
+      // The step to jump to if the branch is not taken. Computed by front end
+      // when adding a branch within an if-then, or a step _after_ (outside) an
+      // if-then.
+      key: 'stepIdToJumpTo',
+      type: 'string' as const,
+      label: 'FILE A BUG IF YOU SEE THIS',
+
+      // Always hidden
+      hiddenIf: {
+        op: 'always_true',
+      },
+      required: false,
+      variables: false,
+    },
+    {
       label: 'Conditions',
       key: 'conditions',
       type: 'multirow-multicol' as const,

--- a/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
+++ b/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
@@ -43,6 +43,21 @@ export async function getBranchStepIdToSkipTo(
     return null
   }
 
+  // New-style pipes store this key on every if-then: a string means there is a
+  // later branch to jump to, while null means "stop".
+  //
+  // NOTE: Returning here skips the MRF approval-boundary check below, which is
+  // safe - the front-end will never set stepIdToJumpTo across an MRF
+  // approval/reject boundary.
+  const params = currBranchStep.parameters
+  if (params && Object.hasOwn(params, 'stepIdToJumpTo')) {
+    const jumpTo = params.stepIdToJumpTo
+    return typeof jumpTo === 'string' ? jumpTo : null
+  }
+
+  // Everything below supports legacy pipes: those created before If-then-then
+  // was implemented, which lack a stored stepIdToJumpTo. They are handled by
+  // the original depth scan (plus the MRF approval-boundary check).
   let currDepth = parseInt(currBranchStep.parameters?.depth as string)
 
   if (isNaN(currDepth)) {

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": "./src",
     "declaration": true,
     "esModuleInterop": true,
-    "lib": ["es2021", "ES2022.Error"],
+    "lib": ["es2021", "ES2022.Error", "ES2022.Object"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Adds the (hidden) `stepIdToJumpTo` parameter step parameter to the If-Then action, and updates our existing `getBranchIdToSkipTo` to account for this.

IMPORTANT: This is a no-op until the front-end wires in support for it.

# Tests

- New unit tests
- Check that `stepIdToJumpTo` does not show up in the UI
- E2E and further regression tests at the top 2 PRs in this stack.