### PR TITLE
[AI-SETUP-16] feat(backend): add registerConnectionService for AI builder step connection

### DIFF
--- a/packages/backend/src/services/mcp/__tests__/register-connection.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/register-connection.itest.ts
@@ -59,7 +59,12 @@ describe('registerConnectionService', () => {
       user,
       name: 'Register Test Pipe',
       steps: [
-        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+        {
+          appKey: 'formsg',
+          key: 'newSubmission',
+          type: 'trigger',
+          position: 1,
+        },
       ],
       traceId: 'trace-register',
     })
@@ -77,7 +82,11 @@ describe('registerConnectionService', () => {
   })
 
   it('registers connection and persists connectionId on the step', async () => {
-    const result = await registerConnectionService(user, triggerStepId, connection.id)
+    const result = await registerConnectionService(
+      user,
+      triggerStepId,
+      connection.id,
+    )
 
     expect(result.registered).toBe(true)
     expect(mocks.registerConnection).toHaveBeenCalledOnce()
@@ -99,7 +108,9 @@ describe('registerConnectionService', () => {
 
   it('throws when registerConnection throws and does not write connectionId', async () => {
     mocks.registerConnection.mockRejectedValue(
-      new Error("We couldn't connect your form. Ensure that you are either the form owner or have been added as an editor."),
+      new Error(
+        "We couldn't connect your form. Ensure that you are either the form owner or have been added as an editor.",
+      ),
     )
 
     await expect(
@@ -108,6 +119,25 @@ describe('registerConnectionService', () => {
 
     const updatedStep = await Step.query().findById(triggerStepId)
     expect(updatedStep?.connectionId).toBeNull()
+  })
+
+  it('throws when connection app does not match step app', async () => {
+    const wrongConnection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'slack',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      formattedData: {},
+    })
+
+    await expect(
+      registerConnectionService(user, triggerStepId, wrongConnection.id),
+    ).rejects.toThrow('Connection app does not match step app')
+
+    const updatedStep = await Step.query().findById(triggerStepId)
+    expect(updatedStep?.connectionId).toBeNull()
+    expect(mocks.registerConnection).not.toHaveBeenCalled()
   })
 
   it('throws when the user is not an editor on the flow and does not call registerConnection', async () => {

--- a/packages/backend/src/services/mcp/__tests__/register-connection.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/register-connection.itest.ts
@@ -1,0 +1,125 @@
+import { randomUUID } from 'crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Connection from '@/models/connection'
+import Step from '@/models/step'
+import User from '@/models/user'
+
+import { createFlowWithStepsService } from '../create-flow-with-steps'
+import { registerConnectionService } from '../register-connection'
+
+const mocks = vi.hoisted(() => ({
+  isStillVerified: vi.fn().mockResolvedValue(true),
+  registerConnection: vi.fn().mockResolvedValue(undefined),
+  getAllLdFlags: vi.fn(),
+  getRestrictedAppKeys: vi.fn(),
+  globalVariable: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@/helpers/global-variable', () => ({ default: mocks.globalVariable }))
+
+vi.mock('@/helpers/launch-darkly', () => ({
+  getAllLdFlags: mocks.getAllLdFlags,
+  getRestrictedAppKeys: mocks.getRestrictedAppKeys,
+}))
+
+vi.mock('@/apps', () => ({
+  default: {
+    formsg: {
+      key: 'formsg',
+      triggers: [{ key: 'newSubmission' }],
+      auth: {
+        connectionRegistrationType: 'per-step' as const,
+        isStillVerified: mocks.isStillVerified,
+        registerConnection: mocks.registerConnection,
+      },
+    },
+  },
+}))
+
+describe('registerConnectionService', () => {
+  let user: User
+  let triggerStepId: string
+  let connection: Connection
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mocks.getAllLdFlags.mockResolvedValue({})
+    mocks.getRestrictedAppKeys.mockReturnValue([])
+    mocks.isStillVerified.mockResolvedValue(true)
+    mocks.registerConnection.mockResolvedValue(undefined)
+    mocks.globalVariable.mockResolvedValue({})
+
+    user = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `register-conn-${randomUUID()}@example.com`,
+    })
+
+    const flow = await createFlowWithStepsService({
+      user,
+      name: 'Register Test Pipe',
+      steps: [
+        { appKey: 'formsg', key: 'newSubmission', type: 'trigger', position: 1 },
+      ],
+      traceId: 'trace-register',
+    })
+
+    triggerStepId = flow.steps[0].id
+
+    connection = await Connection.query().insertAndFetch({
+      id: randomUUID(),
+      key: 'formsg',
+      userId: user.id,
+      verified: true,
+      draft: false,
+      formattedData: { formId: 'https://form.gov.sg/abc123abc123abc123abc123' },
+    })
+  })
+
+  it('registers connection and persists connectionId on the step', async () => {
+    const result = await registerConnectionService(user, triggerStepId, connection.id)
+
+    expect(result.registered).toBe(true)
+    expect(mocks.registerConnection).toHaveBeenCalledOnce()
+
+    const updatedStep = await Step.query().findById(triggerStepId)
+    expect(updatedStep?.connectionId).toBe(connection.id)
+  })
+
+  it('throws when isStillVerified returns false and does not write connectionId', async () => {
+    mocks.isStillVerified.mockResolvedValue(false)
+
+    await expect(
+      registerConnectionService(user, triggerStepId, connection.id),
+    ).rejects.toThrow('Connection is not verified')
+
+    const updatedStep = await Step.query().findById(triggerStepId)
+    expect(updatedStep?.connectionId).toBeNull()
+  })
+
+  it('throws when registerConnection throws and does not write connectionId', async () => {
+    mocks.registerConnection.mockRejectedValue(
+      new Error("We couldn't connect your form. Ensure that you are either the form owner or have been added as an editor."),
+    )
+
+    await expect(
+      registerConnectionService(user, triggerStepId, connection.id),
+    ).rejects.toThrow("We couldn't connect your form")
+
+    const updatedStep = await Step.query().findById(triggerStepId)
+    expect(updatedStep?.connectionId).toBeNull()
+  })
+
+  it('throws when the user is not an editor on the flow and does not call registerConnection', async () => {
+    const nonEditor = await User.query().insertAndFetch({
+      id: randomUUID(),
+      email: `non-editor-${randomUUID()}@example.com`,
+    })
+
+    await expect(
+      registerConnectionService(nonEditor, triggerStepId, connection.id),
+    ).rejects.toThrow('Step not found')
+
+    expect(mocks.registerConnection).not.toHaveBeenCalled()
+  })
+})

--- a/packages/backend/src/services/mcp/register-connection.ts
+++ b/packages/backend/src/services/mcp/register-connection.ts
@@ -1,3 +1,5 @@
+import type { IGlobalVariable } from '@plumber/types'
+
 import apps from '@/apps'
 import { UserFacingError } from '@/errors/user-facing-error'
 import globalVariable from '@/helpers/global-variable'
@@ -46,12 +48,24 @@ export async function registerConnectionService(
     throw new UserFacingError('App not found or does not support auth')
   }
 
-  const flow = await Flow.query().findById(step.flowId)
-  if (!flow) {
-    throw new Error('Flow not found')
+  const connectionRegistrationType = app.auth.connectionRegistrationType
+  if (!connectionRegistrationType) {
+    throw new UserFacingError('App does not support connection registration')
   }
 
-  const $ = await globalVariable({ connection, app, flow, user })
+  // 'global' registration (e.g. m365-excel) is not tied to a specific flow, so
+  // $ is built without one — mirrors makeGlobalVariableForGlobalRegistration in
+  // the equivalent GraphQL registerConnection mutation.
+  let $: IGlobalVariable
+  if (connectionRegistrationType === 'global') {
+    $ = await globalVariable({ connection, app, user })
+  } else {
+    const flow = await Flow.query().findById(step.flowId)
+    if (!flow) {
+      throw new UserFacingError('Flow not found')
+    }
+    $ = await globalVariable({ connection, app, flow, user })
+  }
 
   const isVerified = await app.auth.isStillVerified($)
   if (!isVerified) {

--- a/packages/backend/src/services/mcp/register-connection.ts
+++ b/packages/backend/src/services/mcp/register-connection.ts
@@ -1,0 +1,59 @@
+import apps from '@/apps'
+import globalVariable from '@/helpers/global-variable'
+import Flow from '@/models/flow'
+import Step from '@/models/step'
+import type User from '@/models/user'
+
+export interface RegisterConnectionResult {
+  registered: boolean
+  message: string
+}
+
+export async function registerConnectionService(
+  user: User,
+  stepId: string,
+  connectionId: string,
+): Promise<RegisterConnectionResult> {
+  const step = await user
+    .withAccessibleSteps({ requiredRole: 'editor' })
+    .findOne({ 'steps.id': stepId })
+
+  if (!step) {
+    throw new Error('Step not found')
+  }
+
+  const connection = await user
+    .withAccessibleConnections({ requiredRole: 'viewer' })
+    .findOne({ 'connections.id': connectionId })
+
+  if (!connection) {
+    throw new Error('Connection not found')
+  }
+
+  if (connection.userId !== null && connection.userId !== user.id) {
+    throw new Error('You cannot use a personal connection that you do not own')
+  }
+
+  const app = apps[step.appKey ?? '']
+  if (!app?.auth) {
+    throw new Error('App not found or does not support auth')
+  }
+
+  const flow = await Flow.query().findById(step.flowId)
+  if (!flow) {
+    throw new Error('Flow not found')
+  }
+
+  const $ = await globalVariable({ connection, app, flow, user })
+
+  const isVerified = await app.auth.isStillVerified($)
+  if (!isVerified) {
+    throw new Error('Connection is not verified')
+  }
+
+  await app.auth.registerConnection?.($)
+
+  await Step.query().patchAndFetchById(stepId, { connectionId })
+
+  return { registered: true, message: 'Connection registered successfully' }
+}

--- a/packages/backend/src/services/mcp/register-connection.ts
+++ b/packages/backend/src/services/mcp/register-connection.ts
@@ -1,4 +1,5 @@
 import apps from '@/apps'
+import { UserFacingError } from '@/errors/user-facing-error'
 import globalVariable from '@/helpers/global-variable'
 import Flow from '@/models/flow'
 import Step from '@/models/step'
@@ -19,7 +20,7 @@ export async function registerConnectionService(
     .findOne({ 'steps.id': stepId })
 
   if (!step) {
-    throw new Error('Step not found')
+    throw new UserFacingError('Step not found')
   }
 
   const connection = await user
@@ -27,16 +28,22 @@ export async function registerConnectionService(
     .findOne({ 'connections.id': connectionId })
 
   if (!connection) {
-    throw new Error('Connection not found')
+    throw new UserFacingError('Connection not found')
   }
 
   if (connection.userId !== null && connection.userId !== user.id) {
-    throw new Error('You cannot use a personal connection that you do not own')
+    throw new UserFacingError(
+      'You cannot use a personal connection that you do not own',
+    )
+  }
+
+  if (connection.key !== step.appKey) {
+    throw new UserFacingError('Connection app does not match step app')
   }
 
   const app = apps[step.appKey ?? '']
   if (!app?.auth) {
-    throw new Error('App not found or does not support auth')
+    throw new UserFacingError('App not found or does not support auth')
   }
 
   const flow = await Flow.query().findById(step.flowId)
@@ -48,7 +55,7 @@ export async function registerConnectionService(
 
   const isVerified = await app.auth.isStillVerified($)
   if (!isVerified) {
-    throw new Error('Connection is not verified')
+    throw new UserFacingError('Connection is not verified')
   }
 
   await app.auth.registerConnection?.($)


### PR DESCRIPTION
## TL;DR

Adds `registerConnectionService` — the service layer for a forthcoming MCP `register_connection` tool that lets the AI builder wire a verified connection onto a step (e.g. registering a FormSG webhook endpoint before testing the step).

## What changed?

**`packages/backend/src/services/mcp/register-connection.ts`** (new)
- Looks up the step (editor role) and connection (viewer role) scoped to the calling user
- Guards that `connection.key === step.appKey` to prevent calling the wrong app's auth logic with mismatched credential data (mirrors the same guard in `verifyConnectionRegistrationService`)
- Guards against registering a personal connection owned by another user
- Calls `app.auth.isStillVerified($)` — rejects immediately if the connection is stale
- Calls `app.auth.registerConnection?.($)` — the optional per-app side-effect (e.g. setting the FormSG webhook URL)
- Persists `connectionId` on the step only after all guards and registration succeed
- All user-facing error paths throw `UserFacingError` (consistent with `getDynamicDataService`)

**`packages/backend/src/services/mcp/__tests__/register-connection.itest.ts`** (new)
- Happy path: registers connection and persists `connectionId` on the step
- `isStillVerified = false`: throws `'Connection is not verified'`, no write
- `registerConnection` throws: propagates error, no write
- Cross-app mismatch: throws `'Connection app does not match step app'`, no write, `registerConnection` never called
- Non-editor access: throws `'Step not found'`, no write

## Tests

- [ ] `npm run test packages/backend/src/services/mcp/__tests__/register-connection.itest.ts` — all 5 tests pass

## Deploy notes

No migrations, no new env vars, no new feature flags. Service is not yet wired to an MCP tool or REST endpoint.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>