### PR TITLE
[AI-SETUP-9] PLU-813 feat(backend): extend update_step_parameters with optional connection_id

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -111,7 +111,7 @@ export function createMcpBridgeTools(user: User, traceId: string) {
             "Parameter key/value pairs to save. Only keys matching the step's field schema are kept.",
           ),
         connection_id: z
-          .string()
+          .uuid()
           .optional()
           .describe(
             "Connection ID to assign to this step. Obtain from list_connections. The connection's app must match the step's app.",

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -101,7 +101,7 @@ export function createMcpBridgeTools(user: User, traceId: string) {
 
     update_step_parameters: tool({
       description:
-        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.",
+        "Save parameter values onto an existing step. Only field keys defined in the step's action/trigger schema are saved — unknown keys are silently dropped. Optionally assign a connection by passing connection_id (obtain from list_connections; must match the step's app). Call after create_pipe to fill in step configuration. appKey and key are immutable after creation; to change the action, delete the step and add a new one.",
       inputSchema: z.object({
         pipe_id: z.uuid().describe('ID of the pipe that contains the step'),
         step_id: z.uuid().describe('ID of the step to update'),
@@ -110,13 +110,25 @@ export function createMcpBridgeTools(user: User, traceId: string) {
           .describe(
             "Parameter key/value pairs to save. Only keys matching the step's field schema are kept.",
           ),
+        connection_id: z
+          .string()
+          .optional()
+          .describe(
+            "Connection ID to assign to this step. Obtain from list_connections. The connection's app must match the step's app.",
+          ),
       }),
-      execute: async ({ pipe_id, step_id, parameters }): Promise<Step> => {
+      execute: async ({
+        pipe_id,
+        step_id,
+        parameters,
+        connection_id,
+      }): Promise<Step> => {
         return updateStepParametersService({
           user,
           pipeId: pipe_id,
           stepId: step_id,
           parameters,
+          connectionId: connection_id,
         })
       },
     }),

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import Connection from '@/models/connection'
 import User from '@/models/user'
 
 import { createFlowWithStepsService } from '../create-flow-with-steps'
@@ -234,5 +235,151 @@ describe('updateStepParametersService', () => {
       subject: 'Hello world',
       destinationEmail: ['a@b.com'],
     })
+  })
+
+  it('sets connectionId on the step when a valid connection is provided', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `conn-assign-${randomUUID()}@example.com`,
+    })
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Connection Assign Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-conn-assign',
+    })
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'postman', // matches actionStep.appKey
+      userId: user.id,
+      verified: true,
+      draft: false,
+    })
+
+    const result = await updateStepParametersService({
+      user,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      parameters: { subject: 'Hello' },
+      connectionId: connection.id,
+    })
+
+    expect(result.connectionId).toBe(connection.id)
+  })
+
+  it('throws when the connection belongs to another user', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `owner-conn-${randomUUID()}@example.com`,
+    })
+    const intruder = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `intruder-conn-${randomUUID()}@example.com`,
+    })
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Owned Pipe Conn',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-intruder-conn',
+    })
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    // connection belongs to owner, not intruder
+    const connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'postman',
+      userId: owner.id,
+      verified: true,
+      draft: false,
+    })
+
+    await expect(
+      updateStepParametersService({
+        user: intruder,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: {},
+        connectionId: connection.id,
+      }),
+    ).rejects.toThrow('Step not found') // access denied at step level before connection check
+  })
+
+  it("throws when the connection's app does not match the step's app", async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `app-mismatch-${randomUUID()}@example.com`,
+    })
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'App Mismatch Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-app-mismatch',
+    })
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    // connection is for 'slack', but step is 'postman'
+    const connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: true,
+      draft: false,
+    })
+
+    await expect(
+      updateStepParametersService({
+        user,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: {},
+        connectionId: connection.id,
+      }),
+    ).rejects.toThrow(
+      "Connection app 'slack' does not match step app 'postman'",
+    )
   })
 })

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -270,6 +270,7 @@ describe('updateStepParametersService', () => {
       userId: user.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
 
     const result = await updateStepParametersService({
@@ -321,6 +322,7 @@ describe('updateStepParametersService', () => {
       userId: owner.id,
       verified: true,
       draft: false,
+      formattedData: {},
     })
 
     await expect(
@@ -367,6 +369,7 @@ describe('updateStepParametersService', () => {
       key: 'slack',
       userId: user.id,
       verified: true,
+      formattedData: {},
       draft: false,
     })
 

--- a/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/update-step-parameters.itest.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Connection from '@/models/connection'
+import FlowCollaborator from '@/models/flow-collaborators'
 import User from '@/models/user'
 
 import { createFlowWithStepsService } from '../create-flow-with-steps'
@@ -384,5 +385,101 @@ describe('updateStepParametersService', () => {
     ).rejects.toThrow(
       "Connection app 'slack' does not match step app 'postman'",
     )
+  })
+
+  it('throws when the connection does not exist', async () => {
+    const user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `conn-notfound-${randomUUID()}@example.com`,
+    })
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Conn Not Found Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-conn-notfound',
+    })
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    await expect(
+      updateStepParametersService({
+        user,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: {},
+        connectionId: randomUUID(), // does not exist
+      }),
+    ).rejects.toThrow('Connection not found')
+  })
+
+  it('throws when a collaborator tries to assign a connection they do not own', async () => {
+    const owner = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `collab-owner-${randomUUID()}@example.com`,
+    })
+    const collaborator = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `collab-editor-${randomUUID()}@example.com`,
+    })
+    const flow = await createFlowWithStepsService({
+      user: owner,
+      name: 'Collab Conn IDOR Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-collab-idor',
+    })
+    await FlowCollaborator.query().insert({
+      flowId: flow.id,
+      userId: collaborator.id,
+      role: 'editor',
+      updatedBy: owner.id,
+    })
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    // connection owned by owner, not linked to any shared flow
+    const ownerConnection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'postman',
+      userId: owner.id,
+      verified: true,
+      draft: false,
+      formattedData: {},
+    })
+
+    await expect(
+      updateStepParametersService({
+        user: collaborator,
+        pipeId: flow.id,
+        stepId: actionStep.id,
+        parameters: {},
+        connectionId: ownerConnection.id,
+      }),
+    ).rejects.toThrow('Connection not found')
   })
 })

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -15,6 +15,7 @@ export interface UpdateStepParametersInput {
   pipeId: string
   stepId: string
   parameters: Record<string, unknown>
+  connectionId?: string
 }
 
 export async function updateStepParametersService({
@@ -22,6 +23,7 @@ export async function updateStepParametersService({
   pipeId,
   stepId,
   parameters,
+  connectionId,
 }: UpdateStepParametersInput): Promise<Step> {
   return Step.transaction(async (trx) => {
     const accessible = await user
@@ -101,10 +103,32 @@ export async function updateStepParametersService({
       action.validateStepParameters?.(mergedParameters)
     }
 
+    let resolvedConnectionId: string | undefined
+    if (connectionId !== undefined) {
+      const connection = await user
+        .withAccessibleConnections({ requiredRole: 'viewer' })
+        .findOne({ 'connections.id': connectionId })
+
+      if (!connection) {
+        throw new Error('Connection not found')
+      }
+
+      if (connection.key !== step.appKey) {
+        throw new Error(
+          `Connection app '${connection.key}' does not match step app '${step.appKey}'`,
+        )
+      }
+
+      resolvedConnectionId = connectionId
+    }
+
     return Step.query(trx).patchAndFetchById(stepId, {
       parameters: mergedParameters,
       version,
       status: 'incomplete',
+      ...(resolvedConnectionId !== undefined && {
+        connectionId: resolvedConnectionId,
+      }),
     })
   })
 }

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -55,14 +55,6 @@ export async function updateStepParametersService({
       throw new Error('No such trigger or action')
     }
 
-    if (triggerOrAction.hiddenFromUser) {
-      throw new Error(
-        `${
-          step.type === 'trigger' ? 'Trigger' : 'Action'
-        } can only be updated by system`,
-      )
-    }
-
     // Get arguments from the raw app registry (before getApp transforms them into substeps)
     const rawApp = apps[step.appKey]
     const rawTriggerOrAction = (

--- a/packages/backend/src/services/mcp/update-step-parameters.ts
+++ b/packages/backend/src/services/mcp/update-step-parameters.ts
@@ -45,7 +45,7 @@ export async function updateStepParametersService({
       throw new Error('Step cannot be updated')
     }
 
-    // Use App.findTriggerOrActionByKey for type/validity checks (hidden actions etc.)
+    // Use App.findTriggerOrActionByKey for type/validity checks
     const triggerOrAction = await App.findTriggerOrActionByKey(
       step.appKey,
       step.key,
@@ -53,6 +53,14 @@ export async function updateStepParametersService({
 
     if (!triggerOrAction) {
       throw new Error('No such trigger or action')
+    }
+
+    if (triggerOrAction.hiddenFromUser) {
+      throw new Error(
+        `${
+          step.type === 'trigger' ? 'Trigger' : 'Action'
+        } can only be updated by system`,
+      )
     }
 
     // Get arguments from the raw app registry (before getApp transforms them into substeps)
@@ -95,7 +103,6 @@ export async function updateStepParametersService({
       action.validateStepParameters?.(mergedParameters)
     }
 
-    let resolvedConnectionId: string | undefined
     if (connectionId !== undefined) {
       const connection = await user
         .withAccessibleConnections({ requiredRole: 'viewer' })
@@ -110,17 +117,13 @@ export async function updateStepParametersService({
           `Connection app '${connection.key}' does not match step app '${step.appKey}'`,
         )
       }
-
-      resolvedConnectionId = connectionId
     }
 
     return Step.query(trx).patchAndFetchById(stepId, {
       parameters: mergedParameters,
       version,
       status: 'incomplete',
-      ...(resolvedConnectionId !== undefined && {
-        connectionId: resolvedConnectionId,
-      }),
+      ...(connectionId !== undefined && { connectionId }),
     })
   })
 }


### PR DESCRIPTION
## Stack Context

This stack enables the MCP AI Builder to configure connections for flow steps — the LLM can list a user's available connections, pick the right one, and assign it to a step, completing full step configuration without manual UI interaction.

## TL;DR

`update_step_parameters` gains an optional `connection_id` field. Pass a connection ID (obtained from `list_connections`) and the service validates ownership + app match before writing it to the step.

## What changed?

**`mcp-bridge-tools.ts`**
Adds `connection_id` (optional string) to the `update_step_parameters` tool's input schema and description, and threads it through to the service call.

**`update-step-parameters.ts`**
When `connectionId` is provided, the service:
1. Looks up the connection via `user.withAccessibleConnections()` — enforces ownership so a collaborator cannot reference a connection they don't own (IDOR guard).
2. Checks that the connection's app key matches the step's app key.
3. Writes `connectionId` onto the step alongside the parameter patch.

**Integration tests (`update-step-parameters.itest.ts`)**
Five new test cases added:
- Happy path: connection is assigned successfully.
- Connection not found: throws `'Connection not found'`.
- App mismatch: throws `"Connection app 'X' does not match step app 'Y'"`.
- Cross-user IDOR: intruder cannot assign an owner's connection (caught at step-access level).
- Collaborator IDOR: a flow collaborator cannot assign a connection they don't own (caught at connection-access level).

## Tests

- [ ] Create a flow with an action step in the AI Builder chat. Ask the AI to configure the step, including assigning a connection. Confirm the step ends up with the correct `connectionId` in the database (or visible in the step editor).
- [ ] Ask the AI to assign a connection whose app doesn't match the step (if you can manufacture this) — confirm it surfaces an error rather than silently misconfiguring the step.
- [ ] Confirm existing `update_step_parameters` calls without `connection_id` are unaffected (no regression on parameter-only updates).

## Deploy Notes

No migrations required. No environment changes needed.
