### PR TITLE
[IF-THEN-THEN-9] PLU-743: (frontend) support multiple if-then

### DIFF
--- a/packages/frontend/src/components/FlowStep/utils.test.ts
+++ b/packages/frontend/src/components/FlowStep/utils.test.ts
@@ -1,0 +1,62 @@
+import { IStep } from '@plumber/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+
+import { shouldCreateEmptyStep } from './utils'
+
+function step(overrides: Partial<IStep> = {}): IStep {
+  return {
+    id: 'step-1',
+    appKey: 'postman',
+    key: 'sendTransactionalEmail',
+    parameters: {},
+    ...overrides,
+  } as IStep
+}
+
+function ifThen(id: string, stepIdToJumpTo?: string | null): IStep {
+  return step({
+    id,
+    appKey: TOOLBOX_APP_KEY,
+    key: TOOLBOX_ACTIONS.IfThen,
+    parameters: {
+      depth: 0,
+      ...(stepIdToJumpTo !== undefined ? { stepIdToJumpTo } : {}),
+    },
+  })
+}
+
+describe('shouldCreateEmptyStep', () => {
+  it('creates a placeholder when the deleted step was the last step of a trailing branch', () => {
+    expect(shouldCreateEmptyStep(ifThen('b1'), undefined)).toBe(true)
+  })
+
+  it('creates a placeholder when the deleted step was the only step between two branches', () => {
+    expect(shouldCreateEmptyStep(ifThen('b1'), ifThen('b2'))).toBe(true)
+  })
+
+  it('creates a placeholder when the branch jumps to the next step (the deleted step was its only step)', () => {
+    expect(
+      shouldCreateEmptyStep(ifThen('b1', 'after'), step({ id: 'after' })),
+    ).toBe(true)
+  })
+
+  it('does not create a placeholder when the next step is still inside the branch', () => {
+    expect(
+      shouldCreateEmptyStep(ifThen('b1', 'after'), step({ id: 'inner-2' })),
+    ).toBe(false)
+  })
+
+  it('does not create a placeholder for legacy if-thens followed by a regular step', () => {
+    expect(shouldCreateEmptyStep(ifThen('b1'), step({ id: 'inner-2' }))).toBe(
+      false,
+    )
+  })
+
+  it('does not create a placeholder when the previous step is not an if-then', () => {
+    expect(shouldCreateEmptyStep(step({ id: 'prev' }), step())).toBe(false)
+    expect(shouldCreateEmptyStep(undefined, step())).toBe(false)
+  })
+})

--- a/packages/frontend/src/components/FlowStep/utils.ts
+++ b/packages/frontend/src/components/FlowStep/utils.ts
@@ -22,9 +22,18 @@ function findAdjacentSteps(
  *    which means that the step being deleted is the 'last' step in the if-then group
  * 2. The previous step is an if-then step and there is no next step,
  *    which means that the step being deleted is the 'last' step in the group
+ * 3. The previous step is an if-then step whose step to jump to is the next
+ *    step (i.e. the next step is the first step after the block), which means
+ *    that the step being deleted is the branch's only step
+ *
+ * Without the placeholder a branch would end up empty, which the publish
+ * constraint can't detect (an empty branch contributes no incomplete step).
  */
 function shouldCreateEmptyStep(prev?: IStep, next?: IStep): boolean {
-  return !!prev && isIfThenStep(prev) && (!next || isIfThenStep(next))
+  return (
+    isIfThenStep(prev) &&
+    (!next || next.id === prev.parameters?.stepIdToJumpTo || isIfThenStep(next))
+  )
 }
 
 export { findAdjacentSteps, shouldCreateEmptyStep }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -2,11 +2,12 @@ import { IStep } from '@plumber/types'
 
 import { useContext } from 'react'
 
-import { BranchContext } from '@/components/FlowStepGroup/Content/IfThen/BranchContext'
-import { NESTED_IFTHEN_FEATURE_FLAG } from '@/config/flags'
-import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import {
+  isStepWithinForEachBlock,
+  isStepWithinIfThenBlock,
+  TOOLBOX_ACTIONS,
+} from '@/helpers/toolbox'
 
 /**
  * Helper function to check if Delay action should be selectable
@@ -38,46 +39,6 @@ function isDelaySelectable({
   return !isStepWithinForEach
 }
 
-/**
- * Helper function to check if If-then action should be selectable; supports edge
- * case in ChooseEvent component.
- *
- * If-then should only be selectable if:
- * - We're the last step.
- * - We are not inside a branch (unless we're whitelisted for nested
- *   branches via LD).
- *
- * Using many consts as purpose of the conditions may not be immediately
- * apparent.
- */
-function isIfThenSelectable({
-  depth,
-  hasIfThen,
-  isLastStep,
-  getFlagValue,
-}: {
-  depth: number
-  hasIfThen: boolean
-  isLastStep: boolean
-  getFlagValue: (
-    flagKey: string,
-    defaultValue?: boolean | string,
-  ) => boolean | string
-}) {
-  if (!isLastStep || hasIfThen) {
-    return false
-  }
-
-  const canUseNestedBranch = getFlagValue(NESTED_IFTHEN_FEATURE_FLAG, false)
-  if (canUseNestedBranch) {
-    return true
-  }
-
-  const isNestedBranch = depth > 0
-
-  return !isNestedBranch
-}
-
 export const useIsAppSelectable = ({
   isLastStep,
   step,
@@ -87,9 +48,7 @@ export const useIsAppSelectable = ({
   step?: IStep
   prevStepId?: string
 }): Record<string, boolean> => {
-  const { depth } = useContext(BranchContext)
-  const { groupedSteps } = useContext(StepsToDisplayContext)
-  const { getFlagValue } = useContext(LaunchDarklyContext)
+  const { groupedSteps, regionList } = useContext(StepsToDisplayContext)
 
   const hasIfThen = groupedSteps.some((group) =>
     group.some((step) => step.key === TOOLBOX_ACTIONS.IfThen),
@@ -99,13 +58,27 @@ export const useIsAppSelectable = ({
     group.some((step) => step.key === TOOLBOX_ACTIONS.ForEach),
   )
 
+  // The step the modal is anchored at: the empty step being configured, or the
+  // step we're adding after.
+  const anchorStepId = step?.id ?? prevStepId
+  const isWithinIfThenBlock = isStepWithinIfThenBlock(regionList, anchorStepId)
+  const isWithinForEach = isStepWithinForEachBlock(regionList, anchorStepId)
+
   return {
-    [TOOLBOX_ACTIONS.IfThen]: isIfThenSelectable({
-      depth,
-      hasIfThen,
-      isLastStep,
-      getFlagValue,
-    }),
+    /**
+     * If-then should only be selectable if:
+     * - We are not inside an if-then branch — no nesting if-thens.
+     * - Inside a for-each body, we're the last step (the for-each content
+     *   doesn't render regions yet, so a mid-body block would wrongly absorb
+     *   the body steps after it; we will make for-each render regions in a
+     *   later PR).
+     * It is otherwise addable anywhere, even mid-flow: an inserted block exits
+     * to the step that followed the anchor step (see useIfThenInitializer),
+     * and an if-then elsewhere in the flow no longer disables it (blocks can
+     * follow one another, chained via each branch's step to jump to).
+     */
+    [TOOLBOX_ACTIONS.IfThen]:
+      !isWithinIfThenBlock && (!isWithinForEach || isLastStep),
     /**
      * For-each should only be selectable if:
      * - We're the last step.

--- a/packages/frontend/src/helpers/__tests__/region-list.test.ts
+++ b/packages/frontend/src/helpers/__tests__/region-list.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildRegionList,
+  isStepWithinForEachBlock,
+  isStepWithinIfThenBlock,
   type StepRegion,
   TOOLBOX_ACTIONS,
   TOOLBOX_APP_KEY,
@@ -28,7 +30,7 @@ function step(overrides: Partial<IStep> = {}): IStep {
   } as IStep
 }
 
-function ifThen(id: string, stepIdToJumpTo?: string): IStep {
+function ifThen(id: string, stepIdToJumpTo?: string | null): IStep {
   return step({
     id,
     appKey: TOOLBOX_APP_KEY,
@@ -183,5 +185,95 @@ describe('buildRegionList', () => {
       expect(regions[0]).toEqual({ type: 'SingleSteps', steps: [before] })
       expect(regions[1]).toMatchObject({ branches: [[fe, body]] })
     })
+  })
+})
+
+describe('isStepWithinIfThenBlock', () => {
+  // before | b1 (-> b2), b1a | b2 (-> after), b2a | after
+  const before = step({ id: 'before' })
+  const b1 = ifThen('b1', 'b2')
+  const b1a = step({ id: 'b1a' })
+  const b2 = ifThen('b2', 'after')
+  const b2a = step({ id: 'b2a' })
+  const after = step({ id: 'after' })
+  const regions = buildRegionList(
+    [before, b1, b1a, b2, b2a, after],
+    GROUPING_ACTIONS,
+  )
+
+  it('returns true for a branch if-then and for a step inside a branch', () => {
+    expect(isStepWithinIfThenBlock(regions, 'b1')).toBe(true)
+    expect(isStepWithinIfThenBlock(regions, 'b1a')).toBe(true)
+    expect(isStepWithinIfThenBlock(regions, 'b2a')).toBe(true)
+  })
+
+  it('returns false for single steps before and after the block', () => {
+    expect(isStepWithinIfThenBlock(regions, 'before')).toBe(false)
+    expect(isStepWithinIfThenBlock(regions, 'after')).toBe(false)
+  })
+
+  it('returns false for steps inside a for-each block', () => {
+    const fe = forEach('fe')
+    const body = step({ id: 'body' })
+    const forEachRegions = buildRegionList([fe, body], GROUPING_ACTIONS)
+
+    expect(isStepWithinIfThenBlock(forEachRegions, 'fe')).toBe(false)
+    expect(isStepWithinIfThenBlock(forEachRegions, 'body')).toBe(false)
+  })
+
+  it('returns true for if-then branches nested inside a for-each block', () => {
+    // fe, body | nested if-then branches: n1, n1a | n2, n2a
+    const fe = forEach('fe')
+    const body = step({ id: 'body' })
+    const n1 = ifThen('n1', 'n2')
+    const n1a = step({ id: 'n1a' })
+    const n2 = ifThen('n2', null)
+    const n2a = step({ id: 'n2a' })
+    const forEachRegions = buildRegionList(
+      [fe, body, n1, n1a, n2, n2a],
+      GROUPING_ACTIONS,
+    )
+
+    // The for-each's own body stays selectable...
+    expect(isStepWithinIfThenBlock(forEachRegions, 'fe')).toBe(false)
+    expect(isStepWithinIfThenBlock(forEachRegions, 'body')).toBe(false)
+    // ...but the nested if-then branches are not.
+    expect(isStepWithinIfThenBlock(forEachRegions, 'n1')).toBe(true)
+    expect(isStepWithinIfThenBlock(forEachRegions, 'n1a')).toBe(true)
+    expect(isStepWithinIfThenBlock(forEachRegions, 'n2a')).toBe(true)
+  })
+
+  it('returns false when no step id is given', () => {
+    expect(isStepWithinIfThenBlock(regions, undefined)).toBe(false)
+  })
+})
+
+describe('isStepWithinForEachBlock', () => {
+  // before | fe, body (with nested if-then branch n1)
+  const before = step({ id: 'before' })
+  const fe = forEach('fe')
+  const body = step({ id: 'body' })
+  const n1 = ifThen('n1')
+  const n1a = step({ id: 'n1a' })
+  const regions = buildRegionList([before, fe, body, n1, n1a], GROUPING_ACTIONS)
+
+  it('returns true for any step inside the for-each, including nested if-then branches', () => {
+    expect(isStepWithinForEachBlock(regions, 'fe')).toBe(true)
+    expect(isStepWithinForEachBlock(regions, 'body')).toBe(true)
+    expect(isStepWithinForEachBlock(regions, 'n1')).toBe(true)
+    expect(isStepWithinForEachBlock(regions, 'n1a')).toBe(true)
+  })
+
+  it('returns false for steps outside the for-each and for if-then blocks', () => {
+    expect(isStepWithinForEachBlock(regions, 'before')).toBe(false)
+
+    const b1 = ifThen('b1', 'after')
+    const after = step({ id: 'after' })
+    const ifThenRegions = buildRegionList([b1, after], GROUPING_ACTIONS)
+    expect(isStepWithinForEachBlock(ifThenRegions, 'b1')).toBe(false)
+  })
+
+  it('returns false when no step id is given', () => {
+    expect(isStepWithinForEachBlock(regions, undefined)).toBe(false)
   })
 })

--- a/packages/frontend/src/helpers/toolbox/region-list.ts
+++ b/packages/frontend/src/helpers/toolbox/region-list.ts
@@ -138,3 +138,51 @@ export function buildRegionList(
 
   return regions
 }
+
+/**
+ * Whether the given step sits inside an if-then branch — it's the branch's
+ * if-then or one of the branch's steps. Used to stop if-thens from nesting:
+ * the add-step modal must not offer if-then when it is anchored at a step
+ * inside a branch. Checked per branch (not per block) so that if-then branches
+ * nested inside a for-each block also count, while the for-each's own body
+ * steps don't (if-then remains selectable there).
+ */
+export function isStepWithinIfThenBlock(
+  regions: StepRegion[],
+  stepId?: string,
+): boolean {
+  if (!stepId) {
+    return false
+  }
+  return regions.some(
+    (region) =>
+      region.type === 'Block' &&
+      region.branches.some(
+        (branch) =>
+          isIfThenStep(branch[0]) && branch.some((step) => step.id === stepId),
+      ),
+  )
+}
+
+/**
+ * Whether the given step sits inside a for-each block (including inside an
+ * if-then nested within it). The for-each content doesn't render regions, so
+ * a mid-body if-then would wrongly absorb the body steps after it — if-then
+ * stays last-step-only inside a for-each.
+ */
+export function isStepWithinForEachBlock(
+  regions: StepRegion[],
+  stepId?: string,
+): boolean {
+  if (!stepId) {
+    return false
+  }
+  return regions.some(
+    (region) =>
+      region.type === 'Block' &&
+      isForEachStep(region.branches[0]?.[0]) &&
+      region.branches.some((branch) =>
+        branch.some((step) => step.id === stepId),
+      ),
+  )
+}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates our frontend to allow adding If-Then _after_ an If-Then block, because this is now possible.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.