### PR TITLE
[AI-SETUP-3] PLU-811 feat(backend): create Pipe

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -69,4 +69,43 @@ describe('createMcpBridgeTools', () => {
       traceId: 'trace-123',
     })
   })
+
+  it('create_pipe forwards parameters when present on a step', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.create_pipe.execute(
+      {
+        name: 'If-Then Pipe',
+        steps: [
+          { app_key: 'formsg', trigger_key: 'newSubmission' },
+          {
+            app_key: 'toolbox',
+            action_key: 'ifThen',
+            parameters: { branchName: 'High Priority' },
+          },
+        ],
+        traceId: 'trace-456',
+      },
+      { toolCallId: 'create_pipe', messages: [] },
+    )
+    expect(vi.mocked(createFlowWithStepsService)).toHaveBeenCalledWith({
+      user: mockUser,
+      name: 'If-Then Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'toolbox',
+          key: 'ifThen',
+          type: 'action',
+          position: 2,
+          parameters: { branchName: 'High Priority' },
+        },
+      ],
+      traceId: 'trace-456',
+    })
+  })
 })

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -15,15 +15,16 @@ import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-step
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
 const mockUser = { id: 'u1' } as any
+const mockTraceId = 'trace-123'
 
 describe('createMcpBridgeTools', () => {
   it('contains list_apps and create_pipe tools', () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     expect(Object.keys(tools)).toEqual(['list_apps', 'create_pipe'])
   })
 
   it('each tool has description and execute function', () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     for (const t of Object.values(tools)) {
       expect(t).toHaveProperty('description')
       expect(typeof t.execute).toBe('function')
@@ -31,13 +32,13 @@ describe('createMcpBridgeTools', () => {
   })
 
   it('list_apps calls listAppsService', async () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.list_apps.execute({}, { toolCallId: 'list_apps', messages: [] })
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
   })
 
   it('create_pipe maps snake_case input to IStep-shaped steps', async () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.create_pipe.execute(
       {
         name: 'My Pipe',
@@ -45,7 +46,6 @@ describe('createMcpBridgeTools', () => {
           { app_key: 'formsg', trigger_key: 'newSubmission' },
           { app_key: 'slack', action_key: 'sendMessageToChannel' },
         ],
-        traceId: 'trace-123',
       },
       { toolCallId: 'create_pipe', messages: [] },
     )
@@ -66,12 +66,12 @@ describe('createMcpBridgeTools', () => {
           position: 2,
         },
       ],
-      traceId: 'trace-123',
+      traceId: mockTraceId,
     })
   })
 
   it('create_pipe forwards parameters when present on a step', async () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.create_pipe.execute(
       {
         name: 'If-Then Pipe',
@@ -83,7 +83,6 @@ describe('createMcpBridgeTools', () => {
             parameters: { branchName: 'High Priority' },
           },
         ],
-        traceId: 'trace-456',
       },
       { toolCallId: 'create_pipe', messages: [] },
     )

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
-vi.mock('@/services/mcp/create-pipe', () => ({
-  createPipeService: vi.fn().mockResolvedValue({ pipeId: 'p1', steps: [] }),
+vi.mock('@/services/mcp/create-flow-with-steps', () => ({
+  createFlowWithStepsService: vi
+    .fn()
+    .mockResolvedValue({ id: 'f1', name: 'My Pipe', steps: [] }),
 }))
 
 import { listAppsService } from '@/services/mcp/apps'
-import { createPipeService } from '@/services/mcp/create-pipe'
+import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
@@ -34,26 +36,37 @@ describe('createMcpBridgeTools', () => {
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
   })
 
-  it('create_pipe calls createPipeService with camelCase step keys', async () => {
+  it('create_pipe maps snake_case input to IStep-shaped steps', async () => {
     const tools = createMcpBridgeTools(mockUser)
-    await tools.create_pipe.execute({
+    await tools.create_pipe.execute(
+      {
+        name: 'My Pipe',
+        steps: [
+          { app_key: 'formsg', trigger_key: 'newSubmission' },
+          { app_key: 'slack', action_key: 'sendMessageToChannel' },
+        ],
+        traceId: 'trace-123',
+      },
+      { toolCallId: 'create_pipe', messages: [] },
+    )
+    expect(vi.mocked(createFlowWithStepsService)).toHaveBeenCalledWith({
+      user: mockUser,
       name: 'My Pipe',
       steps: [
-        { app_key: 'formsg', trigger_key: 'newSubmission' },
-        { app_key: 'slack', action_key: 'sendMessageToChannel' },
-      ],
-    })
-    expect(vi.mocked(createPipeService)).toHaveBeenCalledWith(
-      mockUser,
-      'My Pipe',
-      [
-        { appKey: 'formsg', triggerKey: 'newSubmission', actionKey: undefined },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'slack',
-          triggerKey: undefined,
-          actionKey: 'sendMessageToChannel',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 2,
         },
       ],
-    )
+      traceId: 'trace-123',
+    })
   })
 })

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -104,7 +104,7 @@ describe('createMcpBridgeTools', () => {
           parameters: { branchName: 'High Priority' },
         },
       ],
-      traceId: 'trace-456',
+      traceId: mockTraceId,
     })
   })
 })

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -3,28 +3,57 @@ import { describe, expect, it, vi } from 'vitest'
 vi.mock('@/services/mcp/apps', () => ({
   listAppsService: vi.fn().mockReturnValue([]),
 }))
+vi.mock('@/services/mcp/create-pipe', () => ({
+  createPipeService: vi.fn().mockResolvedValue({ pipeId: 'p1', steps: [] }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
+import { createPipeService } from '@/services/mcp/create-pipe'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
 const mockUser = { id: 'u1' } as any
 
 describe('createMcpBridgeTools', () => {
-  it('contains only list_apps tool', () => {
+  it('contains list_apps and create_pipe tools', () => {
     const tools = createMcpBridgeTools(mockUser)
-    expect(Object.keys(tools)).toEqual(['list_apps'])
+    expect(Object.keys(tools)).toEqual(['list_apps', 'create_pipe'])
   })
 
-  it('list_apps has description and execute function', () => {
+  it('each tool has description and execute function', () => {
     const tools = createMcpBridgeTools(mockUser)
-    expect(tools.list_apps).toHaveProperty('description')
-    expect(typeof tools.list_apps.execute).toBe('function')
+    for (const t of Object.values(tools)) {
+      expect(t).toHaveProperty('description')
+      expect(typeof t.execute).toBe('function')
+    }
   })
 
   it('list_apps calls listAppsService', async () => {
     const tools = createMcpBridgeTools(mockUser)
     await tools.list_apps.execute({}, { toolCallId: 'list_apps', messages: [] })
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
+  })
+
+  it('create_pipe calls createPipeService with camelCase step keys', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.create_pipe.execute({
+      name: 'My Pipe',
+      steps: [
+        { app_key: 'formsg', trigger_key: 'newSubmission' },
+        { app_key: 'slack', action_key: 'sendMessageToChannel' },
+      ],
+    })
+    expect(vi.mocked(createPipeService)).toHaveBeenCalledWith(
+      mockUser,
+      'My Pipe',
+      [
+        { appKey: 'formsg', triggerKey: 'newSubmission', actionKey: undefined },
+        {
+          appKey: 'slack',
+          triggerKey: undefined,
+          actionKey: 'sendMessageToChannel',
+        },
+      ],
+    )
   })
 })

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,10 +1,11 @@
-import type { IMcpApp } from '@plumber/types'
+import type { IMcpApp, IMcpCreatePipeResult } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
+import { createPipeService } from '@/services/mcp/create-pipe'
 
 export function createMcpBridgeTools(user: User) {
   return {
@@ -14,6 +15,45 @@ export function createMcpBridgeTools(user: User) {
       inputSchema: z.object({}),
       execute: async (): Promise<IMcpApp[]> => {
         return listAppsService(user)
+      },
+    }),
+
+    create_pipe: tool({
+      description:
+        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation.',
+      inputSchema: z.object({
+        name: z.string().describe('Human-readable name for the pipe'),
+        steps: z
+          .array(
+            z.object({
+              app_key: z.string().describe('App key (e.g. "formsg", "slack")'),
+              trigger_key: z
+                .string()
+                .optional()
+                .describe('Trigger key for step 0 (e.g. "newSubmission")'),
+              action_key: z
+                .string()
+                .optional()
+                .describe(
+                  'Action key for steps 1+ (e.g. "sendMessageToChannel")',
+                ),
+            }),
+          )
+          .min(1)
+          .describe(
+            'Ordered list of steps. First element must have trigger_key.',
+          ),
+      }),
+      execute: async ({ name, steps }): Promise<IMcpCreatePipeResult> => {
+        return createPipeService(
+          user,
+          name,
+          steps.map((s) => ({
+            appKey: s.app_key,
+            triggerKey: s.trigger_key,
+            actionKey: s.action_key,
+          })),
+        )
       },
     }),
   }

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -24,7 +24,7 @@ export function createMcpBridgeTools(user: User) {
 
     create_pipe: tool({
       description:
-        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation.',
+        'Create a new inactive pipe with an ordered list of steps. First step is the trigger, subsequent steps are actions. Always creates inactive — never activate without explicit user confirmation. For toolbox/ifThen steps, include parameters with branchName and conditions in the step.',
       inputSchema: z.object({
         name: z.string().describe('Human-readable name for the pipe'),
         steps: z
@@ -40,6 +40,12 @@ export function createMcpBridgeTools(user: User) {
                 .optional()
                 .describe(
                   'Action key for steps 1+ (e.g. "sendMessageToChannel")',
+                ),
+              parameters: z
+                .record(z.string(), z.unknown())
+                .optional()
+                .describe(
+                  'Initial parameter values for this step. For toolbox/ifThen steps pass branchName and conditions here.',
                 ),
             }),
           )
@@ -59,6 +65,7 @@ export function createMcpBridgeTools(user: User) {
               key: s.trigger_key ?? s.action_key ?? null,
               type: index === 0 ? 'trigger' : 'action',
               position: index + 1,
+              ...(s.parameters && { parameters: s.parameters }),
             }),
           ),
           traceId,

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,4 +1,4 @@
-import type { IMcpApp } from '@plumber/types'
+import type { IApp, IMcpApp } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
@@ -11,9 +11,11 @@ import {
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
 
-export function createMcpBridgeTools(user: User) {
+type ListAppsInput = Record<string, IApp[]>
+
+export function createMcpBridgeTools(user: User, traceId: string) {
   return {
-    list_apps: tool<Record<string, never>, IMcpApp[]>({
+    list_apps: tool<ListAppsInput, IMcpApp[]>({
       description:
         'List all available Plumber apps, triggers, and actions with their field schemas.',
       inputSchema: z.object({}),
@@ -53,9 +55,8 @@ export function createMcpBridgeTools(user: User) {
           .describe(
             'Ordered list of steps. First element must have trigger_key.',
           ),
-        traceId: z.string().describe('Langfuse trace ID for this tool call'),
       }),
-      execute: async ({ name, steps, traceId }): Promise<Flow> => {
+      execute: async ({ name, steps }): Promise<Flow> => {
         return createFlowWithStepsService({
           user,
           name,

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,11 +1,15 @@
-import type { IMcpApp, IMcpCreatePipeResult } from '@plumber/types'
+import type { IMcpApp } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
 
+import type Flow from '@/models/flow'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
-import { createPipeService } from '@/services/mcp/create-pipe'
+import {
+  createFlowWithStepsService,
+  type McpStepInput,
+} from '@/services/mcp/create-flow-with-steps'
 
 export function createMcpBridgeTools(user: User) {
   return {
@@ -43,17 +47,22 @@ export function createMcpBridgeTools(user: User) {
           .describe(
             'Ordered list of steps. First element must have trigger_key.',
           ),
+        traceId: z.string().describe('Langfuse trace ID for this tool call'),
       }),
-      execute: async ({ name, steps }): Promise<IMcpCreatePipeResult> => {
-        return createPipeService(
+      execute: async ({ name, steps, traceId }): Promise<Flow> => {
+        return createFlowWithStepsService({
           user,
           name,
-          steps.map((s) => ({
-            appKey: s.app_key,
-            triggerKey: s.trigger_key,
-            actionKey: s.action_key,
-          })),
-        )
+          steps: steps.map(
+            (s, index): McpStepInput => ({
+              appKey: s.app_key,
+              key: s.trigger_key ?? s.action_key ?? null,
+              type: index === 0 ? 'trigger' : 'action',
+              position: index + 1,
+            }),
+          ),
+          traceId,
+        })
       },
     }),
   }

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -140,7 +140,7 @@ const handleChatStream = observe(
 
       let workflowError = 'Unable to generate the workflow.'
 
-      const mcpTools = createMcpBridgeTools(context.currentUser)
+      const mcpTools = createMcpBridgeTools(context.currentUser, traceId)
 
       const stream = createUIMessageStream({
         execute: async ({ writer }) => {

--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -51,7 +51,12 @@ describe('createFlowWithStepsService', () => {
           type: 'action',
           position: 2,
         },
-        { appKey: 'slack', key: 'sendMessage', type: 'action', position: 3 },
+        {
+          appKey: 'slack',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 3,
+        },
       ],
       traceId: 'trace-id-123',
     })
@@ -77,7 +82,7 @@ describe('createFlowWithStepsService', () => {
 
     expect(secondActionStep.type).toBe('action')
     expect(secondActionStep.appKey).toBe('slack')
-    expect(secondActionStep.key).toBe('sendMessage')
+    expect(secondActionStep.key).toBe('sendMessageToChannel')
     expect(secondActionStep.position).toBe(3)
   })
 
@@ -97,20 +102,42 @@ describe('createFlowWithStepsService', () => {
           type: 'trigger',
           position: 1,
         },
-        { appKey: 'toolbox', key: 'ifThen', type: 'action', position: 2 },
-        { appKey: 'toolbox', key: 'ifThen', type: 'action', position: 3 },
+        {
+          appKey: 'toolbox',
+          key: 'ifThen',
+          type: 'action',
+          position: 2,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 3,
+        },
+        {
+          appKey: 'toolbox',
+          key: 'ifThen',
+          type: 'action',
+          position: 4,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 5,
+        },
       ],
       traceId: 'trace-ifthen',
     })
 
-    const [, branch1, branch2] = result.steps
+    const [, branch1, _, branch2] = result.steps
     expect(branch1.parameters).toMatchObject({
       branchName: 'Branch 1',
-      depth: '0',
+      depth: 0,
     })
     expect(branch2.parameters).toMatchObject({
       branchName: 'Branch 2',
-      depth: '0',
+      depth: 0,
     })
   })
 
@@ -137,6 +164,12 @@ describe('createFlowWithStepsService', () => {
           position: 2,
           parameters: { branchName: 'High Priority' },
         },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 3,
+        },
       ],
       traceId: 'trace-override',
     })
@@ -144,7 +177,7 @@ describe('createFlowWithStepsService', () => {
     const [, branch] = result.steps
     expect(branch.parameters).toMatchObject({
       branchName: 'High Priority',
-      depth: '0',
+      depth: 0,
     })
   })
 

--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -81,6 +81,73 @@ describe('createFlowWithStepsService', () => {
     expect(secondActionStep.position).toBe(3)
   })
 
+  it('auto-initialises branchName and depth for toolbox/ifThen steps', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-ifthen-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: 'If-Then Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        { appKey: 'toolbox', key: 'ifThen', type: 'action', position: 2 },
+        { appKey: 'toolbox', key: 'ifThen', type: 'action', position: 3 },
+      ],
+      traceId: 'trace-ifthen',
+    })
+
+    const [, branch1, branch2] = result.steps
+    expect(branch1.parameters).toMatchObject({
+      branchName: 'Branch 1',
+      depth: '0',
+    })
+    expect(branch2.parameters).toMatchObject({
+      branchName: 'Branch 2',
+      depth: '0',
+    })
+  })
+
+  it('caller-supplied parameters override ifThen defaults', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-ifthen-override-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: 'Override Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'toolbox',
+          key: 'ifThen',
+          type: 'action',
+          position: 2,
+          parameters: { branchName: 'High Priority' },
+        },
+      ],
+      traceId: 'trace-override',
+    })
+
+    const [, branch] = result.steps
+    expect(branch.parameters).toMatchObject({
+      branchName: 'High Priority',
+      depth: '0',
+    })
+  })
+
   it('stores null keys when not provided', async () => {
     const user = await User.query().insertAndFetch({
       id: randomUUID(),

--- a/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/create-flow-with-steps.itest.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Flow from '@/models/flow'
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('createFlowWithStepsService', () => {
+  beforeEach(async () => {
+    mocks.getAllLdFlags.mockResolvedValue({
+      'ai-builder': {
+        enabled: true,
+        config: {
+          generateStepsPromptName: 'generate-steps',
+          version: 'production',
+        },
+      },
+    })
+  })
+
+  it('creates an inactive pipe and persists trigger/action steps in order', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: '  My Pipe  ',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+        { appKey: 'slack', key: 'sendMessage', type: 'action', position: 3 },
+      ],
+      traceId: 'trace-id-123',
+    })
+
+    expect(result).toBeInstanceOf(Flow)
+    expect(result.id).toBeDefined()
+    expect(result.name).toBe('My Pipe')
+    expect(result.userId).toBe(user.id)
+    expect(result.active).toBe(false)
+    expect(result.steps).toHaveLength(3)
+
+    const [triggerStep, firstActionStep, secondActionStep] = result.steps
+
+    expect(triggerStep.type).toBe('trigger')
+    expect(triggerStep.appKey).toBe('formsg')
+    expect(triggerStep.key).toBe('newSubmission')
+    expect(triggerStep.position).toBe(1)
+
+    expect(firstActionStep.type).toBe('action')
+    expect(firstActionStep.appKey).toBe('postman')
+    expect(firstActionStep.key).toBe('sendTransactionalEmail')
+    expect(firstActionStep.position).toBe(2)
+
+    expect(secondActionStep.type).toBe('action')
+    expect(secondActionStep.appKey).toBe('slack')
+    expect(secondActionStep.key).toBe('sendMessage')
+    expect(secondActionStep.position).toBe(3)
+  })
+
+  it('stores null keys when not provided', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `create-pipe-missing-keys-${randomUUID()}@example.com`,
+    })
+
+    const result = await createFlowWithStepsService({
+      user,
+      name: 'No Keys',
+      steps: [
+        { appKey: 'webhook', key: null, type: 'trigger', position: 1 },
+        { appKey: 'slack', key: null, type: 'action', position: 2 },
+      ],
+      traceId: 'trace-id-456',
+    })
+
+    expect(result.steps).toHaveLength(2)
+    expect(result.steps[0].key).toBeNull()
+    expect(result.steps[1].key).toBeNull()
+  })
+})

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -92,7 +92,7 @@ export async function createFlowWithStepsService({
       steps.map((step) => {
         let defaults: Record<string, unknown> = {}
         if (step.appKey === 'toolbox' && step.key === 'ifThen') {
-          defaults = { branchName: `Branch ${++ifThenCount}`, depth: '0' }
+          defaults = { branchName: `Branch ${++ifThenCount}`, depth: 0 }
         }
         return {
           version: getStepVersion(step.appKey, step.key ?? undefined),

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -34,6 +34,10 @@ export async function createFlowWithStepsService({
     throw new Error('Pipe name needs to have at least 1 character.')
   }
 
+  if (steps.length === 0) {
+    throw new Error('At least one step is required.')
+  }
+
   if (
     !steps.every((step, index) => {
       if (index === 0) {
@@ -45,12 +49,11 @@ export async function createFlowWithStepsService({
     throw new Error('Must be contiguous steps!')
   }
 
-  const restrictedApps = getRestrictedAppKeys(await getAllLdFlags(user.email))
-
   // Validate only when all steps have keys
   const allKeysProvided = steps.every((s) => !!s.key)
 
   if (allKeysProvided) {
+    const restrictedApps = getRestrictedAppKeys(await getAllLdFlags(user.email))
     const triggerSchema = generateSchema(
       z.object({ type: z.literal('trigger') }),
       'trigger',

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -1,3 +1,5 @@
+import type { IJSONObject } from '@plumber/types'
+
 import z from 'zod/v3'
 
 import { getActionStepsSchema } from '@/graphql/mutations/ai/schemas/action-steps-schema'
@@ -13,6 +15,7 @@ export interface McpStepInput {
   key?: string | null
   type: 'trigger' | 'action'
   position: number
+  parameters?: Record<string, unknown>
 }
 
 export async function createFlowWithStepsService({
@@ -84,16 +87,26 @@ export async function createFlowWithStepsService({
       config: { aiBuilderConfig: { traceId } },
     })
 
+    let ifThenCount = 0
     await createdFlow.$relatedQuery('steps', trx).insert(
-      steps.map((step) => ({
-        version: getStepVersion(step.appKey, step.key ?? undefined),
-        type: step.type,
-        appKey: step.appKey,
-        key: step.key ?? null,
-        config: {},
-        parameters: {},
-        position: step.position,
-      })),
+      steps.map((step) => {
+        let defaults: Record<string, unknown> = {}
+        if (step.appKey === 'toolbox' && step.key === 'ifThen') {
+          defaults = { branchName: `Branch ${++ifThenCount}`, depth: '0' }
+        }
+        return {
+          version: getStepVersion(step.appKey, step.key ?? undefined),
+          type: step.type,
+          appKey: step.appKey,
+          key: step.key ?? null,
+          config: {},
+          parameters: {
+            ...defaults,
+            ...(step.parameters ?? {}),
+          } as IJSONObject,
+          position: step.position,
+        }
+      }),
     )
 
     return createdFlow

--- a/packages/backend/src/services/mcp/create-flow-with-steps.ts
+++ b/packages/backend/src/services/mcp/create-flow-with-steps.ts
@@ -1,0 +1,103 @@
+import z from 'zod/v3'
+
+import { getActionStepsSchema } from '@/graphql/mutations/ai/schemas/action-steps-schema'
+import { generateSchema } from '@/graphql/mutations/ai/schemas/schema-generator'
+import { getStepVersion } from '@/helpers/get-step-version'
+import { getAllLdFlags, getRestrictedAppKeys } from '@/helpers/launch-darkly'
+import logger from '@/helpers/logger'
+import Flow from '@/models/flow'
+import type User from '@/models/user'
+
+export interface McpStepInput {
+  appKey: string
+  key?: string | null
+  type: 'trigger' | 'action'
+  position: number
+}
+
+export async function createFlowWithStepsService({
+  user,
+  name,
+  steps,
+  traceId,
+}: {
+  user: User
+  name: string
+  steps: McpStepInput[]
+  traceId: string
+}): Promise<Flow> {
+  const trimmedName = name.trim()
+  if (!trimmedName) {
+    throw new Error('Pipe name needs to have at least 1 character.')
+  }
+
+  if (
+    !steps.every((step, index) => {
+      if (index === 0) {
+        return step.position === 1
+      }
+      return step.position === steps[index - 1].position + 1
+    })
+  ) {
+    throw new Error('Must be contiguous steps!')
+  }
+
+  const restrictedApps = getRestrictedAppKeys(await getAllLdFlags(user.email))
+
+  // Validate only when all steps have keys
+  const allKeysProvided = steps.every((s) => !!s.key)
+
+  if (allKeysProvided) {
+    const triggerSchema = generateSchema(
+      z.object({ type: z.literal('trigger') }),
+      'trigger',
+      restrictedApps,
+    )
+    const validatedTrigger = triggerSchema.safeParse(steps[0])
+    if (!validatedTrigger.success) {
+      logger.error(
+        'Failed to create flow with steps: Pipe must always start with a trigger',
+        { error: validatedTrigger.error.errors },
+      )
+      throw new Error('Pipe must always start with a trigger')
+    }
+
+    const actionSteps = steps.slice(1)
+    if (actionSteps.length > 0) {
+      const actionStepsSchema = getActionStepsSchema(restrictedApps)
+      const validatedActions = actionStepsSchema.safeParse(actionSteps)
+      if (!validatedActions.success) {
+        logger.error(
+          'Failed to create flow with steps: Pipe contains invalid action steps',
+          { error: validatedActions.error.errors },
+        )
+        throw new Error('Pipe contains invalid action steps')
+      }
+    }
+  }
+
+  const flow = await Flow.transaction(async (trx) => {
+    const createdFlow = await Flow.query(trx).insertAndFetch({
+      userId: user.id,
+      name: trimmedName,
+      active: false,
+      config: { aiBuilderConfig: { traceId } },
+    })
+
+    await createdFlow.$relatedQuery('steps', trx).insert(
+      steps.map((step) => ({
+        version: getStepVersion(step.appKey, step.key ?? undefined),
+        type: step.type,
+        appKey: step.appKey,
+        key: step.key ?? null,
+        config: {},
+        parameters: {},
+        position: step.position,
+      })),
+    )
+
+    return createdFlow
+  })
+
+  return flow.$fetchGraph('steps')
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1360,24 +1360,6 @@ export interface IMcpFieldOption {
   value: string
 }
 
-export interface IMcpCreatePipeStep {
-  appKey: string
-  triggerKey?: string
-  actionKey?: string
-}
-
-export interface IMcpCreatedStep {
-  stepId: string
-  appKey: string
-  triggerKey?: string
-  actionKey?: string
-  position: number
-}
-
-export interface IMcpCreatePipeResult {
-  pipeId: string
-  steps: IMcpCreatedStep[]
-}
 
 export interface IMcpIncompleteStep {
   stepId: string


### PR DESCRIPTION
## Stack context

This is PR 3 in the MCP AI Builder tool-use stack:

1. **PR #1804** — `feat(types): add MCP bridge API types` — foundational TypeScript interfaces for the MCP Bridge API
2. **PR #1840** — `feat(backend): add MCP tool use to AI Builder chat` — wires the `list_apps` MCP tool into the chat route
3. **PR #1841 (this PR)** — adds the `create_pipe` MCP tool and its backing service

## TL;DR

Adds the `create_pipe` MCP tool, which lets the AI Builder LLM create a new (inactive) Plumber pipe in one tool call. The service persists the flow and its ordered steps in a single Postgres transaction, auto-initialises `toolbox/ifThen` branch defaults, and reuses the existing AI Builder schema validators to enforce trigger-first ordering when all step keys are known.

## What changed?

**`packages/backend/src/services/mcp/create-flow-with-steps.ts`** (new, 116 lines)

- `createFlowWithStepsService({ user, name, steps, traceId })` creates a flow + steps in a single DB transaction and returns the `Flow` with steps eager-loaded.
- Validates: non-empty trimmed name; contiguous step positions; when all steps have keys, enforces trigger-first and valid action steps (reuses the existing `generateSchema`/`getActionStepsSchema` validators from the AI Builder GraphQL mutation path).
- Validation is skipped when any step has a `null` key, allowing partial pipe creation (LLM can omit keys it doesn't know yet).
- Auto-initialises `branchName: "Branch N"` and `depth: 0` for `toolbox/ifThen` steps; caller-supplied parameters override these defaults.
- Stores `traceId` in `flow.config.aiBuilderConfig` for Langfuse traceability.

**`packages/backend/src/helpers/mcp-bridge-tools.ts`** (updated)

- Registers `create_pipe` as a second tool alongside `list_apps`.
- The tool input uses LLM-friendly snake_case (`app_key`, `trigger_key`, `action_key`, `parameters`); the execute handler maps to camelCase `McpStepInput`, inferring `type` (trigger/action) and `position` from the array index.
- Tool description explicitly instructs the LLM: "Always creates inactive — never activate without explicit user confirmation."

**`packages/types/index.d.ts`** (updated)

- Removes `IMcpCreatePipeStep`, `IMcpCreatedStep`, and `IMcpCreatePipeResult` — these were scaffolded in PR #1804 but are superseded by the shared `Flow`/`IStep` model types used by the service.

**Tests**

- `mcp-bridge-tools.test.ts` — adds mock for `createFlowWithStepsService`; new cases for snake_case → camelCase mapping and parameter passthrough.
- `create-flow-with-steps.itest.ts` (new, 204 lines) — integration tests covering: happy-path trigger + N actions; `ifThen` auto-init; caller parameters overriding defaults; null keys for partial pipes.

## Tests

- [ ] Open the AI Builder chat and send a message that should cause the LLM to call `create_pipe` (e.g. "Create a pipe that sends a Postman email when a FormSG form is submitted").
- [ ] Confirm the new pipe appears in the pipe list as **inactive** after the LLM tool call completes.
- [ ] Open the pipe and verify the steps are in the correct order (trigger first, actions following), with the correct app/trigger/action keys set.
- [ ] Send a message requesting a pipe with an `ifThen` branch. Verify the ifThen step has a `branchName` ("Branch 1") and `depth: 0` set by default.
- [ ] Confirm the `list_apps` tool still works as before — send a message asking what apps are available and verify a list is returned.
- [ ] Check that the AI Builder chat does not error when the LLM performs multiple tool calls in one turn (regression: `stopWhen: stepCountIs(10)` from PR #1840).

## Deploy notes

No new environment variables or migrations required. The service writes to the existing `flows` and `steps` Postgres tables using the standard Knex/Objection stack.