### PR TITLE
[AI-SETUP-8] feat(backend): list Connections

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -42,6 +42,7 @@ describe('createMcpBridgeTools', () => {
     const tools = createMcpBridgeTools(mockUser, mockTraceId)
     expect(Object.keys(tools)).toEqual([
       'list_apps',
+      'list_connections',
       'create_pipe',
       'update_step_parameters',
       'create_step',

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -33,12 +33,19 @@ export function createMcpBridgeTools(user: User, traceId: string) {
       },
     }),
 
-    list_connections: tool<Record<string, never>, McpConnection[]>({
+    list_connections: tool<{ app_key?: string }, McpConnection[]>({
       description:
-        "List all connections the user has set up. Returns each connection's ID, app key, verified status, and label. Use the returned id as connection_id when calling update_step_parameters.",
-      inputSchema: z.object({}),
-      execute: async (): Promise<McpConnection[]> => {
-        return listConnectionsService(user)
+        "List connections the user has set up, optionally filtered to a specific app. Returns each connection's ID, app key, verified status, label, and formattedData. Use the returned id as connection_id when calling update_step_parameters.",
+      inputSchema: z.object({
+        app_key: z
+          .string()
+          .optional()
+          .describe(
+            'App key to filter by (e.g. "slack"). Omit to list all connections.',
+          ),
+      }),
+      execute: async ({ app_key }): Promise<McpConnection[]> => {
+        return listConnectionsService(user, app_key)
       },
     }),
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -14,6 +14,10 @@ import {
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
 import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+import {
+  listConnectionsService,
+  type McpConnection,
+} from '@/services/mcp/list-connections'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
 type ListAppsInput = Record<string, IApp[]>
@@ -26,6 +30,15 @@ export function createMcpBridgeTools(user: User, traceId: string) {
       inputSchema: z.object({}),
       execute: async (): Promise<IMcpApp[]> => {
         return listAppsService(user)
+      },
+    }),
+
+    list_connections: tool<Record<string, never>, McpConnection[]>({
+      description:
+        "List all connections the user has set up. Returns each connection's ID, app key, verified status, and label. Use the returned id as connection_id when calling update_step_parameters.",
+      inputSchema: z.object({}),
+      execute: async (): Promise<McpConnection[]> => {
+        return listConnectionsService(user)
       },
     }),
 

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import App from '@/models/app'
 import Connection from '@/models/connection'
 import User from '@/models/user'
 
@@ -20,6 +21,10 @@ describe('listConnectionsService', () => {
   beforeEach(() => {
     mocks.getAllLdFlags.mockResolvedValue({})
     mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('returns connections owned by the user', async () => {
@@ -133,6 +138,37 @@ describe('listConnectionsService', () => {
 
     expect(result.map((c) => c.id)).toContain(slackConn.id)
     expect(result.map((c) => c.id)).not.toContain(postmanConn.id)
+  })
+
+  it('delegates to getSystemAddedConnections for system-added apps', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `system-added-${randomUUID()}@example.com`,
+    })
+    const mockConn = {
+      id: randomUUID(),
+      key: 'm365-excel',
+      verified: true,
+      description: 'Shared Excel connection',
+      formattedData: { screenName: 'Excel' },
+    }
+    const getSystemAddedConnections = vi.fn().mockResolvedValue([mockConn])
+    vi.spyOn(App, 'findOneByKey').mockResolvedValueOnce({
+      auth: { connectionType: 'system-added', getSystemAddedConnections },
+    } as any)
+
+    const result = await listConnectionsService(user, 'm365-excel')
+
+    expect(getSystemAddedConnections).toHaveBeenCalledWith(user)
+    expect(result).toEqual([
+      {
+        id: mockConn.id,
+        appKey: 'm365-excel',
+        verified: true,
+        label: 'Shared Excel connection',
+        formattedData: { screenName: 'Excel' },
+      },
+    ])
   })
 
   it('includes formattedData on the returned connection', async () => {

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -38,7 +38,7 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: true,
       draft: false,
-      description: 'My Slack connection',
+      formattedData: {},
     })
 
     const result = await listConnectionsService(user)
@@ -49,7 +49,6 @@ describe('listConnectionsService', () => {
           id: conn.id,
           appKey: 'slack',
           verified: true,
-          label: 'My Slack connection',
         }),
       ]),
     )
@@ -70,6 +69,7 @@ describe('listConnectionsService', () => {
       userId: owner.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
 
     const result = await listConnectionsService(other)
@@ -88,6 +88,7 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: false,
       draft: true,
+      formattedData: {},
     })
 
     const result = await listConnectionsService(user)
@@ -106,6 +107,7 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
 
     const result = await listConnectionsService(user)
@@ -125,6 +127,7 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
     const postmanConn = await Connection.query().insertAndFetch({
       id: randomUUID(),
@@ -132,6 +135,7 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
 
     const result = await listConnectionsService(user, 'slack')

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -40,12 +40,12 @@ describe('listConnectionsService', () => {
 
     expect(result).toEqual(
       expect.arrayContaining([
-        {
+        expect.objectContaining({
           id: conn.id,
           appKey: 'slack',
           verified: true,
           label: 'My Slack connection',
-        },
+        }),
       ]),
     )
   })
@@ -107,5 +107,51 @@ describe('listConnectionsService', () => {
     const found = result.find((c) => c.id === conn.id)
 
     expect(found?.label).toBe('postman')
+  })
+
+  it('filters by appKey when provided', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `filter-appkey-${randomUUID()}@example.com`,
+    })
+    const slackConn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: true,
+      draft: false,
+    })
+    const postmanConn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'postman',
+      userId: user.id,
+      verified: true,
+      draft: false,
+    })
+
+    const result = await listConnectionsService(user, 'slack')
+
+    expect(result.map((c) => c.id)).toContain(slackConn.id)
+    expect(result.map((c) => c.id)).not.toContain(postmanConn.id)
+  })
+
+  it('includes formattedData on the returned connection', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `formatted-data-${randomUUID()}@example.com`,
+    })
+    const conn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      formattedData: { screenName: 'My Workspace' },
+    })
+
+    const result = await listConnectionsService(user)
+    const found = result.find((c) => c.id === conn.id)
+
+    expect(found?.formattedData).toEqual({ screenName: 'My Workspace' })
   })
 })

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Connection from '@/models/connection'
+import User from '@/models/user'
+
+import { listConnectionsService } from '../list-connections'
+
+const mocks = vi.hoisted(() => ({
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+describe('listConnectionsService', () => {
+  beforeEach(() => {
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+  })
+
+  it('returns connections owned by the user', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `list-conn-owned-${randomUUID()}@example.com`,
+    })
+    const conn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      description: 'My Slack connection',
+    })
+
+    const result = await listConnectionsService(user)
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          id: conn.id,
+          appKey: 'slack',
+          verified: true,
+          label: 'My Slack connection',
+        },
+      ]),
+    )
+  })
+
+  it('does not return connections belonging to another user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-${randomUUID()}@example.com`,
+    })
+    const other = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `other-${randomUUID()}@example.com`,
+    })
+    const conn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: owner.id,
+      verified: true,
+      draft: false,
+    })
+
+    const result = await listConnectionsService(other)
+
+    expect(result.map((c) => c.id)).not.toContain(conn.id)
+  })
+
+  it('excludes draft connections', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `draft-conn-${randomUUID()}@example.com`,
+    })
+    const draftConn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: false,
+      draft: true,
+    })
+
+    const result = await listConnectionsService(user)
+
+    expect(result.map((c) => c.id)).not.toContain(draftConn.id)
+  })
+
+  it('falls back to appKey as label when description is absent', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `fallback-label-${randomUUID()}@example.com`,
+    })
+    const conn = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'postman',
+      userId: user.id,
+      verified: true,
+      draft: false,
+    })
+
+    const result = await listConnectionsService(user)
+    const found = result.find((c) => c.id === conn.id)
+
+    expect(found?.label).toBe('postman')
+  })
+})

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -15,13 +15,17 @@ export async function listConnectionsService(
   user: User,
   appKey?: string,
 ): Promise<McpConnection[]> {
-  // Mirror GetAppConnections (get-app.ts): branch on connectionType when an
-  // appKey is known, just as the pipe editor does.
+  // Mirrors the GetAppConnections GraphQL resolver (get-app.ts) which branches
+  // on connectionType. Today only the pipe owner can invoke MCP tools, so we
+  // return only connections the owner has access to.
   //
-  // Future enhancement — collaborator support: when collaborators are allowed to
-  // use this tool, accept a flowId parameter and also merge in shared connections
-  // via withAccessibleFlowConnections filtered by that flowId, mirroring the
-  // getSharedConnections helper in get-app.ts.
+  // Collaborator support (future): the call site always has a flowId available.
+  // When collaborators gain access, thread flowId through this function and:
+  //   • system-added: also call getSharedConnections(flowId, isDraft=true) and
+  //     return those shared connections, same as getApp does for editor-role users.
+  //   • user-added: merge own connections with getSharedConnections(flowId,
+  //     isDraft=false), same as getApp does for owner/viewer-role users.
+  // See getSharedConnections in get-app.ts for the reference implementation.
   if (appKey) {
     const app = await App.findOneByKey(appKey)
 
@@ -38,7 +42,7 @@ export async function listConnectionsService(
   }
 
   // user-added connections (or no appKey — system-added across all apps is
-  // not enumerable without knowing each app's auth handler)
+  // not enumerable without iterating every app's auth handler)
   const query = user.$relatedQuery('connections').where('draft', false)
   if (appKey) {
     query.andWhere('key', appKey)

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -14,30 +14,28 @@ export async function listConnectionsService(
   user: User,
   appKey?: string,
 ): Promise<McpConnection[]> {
-  const query = user
-    .withAccessibleConnections({ requiredRole: 'viewer' })
-    .where('connections.draft', false)
+  // Use $relatedQuery to match GetAppConnections (get-app.ts) owner behaviour:
+  // return only connections owned by this user, same as the pipe editor when no
+  // flowId is supplied. Only the pipe owner can invoke MCP tools today, so we
+  // don't need to fetch shared connections.
+  //
+  // Future enhancement — collaborator support: when collaborators are allowed to
+  // use this tool, accept a flowId parameter and also merge in shared connections
+  // via withAccessibleFlowConnections filtered by that flowId, mirroring the
+  // getSharedConnections helper in get-app.ts.
+  const query = user.$relatedQuery('connections').where('draft', false)
 
   if (appKey) {
-    query.where('connections.key', appKey)
+    query.andWhere('key', appKey)
   }
 
   const connections = await query
 
-  const seen = new Set<string>()
-  const result: McpConnection[] = []
-  for (const c of connections) {
-    if (seen.has(c.id)) {
-      continue
-    }
-    seen.add(c.id)
-    result.push({
-      id: c.id,
-      appKey: c.key,
-      verified: c.verified,
-      label: c.description ?? c.key,
-      formattedData: c.formattedData,
-    })
-  }
-  return result
+  return connections.map((c) => ({
+    id: c.id,
+    appKey: c.key,
+    verified: c.verified,
+    label: c.description ?? c.key,
+    formattedData: c.formattedData,
+  }))
 }

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -30,6 +30,9 @@ export async function listConnectionsService(
     const app = await App.findOneByKey(appKey)
 
     if (app?.auth?.connectionType === 'system-added') {
+      // getSystemAddedConnections may insert new Connection rows for eligible
+      // tenants as a side effect — this mirrors the GraphQL resolver's behaviour
+      // and is intentional.
       const connections = await app.auth.getSystemAddedConnections(user)
       return connections.map((c) => ({
         id: c.id,

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -1,5 +1,6 @@
 import type { IJSONObject } from '@plumber/types'
 
+import App from '@/models/app'
 import type User from '@/models/user'
 
 export interface McpConnection {
@@ -14,21 +15,34 @@ export async function listConnectionsService(
   user: User,
   appKey?: string,
 ): Promise<McpConnection[]> {
-  // Use $relatedQuery to match GetAppConnections (get-app.ts) owner behaviour:
-  // return only connections owned by this user, same as the pipe editor when no
-  // flowId is supplied. Only the pipe owner can invoke MCP tools today, so we
-  // don't need to fetch shared connections.
+  // Mirror GetAppConnections (get-app.ts): branch on connectionType when an
+  // appKey is known, just as the pipe editor does.
   //
   // Future enhancement — collaborator support: when collaborators are allowed to
   // use this tool, accept a flowId parameter and also merge in shared connections
   // via withAccessibleFlowConnections filtered by that flowId, mirroring the
   // getSharedConnections helper in get-app.ts.
-  const query = user.$relatedQuery('connections').where('draft', false)
+  if (appKey) {
+    const app = await App.findOneByKey(appKey)
 
+    if (app?.auth?.connectionType === 'system-added') {
+      const connections = await app.auth.getSystemAddedConnections(user)
+      return connections.map((c) => ({
+        id: c.id,
+        appKey: c.key,
+        verified: c.verified,
+        label: c.description ?? c.key,
+        formattedData: c.formattedData,
+      }))
+    }
+  }
+
+  // user-added connections (or no appKey — system-added across all apps is
+  // not enumerable without knowing each app's auth handler)
+  const query = user.$relatedQuery('connections').where('draft', false)
   if (appKey) {
     query.andWhere('key', appKey)
   }
-
   const connections = await query
 
   return connections.map((c) => ({

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -1,0 +1,32 @@
+import type User from '@/models/user'
+
+export interface McpConnection {
+  id: string
+  appKey: string
+  verified: boolean
+  label: string
+}
+
+export async function listConnectionsService(
+  user: User,
+): Promise<McpConnection[]> {
+  const connections = await user
+    .withAccessibleConnections({ requiredRole: 'viewer' })
+    .where('connections.draft', false)
+
+  const seen = new Set<string>()
+  const result: McpConnection[] = []
+  for (const c of connections) {
+    if (seen.has(c.id)) {
+      continue
+    }
+    seen.add(c.id)
+    result.push({
+      id: c.id,
+      appKey: c.key,
+      verified: c.verified,
+      label: c.description ?? c.key,
+    })
+  }
+  return result
+}

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -1,3 +1,5 @@
+import type { IJSONObject } from '@plumber/types'
+
 import type User from '@/models/user'
 
 export interface McpConnection {
@@ -5,14 +7,22 @@ export interface McpConnection {
   appKey: string
   verified: boolean
   label: string
+  formattedData?: IJSONObject
 }
 
 export async function listConnectionsService(
   user: User,
+  appKey?: string,
 ): Promise<McpConnection[]> {
-  const connections = await user
+  const query = user
     .withAccessibleConnections({ requiredRole: 'viewer' })
     .where('connections.draft', false)
+
+  if (appKey) {
+    query.where('connections.key', appKey)
+  }
+
+  const connections = await query
 
   const seen = new Set<string>()
   const result: McpConnection[] = []
@@ -26,6 +36,7 @@ export async function listConnectionsService(
       appKey: c.key,
       verified: c.verified,
       label: c.description ?? c.key,
+      formattedData: c.formattedData,
     })
   }
   return result


### PR DESCRIPTION
**TL;DR**

Adds a `list_connections` MCP tool so the AI assistant can enumerate a user's connections and surface their IDs, labels, and `formattedData` to the LLM — e.g. to let the user pick "My Slack workspace" by name when configuring a step.

---

**What changed?**

- **`list-connections.ts`** — new service that returns the user's non-draft connections, optionally filtered by `app_key`. For system-added apps (e.g. M365 Excel, Databricks), delegates to `app.auth.getSystemAddedConnections` to mirror the `GetAppConnections` GraphQL resolver's `connectionType` branch. For user-added apps uses `user.$relatedQuery('connections')` so results are always scoped to the calling user.
- **`mcp-bridge-tools.ts`** — registers `list_connections` as an AI SDK tool, inserted after `list_apps` in the tool map.
- **`list-connections.itest.ts`** — integration tests covering: owner isolation, cross-user isolation, draft exclusion, label fallback, `app_key` filter, system-added delegation, and `formattedData` passthrough.
- **`mcp-bridge-tools.test.ts`** — updated key-order assertion to include `list_connections`.

---

**Tests**

Automated: run the integration tests for this file.

\`\`\`
npm test packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
\`\`\`

Manual regression — in the AI chat:

1. Ask the assistant to list your connections. It should call `list_connections` and return connections you've actually set up (not other users').
2. Ask it to list connections for a specific app (e.g. "which Slack connections do I have?"). It should call `list_connections` with `app_key: "slack"` and return only Slack connections.
3. If you have a system-added app (e.g. M365 Excel), ask it to list those connections. It should return them with a readable label from `formattedData`.
4. Draft (incomplete) connections should not appear in any of the above responses.

---

**Deploy notes**

None. No schema changes, no migrations, no flag gating required.