### PR TITLE
[AI-SETUP-6] PLU-812 feat(backend): delete Step

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -16,10 +16,14 @@ vi.mock('@/services/mcp/update-step-parameters', () => ({
 vi.mock('@/services/mcp/create-step', () => ({
   createStepService: vi.fn().mockResolvedValue({ id: 's2', appKey: 'slack' }),
 }))
+vi.mock('@/services/mcp/delete-step', () => ({
+  deleteStepService: vi.fn().mockResolvedValue({ id: 'f1', steps: [] }),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import { deleteStepService } from '@/services/mcp/delete-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
@@ -35,6 +39,7 @@ describe('createMcpBridgeTools', () => {
       'create_pipe',
       'update_step_parameters',
       'create_step',
+      'delete_step',
     ])
   })
 
@@ -87,6 +92,19 @@ describe('createMcpBridgeTools', () => {
       appKey: 'slack',
       key: 'sendMessageToChannel',
       previousStepId: 'step-0',
+    })
+  })
+
+  it('delete_step calls deleteStepService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.delete_step.execute(
+      { pipe_id: 'flow-1', step_id: 'step-1' },
+      { toolCallId: 'delete_step', messages: [] },
+    )
+    expect(vi.mocked(deleteStepService)).toHaveBeenCalledWith({
+      user: mockUser,
+      pipeId: 'flow-1',
+      stepId: 'step-1',
     })
   })
 

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -96,7 +96,7 @@ describe('createMcpBridgeTools', () => {
   })
 
   it('delete_step calls deleteStepService with camelCase args', async () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.delete_step.execute(
       { pipe_id: 'flow-1', step_id: 'step-1' },
       { toolCallId: 'delete_step', messages: [] },

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -12,6 +12,7 @@ import {
   type McpStepInput,
 } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
+import { deleteStepService } from '@/services/mcp/delete-step'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
@@ -126,6 +127,22 @@ export function createMcpBridgeTools(user: User, traceId: string) {
           appKey: app_key,
           key: action_key,
           previousStepId: previous_step_id,
+        })
+      },
+    }),
+
+    delete_step: tool({
+      description:
+        'Delete a single step from a pipe. Deleting a trigger replaces it with an empty trigger slot; deleting an action removes it and repositions the remaining steps. Steps that reference the deleted step are marked incomplete. Returns the updated pipe with all remaining steps.',
+      inputSchema: z.object({
+        pipe_id: z.string().describe('ID of the pipe that contains the step'),
+        step_id: z.string().describe('ID of the step to delete'),
+      }),
+      execute: async ({ pipe_id, step_id }): Promise<Flow> => {
+        return deleteStepService({
+          user,
+          pipeId: pipe_id,
+          stepId: step_id,
         })
       },
     }),

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -135,8 +135,8 @@ export function createMcpBridgeTools(user: User, traceId: string) {
       description:
         'Delete a single step from a pipe. Deleting a trigger replaces it with an empty trigger slot; deleting an action removes it and repositions the remaining steps. Steps that reference the deleted step are marked incomplete. Returns the updated pipe with all remaining steps.',
       inputSchema: z.object({
-        pipe_id: z.string().describe('ID of the pipe that contains the step'),
-        step_id: z.string().describe('ID of the step to delete'),
+        pipe_id: z.uuid().describe('ID of the pipe that contains the step'),
+        step_id: z.uuid().describe('ID of the step to delete'),
       }),
       execute: async ({ pipe_id, step_id }): Promise<Flow> => {
         return deleteStepService({

--- a/packages/backend/src/services/mcp/__tests__/delete-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/delete-step.itest.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { deleteStepService } from '../delete-step'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('deleteStepService', () => {
+  beforeEach(() => {
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('deletes an action step and repositions remaining steps', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `delete-step-reposition-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Reposition Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+        {
+          appKey: 'slack',
+          key: 'sendMessageToChannel',
+          type: 'action',
+          position: 3,
+        },
+      ],
+      traceId: 'trace-delete-1',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find(
+      (s) => s.type === 'action' && s.appKey === 'postman',
+    )
+    expect(actionStep).toBeDefined()
+
+    const result = await deleteStepService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+    })
+
+    expect(result.steps).toHaveLength(2)
+    const positions = result.steps.map((s) => s.position).sort((a, b) => a - b)
+    expect(positions).toEqual([1, 2])
+  })
+
+  it('deletes a trigger and replaces it with an empty trigger', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `delete-step-trigger-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Trigger Delete Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-2',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const triggerStep = loadedFlow.steps.find((s) => s.type === 'trigger')
+    expect(triggerStep).toBeDefined()
+
+    const result = await deleteStepService({
+      user,
+      pipeId: flow.id,
+      stepId: triggerStep.id,
+    })
+
+    expect(result.steps).toHaveLength(2)
+    const newTrigger = result.steps.find((s) => s.type === 'trigger')
+    expect(newTrigger).toBeDefined()
+    expect(newTrigger.appKey).toBeNull()
+    expect(newTrigger.key).toBeNull()
+    expect(newTrigger.id).not.toBe(triggerStep.id)
+  })
+
+  it('throws if the step does not belong to the requesting user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-delete-step-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-delete-step-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-3',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find((s) => s.type === 'action')
+
+    await expect(
+      deleteStepService({
+        user: intruder,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+
+  it('throws if the stepId does not belong to the given pipeId', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `mismatch-delete-step-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Mismatch Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-delete-4',
+    })
+
+    const loadedFlow = await flow.$fetchGraph('steps')
+    const actionStep = loadedFlow.steps.find((s) => s.type === 'action')
+
+    await expect(
+      deleteStepService({
+        user,
+        pipeId: randomUUID(), // wrong pipe ID
+        stepId: actionStep.id,
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+})

--- a/packages/backend/src/services/mcp/delete-step.ts
+++ b/packages/backend/src/services/mcp/delete-step.ts
@@ -1,0 +1,107 @@
+import { raw } from 'objection'
+
+import { removeMrfSteps } from '@/apps/formsg/triggers/new-submission/remove-mrf-steps'
+import { hasStepReference } from '@/helpers/check-step-parameters'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface DeleteStepInput {
+  user: User
+  pipeId: string
+  stepId: string
+}
+
+export async function deleteStepService({
+  user,
+  pipeId,
+  stepId,
+}: DeleteStepInput): Promise<Flow> {
+  return Step.transaction(async (trx) => {
+    await trx.raw('SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;')
+
+    const step = await user
+      .withAccessibleSteps({ requiredRole: 'editor', trx })
+      .withGraphFetched('flow')
+      .findOne({ 'steps.id': stepId, 'steps.flow_id': pipeId })
+
+    if (!step) {
+      throw new Error('Step not found')
+    }
+
+    const flow = step.flow
+
+    if (step.type === 'trigger') {
+      if (step.appKey === 'formsg' && step.key === 'newSubmission') {
+        await removeMrfSteps(flow.id, trx)
+      }
+
+      const allSteps = await flow
+        .$relatedQuery('steps', trx)
+        .where('id', '!=', stepId)
+        .orderBy('position', 'asc')
+
+      const stepsToInvalidate = getStepsToInvalidate(
+        allSteps,
+        new Set([stepId]),
+      )
+      await Step.query(trx)
+        .findByIds(stepsToInvalidate)
+        .patch({ status: 'incomplete' })
+
+      await step.$query(trx).delete()
+      await flow.$relatedQuery('steps', trx).insert({
+        key: null,
+        appKey: null,
+        type: 'trigger',
+        position: 1,
+        parameters: {},
+        connectionId: null,
+      })
+    } else {
+      const allSteps = await flow
+        .$relatedQuery('steps', trx)
+        .where('id', '!=', stepId)
+        .orderBy('position', 'asc')
+
+      const stepsToInvalidate = getStepsToInvalidate(
+        allSteps,
+        new Set([stepId]),
+      )
+      await Step.query(trx)
+        .findByIds(stepsToInvalidate)
+        .patch({ status: 'incomplete' })
+
+      await Step.query(trx).findById(stepId).delete()
+
+      await flow
+        .$relatedQuery('steps', trx)
+        .where('position', '>', step.position)
+        .patch({ position: raw('position - 1') })
+    }
+
+    await flow.patchLastUpdated({
+      flowId: flow.id,
+      updatedBy: user.id,
+      trx,
+    })
+
+    return flow
+      .$query(trx)
+      .withGraphJoined('steps')
+      .orderBy('steps.position', 'asc')
+  })
+}
+
+function getStepsToInvalidate(
+  steps: Step[],
+  deletedIds: Set<string>,
+): string[] {
+  const stepsToInvalidate = []
+  for (const s of steps) {
+    if (hasStepReference(s.parameters, deletedIds)) {
+      stepsToInvalidate.push(s.id)
+    }
+  }
+  return stepsToInvalidate
+}


### PR DESCRIPTION
## TL;DR

Adds the `delete_step` MCP tool. Trigger deletion is special-cased: the old trigger is removed and an empty trigger slot is inserted in its place (preserving the pipe's trigger-at-position-1 invariant). Action deletion removes the step and shifts subsequent steps down. Both paths scan remaining steps for variable references to the deleted step and mark those steps `'incomplete'`.

## What changed?

**`packages/backend/src/services/mcp/delete-step.ts`** (new, 107 lines)

- `deleteStepService({ user, pipeId, stepId })` runs in a **SERIALIZABLE** transaction, fetching the step via `user.withAccessibleSteps({ requiredRole: 'editor', trx })` joined on both `steps.id` and `steps.flow_id` (throws `'Step not found'` for missing, cross-user, or cross-pipe access).
- **Trigger path**: calls `removeMrfSteps` if the trigger is FormSG `newSubmission` (cleans up linked MRF steps), scans remaining steps for references via `hasStepReference()` and marks them `'incomplete'`, deletes the trigger, then inserts a fresh empty trigger slot (`appKey: null`, `key: null`, `position: 1`).
- **Action path**: scans and invalidates referencing steps, deletes the action, and shifts all steps at `position > deleted.position` down by 1 with `raw('position - 1')`.
- Calls `flow.patchLastUpdated()` and returns the full pipe with remaining steps ordered by position.

**`packages/backend/src/helpers/mcp-bridge-tools.ts`** (updated)

- Registers `delete_step` as a fifth tool.
- Tool description explains trigger vs action behaviour and that steps referencing the deleted step are marked incomplete.
- Input: `pipe_id`, `step_id` (UUID-validated, snake_case); maps to camelCase service args.

**Tests**

- `mcp-bridge-tools.test.ts` — mock for `deleteStepService`; asserts snake_case → camelCase mapping.
- `delete-step.itest.ts` (new, 197 lines) — integration tests covering: action deletion repositions remaining steps to contiguous positions; trigger deletion replaces the old trigger with an empty slot (new ID, null `appKey`/`key`); cross-user access throws `'Step not found'`; mismatched `pipeId` throws `'Step not found'`.

## Tests

- [ ] In AI Builder chat, ask the LLM to delete an action step from an existing pipe — verify the step is removed and the remaining steps renumber correctly in the pipe editor.
- [ ] Ask the LLM to delete the trigger step — verify it is replaced by an empty trigger slot (not a blank pipe).
- [ ] Confirm that steps whose parameters referenced the deleted step are shown as incomplete in the pipe editor.
- [ ] Confirm FormSG `newSubmission` trigger deletion also removes any associated MRF steps.
- [ ] Regression: confirm `create_pipe`, `create_step`, and `update_step_parameters` still work normally.
- [ ] Confirm a user who does not own the pipe cannot delete its steps.

## Deploy notes

No new environment variables or database migrations required. Uses the existing `steps` table; position shifts are plain `UPDATE steps SET position = position - 1 WHERE position > ?` within the same transaction.