### PR TITLE
[AI-SETUP-12] feat(backend): DynamicPicker — STEP_ID/KEY block format + /api/dynamic-data endpoint

### DIFF
--- a/packages/backend/src/errors/user-facing-error.ts
+++ b/packages/backend/src/errors/user-facing-error.ts
@@ -1,0 +1,6 @@
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UserFacingError'
+  }
+}

--- a/packages/backend/src/helpers/build-system-prompt.ts
+++ b/packages/backend/src/helpers/build-system-prompt.ts
@@ -16,25 +16,6 @@
 
 import apps from '@/apps'
 
-// Appended to every system prompt so the LLM knows the correct block format.
-// This is hard-coded (not in LaunchDarkly) because it is tightly coupled to
-// parseDynamicPickerBlock in routes/api/chat/parse-dynamic-picker-block.ts.
-const DYNAMIC_PICKER_INSTRUCTIONS = `
-
-## Dynamic Picker
-
-When you need the user to select a value from live data (e.g. a Slack channel, a Google Sheet, a database table), emit a \`DYNAMIC_PICKER_DATA\` HTML comment block. The frontend fetches and renders the options automatically — you must NOT call \`get_dynamic_data\` to list them, and must NOT include \`N:\`/\`V:\` option lines.
-
-Format:
-\`\`\`
-<!-- DYNAMIC_PICKER_DATA
-Q: <question to show the user>
-STEP_ID: <the step UUID from the current pipe state>
-KEY: <dynamic data key declared by the app, e.g. listChannels>
--->
-\`\`\`
-`
-
 const APP_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
   Object.values(apps).map((app) => [app.key, app.name]),
 )
@@ -58,7 +39,7 @@ export function buildSystemPrompt(
   restrictedApps: string[],
 ): string {
   if (restrictedApps.length === 0) {
-    return basePrompt + DYNAMIC_PICKER_INSTRUCTIONS
+    return basePrompt
   }
 
   // Pre-compile regex patterns once (efficiency)
@@ -131,5 +112,5 @@ export function buildSystemPrompt(
   const safetyNote = `\n\nNote: this user does not have access to the following apps: ${restrictedApps.join(
     ', ',
   )}.`
-  return filteredLines.join('\n') + safetyNote + DYNAMIC_PICKER_INSTRUCTIONS
+  return filteredLines.join('\n') + safetyNote
 }

--- a/packages/backend/src/helpers/build-system-prompt.ts
+++ b/packages/backend/src/helpers/build-system-prompt.ts
@@ -16,6 +16,25 @@
 
 import apps from '@/apps'
 
+// Appended to every system prompt so the LLM knows the correct block format.
+// This is hard-coded (not in LaunchDarkly) because it is tightly coupled to
+// parseDynamicPickerBlock in routes/api/chat/parse-dynamic-picker-block.ts.
+const DYNAMIC_PICKER_INSTRUCTIONS = `
+
+## Dynamic Picker
+
+When you need the user to select a value from live data (e.g. a Slack channel, a Google Sheet, a database table), emit a \`DYNAMIC_PICKER_DATA\` HTML comment block. The frontend fetches and renders the options automatically — you must NOT call \`get_dynamic_data\` to list them, and must NOT include \`N:\`/\`V:\` option lines.
+
+Format:
+\`\`\`
+<!-- DYNAMIC_PICKER_DATA
+Q: <question to show the user>
+STEP_ID: <the step UUID from the current pipe state>
+KEY: <dynamic data key declared by the app, e.g. listChannels>
+-->
+\`\`\`
+`
+
 const APP_DISPLAY_NAMES: Record<string, string> = Object.fromEntries(
   Object.values(apps).map((app) => [app.key, app.name]),
 )
@@ -39,7 +58,7 @@ export function buildSystemPrompt(
   restrictedApps: string[],
 ): string {
   if (restrictedApps.length === 0) {
-    return basePrompt
+    return basePrompt + DYNAMIC_PICKER_INSTRUCTIONS
   }
 
   // Pre-compile regex patterns once (efficiency)
@@ -112,5 +131,5 @@ export function buildSystemPrompt(
   const safetyNote = `\n\nNote: this user does not have access to the following apps: ${restrictedApps.join(
     ', ',
   )}.`
-  return filteredLines.join('\n') + safetyNote
+  return filteredLines.join('\n') + safetyNote + DYNAMIC_PICKER_INSTRUCTIONS
 }

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -15,6 +15,7 @@ import {
   smoothStream,
   stepCountIs,
   streamText,
+  type UIMessageStreamWriter,
 } from 'ai'
 import type { Response } from 'express'
 import { Router } from 'express'
@@ -42,6 +43,24 @@ import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
 import { chatRequestSchema } from './schema'
 
 const MAX_MESSAGES = 50
+
+function emitTextAnnotations(text: string, writer: UIMessageStreamWriter) {
+  const questions = parseClarificationBlock(text)
+  if (questions) {
+    writer.write({
+      type: 'data-clarification',
+      data: { questions },
+    })
+  }
+
+  const dynamicPicker = parseDynamicPickerBlock(text)
+  if (dynamicPicker) {
+    writer.write({
+      type: 'data-dynamicPicker',
+      data: dynamicPicker,
+    })
+  }
+}
 
 const handleChatStream = observe(
   async (req: AuthenticatedRequest, res: Response) => {
@@ -255,21 +274,7 @@ const handleChatStream = observe(
                   }
 
                   // Clarification blocks on both phases
-                  const questions = parseClarificationBlock(event.text)
-                  if (questions) {
-                    writer.write({
-                      type: 'data-clarification',
-                      data: { questions },
-                    })
-                  }
-
-                  const dynamicPicker = parseDynamicPickerBlock(event.text)
-                  if (dynamicPicker) {
-                    writer.write({
-                      type: 'data-dynamicPicker',
-                      data: dynamicPicker,
-                    })
-                  }
+                  emitTextAnnotations(event.text, writer)
                 } else {
                   // Old YAML path — unchanged
                   const hasWorkflowMetadata = WORKFLOW_METADATA_REGEX.test(
@@ -306,21 +311,7 @@ const handleChatStream = observe(
                   })
 
                   if (!hasWorkflowMetadata) {
-                    const questions = parseClarificationBlock(event.text)
-                    if (questions) {
-                      writer.write({
-                        type: 'data-clarification',
-                        data: { questions },
-                      })
-                    }
-
-                    const dynamicPicker = parseDynamicPickerBlock(event.text)
-                    if (dynamicPicker) {
-                      writer.write({
-                        type: 'data-dynamicPicker',
-                        data: dynamicPicker,
-                      })
-                    }
+                    emitTextAnnotations(event.text, writer)
                   }
                 }
               } catch (error) {

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -38,6 +38,7 @@ import { AuthenticatedRequest } from '@/types/express/context'
 
 import { serializeMessagesForLangfuse } from './helpers'
 import { parseClarificationBlock } from './parse-clarification-block'
+import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
 import { chatRequestSchema } from './schema'
 
 const MAX_MESSAGES = 50
@@ -261,6 +262,14 @@ const handleChatStream = observe(
                       data: { questions },
                     })
                   }
+
+                  const dynamicPicker = parseDynamicPickerBlock(event.text)
+                  if (dynamicPicker) {
+                    writer.write({
+                      type: 'data-dynamicPicker',
+                      data: dynamicPicker,
+                    })
+                  }
                 } else {
                   // Old YAML path — unchanged
                   const hasWorkflowMetadata = WORKFLOW_METADATA_REGEX.test(
@@ -302,6 +311,14 @@ const handleChatStream = observe(
                       writer.write({
                         type: 'data-clarification',
                         data: { questions },
+                      })
+                    }
+
+                    const dynamicPicker = parseDynamicPickerBlock(event.text)
+                    if (dynamicPicker) {
+                      writer.write({
+                        type: 'data-dynamicPicker',
+                        data: dynamicPicker,
                       })
                     }
                   }

--- a/packages/backend/src/routes/api/chat/parse-dynamic-picker-block.test.ts
+++ b/packages/backend/src/routes/api/chat/parse-dynamic-picker-block.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseDynamicPickerBlock } from './parse-dynamic-picker-block'
+
+const makeBlock = (inner: string) => `<!-- DYNAMIC_PICKER_DATA\n${inner}\n-->`
+
+describe('parseDynamicPickerBlock', () => {
+  it('returns correct data for a valid block', () => {
+    const text = makeBlock(
+      'Q: Which channel?\nSTEP_ID: step-uuid-123\nKEY: listChannels',
+    )
+    expect(parseDynamicPickerBlock(text)).toEqual({
+      question: 'Which channel?',
+      stepId: 'step-uuid-123',
+      key: 'listChannels',
+    })
+  })
+
+  it('parses questions containing colons correctly', () => {
+    const text = makeBlock(
+      'Q: Which channel: main or secondary?\nSTEP_ID: step-uuid-123\nKEY: listChannels',
+    )
+    expect(parseDynamicPickerBlock(text)).toEqual({
+      question: 'Which channel: main or secondary?',
+      stepId: 'step-uuid-123',
+      key: 'listChannels',
+    })
+  })
+
+  it('returns null when Q: is missing', () => {
+    const text = makeBlock('STEP_ID: step-uuid-123\nKEY: listChannels')
+    expect(parseDynamicPickerBlock(text)).toBeNull()
+  })
+
+  it('returns null when Q: is empty', () => {
+    const text = makeBlock('Q:\nSTEP_ID: step-uuid-123\nKEY: listChannels')
+    expect(parseDynamicPickerBlock(text)).toBeNull()
+  })
+
+  it('returns null when STEP_ID: is missing', () => {
+    const text = makeBlock('Q: Which channel?\nKEY: listChannels')
+    expect(parseDynamicPickerBlock(text)).toBeNull()
+  })
+
+  it('returns null when KEY: is missing', () => {
+    const text = makeBlock('Q: Which channel?\nSTEP_ID: step-uuid-123')
+    expect(parseDynamicPickerBlock(text)).toBeNull()
+  })
+
+  it('returns null when no DYNAMIC_PICKER_DATA block is present', () => {
+    expect(parseDynamicPickerBlock('Some normal text')).toBeNull()
+  })
+
+  it('only parses DYNAMIC_PICKER_DATA when both CLARIFICATION_DATA and DYNAMIC_PICKER_DATA are present', () => {
+    const text = [
+      '<!-- CLARIFICATION_DATA',
+      'Q: Old question',
+      '- Option 1',
+      '-->',
+      makeBlock('Q: Dynamic question\nSTEP_ID: step-uuid-456\nKEY: listSheets'),
+    ].join('\n')
+
+    expect(parseDynamicPickerBlock(text)).toEqual({
+      question: 'Dynamic question',
+      stepId: 'step-uuid-456',
+      key: 'listSheets',
+    })
+  })
+})

--- a/packages/backend/src/routes/api/chat/parse-dynamic-picker-block.ts
+++ b/packages/backend/src/routes/api/chat/parse-dynamic-picker-block.ts
@@ -1,0 +1,39 @@
+export interface DynamicPickerData {
+  question: string
+  stepId: string
+  key: string
+}
+
+export function parseDynamicPickerBlock(
+  text: string,
+): DynamicPickerData | null {
+  const match = text.match(/<!--\s*DYNAMIC_PICKER_DATA\s*([\s\S]*?)\s*-->/)
+  if (!match) {
+    return null
+  }
+
+  const lines = match[1]
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+
+  let question = ''
+  let stepId = ''
+  let key = ''
+
+  for (const line of lines) {
+    if (line.startsWith('Q:')) {
+      question = line.slice(2).trim()
+    } else if (line.startsWith('STEP_ID:')) {
+      stepId = line.slice(8).trim()
+    } else if (line.startsWith('KEY:')) {
+      key = line.slice(4).trim()
+    }
+  }
+
+  if (!question || !stepId || !key) {
+    return null
+  }
+
+  return { question, stepId, key }
+}

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -65,6 +65,14 @@ const messagePartSchema = z.discriminatedUnion('type', [
         .min(1),
     }),
   }),
+  z.object({
+    type: z.literal('data-dynamicPicker'),
+    data: z.object({
+      question: z.string(),
+      stepId: z.string(),
+      key: z.string(),
+    }),
+  }),
   // Pair Foundry / AI SDK dynamic tool part — present in assistant messages when
   // the LLM calls an MCP tool. The frontend echoes these parts back on subsequent turns.
   z.object({

--- a/packages/backend/src/routes/api/dynamic-data.test.ts
+++ b/packages/backend/src/routes/api/dynamic-data.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { UserFacingError } from '@/errors/user-facing-error'
+
+vi.mock('@/services/mcp/get-dynamic-data', () => ({
+  getDynamicDataService: vi.fn(),
+}))
+
+import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+
+import router from './dynamic-data'
+
+function makeReq(body: Record<string, unknown>) {
+  return {
+    body,
+    context: {
+      currentUser: { id: 'user-1', email: 'test@example.com' },
+    },
+  }
+}
+
+function makeRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  }
+}
+
+function getHandler() {
+  return router.stack[0].route.stack[0].handle
+}
+
+describe('POST /api/dynamic-data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns 400 for an invalid request body', async () => {
+    const res = makeRes()
+    const handler = getHandler()
+
+    await handler(
+      makeReq({}) as unknown as Parameters<typeof handler>[0],
+      res as unknown as Parameters<typeof handler>[1],
+      vi.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Invalid request' }),
+    )
+    expect(getDynamicDataService).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 with the message when the service throws a UserFacingError', async () => {
+    vi.mocked(getDynamicDataService).mockRejectedValue(
+      new UserFacingError('Step not found'),
+    )
+    const res = makeRes()
+    const handler = getHandler()
+
+    await handler(
+      makeReq({ stepId: 'step-1', key: 'table' }) as unknown as Parameters<
+        typeof handler
+      >[0],
+      res as unknown as Parameters<typeof handler>[1],
+      vi.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Step not found' })
+  })
+
+  it('returns 500 for an unexpected error', async () => {
+    vi.mocked(getDynamicDataService).mockRejectedValue(new Error('boom'))
+    const res = makeRes()
+    const handler = getHandler()
+
+    await handler(
+      makeReq({ stepId: 'step-1', key: 'table' }) as unknown as Parameters<
+        typeof handler
+      >[0],
+      res as unknown as Parameters<typeof handler>[1],
+      vi.fn(),
+    )
+
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' })
+  })
+
+  it('returns 200 with the fetched data on success', async () => {
+    const data = [{ name: 'Sheet 1', value: 'sheet-1' }]
+    vi.mocked(getDynamicDataService).mockResolvedValue(data)
+    const res = makeRes()
+    const handler = getHandler()
+
+    await handler(
+      makeReq({
+        stepId: 'step-1',
+        key: 'table',
+        parameters: { spreadsheetId: 'abc' },
+      }) as unknown as Parameters<typeof handler>[0],
+      res as unknown as Parameters<typeof handler>[1],
+      vi.fn(),
+    )
+
+    expect(getDynamicDataService).toHaveBeenCalledWith({
+      user: { id: 'user-1', email: 'test@example.com' },
+      stepId: 'step-1',
+      key: 'table',
+      parameters: { spreadsheetId: 'abc' },
+    })
+    expect(res.json).toHaveBeenCalledWith({ data })
+  })
+})

--- a/packages/backend/src/routes/api/dynamic-data.ts
+++ b/packages/backend/src/routes/api/dynamic-data.ts
@@ -34,14 +34,19 @@ router.post('/', async (req: AuthenticatedRequest, res) => {
 
   const { stepId, key, parameters } = parsed.data
 
-  const data = await getDynamicDataService({
-    user,
-    stepId,
-    key,
-    parameters: parameters as IJSONObject | undefined,
-  })
-
-  res.json({ data })
+  try {
+    const data = await getDynamicDataService({
+      user,
+      stepId,
+      key,
+      parameters: parameters as IJSONObject | undefined,
+    })
+    res.json({ data })
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Internal server error'
+    res.status(400).json({ error: message })
+  }
 })
 
 export default router

--- a/packages/backend/src/routes/api/dynamic-data.ts
+++ b/packages/backend/src/routes/api/dynamic-data.ts
@@ -3,6 +3,7 @@ import type { IJSONObject } from '@plumber/types'
 import { Router } from 'express'
 import { z } from 'zod/v4'
 
+import { UserFacingError } from '@/errors/user-facing-error'
 import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import type { AuthenticatedRequest } from '@/types/express/context'
 
@@ -43,9 +44,11 @@ router.post('/', async (req: AuthenticatedRequest, res) => {
     })
     res.json({ data })
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Internal server error'
-    res.status(400).json({ error: message })
+    if (error instanceof UserFacingError) {
+      res.status(400).json({ error: error.message })
+    } else {
+      res.status(500).json({ error: 'Internal server error' })
+    }
   }
 })
 

--- a/packages/backend/src/routes/api/dynamic-data.ts
+++ b/packages/backend/src/routes/api/dynamic-data.ts
@@ -1,0 +1,47 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { Router } from 'express'
+import { z } from 'zod/v4'
+
+import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+import type { AuthenticatedRequest } from '@/types/express/context'
+
+const router = Router()
+
+const bodySchema = z.object({
+  stepId: z.string().min(1),
+  key: z.string().min(1),
+  parameters: z.record(z.string(), z.unknown()).optional(),
+})
+
+router.post('/', async (req: AuthenticatedRequest, res) => {
+  // Auth: resolved from the session cookie via setCurrentUserContext +
+  // requireAuthentication middleware applied to all /api/* routes.
+  //
+  // TODO(MCP): When exposing this endpoint via an MCP transport, resolve the
+  // user from the MCP API key or OAuth token in the Authorization header
+  // instead of the session cookie. The getDynamicDataService call below is
+  // already transport-agnostic — only this user-resolution line changes.
+  const user = req.context.currentUser
+
+  const parsed = bodySchema.safeParse(req.body)
+  if (!parsed.success) {
+    res
+      .status(400)
+      .json({ error: 'Invalid request', details: parsed.error.issues })
+    return
+  }
+
+  const { stepId, key, parameters } = parsed.data
+
+  const data = await getDynamicDataService({
+    user,
+    stepId,
+    key,
+    parameters: parameters as IJSONObject | undefined,
+  })
+
+  res.json({ data })
+})
+
+export default router

--- a/packages/backend/src/routes/api/index.ts
+++ b/packages/backend/src/routes/api/index.ts
@@ -8,6 +8,7 @@ import {
 import adminRouter from './admin'
 import appsRouter from './apps'
 import chatRouter from './chat'
+import dynamicDataRouter from './dynamic-data'
 
 const router = Router()
 
@@ -24,6 +25,7 @@ router.use('/admin', adminRouter)
 router.use(blockAdminOperations)
 
 router.use('/chat', chatRouter)
+router.use('/dynamic-data', dynamicDataRouter)
 
 // Future routes can be added here:
 // router.use('/users', usersRouter)

--- a/packages/backend/src/services/mcp/get-dynamic-data.ts
+++ b/packages/backend/src/services/mcp/get-dynamic-data.ts
@@ -124,7 +124,7 @@ export async function getDynamicDataService({
   }
 
   if (fetchedData.error) {
-    throw new Error(JSON.stringify(fetchedData.error))
+    throw new UserFacingError(JSON.stringify(fetchedData.error))
   }
 
   return fetchedData.data

--- a/packages/backend/src/services/mcp/get-dynamic-data.ts
+++ b/packages/backend/src/services/mcp/get-dynamic-data.ts
@@ -1,6 +1,7 @@
 import type { IDynamicData, IJSONObject } from '@plumber/types'
 
 import apps from '@/apps'
+import { UserFacingError } from '@/errors/user-facing-error'
 import { APP_CONNECTION_FIELDS } from '@/helpers/get-shared-connection-details'
 import globalVariable from '@/helpers/global-variable'
 import type User from '@/models/user'
@@ -32,14 +33,14 @@ export async function getDynamicDataService({
     .findById(stepId)
 
   if (!step || !step.appKey) {
-    throw new Error('Step not found')
+    throw new UserFacingError('Step not found')
   }
 
   const app = apps[step.appKey]
   const connection = step.connection
 
   if (app.auth && !connection) {
-    throw new Error('Step has no verified connection')
+    throw new UserFacingError('Step has no verified connection')
   }
 
   // Phase 1: caller is always the pipe owner; role substitution is never needed.
@@ -56,7 +57,7 @@ export async function getDynamicDataService({
     | undefined
 
   if (!command) {
-    throw new Error(
+    throw new UserFacingError(
       `Dynamic data key '${key}' not found for app '${step.appKey}'`,
     )
   }


### PR DESCRIPTION
## Stack Context

This stack adds a dynamic options picker to the MCP AI Builder chat UI.
When the LLM needs the user to pick from a list of dynamic options (e.g. "which sheet in this spreadsheet?"), it now emits a structured block that the frontend resolves to a proper dropdown — instead of asking the user to type free text.

## TL;DR

The LLM emits a `DYNAMIC_PICKER_DATA` block containing a question, a step ID, and a dynamic-data key. The backend parses this block out of the SSE stream and emits a `data-dynamicPicker` event. A new `POST /api/dynamic-data` endpoint lets the frontend fetch the actual option list directly, bypassing the LLM entirely.

## What changed?

**New parser — `parse-dynamic-picker-block.ts`**
Parses the `DYNAMIC_PICKER_DATA` block format the LLM emits (`Q:`, `STEP_ID:`, `KEY:` lines). Drops the old `N:`/`V:` options lines — the frontend now fetches those itself.

**Chat route — `routes/api/chat/index.ts`**
Both the new (MCP tool-call) and old (YAML) streaming paths call `parseDynamicPickerBlock` on each text event and emit a `data-dynamicPicker` SSE event when a block is found.

**Chat schema — `routes/api/chat/schema.ts`**
Adds `data-dynamicPicker` as a recognised message part type carrying `{ question, stepId, key }`.

**New route — `routes/api/dynamic-data.ts`**
`POST /api/dynamic-data` validates `{ stepId, key, parameters? }` and delegates to the existing `getDynamicDataService`. Known user errors (step not found, no connection, unknown key) return 400; unexpected infrastructure errors return 500 with a generic message. A `UserFacingError` class distinguishes the two — Express 4 doesn't auto-catch async throws, so the explicit try/catch is required to avoid uncaught rejections crashing the Node 22 process.

**Langfuse prompt**
`DYNAMIC_PICKER_INSTRUCTIONS` constant removed from code — the instructions now live in the Langfuse prompt (`chat_v126`) alongside `CLARIFICATION_DATA` and `WORKFLOW_METADATA`. **Deploy note below.**

## Tests

Manual regression checklist for the reviewer:

- [ ] Open the AI Builder chat for a flow that has at least one step with dynamic options (e.g. a Google Sheets step).
- [ ] Ask the AI to configure that step. Confirm the chat still responds normally and no crash occurs on the backend.
- [ ] Confirm that when the LLM emits a `DYNAMIC_PICKER_DATA` block, a picker appears in the UI (covered by the frontend PR, but verify the SSE event reaches the browser via DevTools → Network → EventStream).
- [ ] Hit `POST /api/dynamic-data` directly with a valid `{ stepId, key }` payload (get the stepId from the URL after opening the step in the editor). Confirm a `{ data: [...] }` response with the expected options.
- [ ] Hit `POST /api/dynamic-data` with a bad `stepId` and confirm a 400 is returned without crashing the server.

## Deploy Notes

**Langfuse prompt update required before deploying this PR.**
The `DYNAMIC_PICKER_INSTRUCTIONS` block has been removed from the backend code. The equivalent instructions must be present in the `chat_v126` prompt in Langfuse before this is deployed, otherwise the LLM will not know to emit `DYNAMIC_PICKER_DATA` blocks.

Confirm the Langfuse `chat_v126` prompt includes the `DYNAMIC_PICKER_DATA` format section before merging to production.