### PR TITLE
[CHAT-ID-3] PLU-807 feat: show chat ID badge with copy button in AI Builder header

### DIFF
--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -237,31 +237,54 @@ describe('chatRequestSchema', () => {
     })
   })
 
-  describe('sessionId validation', () => {
-    it('should reject invalid UUID format', () => {
+  describe('tracing id validation', () => {
+    const validUuid = '550e8400-e29b-41d4-a716-446655440000'
+
+    it('should accept a request with chatId and ddRumSessionId', () => {
       const result = chatRequestSchema.safeParse({
         messages: [validMessage],
-        sessionId: 'not-a-uuid',
+        chatId: validUuid,
+        ddRumSessionId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
       })
-      expect(result.success).toBe(false)
-      expect(result.error?.issues[0].message).toBe(
-        'Session ID must be a valid UUID',
-      )
+      expect(result.success).toBe(true)
     })
 
-    it('should accept missing sessionId', () => {
+    it('should accept a legacy request with only sessionId', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [validMessage],
+        sessionId: validUuid,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should accept a request with all tracing ids missing', () => {
       const result = chatRequestSchema.safeParse({
         messages: [validMessage],
       })
       expect(result.success).toBe(true)
     })
 
-    it('should accept empty sessionId', () => {
-      const result = chatRequestSchema.safeParse({
-        messages: [validMessage],
-        sessionId: '',
-      })
-      expect(result.success).toBe(true)
-    })
+    it.each(['chatId', 'ddRumSessionId', 'sessionId'])(
+      'should accept an empty %s',
+      (field) => {
+        const result = chatRequestSchema.safeParse({
+          messages: [validMessage],
+          [field]: '',
+        })
+        expect(result.success).toBe(true)
+      },
+    )
+
+    it.each(['chatId', 'ddRumSessionId', 'sessionId'])(
+      'should reject a malformed %s',
+      (field) => {
+        const result = chatRequestSchema.safeParse({
+          messages: [validMessage],
+          [field]: 'not-a-uuid',
+        })
+        expect(result.success).toBe(false)
+        expect(result.error?.issues[0].message).toBe('Must be a valid UUID')
+      },
+    )
   })
 })

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -71,7 +71,16 @@ const handleChatStream = observe(
         return
       }
 
-      const { messages: rawMessages, sessionId } = validationResult.data
+      const {
+        messages: rawMessages,
+        chatId,
+        ddRumSessionId,
+        sessionId,
+      } = validationResult.data
+
+      // The RUM session id, preferring the new field but accepting the legacy
+      // `sessionId` from clients deployed before the chatId change.
+      const rumSessionId = ddRumSessionId || sessionId
 
       // Convert UIMessages to ModelMessages
       const messages = convertToModelMessages(
@@ -100,7 +109,8 @@ const handleChatStream = observe(
 
       logger.info('Starting AI chat stream', {
         traceId,
-        sessionId,
+        chatId,
+        ddRumSessionId: rumSessionId,
         userId: context.currentUser.email,
         model: MODEL_TYPE,
       })
@@ -150,7 +160,13 @@ const handleChatStream = observe(
               functionId: 'ai-chat-stream',
               metadata: {
                 name: 'ai-chat-stream',
-                sessionId: sessionId || 'unknown',
+                // Langfuse session = the chat session. Falls back to the RUM id for
+                // old clients during rollout, then 'unknown'. The fallbacks are
+                // removed in the cleanup release once old clients have drained.
+                sessionId: chatId || rumSessionId || 'unknown',
+                // Plain metadata (non-special key) so RUM traces can still be
+                // correlated with Langfuse without driving session grouping.
+                ddRumSessionId: rumSessionId || undefined,
                 userId: context.currentUser.email,
                 environment: appConfig.appEnv,
                 promptName: chatPromptName,

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -5,6 +5,19 @@ import { flowStepsSchema } from '@/helpers/ai/types'
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+/**
+ * Lenient schema for the tracing id fields (chatId, ddRumSessionId, and the
+ * legacy sessionId). Optional and allows an empty string (e.g. in dev) so a
+ * missing or malformed telemetry value never fails the chat request — we already
+ * have the user's email for correlation.
+ */
+const optionalTracingId = z
+  .string()
+  .refine((val) => val === '' || UUID_REGEX.test(val), {
+    message: 'Must be a valid UUID',
+  })
+  .optional()
+
 // Limits to protect API and LLM costs
 const MAX_MESSAGES = 50
 const MAX_TEXT_LENGTH = 10000 // characters per message part (~2,500 tokens)
@@ -89,15 +102,21 @@ export const chatRequestSchema = z.object({
     .min(1, 'Messages array must contain at least one message')
     .max(MAX_MESSAGES, `Cannot send more than ${MAX_MESSAGES} messages`),
   /**
-   * Datadog RUM session UUID for debugging. Optional and allows empty string
-   * (e.g., in dev) to avoid failing the API since we already have the user's email.
+   * Unique id for one AI Builder chat session, minted on the frontend. Used as the
+   * Langfuse session id so all traces from one conversation group together.
    */
-  sessionId: z
-    .string()
-    .refine((val) => val === '' || UUID_REGEX.test(val), {
-      message: 'Session ID must be a valid UUID',
-    })
-    .optional(),
+  chatId: optionalTracingId,
+  /**
+   * Datadog RUM session UUID, carried into Langfuse traces as plain metadata for
+   * cross-referencing. Does NOT define the chat session.
+   */
+  ddRumSessionId: optionalTracingId,
+  /**
+   * @deprecated Legacy alias for the Datadog RUM session id sent by clients before
+   * the chatId change. Treated as ddRumSessionId when the newer field is absent.
+   * Remove one release after rollout, once old clients have drained.
+   */
+  sessionId: optionalTracingId,
 })
 
 export type ChatRequest = z.infer<typeof chatRequestSchema>

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -67,7 +67,7 @@ export function useChatStream(options: UseChatStreamOptions) {
   const toast = useToast()
   const navigate = useNavigate()
   const location = useLocation()
-  const { ddSessionId } = useAiBuilderContext()
+  const { ddSessionId, chatId } = useAiBuilderContext()
 
   // Track step readiness from data-isChatReady annotation
   // Initialize based on whether initialMessages contains a ready message.
@@ -88,6 +88,12 @@ export function useChatStream(options: UseChatStreamOptions) {
   // (e.g. the old 50 messages after clicking "New Chat").
   const initialMessagesRef = useRef(options?.initialMessages)
   initialMessagesRef.current = options?.initialMessages
+
+  // chatId is minted after mount and changes on "New Chat" (without a remount), so the
+  // transport closure captured on mount would otherwise send a stale/empty id. Read the
+  // latest value through a ref at send time.
+  const chatIdRef = useRef(chatId)
+  chatIdRef.current = chatId
 
   const {
     messages: aiMessages,
@@ -130,7 +136,10 @@ export function useChatStream(options: UseChatStreamOptions) {
 
         const body = {
           messages: allMessages,
-          sessionId: ddSessionId,
+          // chatId drives the Langfuse session; the RUM session id is sent as plain
+          // metadata for cross-referencing (no longer the session driver).
+          chatId: chatIdRef.current,
+          ddRumSessionId: ddSessionId,
         }
         return { body }
       },

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -17,6 +17,12 @@ export interface AIBuilderDraftState {
   // output can be populated (IStep values) or the initial empty state (empty strings)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   output: Record<string, any>
+  /**
+   * Unique id for this chat session, used as the Langfuse session id. Optional on the
+   * type because freshly-created / legacy drafts may not have one yet; the provider
+   * mints one when it is absent (see AiBuilderContextProvider).
+   */
+  chatId?: string
 }
 
 interface AIBuilderSharedProps extends AIBuilderDraftState {
@@ -40,6 +46,8 @@ interface AIBuilderContextValue extends AIBuilderSharedProps {
   stepGroupCaption: string | null
   // DataDog RUM Session ID so we can associate the trace with the RUM
   ddSessionId: string
+  // Unique id for this chat session, used as the Langfuse session id
+  chatId: string
   isDrawerOpen: boolean
   setIsDrawerOpen: (open: boolean) => void
 }
@@ -68,6 +76,7 @@ export const AiBuilderContextProvider = ({
   chatInput,
   chatMessages,
   output,
+  chatId,
   clearPersistedState,
   setChatState,
 }: AiBuilderContextProviderProps) => {
@@ -75,6 +84,23 @@ export const AiBuilderContextProvider = ({
   const ddSessionId = datadogRum.getInternalContext()?.session_id ?? ''
 
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+
+  // Invariant: a draft must always have a chatId. Mint one when it is absent (a fresh
+  // default draft, or a legacy draft from before this feature). crypto.randomUUID() is
+  // called here at effect time, so each detected absence yields a genuinely new id.
+  // "New Chat" mints its own id explicitly (see ChatInterface) so it does not rely on
+  // this and is guaranteed a new session.
+  useEffect(() => {
+    if (!chatId) {
+      setChatState({
+        flowName,
+        chatInput,
+        chatMessages,
+        output,
+        chatId: crypto.randomUUID(),
+      })
+    }
+  }, [chatId, flowName, chatInput, chatMessages, output, setChatState])
 
   // Update drawer state when isMobile or output changes (handles async isMobile hook)
   useEffect(() => {
@@ -144,6 +170,7 @@ export const AiBuilderContextProvider = ({
         stepGroupType,
         stepGroupCaption,
         ddSessionId,
+        chatId: chatId ?? '',
         clearPersistedState,
         setChatState,
         isDrawerOpen,

--- a/packages/frontend/src/pages/AiBuilder/__tests__/new-chat.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/__tests__/new-chat.test.ts
@@ -1,0 +1,50 @@
+import { webcrypto } from 'node:crypto'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { createNewChatDraft, extractContinuationPrompt } from '../new-chat'
+
+// The test environment doesn't expose `crypto` as a global (no jsdom/browser
+// shim). Wire it up from Node's built-in webcrypto so the tests can run.
+beforeAll(() => {
+  vi.stubGlobal('crypto', webcrypto)
+})
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+describe('extractContinuationPrompt', () => {
+  it('extracts and trims the text inside a <code> block', () => {
+    expect(
+      extractContinuationPrompt(
+        'Sure, try this:\n<code>  Build a form  </code>',
+      ),
+    ).toBe('Build a form')
+  })
+
+  it('returns an empty string when there is no <code> block', () => {
+    expect(extractContinuationPrompt('No code here')).toBe('')
+  })
+
+  it('returns an empty string for undefined input', () => {
+    expect(extractContinuationPrompt(undefined)).toBe('')
+  })
+})
+
+describe('createNewChatDraft', () => {
+  it('mints a valid UUID chatId', () => {
+    expect(createNewChatDraft().chatId).toMatch(UUID_REGEX)
+  })
+
+  it('mints a new chatId on every call (a new chat is always a new session)', () => {
+    const ids = new Set(
+      Array.from({ length: 5 }, () => createNewChatDraft().chatId),
+    )
+    expect(ids.size).toBe(5)
+  })
+
+  it('seeds chatInput with the continuation prompt and starts with no messages', () => {
+    const draft = createNewChatDraft('<code>Send a Slack message</code>')
+    expect(draft.chatInput).toBe('Send a Slack message')
+    expect(draft.chatMessages).toEqual([])
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -8,6 +8,7 @@ import { Message } from '@/hooks/useChatStream'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import ChatMessages from '@/pages/AiBuilder/components/ChatMessages'
 import { PLACEHOLDER_MESSAGES } from '@/pages/AiBuilder/constants'
+import { createNewChatDraft } from '@/pages/AiBuilder/new-chat'
 
 import MessageLimitBanner from './MessageLimitBanner'
 import PromptInput from './PromptInput'
@@ -54,17 +55,11 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat()
     setIsDrawerOpen(false)
 
-    // Extract continuation prompt from the last assistant message (between <code> tags)
+    // Build the new draft from the last assistant message's continuation prompt. This
+    // mints a fresh chatId so the new chat starts a new Langfuse session (set explicitly,
+    // not relying on the provider's mint-if-absent, so it never carries the old id).
     const lastMessage = messages[messages.length - 1]
-    const match = lastMessage?.text?.match(/<code[^>]*>([\s\S]*?)<\/code>/)
-    const continuationPrompt = match ? match[1].trim() : ''
-
-    const newState = {
-      flowName: 'Build with AI',
-      chatInput: continuationPrompt,
-      chatMessages: [],
-      output: { trigger: '', actions: '', name: 'Build with AI', traceId: '' },
-    }
+    const newState = createNewChatDraft(lastMessage?.text)
 
     // Synchronously update persisted state so the next render sees empty messages
     // immediately (avoids a stale intermediate render with old messages)

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -5,6 +5,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import {
   CloseButton,
   Container,
+  Divider,
   Flex,
   HStack,
   Text,
@@ -107,27 +108,33 @@ function AiBuilderContent() {
 
               <Text>{flowName}</Text>
 
+              <Divider
+                orientation="vertical"
+                h={4}
+                borderColor="base.divider.medium"
+              />
+
+              <Text
+                textStyle="caption-1"
+                color="base.content.medium"
+                fontWeight="semibold"
+                letterSpacing="wider"
+                textTransform="uppercase"
+                whiteSpace="nowrap"
+                flexShrink={0}
+              >
+                Chat ID
+              </Text>
+
               <Flex
                 alignItems="center"
-                gap={1}
                 px={2}
                 py={0.5}
                 borderRadius="md"
                 border="1px solid"
                 borderColor="base.divider.medium"
-                bg="base.canvas.alt"
                 flexShrink={0}
               >
-                <Text
-                  textStyle="caption-1"
-                  color="base.content.medium"
-                  fontWeight="semibold"
-                  letterSpacing="wider"
-                  textTransform="uppercase"
-                  whiteSpace="nowrap"
-                >
-                  Chat ID
-                </Text>
                 <Text
                   textStyle="caption-1"
                   fontFamily="mono"
@@ -139,21 +146,23 @@ function AiBuilderContent() {
                 >
                   {chatId}
                 </Text>
-                <Tooltip label={copied ? 'Copied!' : 'Copy chat ID'} hasArrow>
-                  <Flex
-                    as="button"
-                    onClick={handleCopyChatId}
-                    alignItems="center"
-                    justifyContent="center"
-                    color="base.content.medium"
-                    _hover={{ color: 'base.content.default' }}
-                    cursor="pointer"
-                    aria-label="Copy chat ID"
-                  >
-                    <BiCopy size={14} />
-                  </Flex>
-                </Tooltip>
               </Flex>
+
+              <Tooltip label={copied ? 'Copied!' : 'Copy chat ID'} hasArrow>
+                <Flex
+                  as="button"
+                  onClick={handleCopyChatId}
+                  alignItems="center"
+                  justifyContent="center"
+                  color="base.content.medium"
+                  _hover={{ color: 'base.content.default' }}
+                  cursor="pointer"
+                  aria-label="Copy chat ID"
+                  flexShrink={0}
+                >
+                  <BiCopy size={16} />
+                </Flex>
+              </Tooltip>
             </Flex>
           </HStack>
         )}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -131,9 +131,8 @@ function AiBuilderContent() {
                 alignItems="center"
                 px={2}
                 py={0.5}
-                borderRadius="md"
-                border="1px solid"
-                borderColor="base.divider.medium"
+                borderRadius="full"
+                bg="base.canvas.alt"
                 flexShrink={0}
               >
                 <Text

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -132,13 +132,9 @@ function AiBuilderContent() {
                 colorScheme="grey"
                 variant="subtle"
                 fontFamily="mono"
-                maxW="120px"
-                overflow="hidden"
-                textOverflow="ellipsis"
-                whiteSpace="nowrap"
                 flexShrink={0}
               >
-                {chatId}
+                {chatId.length > 16 ? `${chatId.slice(0, 16)}…` : chatId}
               </Badge>
 
               <Tooltip label={copied ? 'Copied!' : 'Copy chat ID'} hasArrow>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -118,7 +118,7 @@ function AiBuilderContent() {
 
               <Text
                 textStyle="caption-1"
-                color="base.content.disabled-content"
+                color="base.divider.strong"
                 fontWeight="semibold"
                 letterSpacing="wider"
                 textTransform="uppercase"

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -118,8 +118,8 @@ function AiBuilderContent() {
 
               <Text
                 textStyle="caption-1"
-                color="base.divider.strong"
-                fontWeight="semibold"
+                color="interaction.support.disabled-content"
+                fontWeight="medium"
                 letterSpacing="wider"
                 textTransform="uppercase"
                 whiteSpace="nowrap"

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -130,7 +130,7 @@ function AiBuilderContent() {
 
               <Badge
                 bgColor="secondary.50"
-                color="secondary.700"
+                color="base.content.medium"
                 fontFamily="mono"
                 fontWeight="normal"
                 flexShrink={0}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -1,7 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Helmet } from 'react-helmet'
+import { BiCopy } from 'react-icons/bi'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { CloseButton, Container, Flex, HStack, Text } from '@chakra-ui/react'
+import {
+  CloseButton,
+  Container,
+  Flex,
+  HStack,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react'
+import copy from 'clipboard-copy'
 
 import * as URLS from '@/config/urls'
 import { useChatStream } from '@/hooks/useChatStream'
@@ -23,7 +32,16 @@ function AiBuilderContent() {
     clearPersistedState,
     isMobile,
     isDrawerOpen,
+    chatId,
   } = useAiBuilderContext()
+
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyChatId = useCallback(async () => {
+    await copy(chatId)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [chatId])
 
   const {
     messages,
@@ -88,6 +106,54 @@ function AiBuilderContent() {
               <CloseButton size="sm" onClick={handleClose} />
 
               <Text>{flowName}</Text>
+
+              <Flex
+                alignItems="center"
+                gap={1}
+                px={2}
+                py={0.5}
+                borderRadius="md"
+                border="1px solid"
+                borderColor="base.divider.medium"
+                bg="base.canvas.alt"
+                flexShrink={0}
+              >
+                <Text
+                  textStyle="caption-1"
+                  color="base.content.medium"
+                  fontWeight="semibold"
+                  letterSpacing="wider"
+                  textTransform="uppercase"
+                  whiteSpace="nowrap"
+                >
+                  Chat ID
+                </Text>
+                <Text
+                  textStyle="caption-1"
+                  fontFamily="mono"
+                  color="base.content.default"
+                  maxW="120px"
+                  overflow="hidden"
+                  textOverflow="ellipsis"
+                  whiteSpace="nowrap"
+                >
+                  {chatId}
+                </Text>
+                <Tooltip label={copied ? 'Copied!' : 'Copy chat ID'} hasArrow>
+                  <Flex
+                    as="button"
+                    onClick={handleCopyChatId}
+                    alignItems="center"
+                    justifyContent="center"
+                    color="base.content.medium"
+                    _hover={{ color: 'base.content.default' }}
+                    cursor="pointer"
+                    aria-label="Copy chat ID"
+                  >
+                    <BiCopy size={14} />
+                  </Flex>
+                </Tooltip>
+              </Flex>
             </Flex>
           </HStack>
         )}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   Tooltip,
 } from '@chakra-ui/react'
+import { Badge } from '@opengovsg/design-system-react'
 import copy from 'clipboard-copy'
 
 import * as URLS from '@/config/urls'
@@ -127,26 +128,18 @@ function AiBuilderContent() {
                 Chat ID
               </Text>
 
-              <Flex
-                alignItems="center"
-                px={2}
-                py={0.5}
-                borderRadius="full"
-                bg="base.canvas.alt"
+              <Badge
+                colorScheme="grey"
+                variant="subtle"
+                fontFamily="mono"
+                maxW="120px"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                whiteSpace="nowrap"
                 flexShrink={0}
               >
-                <Text
-                  textStyle="caption-1"
-                  fontFamily="mono"
-                  color="base.content.default"
-                  maxW="120px"
-                  overflow="hidden"
-                  textOverflow="ellipsis"
-                  whiteSpace="nowrap"
-                >
-                  {chatId}
-                </Text>
-              </Flex>
+                {chatId}
+              </Badge>
 
               <Tooltip label={copied ? 'Copied!' : 'Copy chat ID'} hasArrow>
                 <Flex

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -110,8 +110,9 @@ function AiBuilderContent() {
 
               <Divider
                 orientation="vertical"
-                h={4}
-                borderColor="base.divider.medium"
+                h={5}
+                mx={2}
+                borderColor="base.divider.strong"
               />
 
               <Text

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -144,11 +144,18 @@ export default function AiBuilder() {
   // Sync location state updates (from useChatStream navigate calls) to persisted state
   useEffect(() => {
     if (locationState) {
-      setPersistedState(locationState)
+      setPersistedState((prev: typeof persistedState) => ({
+        ...locationState,
+        // Preserve the existing chatId when the navigation state doesn't carry one.
+        // onFinish navigates after every message; without this the minted chatId would
+        // be wiped and regenerated each message. "New Chat" sets a fresh chatId in
+        // locationState, so it still correctly starts a new session.
+        chatId: locationState.chatId ?? prev.chatId,
+      }))
     }
   }, [locationState, setPersistedState])
 
-  const { flowName, output, chatInput, chatMessages } = persistedState
+  const { flowName, output, chatInput, chatMessages, chatId } = persistedState
 
   return (
     <AiBuilderContextProvider
@@ -156,6 +163,7 @@ export default function AiBuilder() {
       chatInput={chatInput}
       chatMessages={chatMessages}
       output={output}
+      chatId={chatId}
       clearPersistedState={clearPersistedState}
       setChatState={setPersistedState}
     >

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -132,6 +132,8 @@ function AiBuilderContent() {
                 colorScheme="grey"
                 variant="subtle"
                 fontFamily="mono"
+                fontWeight="normal"
+                color="base.content.medium"
                 flexShrink={0}
               >
                 {chatId.length > 16 ? `${chatId.slice(0, 16)}…` : chatId}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -116,6 +116,18 @@ function AiBuilderContent() {
                 borderColor="base.divider.strong"
               />
 
+              <Text
+                textStyle="caption-1"
+                color="interaction.support.disabled-content"
+                fontWeight="medium"
+                letterSpacing="wider"
+                textTransform="uppercase"
+                whiteSpace="nowrap"
+                flexShrink={0}
+              >
+                Chat ID
+              </Text>
+
               <Badge
                 bgColor="secondary.50"
                 color="secondary.700"
@@ -123,7 +135,6 @@ function AiBuilderContent() {
                 fontWeight="normal"
                 flexShrink={0}
               >
-                Chat ID:{' '}
                 {chatId.length > 16 ? `${chatId.slice(0, 16)}…` : chatId}
               </Badge>
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -118,7 +118,7 @@ function AiBuilderContent() {
 
               <Text
                 textStyle="caption-1"
-                color="base.content.medium"
+                color="base.content.disabled-content"
                 fontWeight="semibold"
                 letterSpacing="wider"
                 textTransform="uppercase"

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -116,26 +116,14 @@ function AiBuilderContent() {
                 borderColor="base.divider.strong"
               />
 
-              <Text
-                textStyle="caption-1"
-                color="interaction.support.disabled-content"
-                fontWeight="medium"
-                letterSpacing="wider"
-                textTransform="uppercase"
-                whiteSpace="nowrap"
-                flexShrink={0}
-              >
-                Chat ID
-              </Text>
-
               <Badge
-                colorScheme="grey"
-                variant="subtle"
+                bgColor="secondary.50"
+                color="secondary.700"
                 fontFamily="mono"
                 fontWeight="normal"
-                color="base.content.medium"
                 flexShrink={0}
               >
+                Chat ID:{' '}
                 {chatId.length > 16 ? `${chatId.slice(0, 16)}…` : chatId}
               </Badge>
 

--- a/packages/frontend/src/pages/AiBuilder/new-chat.ts
+++ b/packages/frontend/src/pages/AiBuilder/new-chat.ts
@@ -1,0 +1,27 @@
+import type { AIBuilderDraftState } from './AiBuilderContext'
+
+// The assistant wraps a suggested continuation prompt in a <code> block; "New Chat"
+// pre-fills the input with it so the user can carry the idea into the new conversation.
+const CONTINUATION_PROMPT_REGEX = /<code[^>]*>([\s\S]*?)<\/code>/
+
+/**
+ * Extract the continuation prompt from an assistant message's <code> block, if present.
+ */
+export const extractContinuationPrompt = (lastMessageText?: string): string => {
+  const match = lastMessageText?.match(CONTINUATION_PROMPT_REGEX)
+  return match ? match[1].trim() : ''
+}
+
+/**
+ * Build the draft state for a brand-new chat. Always mints a fresh chatId so the new
+ * chat starts a new Langfuse session — never carrying the previous chat's id forward.
+ */
+export const createNewChatDraft = (
+  lastMessageText?: string,
+): AIBuilderDraftState => ({
+  flowName: 'Build with AI',
+  chatInput: extractContinuationPrompt(lastMessageText),
+  chatMessages: [],
+  output: { trigger: '', actions: '', name: 'Build with AI', traceId: '' },
+  chatId: crypto.randomUUID(),
+})


### PR DESCRIPTION
## Stack context

Part of PLU-806 (AI Builder chat tracing). This is the third PR in the stack:

1. [CHAT-ID-1] #1786 — Backend: accept `chatId` and `ddRumSessionId` fields from the frontend
2. [CHAT-ID-2] #1787 — Frontend: mint a `chatId` per chat session and send it to the backend (drives the Langfuse session)
3. **[CHAT-ID-3] #1842 (this PR)** — Surface the `chatId` in the AI Builder header so operators can cross-reference Langfuse traces

## TL;DR

Shows the current chat session ID in the AI Builder header, truncated to 16 chars, with a copy-to-clipboard button. This lets operators (and users reporting issues) grab the ID and look up the exact Langfuse trace.

## What changed?

**Frontend only — no backend changes.**

- `AiBuilder/index.tsx` — adds a `Chat ID` label + truncated UUID badge + copy button to the header toolbar, separated by a vertical divider from the flow name. The badge uses the design-system `Badge` component with `secondary.50` background and `base.content.medium` text, rendered in monospace. The copy button shows a "Copied!" tooltip for 2 s on click.
- `AiBuilderContext.tsx` — exposes `chatId` from context so the header can read it; mints a fresh `crypto.randomUUID()` if the persisted draft pre-dates this feature and has no `chatId`.
- `useChatStream.ts` — reads `chatId` via a ref (to avoid stale closures across "New Chat" transitions) and sends it as `chatId` in the request body; renames the existing `sessionId` field to `ddRumSessionId` for clarity.
- `new-chat.ts` — new helper that builds a fresh draft state (always with a new `chatId`) for the "New Chat" flow; includes `extractContinuationPrompt` to pre-fill the input from the last assistant message.
- `__tests__/new-chat.test.ts` — unit tests for the two helpers above.

## Tests

1. Open AI Builder and start a conversation — confirm the **Chat ID** label and a truncated UUID badge appear in the header next to the flow name.
2. Click the copy icon — confirm the tooltip says "Copied!" and the full UUID is on your clipboard.
3. Send several messages in the same session — confirm the badge UUID **does not change** between messages.
4. Click **New Chat** — confirm the badge shows a **different** UUID for the new session.
5. Reload the page mid-session — confirm the badge shows the **same** UUID as before the reload (persisted in state).
6. Open a flow that was created before this change is deployed (no saved `chatId`) — confirm a UUID is minted and shown without errors.

## Deploy notes

No migrations, feature flags, or config changes required. The `chatId` field is additive to the existing persisted draft state; legacy drafts without it are handled gracefully at runtime.