### PR TITLE
[AI-SETUP-20] feat(frontend): add parseParameterValue helper for variable segment extraction

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -149,7 +149,7 @@ export function createMcpBridgeTools(
           connectionId: connection_id,
         })
         onPipeChange?.(pipe_id)
-        onStepUpdate?.(step_id, result.step.parameters)
+        onStepUpdate?.(step_id, result.step.parameters as IJSONObject)
         return result
       },
     }),

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -149,7 +149,7 @@ export function createMcpBridgeTools(
           connectionId: connection_id,
         })
         onPipeChange?.(pipe_id)
-        onStepUpdate?.(step_id, result.step.parameters as IJSONObject)
+        onStepUpdate?.(step_id, result.step.parameters)
         return result
       },
     }),

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -114,8 +114,8 @@ export default function Step(props: StepProps) {
           }
           // Active: override border + suppress hover background
           {...(isActive && {
-            borderColor: '#cf1a68',
-            boxShadow: '0 0 0 3px rgba(207, 26, 104, 0.10)',
+            borderColor: 'primary.500',
+            boxShadow: '0 0 0 3px var(--chakra-colors-primary-100)',
             _hover: { bg: 'white', cursor: 'default' },
           })}
           // Pending: suppress hover

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -1,6 +1,8 @@
-import { IApp, IStep } from '@plumber/types'
+import { IApp, IJSONObject, IStep } from '@plumber/types'
 
-import { BiInfoCircle } from 'react-icons/bi'
+import { useState } from 'react'
+import { BiInfoCircle, BiSolidCheckCircle } from 'react-icons/bi'
+import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri'
 import { Box, Divider, Flex, Icon, Text } from '@chakra-ui/react'
 
 import StepAppIcon from '@/components/FlowStep/components/StepAppIcon'
@@ -10,6 +12,8 @@ import { SUPPORT_FORM_LINK } from '@/config/urls'
 import getStepName from '@/helpers/getStepName'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 
+import StepParameterRows from './StepParameterRows'
+
 interface AiStep extends IStep {
   description?: string
 }
@@ -18,16 +22,30 @@ interface StepProps {
   step?: AiStep | null
   isNested?: boolean
   isLastStep?: boolean
+  isActive?: boolean
+  isConfigured?: boolean
+  parameters?: IJSONObject
 }
 
 export default function Step(props: StepProps) {
-  const { step, isNested, isLastStep } = props
+  const {
+    step,
+    isNested,
+    isLastStep,
+    isActive = false,
+    isConfigured = false,
+    parameters,
+  } = props
   const { allApps } = useAiBuilderContext()
+  const [isExpanded, setIsExpanded] = useState(false)
 
   const app = allApps?.find(
     (currentApp: IApp) => currentApp.key === step?.appKey,
   )
   const { stepName } = getStepName(allApps, step as IStep)
+
+  const isPending = !isActive && !isConfigured
+  const showParams = parameters && (isActive || (isConfigured && isExpanded))
 
   if (!step) {
     return (
@@ -71,7 +89,12 @@ export default function Step(props: StepProps) {
   }
 
   return (
-    <Flex flexDir="column" w="100%">
+    <Flex
+      flexDir="column"
+      w="100%"
+      opacity={isPending ? 0.55 : 1}
+      transition="opacity 0.15s"
+    >
       <Flex justifyContent="center">
         <Flex
           data-test="flow-step"
@@ -79,17 +102,60 @@ export default function Step(props: StepProps) {
           borderTopWidth="1px"
           borderTopRadius="lg"
           w={isNested ? '100%' : '600px'}
-          pointerEvents="none"
+          pointerEvents={isPending ? 'none' : 'auto'}
+          flexDir="column"
+          alignItems="stretch"
+          justifyContent="flex-start"
+          cursor={isConfigured && !isActive ? 'pointer' : 'default'}
+          onClick={
+            isConfigured && !isActive
+              ? () => setIsExpanded((v) => !v)
+              : undefined
+          }
+          // Active: override border + suppress hover background
+          {...(isActive && {
+            borderColor: '#cf1a68',
+            boxShadow: '0 0 0 3px rgba(207, 26, 104, 0.10)',
+            _hover: { bg: 'white', cursor: 'default' },
+          })}
+          // Pending: suppress hover
+          {...(isPending && {
+            _hover: { bg: 'white', cursor: 'default' },
+          })}
         >
           <Flex {...flowStepStyles.topHeader} py={isNested ? 3 : 4}>
-            <StepAppIcon
-              isCompleted={step.status === 'completed'}
-              isNested={isNested}
-              isTestSuccessful={step.status === 'completed' ? true : undefined}
-              shouldTestStepAgain={false}
-              app={app}
-              step={step}
-            />
+            {/* App icon with optional completed badge */}
+            <Box position="relative" flexShrink={0} mr={4}>
+              <StepAppIcon
+                isCompleted={false}
+                isNested={isNested}
+                isTestSuccessful={undefined}
+                shouldTestStepAgain={false}
+                app={app}
+                step={step}
+              />
+              {isConfigured && (
+                <Box
+                  position="absolute"
+                  bottom="-3px"
+                  right="-3px"
+                  bg="white"
+                  borderRadius="full"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  w="14px"
+                  h="14px"
+                >
+                  <Icon
+                    as={BiSolidCheckCircle}
+                    color="#0F796F"
+                    boxSize="14px"
+                  />
+                </Box>
+              )}
+            </Box>
+
             <Box w="100%">
               <StepNameAndDemo
                 stepName={stepName}
@@ -97,7 +163,26 @@ export default function Step(props: StepProps) {
               />
               <Text textStyle="body-2">{step.description}</Text>
             </Box>
+
+            {/* Chevron for configured accordion toggle */}
+            {isConfigured && !isActive && (
+              <Icon
+                as={isExpanded ? RiArrowUpSLine : RiArrowDownSLine}
+                boxSize={5}
+                color="base.content.medium"
+                flexShrink={0}
+                ml={2}
+              />
+            )}
           </Flex>
+
+          {showParams && (
+            <StepParameterRows
+              parameters={parameters}
+              appKey={step.appKey ?? ''}
+              stepKey={step.key ?? ''}
+            />
+          )}
         </Flex>
       </Flex>
       {!isLastStep && (

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -1,30 +1,27 @@
-import type { IApp, IJSONObject } from '@plumber/types'
+import type { IApp, IField, IJSONObject } from '@plumber/types'
 
 import { Fragment } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
+import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import { parseParameterValue } from '@/pages/AiBuilder/helpers/parseParameterValue'
 
 import VariablePill from './VariablePill'
-
-const HIDDEN_KEYS = new Set(['depth', 'branchName'])
 
 function camelToSentence(key: string): string {
   const words = key.replace(/([A-Z])/g, ' $1').trim()
   return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase()
 }
 
-function resolveFieldLabel(
+function resolveFieldDef(
   allApps: IApp[],
   appKey: string,
   stepKey: string,
   paramKey: string,
-): string {
+): IField | undefined {
   const app = allApps.find((a) => a.key === appKey)
-  if (!app) {
-    return camelToSentence(paramKey)
-  }
+  if (!app) return undefined
 
   const trigger = app.triggers?.find((t) => t.key === stepKey)
   const action = app.actions?.find((a) => a.key === stepKey)
@@ -32,10 +29,7 @@ function resolveFieldLabel(
     ...(trigger?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
     ...(action?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
   ]
-
-  return (
-    fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
-  )
+  return fields.find((f) => f.key === paramKey)
 }
 
 interface StepParameterRowsProps {
@@ -51,9 +45,18 @@ export default function StepParameterRows({
 }: StepParameterRowsProps) {
   const { allApps } = useAiBuilderContext()
 
-  const rows = Object.entries(parameters).filter(
-    ([key, value]) => !HIDDEN_KEYS.has(key) && value !== '' && value != null,
-  )
+  const rows = Object.entries(parameters)
+    .map(([key, value]) => ({
+      key,
+      value,
+      field: resolveFieldDef(allApps, appKey, stepKey, key),
+    }))
+    .filter(
+      ({ value, field }) =>
+        value !== '' &&
+        value != null &&
+        !isFieldHidden(field?.hiddenIf, parameters),
+    )
 
   if (rows.length === 0) {
     return null
@@ -68,8 +71,8 @@ export default function StepParameterRows({
       borderTop="1px solid"
       borderColor="base.divider.weak"
     >
-      {rows.map(([key, value], rowIndex) => {
-        const label = resolveFieldLabel(allApps, appKey, stepKey, key)
+      {rows.map(({ key, value, field }, rowIndex) => {
+        const label = field?.label ?? camelToSentence(key)
         const strValue = String(value)
         const segments = parseParameterValue(strValue)
 

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -1,0 +1,114 @@
+import type { IApp, IJSONObject } from '@plumber/types'
+
+import { Fragment } from 'react'
+import { Box, Flex, Text } from '@chakra-ui/react'
+
+import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
+import { parseParameterValue } from '@/pages/AiBuilder/helpers/parseParameterValue'
+
+import VariablePill from './VariablePill'
+
+const HIDDEN_KEYS = new Set(['depth', 'branchName'])
+
+function camelToSentence(key: string): string {
+  const words = key.replace(/([A-Z])/g, ' $1').trim()
+  return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase()
+}
+
+function resolveFieldLabel(
+  allApps: IApp[],
+  appKey: string,
+  stepKey: string,
+  paramKey: string,
+): string {
+  const app = allApps.find((a) => a.key === appKey)
+  if (!app) return camelToSentence(paramKey)
+
+  const trigger = app.triggers?.find((t) => t.key === stepKey)
+  const action = app.actions?.find((a) => a.key === stepKey)
+  const fields = [
+    ...(trigger?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
+    ...(action?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
+  ]
+
+  return fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
+}
+
+interface StepParameterRowsProps {
+  parameters: IJSONObject
+  appKey: string
+  stepKey: string
+}
+
+export default function StepParameterRows({
+  parameters,
+  appKey,
+  stepKey,
+}: StepParameterRowsProps) {
+  const { allApps } = useAiBuilderContext()
+
+  const rows = Object.entries(parameters).filter(
+    ([key, value]) => !HIDDEN_KEYS.has(key) && value !== '' && value != null,
+  )
+
+  if (rows.length === 0) return null
+
+  return (
+    <Box
+      pt={1}
+      pb={3}
+      pl="58px"
+      pr={4}
+      borderTop="1px solid"
+      borderColor="base.divider.weak"
+    >
+      {rows.map(([key, value], rowIndex) => {
+        const label = resolveFieldLabel(allApps, appKey, stepKey, key)
+        const strValue = String(value)
+        const segments = parseParameterValue(strValue)
+
+        return (
+          <Flex
+            key={key}
+            align="baseline"
+            gap={2.5}
+            py="5px"
+            borderBottom={rowIndex < rows.length - 1 ? '1px solid' : 'none'}
+            borderColor="base.divider.weak"
+          >
+            <Text
+              as="span"
+              fontSize="12px"
+              color="base.content.medium"
+              fontWeight={500}
+              minW="54px"
+              flexShrink={0}
+            >
+              {label}
+            </Text>
+            <Box
+              as="span"
+              fontSize="13px"
+              color="base.content.default"
+              lineHeight="1.6"
+              display="flex"
+              flexWrap="wrap"
+              alignItems="center"
+              gap={0.75}
+            >
+              {segments.map((seg, i) =>
+                seg.type === 'text' ? (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <Fragment key={i}>{seg.text}</Fragment>
+                ) : (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <VariablePill key={i} label={seg.label} />
+                ),
+              )}
+            </Box>
+          </Flex>
+        )
+      })}
+    </Box>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -22,7 +22,9 @@ function resolveFieldLabel(
   paramKey: string,
 ): string {
   const app = allApps.find((a) => a.key === appKey)
-  if (!app) return camelToSentence(paramKey)
+  if (!app) {
+    return camelToSentence(paramKey)
+  }
 
   const trigger = app.triggers?.find((t) => t.key === stepKey)
   const action = app.actions?.find((a) => a.key === stepKey)
@@ -31,7 +33,9 @@ function resolveFieldLabel(
     ...(action?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
   ]
 
-  return fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
+  return (
+    fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
+  )
 }
 
 interface StepParameterRowsProps {
@@ -51,7 +55,9 @@ export default function StepParameterRows({
     ([key, value]) => !HIDDEN_KEYS.has(key) && value !== '' && value != null,
   )
 
-  if (rows.length === 0) return null
+  if (rows.length === 0) {
+    return null
+  }
 
   return (
     <Box

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -21,7 +21,9 @@ function resolveFieldDef(
   paramKey: string,
 ): IField | undefined {
   const app = allApps.find((a) => a.key === appKey)
-  if (!app) return undefined
+  if (!app) {
+    return undefined
+  }
 
   const trigger = app.triggers?.find((t) => t.key === stepKey)
   const action = app.actions?.find((a) => a.key === stepKey)

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
@@ -1,24 +1,26 @@
+import { Box } from '@chakra-ui/react'
+
 interface VariablePillProps {
   label: string
 }
 
 export default function VariablePill({ label }: VariablePillProps) {
   return (
-    <span
-      style={{
-        display: 'inline-flex',
-        alignItems: 'center',
-        background: '#F9DDE9',
-        borderRadius: '50px',
-        padding: '2px 10px',
-        fontSize: '12px',
-        color: '#2C2E34',
-        fontWeight: 500,
-        whiteSpace: 'nowrap',
-        lineHeight: 1.4,
-      }}
+    <Box
+      as="span"
+      display="inline-flex"
+      alignItems="center"
+      bg="primary.100"
+      borderRadius="50px"
+      px="10px"
+      py="2px"
+      fontSize="12px"
+      color="base.content.strong"
+      fontWeight={500}
+      whiteSpace="nowrap"
+      lineHeight={1.4}
     >
       {label}
-    </span>
+    </Box>
   )
 }

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
@@ -1,0 +1,24 @@
+interface VariablePillProps {
+  label: string
+}
+
+export default function VariablePill({ label }: VariablePillProps) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        background: '#F9DDE9',
+        borderRadius: '50px',
+        padding: '2px 10px',
+        fontSize: '12px',
+        color: '#2C2E34',
+        fontWeight: 500,
+        whiteSpace: 'nowrap',
+        lineHeight: 1.4,
+      }}
+    >
+      {label}
+    </span>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
@@ -56,4 +56,10 @@ describe('parseParameterValue', () => {
       { type: 'variable', label: 'Body' },
     ])
   })
+
+  it('strips the hex-modifier suffix from table variables', () => {
+    expect(
+      parseParameterValue('{{step.abc-123-def.data|7461626c653a636f6c31}}'),
+    ).toEqual([{ type: 'variable', label: 'Data' }])
+  })
 })

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseParameterValue } from './parseParameterValue'
+
+describe('parseParameterValue', () => {
+  it('returns a single text segment for a plain string', () => {
+    expect(parseParameterValue('#general')).toEqual([
+      { type: 'text', text: '#general' },
+    ])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseParameterValue('')).toEqual([])
+  })
+
+  it('returns a single variable segment for a lone variable', () => {
+    expect(parseParameterValue('{{step.abc123.email_address}}')).toEqual([
+      { type: 'variable', label: 'Email address' },
+    ])
+  })
+
+  it('sentence-cases and replaces underscores for the label', () => {
+    expect(parseParameterValue('{{step.abc.full_name}}')).toEqual([
+      { type: 'variable', label: 'Full name' },
+    ])
+  })
+
+  it('uses only the last dot-separated segment of the path', () => {
+    expect(parseParameterValue('{{step.abc.response.email_address}}')).toEqual([
+      { type: 'variable', label: 'Email address' },
+    ])
+  })
+
+  it('handles mixed text + variable', () => {
+    expect(
+      parseParameterValue('Hello {{step.abc.first_name}}, welcome!'),
+    ).toEqual([
+      { type: 'text', text: 'Hello ' },
+      { type: 'variable', label: 'First name' },
+      { type: 'text', text: ', welcome!' },
+    ])
+  })
+
+  it('handles multiple adjacent variables', () => {
+    expect(
+      parseParameterValue('{{step.abc.first_name}} {{step.def.last_name}}'),
+    ).toEqual([
+      { type: 'variable', label: 'First name' },
+      { type: 'text', text: ' ' },
+      { type: 'variable', label: 'Last name' },
+    ])
+  })
+
+  it('handles all-uppercase variable path segment', () => {
+    expect(parseParameterValue('{{step.abc.BODY}}')).toEqual([
+      { type: 'variable', label: 'Body' },
+    ])
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
@@ -3,6 +3,7 @@ export type Segment =
   | { type: 'variable'; label: string }
 
 const VARIABLE_REGEX = /\{\{step\.[^.}]+\.([^}]+)\}\}/g
+const HEX_MODIFIER_SUFFIX_REGEX = /\|[a-fA-F0-9]+$/
 
 export function parseParameterValue(value: string): Segment[] {
   const segments: Segment[] = []
@@ -14,7 +15,7 @@ export function parseParameterValue(value: string): Segment[] {
     if (match.index > lastIndex) {
       segments.push({ type: 'text', text: value.slice(lastIndex, match.index) })
     }
-    const rawPath = match[1]
+    const rawPath = match[1].replace(HEX_MODIFIER_SUFFIX_REGEX, '')
     const lastSegment = rawPath.split('.').pop() ?? rawPath
     const withSpaces = lastSegment.replace(/_/g, ' ')
     const label =

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
@@ -1,0 +1,31 @@
+export type Segment =
+  | { type: 'text'; text: string }
+  | { type: 'variable'; label: string }
+
+const VARIABLE_REGEX = /\{\{step\.[^.}]+\.([^}]+)\}\}/g
+
+export function parseParameterValue(value: string): Segment[] {
+  const segments: Segment[] = []
+  let lastIndex = 0
+
+  VARIABLE_REGEX.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = VARIABLE_REGEX.exec(value)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', text: value.slice(lastIndex, match.index) })
+    }
+    const rawPath = match[1]
+    const lastSegment = rawPath.split('.').pop() ?? rawPath
+    const withSpaces = lastSegment.replace(/_/g, ' ')
+    const label =
+      withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1).toLowerCase()
+    segments.push({ type: 'variable', label })
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < value.length) {
+    segments.push({ type: 'text', text: value.slice(lastIndex) })
+  }
+
+  return segments
+}


### PR DESCRIPTION
## TL;DR

Adds the building blocks for displaying configured step parameters in AI Builder's StepsPreview. The components and helpers are introduced here; they are wired up in the next PR in the stack.

## What changed?

**New helpers**
- `parseParameterValue` — splits a parameter string into plain-text and `{{step.*.field}}` variable segments. Variable labels are derived from the last path segment (underscore → space, sentence-cased).

**New components**
- `VariablePill` — renders a single variable reference as a pink pill (uses `primary.100`/`base.content.strong` theme tokens).
- `StepParameterRows` — renders all non-empty, non-hidden parameters for a step as labelled rows below the step header. Field labels are resolved from the app schema (`IApp.triggers/actions.substeps.arguments`); hidden fields are excluded via the existing `isFieldHidden` helper so any `hiddenIf` condition in the app schema is respected automatically.

**Updated `Step`**
- Accepts three new props: `isActive`, `isConfigured`, `parameters` (all optional, no behaviour change when omitted).
- When `isActive`: primary brand border + glow, parameters shown expanded.
- When `isConfigured` (not active): green check badge on app icon, accordion toggle to expand/collapse parameters.
- When neither (`isPending`): 55% opacity, pointer-events disabled.
- None of the existing `<Step>` call sites pass these props yet — that wiring lands in the next PR.

## Tests

- [ ] Existing StepsPreview renders unchanged (proposal hint, legacy create, DB pipe open-in-editor modes all unaffected — no new props are passed yet).
- [ ] `parseParameterValue` unit tests pass: `npm run test packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts`.

## Deploy notes

None — purely frontend, no schema/config/flag changes required.