### PR TITLE
[IF-THEN-THEN-11] PLU-743: (frontend) support reordering steps after if-then

### DIFF
--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -15,6 +15,7 @@ import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import {
   getEarlierBranchesStepIdToJumpTo,
+  getUpdatedIfThenConfigOnRegionReorder,
   isIfThenStep,
 } from '@/helpers/toolbox'
 import useReorderSteps from '@/hooks/useReorderSteps'
@@ -46,7 +47,7 @@ export function StepsList({ isNested }: StepsListProps) {
   const handleReorderSteps = useCallback(
     async (reorderedSteps: IStep[]) => {
       const allSteps = flow.steps
-      const allReorderedSteps = calculateReorderedSteps({
+      const newStepConfigs = calculateReorderedSteps({
         reorderedSteps,
         allSteps,
         mrfSteps,
@@ -54,13 +55,28 @@ export function StepsList({ isNested }: StepsListProps) {
         approvalBranches,
       })
 
+      // If an earlier if-then is pointing to this region's first step, update
+      // that if-then to the new first step after the reorder. It sits outside
+      // the reordered run, so it travels as an auxiliary change rather than a
+      // reposition.
+      const updatedIfThenConfig = getUpdatedIfThenConfigOnRegionReorder(
+        allSteps,
+        reorderedSteps,
+      )
+      const ifThenRepoint = updatedIfThenConfig
+        ? {
+            stepId: updatedIfThenConfig.branchStep.id,
+            stepIdToJumpTo: updatedIfThenConfig.stepIdToJumpTo,
+          }
+        : undefined
+
       try {
-        await handleReorderUpdate(allReorderedSteps)
+        await handleReorderUpdate(newStepConfigs, ifThenRepoint)
       } catch (error) {
         console.error(
           'Error updating step positions: ',
           error,
-          JSON.stringify(allReorderedSteps),
+          JSON.stringify(newStepConfigs),
         )
       }
     },

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -9,12 +9,16 @@ import { SortableList } from '@/components/SortableList'
 import { EditorContext } from '@/contexts/Editor'
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { FlowStepGroup } from '@/exports/components'
-import { StepEnumType } from '@/graphql/__generated__/graphql'
+import {
+  StepEnumType,
+  StepPositionInput,
+} from '@/graphql/__generated__/graphql'
 import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import {
   buildRegionList,
   getEarlierBranchesStepIdToJumpTo,
+  getUpdatedIfThenConfigOnRegionReorder,
   isIfThenStep,
   type StepRegion,
 } from '@/helpers/toolbox'
@@ -68,14 +72,29 @@ export default function ForEach(props: ForEachProps) {
     // A region's steps occupy a contiguous run of positions; a reorder
     // permutes the steps within that run.
     const basePosition = regionSteps[0].position
-    const stepPositions = items.map((item, index) => ({
+    const stepPositions: StepPositionInput[] = items.map((item, index) => ({
       id: item.id,
       position: basePosition + index,
       type: item.step.type,
     }))
 
+    // If the reorder changed the region's first step and a nested block's last
+    // branch jumps to it (this region is that block's exit), repoint the
+    // branch at the new first step. It sits outside the reordered run, so it
+    // travels as an auxiliary change rather than a reposition.
+    const updatedIfThenConfig = getUpdatedIfThenConfigOnRegionReorder(
+      flow.steps,
+      items.map((item) => item.step),
+    )
+    const ifThenRepoint = updatedIfThenConfig
+      ? {
+          stepId: updatedIfThenConfig.branchStep.id,
+          stepIdToJumpTo: updatedIfThenConfig.stepIdToJumpTo,
+        }
+      : undefined
+
     try {
-      handleReorderUpdate(stepPositions)
+      handleReorderUpdate(stepPositions, ifThenRepoint)
     } catch (error) {
       console.error(
         'Error updating step positions: ',

--- a/packages/frontend/src/helpers/__tests__/if-then.test.ts
+++ b/packages/frontend/src/helpers/__tests__/if-then.test.ts
@@ -6,6 +6,7 @@ import {
   buildRegionList,
   computeJumpTargets,
   getEarlierBranchesStepIdToJumpTo,
+  getUpdatedIfThenConfigOnRegionReorder,
   getUpdatedStepToJumpToOnStepDelete,
   type StepRegion,
   TOOLBOX_ACTIONS,
@@ -264,5 +265,47 @@ describe('getEarlierBranchesStepIdToJumpTo', () => {
       ],
     })
     expect(after[2]).toEqual({ type: 'SingleSteps', steps: [created] })
+  })
+})
+
+describe('getUpdatedIfThenConfigOnRegionReorder', () => {
+  it("repoints the last branch when the region's first step changes", () => {
+    const b1 = ifThen('b1', 'b2')
+    const b1a = step()
+    const b2 = ifThen('b2', 'after1')
+    const b2a = step()
+    const after1 = step({ id: 'after1' })
+    const after2 = step({ id: 'after2' })
+    const steps = [b1, b1a, b2, b2a, after1, after2]
+
+    // Drag after2 in front of after1.
+    expect(
+      getUpdatedIfThenConfigOnRegionReorder(steps, [after2, after1]),
+    ).toEqual({ branchStep: b2, stepIdToJumpTo: 'after2' })
+  })
+
+  it("returns null when the region's first step is unchanged", () => {
+    const b1 = ifThen('b1', 'after1')
+    const b1a = step()
+    const after1 = step({ id: 'after1' })
+    const after2 = step({ id: 'after2' })
+    const after3 = step({ id: 'after3' })
+    const steps = [b1, b1a, after1, after2, after3]
+
+    // Only the region's tail changed; the block still exits at after1.
+    expect(
+      getUpdatedIfThenConfigOnRegionReorder(steps, [after1, after3, after2]),
+    ).toBeNull()
+  })
+
+  it('returns null when no branch jumps to the old first step', () => {
+    // The region before the first block: nothing jumps to its steps.
+    const s1 = step({ id: 's1' })
+    const s2 = step({ id: 's2' })
+    const b1 = ifThen('b1', null)
+    const b1a = step()
+    const steps = [s1, s2, b1, b1a]
+
+    expect(getUpdatedIfThenConfigOnRegionReorder(steps, [s2, s1])).toBeNull()
   })
 })

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -413,3 +413,40 @@ export function getUpdatedStepToJumpToOnStepDelete(
     stepIdToJumpTo: nextStep?.id ?? null,
   }
 }
+
+/**
+ * Computes the repoint needed when a SingleSteps region is reordered: if the
+ * reorder changes the region's first step and a block's last branch jumps to
+ * the old first step (the region is that block's exit), the branch must jump
+ * to the new first step instead. Returns null when the first step is
+ * unchanged, or when no branch jumps to it (a region with no block before it,
+ * or a legacy pipe).
+ */
+export function getUpdatedIfThenConfigOnRegionReorder(
+  steps: IStep[],
+  // The region's steps in their new order (positions not yet renumbered).
+  reorderedRegionSteps: IStep[],
+): { branchStep: IStep; stepIdToJumpTo: string } | null {
+  if (reorderedRegionSteps.length < 2) {
+    return null
+  }
+
+  // Positions are pre-reorder values, so the old first step is the one with
+  // the lowest position.
+  const oldFirst = reorderedRegionSteps.reduce((lowest, step) =>
+    step.position < lowest.position ? step : lowest,
+  )
+  const newFirst = reorderedRegionSteps[0]
+  if (oldFirst.id === newFirst.id) {
+    return null
+  }
+
+  const branchStep = steps.find(
+    (s) => isIfThenStep(s) && s.parameters?.stepIdToJumpTo === oldFirst.id,
+  )
+  if (!branchStep) {
+    return null
+  }
+
+  return { branchStep, stepIdToJumpTo: newFirst.id }
+}

--- a/packages/frontend/src/hooks/useReorderSteps.ts
+++ b/packages/frontend/src/hooks/useReorderSteps.ts
@@ -32,8 +32,14 @@ const useReorderSteps = (flowId: string) => {
       mrfApprovalSteps: IStep[]
       approvalBranches: { [stepId: string]: IStepApprovalBranch }
     }): StepPositionInput[] => {
-      // we start from 2 because the first step is the trigger step and not part of the sortable list
-      let nextPosition = 2
+      // A region's steps occupy a contiguous run of positions; a reorder
+      // permutes the steps within that run, so numbering restarts at the
+      // region's lowest position (e.g. 2 for the region right after the trigger
+      // step (which is not part of the sortable list, another number for the
+      // region right after an if-then block, etc).
+      let nextPosition = Math.min(
+        ...reorderedSteps.map((step) => step.position),
+      )
       let currentApprovalBranch: {
         stepId: string
         branch: 'approve' | 'reject'
@@ -123,11 +129,24 @@ const useReorderSteps = (flowId: string) => {
     [],
   )
 
-  const handleReorderUpdate = async (stepPositions: StepPositionInput[]) => {
+  const handleReorderUpdate = async (
+    stepPositions: StepPositionInput[],
+    // An if-then outside the reordered run whose step to jump to changes with it
+    // (a reorder that moved a block's exit step). Sent via auxiliaryChanges so
+    // stepPositions stays a pure contiguous run; folded into the optimistic
+    // cache update so the block boundary doesn't flicker during the refetch.
+    ifThenRepoint?: { stepId: string; stepIdToJumpTo: string },
+  ) => {
     try {
       await updateStepPositions({
         variables: {
-          input: { stepPositions, flow: { updatedAt: flow.updatedAt } },
+          input: {
+            stepPositions,
+            flow: { updatedAt: flow.updatedAt },
+            ...(ifThenRepoint && {
+              auxiliaryChanges: [{ ifThen: ifThenRepoint }],
+            }),
+          },
         },
         optimisticResponse: {
           updateStepPositions: {
@@ -156,16 +175,29 @@ const useReorderSteps = (flowId: string) => {
               ]),
             )
 
-            // Update steps with new positions
+            // Update steps with new positions, and apply the if-then repoint so
+            // the block boundary doesn't flicker while the refetch is in flight.
             const updatedSteps = flow.steps.map((step: IStep) => {
-              const updatedStep = updatedStepMap.get(step.id)
-              return updatedStep !== undefined
-                ? {
-                    ...step,
-                    position: updatedStep.position,
-                    config: { ...step.config, ...updatedStep.config },
-                  }
-                : step
+              const repositioned = updatedStepMap.get(step.id)
+              const isRepoint =
+                ifThenRepoint && step.id === ifThenRepoint.stepId
+              if (!repositioned && !isRepoint) {
+                return step
+              }
+              return {
+                ...step,
+                ...(repositioned && {
+                  position: repositioned.position,
+                  config: { ...step.config, ...repositioned.config },
+                }),
+                ...(ifThenRepoint &&
+                  step.id === ifThenRepoint.stepId && {
+                    parameters: {
+                      ...step.parameters,
+                      stepIdToJumpTo: ifThenRepoint.stepIdToJumpTo,
+                    },
+                  }),
+              }
             })
 
             // Sort steps by position to maintain proper order


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates the frontend to support re-ordering steps. There are some limitations:

1. Cannot re-order If-Then blocks
2. Cannot re-order steps _before_ If-Then to become a step _after_ If-Then

We can consider adding support for the above 2 if there is lots of user demand but let's see how things go first.

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.