### PR TITLE
[AI-SETUP-4] PLU-813 feat(backend): update Step

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -8,9 +8,15 @@ vi.mock('@/services/mcp/create-flow-with-steps', () => ({
     .fn()
     .mockResolvedValue({ id: 'f1', name: 'My Pipe', steps: [] }),
 }))
+vi.mock('@/services/mcp/update-step-parameters', () => ({
+  updateStepParametersService: vi
+    .fn()
+    .mockResolvedValue({ id: 's1', parameters: {} }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
+import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
 
@@ -20,7 +26,11 @@ const mockTraceId = 'trace-123'
 describe('createMcpBridgeTools', () => {
   it('contains list_apps and create_pipe tools', () => {
     const tools = createMcpBridgeTools(mockUser, mockTraceId)
-    expect(Object.keys(tools)).toEqual(['list_apps', 'create_pipe'])
+    expect(Object.keys(tools)).toEqual([
+      'list_apps',
+      'create_pipe',
+      'update_step_parameters',
+    ])
   })
 
   it('each tool has description and execute function', () => {
@@ -35,6 +45,24 @@ describe('createMcpBridgeTools', () => {
     const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.list_apps.execute({}, { toolCallId: 'list_apps', messages: [] })
     expect(vi.mocked(listAppsService)).toHaveBeenCalled()
+  })
+
+  it('update_step_parameters calls updateStepParametersService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    await tools.update_step_parameters.execute(
+      {
+        pipe_id: 'flow-1',
+        step_id: 'step-1',
+        parameters: { subject: 'Hello' },
+      },
+      { toolCallId: 'update_step_parameters', messages: [] },
+    )
+    expect(vi.mocked(updateStepParametersService)).toHaveBeenCalledWith({
+      user: mockUser,
+      pipeId: 'flow-1',
+      stepId: 'step-1',
+      parameters: { subject: 'Hello' },
+    })
   })
 
   it('create_pipe maps snake_case input to IStep-shaped steps', async () => {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -4,12 +4,14 @@ import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type Flow from '@/models/flow'
+import Step from '@/models/step'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
 import {
   createFlowWithStepsService,
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
+import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
 
@@ -70,6 +72,28 @@ export function createMcpBridgeTools(user: User, traceId: string) {
             }),
           ),
           traceId,
+        })
+      },
+    }),
+
+    update_step_parameters: tool({
+      description:
+        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.",
+      inputSchema: z.object({
+        pipe_id: z.string().describe('ID of the pipe that contains the step'),
+        step_id: z.string().describe('ID of the step to update'),
+        parameters: z
+          .record(z.string(), z.unknown())
+          .describe(
+            "Parameter key/value pairs to save. Only keys matching the step's field schema are kept.",
+          ),
+      }),
+      execute: async ({ pipe_id, step_id, parameters }): Promise<Step> => {
+        return updateStepParametersService({
+          user,
+          pipeId: pipe_id,
+          stepId: step_id,
+          parameters,
         })
       },
     }),

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -80,8 +80,8 @@ export function createMcpBridgeTools(user: User, traceId: string) {
       description:
         "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.",
       inputSchema: z.object({
-        pipe_id: z.string().describe('ID of the pipe that contains the step'),
-        step_id: z.string().describe('ID of the step to update'),
+        pipe_id: z.uuid().describe('ID of the pipe that contains the step'),
+        step_id: z.uuid().describe('ID of the step to update'),
         parameters: z
           .record(z.string(), z.unknown())
           .describe(

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -4,7 +4,7 @@ import { tool } from 'ai'
 import { z } from 'zod/v4'
 
 import type Flow from '@/models/flow'
-import Step from '@/models/step'
+import type Step from '@/models/step'
 import type User from '@/models/user'
 import { listAppsService } from '@/services/mcp/apps'
 import {

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { updateStepParametersService } from '../update-step-parameters'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('updateStepParametersService', () => {
+  beforeEach(() => {
+    // Return no LD flags so no apps are restricted
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('saves only field keys defined in the action schema, silently dropping unknown keys', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `update-params-filter-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Filter Test Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-filter-1',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: {
+        subject: 'Hello world',            // valid — in postman sendTransactionalEmail schema
+        destinationEmail: ['a@b.com'],      // valid — in postman sendTransactionalEmail schema
+        unknownHallucinatedField: 'drop',  // invalid — not in schema, must be dropped
+      },
+    })
+
+    expect(result.parameters).toMatchObject({
+      subject: 'Hello world',
+      destinationEmail: ['a@b.com'],
+    })
+    expect(result.parameters).not.toHaveProperty('unknownHallucinatedField')
+  })
+
+  it('sets status to incomplete after parameter update', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `update-params-status-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Status Test Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-status-2',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: { subject: 'Test' },
+    })
+
+    expect(result.status).toBe('incomplete')
+  })
+
+  it('throws if the step does not belong to the requesting user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-access-3',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    await expect(
+      updateStepParametersService({
+        user: intruder,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: { subject: 'Hack' },
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+
+  it('throws if the stepId does not belong to the given pipeId', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `mismatch-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Mismatch Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+      ],
+      traceId: 'trace-mismatch-4',
+    })
+
+    const triggerStep = flow.steps[0]
+    expect(triggerStep).toBeDefined()
+
+    await expect(
+      updateStepParametersService({
+        user,
+        pipeId: randomUUID(), // wrong pipe ID
+        stepId: triggerStep.id,
+        parameters: {},
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+})

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -33,7 +33,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Filter Test Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -52,9 +57,9 @@ describe('updateStepParametersService', () => {
       pipeId: flow.id,
       stepId: actionStep.id,
       parameters: {
-        subject: 'Hello world',            // valid — in postman sendTransactionalEmail schema
-        destinationEmail: ['a@b.com'],      // valid — in postman sendTransactionalEmail schema
-        unknownHallucinatedField: 'drop',  // invalid — not in schema, must be dropped
+        subject: 'Hello world', // valid — in postman sendTransactionalEmail schema
+        destinationEmail: ['a@b.com'], // valid — in postman sendTransactionalEmail schema
+        unknownHallucinatedField: 'drop', // invalid — not in schema, must be dropped
       },
     })
 
@@ -75,7 +80,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Status Test Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -113,7 +123,12 @@ describe('updateStepParametersService', () => {
       user: owner,
       name: 'Owned Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
         {
           appKey: 'postman',
           key: 'sendTransactionalEmail',
@@ -147,7 +162,12 @@ describe('updateStepParametersService', () => {
       user,
       name: 'Mismatch Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
       ],
       traceId: 'trace-mismatch-4',
     })

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -184,4 +184,55 @@ describe('updateStepParametersService', () => {
       }),
     ).rejects.toThrow('Step not found')
   })
+
+  it('merges parameters across repeated calls instead of overwriting', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `update-params-merge-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Merge Test Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-merge-1',
+    })
+
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    // First call: set subject
+    await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: { subject: 'Hello world' },
+    })
+
+    // Second call: set destinationEmail — must not wipe out subject
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: { destinationEmail: ['a@b.com'] },
+    })
+
+    expect(result.parameters).toMatchObject({
+      subject: 'Hello world',
+      destinationEmail: ['a@b.com'],
+    })
+  })
 })

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -85,8 +85,14 @@ export async function updateStepParametersService({
     action.validateStepParameters?.(patchedParameters)
   }
 
+  // Merge so repeated tool calls (one param at a time) accumulate rather than overwrite.
+  const mergedParameters = {
+    ...(step.parameters ?? {}),
+    ...patchedParameters,
+  } as IJSONObject
+
   return Step.query().patchAndFetchById(stepId, {
-    parameters: patchedParameters,
+    parameters: mergedParameters,
     version,
     status: 'incomplete',
   })

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -23,77 +23,81 @@ export async function updateStepParametersService({
   stepId,
   parameters,
 }: UpdateStepParametersInput): Promise<Step> {
-  const step = await user
-    .withAccessibleSteps({ requiredRole: 'editor' })
-    .findOne({
-      'steps.id': stepId,
-      'steps.flow_id': pipeId,
-    })
+  return Step.transaction(async (trx) => {
+    const step = await user
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
+      .forUpdate()
+      .findOne({
+        'steps.id': stepId,
+        'steps.flow_id': pipeId,
+      })
 
-  if (!step) {
-    throw new Error('Step not found')
-  }
-
-  // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)
-  const triggerOrAction = await App.findTriggerOrActionByKey(
-    step.appKey,
-    step.key,
-  )
-
-  if (!triggerOrAction) {
-    throw new Error('No such trigger or action')
-  }
-
-  if (step.type === 'action') {
-    const action = triggerOrAction as IAction
-    if (action.hiddenFromUser) {
-      throw new Error('Action can only be updated by system')
+    if (!step) {
+      throw new Error('Step not found')
     }
-  }
 
-  // Get arguments from the raw app registry (before getApp transforms them into substeps)
-  const rawApp = apps[step.appKey]
-  const rawTriggerOrAction = (
-    step.type === 'trigger'
-      ? rawApp?.triggers?.find((t) => t.key === step.key)
-      : rawApp?.actions?.find((a) => a.key === step.key)
-  ) as IRawAction | IRawTrigger | undefined
-
-  // Silently drop any keys not in this action/trigger's declared argument schema
-  const allowedKeys = new Set(
-    (rawTriggerOrAction?.arguments ?? []).map((f) => f.key),
-  )
-  const filteredParameters = Object.fromEntries(
-    Object.entries(parameters).filter(([k]) => allowedKeys.has(k)),
-  ) as IJSONObject
-
-  let patchedParameters = filteredParameters
-  let version = step.version
-
-  const transformer = apps[step.appKey]?.stepTransformer
-  if (transformer) {
-    patchedParameters = transformer.transformStepParameters(
+    // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)
+    const triggerOrAction = await App.findTriggerOrActionByKey(
+      step.appKey,
       step.key,
-      filteredParameters,
-      version,
+    )
+
+    if (!triggerOrAction) {
+      throw new Error('No such trigger or action')
+    }
+
+    if (triggerOrAction.hiddenFromUser) {
+      throw new Error(
+        `${
+          step.type === 'trigger' ? 'Trigger' : 'Action'
+        } can only be updated by system`,
+      )
+    }
+
+    // Get arguments from the raw app registry (before getApp transforms them into substeps)
+    const rawApp = apps[step.appKey]
+    const rawTriggerOrAction = (
+      step.type === 'trigger'
+        ? rawApp?.triggers?.find((t) => t.key === step.key)
+        : rawApp?.actions?.find((a) => a.key === step.key)
+    ) as IRawAction | IRawTrigger | undefined
+
+    // Silently drop any keys not in this action/trigger's declared argument schema
+    const allowedKeys = new Set(
+      (rawTriggerOrAction?.arguments ?? []).map((f) => f.key),
+    )
+    const filteredParameters = Object.fromEntries(
+      Object.entries(parameters).filter(([k]) => allowedKeys.has(k)),
     ) as IJSONObject
-    version = transformer.getLatestStepVersion(step.key)
-  }
 
-  if (step.type === 'action') {
-    const action = triggerOrAction as IAction
-    action.validateStepParameters?.(patchedParameters)
-  }
+    let patchedParameters = filteredParameters
+    let version = step.version
 
-  // Merge so repeated tool calls (one param at a time) accumulate rather than overwrite.
-  const mergedParameters = {
-    ...(step.parameters ?? {}),
-    ...patchedParameters,
-  } as IJSONObject
+    const transformer = apps[step.appKey]?.stepTransformer
+    if (transformer) {
+      patchedParameters = transformer.transformStepParameters(
+        step.key,
+        filteredParameters,
+        version,
+      ) as IJSONObject
+      version = transformer.getLatestStepVersion(step.key)
+    }
 
-  return Step.query().patchAndFetchById(stepId, {
-    parameters: mergedParameters,
-    version,
-    status: 'incomplete',
+    // Merge so repeated tool calls (one param at a time) accumulate rather than overwrite.
+    const mergedParameters = {
+      ...(step.parameters ?? {}),
+      ...patchedParameters,
+    } as IJSONObject
+
+    if (step.type === 'action') {
+      const action = triggerOrAction as IAction
+      action.validateStepParameters?.(mergedParameters)
+    }
+
+    return Step.query(trx).patchAndFetchById(stepId, {
+      parameters: mergedParameters,
+      version,
+      status: 'incomplete',
+    })
   })
 }

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -1,0 +1,93 @@
+import type {
+  IAction,
+  IJSONObject,
+  IRawAction,
+  IRawTrigger,
+} from '@plumber/types'
+
+import apps from '@/apps'
+import App from '@/models/app'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface UpdateStepParametersInput {
+  user: User
+  pipeId: string
+  stepId: string
+  parameters: Record<string, unknown>
+}
+
+export async function updateStepParametersService({
+  user,
+  pipeId,
+  stepId,
+  parameters,
+}: UpdateStepParametersInput): Promise<Step> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'editor' })
+    .findOne({
+      'steps.id': stepId,
+      'steps.flow_id': pipeId,
+    })
+
+  if (!step) {
+    throw new Error('Step not found')
+  }
+
+  // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)
+  const triggerOrAction = await App.findTriggerOrActionByKey(
+    step.appKey,
+    step.key,
+  )
+
+  if (!triggerOrAction) {
+    throw new Error('No such trigger or action')
+  }
+
+  if (step.type === 'action') {
+    const action = triggerOrAction as IAction
+    if (action.hiddenFromUser) {
+      throw new Error('Action can only be updated by system')
+    }
+  }
+
+  // Get arguments from the raw app registry (before getApp transforms them into substeps)
+  const rawApp = apps[step.appKey]
+  const rawTriggerOrAction = (
+    step.type === 'trigger'
+      ? rawApp?.triggers?.find((t) => t.key === step.key)
+      : rawApp?.actions?.find((a) => a.key === step.key)
+  ) as IRawAction | IRawTrigger | undefined
+
+  // Silently drop any keys not in this action/trigger's declared argument schema
+  const allowedKeys = new Set(
+    (rawTriggerOrAction?.arguments ?? []).map((f) => f.key),
+  )
+  const filteredParameters = Object.fromEntries(
+    Object.entries(parameters).filter(([k]) => allowedKeys.has(k)),
+  ) as IJSONObject
+
+  let patchedParameters = filteredParameters
+  let version = step.version
+
+  const transformer = apps[step.appKey]?.stepTransformer
+  if (transformer) {
+    patchedParameters = transformer.transformStepParameters(
+      step.key,
+      filteredParameters,
+      version,
+    ) as IJSONObject
+    version = transformer.getLatestStepVersion(step.key)
+  }
+
+  if (step.type === 'action') {
+    const action = triggerOrAction as IAction
+    action.validateStepParameters?.(patchedParameters)
+  }
+
+  return Step.query().patchAndFetchById(stepId, {
+    parameters: patchedParameters,
+    version,
+    status: 'incomplete',
+  })
+}

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -24,16 +24,23 @@ export async function updateStepParametersService({
   parameters,
 }: UpdateStepParametersInput): Promise<Step> {
   return Step.transaction(async (trx) => {
-    const step = await user
+    const accessible = await user
       .withAccessibleSteps({ requiredRole: 'editor', trx })
-      .forUpdate()
       .findOne({
         'steps.id': stepId,
         'steps.flow_id': pipeId,
       })
 
-    if (!step) {
+    if (!accessible) {
       throw new Error('Step not found')
+    }
+
+    // Re-fetch with a row lock to serialise concurrent tool calls for the same
+    // step. forUpdate() cannot be used on the withAccessibleSteps query
+    // directly because it has a LEFT JOIN, which PostgreSQL prohibits locking.
+    const step = await Step.query(trx).forUpdate().findById(stepId)
+    if (!step) {
+      throw new Error('Step cannot be updated')
     }
 
     // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)


### PR DESCRIPTION
## Stack context

This is PR 4 in the MCP AI Builder tool-use stack:

1. **PR #1804** — `feat(types): add MCP bridge API types` — foundational TypeScript interfaces for the MCP Bridge API
2. **PR #1840** — `feat(backend): add MCP tool use to AI Builder chat` — wires MCP tools into the chat route
3. **PR #1841** — `feat(mcp): create Pipe` — adds the `create_pipe` tool and service
4. **PR #1843 (this PR)** — adds the `update_step_parameters` tool, which fills in step configuration after a pipe is created

## TL;DR

Adds the `update_step_parameters` MCP tool so the LLM can set parameter values on individual steps after calling `create_pipe`. The service silently drops any keys the LLM hallucinates that aren't in the step's declared field schema, and merges new values on top of existing parameters rather than overwriting, so the LLM can update one field at a time without clobbering others. A row-level lock ensures concurrent tool calls for the same step serialize correctly rather than silently discarding each other's writes.

## What changed?

**`packages/backend/src/services/mcp/update-step-parameters.ts`** (new, 99 lines)

- `updateStepParametersService({ user, pipeId, stepId, parameters })` runs inside a transaction; the permission check and the locked row-fetch are split: `withAccessibleSteps` confirms ownership (has a LEFT JOIN that PostgreSQL prohibits locking), then `findById(stepId).forUpdate()` acquires the row lock so two concurrent tool calls for the same step serialize rather than racing on stale data.
- Fetches the step via `user.withAccessibleSteps({ requiredRole: 'editor' })` joining on both `steps.id` and `steps.flow_id` — a single failing lookup covers both "step not found" and "step belongs to a different pipe" cases.
- Validates the app/key combo exists via `App.findTriggerOrActionByKey` and rejects updates to any `hiddenFromUser` step (trigger or action).
- **Field filtering**: reads raw `arguments` from the app registry and silently drops any parameter keys not in that list — prevents LLM-hallucinated field names from persisting.
- Applies the app's `stepTransformer` (parameter normalisation + version migration) if one exists.
- **Merges** `patchedParameters` on top of `step.parameters` so repeated calls accumulate rather than overwrite — the LLM can set one field per call without losing previously saved values.
- Runs `action.validateStepParameters?.()` against the fully merged parameter set (not just the delta), so cross-field validation sees the eventual persisted state.
- Sets `status: 'incomplete'` after every update.

**`packages/backend/src/helpers/mcp-bridge-tools.ts`** (updated)

- Registers `update_step_parameters` as a third tool alongside `list_apps` and `create_pipe`.
- Input is snake_case (`pipe_id`, `step_id`, `parameters`); `pipe_id` and `step_id` are validated as UUIDs so a malformed ID returns a clean schema error rather than a raw Postgres syntax error.
- The execute handler maps snake_case to camelCase service args.
- Tool description tells the LLM: only declared field keys are kept; `appKey` and `key` are immutable after creation.

**Tests**

- `mcp-bridge-tools.test.ts` — mock for `updateStepParametersService`; asserts snake_case → camelCase mapping in the tool execute handler.
- `update-step-parameters.itest.ts` (new, 238 lines) — integration tests covering: field filtering drops hallucinated keys; status set to `'incomplete'`; cross-user access throws `'Step not found'`; mismatched `pipeId` throws `'Step not found'`; repeated calls merge parameters rather than overwrite.

## Tests

- [ ] In AI Builder chat, ask the LLM to create a pipe (e.g. FormSG → Postman email) and then fill in step parameters — verify both `create_pipe` and `update_step_parameters` tool calls appear in the chat and the step parameters are saved correctly in the pipe editor.
- [ ] Open the pipe editor after the LLM fills in a step and confirm the parameter values appear in the form fields.
- [ ] Ask the LLM to fill in only one parameter at a time across two separate messages — confirm the second call does not wipe out the first field (merge behaviour).
- [ ] Confirm that asking the LLM to use a field name that doesn't exist in the step schema results in it being silently dropped (check the saved step in the pipe editor has no unexpected keys).
- [ ] Verify that a user who does not own the pipe cannot update its steps — the service should throw `'Step not found'`.
- [ ] Regression: confirm `list_apps` and `create_pipe` tools still work normally.

## Deploy notes

No new environment variables or database migrations required. The service reads and writes to the existing `steps` table.