### PR TITLE
[AI-SETUP-14] PLU-817 feat: execute Step for AI builder step testing

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -51,6 +51,7 @@ describe('createMcpBridgeTools', () => {
       'create_step',
       'delete_step',
       'get_dynamic_data',
+      'execute_step',
     ])
   })
 

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -13,6 +13,10 @@ import {
 } from '@/services/mcp/create-flow-with-steps'
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
+import {
+  executeStepService,
+  type McpExecuteStepResult,
+} from '@/services/mcp/execute-step'
 import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import {
   listConnectionsService,
@@ -222,6 +226,19 @@ export function createMcpBridgeTools(
           key,
           parameters: parameters as IJSONObject | undefined,
         })
+      },
+    }),
+
+    execute_step: tool({
+      description:
+        'Test a configured step in a pipe. Runs the step, marks it as completed on success, and returns its output data. Call after update_step_parameters to verify the step works. The returned dataOut will be used to wire variables into downstream steps.',
+      inputSchema: z.object({
+        step_id: z.string().describe('ID of the step to test'),
+      }),
+      execute: async ({ step_id }): Promise<McpExecuteStepResult> => {
+        const result = await executeStepService(user, step_id)
+        onPipeChange?.(result.pipeId)
+        return result
       },
     }),
   }

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -231,9 +231,9 @@ export function createMcpBridgeTools(
 
     execute_step: tool({
       description:
-        'Test a configured step in a pipe. Runs the step, marks it as completed on success, and returns its output data. Call after update_step_parameters to verify the step works. The returned dataOut will be used to wire variables into downstream steps.',
+        'Test a configured step in a pipe. Runs the step, marks it as completed on success, and returns its output data. Call after update_step_parameters to verify the step works. The returned dataOut will be used to wire variables into downstream steps. Warning: for steps that send a real message (SMS by Postman sendSms, Telegram sendMessage, Slack sendMessageToChannel, PaySG sendEmail), this actually sends it to the configured recipient/channel/number — confirm the details with the user before calling this for those steps.',
       inputSchema: z.object({
-        step_id: z.string().describe('ID of the step to test'),
+        step_id: z.uuid().describe('ID of the step to test'),
       }),
       execute: async ({ step_id }): Promise<McpExecuteStepResult> => {
         let pipeId: string | undefined

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -236,9 +236,16 @@ export function createMcpBridgeTools(
         step_id: z.string().describe('ID of the step to test'),
       }),
       execute: async ({ step_id }): Promise<McpExecuteStepResult> => {
-        const result = await executeStepService(user, step_id)
-        onPipeChange?.(result.pipeId)
-        return result
+        let pipeId: string | undefined
+        try {
+          const result = await executeStepService(user, step_id)
+          pipeId = result.pipeId
+          return result
+        } finally {
+          if (pipeId) {
+            onPipeChange?.(pipeId)
+          }
+        }
       },
     }),
   }

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -109,6 +109,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
   toolPart('tool-create_step'),
   toolPart('tool-delete_step'),
   toolPart('tool-get_dynamic_data'),
+  toolPart('tool-execute_step'),
 ])
 
 const messageSchema = z.object({

--- a/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
@@ -113,6 +113,9 @@ describe('executeStepService', () => {
 
     const updated = await Step.query().findById(actionStep.id)
     expect(updated.status).toBe('completed')
+
+    const updatedFlow = await Flow.query().findById(flow.id)
+    expect(updatedFlow.testExecutionId).toBe(execution.id)
   })
 
   it('does not mark step as completed and returns success:false when testStep fails', async () => {

--- a/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/execute-step.itest.ts
@@ -1,0 +1,167 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Execution from '@/models/execution'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { executeStepService } from '../execute-step'
+
+const mocks = vi.hoisted(() => ({
+  testStep: vi.fn(),
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+}))
+
+vi.mock('@/services/test-step', () => ({
+  default: mocks.testStep,
+}))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+const makeExecutionStep = (
+  overrides: Partial<{
+    id: string
+    status: 'success' | 'failure'
+    dataOut: Record<string, unknown> | null
+    errorDetails: Record<string, unknown> | null
+  }> = {},
+) => {
+  const base: {
+    id: string
+    status: 'success' | 'failure'
+    dataOut: Record<string, unknown> | null
+    errorDetails: Record<string, unknown> | null
+  } = {
+    id: randomUUID(),
+    status: 'success',
+    dataOut: { submissionId: 'abc123' },
+    errorDetails: null,
+    ...overrides,
+  }
+  return {
+    ...base,
+    get isFailed() {
+      return this.status === 'failure'
+    },
+  }
+}
+
+describe('executeStepService', () => {
+  let user: User
+  let flow: Awaited<ReturnType<typeof createFlowWithStepsService>>
+
+  beforeEach(async () => {
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+
+    user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `execute-step-${randomUUID()}@example.com`,
+    })
+
+    flow = await createFlowWithStepsService({
+      user,
+      name: 'Test Pipe',
+      steps: [
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
+        {
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          type: 'action',
+          position: 2,
+        },
+      ],
+      traceId: 'trace-execute-1',
+    })
+  })
+
+  it('marks step as completed and returns success:true when testStep succeeds', async () => {
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+    expect(actionStep).toBeDefined()
+
+    const execution = await Execution.query().insertAndFetch({
+      id: randomUUID(),
+      flowId: flow.id,
+    })
+    const execStep = makeExecutionStep({ dataOut: { output: 'data' } })
+    mocks.testStep.mockResolvedValueOnce({
+      executionStep: execStep,
+      executionId: execution.id,
+    })
+
+    const result = await executeStepService(user, actionStep.id)
+
+    expect(result).toMatchObject({
+      success: true,
+      pipeId: flow.id,
+      stepId: actionStep.id,
+      executionStepId: execStep.id,
+      dataOut: { output: 'data' },
+      errorDetails: null,
+    })
+
+    const updated = await Step.query().findById(actionStep.id)
+    expect(updated.status).toBe('completed')
+  })
+
+  it('does not mark step as completed and returns success:false when testStep fails', async () => {
+    const actionStep = flow.steps.find((s) => s.type === 'action')
+
+    const execution = await Execution.query().insertAndFetch({
+      id: randomUUID(),
+      flowId: flow.id,
+    })
+    const execStep = makeExecutionStep({
+      status: 'failure',
+      dataOut: null,
+      errorDetails: { message: 'Invalid credentials' },
+    })
+    mocks.testStep.mockResolvedValueOnce({
+      executionStep: execStep,
+      executionId: execution.id,
+    })
+
+    const result = await executeStepService(user, actionStep.id)
+
+    expect(result.success).toBe(false)
+    expect(result.errorDetails).toMatchObject({
+      message: 'Invalid credentials',
+    })
+
+    const unchanged = await Step.query().findById(actionStep.id)
+    expect(unchanged.status).not.toBe('completed')
+  })
+
+  it('throws if the pipe is active', async () => {
+    await Flow.knex()
+      .table('flows')
+      .where('id', flow.id)
+      .update({ active: true })
+
+    const anyStep = flow.steps[0]
+    await expect(executeStepService(user, anyStep.id)).rejects.toThrow(
+      'Cannot test a step in an active pipe',
+    )
+  })
+
+  it('throws if the step does not belong to the user', async () => {
+    const otherUser = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `other-user-${randomUUID()}@example.com`,
+    })
+
+    const anyStep = flow.steps[0]
+    await expect(executeStepService(otherUser, anyStep.id)).rejects.toThrow()
+  })
+})

--- a/packages/backend/src/services/mcp/execute-step.ts
+++ b/packages/backend/src/services/mcp/execute-step.ts
@@ -1,0 +1,55 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { raw } from 'objection'
+
+import Flow from '@/models/flow'
+import type User from '@/models/user'
+import testStep from '@/services/test-step'
+
+export interface McpExecuteStepResult {
+  success: boolean
+  pipeId: string
+  stepId: string
+  executionStepId: string
+  dataOut: IJSONObject | null
+  errorDetails: IJSONObject | null
+}
+
+export async function executeStepService(
+  user: User,
+  stepId: string,
+): Promise<McpExecuteStepResult> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'editor' })
+    .withGraphFetched('flow')
+    .findById(stepId)
+    .throwIfNotFound()
+
+  if (step.flow.active) {
+    throw new Error('Cannot test a step in an active pipe')
+  }
+
+  // TODO: MRF redirect when AI builder supports it
+
+  const { executionStep, executionId } = await testStep({ stepId: step.id })
+
+  await Flow.query().patchAndFetchById(step.flowId, {
+    testExecutionId: executionId,
+  })
+
+  if (!executionStep.isFailed) {
+    await step.$query().patchAndFetch({
+      status: 'completed',
+      config: raw(`config - 'templateConfig'`),
+    })
+  }
+
+  return {
+    success: !executionStep.isFailed,
+    pipeId: step.flowId,
+    stepId: step.id,
+    executionStepId: executionStep.id,
+    dataOut: executionStep.dataOut ?? null,
+    errorDetails: executionStep.errorDetails ?? null,
+  }
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -83,9 +83,9 @@ export default function Step(props: StepProps) {
         >
           <Flex {...flowStepStyles.topHeader} py={isNested ? 3 : 4}>
             <StepAppIcon
-              isCompleted={undefined}
+              isCompleted={step.status === 'completed'}
               isNested={isNested}
-              isTestSuccessful={undefined}
+              isTestSuccessful={step.status === 'completed' ? true : undefined}
               shouldTestStepAgain={false}
               app={app}
               step={step}


### PR DESCRIPTION
## Stack context

This PR is part of the MCP AI builder stack. It sits above **#1852** ([DynamicPicker UI](https://github.com/opengovsg/plumber/pull/1852)).

Full stack (bottom → top):
- Foundation + list_apps … list_connections, get_dynamic_data (earlier PRs)
- #1852 — DynamicPicker UI (fetch, search, confirm, fallback, skip)
- **#1854 — execute_step tool (this PR)**

## TL;DR

Adds an `execute_step` MCP bridge tool so Claude can test a configured step during flow construction. On success the step is marked `completed` and the AI builder UI shows a green check badge.

## What changed?

**`packages/backend/src/services/mcp/execute-step.ts`** (new)
- `executeStepService` wraps the existing `testStep` service with MCP-specific guards
- Rejects execution if the pipe is active (can't test a live flow)
- On success: marks the step `status = 'completed'` and strips `templateConfig` from its config
- Updates `flow.testExecutionId` so the frontend can load the latest execution
- Returns `{ success, pipeId, stepId, executionStepId, dataOut, errorDetails }`

**`packages/backend/src/helpers/mcp-bridge-tools.ts`**
- Registers `execute_step` tool — takes a `step_id`, runs `executeStepService`, then fires `onPipeChange(pipeId)` so the frontend re-fetches pipe state
- `onPipeChange` is called in a `finally` block so it fires even if `executeStepService` throws (e.g. network error mid-execution), preventing a stale frontend

**`packages/backend/src/routes/api/chat/schema.ts`**
- Adds `tool-execute_step` to the allowed message part types so the Vercel AI SDK can include this tool invocation in chat history replayed to the backend

**`packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx`**
- `isCompleted` and `isTestSuccessful` are now driven by `step.status === 'completed'` instead of being hardcoded `undefined` — shows the green success badge on steps Claude has successfully tested

**`packages/backend/src/services/mcp/__tests__/execute-step.itest.ts`** (new)
- Integration tests covering: success path (step marked completed, `testExecutionId` updated on flow, error details returned), failure path (step not marked completed, error details returned), active-pipe guard, and IDOR (step belonging to another user)

## Tests

> Prerequisite: AI builder MCP mode enabled via LD flag.

- [ ] Open AI builder, create a new pipe via chat. Ask Claude to configure and test a FormSG trigger step.
  - Claude should call `execute_step` after configuring the step.
  - On success: the step in the StepsPreview sidebar shows a green check badge.
  - On failure: Claude receives `errorDetails` and attempts to fix the configuration.
- [ ] Regression — open an existing non-AI-builder pipe in the pipe editor and confirm it still loads and runs normally.
- [ ] Regression — confirm DynamicPicker (from #1852) still works: dynamic-data fields still show the picker with search and confirm flow.

## Deploy notes

No migrations, no new env vars, no new feature flags. Gated by the existing `mcpStepConfig` AI builder LaunchDarkly flag.