### PR TITLE
[IF-THEN-THEN-10] PLU-743: (frontend) support adding step after if-then _in for-each_

### DIFF
--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -3,11 +3,7 @@ import { IStep } from '@plumber/types'
 import { useContext } from 'react'
 
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
-import {
-  isStepWithinForEachBlock,
-  isStepWithinIfThenBlock,
-  TOOLBOX_ACTIONS,
-} from '@/helpers/toolbox'
+import { isStepWithinIfThenBlock, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 
 /**
  * Helper function to check if Delay action should be selectable
@@ -62,23 +58,17 @@ export const useIsAppSelectable = ({
   // step we're adding after.
   const anchorStepId = step?.id ?? prevStepId
   const isWithinIfThenBlock = isStepWithinIfThenBlock(regionList, anchorStepId)
-  const isWithinForEach = isStepWithinForEachBlock(regionList, anchorStepId)
 
   return {
     /**
-     * If-then should only be selectable if:
-     * - We are not inside an if-then branch — no nesting if-thens.
-     * - Inside a for-each body, we're the last step (the for-each content
-     *   doesn't render regions yet, so a mid-body block would wrongly absorb
-     *   the body steps after it; we will make for-each render regions in a
-     *   later PR).
-     * It is otherwise addable anywhere, even mid-flow: an inserted block exits
-     * to the step that followed the anchor step (see useIfThenInitializer),
-     * and an if-then elsewhere in the flow no longer disables it (blocks can
-     * follow one another, chained via each branch's step to jump to).
+     * If-then should only be selectable if we are not inside an if-then
+     * branch — no nesting if-thens. It is otherwise addable anywhere, even
+     * mid-flow or inside a for-each body: an inserted block exits to the step
+     * that followed the anchor step (see useIfThenInitializer), and an if-then
+     * elsewhere in the flow no longer disables it (blocks can follow one
+     * another, chained via each branch's step to jump to).
      */
-    [TOOLBOX_ACTIONS.IfThen]:
-      !isWithinIfThenBlock && (!isWithinForEach || isLastStep),
+    [TOOLBOX_ACTIONS.IfThen]: !isWithinIfThenBlock,
     /**
      * For-each should only be selectable if:
      * - We're the last step.

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -1,12 +1,23 @@
 import { IStep } from '@plumber/types'
 
-import { useContext, useMemo } from 'react'
+import { Fragment, useContext, useMemo } from 'react'
+import { useMutation } from '@apollo/client'
 import { Flex } from '@chakra-ui/react'
 
+import { AddStepButton } from '@/components/Editor/components/AddStepButton'
 import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
+import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
-import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
+import { GET_FLOW } from '@/graphql/queries/get-flow'
+import {
+  buildRegionList,
+  getEarlierBranchesStepIdToJumpTo,
+  isIfThenStep,
+  type StepRegion,
+} from '@/helpers/toolbox'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
@@ -16,39 +27,50 @@ interface ForEachProps {
   stepsBeforeGroup: IStep[]
 }
 
+// All steps of the regions before `regionIndex`, in flow order. Used to give a
+// nested if-then block its "steps before group".
+function stepsBeforeRegion(
+  regions: StepRegion[],
+  regionIndex: number,
+): IStep[] {
+  return regions
+    .slice(0, regionIndex)
+    .flatMap((region) =>
+      region.type === 'SingleSteps' ? region.steps : region.branches.flat(),
+    )
+}
+
 export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
-  const { flow } = useContext(EditorContext)
+  const { flow, readOnly } = useContext(EditorContext)
+  const { groupingActions } = useContext(StepsToDisplayContext)
   const { handleReorderUpdate } = useReorderSteps(flow.id)
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
+    refetchQueries: [GET_FLOW],
+  })
 
-  const forEachSteps = groupedSteps[0]
-  const ifThenSteps = useMemo(() => {
-    if (groupedSteps.length === 1) {
-      return []
-    }
-    return groupedSteps.slice(1)
-  }, [groupedSteps])
-
-  // NOTE: groupedSteps includes for-each and if-then actions
-  // so groupedSteps === 1 means that there is only the for-each action
-  const nonForEachActionSteps = forEachSteps.filter(
-    (step) => step.type === 'action' && step.key !== TOOLBOX_ACTIONS.ForEach,
+  // The block's steps in flow order: the for-each step itself, then its body.
+  // The body is modelled as a region list — exactly like the top-level flow —
+  // so an if-then inside the loop renders as a block that steps can follow.
+  const allBlockSteps = useMemo(() => groupedSteps.flat(), [groupedSteps])
+  const conditionStep = allBlockSteps[0]
+  const bodyRegions = useMemo(
+    () =>
+      groupingActions
+        ? buildRegionList(allBlockSteps.slice(1), groupingActions)
+        : [],
+    [allBlockSteps, groupingActions],
   )
-  const hasNoActionSteps =
-    nonForEachActionSteps.length === 0 && groupedSteps.length === 1
 
-  const { conditionStep, actionSteps } = useMemo(() => {
-    const conditionStep = forEachSteps[0]
-    const actionSteps = forEachSteps.slice(1)
+  const hasNoActionSteps = allBlockSteps.length === 1
 
-    return { conditionStep, actionSteps }
-  }, [forEachSteps])
-
-  const handleReorderSteps = async (items: any[]) => {
-    const forEachPosition = conditionStep.position
+  const handleReorderSteps = (regionSteps: IStep[]) => async (items: any[]) => {
+    // A region's steps occupy a contiguous run of positions; a reorder
+    // permutes the steps within that run.
+    const basePosition = regionSteps[0].position
     const stepPositions = items.map((item, index) => ({
       id: item.id,
-      position: forEachPosition + index + 1, // index is 0-based
+      position: basePosition + index,
       type: item.step.type,
     }))
 
@@ -63,6 +85,9 @@ export default function ForEach(props: ForEachProps) {
     }
   }
 
+  const firstBodyRegionSteps =
+    bodyRegions[0]?.type === 'SingleSteps' ? bodyRegions[0].steps : []
+
   return (
     <Flex flexDir="column" alignItems="center" borderRadius="lg" w="100%">
       <Flex flexDir="column" w="100%" px={4} py={3}>
@@ -72,41 +97,101 @@ export default function ForEach(props: ForEachProps) {
           isLastStep={hasNoActionSteps}
           allowReorder={false}
           showEmptyAction={hasNoActionSteps}
-          canChildStepsReorder={actionSteps.length > 1}
+          canChildStepsReorder={firstBodyRegionSteps.length > 1}
         />
-        <SortableList
-          items={actionSteps.map((step, index) => ({
-            id: step.id,
-            step,
-            index,
-          }))}
-          onChange={handleReorderSteps}
-          renderItem={(item, isOverlay) => {
-            const { step, index } = item
-            const isLastStep =
-              index === actionSteps.length - 1 && ifThenSteps.length === 0
-            return (
-              <SortableList.Item id={item.id}>
-                <Flex w="100%" flexDir="column">
-                  <GroupStepWithAddButton
-                    step={step}
-                    canAddStep={true}
-                    isLastStep={isLastStep}
-                    isOverlay={isOverlay}
-                    allowReorder={actionSteps.length > 1}
-                  />
-                </Flex>
-              </SortableList.Item>
-            )
-          }}
-        />
+        {bodyRegions.map((region, regionIndex) => {
+          const isLastRegion = regionIndex === bodyRegions.length - 1
 
-        {ifThenSteps.length > 0 && (
-          <FlowStepGroup
-            stepsBeforeGroup={forEachSteps}
-            groupedSteps={ifThenSteps}
-          />
-        )}
+          if (region.type === 'Block') {
+            const { branches } = region
+            const lastBranch = branches[branches.length - 1]
+            const lastBranchIfThen = lastBranch?.[0]
+            const blockLastStep = lastBranch?.[lastBranch.length - 1]
+            return (
+              <Fragment key={`block-${branches[0]?.[0]?.id ?? regionIndex}`}>
+                <FlowStepGroup
+                  stepsBeforeGroup={[
+                    conditionStep,
+                    ...stepsBeforeRegion(bodyRegions, regionIndex),
+                  ]}
+                  groupedSteps={branches}
+                />
+                {/* Add a step immediately after the nested block, mirroring
+                    the top-level after-block affordance: repoints the block's
+                    last branch at the new step so the block ends there instead
+                    of absorbing it. */}
+                {isIfThenStep(lastBranchIfThen) && blockLastStep && (
+                  <AddStepButton
+                    isLastStep={isLastRegion}
+                    step={blockLastStep}
+                    isHidden={readOnly}
+                    isDisabled={false}
+                    showEmptyAction={false}
+                    onAfterCreateStep={async (createdStep) => {
+                      // See StepsList for the reasoning: repoint the last branch
+                      // at the new step, and chain the earlier branches via
+                      // auxiliary changes so a legacy (marker-less) block is
+                      // upgraded to new-style rather than swallowing the new
+                      // step. No-ops for an already-chained block.
+                      const earlierBranchJumpTargets =
+                        getEarlierBranchesStepIdToJumpTo(branches)
+                      await updateStepPositions({
+                        variables: {
+                          input: {
+                            stepPositions: [
+                              {
+                                id: lastBranchIfThen.id,
+                                position: lastBranchIfThen.position,
+                                type: lastBranchIfThen.type as StepEnumType,
+                                stepIdToJumpTo: createdStep.id,
+                              },
+                            ],
+                            ...(earlierBranchJumpTargets.length > 0 && {
+                              auxiliaryChanges: earlierBranchJumpTargets.map(
+                                (jumpTarget) => ({ ifThen: jumpTarget }),
+                              ),
+                            }),
+                            flow: { updatedAt: createdStep.flow.updatedAt },
+                          },
+                        },
+                      })
+                    }}
+                  />
+                )}
+              </Fragment>
+            )
+          }
+
+          const regionSteps = region.steps
+          const lastStepId = regionSteps[regionSteps.length - 1]?.id
+          return (
+            <SortableList
+              key={`single-${regionIndex}`}
+              items={regionSteps.map((step, index) => ({
+                id: step.id,
+                step,
+                index,
+              }))}
+              onChange={handleReorderSteps(regionSteps)}
+              renderItem={(item, isOverlay) => {
+                const { step } = item
+                return (
+                  <SortableList.Item id={item.id}>
+                    <Flex w="100%" flexDir="column">
+                      <GroupStepWithAddButton
+                        step={step}
+                        canAddStep={true}
+                        isLastStep={isLastRegion && step.id === lastStepId}
+                        isOverlay={isOverlay}
+                        allowReorder={regionSteps.length > 1}
+                      />
+                    </Flex>
+                  </SortableList.Item>
+                )
+              }}
+            />
+          )
+        })}
       </Flex>
     </Flex>
   )

--- a/packages/frontend/src/helpers/__tests__/region-list.test.ts
+++ b/packages/frontend/src/helpers/__tests__/region-list.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildRegionList,
-  isStepWithinForEachBlock,
   isStepWithinIfThenBlock,
   type StepRegion,
   TOOLBOX_ACTIONS,
@@ -245,35 +244,5 @@ describe('isStepWithinIfThenBlock', () => {
 
   it('returns false when no step id is given', () => {
     expect(isStepWithinIfThenBlock(regions, undefined)).toBe(false)
-  })
-})
-
-describe('isStepWithinForEachBlock', () => {
-  // before | fe, body (with nested if-then branch n1)
-  const before = step({ id: 'before' })
-  const fe = forEach('fe')
-  const body = step({ id: 'body' })
-  const n1 = ifThen('n1')
-  const n1a = step({ id: 'n1a' })
-  const regions = buildRegionList([before, fe, body, n1, n1a], GROUPING_ACTIONS)
-
-  it('returns true for any step inside the for-each, including nested if-then branches', () => {
-    expect(isStepWithinForEachBlock(regions, 'fe')).toBe(true)
-    expect(isStepWithinForEachBlock(regions, 'body')).toBe(true)
-    expect(isStepWithinForEachBlock(regions, 'n1')).toBe(true)
-    expect(isStepWithinForEachBlock(regions, 'n1a')).toBe(true)
-  })
-
-  it('returns false for steps outside the for-each and for if-then blocks', () => {
-    expect(isStepWithinForEachBlock(regions, 'before')).toBe(false)
-
-    const b1 = ifThen('b1', 'after')
-    const after = step({ id: 'after' })
-    const ifThenRegions = buildRegionList([b1, after], GROUPING_ACTIONS)
-    expect(isStepWithinForEachBlock(ifThenRegions, 'b1')).toBe(false)
-  })
-
-  it('returns false when no step id is given', () => {
-    expect(isStepWithinForEachBlock(regions, undefined)).toBe(false)
   })
 })

--- a/packages/frontend/src/helpers/toolbox/region-list.ts
+++ b/packages/frontend/src/helpers/toolbox/region-list.ts
@@ -163,26 +163,3 @@ export function isStepWithinIfThenBlock(
       ),
   )
 }
-
-/**
- * Whether the given step sits inside a for-each block (including inside an
- * if-then nested within it). The for-each content doesn't render regions, so
- * a mid-body if-then would wrongly absorb the body steps after it — if-then
- * stays last-step-only inside a for-each.
- */
-export function isStepWithinForEachBlock(
-  regions: StepRegion[],
-  stepId?: string,
-): boolean {
-  if (!stepId) {
-    return false
-  }
-  return regions.some(
-    (region) =>
-      region.type === 'Block' &&
-      isForEachStep(region.branches[0]?.[0]) &&
-      region.branches.some((branch) =>
-        branch.some((step) => step.id === stepId),
-      ),
-  )
-}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

If you recall in #1820 , I implemented region list concept for top level pipe. This implements it for For-Each so that users can now add steps after If-Then in a For-Each block.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.