### PR TITLE
[IF-THEN-THEN-4] PLU-743: (frontend) introduce region list concept

### DIFF
--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -1,6 +1,6 @@
 import { IStep } from '@plumber/types'
 
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { Center, Flex } from '@chakra-ui/react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
@@ -9,7 +9,6 @@ import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import { EDITOR_RIGHT_DRAWER_WIDTH } from '../constants'
@@ -22,13 +21,8 @@ interface StepsListProps {
 }
 
 export function StepsList({ isNested }: StepsListProps) {
-  const {
-    triggerStep,
-    actionStepsBeforeGroup,
-    groupedSteps,
-    appsWithActions,
-    groupingActions,
-  } = useContext(StepsToDisplayContext)
+  const { triggerStep, regionList, appsWithActions, groupingActions } =
+    useContext(StepsToDisplayContext)
   const { flow, isDrawerOpen, isMobile, readOnly } = useContext(EditorContext)
   const { mrfSteps, mrfApprovalSteps, approvalBranches } =
     useContext(MrfContext)
@@ -68,20 +62,28 @@ export function StepsList({ isNested }: StepsListProps) {
     ],
   )
 
-  const nonIfThenActionSteps = actionStepsBeforeGroup.filter(
-    (step) => step.key !== TOOLBOX_ACTIONS.IfThen,
+  // Single steps across all regions (blocks contribute none). These drive the
+  // whole-flow empty/disabled affordances, matching the previous behaviour where
+  // they were derived from the single "before group" list.
+  const allSingleSteps = useMemo(
+    () =>
+      regionList.flatMap((region) =>
+        region.type === 'SingleSteps' ? region.steps : [],
+      ),
+    [regionList],
   )
+  const hasBlock = regionList.some((region) => region.type === 'Block')
 
   // Disables last add step and hide in-between add step buttons
   const hasExactlyOneEmptyActionStep =
-    nonIfThenActionSteps.length === 1 && !nonIfThenActionSteps[0].appKey
+    allSingleSteps.length === 1 && !allSingleSteps[0].appKey
 
   // Disables last add step button but show empty action instead
-  const hasNoActionSteps = nonIfThenActionSteps.length === 0
-  const shouldShowEmptyAction = hasNoActionSteps && !groupedSteps.length
+  const hasNoActionSteps = allSingleSteps.length === 0
+  const shouldShowEmptyAction = hasNoActionSteps && !hasBlock
   // for backwards compatibility where empty step is created
   const shouldDisableAddButton =
-    (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !groupedSteps.length
+    (hasExactlyOneEmptyActionStep || hasNoActionSteps) && !hasBlock
 
   if (!appsWithActions || !groupingActions) {
     return (
@@ -114,13 +116,11 @@ export function StepsList({ isNested }: StepsListProps) {
       {triggerStep && (
         <FlowStepWithAddButton
           step={triggerStep}
-          isLastStep={
-            actionStepsBeforeGroup.length === 0 && groupedSteps.length === 0
-          }
+          isLastStep={hasNoActionSteps && !hasBlock}
           isNested={isNested}
           allowReorder={false}
           stepsBeforeGroup={[]} // no reason to pass in for this
-          groupedSteps={groupedSteps}
+          groupedSteps={[]}
           addButtonProps={{
             isHidden: readOnly,
             isDisabled: shouldDisableAddButton,
@@ -129,47 +129,59 @@ export function StepsList({ isNested }: StepsListProps) {
         />
       )}
 
-      <SortableList
-        items={actionStepsBeforeGroup}
-        onChange={handleReorderSteps}
-        renderItem={(step, isOverlay) => {
-          const { id, position } = step
+      {regionList.map((region, regionIndex) => {
+        const isLastRegion = regionIndex === regionList.length - 1
+
+        if (region.type === 'Block') {
+          const previousRegion = regionList[regionIndex - 1]
+          const stepsBeforeGroup =
+            previousRegion?.type === 'SingleSteps' ? previousRegion.steps : []
           return (
-            <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
-              <Flex
-                key={`${id}-${position}`}
-                width={isDrawerOpen || isMobile ? '100%' : 'auto'}
-                flexDir="column"
-                position="relative"
-              >
-                <FlowStepWithAddButton
-                  step={step}
-                  isLastStep={
-                    groupedSteps.length === 0 &&
-                    actionStepsBeforeGroup[actionStepsBeforeGroup.length - 1]
-                      .id === step.id
-                  }
-                  isNested={isNested}
-                  allowReorder={nonIfThenActionSteps.length > 1}
-                  stepsBeforeGroup={actionStepsBeforeGroup}
-                  groupedSteps={groupedSteps}
-                  addButtonProps={{
-                    isHidden: readOnly || !!isOverlay,
-                    isDisabled: shouldDisableAddButton,
-                    showEmptyAction: shouldShowEmptyAction,
-                  }}
-                />
-              </Flex>
-            </SortableList.Item>
+            <FlowStepGroup
+              key={`block-${region.branches[0]?.[0]?.id ?? regionIndex}`}
+              stepsBeforeGroup={stepsBeforeGroup}
+              groupedSteps={region.branches}
+            />
           )
-        }}
-      />
-      {groupedSteps.length > 0 && (
-        <FlowStepGroup
-          stepsBeforeGroup={actionStepsBeforeGroup}
-          groupedSteps={groupedSteps}
-        />
-      )}
+        }
+
+        const regionSteps = region.steps
+        const lastStepId = regionSteps[regionSteps.length - 1]?.id
+        return (
+          <SortableList
+            key={`single-${regionIndex}`}
+            items={regionSteps}
+            onChange={handleReorderSteps}
+            renderItem={(step, isOverlay) => {
+              const { id, position } = step
+              return (
+                <SortableList.Item id={id} isOverlay={isOverlay ?? false}>
+                  <Flex
+                    key={`${id}-${position}`}
+                    width={isDrawerOpen || isMobile ? '100%' : 'auto'}
+                    flexDir="column"
+                    position="relative"
+                  >
+                    <FlowStepWithAddButton
+                      step={step}
+                      isLastStep={isLastRegion && id === lastStepId}
+                      isNested={isNested}
+                      allowReorder={regionSteps.length > 1}
+                      stepsBeforeGroup={regionSteps}
+                      groupedSteps={[]}
+                      addButtonProps={{
+                        isHidden: readOnly || !!isOverlay,
+                        isDisabled: shouldDisableAddButton,
+                        showEmptyAction: shouldShowEmptyAction,
+                      }}
+                    />
+                  </Flex>
+                </SortableList.Item>
+              )
+            }}
+          />
+        )
+      })}
     </Flex>
   )
 }

--- a/packages/frontend/src/contexts/StepsToDisplay.tsx
+++ b/packages/frontend/src/contexts/StepsToDisplay.tsx
@@ -3,7 +3,11 @@ import type { IApp, IStep } from '@plumber/types'
 import type { ReactNode } from 'react'
 import { createContext, useContext, useEffect, useMemo } from 'react'
 
-import { extractBranchesWithSteps } from '@/helpers/toolbox'
+import {
+  buildRegionList,
+  extractBranchesWithSteps,
+  type StepRegion,
+} from '@/helpers/toolbox'
 
 import { EditorContext } from './Editor'
 import { MrfContext } from './MrfContext'
@@ -12,6 +16,7 @@ export type StepToDisplayContextValue = {
   triggerStep: IStep | null
   actionStepsBeforeGroup: IStep[]
   groupedSteps: IStep[][]
+  regionList: StepRegion[]
   appsWithActions: IApp[]
   groupingActions: Set<string> | null
   stepIdToOrder: Record<string, number>
@@ -21,6 +26,7 @@ export const StepsToDisplayContext = createContext<StepToDisplayContextValue>({
   triggerStep: null,
   actionStepsBeforeGroup: [],
   groupedSteps: [],
+  regionList: [],
   appsWithActions: [],
   groupingActions: null,
   stepIdToOrder: {},
@@ -128,6 +134,14 @@ export function StepsToDisplayProvider({
       : [triggerStep, stepsToDisplay.slice(1, groupStepIdx), branchesWithSteps]
   }, [groupingActions, stepsToDisplay])
 
+  const regionList = useMemo(() => {
+    if (!groupingActions) {
+      return []
+    }
+    // Region list covers the steps after the trigger.
+    return buildRegionList(stepsToDisplay.slice(1), groupingActions)
+  }, [groupingActions, stepsToDisplay])
+
   useEffect(() => {
     if (
       currentStepId &&
@@ -144,6 +158,7 @@ export function StepsToDisplayProvider({
         triggerStep,
         actionStepsBeforeGroup,
         groupedSteps,
+        regionList,
         appsWithActions,
         groupingActions,
         stepIdToOrder,

--- a/packages/frontend/src/helpers/__tests__/toolbox.test.ts
+++ b/packages/frontend/src/helpers/__tests__/toolbox.test.ts
@@ -1,0 +1,264 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRegionList,
+  computeJumpTargets,
+  type StepRegion,
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/helpers/toolbox'
+
+// Grouping actions used by the region builder: both toolbox grouping actions.
+const GROUPING_ACTIONS = new Set([
+  `${TOOLBOX_APP_KEY}-${TOOLBOX_ACTIONS.IfThen}`,
+  `${TOOLBOX_APP_KEY}-${TOOLBOX_ACTIONS.ForEach}`,
+])
+
+let stepCounter = 0
+function step(overrides: Partial<IStep> = {}): IStep {
+  stepCounter += 1
+  return {
+    id: overrides.id ?? `step-${stepCounter}`,
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+    position: stepCounter,
+    parameters: {},
+    ...overrides,
+  } as IStep
+}
+
+function ifThen(id: string, stepIdToJumpTo?: string): IStep {
+  return step({
+    id,
+    appKey: TOOLBOX_APP_KEY,
+    key: TOOLBOX_ACTIONS.IfThen,
+    parameters: {
+      depth: 0,
+      ...(stepIdToJumpTo !== undefined ? { stepIdToJumpTo } : {}),
+    },
+  })
+}
+
+function forEach(id: string): IStep {
+  return step({ id, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.ForEach })
+}
+
+// Convenience: the ids of every step within a region, flattened.
+function regionStepIds(region: StepRegion): string[] {
+  return region.type === 'SingleSteps'
+    ? region.steps.map((s) => s.id)
+    : region.branches.flatMap((branch) => branch.map((s) => s.id))
+}
+
+describe('buildRegionList', () => {
+  it('returns a single (possibly empty) region when there are no action steps', () => {
+    const regions = buildRegionList([], GROUPING_ACTIONS)
+    expect(regions).toEqual([{ type: 'SingleSteps', steps: [] }])
+  })
+
+  it('groups a run of ordinary steps into one SingleSteps region', () => {
+    const s1 = step()
+    const s2 = step()
+    const regions = buildRegionList([s1, s2], GROUPING_ACTIONS)
+    expect(regions).toEqual([{ type: 'SingleSteps', steps: [s1, s2] }])
+  })
+
+  describe('legacy flows (no stepIdToJumpTo)', () => {
+    it('treats a single if-then group as one trailing block (byte-identical to before)', () => {
+      const before = step()
+      const b1 = ifThen('b1')
+      const b1a = step()
+      const b2 = ifThen('b2')
+      const b2a = step()
+      const regions = buildRegionList(
+        [before, b1, b1a, b2, b2a],
+        GROUPING_ACTIONS,
+      )
+
+      expect(regions).toHaveLength(2)
+      expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [before] })
+      expect(regions[1].type).toBe('Block')
+      expect(regions[1]).toMatchObject({
+        branches: [
+          [b1, b1a],
+          [b2, b2a],
+        ],
+      })
+    })
+
+    it('runs a legacy block to the end of the flow, absorbing later steps', () => {
+      // Without stepIdToJumpTo, steps after the block are absorbed into it,
+      // exactly as the old grouping code did.
+      const b1 = ifThen('b1')
+      const trailing = step()
+      const regions = buildRegionList([b1, trailing], GROUPING_ACTIONS)
+
+      expect(regions).toHaveLength(2)
+      expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [] })
+      expect(regions[1]).toMatchObject({ branches: [[b1, trailing]] })
+    })
+  })
+
+  describe('flows with stepIdToJumpTo', () => {
+    it('ends a block at the after-block single step and resumes a SingleSteps region', () => {
+      // before | b1 -> b2 (next if-then), b2 -> after (single step) | after
+      const before = step()
+      const b1 = ifThen('b1', 'b2')
+      const b1a = step()
+      const b2 = ifThen('b2', 'after')
+      const b2a = step()
+      const after = step({ id: 'after' })
+      const regions = buildRegionList(
+        [before, b1, b1a, b2, b2a, after],
+        GROUPING_ACTIONS,
+      )
+
+      expect(regions.map((r) => r.type)).toEqual([
+        'SingleSteps',
+        'Block',
+        'SingleSteps',
+      ])
+      expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [before] })
+      expect(regions[1]).toMatchObject({
+        branches: [
+          [b1, b1a],
+          [b2, b2a],
+        ],
+      })
+      expect(regions[2]).toEqual({ type: 'SingleSteps', steps: [after] })
+    })
+
+    it('chains a second block after an intervening single step', () => {
+      // before | Block A (b1 -> after) | after | Block B (c1 absent => last)
+      const before = step()
+      const b1 = ifThen('b1', 'after')
+      const b1a = step()
+      const after = step({ id: 'after' })
+      const c1 = ifThen('c1') // last block, last branch => no target
+      const c1a = step()
+      const regions = buildRegionList(
+        [before, b1, b1a, after, c1, c1a],
+        GROUPING_ACTIONS,
+      )
+
+      expect(regions.map((r) => r.type)).toEqual([
+        'SingleSteps',
+        'Block',
+        'SingleSteps',
+        'Block',
+      ])
+      expect(regionStepIds(regions[0])).toEqual([before.id])
+      expect(regionStepIds(regions[1])).toEqual(['b1', b1a.id])
+      expect(regionStepIds(regions[2])).toEqual(['after'])
+      expect(regionStepIds(regions[3])).toEqual(['c1', c1a.id])
+    })
+
+    it('always begins with a (possibly empty) SingleSteps region for a block-first flow', () => {
+      // trigger -> if-then with no steps before it: the leading region is empty,
+      // matching the previous empty "steps before group".
+      const b1 = ifThen('b1', 'after')
+      const after = step({ id: 'after' })
+      const regions = buildRegionList([b1, after], GROUPING_ACTIONS)
+
+      expect(regions.map((r) => r.type)).toEqual([
+        'SingleSteps',
+        'Block',
+        'SingleSteps',
+      ])
+      expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [] })
+      expect(regionStepIds(regions[1])).toEqual(['b1'])
+      expect(regionStepIds(regions[2])).toEqual(['after'])
+    })
+  })
+
+  describe('for-each', () => {
+    it('treats a for-each as a last-step block running to the end', () => {
+      const before = step()
+      const fe = forEach('fe')
+      const body = step()
+      const regions = buildRegionList([before, fe, body], GROUPING_ACTIONS)
+
+      expect(regions).toHaveLength(2)
+      expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [before] })
+      expect(regions[1]).toMatchObject({ branches: [[fe, body]] })
+    })
+  })
+})
+
+describe('computeJumpTargets', () => {
+  it('points each non-last branch at the next if-then and the last branch at the after-block step', () => {
+    const b1 = ifThen('b1')
+    const b1a = step()
+    const b2 = ifThen('b2')
+    const b2a = step()
+    const after = step({ id: 'after' })
+    const regions: StepRegion[] = [
+      {
+        type: 'Block',
+        branches: [
+          [b1, b1a],
+          [b2, b2a],
+        ],
+      },
+      { type: 'SingleSteps', steps: [after] },
+    ]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.get('b1')).toBe('b2')
+    expect(targets.get('b2')).toBe('after')
+  })
+
+  it('sets the last branch of a trailing block to null (stop execution)', () => {
+    const b1 = ifThen('b1')
+    const b2 = ifThen('b2')
+    const regions: StepRegion[] = [{ type: 'Block', branches: [[b1], [b2]] }]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.get('b1')).toBe('b2')
+    // null (not undefined) so the "stop" sentinel is always persisted.
+    expect(targets.get('b2')).toBeNull()
+    expect(targets.has('b2')).toBe(true)
+  })
+
+  it('points the last branch of a block at the first if-then of the following block', () => {
+    const b1 = ifThen('b1')
+    const single = step({ id: 'single' })
+    const c1 = ifThen('c1')
+    const regions: StepRegion[] = [
+      { type: 'Block', branches: [[b1]] },
+      { type: 'SingleSteps', steps: [single] },
+      { type: 'Block', branches: [[c1]] },
+    ]
+
+    const targets = computeJumpTargets(regions)
+    // Block A's last branch exits to the single step after it.
+    expect(targets.get('b1')).toBe('single')
+    // Block B is last, so its branch stops (null sentinel).
+    expect(targets.get('c1')).toBeNull()
+  })
+
+  it('ignores for-each blocks', () => {
+    const fe = forEach('fe')
+    const body = step()
+    const regions: StepRegion[] = [{ type: 'Block', branches: [[fe, body]] }]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.size).toBe(0)
+  })
+
+  it('round-trips with buildRegionList for a chained/after-block flow', () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after')
+    const b2a = step()
+    const after = step({ id: 'after' })
+    const steps = [b1, b1a, b2, b2a, after]
+
+    const targets = computeJumpTargets(buildRegionList(steps, GROUPING_ACTIONS))
+    // The recomputed targets match what the steps already store.
+    expect(targets.get('b1')).toBe('b2')
+    expect(targets.get('b2')).toBe('after')
+  })
+})

--- a/packages/frontend/src/helpers/toolbox.ts
+++ b/packages/frontend/src/helpers/toolbox.ts
@@ -335,3 +335,189 @@ export function getStepGroupTypeAndCaption(groupedSteps: IStep[][]): {
 
   return { stepGroupType, stepGroupCaption }
 }
+
+//
+// Region list
+//
+// Models a flow's action steps (i.e. everything after the trigger) as an
+// ordered list of regions, so that single steps can appear after — and between
+// — if-then blocks. A `SingleSteps` region is a run of ordinary steps; a `Block`
+// region is a chain of if-then branches (or a for-each). See the hidden
+// `stepIdToJumpTo` parameter on if-then for how block membership is stored.
+//
+export type StepRegion =
+  | { type: 'SingleSteps'; steps: IStep[] }
+  | { type: 'Block'; branches: IStep[][] }
+
+function isGroupingStep(step: IStep, groupingActions: Set<string>): boolean {
+  return (
+    !!step.appKey &&
+    !!step.key &&
+    groupingActions.has(`${step.appKey}-${step.key}`)
+  )
+}
+
+/**
+ * Follows the `stepIdToJumpTo` chain from an if-then block's first branch to
+ * find the index just past the block (its exit). A branch whose target is
+ * another if-then continues the block; a branch whose target is a single step
+ * ends it there. Returns `actionSteps.length` when the block runs to the end of
+ * the flow (last branch's target absent, or a dangling/backward target).
+ */
+function findIfThenBlockExitIndex(
+  actionSteps: IStep[],
+  startIndex: number,
+  idToIndex: Map<string, number>,
+): number {
+  const visited = new Set<string>()
+  let current = actionSteps[startIndex]
+  let target = current.parameters?.stepIdToJumpTo
+
+  while (typeof target === 'string' && !visited.has(current.id)) {
+    visited.add(current.id)
+    const targetIndex = idToIndex.get(target)
+    const targetStep =
+      targetIndex === undefined ? undefined : actionSteps[targetIndex]
+
+    // Target is another if-then => it's the next branch; keep extending.
+    if (targetStep && isIfThenStep(targetStep)) {
+      current = targetStep
+      target = targetStep.parameters?.stepIdToJumpTo
+      continue
+    }
+
+    // Target is a single step after the block => the block exits there.
+    if (targetIndex !== undefined && targetIndex > startIndex) {
+      return targetIndex
+    }
+
+    // Dangling or backward target: treat the block as running to the end.
+    return actionSteps.length
+  }
+
+  // No (further) target => block runs to the end of the flow.
+  return actionSteps.length
+}
+
+/**
+ * Models the flow's action steps (steps after the trigger) as an ordered region
+ * list. Runs of ordinary steps become `SingleSteps` regions; if-then chains and
+ * for-each groups become `Block` regions.
+ *
+ * Legacy flows lack `stepIdToJumpTo`, so an if-then block runs to the end of the
+ * flow (consecutive if-thens = one block) — byte-identical to the previous
+ * "group is always last" behaviour. For-each likewise stays a last-step group.
+ *
+ * The list always begins with a `SingleSteps` region (the steps before the
+ * first block, possibly empty) so that a block-first flow renders exactly as
+ * before. Otherwise no empty regions are emitted (blocks are separated by >= 1
+ * single step, so between-block regions are never empty).
+ */
+export function buildRegionList(
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+): StepRegion[] {
+  const regions: StepRegion[] = []
+  const idToIndex = new Map(actionSteps.map((step, index) => [step.id, index]))
+
+  let singleSteps: IStep[] = []
+  // The leading region is always emitted (even if empty); later empty runs are
+  // not.
+  let isLeadingRegion = true
+  const flushSingleSteps = () => {
+    if (singleSteps.length > 0 || isLeadingRegion) {
+      regions.push({ type: 'SingleSteps', steps: singleSteps })
+      singleSteps = []
+    }
+    isLeadingRegion = false
+  }
+
+  let i = 0
+  while (i < actionSteps.length) {
+    const step = actionSteps[i]
+
+    if (!isGroupingStep(step, groupingActions)) {
+      singleSteps.push(step)
+      i++
+      continue
+    }
+
+    // A grouping action starts a Block. The accumulated single steps (the
+    // leading region may be empty, mirroring the previous "steps before group")
+    // become their own region first.
+    flushSingleSteps()
+
+    // For-each stays a last-step group, and a legacy if-then (one with no
+    // stored stepIdToJumpTo key) runs to the end of the flow. Otherwise follow
+    // the chain to find the exit.
+    const isLegacyIfThen =
+      isIfThenStep(step) &&
+      !Object.hasOwn(step.parameters ?? {}, 'stepIdToJumpTo')
+    const exitIndex =
+      isForEachStep(step) || isLegacyIfThen
+        ? actionSteps.length
+        : findIfThenBlockExitIndex(actionSteps, i, idToIndex)
+
+    regions.push({
+      type: 'Block',
+      branches: extractBranchesWithSteps(actionSteps.slice(i, exitIndex), 0),
+    })
+    i = exitIndex
+  }
+
+  // Flush any trailing single steps (and the leading region for a flow that has
+  // no blocks at all, including a flow with no action steps).
+  flushSingleSteps()
+
+  return regions
+}
+
+/**
+ * Computes what each if-then branch's `stepIdToJumpTo` should be for a given
+ * region list: within a block, branch[i] points to branch[i+1]'s if-then;
+ * the last branch points to the first step of the following region, or `null`
+ * when the block is last (the "stop" sentinel). We use `null` rather than
+ * `undefined` so the target is always persisted — every if-then in a new-style
+ * pipe keeps the key present, so execution never falls back to the legacy scan.
+ * The write-path callers persist these targets.
+ */
+export function computeJumpTargets(
+  regions: StepRegion[],
+): Map<string, string | null> {
+  const targets = new Map<string, string | null>()
+
+  for (let r = 0; r < regions.length; r++) {
+    const region = regions[r]
+    if (region.type !== 'Block') {
+      continue
+    }
+    const { branches } = region
+
+    // For-each blocks don't use stepIdToJumpTo.
+    if (!branches.length || !isIfThenStep(branches[0][0])) {
+      continue
+    }
+
+    for (let b = 0; b < branches.length; b++) {
+      const ifThenId = branches[b][0].id
+
+      if (b < branches.length - 1) {
+        // Non-last branch => the next branch's if-then.
+        targets.set(ifThenId, branches[b + 1][0].id)
+        continue
+      }
+
+      // Last branch => the first step of the following region, or null (stop)
+      // when the block is last.
+      const nextRegion = regions[r + 1]
+      const nextFirstStepId = !nextRegion
+        ? null
+        : nextRegion.type === 'SingleSteps'
+        ? nextRegion.steps[0]?.id
+        : nextRegion.branches[0]?.[0]?.id
+      targets.set(ifThenId, nextFirstStepId ?? null)
+    }
+  }
+
+  return targets
+}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates our frontend to support rendering steps after an If-Then (including later If-then blocks), by changing the current concept of "grouped steps" into what Claude and I call the "Region" list:

1. A region is a group of single steps, or one block (e.g. If-Then / For-Each)
2. A pipe is split into multiple "regions".

IMPORTANT: This PR only updates the pipe root step rendering code. For-Each's code also needs to be updated to support region lists; a later PR will do that. _Technically_, If-Then's step rendering code should also receive this upgrade, but If-Then will only have single steps so I'll do that another time.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.