### PR TITLE
[IF-THEN-THEN-6] PLU-743: (frontend) support stepIdToJumpTo on branch add/init/delete

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/Branch.tsx
@@ -16,7 +16,9 @@ import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAl
 import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import useReorderSteps from '@/hooks/useReorderSteps'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
@@ -30,10 +32,14 @@ import useDuplicateBranch from './useDuplicateBranch'
 interface BranchProps {
   branchSteps: IStep[]
   stepsBeforeGroup: IStep[]
+  // The if-then step of the branch immediately before this one in the block, or
+  // undefined for the first branch. Used to maintain the stepIdToJumpTo chain on
+  // deletion: the predecessor inherits this branch's step to jump to.
+  previousBranchStep?: IStep
 }
 
 export default function Branch(props: BranchProps) {
-  const { branchSteps } = props
+  const { branchSteps, previousBranchStep } = props
 
   const {
     flow,
@@ -55,6 +61,7 @@ export default function Branch(props: BranchProps) {
   const [deleteStep, { loading: isDeletingBranch }] = useMutation(DELETE_STEP, {
     refetchQueries: [GET_FLOW],
   })
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS)
   const { handleReorderUpdate } = useReorderSteps(flow.id)
   const openDeleteConfirmation = useCallback<MouseEventHandler>(
     (e) => {
@@ -65,9 +72,42 @@ export default function Branch(props: BranchProps) {
   )
   const deleteBranch = useCallback(async () => {
     const idsToDelete = branchSteps.map((step) => step.id)
+
+    // The predecessor branch inherits this branch's step to jump to so the
+    // chain skips the gap left by the deletion. Skip when there's no predecessor
+    // (deleting the first branch — nothing points to it) or when this is a
+    // legacy branch with no stored step to jump to (the execution scan handles
+    // those) — a branch is new-style iff parameters has the stepIdToJumpTo key.
+    const deletionParams = branchSteps[0].parameters
+    let updatedAt = flow.updatedAt
+    if (
+      previousBranchStep &&
+      deletionParams &&
+      Object.hasOwn(deletionParams, 'stepIdToJumpTo')
+    ) {
+      const deletedTarget = deletionParams.stepIdToJumpTo as string | null
+      const updatedPositions = await updateStepPositions({
+        variables: {
+          input: {
+            stepPositions: [
+              {
+                id: previousBranchStep.id,
+                position: previousBranchStep.position,
+                type: previousBranchStep.type as StepEnumType,
+                stepIdToJumpTo: deletedTarget,
+              },
+            ],
+            flow: { updatedAt },
+          },
+        },
+      })
+      updatedAt =
+        updatedPositions.data?.updateStepPositions?.updatedAt ?? updatedAt
+    }
+
     await deleteStep({
       variables: {
-        input: { ids: idsToDelete, flow: { updatedAt: flow.updatedAt } },
+        input: { ids: idsToDelete, flow: { updatedAt } },
       },
     })
 
@@ -76,6 +116,8 @@ export default function Branch(props: BranchProps) {
     onDrawerClose()
   }, [
     branchSteps,
+    previousBranchStep,
+    updateStepPositions,
     deleteStep,
     onDrawerClose,
     closeDeleteConfirmation,

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
@@ -8,7 +8,9 @@ import { Button } from '@opengovsg/design-system-react'
 
 import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getMrfApprovalConfig } from '@/helpers/formsg'
 import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
@@ -46,13 +48,26 @@ export default function IfThen(props: IfThenProps): JSX.Element {
   const [createStep, { loading: isAddingBranch }] = useMutation(CREATE_STEP, {
     refetchQueries: [GET_FLOW],
   })
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS)
   const onAddBranch = useCallback(async () => {
     if (isAddingBranch) {
       return
     }
 
-    const lastGroup = groupedSteps[groupedSteps.length - 1]
-    const lastStep = lastGroup[lastGroup.length - 1]
+    const lastBranch = groupedSteps[groupedSteps.length - 1]
+    const lastBranchIfThen = lastBranch[0]
+    const lastStep = lastBranch[lastBranch.length - 1]
+
+    // The new branch is appended at the end of the block, so it takes over as
+    // the last branch: it inherits the old last branch's step to jump to, and
+    // the old last branch is repointed at the new branch's if-then. A legacy
+    // last branch has no stored target, so the new branch inherits the "stop"
+    // sentinel (null) — a legacy block runs to the end of the flow.
+    const lastBranchStepIdToJumpTo =
+      (lastBranchIfThen.parameters?.stepIdToJumpTo as
+        | string
+        | null
+        | undefined) ?? null
 
     const approvalConfig = getMrfApprovalConfig({
       previousStep: lastStep,
@@ -74,10 +89,29 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           parameters: {
             depth,
             branchName: `Branch ${numBranches + 1}`,
+            stepIdToJumpTo: lastBranchStepIdToJumpTo,
           },
           config: {
             approval: approvalConfig,
           },
+        },
+      },
+    })
+    const newBranchStep = branchStep.data.createStep
+
+    // Repoint the old last branch's step to jump to at the new branch.
+    const updatedPositions = await updateStepPositions({
+      variables: {
+        input: {
+          stepPositions: [
+            {
+              id: lastBranchIfThen.id,
+              position: lastBranchIfThen.position,
+              type: lastBranchIfThen.type as StepEnumType,
+              stepIdToJumpTo: newBranchStep.id,
+            },
+          ],
+          flow: { updatedAt: newBranchStep.flow.updatedAt },
         },
       },
     })
@@ -88,11 +122,11 @@ export default function IfThen(props: IfThenProps): JSX.Element {
       variables: {
         input: {
           previousStep: {
-            id: branchStep.data.createStep.id,
+            id: newBranchStep.id,
           },
           flow: {
             id: flowId,
-            updatedAt: branchStep.data.createStep.flow.updatedAt,
+            updatedAt: updatedPositions.data?.updateStepPositions?.updatedAt,
           },
           config: {
             approval: approvalConfig,
@@ -101,12 +135,13 @@ export default function IfThen(props: IfThenProps): JSX.Element {
       },
     })
 
-    setCurrentStepId(branchStep.data.createStep.id)
+    setCurrentStepId(newBranchStep.id)
     onDrawerOpen()
   }, [
     isAddingBranch,
     groupedSteps,
     createStep,
+    updateStepPositions,
     flowId,
     depth,
     approvalBranches,
@@ -119,12 +154,15 @@ export default function IfThen(props: IfThenProps): JSX.Element {
   return (
     <Flex flexDir="column" alignItems="center" gap={4} w="100%" mt={2}>
       <Flex flexDir="column" w="100%" px={2} gap={4}>
-        {groupedSteps.map((branchSteps) => {
+        {groupedSteps.map((branchSteps, index) => {
           return (
             <Branch
               key={branchSteps[0].id}
               branchSteps={branchSteps}
               stepsBeforeGroup={stepsBeforeGroup}
+              previousBranchStep={
+                index > 0 ? groupedSteps[index - 1][0] : undefined
+              }
             />
           )
         })}

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -153,28 +153,10 @@ export function useIfThenInitializer(): [
         }),
       }
 
-      const updateFirstBranch = await updateStep({
-        variables: {
-          input: {
-            id: currStep.id,
-            appKey: TOOLBOX_APP_KEY,
-            key: TOOLBOX_ACTIONS.IfThen,
-            flow: {
-              id: currStep.flowId,
-              updatedAt: currStep.flow.updatedAt,
-            },
-            parameters: {
-              branchName: 'Branch 1',
-              depth,
-            },
-            connection: {
-              id: null,
-            },
-            // no need to set config here since it's already set
-          },
-        },
-      })
-      const updatedFirstBranch = updateFirstBranch?.data?.updateStep
+      // Create Branch 2 first so Branch 1 can point its step to jump to
+      // (stepIdToJumpTo) at Branch 2's if-then. A freshly created block is the
+      // last thing in the flow, so Branch 2 — the block's last branch — stops
+      // execution: its stepIdToJumpTo is the "stop" sentinel (null).
       const createSecondBranch = await createStep({
         variables: {
           input: {
@@ -185,21 +167,42 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
-              updatedAt: updatedFirstBranch?.flow?.updatedAt,
+              updatedAt: currStep.flow.updatedAt,
             },
             parameters: {
               depth,
               branchName: 'Branch 2',
+              stepIdToJumpTo: null,
             },
             config: commonConfig,
           },
         },
       })
       const createdSecondBranch = createSecondBranch?.data?.createStep
-      const [_firstBranch, secondBranch] = await Promise.all([
-        updateFirstBranch,
-        createSecondBranch,
-      ])
+
+      const updateFirstBranch = await updateStep({
+        variables: {
+          input: {
+            id: currStep.id,
+            appKey: TOOLBOX_APP_KEY,
+            key: TOOLBOX_ACTIONS.IfThen,
+            flow: {
+              id: currStep.flowId,
+              updatedAt: createdSecondBranch.flow.updatedAt,
+            },
+            parameters: {
+              branchName: 'Branch 1',
+              depth,
+              stepIdToJumpTo: createdSecondBranch.id,
+            },
+            connection: {
+              id: null,
+            },
+            // no need to set config here since it's already set
+          },
+        },
+      })
+      const updatedFirstBranch = updateFirstBranch?.data?.updateStep
 
       // After creating branches, we create a sample step to each branch. This is
       // because users always get confused on how to add actions within a
@@ -215,7 +218,7 @@ export function useIfThenInitializer(): [
             },
             flow: {
               id: currStep.flowId,
-              updatedAt: createdSecondBranch.flow.updatedAt,
+              updatedAt: updatedFirstBranch?.flow?.updatedAt,
             },
             config: commonConfig,
           },
@@ -226,7 +229,7 @@ export function useIfThenInitializer(): [
         variables: {
           input: {
             previousStep: {
-              id: secondBranch.data.createStep.id,
+              id: createdSecondBranch.id,
             },
             flow: {
               id: currStep.flowId,


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates the frontend to populate `stepIdToJumpTo` when doing these operations within an If-Then block:

1. Creating the initial If-then block itself (i.e. the initial 2 branches)
2. Creating a new branch in the block
3. Deleting a branch in the block

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.