### PR TITLE
[AI-SETUP-18] feat(ai-builder): emit stepUpdate annotation from update_step_parameters

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -326,7 +326,7 @@ describe('createMcpBridgeTools', () => {
     })
 
     it('does not throw when onStepUpdate is not provided', async () => {
-      const tools = createMcpBridgeTools(mockUser)
+      const tools = createMcpBridgeTools(mockUser, mockTraceId)
       await expect(
         tools.update_step_parameters.execute(
           { pipe_id: 'flow-1', step_id: 's1', parameters: {} },

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -313,7 +313,12 @@ describe('createMcpBridgeTools', () => {
       })
 
       const onStepUpdate = vi.fn()
-      const tools = createMcpBridgeTools(mockUser, undefined, onStepUpdate)
+      const tools = createMcpBridgeTools(
+        mockUser,
+        mockTraceId,
+        undefined,
+        onStepUpdate,
+      )
       await tools.update_step_parameters.execute(
         {
           pipe_id: 'flow-1',

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/services/mcp/create-flow-with-steps', () => ({
 vi.mock('@/services/mcp/update-step-parameters', () => ({
   updateStepParametersService: vi
     .fn()
-    .mockResolvedValue({ id: 's1', parameters: {} }),
+    .mockResolvedValue({ step: { id: 's1', parameters: {} } }),
 }))
 vi.mock('@/services/mcp/create-step', () => ({
   createStepService: vi.fn().mockResolvedValue({ id: 's2', appKey: 'slack' }),
@@ -301,6 +301,36 @@ describe('createMcpBridgeTools', () => {
             steps: [{ app_key: 'formsg', trigger_key: 'newSubmission' }],
           },
           { toolCallId: 'create_pipe', messages: [] },
+        ),
+      ).resolves.not.toThrow()
+    })
+  })
+
+  describe('onStepUpdate callback', () => {
+    it('is called with step_id and saved parameters after update_step_parameters succeeds', async () => {
+      vi.mocked(updateStepParametersService).mockResolvedValueOnce({
+        step: { id: 'step-1', parameters: { subject: 'Hello' } } as any,
+      })
+
+      const onStepUpdate = vi.fn()
+      const tools = createMcpBridgeTools(mockUser, undefined, onStepUpdate)
+      await tools.update_step_parameters.execute(
+        {
+          pipe_id: 'flow-1',
+          step_id: 'step-1',
+          parameters: { subject: 'Hello' },
+        },
+        { toolCallId: 'update_step_parameters', messages: [] },
+      )
+      expect(onStepUpdate).toHaveBeenCalledWith('step-1', { subject: 'Hello' })
+    })
+
+    it('does not throw when onStepUpdate is not provided', async () => {
+      const tools = createMcpBridgeTools(mockUser)
+      await expect(
+        tools.update_step_parameters.execute(
+          { pipe_id: 'flow-1', step_id: 's1', parameters: {} },
+          { toolCallId: 'update_step_parameters', messages: [] },
         ),
       ).resolves.not.toThrow()
     })

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -37,6 +37,7 @@ export function createMcpBridgeTools(
   user: User,
   traceId: string,
   onPipeChange?: (pipeId: string) => void,
+  onStepUpdate?: (stepId: string, parameters: IJSONObject) => void,
 ) {
   return {
     list_apps: tool<ListAppsInput, IMcpApp[]>({
@@ -148,6 +149,7 @@ export function createMcpBridgeTools(
           connectionId: connection_id,
         })
         onPipeChange?.(pipe_id)
+        onStepUpdate?.(step_id, result.step.parameters as IJSONObject)
         return result
       },
     }),

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -149,7 +149,7 @@ export function createMcpBridgeTools(
           connectionId: connection_id,
         })
         onPipeChange?.(pipe_id)
-        onStepUpdate?.(step_id, result.step.parameters as IJSONObject)
+        onStepUpdate?.(step_id, result.step.parameters)
         return result
       },
     }),

--- a/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
+++ b/packages/backend/src/routes/api/__tests__/chat/schema.test.ts
@@ -122,6 +122,26 @@ describe('chatRequestSchema', () => {
       })
       expect(result.success).toBe(true)
     })
+
+    it('should accept data-stepUpdate part', () => {
+      const result = chatRequestSchema.safeParse({
+        messages: [
+          {
+            role: 'assistant',
+            parts: [
+              {
+                type: 'data-stepUpdate',
+                data: {
+                  stepId: '550e8400-e29b-41d4-a716-446655440000',
+                  parameters: { subject: 'Hello', recipient: 'test@gov.sg' },
+                },
+              },
+            ],
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('messages validation', () => {

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -162,16 +162,23 @@ const handleChatStream = observe(
       let workflowError = 'Unable to generate the workflow.'
 
       let activePipeId: string | null = null
-      const mcpTools = createMcpBridgeTools(
-        context.currentUser,
-        traceId,
-        (pipeId) => {
-          activePipeId = pipeId
-        },
-      )
 
       const stream = createUIMessageStream({
         execute: async ({ writer }) => {
+          const mcpTools = createMcpBridgeTools(
+            context.currentUser,
+            traceId,
+            (pipeId) => {
+              activePipeId = pipeId
+            },
+            (stepId, parameters) => {
+              writer.write({
+                type: 'data-stepUpdate',
+                data: { stepId, parameters },
+              })
+            },
+          )
+
           const result = streamText({
             model,
             messages: allMessages,

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -69,7 +69,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
     type: z.literal('data-dynamicPicker'),
     data: z.object({
       question: z.string(),
-      stepId: z.string(),
+      stepId: z.uuid(),
       key: z.string(),
     }),
   }),
@@ -86,17 +86,17 @@ const messagePartSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('data-stepUpdate'),
     data: z.object({
-      stepId: z.string(),
+      stepId: z.uuid(),
       parameters: z.record(z.string(), z.unknown()),
     }),
   }),
   z.object({
     type: z.literal('data-pipeState'),
     data: z.object({
-      pipeId: z.string(),
+      pipeId: z.uuid(),
       steps: z.array(
         z.object({
-          id: z.string(),
+          id: z.uuid(),
           appKey: z.string(),
           key: z.string(),
           type: z.string(),

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -84,6 +84,13 @@ const messagePartSchema = z.discriminatedUnion('type', [
     output: z.unknown().optional(),
   }),
   z.object({
+    type: z.literal('data-stepUpdate'),
+    data: z.object({
+      stepId: z.string(),
+      parameters: z.record(z.string(), z.unknown()),
+    }),
+  }),
+  z.object({
     type: z.literal('data-pipeState'),
     data: z.object({
       pipeId: z.string(),


### PR DESCRIPTION
## TL;DR

After `update_step_parameters` succeeds, the chat stream now emits a `data-stepUpdate` SSE annotation carrying the step ID and saved parameters, giving the frontend a hook to reflect confirmed saves in the UI.

## What changed?

**`mcp-bridge-tools.ts`**
- Added optional `onStepUpdate(stepId, parameters)` callback to `createMcpBridgeTools`, called immediately after `updateStepParametersService` resolves.

**`chat/index.ts`**
- Passes an `onStepUpdate` handler that writes a `data-stepUpdate` data part to the `UIMessageStream` writer.
- Moved `mcpTools` construction inside the `execute` callback (required since `writer` is only in scope there).

**`chat/schema.ts`**
- Added `data-stepUpdate` to the `messagePartSchema` discriminated union so the part can round-trip in subsequent requests (the frontend echoes received stream parts back as message history).

## Tests

The unit tests cover the new callback path — run them to confirm nothing is broken:
```
npm run test packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
npm run test packages/backend/src/routes/api/__tests__/chat/schema.test.ts
```

**Manual smoke test:**
1. Open the AI Builder chat and build or edit a pipe so the LLM calls `update_step_parameters`.
2. In DevTools → Network, find the `/api/chat` request and inspect the SSE stream.
3. Confirm a `data-stepUpdate` event appears with the correct `stepId` and `parameters` after the tool call resolves.
4. Send a follow-up message; verify the `data-stepUpdate` part round-trips in the request body without causing a schema validation error.

> Note: the frontend has no handler for `data-stepUpdate` yet — the event will be present in the stream but silently ignored by the UI. That wiring comes in a later PR (`mcp/ai-builder-step-config-context`), after the frontend component groundwork in PR #1861.

## Deploy notes

No migrations, no new env vars, no config changes required. Backend deploy only.