### PR TITLE
[AI-SETUP-15] PLU-822 feat(backend): add verifyConnectionRegistrationService with status mapping

### DIFF
--- a/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
@@ -38,16 +38,18 @@ const makeUser = () =>
     id: 'user-1',
     email: 'test@example.com',
     withAccessibleSteps: vi.fn().mockReturnValue({
-      findOne: vi
-        .fn()
-        .mockResolvedValue({ id: 'step-1', appKey: 'formsg', flowId: 'flow-1' }),
+      findOne: vi.fn().mockResolvedValue({
+        id: 'step-1',
+        appKey: 'formsg',
+        flowId: 'flow-1',
+      }),
     }),
     withAccessibleConnections: vi.fn().mockReturnValue({
       findOne: vi
         .fn()
         .mockResolvedValue({ id: 'conn-1', key: 'formsg', userId: 'user-1' }),
     }),
-  }) as any
+  } as any)
 
 describe('verifyConnectionRegistrationService', () => {
   let user: ReturnType<typeof makeUser>
@@ -64,7 +66,11 @@ describe('verifyConnectionRegistrationService', () => {
       message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.VERIFIED,
     })
 
-    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+    const result = await verifyConnectionRegistrationService(
+      user,
+      'step-1',
+      'conn-1',
+    )
 
     expect(result.status).toBe('VERIFIED')
   })
@@ -75,10 +81,16 @@ describe('verifyConnectionRegistrationService', () => {
       message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT,
     })
 
-    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+    const result = await verifyConnectionRegistrationService(
+      user,
+      'step-1',
+      'conn-1',
+    )
 
     expect(result.status).toBe('ANOTHER_ENDPOINT')
-    expect(result.message).toBe(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT)
+    expect(result.message).toBe(
+      FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT,
+    )
   })
 
   it('returns ANOTHER_PIPE when message matches that constant', async () => {
@@ -87,10 +99,16 @@ describe('verifyConnectionRegistrationService', () => {
       message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE,
     })
 
-    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+    const result = await verifyConnectionRegistrationService(
+      user,
+      'step-1',
+      'conn-1',
+    )
 
     expect(result.status).toBe('ANOTHER_PIPE')
-    expect(result.message).toBe(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE)
+    expect(result.message).toBe(
+      FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE,
+    )
   })
 
   it('returns UNREGISTERED when registrationVerified is false and message is undefined', async () => {
@@ -98,7 +116,11 @@ describe('verifyConnectionRegistrationService', () => {
       registrationVerified: false,
     })
 
-    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+    const result = await verifyConnectionRegistrationService(
+      user,
+      'step-1',
+      'conn-1',
+    )
 
     expect(result.status).toBe('UNREGISTERED')
   })
@@ -137,14 +159,18 @@ describe('verifyConnectionRegistrationService', () => {
 
     it('throws when connection belongs to another user', async () => {
       user.withAccessibleConnections.mockReturnValue({
-        findOne: vi
-          .fn()
-          .mockResolvedValue({ id: 'conn-1', key: 'formsg', userId: 'other-user' }),
+        findOne: vi.fn().mockResolvedValue({
+          id: 'conn-1',
+          key: 'formsg',
+          userId: 'other-user',
+        }),
       })
 
       await expect(
         verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
-      ).rejects.toThrow('You cannot use a personal connection that you do not own')
+      ).rejects.toThrow(
+        'You cannot use a personal connection that you do not own',
+      )
     })
 
     it('throws when connection app does not match step app', async () => {
@@ -162,9 +188,11 @@ describe('verifyConnectionRegistrationService', () => {
     it('throws when app does not support connection registration verification', async () => {
       // Use an appKey not present in the mocked apps registry
       user.withAccessibleSteps.mockReturnValue({
-        findOne: vi
-          .fn()
-          .mockResolvedValue({ id: 'step-1', appKey: 'slack', flowId: 'flow-1' }),
+        findOne: vi.fn().mockResolvedValue({
+          id: 'step-1',
+          appKey: 'slack',
+          flowId: 'flow-1',
+        }),
       })
       user.withAccessibleConnections.mockReturnValue({
         findOne: vi
@@ -174,7 +202,9 @@ describe('verifyConnectionRegistrationService', () => {
 
       await expect(
         verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
-      ).rejects.toThrow('App does not support connection registration verification')
+      ).rejects.toThrow(
+        'App does not support connection registration verification',
+      )
     })
 
     it('throws when flow is not found', async () => {

--- a/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
@@ -6,6 +6,7 @@ import { verifyConnectionRegistrationService } from '../verify-connection-regist
 
 const mocks = vi.hoisted(() => ({
   verifyConnectionRegistration: vi.fn(),
+  flowFindById: vi.fn(),
 }))
 
 vi.mock('@/apps', () => ({
@@ -27,7 +28,7 @@ vi.mock('@/helpers/global-variable', () => ({
 vi.mock('@/models/flow', () => ({
   default: {
     query: vi.fn().mockReturnValue({
-      findById: vi.fn().mockResolvedValue({ id: 'flow-1', name: 'Test' }),
+      findById: mocks.flowFindById,
     }),
   },
 }))
@@ -54,6 +55,7 @@ describe('verifyConnectionRegistrationService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     user = makeUser()
+    mocks.flowFindById.mockResolvedValue({ id: 'flow-1', name: 'Test' })
   })
 
   it('returns VERIFIED when registrationVerified is true', async () => {
@@ -110,5 +112,77 @@ describe('verifyConnectionRegistrationService', () => {
     await expect(
       verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
     ).rejects.toThrow(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.UNAUTHORIZED)
+  })
+
+  describe('guard branches', () => {
+    it('throws when step is not found', async () => {
+      user.withAccessibleSteps.mockReturnValue({
+        findOne: vi.fn().mockResolvedValue(null),
+      })
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('Step not found')
+    })
+
+    it('throws when connection is not found', async () => {
+      user.withAccessibleConnections.mockReturnValue({
+        findOne: vi.fn().mockResolvedValue(null),
+      })
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('Connection not found')
+    })
+
+    it('throws when connection belongs to another user', async () => {
+      user.withAccessibleConnections.mockReturnValue({
+        findOne: vi
+          .fn()
+          .mockResolvedValue({ id: 'conn-1', key: 'formsg', userId: 'other-user' }),
+      })
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('You cannot use a personal connection that you do not own')
+    })
+
+    it('throws when connection app does not match step app', async () => {
+      user.withAccessibleConnections.mockReturnValue({
+        findOne: vi
+          .fn()
+          .mockResolvedValue({ id: 'conn-1', key: 'slack', userId: 'user-1' }),
+      })
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('Connection app does not match step app')
+    })
+
+    it('throws when app does not support connection registration verification', async () => {
+      // Use an appKey not present in the mocked apps registry
+      user.withAccessibleSteps.mockReturnValue({
+        findOne: vi
+          .fn()
+          .mockResolvedValue({ id: 'step-1', appKey: 'slack', flowId: 'flow-1' }),
+      })
+      user.withAccessibleConnections.mockReturnValue({
+        findOne: vi
+          .fn()
+          .mockResolvedValue({ id: 'conn-1', key: 'slack', userId: 'user-1' }),
+      })
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('App does not support connection registration verification')
+    })
+
+    it('throws when flow is not found', async () => {
+      mocks.flowFindById.mockResolvedValue(null)
+
+      await expect(
+        verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+      ).rejects.toThrow('Flow not found')
+    })
   })
 })

--- a/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FORMSG_WEBHOOK_VERIFICATION_MESSAGE } from '@/apps/formsg/common/webhook-settings'
+
+import { verifyConnectionRegistrationService } from '../verify-connection-registration'
+
+const mocks = vi.hoisted(() => ({
+  verifyConnectionRegistration: vi.fn(),
+}))
+
+vi.mock('@/apps', () => ({
+  default: {
+    formsg: {
+      key: 'formsg',
+      auth: {
+        connectionRegistrationType: 'per-step' as const,
+        verifyConnectionRegistration: mocks.verifyConnectionRegistration,
+      },
+    },
+  },
+}))
+
+vi.mock('@/helpers/global-variable', () => ({
+  default: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/models/flow', () => ({
+  default: {
+    query: vi.fn().mockReturnValue({
+      findById: vi.fn().mockResolvedValue({ id: 'flow-1', name: 'Test' }),
+    }),
+  },
+}))
+
+const makeUser = () =>
+  ({
+    id: 'user-1',
+    email: 'test@example.com',
+    withAccessibleSteps: vi.fn().mockReturnValue({
+      findOne: vi
+        .fn()
+        .mockResolvedValue({ id: 'step-1', appKey: 'formsg', flowId: 'flow-1' }),
+    }),
+    withAccessibleConnections: vi.fn().mockReturnValue({
+      findOne: vi
+        .fn()
+        .mockResolvedValue({ id: 'conn-1', key: 'formsg', userId: 'user-1' }),
+    }),
+  }) as any
+
+describe('verifyConnectionRegistrationService', () => {
+  let user: ReturnType<typeof makeUser>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    user = makeUser()
+  })
+
+  it('returns VERIFIED when registrationVerified is true', async () => {
+    mocks.verifyConnectionRegistration.mockResolvedValue({
+      registrationVerified: true,
+      message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.VERIFIED,
+    })
+
+    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+
+    expect(result.status).toBe('VERIFIED')
+  })
+
+  it('returns ANOTHER_ENDPOINT when message matches that constant', async () => {
+    mocks.verifyConnectionRegistration.mockResolvedValue({
+      registrationVerified: false,
+      message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT,
+    })
+
+    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+
+    expect(result.status).toBe('ANOTHER_ENDPOINT')
+    expect(result.message).toBe(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT)
+  })
+
+  it('returns ANOTHER_PIPE when message matches that constant', async () => {
+    mocks.verifyConnectionRegistration.mockResolvedValue({
+      registrationVerified: false,
+      message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE,
+    })
+
+    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+
+    expect(result.status).toBe('ANOTHER_PIPE')
+    expect(result.message).toBe(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE)
+  })
+
+  it('returns UNREGISTERED when registrationVerified is false and message is undefined', async () => {
+    mocks.verifyConnectionRegistration.mockResolvedValue({
+      registrationVerified: false,
+    })
+
+    const result = await verifyConnectionRegistrationService(user, 'step-1', 'conn-1')
+
+    expect(result.status).toBe('UNREGISTERED')
+  })
+
+  it('throws when message is an auth/network error (UNAUTHORIZED)', async () => {
+    mocks.verifyConnectionRegistration.mockResolvedValue({
+      registrationVerified: false,
+      message: FORMSG_WEBHOOK_VERIFICATION_MESSAGE.UNAUTHORIZED,
+    })
+
+    await expect(
+      verifyConnectionRegistrationService(user, 'step-1', 'conn-1'),
+    ).rejects.toThrow(FORMSG_WEBHOOK_VERIFICATION_MESSAGE.UNAUTHORIZED)
+  })
+})

--- a/packages/backend/src/services/mcp/verify-connection-registration.ts
+++ b/packages/backend/src/services/mcp/verify-connection-registration.ts
@@ -42,6 +42,10 @@ export async function verifyConnectionRegistrationService(
     throw new Error('You cannot use a personal connection that you do not own')
   }
 
+  if (connection.key !== step.appKey) {
+    throw new Error('Connection app does not match step app')
+  }
+
   const app = apps[step.appKey ?? '']
   if (!app?.auth?.verifyConnectionRegistration) {
     throw new Error('App does not support connection registration verification')
@@ -64,6 +68,9 @@ export async function verifyConnectionRegistrationService(
     return { status: 'UNREGISTERED' }
   }
 
+  // The statuses below reflect FormSG's specific message constants. If a future
+  // app implements verifyConnectionRegistration with its own message semantics,
+  // add a dedicated branch here (or move status derivation into each app module).
   if (output.message === FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT) {
     return { status: 'ANOTHER_ENDPOINT', message: output.message }
   }

--- a/packages/backend/src/services/mcp/verify-connection-registration.ts
+++ b/packages/backend/src/services/mcp/verify-connection-registration.ts
@@ -1,0 +1,77 @@
+import type { IVerifyConnectionRegistrationOutput } from '@plumber/types'
+
+import apps from '@/apps'
+import { FORMSG_WEBHOOK_VERIFICATION_MESSAGE } from '@/apps/formsg/common/webhook-settings'
+import globalVariable from '@/helpers/global-variable'
+import Flow from '@/models/flow'
+import type User from '@/models/user'
+
+export type VerifyRegistrationStatus =
+  | 'VERIFIED'
+  | 'UNREGISTERED'
+  | 'ANOTHER_ENDPOINT'
+  | 'ANOTHER_PIPE'
+
+export interface VerifyRegistrationResult {
+  status: VerifyRegistrationStatus
+  message?: string
+}
+
+export async function verifyConnectionRegistrationService(
+  user: User,
+  stepId: string,
+  connectionId: string,
+): Promise<VerifyRegistrationResult> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'editor' })
+    .findOne({ 'steps.id': stepId })
+
+  if (!step) {
+    throw new Error('Step not found')
+  }
+
+  const connection = await user
+    .withAccessibleConnections({ requiredRole: 'viewer' })
+    .findOne({ 'connections.id': connectionId })
+
+  if (!connection) {
+    throw new Error('Connection not found')
+  }
+
+  if (connection.userId !== null && connection.userId !== user.id) {
+    throw new Error('You cannot use a personal connection that you do not own')
+  }
+
+  const app = apps[step.appKey ?? '']
+  if (!app?.auth?.verifyConnectionRegistration) {
+    throw new Error('App does not support connection registration verification')
+  }
+
+  const flow = await Flow.query().findById(step.flowId)
+  if (!flow) {
+    throw new Error('Flow not found')
+  }
+
+  const $ = await globalVariable({ connection, app, flow, user })
+  const output: IVerifyConnectionRegistrationOutput =
+    await app.auth.verifyConnectionRegistration($)
+
+  if (output.registrationVerified) {
+    return { status: 'VERIFIED', message: output.message }
+  }
+
+  if (!output.message) {
+    return { status: 'UNREGISTERED' }
+  }
+
+  if (output.message === FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_ENDPOINT) {
+    return { status: 'ANOTHER_ENDPOINT', message: output.message }
+  }
+
+  if (output.message === FORMSG_WEBHOOK_VERIFICATION_MESSAGE.ANOTHER_PIPE) {
+    return { status: 'ANOTHER_PIPE', message: output.message }
+  }
+
+  // UNAUTHORIZED, USER_NOT_FOUND, ERROR — auth/network errors; caller must surface these
+  throw new Error(output.message)
+}


### PR DESCRIPTION
## TL;DR

Adds `verifyConnectionRegistrationService` — the service layer for a forthcoming MCP `verify_connection_registration` tool that lets the AI builder confirm a step's webhook/connection is properly registered before continuing flow construction.

## What changed?

**`packages/backend/src/services/mcp/verify-connection-registration.ts`** (new)
- Looks up the step (editor role) and connection (viewer role) scoped to the calling user
- Guards that `connection.key === step.appKey` to prevent calling the wrong app's verification logic with mismatched credential data
- Delegates to the app's `verifyConnectionRegistration` implementation via `globalVariable`
- Maps output to a typed `VerifyRegistrationStatus` (`VERIFIED`, `UNREGISTERED`, `ANOTHER_ENDPOINT`, `ANOTHER_PIPE`); throws on auth/network error messages so callers can surface them directly

**`packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts`** (new)
- Happy-path statuses: `VERIFIED`, `ANOTHER_ENDPOINT`, `ANOTHER_PIPE`, `UNREGISTERED`, throw on `UNAUTHORIZED`
- Guard branches: step not found, connection not found, connection owned by another user, cross-app mismatch, app doesn't support verification, flow not found

## Tests

- [ ] Run unit tests: `npm run test packages/backend/src/services/mcp/__tests__/verify-connection-registration.test.ts` — all 11 tests should pass.

## Deploy notes

No migrations, no new env vars, no new feature flags. Service is not yet wired to an MCP tool endpoint.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>