### PR TITLE
[IF-THEN-THEN-12] PLU-743: (frontend) re-wire stepIdToJumpTo when duplicating branch

### DIFF
--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/useDuplicateBranch.tsx
@@ -5,7 +5,9 @@ import { useMutation } from '@apollo/client'
 import { useDisclosure } from '@chakra-ui/react'
 
 import { EditorContext } from '@/contexts/Editor'
+import { StepEnumType } from '@/graphql/__generated__/graphql'
 import { DUPLICATE_BRANCH } from '@/graphql/mutations/duplicate-branch'
+import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions'
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 
 export default function useDuplicateBranch(branchSteps: IStep[]) {
@@ -21,6 +23,9 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
 
   const [duplicateBranch] = useMutation(DUPLICATE_BRANCH, {
     fetchPolicy: 'no-cache',
+    refetchQueries: [GET_FLOW],
+  })
+  const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
   })
 
@@ -73,6 +78,31 @@ export default function useDuplicateBranch(branchSteps: IStep[]) {
       })
 
       const newSteps = duplicatedBranch.data.duplicateBranch.steps
+
+      // Splice the duplicate into the chain: the duplicated branch now points
+      // its step to jump to at the new branch, which already inherited the
+      // duplicated branch's old target via the copied parameters. Skip legacy
+      // branches (no stored step to jump to) — the execution scan handles those.
+      const duplicatedIfThen = branchSteps[0]
+      if (Object.hasOwn(duplicatedIfThen.parameters ?? {}, 'stepIdToJumpTo')) {
+        await updateStepPositions({
+          variables: {
+            input: {
+              stepPositions: [
+                {
+                  id: duplicatedIfThen.id,
+                  position: duplicatedIfThen.position,
+                  type: duplicatedIfThen.type as StepEnumType,
+                  stepIdToJumpTo: newSteps[0].id,
+                },
+              ],
+              flow: {
+                updatedAt: duplicatedBranch.data.duplicateBranch.flow.updatedAt,
+              },
+            },
+          },
+        })
+      }
 
       setCurrentStepId(newSteps[0].id)
       if (!isDrawerOpen) {


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates the frontend to support duplicating branches (i.e. remapping stepIdToJumpTo on the duplicated steps).

# Tests

- New unit tests
- E2E and further regression tests at the top 2 PRs in this stack.