### PR TITLE
[IF-THEN-THEN-5] PLU-743: (frontend) split up helpers/toolbox.ts

### DIFF
--- a/packages/frontend/src/helpers/__tests__/if-then.test.ts
+++ b/packages/frontend/src/helpers/__tests__/if-then.test.ts
@@ -1,0 +1,122 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRegionList,
+  computeJumpTargets,
+  type StepRegion,
+  TOOLBOX_ACTIONS,
+  TOOLBOX_APP_KEY,
+} from '@/helpers/toolbox'
+
+// Grouping actions used by the region builder: both toolbox grouping actions.
+const GROUPING_ACTIONS = new Set([
+  `${TOOLBOX_APP_KEY}-${TOOLBOX_ACTIONS.IfThen}`,
+  `${TOOLBOX_APP_KEY}-${TOOLBOX_ACTIONS.ForEach}`,
+])
+
+let stepCounter = 0
+function step(overrides: Partial<IStep> = {}): IStep {
+  stepCounter += 1
+  return {
+    id: overrides.id ?? `step-${stepCounter}`,
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+    position: stepCounter,
+    parameters: {},
+    ...overrides,
+  } as IStep
+}
+
+function ifThen(id: string, stepIdToJumpTo?: string): IStep {
+  return step({
+    id,
+    appKey: TOOLBOX_APP_KEY,
+    key: TOOLBOX_ACTIONS.IfThen,
+    parameters: {
+      depth: 0,
+      ...(stepIdToJumpTo !== undefined ? { stepIdToJumpTo } : {}),
+    },
+  })
+}
+
+function forEach(id: string): IStep {
+  return step({ id, appKey: TOOLBOX_APP_KEY, key: TOOLBOX_ACTIONS.ForEach })
+}
+
+describe('computeJumpTargets', () => {
+  it('points each non-last branch at the next if-then and the last branch at the after-block step', () => {
+    const b1 = ifThen('b1')
+    const b1a = step()
+    const b2 = ifThen('b2')
+    const b2a = step()
+    const after = step({ id: 'after' })
+    const regions: StepRegion[] = [
+      {
+        type: 'Block',
+        branches: [
+          [b1, b1a],
+          [b2, b2a],
+        ],
+      },
+      { type: 'SingleSteps', steps: [after] },
+    ]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.get('b1')).toBe('b2')
+    expect(targets.get('b2')).toBe('after')
+  })
+
+  it('sets the last branch of a trailing block to null (stop execution)', () => {
+    const b1 = ifThen('b1')
+    const b2 = ifThen('b2')
+    const regions: StepRegion[] = [{ type: 'Block', branches: [[b1], [b2]] }]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.get('b1')).toBe('b2')
+    // null (not undefined) so the "stop" sentinel is always persisted.
+    expect(targets.get('b2')).toBeNull()
+    expect(targets.has('b2')).toBe(true)
+  })
+
+  it('points the last branch of a block at the first if-then of the following block', () => {
+    const b1 = ifThen('b1')
+    const single = step({ id: 'single' })
+    const c1 = ifThen('c1')
+    const regions: StepRegion[] = [
+      { type: 'Block', branches: [[b1]] },
+      { type: 'SingleSteps', steps: [single] },
+      { type: 'Block', branches: [[c1]] },
+    ]
+
+    const targets = computeJumpTargets(regions)
+    // Block A's last branch exits to the single step after it.
+    expect(targets.get('b1')).toBe('single')
+    // Block B is last, so its branch stops (null sentinel).
+    expect(targets.get('c1')).toBeNull()
+  })
+
+  it('ignores for-each blocks', () => {
+    const fe = forEach('fe')
+    const body = step()
+    const regions: StepRegion[] = [{ type: 'Block', branches: [[fe, body]] }]
+
+    const targets = computeJumpTargets(regions)
+    expect(targets.size).toBe(0)
+  })
+
+  it('round-trips with buildRegionList for a chained/after-block flow', () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after')
+    const b2a = step()
+    const after = step({ id: 'after' })
+    const steps = [b1, b1a, b2, b2a, after]
+
+    const targets = computeJumpTargets(buildRegionList(steps, GROUPING_ACTIONS))
+    // The recomputed targets match what the steps already store.
+    expect(targets.get('b1')).toBe('b2')
+    expect(targets.get('b2')).toBe('after')
+  })
+})

--- a/packages/frontend/src/helpers/__tests__/region-list.test.ts
+++ b/packages/frontend/src/helpers/__tests__/region-list.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildRegionList,
-  computeJumpTargets,
   type StepRegion,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -184,81 +183,5 @@ describe('buildRegionList', () => {
       expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [before] })
       expect(regions[1]).toMatchObject({ branches: [[fe, body]] })
     })
-  })
-})
-
-describe('computeJumpTargets', () => {
-  it('points each non-last branch at the next if-then and the last branch at the after-block step', () => {
-    const b1 = ifThen('b1')
-    const b1a = step()
-    const b2 = ifThen('b2')
-    const b2a = step()
-    const after = step({ id: 'after' })
-    const regions: StepRegion[] = [
-      {
-        type: 'Block',
-        branches: [
-          [b1, b1a],
-          [b2, b2a],
-        ],
-      },
-      { type: 'SingleSteps', steps: [after] },
-    ]
-
-    const targets = computeJumpTargets(regions)
-    expect(targets.get('b1')).toBe('b2')
-    expect(targets.get('b2')).toBe('after')
-  })
-
-  it('sets the last branch of a trailing block to null (stop execution)', () => {
-    const b1 = ifThen('b1')
-    const b2 = ifThen('b2')
-    const regions: StepRegion[] = [{ type: 'Block', branches: [[b1], [b2]] }]
-
-    const targets = computeJumpTargets(regions)
-    expect(targets.get('b1')).toBe('b2')
-    // null (not undefined) so the "stop" sentinel is always persisted.
-    expect(targets.get('b2')).toBeNull()
-    expect(targets.has('b2')).toBe(true)
-  })
-
-  it('points the last branch of a block at the first if-then of the following block', () => {
-    const b1 = ifThen('b1')
-    const single = step({ id: 'single' })
-    const c1 = ifThen('c1')
-    const regions: StepRegion[] = [
-      { type: 'Block', branches: [[b1]] },
-      { type: 'SingleSteps', steps: [single] },
-      { type: 'Block', branches: [[c1]] },
-    ]
-
-    const targets = computeJumpTargets(regions)
-    // Block A's last branch exits to the single step after it.
-    expect(targets.get('b1')).toBe('single')
-    // Block B is last, so its branch stops (null sentinel).
-    expect(targets.get('c1')).toBeNull()
-  })
-
-  it('ignores for-each blocks', () => {
-    const fe = forEach('fe')
-    const body = step()
-    const regions: StepRegion[] = [{ type: 'Block', branches: [[fe, body]] }]
-
-    const targets = computeJumpTargets(regions)
-    expect(targets.size).toBe(0)
-  })
-
-  it('round-trips with buildRegionList for a chained/after-block flow', () => {
-    const b1 = ifThen('b1', 'b2')
-    const b1a = step()
-    const b2 = ifThen('b2', 'after')
-    const b2a = step()
-    const after = step({ id: 'after' })
-    const steps = [b1, b1a, b2, b2a, after]
-
-    const targets = computeJumpTargets(buildRegionList(steps, GROUPING_ACTIONS))
-    // The recomputed targets match what the steps already store.
-    expect(targets.get('b1')).toBe('b2')
-    expect(targets.get('b2')).toBe('after')
   })
 })

--- a/packages/frontend/src/helpers/toolbox/common.ts
+++ b/packages/frontend/src/helpers/toolbox/common.ts
@@ -1,0 +1,50 @@
+import { IApp, type IStep } from '@plumber/types'
+
+export const TOOLBOX_APP_KEY = 'toolbox'
+
+export enum TOOLBOX_ACTIONS {
+  IfThen = 'ifThen',
+  ForEach = 'forEach',
+}
+
+//
+// General toolbox helpers
+//
+export function getGroupingActions(appsWithActions: IApp[]) {
+  if (!appsWithActions) {
+    return null
+  }
+
+  return new Set(
+    appsWithActions?.flatMap((app) =>
+      app.actions
+        ?.filter((action) => action.groupsLaterSteps)
+        ?.map((action) => `${app.key}-${action.key}`),
+    ) ?? [],
+  )
+}
+
+export function getStepGroupTypeAndCaption(groupedSteps: IStep[][]): {
+  stepGroupType: string | null
+  stepGroupCaption: string | null
+} {
+  let stepGroupType: string | null = null
+  let stepGroupCaption: string | null = null
+
+  const groupKey = groupedSteps[0]?.[0]?.key
+  if (!groupKey) {
+    return { stepGroupType: null, stepGroupCaption: null }
+  }
+
+  if (groupKey === TOOLBOX_ACTIONS.IfThen) {
+    stepGroupType = TOOLBOX_ACTIONS.IfThen
+    stepGroupCaption = 'If-then'
+  }
+
+  if (groupKey === TOOLBOX_ACTIONS.ForEach) {
+    stepGroupType = TOOLBOX_ACTIONS.ForEach
+    stepGroupCaption = 'For each'
+  }
+
+  return { stepGroupType, stepGroupCaption }
+}

--- a/packages/frontend/src/helpers/toolbox/for-each.ts
+++ b/packages/frontend/src/helpers/toolbox/for-each.ts
@@ -1,0 +1,14 @@
+import { type IStep } from '@plumber/types'
+
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from './common'
+
+//
+// Helpers for For-each
+//
+export function isForEachStep(step: IStep | null | undefined): step is IStep {
+  return (
+    !!step &&
+    step.appKey === TOOLBOX_APP_KEY &&
+    step.key === TOOLBOX_ACTIONS.ForEach
+  )
+}

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -7,21 +7,19 @@ import { BranchContext } from '@/components/FlowStepGroup/Content/IfThen/BranchC
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
 
-export const TOOLBOX_APP_KEY = 'toolbox'
-
-export enum TOOLBOX_ACTIONS {
-  IfThen = 'ifThen',
-  ForEach = 'forEach',
-}
+import { getGroupingActions, TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from './common'
+import type { StepRegion } from './region-list'
 
 //
 // Helpers for If-then
 //
-// TODO: Move into separate file if we get more toolbox stuff.
-//
 
-export function isIfThenStep(step: IStep): boolean {
-  return step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.IfThen
+export function isIfThenStep(step: IStep | null | undefined): step is IStep {
+  return (
+    !!step &&
+    step.appKey === TOOLBOX_APP_KEY &&
+    step.key === TOOLBOX_ACTIONS.IfThen
+  )
 }
 
 /**
@@ -252,29 +250,11 @@ export function useIfThenInitializer(): [
 }
 
 //
-// Helpers for For-each
+// Flow structure
 //
-export function isForEachStep(step: IStep): boolean {
-  return step.appKey === TOOLBOX_APP_KEY && step.key === TOOLBOX_ACTIONS.ForEach
-}
-
+// These live here (rather than common) because they split the flow around
+// if-then groups and so depend on `extractBranchesWithSteps`.
 //
-// General toolbox helpers
-//
-export function getGroupingActions(appsWithActions: IApp[]) {
-  if (!appsWithActions) {
-    return null
-  }
-
-  return new Set(
-    appsWithActions?.flatMap((app) =>
-      app.actions
-        ?.filter((action) => action.groupsLaterSteps)
-        ?.map((action) => `${app.key}-${action.key}`),
-    ) ?? [],
-  )
-}
-
 export function getStepStructure(
   appsWithActions: IApp[],
   steps: IStep[],
@@ -311,166 +291,15 @@ export function getStepStructure(
     : [triggerStep, steps.slice(1, groupStepIdx), branchesWithSteps]
 }
 
-export function getStepGroupTypeAndCaption(groupedSteps: IStep[][]): {
-  stepGroupType: string | null
-  stepGroupCaption: string | null
-} {
-  let stepGroupType: string | null = null
-  let stepGroupCaption: string | null = null
-
-  const groupKey = groupedSteps[0]?.[0]?.key
-  if (!groupKey) {
-    return { stepGroupType: null, stepGroupCaption: null }
-  }
-
-  if (groupKey === TOOLBOX_ACTIONS.IfThen) {
-    stepGroupType = TOOLBOX_ACTIONS.IfThen
-    stepGroupCaption = 'If-then'
-  }
-
-  if (groupKey === TOOLBOX_ACTIONS.ForEach) {
-    stepGroupType = TOOLBOX_ACTIONS.ForEach
-    stepGroupCaption = 'For each'
-  }
-
-  return { stepGroupType, stepGroupCaption }
-}
-
 //
-// Region list
+// Jump targets
 //
-// Models a flow's action steps (i.e. everything after the trigger) as an
-// ordered list of regions, so that single steps can appear after — and between
-// — if-then blocks. A `SingleSteps` region is a run of ordinary steps; a `Block`
-// region is a chain of if-then branches (or a for-each). See the hidden
-// `stepIdToJumpTo` parameter on if-then for how block membership is stored.
+// The write-side companion to `buildRegionList` (in region-list.ts): given a
+// region list, derive what each if-then branch's `stepIdToJumpTo` should be.
+// Kept here because it writes an if-then parameter and its only value
+// dependency is `isIfThenStep`; it references the `StepRegion` shape as a
+// type only (erased at runtime, so no import cycle with region-list.ts).
 //
-export type StepRegion =
-  | { type: 'SingleSteps'; steps: IStep[] }
-  | { type: 'Block'; branches: IStep[][] }
-
-function isGroupingStep(step: IStep, groupingActions: Set<string>): boolean {
-  return (
-    !!step.appKey &&
-    !!step.key &&
-    groupingActions.has(`${step.appKey}-${step.key}`)
-  )
-}
-
-/**
- * Follows the `stepIdToJumpTo` chain from an if-then block's first branch to
- * find the index just past the block (its exit). A branch whose target is
- * another if-then continues the block; a branch whose target is a single step
- * ends it there. Returns `actionSteps.length` when the block runs to the end of
- * the flow (last branch's target absent, or a dangling/backward target).
- */
-function findIfThenBlockExitIndex(
-  actionSteps: IStep[],
-  startIndex: number,
-  idToIndex: Map<string, number>,
-): number {
-  const visited = new Set<string>()
-  let current = actionSteps[startIndex]
-  let target = current.parameters?.stepIdToJumpTo
-
-  while (typeof target === 'string' && !visited.has(current.id)) {
-    visited.add(current.id)
-    const targetIndex = idToIndex.get(target)
-    const targetStep =
-      targetIndex === undefined ? undefined : actionSteps[targetIndex]
-
-    // Target is another if-then => it's the next branch; keep extending.
-    if (targetStep && isIfThenStep(targetStep)) {
-      current = targetStep
-      target = targetStep.parameters?.stepIdToJumpTo
-      continue
-    }
-
-    // Target is a single step after the block => the block exits there.
-    if (targetIndex !== undefined && targetIndex > startIndex) {
-      return targetIndex
-    }
-
-    // Dangling or backward target: treat the block as running to the end.
-    return actionSteps.length
-  }
-
-  // No (further) target => block runs to the end of the flow.
-  return actionSteps.length
-}
-
-/**
- * Models the flow's action steps (steps after the trigger) as an ordered region
- * list. Runs of ordinary steps become `SingleSteps` regions; if-then chains and
- * for-each groups become `Block` regions.
- *
- * Legacy flows lack `stepIdToJumpTo`, so an if-then block runs to the end of the
- * flow (consecutive if-thens = one block) — byte-identical to the previous
- * "group is always last" behaviour. For-each likewise stays a last-step group.
- *
- * The list always begins with a `SingleSteps` region (the steps before the
- * first block, possibly empty) so that a block-first flow renders exactly as
- * before. Otherwise no empty regions are emitted (blocks are separated by >= 1
- * single step, so between-block regions are never empty).
- */
-export function buildRegionList(
-  actionSteps: IStep[],
-  groupingActions: Set<string>,
-): StepRegion[] {
-  const regions: StepRegion[] = []
-  const idToIndex = new Map(actionSteps.map((step, index) => [step.id, index]))
-
-  let singleSteps: IStep[] = []
-  // The leading region is always emitted (even if empty); later empty runs are
-  // not.
-  let isLeadingRegion = true
-  const flushSingleSteps = () => {
-    if (singleSteps.length > 0 || isLeadingRegion) {
-      regions.push({ type: 'SingleSteps', steps: singleSteps })
-      singleSteps = []
-    }
-    isLeadingRegion = false
-  }
-
-  let i = 0
-  while (i < actionSteps.length) {
-    const step = actionSteps[i]
-
-    if (!isGroupingStep(step, groupingActions)) {
-      singleSteps.push(step)
-      i++
-      continue
-    }
-
-    // A grouping action starts a Block. The accumulated single steps (the
-    // leading region may be empty, mirroring the previous "steps before group")
-    // become their own region first.
-    flushSingleSteps()
-
-    // For-each stays a last-step group, and a legacy if-then (one with no
-    // stored stepIdToJumpTo key) runs to the end of the flow. Otherwise follow
-    // the chain to find the exit.
-    const isLegacyIfThen =
-      isIfThenStep(step) &&
-      !Object.hasOwn(step.parameters ?? {}, 'stepIdToJumpTo')
-    const exitIndex =
-      isForEachStep(step) || isLegacyIfThen
-        ? actionSteps.length
-        : findIfThenBlockExitIndex(actionSteps, i, idToIndex)
-
-    regions.push({
-      type: 'Block',
-      branches: extractBranchesWithSteps(actionSteps.slice(i, exitIndex), 0),
-    })
-    i = exitIndex
-  }
-
-  // Flush any trailing single steps (and the leading region for a flow that has
-  // no blocks at all, including a flow with no action steps).
-  flushSingleSteps()
-
-  return regions
-}
 
 /**
  * Computes what each if-then branch's `stepIdToJumpTo` should be for a given
@@ -494,7 +323,7 @@ export function computeJumpTargets(
     const { branches } = region
 
     // For-each blocks don't use stepIdToJumpTo.
-    if (!branches.length || !isIfThenStep(branches[0][0])) {
+    if (!isIfThenStep(branches[0]?.[0])) {
       continue
     }
 

--- a/packages/frontend/src/helpers/toolbox/index.ts
+++ b/packages/frontend/src/helpers/toolbox/index.ts
@@ -1,0 +1,9 @@
+//
+// Barrel for toolbox helpers. Split into common / if-then / for-each /
+// region-list modules; re-exported here so `@/helpers/toolbox` imports keep
+// working.
+//
+export * from './common'
+export * from './for-each'
+export * from './if-then'
+export * from './region-list'

--- a/packages/frontend/src/helpers/toolbox/region-list.ts
+++ b/packages/frontend/src/helpers/toolbox/region-list.ts
@@ -1,0 +1,140 @@
+import { type IStep } from '@plumber/types'
+
+import { isForEachStep } from './for-each'
+import { extractBranchesWithSteps, isIfThenStep } from './if-then'
+
+//
+// Region list
+//
+// Models a flow's action steps (i.e. everything after the trigger) as an
+// ordered list of regions, so that single steps can appear after — and between
+// — if-then blocks. A `SingleSteps` region is a run of ordinary steps; a `Block`
+// region is a chain of if-then branches (or a for-each). See the hidden
+// `stepIdToJumpTo` parameter on if-then for how block membership is stored.
+//
+export type StepRegion =
+  | { type: 'SingleSteps'; steps: IStep[] }
+  | { type: 'Block'; branches: IStep[][] }
+
+function isGroupingStep(step: IStep, groupingActions: Set<string>): boolean {
+  return (
+    !!step.appKey &&
+    !!step.key &&
+    groupingActions.has(`${step.appKey}-${step.key}`)
+  )
+}
+
+/**
+ * Follows the `stepIdToJumpTo` chain from an if-then block's first branch to
+ * find the index just past the block (its exit). A branch whose target is
+ * another if-then continues the block; a branch whose target is a single step
+ * ends it there. Returns `actionSteps.length` when the block runs to the end of
+ * the flow (last branch's target absent, or a dangling/backward target).
+ */
+function findIfThenBlockExitIndex(
+  actionSteps: IStep[],
+  startIndex: number,
+  idToIndex: Map<string, number>,
+): number {
+  const visited = new Set<string>()
+  let current = actionSteps[startIndex]
+  let target = current.parameters?.stepIdToJumpTo
+
+  while (typeof target === 'string' && !visited.has(current.id)) {
+    visited.add(current.id)
+    const targetIndex = idToIndex.get(target)
+    const targetStep =
+      targetIndex === undefined ? undefined : actionSteps[targetIndex]
+
+    // Target is another if-then => it's the next branch; keep extending.
+    if (isIfThenStep(targetStep)) {
+      current = targetStep
+      target = targetStep.parameters?.stepIdToJumpTo
+      continue
+    }
+
+    // Target is a single step after the block => the block exits there.
+    if (targetIndex !== undefined && targetIndex > startIndex) {
+      return targetIndex
+    }
+
+    // Dangling or backward target: treat the block as running to the end.
+    return actionSteps.length
+  }
+
+  // No (further) target => block runs to the end of the flow.
+  return actionSteps.length
+}
+
+/**
+ * Models the flow's action steps (steps after the trigger) as an ordered region
+ * list. Runs of ordinary steps become `SingleSteps` regions; if-then chains and
+ * for-each groups become `Block` regions.
+ *
+ * Legacy flows lack `stepIdToJumpTo`, so an if-then block runs to the end of the
+ * flow (consecutive if-thens = one block) — byte-identical to the previous
+ * "group is always last" behaviour. For-each likewise stays a last-step group.
+ *
+ * The list always begins with a `SingleSteps` region (the steps before the
+ * first block, possibly empty) so that a block-first flow renders exactly as
+ * before. Otherwise no empty regions are emitted (blocks are separated by >= 1
+ * single step, so between-block regions are never empty).
+ */
+export function buildRegionList(
+  actionSteps: IStep[],
+  groupingActions: Set<string>,
+): StepRegion[] {
+  const regions: StepRegion[] = []
+  const idToIndex = new Map(actionSteps.map((step, index) => [step.id, index]))
+
+  let singleSteps: IStep[] = []
+  // The leading region is always emitted (even if empty); later empty runs are
+  // not.
+  let isLeadingRegion = true
+  const flushSingleSteps = () => {
+    if (singleSteps.length > 0 || isLeadingRegion) {
+      regions.push({ type: 'SingleSteps', steps: singleSteps })
+      singleSteps = []
+    }
+    isLeadingRegion = false
+  }
+
+  let i = 0
+  while (i < actionSteps.length) {
+    const step = actionSteps[i]
+
+    if (!isGroupingStep(step, groupingActions)) {
+      singleSteps.push(step)
+      i++
+      continue
+    }
+
+    // A grouping action starts a Block. The accumulated single steps (the
+    // leading region may be empty, mirroring the previous "steps before group")
+    // become their own region first.
+    flushSingleSteps()
+
+    // For-each stays a last-step group, and a legacy if-then (one with no
+    // stored stepIdToJumpTo key) runs to the end of the flow. Otherwise follow
+    // the chain to find the exit.
+    const isLegacyIfThen =
+      isIfThenStep(step) &&
+      !Object.hasOwn(step.parameters ?? {}, 'stepIdToJumpTo')
+    const exitIndex =
+      isForEachStep(step) || isLegacyIfThen
+        ? actionSteps.length
+        : findIfThenBlockExitIndex(actionSteps, i, idToIndex)
+
+    regions.push({
+      type: 'Block',
+      branches: extractBranchesWithSteps(actionSteps.slice(i, exitIndex), 0),
+    })
+    i = exitIndex
+  }
+
+  // Flush any trailing single steps (and the leading region for a flow that has
+  // no blocks at all, including a flow with no action steps).
+  flushSingleSteps()
+
+  return regions
+}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

I noticed that our `toolbox.ts` helper file was a bit large so I broke it up into a few files. 

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.