### PR TITLE
[IF-THEN-THEN-8] PLU-743: (frontend) support deleting step after if-then

### DIFF
--- a/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
+++ b/packages/frontend/src/components/FlowStep/components/DeleteStepButton.tsx
@@ -9,11 +9,14 @@ import { IconButton } from '@opengovsg/design-system-react'
 import UnsavedChangesAlert from '@/components/Editor/components/UnsavedChangesAlert'
 import MenuAlertDialog from '@/components/MenuAlertDialog'
 import { EditorContext } from '@/contexts/Editor'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import client from '@/graphql/client'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { DELETE_STEP } from '@/graphql/mutations/delete-step'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
+import { getUpdatedStepToJumpToOnStepDelete } from '@/helpers/toolbox'
 import { useUnsavedChanges } from '@/hooks/useUnsavedChanges'
 
 import { findAdjacentSteps, shouldCreateEmptyStep } from '../utils'
@@ -68,14 +71,46 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
   const [createStep, { loading: isCreatingStep }] = useMutation(CREATE_STEP, {
     fetchPolicy: 'no-cache',
   })
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    fetchPolicy: 'no-cache',
+  })
 
   const onDelete = useCallback<MouseEventHandler>(
     async (e) => {
       e.stopPropagation()
 
+      // If an if-then branch jumps to this step (it's the first step after a
+      // block), repoint the branch at the step after it before deleting, so
+      // its stored step to jump to never dangles.
+      const matchingBranchUpdateInfo = getUpdatedStepToJumpToOnStepDelete(
+        flow.steps,
+        step,
+      )
+      let updatedAt = flow.updatedAt
+      if (matchingBranchUpdateInfo) {
+        const updatedPositions = await updateStepPositions({
+          variables: {
+            input: {
+              stepPositions: [
+                {
+                  id: matchingBranchUpdateInfo.branchStep.id,
+                  position: matchingBranchUpdateInfo.branchStep.position,
+                  type: matchingBranchUpdateInfo.branchStep
+                    .type as StepEnumType,
+                  stepIdToJumpTo: matchingBranchUpdateInfo.stepIdToJumpTo,
+                },
+              ],
+              flow: { updatedAt },
+            },
+          },
+        })
+        updatedAt =
+          updatedPositions.data?.updateStepPositions?.updatedAt ?? updatedAt
+      }
+
       const deletedStep = await deleteStep({
         variables: {
-          input: { ids: [step.id], flow: { updatedAt: flow.updatedAt } },
+          input: { ids: [step.id], flow: { updatedAt } },
         },
       })
       const updatedFlow = deletedStep.data?.deleteStep
@@ -113,6 +148,7 @@ export default function DeleteStepButton(props: DeleteStepButtonProps) {
       flow,
       step,
       deleteStep,
+      updateStepPositions,
       setCurrentStepId,
       setShouldWarnOnLeave,
       onDrawerClose,

--- a/packages/frontend/src/helpers/__tests__/if-then.test.ts
+++ b/packages/frontend/src/helpers/__tests__/if-then.test.ts
@@ -6,6 +6,7 @@ import {
   buildRegionList,
   computeJumpTargets,
   getEarlierBranchesStepIdToJumpTo,
+  getUpdatedStepToJumpToOnStepDelete,
   type StepRegion,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -30,7 +31,7 @@ function step(overrides: Partial<IStep> = {}): IStep {
   } as IStep
 }
 
-function ifThen(id: string, stepIdToJumpTo?: string): IStep {
+function ifThen(id: string, stepIdToJumpTo?: string | null): IStep {
   return step({
     id,
     appKey: TOOLBOX_APP_KEY,
@@ -119,6 +120,72 @@ describe('computeJumpTargets', () => {
     // The recomputed targets match what the steps already store.
     expect(targets.get('b1')).toBe('b2')
     expect(targets.get('b2')).toBe('after')
+  })
+})
+
+describe('getUpdatedStepToJumpToOnStepDelete', () => {
+  it('repoints the last branch at the next step when the first after-block step is deleted', () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after1')
+    const b2a = step()
+    const after1 = step({ id: 'after1' })
+    const after2 = step({ id: 'after2' })
+    const steps = [b1, b1a, b2, b2a, after1, after2]
+
+    expect(getUpdatedStepToJumpToOnStepDelete(steps, after1)).toEqual({
+      branchStep: b2,
+      stepIdToJumpTo: 'after2',
+    })
+  })
+
+  it('repoints the last branch to null (stop) when the only after-block step is deleted', () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after')
+    const b2a = step()
+    const after = step({ id: 'after' })
+    const steps = [b1, b1a, b2, b2a, after]
+
+    expect(getUpdatedStepToJumpToOnStepDelete(steps, after)).toEqual({
+      branchStep: b2,
+      stepIdToJumpTo: null,
+    })
+  })
+
+  it('repoints at the next block when the only step between two blocks is deleted (blocks merge)', () => {
+    const b1 = ifThen('b1', 'mid')
+    const b1a = step()
+    const mid = step({ id: 'mid' })
+    const c1 = ifThen('c1', null)
+    const c1a = step()
+    const steps = [b1, b1a, mid, c1, c1a]
+
+    expect(getUpdatedStepToJumpToOnStepDelete(steps, mid)).toEqual({
+      branchStep: b1,
+      stepIdToJumpTo: 'c1',
+    })
+  })
+
+  it('returns null when no branch jumps to the deleted step', () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after')
+    const after = step({ id: 'after' })
+    const steps = [b1, b1a, b2, after]
+
+    // b1a is a step inside a branch; nothing jumps to it.
+    expect(getUpdatedStepToJumpToOnStepDelete(steps, b1a)).toBeNull()
+  })
+
+  it('returns null for legacy if-thens with no stored step to jump to', () => {
+    const b1 = ifThen('b1')
+    const b1a = step()
+    const b2 = ifThen('b2')
+    const b2a = step()
+    const steps = [b1, b1a, b2, b2a]
+
+    expect(getUpdatedStepToJumpToOnStepDelete(steps, b2a)).toBeNull()
   })
 })
 

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -383,3 +383,33 @@ export function getEarlierBranchesStepIdToJumpTo(
     stepIdToJumpTo: branches[index + 1][0].id,
   }))
 }
+
+/**
+ * Computes the repoint needed when a single step is deleted: if a block's last
+ * branch jumps to the deleted step (it's the first step after the block), that
+ * branch must be repointed at the step following the deleted one — the next
+ * single step, the next block's if-then when the region empties (the blocks
+ * merge), or the "stop" sentinel (null) when the flow ends there. Returns null
+ * when no branch jumps to the deleted step. At most one branch can jump to any
+ * given step, so a single repoint suffices.
+ *
+ * Deleting an if-then step itself is branch deletion, handled by deleteBranch
+ * in Branch.tsx (the predecessor inherits the deleted branch's target).
+ */
+export function getUpdatedStepToJumpToOnStepDelete(
+  steps: IStep[],
+  deletedStep: IStep,
+): { branchStep: IStep; stepIdToJumpTo: string | null } | null {
+  const matchingBranchStep = steps.find(
+    (s) => isIfThenStep(s) && s.parameters?.stepIdToJumpTo === deletedStep.id,
+  )
+  if (!matchingBranchStep) {
+    return null
+  }
+
+  const nextStep = steps.find((s) => s.position === deletedStep.position + 1)
+  return {
+    branchStep: matchingBranchStep,
+    stepIdToJumpTo: nextStep?.id ?? null,
+  }
+}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates the frontend to support deleting the 1st step after an If-then block (it just updates the If-Then branch's `stepIdToJumpTo` as needed)

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.