### PR TITLE
[AI-SETUP-11] feat: allow free-text parameter collection via clarification UI

### DIFF
--- a/packages/backend/src/routes/api/__tests__/chat/parse-clarification-block.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/parse-clarification-block.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseClarificationBlock } from './parse-clarification-block'
+import { parseClarificationBlock } from '../../chat/parse-clarification-block'
 
 describe('parseClarificationBlock', () => {
   it('returns null when no block is present', () => {

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.test.ts
@@ -16,7 +16,7 @@ describe('parseClarificationBlock', () => {
     expect(parseClarificationBlock(text)).toBeNull()
   })
 
-  it('returns null when a question has fewer than 2 options', () => {
+  it('returns a question with a single option', () => {
     const text = `
 Some response.
 <!-- CLARIFICATION_DATA
@@ -24,7 +24,35 @@ Q: What trigger?
 - Form submission
 -->
     `.trim()
-    expect(parseClarificationBlock(text)).toBeNull()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission'] },
+    ])
+  })
+
+  it('returns a free-text question with no options', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: What is the row ID to update?
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What is the row ID to update?', options: [] },
+    ])
+  })
+
+  it('returns a mix of option-based and free-text questions', () => {
+    const text = `
+<!-- CLARIFICATION_DATA
+Q: Which trigger?
+- FormSG
+- Webhook
+Q: What is your table ID?
+-->
+    `.trim()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'Which trigger?', options: ['FormSG', 'Webhook'] },
+      { question: 'What is your table ID?', options: [] },
+    ])
   })
 
   it('parses a single question with 2 options', () => {
@@ -189,13 +217,15 @@ Q:  What trigger?
     ])
   })
 
-  it('returns null when block is present but all questions have < 2 options', () => {
+  it('returns a question with exactly 1 option (no longer requires min 2)', () => {
     const text = `
 <!-- CLARIFICATION_DATA
 Q: What trigger?
 - Form submission
 -->
     `.trim()
-    expect(parseClarificationBlock(text)).toBeNull()
+    expect(parseClarificationBlock(text)).toEqual([
+      { question: 'What trigger?', options: ['Form submission'] },
+    ])
   })
 })

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.ts
@@ -55,6 +55,5 @@ export function parseClarificationBlock(
     questions.push(current)
   }
 
-  const valid = questions.filter((q) => q.question.length > 0)
-  return valid.length > 0 ? valid : null
+  return questions.length > 0 ? questions : null
 }

--- a/packages/backend/src/routes/api/chat/parse-clarification-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-clarification-block.ts
@@ -55,6 +55,6 @@ export function parseClarificationBlock(
     questions.push(current)
   }
 
-  const valid = questions.filter((q) => q.options.length >= 2)
+  const valid = questions.filter((q) => q.question.length > 0)
   return valid.length > 0 ? valid : null
 }

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -59,7 +59,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
         .array(
           z.object({
             question: z.string(),
-            options: z.array(z.string()).min(2),
+            options: z.array(z.string()),
           }),
         )
         .min(1),

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/ChoicePicker.tsx
@@ -77,37 +77,39 @@ export default function ChoicePicker({
           )}
         </Flex>
 
-        <Flex direction="column" gap={2}>
-          {currentQ.options.map((opt, optIdx) => (
-            <Button
-              key={optIdx}
-              variant="outline"
-              justifyContent="flex-start"
-              h="auto"
-              py={2}
-              isDisabled={isStreaming}
-              onClick={() => onOptionClick(optIdx)}
-              borderColor="gray.200"
-              bg="white"
-              color="gray.800"
-              _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
-              _active={{ bg: 'primary.100' }}
-              gap={2}
-            >
-              <Badge
-                colorScheme="secondary"
-                variant="subtle"
-                size="sm"
-                flexShrink={0}
+        {currentQ.options.length > 0 && (
+          <Flex direction="column" gap={2}>
+            {currentQ.options.map((opt, optIdx) => (
+              <Button
+                key={optIdx}
+                variant="outline"
+                justifyContent="flex-start"
+                h="auto"
+                py={2}
+                isDisabled={isStreaming}
+                onClick={() => onOptionClick(optIdx)}
+                borderColor="gray.200"
+                bg="white"
+                color="gray.800"
+                _hover={{ borderColor: 'primary.300', bg: 'primary.50' }}
+                _active={{ bg: 'primary.100' }}
+                gap={2}
               >
-                {optIdx + 1}
-              </Badge>
-              <Text textAlign="left" whiteSpace="normal" color="gray.800">
-                {opt}
-              </Text>
-            </Button>
-          ))}
-        </Flex>
+                <Badge
+                  colorScheme="secondary"
+                  variant="subtle"
+                  size="sm"
+                  flexShrink={0}
+                >
+                  {optIdx + 1}
+                </Badge>
+                <Text textAlign="left" whiteSpace="normal" color="gray.800">
+                  {opt}
+                </Text>
+              </Button>
+            ))}
+          </Flex>
+        )}
 
         <Box borderTop="1px" borderColor="gray.100" mt={4} pt={3}>
           <Flex gap={2} align="flex-end">
@@ -116,7 +118,11 @@ export default function ChoicePicker({
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyPress}
-              placeholder="Or describe your answer..."
+              placeholder={
+                currentQ.options.length > 0
+                  ? 'Or describe your answer...'
+                  : 'Enter your answer...'
+              }
               resize="none"
               border="none"
               bg="transparent"


### PR DESCRIPTION
## Stack context

This PR is part of the MCP AI Builder stack, which wires Claude into Plumber's pipe-builder as a chat assistant. The stack adds MCP bridge tools (`create_pipe`, `create_step`, `update_step_parameters`, etc.) and builds the accompanying UI — step previews, in-chat pipe state, parameter collection, and dynamic pickers — so the AI can gather the information it needs to build and configure a pipe in real time.

This PR sits directly on top of `mcp/pipe-state-ui` (PR #1849), which added the in-chat pipe state display and `StepsPreview` three-mode rendering.

## TL;DR

Lifts the minimum-2-options constraint from the clarification block parser and schema, enabling the AI to ask **free-text questions** (e.g. "What is the table ID?") in addition to multiple-choice ones. The `ChoicePicker` UI hides the options list when none are provided and adjusts the textarea placeholder accordingly.

## What changed?

**Backend**
- `parse-clarification-block.ts` — removed the `options.length >= 2` validity filter; questions with 0 or 1 options now pass through (the parser already rejects empty question strings, so the filter was redundant)
- `schema.ts` — removed `.min(2)` from the `options` array in the clarification message part schema

**Frontend**
- `ChoicePicker.tsx` — wraps the options list in a `currentQ.options.length > 0` guard so it is hidden for free-text questions; changes the textarea placeholder to "Enter your answer…" (vs. "Or describe your answer…" when options are present)

**Tests**
- `parse-clarification-block.test.ts` — updated two test names/expectations that previously required ≥ 2 options; added cases for a zero-option free-text question and a mixed question block; moved to `routes/api/__tests__/chat/`

## Tests

1. In AI Builder (with `mcpStepConfig` flag on), trigger a flow where the AI needs a free-form value (e.g. a row ID or table name). Confirm the `ChoicePicker` renders with only the textarea — no numbered option buttons — and the placeholder reads "Enter your answer…".
2. Trigger a clarification with pre-defined options (e.g. choosing a trigger type). Confirm the option buttons still appear and the placeholder reads "Or describe your answer…".
3. Submit a free-text answer and confirm the chat continues correctly.
4. Run `npm run test packages/backend/src/routes/api/__tests__/chat/parse-clarification-block.test.ts` — all tests should pass.

## Deploy notes

No migration or flag changes needed. This change is additive — it widens the accepted format for clarification blocks without breaking existing multiple-choice behaviour.