### PR TITLE
feat(gathersg): rate-limit actions by connection ID

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/queue.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/queue.test.ts
@@ -1,0 +1,55 @@
+// Avoid cyclic imports when importing gathersgApp
+import '@/apps'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import gathersgApp from '..'
+
+const mocks = vi.hoisted(() => ({
+  stepQueryResult: vi.fn(),
+}))
+
+vi.mock('@/models/step', () => ({
+  default: {
+    query: vi.fn(() => ({
+      findById: vi.fn(() => ({
+        throwIfNotFound: mocks.stepQueryResult,
+      })),
+    })),
+  },
+}))
+
+describe('Queue config', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('sets group ID to the connection ID', async () => {
+    mocks.stepQueryResult.mockResolvedValueOnce({
+      connectionId: 'mock-connection-id',
+    })
+    const groupConfig = await gathersgApp.queue.getGroupConfigForJob({
+      flowId: 'test-flow-id',
+      stepId: 'test-step-id',
+      executionId: 'test-execution-id',
+    })
+    expect(groupConfig).toEqual({
+      id: 'mock-connection-id',
+    })
+  })
+
+  it('rate limits each connection and spreads calls evenly', () => {
+    expect(gathersgApp.queue.groupLimits).toMatchObject({
+      type: 'rate-limit',
+      limit: {
+        max: 1,
+        // Duration intentionally left blank here to enable config.
+      },
+    })
+  })
+
+  it('runs on an action worker and does not delay the whole queue', () => {
+    expect(gathersgApp.queue.workerType).toEqual('action')
+    expect(gathersgApp.queue.isQueueDelayable).toEqual(false)
+  })
+})

--- a/packages/backend/src/apps/gathersg/index.ts
+++ b/packages/backend/src/apps/gathersg/index.ts
@@ -4,6 +4,7 @@ import addAuthHeader from './common/add-auth-header'
 import actions from './actions'
 import auth from './auth'
 import dynamicData from './dynamic-data'
+import queue from './queue'
 import triggers from './triggers'
 
 const app: IApp = {
@@ -20,6 +21,7 @@ const app: IApp = {
   actions,
   triggers,
   dynamicData,
+  queue,
   category: 'data',
 }
 

--- a/packages/backend/src/apps/gathersg/queue/index.ts
+++ b/packages/backend/src/apps/gathersg/queue/index.ts
@@ -1,0 +1,33 @@
+import type { IAppQueue } from '@plumber/types'
+
+import Step from '@/models/step'
+
+// Rate limit each connection to 80 actions-ish per 5 minutes, spread evenly
+const MAX_ACTIONS = 80
+const WINDOW_MS = 5 * 60 * 1000 // 5 min
+const ACTION_INTERVAL_MS = Math.ceil(WINDOW_MS / MAX_ACTIONS)
+
+const getGroupConfigForJob: IAppQueue['getGroupConfigForJob'] = async ({
+  stepId,
+}) => {
+  const step = await Step.query().findById(stepId).throwIfNotFound()
+
+  return {
+    id: step.connectionId,
+  }
+}
+
+const queueSettings = {
+  getGroupConfigForJob,
+  groupLimits: {
+    type: 'rate-limit',
+    limit: {
+      max: 1,
+      duration: ACTION_INTERVAL_MS,
+    },
+  },
+  isQueueDelayable: false,
+  workerType: 'action',
+} satisfies IAppQueue
+
+export default queueSettings


### PR DESCRIPTION
# Context

GatherSG has a rate limit per API key (100 calls per 5 min), let's respect that.

# Approach

We'll spread out 80 calls evenly over 5 min (3s between each action) because no one likes spikes (except end users). We leave 20 for some buffer as individual actions and dynamic data call also consume API calls (e.g. create case uses 2 calls)

This is not the most ideal UX; ideally we can burst (e.g. max 10 within 30s) but given that plumber is async, I'd rather err towards system load predictability for our downstream systems.

# Deploy notes

- We might burst rate limit until gathersg actions in the main queue drain, thats OK
- If we ever need to roll back, we'll need to drain the queue _or_ redeploy this code.