### PR TITLE
[IF-THEN-THEN-13] PLU-743: (frontend) gate If-Then-Then behind LD

### DIFF
--- a/packages/frontend/src/components/Editor/components/StepsList.tsx
+++ b/packages/frontend/src/components/Editor/components/StepsList.tsx
@@ -18,6 +18,7 @@ import {
   getUpdatedIfThenConfigOnRegionReorder,
   isIfThenStep,
 } from '@/helpers/toolbox'
+import { useIfThenThenEnabled } from '@/hooks/useIfThenThenEnabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import { EDITOR_RIGHT_DRAWER_WIDTH } from '../constants'
@@ -36,6 +37,7 @@ export function StepsList({ isNested }: StepsListProps) {
   const { flow, isDrawerOpen, isMobile, readOnly } = useContext(EditorContext)
   const { mrfSteps, mrfApprovalSteps, approvalBranches } =
     useContext(MrfContext)
+  const ifThenThenEnabled = useIfThenThenEnabled()
   const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
   })
@@ -181,48 +183,52 @@ export function StepsList({ isNested }: StepsListProps) {
                   step so the block ends there instead of absorbing it; the new
                   step becomes the first step of the following region (or a fresh
                   trailing region when the block is last). isLastStep reflects
-                  whether the block currently ends the flow. */}
-              {isIfThenBlock && lastBranchIfThen && blockLastStep && (
-                <AddStepButton
-                  isLastStep={isLastRegion}
-                  step={blockLastStep}
-                  isHidden={readOnly}
-                  isDisabled={false}
-                  showEmptyAction={false}
-                  onAfterCreateStep={async (createdStep) => {
-                    // Repoint the block's last branch at the new step (its
-                    // position is unchanged; the entry just carries the new step
-                    // to jump to and anchors the mutation). For a legacy block
-                    // the earlier branches carry no chain yet, so send their
-                    // step-to-jump-to updates as auxiliary changes (branch
-                    // if-thens aren't contiguous) — this upgrades the whole block
-                    // to new-style so buildRegionList reads the new step as the
-                    // block's exit. No-ops for an already-chained block.
-                    const earlierBranchJumpTargets =
-                      getEarlierBranchesStepIdToJumpTo(branches)
-                    await updateStepPositions({
-                      variables: {
-                        input: {
-                          stepPositions: [
-                            {
-                              id: lastBranchIfThen.id,
-                              position: lastBranchIfThen.position,
-                              type: lastBranchIfThen.type as StepEnumType,
-                              stepIdToJumpTo: createdStep.id,
-                            },
-                          ],
-                          ...(earlierBranchJumpTargets.length > 0 && {
-                            auxiliaryChanges: earlierBranchJumpTargets.map(
-                              (jumpTarget) => ({ ifThen: jumpTarget }),
-                            ),
-                          }),
-                          flow: { updatedAt: createdStep.flow.updatedAt },
+                  whether the block currently ends the flow. Gated behind the
+                  if-then-then flag — the only creation affordance here. */}
+              {ifThenThenEnabled &&
+                isIfThenBlock &&
+                lastBranchIfThen &&
+                blockLastStep && (
+                  <AddStepButton
+                    isLastStep={isLastRegion}
+                    step={blockLastStep}
+                    isHidden={readOnly}
+                    isDisabled={false}
+                    showEmptyAction={false}
+                    onAfterCreateStep={async (createdStep) => {
+                      // Repoint the block's last branch at the new step (its
+                      // position is unchanged; the entry just carries the new
+                      // step to jump to and anchors the mutation). For a legacy
+                      // block the earlier branches carry no chain yet, so send
+                      // their step-to-jump-to updates as auxiliary changes
+                      // (branch if-thens aren't contiguous) — this upgrades the
+                      // whole block to new-style so buildRegionList reads the new
+                      // step as the block's exit. No-ops for a chained block.
+                      const earlierBranchJumpTargets =
+                        getEarlierBranchesStepIdToJumpTo(branches)
+                      await updateStepPositions({
+                        variables: {
+                          input: {
+                            stepPositions: [
+                              {
+                                id: lastBranchIfThen.id,
+                                position: lastBranchIfThen.position,
+                                type: lastBranchIfThen.type as StepEnumType,
+                                stepIdToJumpTo: createdStep.id,
+                              },
+                            ],
+                            ...(earlierBranchJumpTargets.length > 0 && {
+                              auxiliaryChanges: earlierBranchJumpTargets.map(
+                                (jumpTarget) => ({ ifThen: jumpTarget }),
+                              ),
+                            }),
+                            flow: { updatedAt: createdStep.flow.updatedAt },
+                          },
                         },
-                      },
-                    })
-                  }}
-                />
-              )}
+                      })
+                    }}
+                  />
+                )}
             </Fragment>
           )
         }

--- a/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
+++ b/packages/frontend/src/components/FlowStepConfigurationModal/hooks/useIsAppSelectable.ts
@@ -4,6 +4,7 @@ import { useContext } from 'react'
 
 import { StepsToDisplayContext } from '@/contexts/StepsToDisplay'
 import { isStepWithinIfThenBlock, TOOLBOX_ACTIONS } from '@/helpers/toolbox'
+import { useIfThenThenEnabled } from '@/hooks/useIfThenThenEnabled'
 
 /**
  * Helper function to check if Delay action should be selectable
@@ -45,6 +46,7 @@ export const useIsAppSelectable = ({
   prevStepId?: string
 }): Record<string, boolean> => {
   const { groupedSteps, regionList } = useContext(StepsToDisplayContext)
+  const ifThenThenEnabled = useIfThenThenEnabled()
 
   const hasIfThen = groupedSteps.some((group) =>
     group.some((step) => step.key === TOOLBOX_ACTIONS.IfThen),
@@ -61,14 +63,17 @@ export const useIsAppSelectable = ({
 
   return {
     /**
-     * If-then should only be selectable if we are not inside an if-then
-     * branch — no nesting if-thens. It is otherwise addable anywhere, even
-     * mid-flow or inside a for-each body: an inserted block exits to the step
-     * that followed the anchor step (see useIfThenInitializer), and an if-then
-     * elsewhere in the flow no longer disables it (blocks can follow one
-     * another, chained via each branch's step to jump to).
+     * When the if-then-then feature is ON, if-then is selectable anywhere
+     * except inside an if-then branch (no nesting) — addable mid-flow, after a
+     * block, or inside a for-each body; an existing if-then no longer disables
+     * a second one (blocks chain via each branch's step to jump to).
+     *
+     * When OFF, restore the pre-feature rule: if-then only at the last step,
+     * and only when the flow has no if-then yet.
      */
-    [TOOLBOX_ACTIONS.IfThen]: !isWithinIfThenBlock,
+    [TOOLBOX_ACTIONS.IfThen]: ifThenThenEnabled
+      ? !isWithinIfThenBlock
+      : isLastStep && !hasIfThen,
     /**
      * For-each should only be selectable if:
      * - We're the last step.

--- a/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/ForEach/index.tsx
@@ -22,6 +22,7 @@ import {
   isIfThenStep,
   type StepRegion,
 } from '@/helpers/toolbox'
+import { useIfThenThenEnabled } from '@/hooks/useIfThenThenEnabled'
 import useReorderSteps from '@/hooks/useReorderSteps'
 
 import GroupStepWithAddButton from '../../components/GroupStepWithAddButton'
@@ -48,6 +49,7 @@ export default function ForEach(props: ForEachProps) {
   const { groupedSteps } = props
   const { flow, readOnly } = useContext(EditorContext)
   const { groupingActions } = useContext(StepsToDisplayContext)
+  const ifThenThenEnabled = useIfThenThenEnabled()
   const { handleReorderUpdate } = useReorderSteps(flow.id)
   const [updateStepPositions] = useMutation(UPDATE_STEP_POSITIONS, {
     refetchQueries: [GET_FLOW],
@@ -138,45 +140,47 @@ export default function ForEach(props: ForEachProps) {
                 {/* Add a step immediately after the nested block, mirroring
                     the top-level after-block affordance: repoints the block's
                     last branch at the new step so the block ends there instead
-                    of absorbing it. */}
-                {isIfThenStep(lastBranchIfThen) && blockLastStep && (
-                  <AddStepButton
-                    isLastStep={isLastRegion}
-                    step={blockLastStep}
-                    isHidden={readOnly}
-                    isDisabled={false}
-                    showEmptyAction={false}
-                    onAfterCreateStep={async (createdStep) => {
-                      // See StepsList for the reasoning: repoint the last branch
-                      // at the new step, and chain the earlier branches via
-                      // auxiliary changes so a legacy (marker-less) block is
-                      // upgraded to new-style rather than swallowing the new
-                      // step. No-ops for an already-chained block.
-                      const earlierBranchJumpTargets =
-                        getEarlierBranchesStepIdToJumpTo(branches)
-                      await updateStepPositions({
-                        variables: {
-                          input: {
-                            stepPositions: [
-                              {
-                                id: lastBranchIfThen.id,
-                                position: lastBranchIfThen.position,
-                                type: lastBranchIfThen.type as StepEnumType,
-                                stepIdToJumpTo: createdStep.id,
-                              },
-                            ],
-                            ...(earlierBranchJumpTargets.length > 0 && {
-                              auxiliaryChanges: earlierBranchJumpTargets.map(
-                                (jumpTarget) => ({ ifThen: jumpTarget }),
-                              ),
-                            }),
-                            flow: { updatedAt: createdStep.flow.updatedAt },
+                    of absorbing it. Gated behind the if-then-then flag. */}
+                {ifThenThenEnabled &&
+                  isIfThenStep(lastBranchIfThen) &&
+                  blockLastStep && (
+                    <AddStepButton
+                      isLastStep={isLastRegion}
+                      step={blockLastStep}
+                      isHidden={readOnly}
+                      isDisabled={false}
+                      showEmptyAction={false}
+                      onAfterCreateStep={async (createdStep) => {
+                        // See StepsList for the reasoning: repoint the last
+                        // branch at the new step, and chain the earlier branches
+                        // via auxiliary changes so a legacy (marker-less) block
+                        // is upgraded to new-style rather than swallowing the new
+                        // step. No-ops for an already-chained block.
+                        const earlierBranchJumpTargets =
+                          getEarlierBranchesStepIdToJumpTo(branches)
+                        await updateStepPositions({
+                          variables: {
+                            input: {
+                              stepPositions: [
+                                {
+                                  id: lastBranchIfThen.id,
+                                  position: lastBranchIfThen.position,
+                                  type: lastBranchIfThen.type as StepEnumType,
+                                  stepIdToJumpTo: createdStep.id,
+                                },
+                              ],
+                              ...(earlierBranchJumpTargets.length > 0 && {
+                                auxiliaryChanges: earlierBranchJumpTargets.map(
+                                  (jumpTarget) => ({ ifThen: jumpTarget }),
+                                ),
+                              }),
+                              flow: { updatedAt: createdStep.flow.updatedAt },
+                            },
                           },
-                        },
-                      })
-                    }}
-                  />
-                )}
+                        })
+                      }}
+                    />
+                  )}
               </Fragment>
             )
           }

--- a/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
+++ b/packages/frontend/src/components/FlowStepGroup/Content/IfThen/index.tsx
@@ -14,6 +14,7 @@ import { UPDATE_STEP_POSITIONS } from '@/graphql/mutations/update-step-positions
 import { GET_FLOW } from '@/graphql/queries/get-flow'
 import { getMrfApprovalConfig } from '@/helpers/formsg'
 import { TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from '@/helpers/toolbox'
+import { useIfThenThenEnabled } from '@/hooks/useIfThenThenEnabled'
 
 import Branch from './Branch'
 import { BranchContext } from './BranchContext'
@@ -28,6 +29,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
   const { groupedSteps, stepsBeforeGroup } = props
 
   const { depth } = useContext(BranchContext)
+  const ifThenThenEnabled = useIfThenThenEnabled()
   const { approvalBranches } = useContext(MrfContext)
   const {
     flow,
@@ -69,6 +71,14 @@ export default function IfThen(props: IfThenProps): JSX.Element {
         | null
         | undefined) ?? null
 
+    // Maintain the step-to-jump-to chain only when the feature is on, or when
+    // the block already has markers (built while on). When off and the block is
+    // marker-less, add the branch the pre-feature way — no marker written, no
+    // repoint — so an off-built block stays legacy.
+    const maintainChain =
+      ifThenThenEnabled ||
+      Object.hasOwn(lastBranchIfThen.parameters ?? {}, 'stepIdToJumpTo')
+
     const approvalConfig = getMrfApprovalConfig({
       previousStep: lastStep,
       approvalBranches,
@@ -89,7 +99,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           parameters: {
             depth,
             branchName: `Branch ${numBranches + 1}`,
-            stepIdToJumpTo: lastBranchStepIdToJumpTo,
+            ...(maintainChain && { stepIdToJumpTo: lastBranchStepIdToJumpTo }),
           },
           config: {
             approval: approvalConfig,
@@ -99,22 +109,28 @@ export default function IfThen(props: IfThenProps): JSX.Element {
     })
     const newBranchStep = branchStep.data.createStep
 
-    // Repoint the old last branch's step to jump to at the new branch.
-    const updatedPositions = await updateStepPositions({
-      variables: {
-        input: {
-          stepPositions: [
-            {
-              id: lastBranchIfThen.id,
-              position: lastBranchIfThen.position,
-              type: lastBranchIfThen.type as StepEnumType,
-              stepIdToJumpTo: newBranchStep.id,
-            },
-          ],
-          flow: { updatedAt: newBranchStep.flow.updatedAt },
+    // Repoint the old last branch's step to jump to at the new branch (only
+    // when maintaining the chain).
+    let updatedAt = newBranchStep.flow.updatedAt
+    if (maintainChain) {
+      const updatedPositions = await updateStepPositions({
+        variables: {
+          input: {
+            stepPositions: [
+              {
+                id: lastBranchIfThen.id,
+                position: lastBranchIfThen.position,
+                type: lastBranchIfThen.type as StepEnumType,
+                stepIdToJumpTo: newBranchStep.id,
+              },
+            ],
+            flow: { updatedAt },
+          },
         },
-      },
-    })
+      })
+      updatedAt =
+        updatedPositions.data?.updateStepPositions?.updatedAt ?? updatedAt
+    }
 
     // Add an empty blank step; otherwise users are confused how to add more
     // steps to the branch.
@@ -126,7 +142,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
           },
           flow: {
             id: flowId,
-            updatedAt: updatedPositions.data?.updateStepPositions?.updatedAt,
+            updatedAt,
           },
           config: {
             approval: approvalConfig,
@@ -139,6 +155,7 @@ export default function IfThen(props: IfThenProps): JSX.Element {
     onDrawerOpen()
   }, [
     isAddingBranch,
+    ifThenThenEnabled,
     groupedSteps,
     createStep,
     updateStepPositions,

--- a/packages/frontend/src/config/flags.ts
+++ b/packages/frontend/src/config/flags.ts
@@ -14,6 +14,8 @@ export const SGID_FEATURE_FLAG = 'sgid-login'
 export const SSO_FEATURE_FLAG = 'ogp-sso-enabled'
 export const NESTED_IFTHEN_FEATURE_FLAG = 'feature_nested_if_then'
 export const AI_BUILDER_FEATURE_FLAG = 'ai-builder'
+// Gates adding steps after an if-then block and chaining multiple if-then blocks.
+export const IF_THEN_THEN_FEATURE_FLAG = 'feature_if_then_then'
 
 /**
  * App/events flags

--- a/packages/frontend/src/helpers/toolbox/if-then.ts
+++ b/packages/frontend/src/helpers/toolbox/if-then.ts
@@ -6,6 +6,7 @@ import { useMutation } from '@apollo/client'
 import { BranchContext } from '@/components/FlowStepGroup/Content/IfThen/BranchContext'
 import { CREATE_STEP } from '@/graphql/mutations/create-step'
 import { UPDATE_STEP } from '@/graphql/mutations/update-step'
+import { useIfThenThenEnabled } from '@/hooks/useIfThenThenEnabled'
 
 import { getGroupingActions, TOOLBOX_ACTIONS, TOOLBOX_APP_KEY } from './common'
 import type { StepRegion } from './region-list'
@@ -136,6 +137,7 @@ export function useIfThenInitializer(): [
 ] {
   const [isInitializing, setIsInitializing] = useState(false)
   const { depth } = useContext(BranchContext)
+  const ifThenThenEnabled = useIfThenThenEnabled()
 
   // We run these in parallel without updating the cache, and explicitly
   // re-fetch pipe _after_. This is because we don't want users on slow
@@ -163,6 +165,10 @@ export function useIfThenInitializer(): [
       // branch — jumps to the block's exit: the step that followed the anchor
       // step when the block was created, or the "stop" sentinel (null) when
       // the block is added at the end of the flow.
+      //
+      // When the if-then-then feature is off, the marker is omitted entirely
+      // (pre-feature behaviour) so a block built while off stays legacy and
+      // executes via the scan.
       const createSecondBranch = await createStep({
         variables: {
           input: {
@@ -178,7 +184,9 @@ export function useIfThenInitializer(): [
             parameters: {
               depth,
               branchName: 'Branch 2',
-              stepIdToJumpTo: lastBranchStepIdToJumpTo,
+              ...(ifThenThenEnabled && {
+                stepIdToJumpTo: lastBranchStepIdToJumpTo,
+              }),
             },
             config: commonConfig,
           },
@@ -199,7 +207,9 @@ export function useIfThenInitializer(): [
             parameters: {
               branchName: 'Branch 1',
               depth,
-              stepIdToJumpTo: createdSecondBranch.id,
+              ...(ifThenThenEnabled && {
+                stepIdToJumpTo: createdSecondBranch.id,
+              }),
             },
             connection: {
               id: null,
@@ -252,7 +262,7 @@ export function useIfThenInitializer(): [
 
       return currStep
     },
-    [createStep, depth, updateStep],
+    [createStep, depth, ifThenThenEnabled, updateStep],
   )
 
   return [initialize, isInitializing]

--- a/packages/frontend/src/hooks/useIfThenThenEnabled.ts
+++ b/packages/frontend/src/hooks/useIfThenThenEnabled.ts
@@ -1,0 +1,17 @@
+import { useContext } from 'react'
+
+import { IF_THEN_THEN_FEATURE_FLAG } from '@/config/flags'
+import { LaunchDarklyContext } from '@/contexts/LaunchDarkly'
+
+/**
+ * Whether the "if-then-then" feature (adding steps after an if-then block and
+ * chaining multiple if-then blocks) is enabled for the current user.
+ *
+ * Gates only the new creation affordances; the read path (region rendering) and
+ * chain-maintenance handlers stay on so existing feature-built flows still
+ * render and edit correctly when the flag is off.
+ */
+export function useIfThenThenEnabled(): boolean {
+  const { getFlagValue } = useContext(LaunchDarklyContext)
+  return getFlagValue(IF_THEN_THEN_FEATURE_FLAG, false) as boolean
+}


### PR DESCRIPTION
# Context

We want to support adding steps after If-Then, at both the top level pipe and within For-Each. To do this, we will update our If-Then approach to store a `stepIdToJumpTo` parameter; with this, we know an If-Then branch is the last branch if it points to a non-If-Then step

We will gate this behind a LD flag for initial rollout.

# This PR

Updates the frontend to gate the If-Then-Then behind a LD flag - `feature_if_then_then`. This is also the top PR of the stack, so full tests here.

Will update e2e as well.

# Tests

### With LD flag OFF

- Check that published legacy pipes' If-Then still work.
- Check that I cannot add If-Then in an If-Then
- Check that I cannot add For-Each in an If-Then.
- [Legacy pipe] Check that I can only add If-Then at the end of a pipe without For-Each
- [Legacy pipe] Check that I can only add If-Then at the end of For-Each, in a pipe with For-each
- [Legacy pipe] Check that I cannot add steps after If-then.
- [Legacy pipe] Check that I cannot add steps after If-then when the If-Then is in a For-each.
- [Legacy pipe] Check that when I create a new If-Then branch in a legacy pipe with existing If-Then, `stepIdToJumpTo` is not populated 
- [Legacy pipe] Check that when I create a new If-Then block in a pipe without existing If-then, `stepIdToJumpTo` is not populated.
- [Legacy pipe] Check that I can re-order branches within an If-Then block, and the new step order is respected when the pipe runs
- [Legacy pipe] Check that I can re-order steps outside the If-Then block, and the new step order is respected when the pipe runs

### With LD flag ON

- Check that all If-Thens (>=1 block) in published pipe work.
- Check that I cannot add If-Then in an If-Then.
- Check that I cannot add For-Each in an If-Then.
- Check that I can add steps after If-Then
- Check that I can add steps after an If-Then located in a For-Each 
- Check that I can add If-Then in the middle of a pipe.
- Check that I can add If-Then in the middle of a For-Each
- Check that when I create a new If-Then block in a pipe without any If-Then, `stepIdToJumpTo` is populated.
- Check that when I create a new If-Then block in a For-Each in a pipe without any If-Then, `stepIdToJumpTo` is populated.
- Check that I can re-order steps outside If-Then (both before and after), and the new step order is respected when the pipe runs
- Check that I can re-order steps outside If-Then (both before and after) within a For-Each, and the new step order is respected when the pipe runs
- [Legacy -> new] Check that I can add steps after an If-Then when the pipe has a legacy If-then (i.e. no `stepIdToJumpTo`), and that the added steps run outside of the If-Then conditional
- [Legacy -> new] Check that I can add steps after an If-Then in a For-Each when the pipe has a legacy If-then (i.e. no `stepIdToJumpTo`), and that the added steps run outside of the If-Then conditional