### PR TITLE
[IF-THEN-THEN-3] PLU-743: (backend) support stepIdToJumpTo when duplicating

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/duplicate-flow.itest.ts
@@ -1,0 +1,204 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import duplicateFlow from '@/graphql/mutations/duplicate-flow'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import type Context from '@/types/express/context'
+
+import { generateMockContext } from './tiles/table.mock'
+import { generateMockFlow, generateMockStep } from './flow.mock'
+
+/**
+ * Builds a flow with two chained if-then blocks plus a single step after the
+ * second block, wiring each branch's step to jump to via stepIdToJumpTo:
+ *
+ *   trigger (1)
+ *   ifThenA (2)  stepIdToJumpTo -> ifThenB
+ *   actionA (3)
+ *   ifThenB (4)  stepIdToJumpTo -> afterStep
+ *   actionB (5)
+ *   afterStep (6)
+ *
+ * Steps are created target-first so the (forward-pointing) ids exist when we
+ * wire each pointer.
+ */
+async function buildFlowWithJumpTargets(
+  context: Context,
+  flowId: string,
+): Promise<{
+  afterStep: Step
+  ifThenB: Step
+  ifThenA: Step
+}> {
+  const afterStep = await generateMockStep(
+    context,
+    'sendTransactionalEmail',
+    'postman',
+    'action',
+    flowId,
+    6,
+  )
+  const ifThenB = await generateMockStep(
+    context,
+    'ifThen',
+    'toolbox',
+    'action',
+    flowId,
+    4,
+    { depth: 0, branchName: 'B', stepIdToJumpTo: afterStep.id },
+  )
+  const ifThenA = await generateMockStep(
+    context,
+    'ifThen',
+    'toolbox',
+    'action',
+    flowId,
+    2,
+    { depth: 0, branchName: 'A', stepIdToJumpTo: ifThenB.id },
+  )
+  await generateMockStep(
+    context,
+    'newSubmission',
+    'formsg',
+    'trigger',
+    flowId,
+    1,
+  )
+  await generateMockStep(
+    context,
+    'sendTransactionalEmail',
+    'postman',
+    'action',
+    flowId,
+    3,
+  )
+  await generateMockStep(
+    context,
+    'sendTransactionalEmail',
+    'postman',
+    'action',
+    flowId,
+    5,
+  )
+
+  return { afterStep, ifThenB, ifThenA }
+}
+
+function jumpTarget(step: Step): unknown {
+  return (step.parameters as Record<string, unknown>)?.stepIdToJumpTo
+}
+
+describe('duplicateFlow mutation - stepIdToJumpTo remapping', () => {
+  let context: Context
+  const flowId = randomUUID()
+
+  beforeEach(async () => {
+    context = await generateMockContext()
+    await generateMockFlow(context, flowId)
+  })
+
+  it('remaps every branch stepIdToJumpTo to the duplicated step ids', async () => {
+    const { afterStep, ifThenB, ifThenA } = await buildFlowWithJumpTargets(
+      context,
+      flowId,
+    )
+
+    const duplicatedFlow = await duplicateFlow(
+      null,
+      { input: { id: flowId } },
+      context,
+    )
+
+    const newSteps = await Step.query()
+      .where('flow_id', duplicatedFlow.id)
+      .orderBy('position', 'asc')
+
+    const byPosition = (position: number) =>
+      newSteps.find((step) => step.position === position)
+    const newIfThenA = byPosition(2)
+    const newIfThenB = byPosition(4)
+    const newAfterStep = byPosition(6)
+
+    // Each branch now points at the duplicated step, not the original.
+    expect(jumpTarget(newIfThenA)).toBe(newIfThenB.id)
+    expect(jumpTarget(newIfThenB)).toBe(newAfterStep.id)
+
+    // Sanity: the new ids are genuinely new, so the old targets would dangle.
+    expect(newIfThenB.id).not.toBe(ifThenB.id)
+    expect(newAfterStep.id).not.toBe(afterStep.id)
+    expect(jumpTarget(newIfThenA)).not.toBe(ifThenB.id)
+    expect(jumpTarget(newIfThenB)).not.toBe(afterStep.id)
+
+    // Other parameters are preserved.
+    expect((newIfThenA.parameters as Record<string, unknown>).branchName).toBe(
+      'A',
+    )
+    expect(ifThenA.position).toBe(2)
+  })
+
+  it('leaves legacy if-then steps (no stepIdToJumpTo) without the key', async () => {
+    await generateMockStep(
+      context,
+      'newSubmission',
+      'formsg',
+      'trigger',
+      flowId,
+      1,
+    )
+    await generateMockStep(context, 'ifThen', 'toolbox', 'action', flowId, 2, {
+      depth: 0,
+      branchName: 'legacy',
+    })
+
+    const duplicatedFlow = await duplicateFlow(
+      null,
+      { input: { id: flowId } },
+      context,
+    )
+
+    const newIfThen = (
+      await Step.query()
+        .where('flow_id', duplicatedFlow.id)
+        .orderBy('position', 'asc')
+    ).find((step) => step.position === 2)
+
+    expect(
+      'stepIdToJumpTo' in (newIfThen.parameters as Record<string, unknown>),
+    ).toBe(false)
+  })
+
+  it('does not mutate the original flow', async () => {
+    const { ifThenB, ifThenA } = await buildFlowWithJumpTargets(context, flowId)
+
+    await duplicateFlow(null, { input: { id: flowId } }, context)
+
+    const originalIfThenA = await Step.query().findById(ifThenA.id)
+    expect(jumpTarget(originalIfThenA)).toBe(ifThenB.id)
+  })
+
+  it('throws and rolls back if a branch stepIdToJumpTo dangles', async () => {
+    const danglingId = randomUUID()
+    await generateMockStep(
+      context,
+      'newSubmission',
+      'formsg',
+      'trigger',
+      flowId,
+      1,
+    )
+    await generateMockStep(context, 'ifThen', 'toolbox', 'action', flowId, 2, {
+      depth: 0,
+      branchName: 'dangling',
+      stepIdToJumpTo: danglingId,
+    })
+
+    await expect(
+      duplicateFlow(null, { input: { id: flowId } }, context),
+    ).rejects.toThrow('Could not remap stepIdToJumpTo')
+
+    // The rolled-back transaction leaves no duplicated flow behind.
+    const copies = await Flow.query().where('name', '[COPY] Test Flow')
+    expect(copies).toHaveLength(0)
+  })
+})

--- a/packages/backend/src/graphql/mutations/duplicate-flow.ts
+++ b/packages/backend/src/graphql/mutations/duplicate-flow.ts
@@ -1,9 +1,11 @@
+import { Knex } from 'knex'
 import { isEmpty } from 'lodash'
 
 import { getStepVersion } from '@/helpers/get-step-version'
 import logger from '@/helpers/logger'
 import { updateStepVariables } from '@/helpers/update-duplicated-steps'
 import Flow from '@/models/flow'
+import Step from '@/models/step'
 
 import { MutationResolvers } from '../__generated__/types.generated'
 
@@ -88,6 +90,12 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
       oldToNewStepIdsMap[oldStep.id] = duplicatedStep.id // update map after duplicating step
     }
 
+    // Keep each if-then branch's step to jump to valid in the copy.
+    await remapBranchJumpTargets(trx, flow.steps, oldToNewStepIdsMap, {
+      oldFlowId,
+      newFlowId: duplicatedFlow.id,
+    })
+
     logger.info('Duplicate flow details', {
       event: 'duplicate-flow-request',
       originalFlow: oldFlowId,
@@ -97,6 +105,62 @@ const duplicateFlow: MutationResolvers['duplicateFlow'] = async (
 
     return duplicatedFlow
   })
+}
+
+/**
+ * Remaps every if-then branch's step to jump to (parameters.stepIdToJumpTo)
+ * onto the duplicated step ids, in a single UPDATE.
+ *
+ * Unlike config.approval.stepId (a backward reference to an already-duplicated
+ * step), this target points forward — to the next if-then or the first single
+ * step after the block — so it can only be resolved once every step has a new
+ * id. updateStepVariables leaves the raw id untouched (it isn't a `step.<id>.`
+ * variable reference), so we translate it here. A dangling target throws, so the
+ * surrounding transaction rolls back rather than persisting a broken copy.
+ */
+async function remapBranchJumpTargets(
+  trx: Knex.Transaction,
+  oldSteps: Step[],
+  oldToNewStepIdsMap: Record<string, string>,
+  flowIds: { oldFlowId: string; newFlowId: string },
+): Promise<void> {
+  const remaps: Array<{ newStepId: string; newJumpTo: string }> = []
+  for (const oldStep of oldSteps) {
+    const oldJumpTo = oldStep.parameters?.stepIdToJumpTo
+    if (typeof oldJumpTo !== 'string') {
+      continue
+    }
+
+    const newJumpTo = oldToNewStepIdsMap[oldJumpTo]
+    if (!newJumpTo) {
+      logger.error('Could not remap stepIdToJumpTo while duplicating flow', {
+        event: 'duplicate-flow-bad-step-id-to-jump-to',
+        originalFlow: flowIds.oldFlowId,
+        duplicatedFlow: flowIds.newFlowId,
+        oldStepId: oldStep.id,
+        oldJumpTo,
+      })
+      throw new Error(
+        `Could not remap stepIdToJumpTo "${oldJumpTo}" for step ${oldStep.id} while duplicating flow ${flowIds.oldFlowId}`,
+      )
+    }
+
+    remaps.push({ newStepId: oldToNewStepIdsMap[oldStep.id], newJumpTo })
+  }
+
+  if (remaps.length === 0) {
+    return
+  }
+
+  // A single UPDATE ... FROM (VALUES ...) join, rather than one UPDATE per branch.
+  const valuesPlaceholders = remaps.map(() => '(?, ?)').join(', ')
+  await trx.raw(
+    `UPDATE steps AS s
+     SET parameters = jsonb_set(s.parameters, '{stepIdToJumpTo}', to_jsonb(v.new_jump_to::text), true)
+     FROM (VALUES ${valuesPlaceholders}) AS v(step_id, new_jump_to)
+     WHERE s.id = v.step_id::uuid`,
+    remaps.flatMap((remap) => [remap.newStepId, remap.newJumpTo]),
+  )
 }
 
 export default duplicateFlow


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates our backend GraphQL duplicate pipe mutation to support `stepIdToJumpTo`; we just need to update the old IDs to point to the duplicated IDs.

IMPORTANT: this is a no-op until the front-end wires support for it.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.