### PR TITLE
chore: allocate per-worktree dev ports for Superset worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,10 @@ tmp/
 .claude/settings.local.json
 
 docs/plans
+docs/superpowers/specs
 .codegraph
+
+# superset worktree port allocation (local / per-machine, never committed)
+/.superset/port-registry
+/.superset/port-registry.lock
+/.superset/config.local.json

--- a/.superset/base_port.sh
+++ b/.superset/base_port.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# NOTE: based on https://github.com/superset-sh/superset/pull/1494.
+#
+# Assign this worktree a port base from a project-local registry shared across
+# Plumber worktrees (via $SUPERSET_ROOT_PATH) and print the port base.
+#   bash base_port.sh            -> print the port base (allocating if needed)
+#   bash base_port.sh --release  -> remove this worktree's ($PWD) allocation
+#
+# Allocating also prunes entries whose worktree directory is gone, so bases
+# from worktrees deleted outside Superset (which never ran --release) are reused.
+#
+# Only runs under Superset (needs SUPERSET_ROOT_PATH). A plain `npm run dev`
+# never calls this and falls back to 3000/3001 in vite.config.ts / package.json.
+set -euo pipefail
+
+# Base port for this project's worktrees. Teammates who run other Superset
+# projects in the 13000 range can relocate Plumber's by exporting this (e.g. via
+# a .superset/config.local.json `run.before`, or their shell profile).
+START="${PLUMBER_SUPERSET_PORT_BASE:-13000}"
+STRIDE=10
+LOCK_TIMEOUT=30
+LOCK_STALE=300
+
+if [ -z "${SUPERSET_ROOT_PATH:-}" ]; then
+  echo "base_port.sh: SUPERSET_ROOT_PATH is not set (run under Superset)" >&2
+  exit 1
+fi
+REG="$SUPERSET_ROOT_PATH/.superset/port-registry"
+LOCK_DIR="$SUPERSET_ROOT_PATH/.superset/port-registry.lock"
+
+acquire_lock() {
+  local waited=0 pid mtime
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    pid=""
+    [ -f "$LOCK_DIR/pid" ] && pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      rm -rf "$LOCK_DIR" 2>/dev/null || true # dead holder -> reclaim
+      continue
+    fi
+    mtime="$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || true)"
+    if [ -n "$mtime" ] && [ "$(($(date +%s) - mtime))" -ge "$LOCK_STALE" ]; then
+      rm -rf "$LOCK_DIR" 2>/dev/null || true # stale -> reclaim
+      continue
+    fi
+    if [ "$waited" -ge "$LOCK_TIMEOUT" ]; then
+      echo "base_port.sh: timed out waiting for lock: $LOCK_DIR" >&2
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  printf '%s\n' "$$" > "$LOCK_DIR/pid" 2>/dev/null || true
+}
+
+release_lock() { rm -rf "$LOCK_DIR" 2>/dev/null || true; }
+
+ensure_reg() {
+  mkdir -p "$(dirname "$REG")"
+  [ -f "$REG" ] || : > "$REG"
+}
+
+lookup_base() { # print existing base for $PWD, else nothing
+  local b p
+  while IFS="$(printf '\t')" read -r b p; do
+    if [ "$p" = "$PWD" ]; then
+      printf '%s' "$b"
+      return 0
+    fi
+  done < "$REG"
+  return 0
+}
+
+prune_dead() { # best-effort: drop registry entries whose worktree dir is gone
+  local tmp b p pruned=0
+  tmp="${REG}.prune.$$"
+  while IFS="$(printf '\t')" read -r b p; do
+    if [ -n "$p" ] && [ -d "$p" ]; then
+      printf '%s\t%s\n' "$b" "$p"
+    elif [ -n "$p" ]; then
+      pruned=$((pruned + 1))
+    fi
+  done < "$REG" > "$tmp" || { rm -f "$tmp"; return 0; }
+  if [ "$pruned" -gt 0 ] && mv "$tmp" "$REG"; then
+    echo "base_port.sh: pruned $pruned stale registry entries (worktree deleted outside Superset)" >&2
+  else
+    rm -f "$tmp"
+  fi
+  return 0
+}
+
+if [ "${1:-}" = "--release" ]; then
+  ensure_reg
+  acquire_lock || exit 1
+  trap release_lock EXIT
+  tmp="${REG}.tmp.$$"
+  if awk -F'\t' -v k="$PWD" '$2 != k' "$REG" > "$tmp" && mv "$tmp" "$REG"; then
+    echo "base_port.sh: released allocation for $PWD" >&2
+  else
+    rm -f "$tmp"
+    echo "base_port.sh: failed to release allocation" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+ensure_reg
+acquire_lock || exit 1
+trap release_lock EXIT
+
+# Reclaim bases from worktrees deleted outside Superset (they never ran
+# --release). Safe: $PWD always exists, so this worktree is never pruned.
+prune_dead
+
+base="$(lookup_base)"
+if [ -z "$base" ]; then
+  used="$(cut -f1 "$REG")"
+  base=$START
+  while printf '%s\n' "$used" | grep -qx "$base"; do
+    base=$((base + STRIDE))
+  done
+  printf '%s\t%s\n' "$base" "$PWD" >> "$REG"
+fi
+
+release_lock
+trap - EXIT
+
+printf '%s\n' "$base"

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,10 @@
+{
+  "_note": "Frontend/backend ports for Superset worktrees are allocated from PLUMBER_SUPERSET_PORT_BASE (default 13000) by .superset/base_port.sh. To use a different base on your machine (e.g. another Superset project already uses the 13000 range), create a git-ignored .superset/config.local.json containing: { \"run\": { \"before\": [\"export PLUMBER_SUPERSET_PORT_BASE=20000\"] } }",
+  "setup": [
+    "npm install",
+    "cp \"$SUPERSET_ROOT_PATH/packages/backend/.env\" packages/backend/.env",
+    "codegraph init -i"
+  ],
+  "teardown": ["bash .superset/base_port.sh --release"],
+  "run": ["bash .superset/run.sh"]
+}

--- a/.superset/run.sh
+++ b/.superset/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Assign this Superset worktree's ports, then start the dev servers.
+# Wired up via .superset/config.json: "run": ["bash .superset/run.sh"].
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+base="$(bash "$SCRIPT_DIR/base_port.sh")" # set -e propagates base_port.sh failure
+export PORT="$base"
+export BASE_URL="http://localhost:$base"
+export WEB_APP_URL="http://localhost:$((base + 1))"
+export DEV_BACKEND_PORT="$base"
+export DEV_FRONTEND_PORT="$((base + 1))"
+exec npm run dev

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.72.0",
   "type": "module",
   "scripts": {
-    "dev": "wait-on tcp:3000 && vite --host --force",
+    "dev": "wait-on tcp:${DEV_BACKEND_PORT:-3000} && vite --host --force",
     "build": "tsc && vite build --mode=${VITE_MODE:-prod}",
     "build:lib": "vite build -c vite.config.lib.ts --mode=${VITE_MODE:-prod} && tsc-alias -p tsconfig.lib.json",
     "prebuild": "rimraf ./build",

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -5,6 +5,13 @@ import viteTsconfigPaths from 'vite-tsconfig-paths'
 
 import { failOnLeakedNodeBuiltins } from './vite-config-utils'
 
+// Ports are assigned per Superset worktree by .superset/base_port.sh and exported as
+// DEV_BACKEND_PORT / DEV_FRONTEND_PORT. Fall back to the classic 3000/3001 for a
+// plain, non-Superset `npm run dev`.
+const backendPort = process.env.DEV_BACKEND_PORT || '3000'
+const frontendPort = Number(process.env.DEV_FRONTEND_PORT) || 3001
+const backendTarget = `http://localhost:${backendPort}`
+
 // https://vitejs.dev/config/
 export default defineConfig({
   // loadVersion injects package.json version into import.meta.env.PACKAGE_VERSION
@@ -17,21 +24,24 @@ export default defineConfig({
     },
   },
   server: {
-    open: 'http://localhost:3001',
-    port: 3001,
+    open: `http://localhost:${frontendPort}`,
+    port: frontendPort,
+    // Fail loudly if the assigned port is taken (Superset worktrees). Stay
+    // lenient for plain dev so vite can auto-pick a free port as before.
+    strictPort: Boolean(process.env.DEV_FRONTEND_PORT),
     proxy: {
       '/graphql': {
-        target: 'http://localhost:3000',
+        target: backendTarget,
         changeOrigin: true,
         secure: false,
       },
       '/api': {
-        target: 'http://localhost:3000',
+        target: backendTarget,
         changeOrigin: true,
         secure: false,
       },
       '/apps': {
-        target: 'http://localhost:3000',
+        target: backendTarget,
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
# Context

I want to start multiple worktrees in superset and have each worktree have their own port, so that I can test multiple things.

# Approach

Adapt the approach from https://github.com/superset-sh/superset/pull/1494.

## TLDR

When starting a worktree, superset will grab a base port number (starts from 13000 by default) to serve from. Taken ports are written to a file so that the next worktree knows to grab a different base port.

IMPORTANT: This is project-wide, not system wide. Superset worktrees in other projects won't get this.