### PR TITLE
[AI-SETUP-21] PLU-814 feat: add StepConfigContext for step active/configured state

### DIFF
--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -327,7 +327,11 @@ describe('createMcpBridgeTools', () => {
         },
         { toolCallId: 'update_step_parameters', messages: [] },
       )
-      expect(onStepUpdate).toHaveBeenCalledWith('step-1', { subject: 'Hello' })
+      expect(onStepUpdate).toHaveBeenCalledWith(
+        'step-1',
+        { subject: 'Hello' },
+        undefined,
+      )
     })
 
     it('does not throw when onStepUpdate is not provided', async () => {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -37,7 +37,11 @@ export function createMcpBridgeTools(
   user: User,
   traceId: string,
   onPipeChange?: (pipeId: string) => void,
-  onStepUpdate?: (stepId: string, parameters: IJSONObject) => void,
+  onStepUpdate?: (
+    stepId: string,
+    parameters: IJSONObject,
+    parameterLabels?: Record<string, string>,
+  ) => void,
 ) {
   return {
     list_apps: tool<ListAppsInput, IMcpApp[]>({
@@ -134,12 +138,19 @@ export function createMcpBridgeTools(
           .describe(
             "Connection ID to assign to this step. Obtain from list_connections. The connection's app must match the step's app.",
           ),
+        parameter_labels: z
+          .record(z.string(), z.string())
+          .optional()
+          .describe(
+            'Human-readable display labels for parameter values that are IDs or opaque keys (e.g. dynamic dropdown selections). Map each parameter key to the label the user would recognise. Used for display only — does not affect what is saved.',
+          ),
       }),
       execute: async ({
         pipe_id,
         step_id,
         parameters,
         connection_id,
+        parameter_labels,
       }): Promise<McpUpdateStepParametersResult> => {
         const result = await updateStepParametersService({
           user,
@@ -149,7 +160,7 @@ export function createMcpBridgeTools(
           connectionId: connection_id,
         })
         onPipeChange?.(pipe_id)
-        onStepUpdate?.(step_id, result.step.parameters)
+        onStepUpdate?.(step_id, result.step.parameters, parameter_labels)
         return result
       },
     }),

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -171,10 +171,10 @@ const handleChatStream = observe(
             (pipeId) => {
               activePipeId = pipeId
             },
-            (stepId, parameters) => {
+            (stepId, parameters, parameterLabels) => {
               writer.write({
                 type: 'data-stepUpdate',
-                data: { stepId, parameters },
+                data: { stepId, parameters, parameterLabels },
               })
             },
           )

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -88,6 +88,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
     data: z.object({
       stepId: z.uuid(),
       parameters: z.record(z.string(), z.unknown()),
+      parameterLabels: z.record(z.string(), z.string()).optional(),
     }),
   }),
   z.object({

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -39,7 +39,6 @@ import {
 } from '@/helpers/toolbox'
 import { extractVariables, StepWithVariables } from '@/helpers/variables'
 import { useApps } from '@/hooks/useApps'
-import { usePersistedState } from '@/hooks/usePersistedState'
 
 interface IEditorContextValue {
   flow: IFlow
@@ -138,10 +137,7 @@ export const EditorProvider = ({
   const readOnly = hasFlowTransfer || flow?.active || flow?.role === 'viewer'
 
   const flowId = flow.id
-  const [currentStepId, setCurrentStepId] = usePersistedState<string | null>(
-    `plumber.editor.${flowId}.currentStepId`,
-    null,
-  )
+  const [currentStepId, setCurrentStepId] = useState<string | null>(null)
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
   // Use REST API for apps data (faster than GraphQL due to caching)
@@ -193,20 +189,6 @@ export const EditorProvider = ({
     onOpen: onDrawerOpen,
     onClose: onDrawerClose,
   } = useDisclosure()
-
-  // On mount, restore the drawer for a previously selected step.
-  // If the step no longer exists in the flow, clear the stale persisted ID.
-  useEffect(() => {
-    if (!currentStepId) {
-      return
-    }
-    if (flow.steps.some((s) => s.id === currentStepId)) {
-      onDrawerOpen()
-    } else {
-      setCurrentStepId(null)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   /**
    * CreateStep mutation

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -197,7 +197,9 @@ export const EditorProvider = ({
   // On mount, restore the drawer for a previously selected step.
   // If the step no longer exists in the flow, clear the stale persisted ID.
   useEffect(() => {
-    if (!currentStepId) return
+    if (!currentStepId) {
+      return
+    }
     if (flow.steps.some((s) => s.id === currentStepId)) {
       onDrawerOpen()
     } else {
@@ -255,7 +257,7 @@ export const EditorProvider = ({
 
       return newStep as IStep
     },
-    [createStep, flow, flowId, initializeIfThen],
+    [createStep, flow.updatedAt, flowId, initializeIfThen, setCurrentStepId],
   )
 
   /**

--- a/packages/frontend/src/contexts/Editor.tsx
+++ b/packages/frontend/src/contexts/Editor.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/helpers/toolbox'
 import { extractVariables, StepWithVariables } from '@/helpers/variables'
 import { useApps } from '@/hooks/useApps'
+import { usePersistedState } from '@/hooks/usePersistedState'
 
 interface IEditorContextValue {
   flow: IFlow
@@ -137,7 +138,10 @@ export const EditorProvider = ({
   const readOnly = hasFlowTransfer || flow?.active || flow?.role === 'viewer'
 
   const flowId = flow.id
-  const [currentStepId, setCurrentStepId] = useState<string | null>(null)
+  const [currentStepId, setCurrentStepId] = usePersistedState<string | null>(
+    `plumber.editor.${flowId}.currentStepId`,
+    null,
+  )
   const [resetTimestamp, setResetTimestamp] = useState<number>(Date.now())
 
   // Use REST API for apps data (faster than GraphQL due to caching)
@@ -189,6 +193,18 @@ export const EditorProvider = ({
     onOpen: onDrawerOpen,
     onClose: onDrawerClose,
   } = useDisclosure()
+
+  // On mount, restore the drawer for a previously selected step.
+  // If the step no longer exists in the flow, clear the stale persisted ID.
+  useEffect(() => {
+    if (!currentStepId) return
+    if (flow.steps.some((s) => s.id === currentStepId)) {
+      onDrawerOpen()
+    } else {
+      setCurrentStepId(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   /**
    * CreateStep mutation

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -1,4 +1,4 @@
-import type { IJSONObject, IFlowSteps } from '@plumber/types'
+import type { IFlowSteps, IJSONObject } from '@plumber/types'
 
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -311,23 +311,38 @@ export function useChatStream(options: UseChatStreamOptions) {
     return ''
   }, [aiMessages, status])
 
-  const { stepParametersByStepId, activeStepId } = useMemo(() => {
-    const byStepId: Record<string, IJSONObject> = {}
-    let latestStepId: string | null = null
+  const { stepParametersByStepId, activeStepId, completedStepIds } =
+    useMemo(() => {
+      const byStepId: Record<string, IJSONObject> = {}
+      let latestStepId: string | null = null
+      const completed = new Set<string>()
 
-    for (const msg of aiMessages) {
-      if (msg.role !== 'assistant') continue
-      for (const part of msg.parts ?? []) {
-        if (part.type === 'data-stepUpdate') {
-          const { stepId, parameters } = (part as StepUpdatePart).data
-          byStepId[stepId] = parameters
-          latestStepId = stepId
+      for (const msg of aiMessages) {
+        if (msg.role !== 'assistant') {
+          continue
+        }
+        for (const part of msg.parts ?? []) {
+          if (part.type === 'data-stepUpdate') {
+            const { stepId, parameters } = (part as StepUpdatePart).data
+            byStepId[stepId] = parameters
+            latestStepId = stepId
+          }
+          if (part.type === 'data-pipeState') {
+            for (const step of (part as PipeStatePart).data.steps) {
+              if (step.status === 'completed') {
+                completed.add(step.id)
+              }
+            }
+          }
         }
       }
-    }
 
-    return { stepParametersByStepId: byStepId, activeStepId: latestStepId }
-  }, [aiMessages])
+      return {
+        stepParametersByStepId: byStepId,
+        activeStepId: latestStepId,
+        completedStepIds: completed,
+      }
+    }, [aiMessages])
 
   const resetChat = useCallback(() => {
     setMessages([])
@@ -359,5 +374,6 @@ export function useChatStream(options: UseChatStreamOptions) {
     hasReachedLimit: messages.length >= MAX_MESSAGES,
     activeStepId,
     stepParametersByStepId,
+    completedStepIds,
   }
 }

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -1,4 +1,4 @@
-import type { IFlowSteps } from '@plumber/types'
+import type { IJSONObject, IFlowSteps } from '@plumber/types'
 
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -86,6 +86,14 @@ export type ClarificationPart = {
   type: 'data-clarification'
   data: {
     questions: ClarificationQuestion[]
+  }
+}
+
+export type StepUpdatePart = {
+  type: 'data-stepUpdate'
+  data: {
+    stepId: string
+    parameters: IJSONObject
   }
 }
 
@@ -303,6 +311,24 @@ export function useChatStream(options: UseChatStreamOptions) {
     return ''
   }, [aiMessages, status])
 
+  const { stepParametersByStepId, activeStepId } = useMemo(() => {
+    const byStepId: Record<string, IJSONObject> = {}
+    let latestStepId: string | null = null
+
+    for (const msg of aiMessages) {
+      if (msg.role !== 'assistant') continue
+      for (const part of msg.parts ?? []) {
+        if (part.type === 'data-stepUpdate') {
+          const { stepId, parameters } = (part as StepUpdatePart).data
+          byStepId[stepId] = parameters
+          latestStepId = stepId
+        }
+      }
+    }
+
+    return { stepParametersByStepId: byStepId, activeStepId: latestStepId }
+  }, [aiMessages])
+
   const resetChat = useCallback(() => {
     setMessages([])
     setIsReady(false)
@@ -331,5 +357,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     cancelStream: stop,
     resetChat,
     hasReachedLimit: messages.length >= MAX_MESSAGES,
+    activeStepId,
+    stepParametersByStepId,
   }
 }

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -94,6 +94,7 @@ export type StepUpdatePart = {
   data: {
     stepId: string
     parameters: IJSONObject
+    parameterLabels?: Record<string, string>
   }
 }
 
@@ -311,38 +312,52 @@ export function useChatStream(options: UseChatStreamOptions) {
     return ''
   }, [aiMessages, status])
 
-  const { stepParametersByStepId, activeStepId, completedStepIds } =
-    useMemo(() => {
-      const byStepId: Record<string, IJSONObject> = {}
-      let latestStepId: string | null = null
-      const completed = new Set<string>()
+  const {
+    stepParametersByStepId,
+    parameterLabelsByStepId,
+    activeStepId,
+    completedStepIds,
+  } = useMemo(() => {
+    const byStepId: Record<string, IJSONObject> = {}
+    const labelsByStepId: Record<string, Record<string, string>> = {}
+    let latestStepId: string | null = null
+    const completed = new Set<string>()
 
-      for (const msg of aiMessages) {
-        if (msg.role !== 'assistant') {
-          continue
-        }
-        for (const part of msg.parts ?? []) {
-          if (part.type === 'data-stepUpdate') {
-            const { stepId, parameters } = (part as StepUpdatePart).data
-            byStepId[stepId] = parameters
-            latestStepId = stepId
+    for (const msg of aiMessages) {
+      if (msg.role !== 'assistant') {
+        continue
+      }
+      for (const part of msg.parts ?? []) {
+        if (part.type === 'data-stepUpdate') {
+          const { stepId, parameters, parameterLabels } = (
+            part as StepUpdatePart
+          ).data
+          byStepId[stepId] = parameters
+          if (parameterLabels) {
+            labelsByStepId[stepId] = {
+              ...(labelsByStepId[stepId] ?? {}),
+              ...parameterLabels,
+            }
           }
-          if (part.type === 'data-pipeState') {
-            for (const step of (part as PipeStatePart).data.steps) {
-              if (step.status === 'completed') {
-                completed.add(step.id)
-              }
+          latestStepId = stepId
+        }
+        if (part.type === 'data-pipeState') {
+          for (const step of (part as PipeStatePart).data.steps) {
+            if (step.status === 'completed') {
+              completed.add(step.id)
             }
           }
         }
       }
+    }
 
-      return {
-        stepParametersByStepId: byStepId,
-        activeStepId: latestStepId,
-        completedStepIds: completed,
-      }
-    }, [aiMessages])
+    return {
+      stepParametersByStepId: byStepId,
+      parameterLabelsByStepId: labelsByStepId,
+      activeStepId: latestStepId,
+      completedStepIds: completed,
+    }
+  }, [aiMessages])
 
   const resetChat = useCallback(() => {
     setMessages([])
@@ -374,6 +389,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     hasReachedLimit: messages.length >= MAX_MESSAGES,
     activeStepId,
     stepParametersByStepId,
+    parameterLabelsByStepId,
     completedStepIds,
   }
 }

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -334,10 +334,7 @@ export function useChatStream(options: UseChatStreamOptions) {
           ).data
           byStepId[stepId] = parameters
           if (parameterLabels) {
-            labelsByStepId[stepId] = {
-              ...(labelsByStepId[stepId] ?? {}),
-              ...parameterLabels,
-            }
+            labelsByStepId[stepId] = parameterLabels
           }
           latestStepId = stepId
         }

--- a/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
@@ -5,11 +5,13 @@ import { createContext, useContext } from 'react'
 interface StepConfigContextValue {
   activeStepId: string | null
   stepParametersByStepId: Record<string, IJSONObject>
+  completedStepIds: Set<string>
 }
 
 const StepConfigContext = createContext<StepConfigContextValue>({
   activeStepId: null,
   stepParametersByStepId: {},
+  completedStepIds: new Set(),
 })
 
 export const useStepConfigContext = () => useContext(StepConfigContext)

--- a/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
@@ -5,12 +5,14 @@ import { createContext, useContext } from 'react'
 interface StepConfigContextValue {
   activeStepId: string | null
   stepParametersByStepId: Record<string, IJSONObject>
+  parameterLabelsByStepId: Record<string, Record<string, string>>
   completedStepIds: Set<string>
 }
 
 const StepConfigContext = createContext<StepConfigContextValue>({
   activeStepId: null,
   stepParametersByStepId: {},
+  parameterLabelsByStepId: {},
   completedStepIds: new Set(),
 })
 

--- a/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
@@ -1,0 +1,17 @@
+import type { IJSONObject } from '@plumber/types'
+
+import { createContext, useContext } from 'react'
+
+interface StepConfigContextValue {
+  activeStepId: string | null
+  stepParametersByStepId: Record<string, IJSONObject>
+}
+
+const StepConfigContext = createContext<StepConfigContextValue>({
+  activeStepId: null,
+  stepParametersByStepId: {},
+})
+
+export const useStepConfigContext = () => useContext(StepConfigContext)
+
+export default StepConfigContext

--- a/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
@@ -3,14 +3,12 @@ import type { IJSONObject } from '@plumber/types'
 import { createContext, useContext } from 'react'
 
 interface StepConfigContextValue {
-  activeStepId: string | null
   stepParametersByStepId: Record<string, IJSONObject>
   parameterLabelsByStepId: Record<string, Record<string, string>>
   completedStepIds: Set<string>
 }
 
 const StepConfigContext = createContext<StepConfigContextValue>({
-  activeStepId: null,
   stepParametersByStepId: {},
   parameterLabelsByStepId: {},
   completedStepIds: new Set(),

--- a/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/StepConfigContext.tsx
@@ -6,12 +6,14 @@ interface StepConfigContextValue {
   stepParametersByStepId: Record<string, IJSONObject>
   parameterLabelsByStepId: Record<string, Record<string, string>>
   completedStepIds: Set<string>
+  activeStepId: string | null
 }
 
 const StepConfigContext = createContext<StepConfigContextValue>({
   stepParametersByStepId: {},
   parameterLabelsByStepId: {},
   completedStepIds: new Set(),
+  activeStepId: null,
 })
 
 export const useStepConfigContext = () => useContext(StepConfigContext)

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/BranchStep.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/BranchStep.tsx
@@ -3,17 +3,23 @@ import { IStep } from '@plumber/types'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { branchStyles } from '@/components/FlowStepGroup/Content/IfThen/styles'
+import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
+import { useStepConfigContext } from '@/pages/AiBuilder/StepConfigContext'
 
 import Step from './Step'
 
 interface BranchStepProps {
   branchSteps: IStep[]
   isMobile: boolean
+  effectiveActiveStepId?: string | null
 }
 
 export default function BranchStep(props: BranchStepProps) {
-  const { branchSteps } = props
+  const { branchSteps, effectiveActiveStepId } = props
+  const { output } = useAiBuilderContext()
+  const { stepParametersByStepId, completedStepIds } = useStepConfigContext()
 
+  const isMcpPipeMode = Boolean(output?.pipeId)
   const branchName = branchSteps[0].parameters?.branchName as string
 
   return (
@@ -30,6 +36,11 @@ export default function BranchStep(props: BranchStepProps) {
             step={step}
             isNested={true}
             isLastStep={index === branchSteps.length - 1}
+            {...(isMcpPipeMode && {
+              isActive: step.id === effectiveActiveStepId,
+              isConfigured: Boolean(step.id && completedStepIds.has(step.id)),
+              parameters: step.id ? stepParametersByStepId[step.id] : undefined,
+            })}
           />
         ))}
       </Box>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepContainer.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/GroupedStepContainer.tsx
@@ -11,13 +11,21 @@ interface GroupedStepContainerProps {
   isNested: boolean
   stepGroupType: string
   stepGroupCaption: string
+  isPending?: boolean
 }
 
 export default function GroupedStepContainer(props: GroupedStepContainerProps) {
-  const { children, isNested, stepGroupType, stepGroupCaption } = props
+  const { children, isNested, stepGroupType, stepGroupCaption, isPending } =
+    props
   const isMobile = useIsMobile()
   return (
-    <Flex justifyContent="center" w="100%">
+    <Flex
+      justifyContent="center"
+      w="100%"
+      opacity={isPending ? 0.55 : 1}
+      transition="opacity 0.15s"
+      pointerEvents={isPending ? 'none' : 'auto'}
+    >
       <Flex
         {...flowStepGroupStyles.container}
         display={isMobile ? 'block' : 'flex'}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -154,6 +154,7 @@ export default function Step(props: StepProps) {
               parameters={parameters}
               appKey={step.appKey ?? ''}
               stepKey={step.key ?? ''}
+              stepId={step.id ?? ''}
             />
           )}
         </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -1,7 +1,7 @@
 import { IApp, IJSONObject, IStep } from '@plumber/types'
 
 import { useState } from 'react'
-import { BiInfoCircle, BiSolidCheckCircle } from 'react-icons/bi'
+import { BiInfoCircle } from 'react-icons/bi'
 import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri'
 import { Box, Divider, Flex, Icon, Text } from '@chakra-ui/react'
 
@@ -28,14 +28,8 @@ interface StepProps {
 }
 
 export default function Step(props: StepProps) {
-  const {
-    step,
-    isNested,
-    isLastStep,
-    isActive = false,
-    isConfigured = false,
-    parameters,
-  } = props
+  const { step, isNested, isLastStep, isActive, isConfigured, parameters } =
+    props
   const { allApps } = useAiBuilderContext()
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -44,7 +38,9 @@ export default function Step(props: StepProps) {
   )
   const { stepName } = getStepName(allApps, step as IStep)
 
-  const isPending = !isActive && !isConfigured
+  // Only mute when we're in configuration mode (props explicitly set to false)
+  // Undefined means proposal mode — show all steps at full opacity
+  const isPending = isActive === false && isConfigured === false
   const showParams = parameters && (isActive || (isConfigured && isExpanded))
 
   if (!step) {
@@ -124,37 +120,14 @@ export default function Step(props: StepProps) {
           })}
         >
           <Flex {...flowStepStyles.topHeader} py={isNested ? 3 : 4}>
-            {/* App icon with optional completed badge */}
-            <Box position="relative" flexShrink={0} mr={4}>
-              <StepAppIcon
-                isCompleted={false}
-                isNested={isNested}
-                isTestSuccessful={undefined}
-                shouldTestStepAgain={false}
-                app={app}
-                step={step}
-              />
-              {isConfigured && (
-                <Box
-                  position="absolute"
-                  bottom="-3px"
-                  right="-3px"
-                  bg="white"
-                  borderRadius="full"
-                  display="flex"
-                  alignItems="center"
-                  justifyContent="center"
-                  w="14px"
-                  h="14px"
-                >
-                  <Icon
-                    as={BiSolidCheckCircle}
-                    color="#0F796F"
-                    boxSize="14px"
-                  />
-                </Box>
-              )}
-            </Box>
+            <StepAppIcon
+              isCompleted={isConfigured}
+              isNested={isNested}
+              isTestSuccessful={isConfigured ? true : undefined}
+              shouldTestStepAgain={false}
+              app={app}
+              step={step}
+            />
 
             <Box w="100%">
               <StepNameAndDemo
@@ -187,7 +160,7 @@ export default function Step(props: StepProps) {
       </Flex>
       {!isLastStep && (
         <Flex justifyContent="center" h={isNested ? 6 : 12}>
-          <Divider orientation="vertical" borderColor="base.divider.strong" />
+          <Divider orientation="vertical" borderColor="base.divider.medium" />
         </Flex>
       )}
     </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -78,6 +78,11 @@ function flattenValue(
       .filter((k) => obj[k] !== '' && obj[k] != null)
       .map((k) => {
         const subField = subFields?.find((f) => f.key === k)
+        // obj[k] is assumed scalar here: no current app schema nests a
+        // multirow/multirow-multicol subField inside another one's subFields,
+        // even though IField's type allows it. If that ever changes, this
+        // needs a typeof-object branch that recurses into flattenValue
+        // instead of stringifying — see PR #1864 review discussion.
         return resolveOptionLabel(subField, String(obj[k]))
       })
     return parts.length > 0 ? parts.join(' ') : null

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -122,6 +122,7 @@ export default function StepParameterRows({
   const parameterLabels = parameterLabelsByStepId[stepId] ?? {}
 
   const stepFields = getStepFields(allApps, appKey, stepKey)
+  const fieldIndexMap = new Map(stepFields.map((f, i) => [f.key, i]))
   const rows = Object.entries(parameters)
     .filter(([, value]) => value !== '' && value != null)
     .map(([key, value]) => {
@@ -141,6 +142,11 @@ export default function StepParameterRows({
         displayValue !== '' &&
         !isFieldHidden(hiddenIf, parameters),
     )
+    .sort((a, b) => {
+      const posA = fieldIndexMap.get(a.key) ?? Infinity
+      const posB = fieldIndexMap.get(b.key) ?? Infinity
+      return posA - posB
+    })
 
   if (rows.length === 0) {
     return null

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -1,4 +1,4 @@
-import type { IApp, IFieldDropdown, IJSONObject } from '@plumber/types'
+import type { IApp, IJSONObject } from '@plumber/types'
 
 import { Fragment } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
@@ -39,6 +39,50 @@ function resolveFieldLabel(
   )
 }
 
+type FieldWithOptions = {
+  options?: Array<{ label: string; value: string | number }>
+  subFields?: FieldWithOptions[]
+}
+
+// Resolve a single scalar value against a field's option list.
+function resolveOptionLabel(
+  field: FieldWithOptions | undefined,
+  strValue: string,
+): string {
+  const option = field?.options?.find((o) => String(o.value) === strValue)
+  return option ? option.label : strValue
+}
+
+// Recursively flatten object/array values into a readable string,
+// resolving option labels from subField definitions where available.
+function flattenValue(
+  value: unknown,
+  subFields?: FieldWithOptions[],
+): string | null {
+  if (Array.isArray(value)) {
+    // Array of rows (e.g. multirow-multicol): join each row with ', '
+    const rows = value
+      .map((item) => flattenValue(item, subFields))
+      .filter(Boolean)
+    return rows.length > 0 ? rows.join(', ') : null
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    // Object row: resolve each key against its subField options, join with ' '
+    const parts = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== '' && v != null)
+      .map(([k, v]) => {
+        const subField = subFields?.find(
+          (f) => (f as unknown as { key?: string }).key === k,
+        )
+        return resolveOptionLabel(subField, String(v))
+      })
+    return parts.length > 0 ? parts.join(' ') : null
+  }
+
+  return String(value)
+}
+
 function resolveDisplayValue(
   allApps: IApp[],
   appKey: string,
@@ -46,26 +90,18 @@ function resolveDisplayValue(
   paramKey: string,
   value: unknown,
 ): string | null {
-  // Skip object/array values — they can't be displayed meaningfully as a flat string
-  if (typeof value === 'object' && value !== null) {
-    return null
-  }
-
-  const strValue = String(value)
-
-  // For dropdown fields with static options, show the option label not the raw key
   const fields = getStepFields(allApps, appKey, stepKey)
-  const field = fields.find((f) => f.key === paramKey)
-  if (field?.type === 'dropdown') {
-    const option = (field as IFieldDropdown).options?.find(
-      (o) => String(o.value) === strValue,
-    )
-    if (option) {
-      return option.label
-    }
+  const field = fields.find((f) => f.key === paramKey) as
+    | FieldWithOptions
+    | undefined
+
+  // For objects/arrays (e.g. multirow-multicol), recursively flatten with sub-field label resolution
+  if (typeof value === 'object' && value !== null) {
+    return flattenValue(value, field?.subFields)
   }
 
-  return strValue
+  // For scalar values, resolve option label if the field has static options
+  return resolveOptionLabel(field, String(value))
 }
 
 interface StepParameterRowsProps {

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -69,14 +69,20 @@ function flattenValue(
   }
 
   if (typeof value === 'object' && value !== null) {
-    // Object row: resolve each key against its subField options, join with ' '
-    const parts = Object.entries(value as Record<string, unknown>)
-      .filter(([, v]) => v !== '' && v != null)
-      .map(([k, v]) => {
+    const obj = value as Record<string, unknown>
+    // Follow subField definition order if available; otherwise use object key order
+    const keys = subFields
+      ? subFields
+          .map((f) => (f as unknown as { key?: string }).key)
+          .filter((k): k is string => k != null && k in obj)
+      : Object.keys(obj)
+    const parts = keys
+      .filter((k) => obj[k] !== '' && obj[k] != null)
+      .map((k) => {
         const subField = subFields?.find(
           (f) => (f as unknown as { key?: string }).key === k,
         )
-        return resolveOptionLabel(subField, String(v))
+        return resolveOptionLabel(subField, String(obj[k]))
       })
     return parts.length > 0 ? parts.join(' ') : null
   }

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -29,18 +29,16 @@ function getStepFields(allApps: IApp[], appKey: string, stepKey: string) {
 }
 
 function resolveFieldLabel(
-  allApps: IApp[],
-  appKey: string,
-  stepKey: string,
+  fields: ReturnType<typeof getStepFields>,
   paramKey: string,
 ): string {
-  const fields = getStepFields(allApps, appKey, stepKey)
   return (
     fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
   )
 }
 
 type FieldWithOptions = {
+  key?: string
   options?: Array<{ label: string; value: string | number }>
   subFields?: FieldWithOptions[]
 }
@@ -73,15 +71,13 @@ function flattenValue(
     // Follow subField definition order if available; otherwise use object key order
     const keys = subFields
       ? subFields
-          .map((f) => (f as unknown as { key?: string }).key)
+          .map((f) => f.key)
           .filter((k): k is string => k != null && k in obj)
       : Object.keys(obj)
     const parts = keys
       .filter((k) => obj[k] !== '' && obj[k] != null)
       .map((k) => {
-        const subField = subFields?.find(
-          (f) => (f as unknown as { key?: string }).key === k,
-        )
+        const subField = subFields?.find((f) => f.key === k)
         return resolveOptionLabel(subField, String(obj[k]))
       })
     return parts.length > 0 ? parts.join(' ') : null
@@ -91,13 +87,10 @@ function flattenValue(
 }
 
 function resolveDisplayValue(
-  allApps: IApp[],
-  appKey: string,
-  stepKey: string,
+  fields: ReturnType<typeof getStepFields>,
   paramKey: string,
   value: unknown,
 ): string | null {
-  const fields = getStepFields(allApps, appKey, stepKey)
   const field = fields.find((f) => f.key === paramKey) as
     | FieldWithOptions
     | undefined
@@ -135,11 +128,10 @@ export default function StepParameterRows({
       const field = stepFields.find((f) => f.key === key)
       return {
         key,
-        label: resolveFieldLabel(allApps, appKey, stepKey, key),
+        label: resolveFieldLabel(stepFields, key),
         // AI-provided labels take priority over static option resolution
         displayValue:
-          parameterLabels[key] ??
-          resolveDisplayValue(allApps, appKey, stepKey, key, value),
+          parameterLabels[key] ?? resolveDisplayValue(stepFields, key, value),
         hiddenIf: field?.hiddenIf,
       }
     })

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -1,4 +1,4 @@
-import type { IApp, IField, IJSONObject } from '@plumber/types'
+import type { IApp, IFieldDropdown, IJSONObject } from '@plumber/types'
 
 import { Fragment } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
@@ -14,24 +14,58 @@ function camelToSentence(key: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1).toLowerCase()
 }
 
-function resolveFieldDef(
+function getStepFields(allApps: IApp[], appKey: string, stepKey: string) {
+  const app = allApps.find((a) => a.key === appKey)
+  if (!app) {
+    return []
+  }
+  const trigger = app.triggers?.find((t) => t.key === stepKey)
+  const action = app.actions?.find((a) => a.key === stepKey)
+  return [
+    ...(trigger?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
+    ...(action?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
+  ]
+}
+
+function resolveFieldLabel(
   allApps: IApp[],
   appKey: string,
   stepKey: string,
   paramKey: string,
-): IField | undefined {
-  const app = allApps.find((a) => a.key === appKey)
-  if (!app) {
-    return undefined
+): string {
+  const fields = getStepFields(allApps, appKey, stepKey)
+  return (
+    fields.find((f) => f.key === paramKey)?.label ?? camelToSentence(paramKey)
+  )
+}
+
+function resolveDisplayValue(
+  allApps: IApp[],
+  appKey: string,
+  stepKey: string,
+  paramKey: string,
+  value: unknown,
+): string | null {
+  // Skip object/array values — they can't be displayed meaningfully as a flat string
+  if (typeof value === 'object' && value !== null) {
+    return null
   }
 
-  const trigger = app.triggers?.find((t) => t.key === stepKey)
-  const action = app.actions?.find((a) => a.key === stepKey)
-  const fields = [
-    ...(trigger?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
-    ...(action?.substeps?.flatMap((s) => s.arguments ?? []) ?? []),
-  ]
-  return fields.find((f) => f.key === paramKey)
+  const strValue = String(value)
+
+  // For dropdown fields with static options, show the option label not the raw key
+  const fields = getStepFields(allApps, appKey, stepKey)
+  const field = fields.find((f) => f.key === paramKey)
+  if (field?.type === 'dropdown') {
+    const option = (field as IFieldDropdown).options?.find(
+      (o) => String(o.value) === strValue,
+    )
+    if (option) {
+      return option.label
+    }
+  }
+
+  return strValue
 }
 
 interface StepParameterRowsProps {
@@ -47,17 +81,23 @@ export default function StepParameterRows({
 }: StepParameterRowsProps) {
   const { allApps } = useAiBuilderContext()
 
+  const stepFields = getStepFields(allApps, appKey, stepKey)
   const rows = Object.entries(parameters)
-    .map(([key, value]) => ({
-      key,
-      value,
-      field: resolveFieldDef(allApps, appKey, stepKey, key),
-    }))
+    .filter(([, value]) => value !== '' && value != null)
+    .map(([key, value]) => {
+      const field = stepFields.find((f) => f.key === key)
+      return {
+        key,
+        label: resolveFieldLabel(allApps, appKey, stepKey, key),
+        displayValue: resolveDisplayValue(allApps, appKey, stepKey, key, value),
+        hiddenIf: field?.hiddenIf,
+      }
+    })
     .filter(
-      ({ value, field }) =>
-        value !== '' &&
-        value != null &&
-        !isFieldHidden(field?.hiddenIf, parameters),
+      ({ displayValue, hiddenIf }) =>
+        displayValue !== null &&
+        displayValue !== '' &&
+        !isFieldHidden(hiddenIf, parameters),
     )
 
   if (rows.length === 0) {
@@ -73,15 +113,13 @@ export default function StepParameterRows({
       borderTop="1px solid"
       borderColor="base.divider.weak"
     >
-      {rows.map(({ key, value, field }, rowIndex) => {
-        const label = field?.label ?? camelToSentence(key)
-        const strValue = String(value)
-        const segments = parseParameterValue(strValue)
+      {rows.map(({ key, label, displayValue }, rowIndex) => {
+        const segments = parseParameterValue(displayValue as string)
 
         return (
           <Flex
             key={key}
-            align="baseline"
+            align="center"
             gap={2.5}
             py="5px"
             borderBottom={rowIndex < rows.length - 1 ? '1px solid' : 'none'}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -6,6 +6,7 @@ import { Box, Flex, Text } from '@chakra-ui/react'
 import { isFieldHidden } from '@/helpers/isFieldHidden'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import { parseParameterValue } from '@/pages/AiBuilder/helpers/parseParameterValue'
+import { useStepConfigContext } from '@/pages/AiBuilder/StepConfigContext'
 
 import VariablePill from './VariablePill'
 
@@ -108,14 +109,18 @@ interface StepParameterRowsProps {
   parameters: IJSONObject
   appKey: string
   stepKey: string
+  stepId: string
 }
 
 export default function StepParameterRows({
   parameters,
   appKey,
   stepKey,
+  stepId,
 }: StepParameterRowsProps) {
   const { allApps } = useAiBuilderContext()
+  const { parameterLabelsByStepId } = useStepConfigContext()
+  const parameterLabels = parameterLabelsByStepId[stepId] ?? {}
 
   const stepFields = getStepFields(allApps, appKey, stepKey)
   const rows = Object.entries(parameters)
@@ -125,7 +130,10 @@ export default function StepParameterRows({
       return {
         key,
         label: resolveFieldLabel(allApps, appKey, stepKey, key),
-        displayValue: resolveDisplayValue(allApps, appKey, stepKey, key, value),
+        // AI-provided labels take priority over static option resolution
+        displayValue:
+          parameterLabels[key] ??
+          resolveDisplayValue(allApps, appKey, stepKey, key, value),
         hiddenIf: field?.hiddenIf,
       }
     })
@@ -147,20 +155,13 @@ export default function StepParameterRows({
       pl="58px"
       pr={4}
       borderTop="1px solid"
-      borderColor="base.divider.weak"
+      borderColor="base.divider.medium"
     >
-      {rows.map(({ key, label, displayValue }, rowIndex) => {
+      {rows.map(({ key, label, displayValue }) => {
         const segments = parseParameterValue(displayValue as string)
 
         return (
-          <Flex
-            key={key}
-            align="center"
-            gap={2.5}
-            py="5px"
-            borderBottom={rowIndex < rows.length - 1 ? '1px solid' : 'none'}
-            borderColor="base.divider.weak"
-          >
+          <Flex key={key} align="center" gap={2.5} py="5px">
             <Text
               as="span"
               fontSize="12px"

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
@@ -20,6 +20,7 @@ export default function VariablePill({ label }: VariablePillProps) {
       whiteSpace="nowrap"
       lineHeight={1.4}
     >
+      <span style={{ color: '#888', fontWeight: 400 }}>{'{}'}</span>
       {label}
     </Box>
   )

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
@@ -20,7 +20,9 @@ export default function VariablePill({ label }: VariablePillProps) {
       whiteSpace="nowrap"
       lineHeight={1.4}
     >
-      <span style={{ color: '#888', fontWeight: 400 }}>{'{}'}</span>
+      <Box as="span" color="base.content.medium" fontWeight={400} mr="2px">
+        {'{}'}
+      </Box>
       {label}
     </Box>
   )

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -227,6 +227,7 @@ export default function StepsPreview() {
                     key={String(branchSteps[0].position)}
                     branchSteps={branchSteps}
                     isMobile={isMobile}
+                    effectiveActiveStepId={effectiveActiveStepId}
                   />
                 ))}
               </Flex>
@@ -242,6 +243,15 @@ export default function StepsPreview() {
                         forEachSteps.length - 1 === index &&
                         ifThenSteps.length === 0
                       }
+                      {...(isMcpPipeMode && {
+                        isActive: step.id === effectiveActiveStepId,
+                        isConfigured: Boolean(
+                          step.id && completedStepIds.has(step.id),
+                        ),
+                        parameters: step.id
+                          ? stepParametersByStepId[step.id]
+                          : undefined,
+                      })}
                     />
                   ))}
                   {ifThenSteps.length > 0 && (
@@ -256,6 +266,7 @@ export default function StepsPreview() {
                             key={String(branchSteps[0].position)}
                             branchSteps={branchSteps}
                             isMobile={isMobile}
+                            effectiveActiveStepId={effectiveActiveStepId}
                           />
                         ))}
                       </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -42,12 +42,26 @@ export default function StepsPreview() {
     stepGroupCaption,
     clearPersistedState,
   } = useAiBuilderContext()
-  const { activeStepId, stepParametersByStepId } = useStepConfigContext()
+  const { stepParametersByStepId, completedStepIds } = useStepConfigContext()
 
   const isMobile = useIsMobile()
 
   const isMcpPipeMode = Boolean(output?.pipeId) // Phase 2b+: DB pipe exists
   const isMcpProposalMode = !isMcpPipeMode && Boolean(output?.mcpMode) // Phase 2a: proposal, no DB
+
+  // Derive the active step as the first uncompleted step in order.
+  // This correctly highlights the step currently being configured even before
+  // any update_step_parameters call has been made for it (e.g. while collecting
+  // field value clarifications for a step with no connection requirement).
+  const effectiveActiveStepId = useMemo(() => {
+    if (!isMcpPipeMode || !output?.steps?.length) {
+      return null
+    }
+    const firstUncompleted = output.steps.find(
+      (s: { id: string }) => !completedStepIds.has(s.id),
+    )
+    return firstUncompleted?.id ?? null
+  }, [isMcpPipeMode, output?.steps, completedStepIds])
 
   const [createFlowWithSteps, { loading: isCreatingFlow }] = useMutation(
     CREATE_FLOW_WITH_STEPS,
@@ -157,14 +171,15 @@ export default function StepsPreview() {
       >
         <Step
           step={triggerStep}
-          isActive={Boolean(triggerStep?.id && triggerStep.id === activeStepId)}
-          isConfigured={Boolean(
-            triggerStep?.id &&
-              stepParametersByStepId[triggerStep.id] !== undefined,
-          )}
-          parameters={
-            triggerStep?.id ? stepParametersByStepId[triggerStep.id] : undefined
-          }
+          {...(isMcpPipeMode && {
+            isActive: triggerStep?.id === effectiveActiveStepId,
+            isConfigured: Boolean(
+              triggerStep?.id && completedStepIds.has(triggerStep.id),
+            ),
+            parameters: triggerStep?.id
+              ? stepParametersByStepId[triggerStep.id]
+              : undefined,
+          })}
         />
         {stepsBeforeGroup.map((action) => (
           <Fragment key={`${action.position}-${action.appKey}`}>
@@ -172,13 +187,15 @@ export default function StepsPreview() {
               key={`${action.position}-${action.appKey}`}
               step={action}
               isLastStep={action.position === actionSteps.length + 1}
-              isActive={Boolean(action.id && action.id === activeStepId)}
-              isConfigured={Boolean(
-                action.id && stepParametersByStepId[action.id] !== undefined,
-              )}
-              parameters={
-                action.id ? stepParametersByStepId[action.id] : undefined
-              }
+              {...(isMcpPipeMode && {
+                isActive: action.id === effectiveActiveStepId,
+                isConfigured: Boolean(
+                  action.id && completedStepIds.has(action.id),
+                ),
+                parameters: action.id
+                  ? stepParametersByStepId[action.id]
+                  : undefined,
+              })}
             />
           </Fragment>
         ))}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -42,26 +42,43 @@ export default function StepsPreview() {
     stepGroupCaption,
     clearPersistedState,
   } = useAiBuilderContext()
-  const { stepParametersByStepId, completedStepIds } = useStepConfigContext()
+  const {
+    stepParametersByStepId,
+    completedStepIds,
+    activeStepId,
+  } = useStepConfigContext()
 
   const isMobile = useIsMobile()
 
   const isMcpPipeMode = Boolean(output?.pipeId) // Phase 2b+: DB pipe exists
   const isMcpProposalMode = !isMcpPipeMode && Boolean(output?.mcpMode) // Phase 2a: proposal, no DB
 
-  // Derive the active step as the first uncompleted step in order.
-  // This correctly highlights the step currently being configured even before
-  // any update_step_parameters call has been made for it (e.g. while collecting
-  // field value clarifications for a step with no connection requirement).
+  // Derive the active step as the first uncompleted step in order,
+  // but advance past it if the AI has already moved on (e.g. after a step
+  // failed and was skipped — the failed step stays uncompleted but the AI
+  // is configuring a later one).
   const effectiveActiveStepId = useMemo(() => {
     if (!isMcpPipeMode || !output?.steps?.length) {
       return null
     }
-    const firstUncompleted = output.steps.find(
-      (s: { id: string }) => !completedStepIds.has(s.id),
-    )
-    return firstUncompleted?.id ?? null
-  }, [isMcpPipeMode, output?.steps, completedStepIds])
+    const steps: Array<{ id: string }> = output.steps
+    const firstUncompleted = steps.find((s) => !completedStepIds.has(s.id))
+    if (!firstUncompleted) {
+      return null
+    }
+    // If the AI has sent an update for a step that comes after firstUncompleted
+    // (skipped failure case), highlight that later step instead.
+    if (activeStepId && activeStepId !== firstUncompleted.id) {
+      const firstUncompletedIndex = steps.findIndex(
+        (s) => s.id === firstUncompleted.id,
+      )
+      const activeIndex = steps.findIndex((s) => s.id === activeStepId)
+      if (activeIndex > firstUncompletedIndex) {
+        return activeStepId
+      }
+    }
+    return firstUncompleted.id
+  }, [isMcpPipeMode, output?.steps, completedStepIds, activeStepId])
 
   const [createFlowWithSteps, { loading: isCreatingFlow }] = useMutation(
     CREATE_FLOW_WITH_STEPS,

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -22,6 +22,7 @@ import { CREATE_FLOW_WITH_STEPS } from '@/graphql/mutations/create-flow-with-ste
 import { TOOLBOX_ACTIONS } from '@/helpers/toolbox'
 import { useAiBuilderContext } from '@/pages/AiBuilder/AiBuilderContext'
 import aiBuilderErrorImg from '@/pages/AiBuilder/assets/AiBuilderError.svg'
+import { useStepConfigContext } from '@/pages/AiBuilder/StepConfigContext'
 
 import BranchStep from './BranchStep'
 import GroupedStepContainer from './GroupedStepContainer'
@@ -41,6 +42,7 @@ export default function StepsPreview() {
     stepGroupCaption,
     clearPersistedState,
   } = useAiBuilderContext()
+  const { activeStepId, stepParametersByStepId } = useStepConfigContext()
 
   const isMobile = useIsMobile()
 
@@ -153,13 +155,30 @@ export default function StepsPreview() {
         pos="relative"
         w="100%"
       >
-        <Step step={triggerStep} />
+        <Step
+          step={triggerStep}
+          isActive={Boolean(triggerStep?.id && triggerStep.id === activeStepId)}
+          isConfigured={Boolean(
+            triggerStep?.id &&
+              stepParametersByStepId[triggerStep.id] !== undefined,
+          )}
+          parameters={
+            triggerStep?.id ? stepParametersByStepId[triggerStep.id] : undefined
+          }
+        />
         {stepsBeforeGroup.map((action) => (
           <Fragment key={`${action.position}-${action.appKey}`}>
             <Step
               key={`${action.position}-${action.appKey}`}
               step={action}
               isLastStep={action.position === actionSteps.length + 1}
+              isActive={Boolean(action.id && action.id === activeStepId)}
+              isConfigured={Boolean(
+                action.id && stepParametersByStepId[action.id] !== undefined,
+              )}
+              parameters={
+                action.id ? stepParametersByStepId[action.id] : undefined
+              }
             />
           </Fragment>
         ))}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -42,11 +42,8 @@ export default function StepsPreview() {
     stepGroupCaption,
     clearPersistedState,
   } = useAiBuilderContext()
-  const {
-    stepParametersByStepId,
-    completedStepIds,
-    activeStepId,
-  } = useStepConfigContext()
+  const { stepParametersByStepId, completedStepIds, activeStepId } =
+    useStepConfigContext()
 
   const isMobile = useIsMobile()
 

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -76,6 +76,20 @@ export default function StepsPreview() {
     return groupedSteps.slice(1)
   }, [groupedSteps])
 
+  // When in pipe mode, mute the grouped container if none of its steps are active or completed.
+  const isGroupedContainerPending = useMemo(() => {
+    if (!isMcpPipeMode) {
+      return false
+    }
+    const allGroupedSteps = groupedSteps.flat()
+    const hasActiveOrCompleted = allGroupedSteps.some(
+      (s) =>
+        s.id === effectiveActiveStepId ||
+        (s.id != null && completedStepIds.has(s.id)),
+    )
+    return !hasActiveOrCompleted
+  }, [isMcpPipeMode, groupedSteps, effectiveActiveStepId, completedStepIds])
+
   const onCreateFlowWithSteps = useCallback(async () => {
     const { data } = await createFlowWithSteps({
       variables: {
@@ -204,6 +218,7 @@ export default function StepsPreview() {
             stepGroupType={stepGroupType as string}
             stepGroupCaption={stepGroupCaption as string}
             isNested={false}
+            isPending={isGroupedContainerPending}
           >
             {stepGroupType === TOOLBOX_ACTIONS.IfThen ? (
               <Flex flexDir="column" w="100%" px={2} gap={4} mt={2}>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -35,7 +35,6 @@ function AiBuilderContent() {
     cancelStream,
     resetChat,
     hasReachedLimit,
-    activeStepId,
     stepParametersByStepId,
     parameterLabelsByStepId,
     completedStepIds,
@@ -71,7 +70,6 @@ function AiBuilderContent() {
   return (
     <StepConfigContext.Provider
       value={{
-        activeStepId,
         stepParametersByStepId,
         parameterLabelsByStepId,
         completedStepIds,

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -37,6 +37,7 @@ function AiBuilderContent() {
     hasReachedLimit,
     activeStepId,
     stepParametersByStepId,
+    parameterLabelsByStepId,
     completedStepIds,
   } = useChatStream({ initialMessages: chatMessages })
 
@@ -69,7 +70,12 @@ function AiBuilderContent() {
 
   return (
     <StepConfigContext.Provider
-      value={{ activeStepId, stepParametersByStepId, completedStepIds }}
+      value={{
+        activeStepId,
+        stepParametersByStepId,
+        parameterLabelsByStepId,
+        completedStepIds,
+      }}
     >
       <>
         <Helmet>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -14,6 +14,7 @@ import {
   AiBuilderContextProvider,
   useAiBuilderContext,
 } from './AiBuilderContext'
+import StepConfigContext from './StepConfigContext'
 
 function AiBuilderContent() {
   const navigate = useNavigate()
@@ -34,6 +35,8 @@ function AiBuilderContent() {
     cancelStream,
     resetChat,
     hasReachedLimit,
+    activeStepId,
+    stepParametersByStepId,
   } = useChatStream({ initialMessages: chatMessages })
 
   const cancelRef = useRef(null)
@@ -64,61 +67,65 @@ function AiBuilderContent() {
   }, [guardedNavigate, navigate])
 
   return (
-    <>
-      <Helmet>
-        <title>{flowName} | WIP</title>
-      </Helmet>
-      <Flex h="100vh" flexDirection="column">
-        {!(isMobile && isDrawerOpen) && (
-          <HStack
-            position="fixed"
-            top={0}
-            left={0}
-            right={0}
-            zIndex={10}
-            bg="white"
-            justifyContent="space-between"
-            alignItems="center"
-            py={2}
-            px={{ base: 4, md: 8 }}
-            borderBottom="1px solid"
-            borderColor="base.divider.medium"
-          >
-            <Flex flex={1} alignItems="center" minWidth={0} gap={2}>
-              <CloseButton size="sm" onClick={handleClose} />
+    <StepConfigContext.Provider
+      value={{ activeStepId, stepParametersByStepId }}
+    >
+      <>
+        <Helmet>
+          <title>{flowName} | WIP</title>
+        </Helmet>
+        <Flex h="100vh" flexDirection="column">
+          {!(isMobile && isDrawerOpen) && (
+            <HStack
+              position="fixed"
+              top={0}
+              left={0}
+              right={0}
+              zIndex={10}
+              bg="white"
+              justifyContent="space-between"
+              alignItems="center"
+              py={2}
+              px={{ base: 4, md: 8 }}
+              borderBottom="1px solid"
+              borderColor="base.divider.medium"
+            >
+              <Flex flex={1} alignItems="center" minWidth={0} gap={2}>
+                <CloseButton size="sm" onClick={handleClose} />
 
-              <Text>{flowName}</Text>
-            </Flex>
-          </HStack>
-        )}
-        <Container
-          maxW="full"
-          px={0}
-          py={0}
-          mt={isMobile && isDrawerOpen ? 0 : '57px'}
-          flex={1}
-          overflowY="auto"
-          bg="white"
-        >
-          <ChatInterface
-            messages={messages}
-            currentResponse={currentResponse}
-            isStreaming={isStreaming}
-            isReadyForPreview={isReadyForPreview}
-            sendMessage={sendMessage}
-            cancelStream={cancelStream}
-            resetChat={resetChat}
-            hasReachedLimit={hasReachedLimit}
-          />
-        </Container>
-      </Flex>
-      <ExitAlert
-        cancelRef={cancelRef}
-        isOpen={showWarning}
-        onClose={cancel}
-        onExit={confirm}
-      />
-    </>
+                <Text>{flowName}</Text>
+              </Flex>
+            </HStack>
+          )}
+          <Container
+            maxW="full"
+            px={0}
+            py={0}
+            mt={isMobile && isDrawerOpen ? 0 : '57px'}
+            flex={1}
+            overflowY="auto"
+            bg="white"
+          >
+            <ChatInterface
+              messages={messages}
+              currentResponse={currentResponse}
+              isStreaming={isStreaming}
+              isReadyForPreview={isReadyForPreview}
+              sendMessage={sendMessage}
+              cancelStream={cancelStream}
+              resetChat={resetChat}
+              hasReachedLimit={hasReachedLimit}
+            />
+          </Container>
+        </Flex>
+        <ExitAlert
+          cancelRef={cancelRef}
+          isOpen={showWarning}
+          onClose={cancel}
+          onExit={confirm}
+        />
+      </>
+    </StepConfigContext.Provider>
   )
 }
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -38,6 +38,7 @@ function AiBuilderContent() {
     stepParametersByStepId,
     parameterLabelsByStepId,
     completedStepIds,
+    activeStepId,
   } = useChatStream({ initialMessages: chatMessages })
 
   const cancelRef = useRef(null)
@@ -73,6 +74,7 @@ function AiBuilderContent() {
         stepParametersByStepId,
         parameterLabelsByStepId,
         completedStepIds,
+        activeStepId,
       }}
     >
       <>

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -37,6 +37,7 @@ function AiBuilderContent() {
     hasReachedLimit,
     activeStepId,
     stepParametersByStepId,
+    completedStepIds,
   } = useChatStream({ initialMessages: chatMessages })
 
   const cancelRef = useRef(null)
@@ -68,7 +69,7 @@ function AiBuilderContent() {
 
   return (
     <StepConfigContext.Provider
-      value={{ activeStepId, stepParametersByStepId }}
+      value={{ activeStepId, stepParametersByStepId, completedStepIds }}
     >
       <>
         <Helmet>


### PR DESCRIPTION
## TL;DR

During AI Builder pipe configuration (Phase 2b+), the StepsPreview now tracks which step is actively being configured and which are completed — highlighting the active step, muting pending ones, and showing resolved human-readable parameter values in real time as the AI configures each step.

## What changed?

**Backend**
- Added optional `parameter_labels` field to the `update_step_parameters` MCP tool. The AI can pass human-readable labels for parameters that are stored as opaque IDs (e.g. tile names, sheet names, channel IDs). These are display-only and do not affect what is saved.
- `data-stepUpdate` SSE events now include `parameterLabels` alongside `parameters`.

**Frontend**
- New `StepConfigContext` propagates `stepParametersByStepId`, `parameterLabelsByStepId`, and `completedStepIds` (derived from stream events) down to all `StepsPreview` components without prop-drilling.
- Active step is derived as the **first uncompleted step in order** (from `data-pipeState` status), so the correct step is highlighted even before `update_step_parameters` is called for it (e.g. while the AI is still collecting field values via clarifications).
- Steps in proposal mode (Phase 2a, no DB pipe) are no longer muted — `isPending` only triggers when `isActive`/`isConfigured` are explicitly `false`, not `undefined`.
- `GroupedStepContainer` (ForEach/IfThen) is muted when none of its nested steps are active or completed. Nested steps inside ForEach and IfThen branches also receive active/configured/parameters state.
- `StepParameterRows` resolves display values in priority order: AI-provided labels → static option list lookup → recursive flattening for object/array values (e.g. multirow-multicol renders as `"Add 5 Days"` not `[object Object]`). Sub-field definition order is respected when flattening.
- Completed steps show the built-in `StepAppIcon` checkmark badge.
- `VariablePill` gets a `{}` prefix using the `base.content.medium` design token.

## Tests

- [ ] Start an AI Builder session and ask the AI to build a flow with multiple steps (including at least one with dynamic dropdowns, e.g. Tiles lookup or Postman SMS).
- [ ] Verify: as the AI configures each step, the active step is highlighted and pending steps are visually muted.
- [ ] Verify: once a step is configured, it shows a checkmark badge and the next step becomes active.
- [ ] Verify: parameter rows show human-readable labels (e.g. sheet name, not sheet ID) for dynamic dropdown values.
- [ ] Verify: flows with ForEach or IfThen branches correctly mute/highlight the grouped container as nested steps are configured.
- [ ] Verify: flows in proposal mode (before the pipe is created) show all steps at full opacity with no muting.
- [ ] Verify: if the AI reconfigures a step (calls `update_step_parameters` a second time), the displayed labels update to match the new values.

## Deploy notes

None — no migrations, no environment variable changes, no feature flag changes required.