### PR TITLE
[OR condition] add fix for adding empty or condition

### DIFF
--- a/packages/frontend/src/components/GroupedMultiRow/index.tsx
+++ b/packages/frontend/src/components/GroupedMultiRow/index.tsx
@@ -53,7 +53,7 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
     ...forwardedInputCreatorProps
   } = props
 
-  const { control } = useFormContext()
+  const { control, getValues, setValue } = useFormContext()
   const { readOnly: isEditorReadOnly } = useContext(EditorContext)
 
   const {
@@ -88,7 +88,26 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
           : newRowDefaultValue,
       ],
     })
-  }, [append, newRowDefaultValue, subFields])
+    // Mirrors MultiRow: a field array's `append`/`remove` update the form
+    // value but don't fire the form's `watch` subject, so subscribers like
+    // the step validator never recompute. Re-assert the already-updated
+    // value through `setValue`, which does notify.
+    setValue(name, getValues(name), {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [append, newRowDefaultValue, subFields, setValue, getValues, name])
+
+  const handleRemoveGroup = useCallback(
+    (index: number) => {
+      remove(index)
+      setValue(name, getValues(name), {
+        shouldDirty: true,
+        shouldValidate: true,
+      })
+    },
+    [remove, setValue, getValues, name],
+  )
 
   return (
     <Controller
@@ -131,7 +150,9 @@ function GroupedMultiRow(props: GroupedMultiRowProps): JSX.Element {
                     addRowButtonText={addRowButtonText ?? 'And'}
                     maxRows={maxRowsPerGroup}
                     onRequestRemoveLastRow={
-                      canRemoveGroup ? () => remove(index) : undefined
+                      canRemoveGroup
+                        ? () => handleRemoveGroup(index)
+                        : undefined
                     }
                     addButtonSuffix={
                       // `+ Or` lives next to the last group's `+ And`.

--- a/packages/frontend/src/components/MultiRow/index.tsx
+++ b/packages/frontend/src/components/MultiRow/index.tsx
@@ -28,7 +28,7 @@ export type MultiRowProps = {
   // Optional node rendered beside the "+ And" add-row button (e.g. a wrapper's
   // own controls). Renders even when the add-row button is hidden at maxRows.
   addButtonSuffix?: ReactNode
-  // Optional override for deleting the LAST remaining row. When provided, the
+  // Optional override for deleting the LAST remaining row. When provided and non-null, the
   // last row's delete control is shown (even when `required`) and clicking it
   // calls this instead of the internal remove — letting a wrapper (e.g.
   // GroupedMultiRow) remove the whole containing group instead of leaving it


### PR DESCRIPTION
**File:** `packages/frontend/src/components/GroupedMultiRow/index.tsx`

**Problem:** `GroupedMultiRow` owns the OR-group-level array (via its own `useFieldArray`), separate from `MultiRow`'s row-level array. PR 1814 fixed the "Check step stays disabled" bug for row-level `append`/`remove` (adding/deleting an AND row) by manually firing `watch` via `setValue(name, getValues(name), ...)`, since react-hook-form's `useFieldArray` doesn't trigger `watch` on its own. But that fix never got applied to the group level — so adding a new OR group, or deleting one (which happens whenever you delete the last row of a group), still didn't recompute step validity.

**Fix:**

- Pulled `getValues`/`setValue` from `useFormContext()`.
- `handleAddGroup`: after `append()`, calls `setValue(name, getValues(name), { shouldDirty: true, shouldValidate: true })`.
- New `handleRemoveGroup(index)`: wraps `remove(index)` with the same `setValue` call, and is now what `onRequestRemoveLastRow` invokes (previously called `remove(index)` directly).

Net effect: "Check step" now correctly re-enables/disables when a whole OR group is added or removed, not just when a row within a group is added or removed.

## Tests to run

**Primary repro (the bug this fixes):**

1. Fill in one valid condition, confirm **Check step** is enabled.
2. Click **\+ Or** to add a new OR group, leave it completely empty.
3. Confirm **Check step** becomes disabled (empty group makes the config invalid).
4. Delete that empty group (trash icon on its only row).
5. Confirm **Check step** re-enables immediately — this is the case that was broken before this fix.

**Regression checks:**

- Add/remove a plain row within a single group (AND, not OR) — should still enable/disable correctly (already covered by PR 1814, shouldn't regress).
- With 3+ OR groups, delete one from the middle — remaining groups' data should be unaffected, and Check step validity should reflect the correct remaining state.
- Do a full successful Check step, then add an OR group and delete it without saving — infobox should still show "Previous result" (PR 1816's fix), not an error.
- Confirm no console errors/warnings from `setValue` firing on an unmounted/removed group (e.g. rapid add+delete clicks).

No automated test suite covers this component today (no existing `.test.tsx` for `GroupedMultiRow` or `MultiRow`), so this needs to be manually verified in the running dev environment — I can't verify it myself since I don't have browser access in this session.