### PR TITLE
fix(if-then): stop instead of jumping backward for an after-block only-continue-if

### DIFF
--- a/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
+++ b/packages/backend/src/apps/toolbox/__tests__/common/get-branch-step-id-to-skip-to.test.ts
@@ -411,6 +411,216 @@ describe('getBranchStepIdToSkipTo', () => {
     })
   })
 
+  describe('new-style step to jump to (marker)', () => {
+    it('returns the stored step to jump to when it points forward', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce([
+        {
+          id: 'step1',
+          appKey: 'formsg',
+          key: 'newSubmission',
+          parameters: {},
+          position: 1,
+        },
+        {
+          id: 'step2',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: 'step4' },
+          position: 2,
+        },
+        {
+          id: 'step3',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 3,
+        },
+        {
+          id: 'step4',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: null },
+          position: 4,
+        },
+        {
+          id: 'step5',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 5,
+        },
+      ])
+
+      const $ = {
+        flow: { id: 'flow-marker' },
+        step: { id: 'step2', position: 2 },
+      }
+      expect(await getBranchStepIdToSkipTo($ as any)).toBe('step4')
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns null when the last branch stores the "stop" sentinel', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce([
+        {
+          id: 'step1',
+          appKey: 'formsg',
+          key: 'newSubmission',
+          parameters: {},
+          position: 1,
+        },
+        {
+          id: 'step2',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: 'step4' },
+          position: 2,
+        },
+        {
+          id: 'step3',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 3,
+        },
+        {
+          id: 'step4',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: null },
+          position: 4,
+        },
+      ])
+
+      const $ = {
+        flow: { id: 'flow-marker' },
+        step: { id: 'step4', position: 4 },
+      }
+      expect(await getBranchStepIdToSkipTo($ as any)).toBeNull()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    // L1: an "only continue if" placed *after* the block resolves its preceding
+    // if-then to the block's last branch, whose marker points back into the
+    // after-block region. The forward guard must stop rather than jump — a
+    // self-jump would loop forever; a backward jump would re-run earlier steps.
+    it('returns null (stop) when the marker points at the current step (self-jump)', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce([
+        {
+          id: 'step1',
+          appKey: 'formsg',
+          key: 'newSubmission',
+          parameters: {},
+          position: 1,
+        },
+        // Block's last branch; its exit is the after-block OCI (step4).
+        {
+          id: 'step2',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: 'step4' },
+          position: 2,
+        },
+        {
+          id: 'step3',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 3,
+        },
+        // After-block region: the OCI is its first step (and the current step).
+        {
+          id: 'step4',
+          appKey: 'toolbox',
+          key: 'onlyContinueIf',
+          parameters: {},
+          position: 4,
+        },
+      ])
+
+      const $ = {
+        flow: { id: 'flow-after-block' },
+        step: { id: 'step4', position: 4 },
+      }
+      expect(await getBranchStepIdToSkipTo($ as any)).toBeNull()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns null (stop) when the marker points before the current step (backward jump)', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce([
+        {
+          id: 'step1',
+          appKey: 'formsg',
+          key: 'newSubmission',
+          parameters: {},
+          position: 1,
+        },
+        {
+          id: 'step2',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: 'step4' },
+          position: 2,
+        },
+        {
+          id: 'step3',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 3,
+        },
+        // After-block region: step4 first, the OCI (step5) later in the region.
+        {
+          id: 'step4',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 4,
+        },
+        {
+          id: 'step5',
+          appKey: 'toolbox',
+          key: 'onlyContinueIf',
+          parameters: {},
+          position: 5,
+        },
+      ])
+
+      const $ = {
+        flow: { id: 'flow-after-block' },
+        step: { id: 'step5', position: 5 },
+      }
+      expect(await getBranchStepIdToSkipTo($ as any)).toBeNull()
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns a dangling forward id unchanged (fails loudly downstream)', async () => {
+      mocks.stepQueryResult.mockResolvedValueOnce([
+        {
+          id: 'step1',
+          appKey: 'formsg',
+          key: 'newSubmission',
+          parameters: {},
+          position: 1,
+        },
+        {
+          id: 'step2',
+          appKey: 'toolbox',
+          key: 'ifThen',
+          parameters: { depth: '1', stepIdToJumpTo: 'ghost' },
+          position: 2,
+        },
+        {
+          id: 'step3',
+          appKey: 'postman',
+          key: 'sendTransactionalEmail',
+          position: 3,
+        },
+      ])
+
+      const $ = {
+        flow: { id: 'flow-marker' },
+        step: { id: 'step2', position: 2 },
+      }
+      // Not remapped to null: an id absent from the flow is left to
+      // findById().throwIfNotFound() so a corrupt marker fails loudly.
+      expect(await getBranchStepIdToSkipTo($ as any)).toBe('ghost')
+    })
+  })
+
   describe('MRF approval flows', () => {
     const makeSteps = (step2Config: object, step4Config: object) => [
       {

--- a/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
+++ b/packages/backend/src/apps/toolbox/common/get-branch-step-id-to-skip-to.ts
@@ -52,7 +52,23 @@ export async function getBranchStepIdToSkipTo(
   const params = currBranchStep.parameters
   if (params && Object.hasOwn(params, 'stepIdToJumpTo')) {
     const jumpTo = params.stepIdToJumpTo
-    return typeof jumpTo === 'string' ? jumpTo : null
+    if (typeof jumpTo !== 'string') {
+      return null
+    }
+
+    // A branch's step to jump to always points *forward* — to a later branch or
+    // to a step after the block. If the current step sits outside the branch
+    // (e.g. an "only continue if" placed after the block), the nearest preceding
+    // if-then is the block's last branch, whose target points back to the
+    // after-block region's first step — at or before this step. Jumping there
+    // would re-run earlier steps or loop forever, so stop instead. A genuinely
+    // dangling id (not in this flow) is left to fail loudly downstream.
+    const targetIndex = flowSteps.findIndex((step) => step.id === jumpTo)
+    if (targetIndex !== -1 && targetIndex <= indexOfCurrentStep) {
+      return null
+    }
+
+    return jumpTo
   }
 
   // Everything below supports legacy pipes: those created before If-then-then


### PR DESCRIPTION
# Problem

There is an infinite loop bug which occurs when the Only-Continue-If is placed immediately after an If-Then.

When Only-Continue-If condition fails, it searches backwards for the latest If-Then branch and takes that branch's jump (via `getBranchStepIdToSkipTo`. This results in a infinite loop when it's the 1st step after an if-then block, because the last branch will jump to this Only-Continue-If.

# Fix

Update `getBranchStepIdToSkipTo`to only return steps _strictly after_ the current step's positon.