### PR TITLE
[IF-THEN-THEN-2] PLU-743: (backend) support stepIdToJumpTo when re-ordering

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/update-step-positions.itest.ts
@@ -165,6 +165,74 @@ describe('updateStepPositions mutation', () => {
     })
   })
 
+  it('sets an if-then branch stepIdToJumpTo via jsonb_set, leaving omitted steps untouched', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+          stepIdToJumpTo: 'step-3',
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          type: 'action' as const,
+        },
+      ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
+    }
+
+    await updateStepPositions(null, { input }, context)
+
+    // step-1 carries the jump target: position + a jsonb_set on parameters.
+    const firstPatch: any = stepPatchSpy.mock.calls[0][0]
+    expect(firstPatch.position).toBe(2)
+    expect(firstPatch.parameters._sql).toBe(
+      `jsonb_set(parameters, '{stepIdToJumpTo}', ?::jsonb, true)`,
+    )
+    expect(firstPatch.parameters._args).toEqual([JSON.stringify('step-3')])
+
+    // step-2 omitted stepIdToJumpTo => parameters left untouched.
+    const secondPatch: any = stepPatchSpy.mock.calls[1][0]
+    expect(secondPatch).toEqual({ position: 3 })
+    expect('parameters' in secondPatch).toBe(false)
+  })
+
+  it('stores JSON null as the stop sentinel when stepIdToJumpTo is null', async () => {
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+          stepIdToJumpTo: null as string | null,
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          type: 'action' as const,
+        },
+      ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
+    }
+
+    await updateStepPositions(null, { input }, context)
+
+    // null keeps the key present (set to JSON null) rather than removing it, so
+    // execution stops via the pointer instead of falling back to the scan.
+    const firstPatch: any = stepPatchSpy.mock.calls[0][0]
+    expect(firstPatch.position).toBe(2)
+    expect(firstPatch.parameters._sql).toBe(
+      `jsonb_set(parameters, '{stepIdToJumpTo}', ?::jsonb, true)`,
+    )
+    expect(firstPatch.parameters._args).toEqual([JSON.stringify(null)])
+  })
+
   it('should throw an error if the step ids are not found', async () => {
     // Mock throwIfNotFound to throw an error for missing steps
     fakeQuery.throwIfNotFound.mockRejectedValue(new Error('Step not found'))
@@ -213,13 +281,13 @@ describe('updateStepPositions mutation', () => {
       stepPositions: [
         {
           id: 'step-1',
-          position: 1,
-          step: { id: 'step-1', type: 'action' as const },
+          position: 2,
+          type: 'action' as const,
         },
         {
           id: 'step-2',
-          position: 3,
-          step: { id: 'step-2', type: 'action' as const },
+          position: 4,
+          type: 'action' as const,
         },
       ],
     } as any
@@ -229,6 +297,73 @@ describe('updateStepPositions mutation', () => {
     )
     await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
       'Failed to update: must update contiguous action steps!',
+    )
+  })
+
+  it('applies auxiliary if-then jump-target changes alongside the reposition', async () => {
+    // A reorder repositions a contiguous run (step-1@2, step-2@3) and, via
+    // auxiliaryChanges, repoints an out-of-run if-then (step-4) — kept separate
+    // so stepPositions stays purely about positions.
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+        },
+        {
+          id: 'step-2',
+          position: 3,
+          type: 'action' as const,
+        },
+      ],
+      auxiliaryChanges: [
+        { ifThen: { stepId: 'step-4', stepIdToJumpTo: 'step-2' } },
+      ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
+    }
+
+    await updateStepPositions(null, { input }, context)
+
+    // Two reposition patches, then the auxiliary jsonb_set repoint on step-4.
+    expect(stepPatchSpy).toHaveBeenCalledTimes(3)
+    expect(stepPatchSpy.mock.calls[0][0]).toEqual({ position: 2 })
+    expect(stepPatchSpy.mock.calls[1][0]).toEqual({ position: 3 })
+    const auxPatch: any = stepPatchSpy.mock.calls[2][0]
+    expect(stepFindByIdSpy).toHaveBeenNthCalledWith(3, 'step-4')
+    expect(auxPatch.parameters._sql).toBe(
+      `jsonb_set(parameters, '{stepIdToJumpTo}', ?::jsonb, true)`,
+    )
+    expect(auxPatch.parameters._args).toEqual([JSON.stringify('step-2')])
+  })
+
+  it('throws when an auxiliary change step is not in the flow', async () => {
+    // The reposition fetch resolves normally; the auxiliary fetch resolves a
+    // step belonging to a different flow, which must be rejected.
+    fakeQuery.throwIfNotFound
+      .mockResolvedValueOnce(fakeSteps)
+      .mockResolvedValueOnce([{ id: 'step-4', flowId: 'different-flow-id' }])
+
+    const input = {
+      stepPositions: [
+        {
+          id: 'step-1',
+          position: 2,
+          type: 'action' as const,
+        },
+      ],
+      auxiliaryChanges: [
+        { ifThen: { stepId: 'step-4', stepIdToJumpTo: 'step-2' } },
+      ],
+      flow: {
+        updatedAt: new Date().toISOString(),
+      },
+    }
+
+    await expect(updateStepPositions(null, { input }, context)).rejects.toThrow(
+      'Failed to update: auxiliary change steps were not found in this flow',
     )
   })
 

--- a/packages/backend/src/graphql/mutations/update-step-positions.ts
+++ b/packages/backend/src/graphql/mutations/update-step-positions.ts
@@ -14,8 +14,10 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
   context,
 ) => {
   const { input } = params
-  const { stepPositions } = input
+  const { stepPositions, auxiliaryChanges } = input
 
+  // stepPositions repositions a contiguous run of action steps. Jump-target
+  // changes to if-thens outside that run travel separately in auxiliaryChanges.
   if (
     !stepPositions.every(
       (
@@ -90,7 +92,55 @@ const updateStepPositions: MutationResolvers['updateStepPositions'] = async (
             ])
           : raw(`config - 'approval'`)
       }
+      // Maintain an if-then branch's step to jump to. Omitted => leave the
+      // existing parameters untouched. A string sets the target; null stores the
+      // "stop" sentinel (last branch of the last block). Both keep the key
+      // present, so execution reads the pointer instead of the legacy scan.
+      if (stepPosition.stepIdToJumpTo !== undefined) {
+        patchData.parameters = raw(
+          `jsonb_set(parameters, '{stepIdToJumpTo}', ?::jsonb, true)`,
+          [JSON.stringify(stepPosition.stepIdToJumpTo)],
+        )
+      }
       await Step.query(trx).findById(stepPosition.id).patch(patchData)
+    }
+
+    // Apply auxiliary if-then jump-target changes: steps outside the
+    // repositioned run whose stepIdToJumpTo must move in the same transaction
+    // (e.g. reordering an after-block region repoints the block's last branch).
+    const auxIfThenChanges = (auxiliaryChanges ?? [])
+      .map((change) => change.ifThen)
+      .filter((ifThen): ifThen is NonNullable<typeof ifThen> => !!ifThen)
+    if (auxIfThenChanges.length > 0) {
+      const auxStepIds = auxIfThenChanges.map((change) => change.stepId)
+      const auxSteps = await context.currentUser
+        .withAccessibleSteps({ requiredRole: 'editor', trx })
+        .whereIn('steps.id', auxStepIds)
+        .throwIfNotFound()
+
+      // Authz + same-flow guard: every referenced step must be accessible and
+      // belong to the flow being edited, so a change can't reach into another.
+      const inFlowAuxStepIds = new Set(
+        auxSteps
+          .filter((step) => step.flowId === flow.id)
+          .map((step) => step.id),
+      )
+      if (auxStepIds.some((id) => !inFlowAuxStepIds.has(id))) {
+        throw new BadUserInputError(
+          'Failed to update: auxiliary change steps were not found in this flow',
+        )
+      }
+
+      for (const change of auxIfThenChanges) {
+        await Step.query(trx)
+          .findById(change.stepId)
+          .patch({
+            parameters: raw(
+              `jsonb_set(parameters, '{stepIdToJumpTo}', ?::jsonb, true)`,
+              [JSON.stringify(change.stepIdToJumpTo)],
+            ),
+          })
+      }
     }
 
     // Update the flow's lastUpdatedAt timestamp

--- a/packages/backend/src/graphql/schema.graphql
+++ b/packages/backend/src/graphql/schema.graphql
@@ -726,11 +726,30 @@ input StepPositionInput {
   position: Int!
   type: StepEnumType!
   config: StepConfigInput
+  # If-then branch's step to jump to (parameters.stepIdToJumpTo). A string
+  # sets/updates it; null stores the "stop" sentinel (last branch of the last
+  # block); omitted leaves it untouched.
+  stepIdToJumpTo: String
 }
 
 input UpdateStepPositionsInput {
   stepPositions: [StepPositionInput!]!
   flow: StepFlowInput!
+  # Changes to steps outside the repositioned run (e.g. repointing an if-then
+  # block's last branch when reordering the region after it), kept separate so
+  # stepPositions stays purely about positions.
+  auxiliaryChanges: [UpdateStepPositionsAuxiliaryChangeInput!]
+}
+
+# oneOf is to support future expansion for other aux changes
+input UpdateStepPositionsAuxiliaryChangeInput @oneOf {
+  ifThen: UpdateStepPositionsAuxiliaryChangeForIfThenInput
+}
+
+input UpdateStepPositionsAuxiliaryChangeForIfThenInput {
+  # StepID of the if-then step to change.
+  stepId: String!
+  stepIdToJumpTo: String!
 }
 
 input DeleteStepInput {


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates our backend GraphQL re-order mutation to support `stepIdToJumpTo`. This is needed in case a re-order changes the 1st step of after-If-Then steps; the last If-Then branch needs to be updated to jump to this new 1st step.

IMPORTANT: this is a no-op until the front-end wires support for it.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.