### PR TITLE
[AI-SETUP-7] feat(backend): get dynamic data

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -116,7 +116,7 @@ describe('createMcpBridgeTools', () => {
   })
 
   it('get_dynamic_data calls getDynamicDataService with camelCase args', async () => {
-    const tools = createMcpBridgeTools(mockUser)
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
     await tools.get_dynamic_data.execute(
       {
         step_id: 'step-1',

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -19,11 +19,17 @@ vi.mock('@/services/mcp/create-step', () => ({
 vi.mock('@/services/mcp/delete-step', () => ({
   deleteStepService: vi.fn().mockResolvedValue({ id: 'f1', steps: [] }),
 }))
+vi.mock('@/services/mcp/get-dynamic-data', () => ({
+  getDynamicDataService: vi
+    .fn()
+    .mockResolvedValue([{ name: 'Channel', value: 'C123' }]),
+}))
 
 import { listAppsService } from '@/services/mcp/apps'
 import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
+import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 import { createMcpBridgeTools } from '../mcp-bridge-tools'
@@ -40,6 +46,7 @@ describe('createMcpBridgeTools', () => {
       'update_step_parameters',
       'create_step',
       'delete_step',
+      'get_dynamic_data',
     ])
   })
 
@@ -105,6 +112,24 @@ describe('createMcpBridgeTools', () => {
       user: mockUser,
       pipeId: 'flow-1',
       stepId: 'step-1',
+    })
+  })
+
+  it('get_dynamic_data calls getDynamicDataService with camelCase args', async () => {
+    const tools = createMcpBridgeTools(mockUser)
+    await tools.get_dynamic_data.execute(
+      {
+        step_id: 'step-1',
+        key: 'listChannels',
+        parameters: { tableId: 'xyz' },
+      },
+      { toolCallId: 'get_dynamic_data', messages: [] },
+    )
+    expect(vi.mocked(getDynamicDataService)).toHaveBeenCalledWith({
+      user: mockUser,
+      stepId: 'step-1',
+      key: 'listChannels',
+      parameters: { tableId: 'xyz' },
     })
   })
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -1,4 +1,4 @@
-import type { IApp, IMcpApp } from '@plumber/types'
+import type { IApp, IJSONObject, IMcpApp } from '@plumber/types'
 
 import { tool } from 'ai'
 import { z } from 'zod/v4'
@@ -152,7 +152,9 @@ export function createMcpBridgeTools(user: User, traceId: string) {
       description:
         'Fetch live options for a dynamic dropdown field on a configured step (e.g. list channels, list tables, list files). Requires the step to have a verified connection. For cascading selections (e.g. list columns for a chosen table), pass the dependency value in parameters.',
       inputSchema: z.object({
-        step_id: z.string().describe('ID of the step whose dynamic data to fetch'),
+        step_id: z
+          .string()
+          .describe('ID of the step whose dynamic data to fetch'),
         key: z
           .string()
           .describe(
@@ -174,7 +176,7 @@ export function createMcpBridgeTools(user: User, traceId: string) {
           user,
           stepId: step_id,
           key,
-          parameters,
+          parameters: parameters as IJSONObject | undefined,
         })
       },
     }),

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -150,7 +150,7 @@ export function createMcpBridgeTools(user: User, traceId: string) {
 
     get_dynamic_data: tool({
       description:
-        'Fetch live options for a dynamic dropdown field on a configured step (e.g. list channels, list tables, list files). Requires the step to have a verified connection. For cascading selections (e.g. list columns for a chosen table), pass the dependency value in parameters.',
+        'Fetch live options for a dynamic dropdown field on a configured step (e.g. list channels, list tables, list files). Requires the step to have a connection set up. For cascading selections (e.g. list columns for a chosen table), pass the dependency value in parameters.',
       inputSchema: z.object({
         step_id: z
           .string()

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -13,6 +13,7 @@ import {
 } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
+import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
@@ -143,6 +144,37 @@ export function createMcpBridgeTools(user: User, traceId: string) {
           user,
           pipeId: pipe_id,
           stepId: step_id,
+        })
+      },
+    }),
+
+    get_dynamic_data: tool({
+      description:
+        'Fetch live options for a dynamic dropdown field on a configured step (e.g. list channels, list tables, list files). Requires the step to have a verified connection. For cascading selections (e.g. list columns for a chosen table), pass the dependency value in parameters.',
+      inputSchema: z.object({
+        step_id: z.string().describe('ID of the step whose dynamic data to fetch'),
+        key: z
+          .string()
+          .describe(
+            'Dynamic data key declared by the app (e.g. "listChannels", "listTables"). Check isDynamic fields from list_apps to find valid keys.',
+          ),
+        parameters: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe(
+            'Optional parameter overrides for cascading selections (e.g. { "tableId": "..." } to list columns for a specific table).',
+          ),
+      }),
+      execute: async ({
+        step_id,
+        key,
+        parameters,
+      }): Promise<Array<{ name: string; value: string }>> => {
+        return getDynamicDataService({
+          user,
+          stepId: step_id,
+          key,
+          parameters,
         })
       },
     }),

--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -52,6 +52,16 @@ vi.mock('@/apps', () => ({
               type: 'string',
               required: true,
             },
+            {
+              key: 'noKeySource',
+              label: 'No Key Source',
+              type: 'dropdown',
+              source: {
+                type: 'query',
+                name: 'getDynamicData',
+                arguments: [{ name: 'notKey', value: 'something' }],
+              },
+            },
           ],
         },
       ],
@@ -227,6 +237,16 @@ describe('listAppsService', () => {
       )
       expect(channelField?.isDynamic).toBeUndefined()
       expect(channelField?.dynamicDataKey).toBeUndefined()
+    })
+
+    it('does not set isDynamic when source has arguments but no key argument', async () => {
+      const apps = await listAppsService(user)
+      const slack = apps.find((a) => a.key === 'slack')
+      const field = slack?.actions[0].fields.find(
+        (f) => f.key === 'noKeySource',
+      )
+      expect(field?.isDynamic).toBeUndefined()
+      expect(field?.dynamicDataKey).toBeUndefined()
     })
   })
 

--- a/packages/backend/src/services/mcp/__tests__/apps.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/apps.test.ts
@@ -56,6 +56,62 @@ vi.mock('@/apps', () => ({
         },
       ],
     },
+    tiles: {
+      key: 'tiles',
+      name: 'Tiles',
+      triggers: [],
+      actions: [
+        {
+          key: 'updateSingleRow',
+          name: 'Update Single Row',
+          description: 'Updates a row in a tile',
+          arguments: [
+            {
+              key: 'tableId',
+              label: 'Select Tile',
+              type: 'dropdown',
+              required: true,
+              source: {
+                type: 'query',
+                name: 'getDynamicData',
+                arguments: [{ name: 'key', value: 'listTables' }],
+              },
+            },
+            {
+              key: 'rowData',
+              label: 'Row data',
+              type: 'multirow-multicol',
+              required: true,
+              subFields: [
+                {
+                  key: 'columnId',
+                  label: 'Column',
+                  type: 'dropdown',
+                  required: true,
+                  source: {
+                    type: 'query',
+                    name: 'getDynamicData',
+                    arguments: [
+                      { name: 'key', value: 'listColumns' },
+                      {
+                        name: 'parameters.tableId',
+                        value: '{parameters.tableId}',
+                      },
+                    ],
+                  },
+                },
+                {
+                  key: 'value',
+                  label: 'Value',
+                  type: 'string',
+                  required: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
     toolbox: {
       key: 'toolbox',
       name: 'Toolbox',
@@ -92,8 +148,8 @@ describe('listAppsService', () => {
 
   it('returns visible apps with triggers and actions', async () => {
     const apps = await listAppsService(user)
-    // toolbox excluded by default; formsg + slack returned
-    expect(apps).toHaveLength(2)
+    // toolbox excluded by default; formsg + slack + tiles returned
+    expect(apps).toHaveLength(3)
     const formsg = apps.find((a) => a.key === 'formsg')
     expect(formsg?.triggers).toHaveLength(1)
     expect(formsg?.actions).toHaveLength(0)
@@ -116,8 +172,62 @@ describe('listAppsService', () => {
     const channelField = slack?.actions[0].fields.find(
       (f) => f.key === 'channel',
     )
-    // dynamic source dropdown — options should be omitted
+    // source with no arguments — not a getDynamicData source, no isDynamic
     expect(channelField?.options).toBeUndefined()
+    expect(channelField?.isDynamic).toBeUndefined()
+  })
+
+  describe('dynamic dropdown fields', () => {
+    it('exposes dynamicDataKey for a dropdown with getDynamicData source (no cascading deps)', async () => {
+      const apps = await listAppsService(user)
+      const tiles = apps.find((a) => a.key === 'tiles')
+      const tableIdField = tiles?.actions[0].fields.find(
+        (f) => f.key === 'tableId',
+      )
+      expect(tableIdField?.isDynamic).toBe(true)
+      expect(tableIdField?.dynamicDataKey).toBe('listTables')
+      expect(tableIdField?.dynamicDataParameters).toBeUndefined()
+      expect(tableIdField?.options).toBeUndefined()
+    })
+
+    it('exposes dynamicDataKey and dynamicDataParameters for a cascading dropdown', async () => {
+      const apps = await listAppsService(user)
+      const tiles = apps.find((a) => a.key === 'tiles')
+      const rowDataField = tiles?.actions[0].fields.find(
+        (f) => f.key === 'rowData',
+      )
+      const columnIdField = rowDataField?.subFields?.find(
+        (f) => f.key === 'columnId',
+      )
+      expect(columnIdField?.isDynamic).toBe(true)
+      expect(columnIdField?.dynamicDataKey).toBe('listColumns')
+      expect(columnIdField?.dynamicDataParameters).toEqual({
+        tableId: '{parameters.tableId}',
+      })
+      expect(columnIdField?.options).toBeUndefined()
+    })
+
+    it('serializes subFields on compound fields', async () => {
+      const apps = await listAppsService(user)
+      const tiles = apps.find((a) => a.key === 'tiles')
+      const rowDataField = tiles?.actions[0].fields.find(
+        (f) => f.key === 'rowData',
+      )
+      expect(rowDataField?.subFields).toHaveLength(2)
+      const valueField = rowDataField?.subFields?.find((f) => f.key === 'value')
+      expect(valueField?.type).toBe('string')
+      expect(valueField?.isDynamic).toBeUndefined()
+    })
+
+    it('leaves source-less dynamic dropdown without isDynamic (no source.arguments)', async () => {
+      const apps = await listAppsService(user)
+      const slack = apps.find((a) => a.key === 'slack')
+      const channelField = slack?.actions[0].fields.find(
+        (f) => f.key === 'channel',
+      )
+      expect(channelField?.isDynamic).toBeUndefined()
+      expect(channelField?.dynamicDataKey).toBeUndefined()
+    })
   })
 
   it('includes required flag on fields', async () => {

--- a/packages/backend/src/services/mcp/__tests__/get-dynamic-data.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/get-dynamic-data.itest.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+
+import { getDynamicDataService } from '../get-dynamic-data'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+  runDynamicData: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+// Extend real apps registry with a test app that has local dynamic data —
+// no HTTP calls, no external dependencies.
+vi.mock('@/apps', async (importOriginal) => {
+  const real = await importOriginal<typeof import('@/apps')>()
+  return {
+    default: {
+      ...(real as any).default,
+      'test-dynamic': {
+        key: 'test-dynamic',
+        name: 'Test Dynamic App',
+        auth: null,
+        triggers: [],
+        actions: [],
+        dynamicData: [
+          {
+            name: 'List Things',
+            key: 'listThings',
+            run: mocks.runDynamicData,
+          },
+        ],
+      },
+    },
+  }
+})
+
+describe('getDynamicDataService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+    mocks.runDynamicData.mockResolvedValue({
+      data: [{ name: 'Thing One', value: 'thing-1' }],
+    })
+  })
+
+  async function setupFlowAndStep(userId: string) {
+    const flow = await Flow.query().insertAndFetch({
+      id: randomUUID(),
+      userId,
+      name: 'Test Dynamic Flow',
+      active: false,
+    })
+    // Insert a placeholder trigger so the flow has a valid trigger at position 1
+    await Step.query().insertAndFetch({
+      id: randomUUID(),
+      flowId: flow.id,
+      appKey: null,
+      key: null,
+      type: 'trigger',
+      position: 1,
+      parameters: {},
+      status: 'incomplete',
+    })
+    // The step we actually test dynamic data on is an action (avoids
+    // getTriggerCommand() in globalVariable, which accesses apps[appKey].triggers)
+    const step = await Step.query().insertAndFetch({
+      id: randomUUID(),
+      flowId: flow.id,
+      appKey: 'test-dynamic',
+      key: 'testAction',
+      type: 'action',
+      position: 2,
+      parameters: { existingParam: 'existing-value' },
+      status: 'incomplete',
+    })
+    return { flow, step }
+  }
+
+  it('returns dynamic data for a valid step and key', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-basic-${randomUUID()}@example.com`,
+    })
+    const { step } = await setupFlowAndStep(user.id)
+
+    const result = await getDynamicDataService({
+      user,
+      stepId: step.id,
+      key: 'listThings',
+    })
+
+    expect(result).toEqual([{ name: 'Thing One', value: 'thing-1' }])
+    expect(mocks.runDynamicData).toHaveBeenCalledOnce()
+  })
+
+  it('merges parameters overrides into $.step.parameters before calling run()', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-params-${randomUUID()}@example.com`,
+    })
+    const { step } = await setupFlowAndStep(user.id)
+
+    await getDynamicDataService({
+      user,
+      stepId: step.id,
+      key: 'listThings',
+      parameters: { tableId: 'xyz', existingParam: 'overridden' },
+    })
+
+    const receivedGlobal = mocks.runDynamicData.mock.calls[0][0]
+    expect(receivedGlobal.step.parameters.tableId).toBe('xyz')
+    expect(receivedGlobal.step.parameters.existingParam).toBe('overridden')
+  })
+
+  it('throws if the dynamic data key does not exist on the app', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-bad-key-${randomUUID()}@example.com`,
+    })
+    const { step } = await setupFlowAndStep(user.id)
+
+    await expect(
+      getDynamicDataService({
+        user,
+        stepId: step.id,
+        key: 'nonExistentKey',
+      }),
+    ).rejects.toThrow(
+      "Dynamic data key 'nonExistentKey' not found for app 'test-dynamic'",
+    )
+  })
+
+  it('throws if the user does not have access to the step', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-owner-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-intruder-${randomUUID()}@example.com`,
+    })
+    const { step } = await setupFlowAndStep(owner.id)
+
+    await expect(
+      getDynamicDataService({
+        user: intruder,
+        stepId: step.id,
+        key: 'listThings',
+      }),
+    ).rejects.toThrow('Step not found')
+  })
+})

--- a/packages/backend/src/services/mcp/__tests__/get-dynamic-data.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/get-dynamic-data.itest.ts
@@ -28,7 +28,7 @@ vi.mock('@/apps', async (importOriginal) => {
       'test-dynamic': {
         key: 'test-dynamic',
         name: 'Test Dynamic App',
-        auth: null,
+        auth: undefined,
         triggers: [],
         actions: [],
         dynamicData: [
@@ -138,6 +138,26 @@ describe('getDynamicDataService', () => {
     ).rejects.toThrow(
       "Dynamic data key 'nonExistentKey' not found for app 'test-dynamic'",
     )
+  })
+
+  it('throws if the dynamic data handler returns an error', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `get-dynamic-data-error-${randomUUID()}@example.com`,
+    })
+    const { step } = await setupFlowAndStep(user.id)
+    mocks.runDynamicData.mockResolvedValue({
+      data: [],
+      error: { message: 'upstream failure' },
+    })
+
+    await expect(
+      getDynamicDataService({
+        user,
+        stepId: step.id,
+        key: 'listThings',
+      }),
+    ).rejects.toThrow('upstream failure')
   })
 
   it('throws if the user does not have access to the step', async () => {

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -42,18 +42,18 @@ function serializeField(
       value: String(o.value),
     }))
   } else if (field.type === 'dropdown' && source?.arguments?.length) {
-    base.isDynamic = true
     const keyArg = source.arguments.find((a) => a.name === 'key')
     if (keyArg) {
+      base.isDynamic = true
       base.dynamicDataKey = keyArg.value
-    }
-    const paramArgs = source.arguments.filter((a) =>
-      a.name.startsWith('parameters.'),
-    )
-    if (paramArgs.length > 0) {
-      base.dynamicDataParameters = Object.fromEntries(
-        paramArgs.map((a) => [a.name.slice('parameters.'.length), a.value]),
+      const paramArgs = source.arguments.filter((a) =>
+        a.name.startsWith('parameters.'),
       )
+      if (paramArgs.length > 0) {
+        base.dynamicDataParameters = Object.fromEntries(
+          paramArgs.map((a) => [a.name.slice('parameters.'.length), a.value]),
+        )
+      }
     }
   }
 

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -21,15 +21,46 @@ function serializeField(
     description: (field as any).description,
     required: (field as any).required ?? false,
   }
+
   const options = (field as any).options as
     | Array<{ label: string; value: unknown }>
     | undefined
-  if (field.type === 'dropdown' && options?.length && !(field as any).source) {
+  const source = (field as any).source as
+    | {
+        type: string
+        name: string
+        arguments?: Array<{ name: string; value: string }>
+      }
+    | undefined
+  const subFields = (field as any).subFields as
+    | NonNullable<IRawTrigger['arguments']>
+    | undefined
+
+  if (field.type === 'dropdown' && options?.length && !source) {
     base.options = options.map((o) => ({
       label: o.label,
       value: String(o.value),
     }))
+  } else if (field.type === 'dropdown' && source?.arguments?.length) {
+    base.isDynamic = true
+    const keyArg = source.arguments.find((a) => a.name === 'key')
+    if (keyArg) {
+      base.dynamicDataKey = keyArg.value
+    }
+    const paramArgs = source.arguments.filter((a) =>
+      a.name.startsWith('parameters.'),
+    )
+    if (paramArgs.length > 0) {
+      base.dynamicDataParameters = Object.fromEntries(
+        paramArgs.map((a) => [a.name.slice('parameters.'.length), a.value]),
+      )
+    }
   }
+
+  if (subFields?.length) {
+    base.subFields = subFields.map(serializeField)
+  }
+
   return base
 }
 

--- a/packages/backend/src/services/mcp/apps.ts
+++ b/packages/backend/src/services/mcp/apps.ts
@@ -18,47 +18,38 @@ function serializeField(
     key: field.key,
     label: field.label,
     type: field.type,
-    description: (field as any).description,
-    required: (field as any).required ?? false,
+    description: field.description,
+    required: field.required ?? false,
   }
 
-  const options = (field as any).options as
-    | Array<{ label: string; value: unknown }>
-    | undefined
-  const source = (field as any).source as
-    | {
-        type: string
-        name: string
-        arguments?: Array<{ name: string; value: string }>
-      }
-    | undefined
-  const subFields = (field as any).subFields as
-    | NonNullable<IRawTrigger['arguments']>
-    | undefined
-
-  if (field.type === 'dropdown' && options?.length && !source) {
-    base.options = options.map((o) => ({
-      label: o.label,
-      value: String(o.value),
-    }))
-  } else if (field.type === 'dropdown' && source?.arguments?.length) {
-    const keyArg = source.arguments.find((a) => a.name === 'key')
-    if (keyArg) {
-      base.isDynamic = true
-      base.dynamicDataKey = keyArg.value
-      const paramArgs = source.arguments.filter((a) =>
-        a.name.startsWith('parameters.'),
-      )
-      if (paramArgs.length > 0) {
-        base.dynamicDataParameters = Object.fromEntries(
-          paramArgs.map((a) => [a.name.slice('parameters.'.length), a.value]),
+  if (field.type === 'dropdown') {
+    if (field.options?.length && !field.source) {
+      base.options = field.options.map((o) => ({
+        label: o.label,
+        value: String(o.value),
+      }))
+    } else if (field.source?.arguments?.length) {
+      const keyArg = field.source.arguments.find((a) => a.name === 'key')
+      if (keyArg) {
+        base.isDynamic = true
+        base.dynamicDataKey = keyArg.value
+        const paramArgs = field.source.arguments.filter((a) =>
+          a.name.startsWith('parameters.'),
         )
+        if (paramArgs.length > 0) {
+          base.dynamicDataParameters = Object.fromEntries(
+            paramArgs.map((a) => [a.name.slice('parameters.'.length), a.value]),
+          )
+        }
       }
     }
   }
 
-  if (subFields?.length) {
-    base.subFields = subFields.map(serializeField)
+  if (
+    (field.type === 'multirow' || field.type === 'multirow-multicol') &&
+    field.subFields.length
+  ) {
+    base.subFields = field.subFields.map(serializeField)
   }
 
   return base

--- a/packages/backend/src/services/mcp/get-dynamic-data.ts
+++ b/packages/backend/src/services/mcp/get-dynamic-data.ts
@@ -1,0 +1,130 @@
+import type { IDynamicData, IJSONObject } from '@plumber/types'
+
+import apps from '@/apps'
+import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
+import globalVariable from '@/helpers/global-variable'
+import type User from '@/models/user'
+
+export interface GetDynamicDataInput {
+  user: User
+  stepId: string
+  key: string
+  parameters?: IJSONObject
+}
+
+// TODO: Consider extracting shared logic with the getDynamicData GraphQL resolver
+// (src/graphql/queries/get-dynamic-data.ts) into a shared helper when Phase 2
+// editor role support is added.
+export async function getDynamicDataService({
+  user,
+  stepId,
+  key,
+  parameters,
+}: GetDynamicDataInput): Promise<Array<{ name: string; value: string }>> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'viewer' })
+    .withGraphFetched({
+      connection: true,
+      flow: {
+        user: true,
+      },
+    })
+    .findById(stepId)
+
+  if (!step || !step.appKey) {
+    throw new Error('Step not found')
+  }
+
+  const app = apps[step.appKey]
+  const connection = step.connection
+
+  if (app.auth && !connection) {
+    throw new Error('Step has no verified connection')
+  }
+
+  // Phase 1: caller is always the pipe owner; role substitution is never needed.
+  // Phase 2 (editor role support): enable the commented logic so that viewers and
+  // editors of editorReadOnly apps use the flow owner's credentials for run().
+  // TODO: enable when Phase 2 editor support is added.
+  const shouldUseOwnerUser = false
+  // const shouldUseOwnerUser =
+  //   step.flow.role === 'viewer' ||
+  //   APP_CONNECTION_FIELDS[step.appKey]?.editorReadOnly
+
+  const command = app.dynamicData?.find((data) => data.key === key) as
+    | IDynamicData
+    | undefined
+
+  if (!command) {
+    throw new Error(
+      `Dynamic data key '${key}' not found for app '${step.appKey}'`,
+    )
+  }
+
+  const $ = await globalVariable({
+    connection: connection ?? undefined,
+    app,
+    flow: step.flow,
+    step,
+    user: shouldUseOwnerUser ? step.flow.user : user,
+  })
+
+  if (parameters) {
+    for (const [paramKey, paramValue] of Object.entries(parameters)) {
+      $.step.parameters[paramKey] = paramValue
+    }
+  }
+
+  const fetchedData = await command.run($)
+
+  // NOTE: APP_CONNECTION_FIELDS filtering is applied here for Phase 2 readiness.
+  // In Phase 1 (pipe owner only), step.flow.role is always 'owner' so this block
+  // is always skipped. When Phase 2 editor support is added, this becomes meaningful.
+  if (
+    step.flow.role !== 'owner' &&
+    APP_CONNECTION_FIELDS[step.appKey] &&
+    APP_CONNECTION_FIELDS[step.appKey]?.dynamicDataKey === key
+  ) {
+    switch (step.appKey) {
+      case 'tiles': {
+        if (step.flow.role === 'viewer') {
+          const flowConnections = await user
+            .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+            .where({
+              connection_type: 'table',
+              'flow_connections.flow_id': step.flowId,
+            })
+          return fetchedData.data.filter((data) =>
+            flowConnections.some((fc) => fc.connectionId === data.value),
+          )
+        }
+        return fetchedData.data
+      }
+
+      default: {
+        const flowConnections = await user
+          .withAccessibleFlowConnections({ requiredRole: 'viewer' })
+          .where({
+            connection_id: step.connectionId,
+            'flow_connections.flow_id': step.flowId,
+          })
+        const allowedValues = flowConnections
+          .map(
+            (fc) =>
+              fc.metadata[APP_CONNECTION_FIELDS[step.appKey].parameterKey],
+          )
+          .filter((v) => v !== undefined)
+          .flat()
+        return fetchedData.data.filter((data) =>
+          allowedValues.includes(data.value),
+        )
+      }
+    }
+  }
+
+  if (fetchedData.error) {
+    throw new Error(JSON.stringify(fetchedData.error))
+  }
+
+  return fetchedData.data
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1293,7 +1293,7 @@ export interface IMcpAppField {
   type: string
   description?: string
   required: boolean
-  options?: Array<{ label: string; value: string }>
+  options?: IMcpFieldOption[]
   isDynamic?: boolean
   dynamicDataKey?: string
   dynamicDataParameters?: Record<string, string>

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1293,7 +1293,11 @@ export interface IMcpAppField {
   type: string
   description?: string
   required: boolean
-  options?: IMcpFieldOption[]
+  options?: Array<{ label: string; value: string }>
+  isDynamic?: boolean
+  dynamicDataKey?: string
+  dynamicDataParameters?: Record<string, string>
+  subFields?: IMcpAppField[]
 }
 
 export interface IMcpAppAction {


### PR DESCRIPTION
## TL;DR

Adds the `get_dynamic_data` MCP tool, which lets the LLM resolve live dropdown options (e.g. Slack channels, Tiles tables) for a configured step. Simultaneously extends `listAppsService` to expose `isDynamic`, `dynamicDataKey`, `dynamicDataParameters`, and `subFields` on field metadata so the LLM can discover which fields require a `get_dynamic_data` call and what cascading parameter dependencies they have.

## What changed?

**`packages/backend/src/services/mcp/get-dynamic-data.ts`** (new, 130 lines)

- `getDynamicDataService({ user, stepId, key, parameters? })` fetches the step via `user.withAccessibleSteps({ requiredRole: 'viewer' })` with connection and flow/user graph (throws `'Step not found'` on missing or cross-user access).
- Validates: app requires auth → step must have a verified connection.
- Resolves the dynamic data handler by `key` from `app.dynamicData` — throws `"Dynamic data key '${key}' not found for app '${appKey}'"` if absent.
- Builds a `globalVariable` context (same pattern as the existing GraphQL `getDynamicData` resolver) and merges any caller-supplied `parameters` overrides into `$.step.parameters` before calling `command.run($)` — enables cascading selections (e.g. passing `tableId` to `listColumns`).
- Throws if `fetchedData.error` is set; otherwise returns `fetchedData.data`.
- Contains commented-out Phase 2 scaffolding for editor-role credential substitution and `APP_CONNECTION_FIELDS` filtering — no behavioural change in Phase 1.

**`packages/backend/src/services/mcp/apps.ts`** (updated)

- `serializeField` now reads `source` and `subFields` from raw field definitions.
- Dropdowns with a `getDynamicData` source get `isDynamic: true` and `dynamicDataKey` — both are gated on finding a `key` argument in the source, so a field whose source has arguments but no `key` arg is left unmarked rather than emitting `isDynamic: true` without a usable key.
- Cascading dropdowns (source arguments prefixed `parameters.`) additionally get `dynamicDataParameters` — a record mapping the dependency param name to its template value (e.g. `{ tableId: '{parameters.tableId}' }`).
- Compound fields (`multirow-multicol`) get `subFields` serialized recursively, including their own dynamic metadata.

**`packages/types/index.d.ts`** (updated)

- Adds `isDynamic?`, `dynamicDataKey?`, `dynamicDataParameters?`, and `subFields?` to `IMcpAppField`.

**`packages/backend/src/helpers/mcp-bridge-tools.ts`** (updated)

- Registers `get_dynamic_data` as a sixth tool.
- Tool description instructs the LLM to check `isDynamic` fields from `list_apps` to find valid keys, and to pass cascading dependency values in `parameters`.

**Tests**

- `mcp-bridge-tools.test.ts` — mock for `getDynamicDataService`; asserts snake_case → camelCase mapping in the tool execute handler.
- `apps.test.ts` — five cases covering: non-cascading dynamic dropdown (`isDynamic`, `dynamicDataKey` set, no `dynamicDataParameters`); cascading dropdown (`dynamicDataParameters` present); `subFields` serialized on compound fields; source-less dropdown unchanged; source with arguments but no `key` arg leaves `isDynamic` unset.
- `get-dynamic-data.itest.ts` (new, 182 lines) — integration tests covering: happy-path data return; parameter overrides merged into `$.step.parameters`; invalid key throws; `fetchedData.error` throws; cross-user access throws `'Step not found'`.

## Tests

- [ ] In AI Builder chat, ask the LLM to fill in a dynamic dropdown field (e.g. Slack channel or Tiles table) — verify `get_dynamic_data` is called and the LLM uses a returned value when setting the parameter via `update_step_parameters`.
- [ ] For an app with cascading dropdowns (e.g. Tiles `listColumns` depending on `tableId`), verify the LLM passes the dependency value in `parameters` and receives the correct filtered options.
- [ ] Call `list_apps` and confirm that dynamic dropdown fields now include `isDynamic`, `dynamicDataKey`, and (for cascading fields) `dynamicDataParameters` in the response.
- [ ] Confirm that compound (`multirow-multicol`) fields expose `subFields` including their own dynamic metadata.
- [ ] Verify a step without a verified connection returns an appropriate error when `get_dynamic_data` is called.
- [ ] Regression: confirm `list_apps`, `create_pipe`, `create_step`, `update_step_parameters`, and `delete_step` all still work normally.

## Deploy notes

No new environment variables or database migrations required.