### PR TITLE
[IF-THEN-THEN-7] PLU-743: (frontend) support add step after if-then

### DIFF
--- a/packages/frontend/src/components/Editor/components/AddStepButton.tsx
+++ b/packages/frontend/src/components/Editor/components/AddStepButton.tsx
@@ -6,6 +6,7 @@ import { IconButton, TouchableTooltip } from '@opengovsg/design-system-react'
 
 import EmptyFlowStepHeader from '@/components/EmptyFlowStepHeader'
 import FlowStepConfigurationModal from '@/components/FlowStepConfigurationModal'
+import { type OnAfterCreateStep } from '@/components/FlowStepConfigurationModal/FlowStepConfigurationContext'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import UnsavedChangesAlert from './UnsavedChangesAlert'
@@ -16,10 +17,20 @@ interface AddStepButtonProps {
   isLastStep: boolean
   showEmptyAction: boolean
   step: IStep
+  // Post-create hook forwarded to onCreateStep; used e.g. to repoint an if-then
+  // block's last branch when adding a step after the block.
+  onAfterCreateStep?: OnAfterCreateStep
 }
 
 export function AddStepButton(props: AddStepButtonProps): JSX.Element {
-  const { isHidden, isLastStep, step, isDisabled, showEmptyAction } = props
+  const {
+    isHidden,
+    isLastStep,
+    step,
+    isDisabled,
+    showEmptyAction,
+    onAfterCreateStep,
+  } = props
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const {
@@ -111,6 +122,7 @@ export function AddStepButton(props: AddStepButtonProps): JSX.Element {
               isTrigger={false} // Can only add an action all the time
               isLastStep={isLastStep}
               prevStep={step}
+              onAfterCreateStep={onAfterCreateStep}
             />
           )}
         </>

--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -1,6 +1,7 @@
 import { IStep } from '@plumber/types'
 
-import { useCallback, useContext, useMemo } from 'react'
+import { Fragment, useCallback, useContext, useMemo } from 'react'
+import { useMutation } from '@apollo/client'
 import { Center, Flex } from '@chakra-ui/react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
@@ -9,11 +10,19 @@ import { EditorContext } from '@/contexts/Editor'
 import { MrfContext } from '@/contexts/MrfContext'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
+import {
+  getEarlierBranchesStepIdToJumpTo,
+  isIfThenStep,
+} from '@/helpers/toolbox'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import { EDITOR_RIGHT_DRAWER_WIDTH } from '../constants'
 import { editorStyles } from '../styles'
 
+import { AddStepButton } from './AddStepButton'
 import FlowStepWithAddButton from './FlowStepWithAddButton'
 
 interface StepsListProps {
@@ -26,6 +35,9 @@ export function StepsList({ isNested }: StepsListProps) {
   const { flow, isDrawerOpen, isMobile, readOnly } = useContext(EditorContext)
   const { mrfSteps, mrfApprovalSteps, approvalBranches } =
     useContext(MrfContext)
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    refetchQueries: [GET_FLOW],
+  })
 
   const { calculateReorderedSteps, handleReorderUpdate } = useReorderSteps(
     flow.id,
@@ -136,12 +148,66 @@ export function StepsList({ isNested }: StepsListProps) {
           const previousRegion = regionList[regionIndex - 1]
           const stepsBeforeGroup =
             previousRegion?.type === 'SingleSteps' ? previousRegion.steps : []
+          const { branches } = region
+          const isIfThenBlock = isIfThenStep(branches[0]?.[0])
+          const lastBranch = branches[branches.length - 1]
+          const lastBranchIfThen = lastBranch?.[0]
+          const blockLastStep = lastBranch?.[lastBranch.length - 1]
           return (
-            <FlowStepGroup
-              key={`block-${region.branches[0]?.[0]?.id ?? regionIndex}`}
-              stepsBeforeGroup={stepsBeforeGroup}
-              groupedSteps={region.branches}
-            />
+            <Fragment key={`block-${branches[0]?.[0]?.id ?? regionIndex}`}>
+              <FlowStepGroup
+                stepsBeforeGroup={stepsBeforeGroup}
+                groupedSteps={branches}
+              />
+              {/* Add a step immediately after the block, before any following
+                  region. Rendered after every if-then block (for-each stays a
+                  terminal group). Repoints the block's last branch at the new
+                  step so the block ends there instead of absorbing it; the new
+                  step becomes the first step of the following region (or a fresh
+                  trailing region when the block is last). isLastStep reflects
+                  whether the block currently ends the flow. */}
+              {isIfThenBlock && lastBranchIfThen && blockLastStep && (
+                <AddStepButton
+                  isLastStep={isLastRegion}
+                  step={blockLastStep}
+                  isHidden={readOnly}
+                  isDisabled={false}
+                  showEmptyAction={false}
+                  onAfterCreateStep={async (createdStep) => {
+                    // Repoint the block's last branch at the new step (its
+                    // position is unchanged; the entry just carries the new step
+                    // to jump to and anchors the mutation). For a legacy block
+                    // the earlier branches carry no chain yet, so send their
+                    // step-to-jump-to updates as auxiliary changes (branch
+                    // if-thens aren't contiguous) — this upgrades the whole block
+                    // to new-style so buildRegionList reads the new step as the
+                    // block's exit. No-ops for an already-chained block.
+                    const earlierBranchJumpTargets =
+                      getEarlierBranchesStepIdToJumpTo(branches)
+                    await updateStepPositions({
+                      variables: {
+                        input: {
+                          stepPositions: [
+                            {
+                              id: lastBranchIfThen.id,
+                              position: lastBranchIfThen.position,
+                              type: lastBranchIfThen.type as StepEnumType,
+                              stepIdToJumpTo: createdStep.id,
+                            },
+                          ],
+                          ...(earlierBranchJumpTargets.length > 0 && {
+                            auxiliaryChanges: earlierBranchJumpTargets.map(
+                              (jumpTarget) => ({ ifThen: jumpTarget }),
+                            ),
+                          }),
+                          flow: { updatedAt: createdStep.flow.updatedAt },
+                        },
+                      },
+                    })
+                  }}
+                />
+              )}
+            </Fragment>
           )
         }
 

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAndAddConnection/index.tsx
@@ -79,9 +79,8 @@ export default function ChooseAndAddConnection(
     setCurrentStepId,
     executeTestStep,
   } = useContext(EditorContext)
-  const { modalState, patchModalState, step, prevStep } = useContext(
-    FlowStepConfigurationContext,
-  )
+  const { modalState, patchModalState, step, prevStep, onAfterCreateStep } =
+    useContext(FlowStepConfigurationContext)
 
   const { approvalBranches } = useContext(MrfContext)
   const { currentScreen, selectedApp, selectedEvent } = modalState
@@ -144,6 +143,7 @@ export default function ChooseAndAddConnection(
             connectionId,
             approvalConfig && { approval: approvalConfig },
           )
+          await onAfterCreateStep?.(createdStep)
           newStepId = createdStep.id
         } else if (step) {
           const updatedStep = await onUpdateStep({
@@ -181,6 +181,7 @@ export default function ChooseAndAddConnection(
       setCurrentStepId,
       approvalBranches,
       onCreateStep,
+      onAfterCreateStep,
       onUpdateStep,
       executeTestStep,
     ],

--- a/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/ChooseAppAndEvent/index.tsx
@@ -47,12 +47,18 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
     allApps,
     onDrawerOpen,
     setCurrentStepId,
+    flow,
     flowId,
   } = useContext(EditorContext)
 
-  const { modalState, patchModalState, prevStep, isTrigger, step } = useContext(
-    FlowStepConfigurationContext,
-  )
+  const {
+    modalState,
+    patchModalState,
+    prevStep,
+    isTrigger,
+    step,
+    onAfterCreateStep,
+  } = useContext(FlowStepConfigurationContext)
   const { approvalBranches } = useContext(MrfContext)
 
   const { currentScreen, selectedApp } = modalState
@@ -131,6 +137,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             systemConnection?.id || undefined,
             approvalConfig && { approval: approvalConfig },
           )
+          await onAfterCreateStep?.(createdStep)
           newStepId = createdStep.id
         } else if (step) {
           // This part of the code happens when updating an empty step
@@ -139,7 +146,13 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
             app.key === TOOLBOX_APP_KEY &&
             triggerOrAction.key === TOOLBOX_ACTIONS.IfThen
           ) {
-            const ifThen = await initializeIfThen(step)
+            // The converted step keeps its position, so the new block exits to
+            // the step that follows it — or stops (the null sentinel) when the
+            // converted step is the last in the flow.
+            const nextStep = flow.steps.find(
+              (s) => s.position === step.position + 1,
+            )
+            const ifThen = await initializeIfThen(step, nextStep?.id ?? null)
             newStepId = ifThen.id
           } else {
             const updatedStep = await onUpdateStep({
@@ -166,6 +179,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
     },
     [
       fetchAppConnections,
+      flow,
       flowId,
       patchModalState,
       prevStep,
@@ -175,6 +189,7 @@ export default function ChooseAppAndEvent(props: ChooseAppAndEventProps) {
       setCurrentStepId,
       approvalBranches,
       onCreateStep,
+      onAfterCreateStep,
       initializeIfThen,
       onUpdateStep,
     ],

--- a/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/FlowStepConfigurationContext.tsx
@@ -4,6 +4,11 @@ import { IAction, IApp, IStep, ITrigger } from '@plumber/types'
 
 import { createContext, useCallback, useState } from 'react'
 
+// Runs after the modal creates a step (after the editor's onCreateStep and its
+// refetch), receiving the created step. Used e.g. to repoint an if-then block's
+// last branch at the new step; the hook issues its own write + refetch.
+export type OnAfterCreateStep = (createdStep: IStep) => Promise<void>
+
 interface FlowStepConfigurationContextValue {
   modalState: ModalState
   patchModalState: (modalState: Partial<ModalState>) => void
@@ -12,6 +17,9 @@ interface FlowStepConfigurationContextValue {
   prevStep?: IStep
   prevStepId?: string
   step?: IStep
+  // Optional hook forwarded to the editor's onCreateStep, run after the step is
+  // created (e.g. to repoint an if-then block's last branch at the new step).
+  onAfterCreateStep?: OnAfterCreateStep
 }
 
 export const FlowStepConfigurationContext =
@@ -52,6 +60,7 @@ interface FlowStepConfigurationContextProps {
   isTrigger: boolean
   isLastStep: boolean
   prevStep?: IStep
+  onAfterCreateStep?: OnAfterCreateStep
   children: React.ReactNode
 }
 
@@ -62,6 +71,7 @@ export const FlowStepConfigurationContextProvider = ({
   isTrigger,
   isLastStep,
   prevStep,
+  onAfterCreateStep,
   children,
 }: FlowStepConfigurationContextProps) => {
   const [modalState, setModalState] = useState<ModalState>({
@@ -86,6 +96,7 @@ export const FlowStepConfigurationContextProvider = ({
         prevStep,
         prevStepId: prevStep?.id,
         step,
+        onAfterCreateStep,
       }}
     >
       {children}

--- a/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/index.tsx
@@ -8,6 +8,7 @@ import ChooseAppAndEvent from './ChooseAppAndEvent'
 import {
   FlowStepConfigurationContext,
   FlowStepConfigurationContextProvider,
+  type OnAfterCreateStep,
 } from './FlowStepConfigurationContext'
 import InvalidModalScreen from './InvalidModalScreen'
 import LoadingOverlay from './LoadingOverlay'
@@ -21,6 +22,9 @@ interface FlowStepConfigurationModalProps {
   app?: IApp
   event?: ITrigger | IAction
   prevStep?: IStep
+  // Post-create hook forwarded to onCreateStep; used e.g. to repoint an if-then
+  // block's last branch when adding a step after the block.
+  onAfterCreateStep?: OnAfterCreateStep
 }
 
 function FlowStepConfigurationModalContent({
@@ -53,7 +57,16 @@ function FlowStepConfigurationModalContent({
 export default function FlowStepConfigurationModal(
   props: FlowStepConfigurationModalProps,
 ): JSX.Element {
-  const { onClose, isTrigger, isLastStep, step, app, event, prevStep } = props
+  const {
+    onClose,
+    isTrigger,
+    isLastStep,
+    step,
+    app,
+    event,
+    prevStep,
+    onAfterCreateStep,
+  } = props
 
   return (
     <FlowStepConfigurationContextProvider
@@ -62,6 +75,7 @@ export default function FlowStepConfigurationModal(
       app={app}
       event={event}
       prevStep={prevStep}
+      onAfterCreateStep={onAfterCreateStep}
       step={step}
     >
       <Modal

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -232,7 +232,18 @@ export const EditorProvider = ({
 
       // account for the for-each and if-then
       if (appKey === TOOLBOX_APP_KEY && eventKey === TOOLBOX_ACTIONS.IfThen) {
-        newStep = await initializeIfThen(newStep)
+        // The new block exits to the step that followed the anchor step before
+        // the insert, or stops (the null sentinel) when the block is added at
+        // the end of the flow. `flow.steps` still holds the pre-insert flow.
+        const previousStep = flow.steps.find(
+          (s: IStep) => s.id === previousStepId,
+        )
+        const nextStep =
+          previousStep &&
+          flow.steps.find(
+            (s: IStep) => s.position === previousStep.position + 1,
+          )
+        newStep = await initializeIfThen(newStep, nextStep?.id ?? null)
       }
       // we refetch GET_FLOW after everything is completed
       await client.refetchQueries({ include: [GET_FLOW] })

--- a/packages/frontend/src/helpers/__tests__/if-then.test.ts
+++ b/packages/frontend/src/helpers/__tests__/if-then.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildRegionList,
   computeJumpTargets,
+  getEarlierBranchesStepIdToJumpTo,
   type StepRegion,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -118,5 +119,83 @@ describe('computeJumpTargets', () => {
     // The recomputed targets match what the steps already store.
     expect(targets.get('b1')).toBe('b2')
     expect(targets.get('b2')).toBe('after')
+  })
+})
+
+describe('getEarlierBranchesStepIdToJumpTo', () => {
+  it("points each branch except the last at the next branch's if-then", () => {
+    const b1 = ifThen('b1')
+    const b1a = step()
+    const b2 = ifThen('b2')
+    const b2a = step()
+    const b3 = ifThen('b3')
+    const b3a = step()
+
+    expect(
+      getEarlierBranchesStepIdToJumpTo([
+        [b1, b1a],
+        [b2, b2a],
+        [b3, b3a],
+      ]),
+    ).toEqual([
+      { stepId: 'b1', stepIdToJumpTo: 'b2' },
+      { stepId: 'b2', stepIdToJumpTo: 'b3' },
+    ])
+  })
+
+  it('returns an empty array for a single-branch block', () => {
+    const b1 = ifThen('b1')
+    const b1a = step()
+
+    expect(getEarlierBranchesStepIdToJumpTo([[b1, b1a]])).toEqual([])
+  })
+
+  it('upgrades a legacy block so an added after-block step reads as its exit', () => {
+    // A legacy if-then block (no branch carries a step to jump to) at the end
+    // of the flow, with a step freshly added after it.
+    const b1 = ifThen('b1')
+    const b1a = step()
+    const b2 = ifThen('b2')
+    const b2a = step()
+    const created = step({ id: 'created' })
+    const steps = [b1, b1a, b2, b2a, created]
+
+    // Before the handler's writes, the legacy block runs to the end of the flow
+    // and swallows the new step into its last branch.
+    const before = buildRegionList(steps, GROUPING_ACTIONS)
+    expect(before.map((r) => r.type)).toEqual(['SingleSteps', 'Block'])
+    expect(before[1]).toMatchObject({
+      branches: [
+        [b1, b1a],
+        [b2, b2a, created],
+      ],
+    })
+
+    // Apply exactly what the after-block handler writes: the last branch jumps
+    // to the new step, and getEarlierBranchesStepIdToJumpTo chains the rest.
+    b2.parameters = { ...b2.parameters, stepIdToJumpTo: 'created' }
+    for (const { stepId, stepIdToJumpTo } of getEarlierBranchesStepIdToJumpTo([
+      [b1, b1a],
+      [b2, b2a],
+    ])) {
+      const branchStep = steps.find((s) => s.id === stepId)!
+      branchStep.parameters = { ...branchStep.parameters, stepIdToJumpTo }
+    }
+
+    // Now the block exits at the new step: two branches, then a SingleSteps
+    // region holding the added step.
+    const after = buildRegionList(steps, GROUPING_ACTIONS)
+    expect(after.map((r) => r.type)).toEqual([
+      'SingleSteps',
+      'Block',
+      'SingleSteps',
+    ])
+    expect(after[1]).toMatchObject({
+      branches: [
+        [b1, b1a],
+        [b2, b2a],
+      ],
+    })
+    expect(after[2]).toEqual({ type: 'SingleSteps', steps: [created] })
   })
 })

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -124,9 +124,14 @@ export function areAllIfThenBranchesCompleted(
 /**
  * Hook used for initializing If-then when the user _first_ chooses it via the
  * "Choose App & Event" substep.
+ *
+ * `lastBranchStepIdToJumpTo` is the new block's exit: the id of the step that
+ * follows the block (callers pass the step that followed the anchor step when
+ * the block was created), or null — the "stop" sentinel — when the block is
+ * added at the end of the flow.
  */
 export function useIfThenInitializer(): [
-  (currStep: IStep) => Promise<IStep>,
+  (currStep: IStep, lastBranchStepIdToJumpTo: string | null) => Promise<IStep>,
   boolean,
 ] {
   const [isInitializing, setIsInitializing] = useState(false)
@@ -144,7 +149,7 @@ export function useIfThenInitializer(): [
   const [createStep] = useMutation(CREATE_STEP, { fetchPolicy: 'no-cache' })
 
   const initialize = useCallback(
-    async (currStep: IStep) => {
+    async (currStep: IStep, lastBranchStepIdToJumpTo: string | null) => {
       setIsInitializing(true)
 
       const commonConfig = {
@@ -154,9 +159,10 @@ export function useIfThenInitializer(): [
       }
 
       // Create Branch 2 first so Branch 1 can point its step to jump to
-      // (stepIdToJumpTo) at Branch 2's if-then. A freshly created block is the
-      // last thing in the flow, so Branch 2 — the block's last branch — stops
-      // execution: its stepIdToJumpTo is the "stop" sentinel (null).
+      // (stepIdToJumpTo) at Branch 2's if-then. Branch 2 — the block's last
+      // branch — jumps to the block's exit: the step that followed the anchor
+      // step when the block was created, or the "stop" sentinel (null) when
+      // the block is added at the end of the flow.
       const createSecondBranch = await createStep({
         variables: {
           input: {
@@ -172,7 +178,7 @@ export function useIfThenInitializer(): [
             parameters: {
               depth,
               branchName: 'Branch 2',
-              stepIdToJumpTo: null,
+              stepIdToJumpTo: lastBranchStepIdToJumpTo,
             },
             config: commonConfig,
           },
@@ -352,4 +358,28 @@ export function computeJumpTargets(
   }
 
   return targets
+}
+
+/**
+ * The step-to-jump-to updates for every branch *except the last* of an if-then
+ * block: each points at the next branch's if-then. Returned as
+ * `{ stepId, stepIdToJumpTo }` pairs (empty for a single-branch block).
+ *
+ * Used when adding a step immediately after a block. The caller repoints the
+ * last branch at the new step; these updates chain the earlier branches. They
+ * matter for a *legacy* block (branches carry no step to jump to): the read
+ * path (`buildRegionList` → `findIfThenBlockExitIndex`) locates a block's exit
+ * by following the chain from the *first* branch, so unless every earlier
+ * branch also carries a marker the block is still read as running to the end of
+ * the flow — swallowing the new step into the last branch. Writing the whole
+ * chain upgrades the block to new-style. For an already-chained block these
+ * repeat existing values (no-ops).
+ */
+export function getEarlierBranchesStepIdToJumpTo(
+  branches: IStep[][],
+): Array<{ stepId: string; stepIdToJumpTo: string }> {
+  return branches.slice(0, -1).map((branch, index) => ({
+    stepId: branch[0].id,
+    stepIdToJumpTo: branches[index + 1][0].id,
+  }))
 }


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates our frontend to enable adding steps _after_ an If-Then block. The high level idea:

1. We expose an afterCreateStep callback in the "Add step" button
2. This callback is populated for "Add step" buttons rendered immediately after an If-then block

This approach has a tradeoff where we do 2 mutations (_createStep creates the new step -> afterCreateStep sets up the previous If-Then branch_) for "simplicity" - the alternative is coupling If-Then specific logic to Create Step, which seems a bit wonky.

IMPORTANT: Adding a step _after_ a legacy If-Then block will upgrade **all branches in it** to the new If-Then; without `stepIdtoJumpTo`, we can't tell where the block ends. 

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.