### PR TITLE
PLU-835: add silent whitelisting for email verified form fields

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -45,8 +45,10 @@ const mocks = vi.hoisted(() => {
     cryptoDecryptWithAttachments,
     consoleError: vi.fn(),
     consoleWarn: vi.fn(),
+    consoleInfo: vi.fn(),
     getSdk: vi.fn(() => mockSdk),
     parseFormEnv: vi.fn(),
+    whitelistEmails: vi.fn().mockResolvedValue([]),
   }
 })
 
@@ -55,6 +57,14 @@ vi.mock('@/helpers/logger', () => ({
   default: {
     error: mocks.consoleError,
     warn: mocks.consoleWarn,
+    info: mocks.consoleInfo,
+  },
+}))
+
+// mock email suppression model
+vi.mock('@/models/email-suppression-entry', () => ({
+  default: {
+    whitelistEmails: mocks.whitelistEmails,
   },
 }))
 
@@ -954,6 +964,172 @@ describe('decrypt form response', () => {
               order: 1,
             },
           },
+        }),
+      )
+    })
+  })
+
+  describe('verified email suppression removal', () => {
+    it('whitelists the email when isUserVerified is true (v1 shape)', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField',
+            fieldType: 'email',
+            question: 'Email',
+            answer: 'jack@open.gov.sg',
+            isUserVerified: true,
+            signature: 'f=...,v=...,t=...,s=...',
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.whitelistEmails).toHaveBeenCalledWith(['jack@open.gov.sg'])
+    })
+
+    it('whitelists the email via signature presence when isUserVerified is absent (v3/v4 shape)', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField',
+            fieldType: 'email',
+            question: 'Email',
+            answer: 'jane@open.gov.sg',
+            signature: 'f=...,v=...,t=...,s=...',
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.whitelistEmails).toHaveBeenCalledWith(['jane@open.gov.sg'])
+    })
+
+    it('does not whitelist when isUserVerified is false', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField',
+            fieldType: 'email',
+            question: 'Email',
+            answer: 'unverified@open.gov.sg',
+            isUserVerified: false,
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.whitelistEmails).not.toHaveBeenCalled()
+    })
+
+    it('does not whitelist when there is no email field at all', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'textField',
+            fieldType: 'text',
+            question: 'What is your name?',
+            answer: 'John Tan',
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.whitelistEmails).not.toHaveBeenCalled()
+    })
+
+    it('batches multiple verified email fields into a single whitelistEmails call', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField1',
+            fieldType: 'email',
+            question: 'Personal email',
+            answer: 'personal@open.gov.sg',
+            isUserVerified: true,
+          },
+          {
+            _id: 'emailField2',
+            fieldType: 'email',
+            question: 'Work email',
+            answer: 'work@open.gov.sg',
+            isUserVerified: true,
+          },
+        ],
+      })
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.whitelistEmails).toHaveBeenCalledTimes(1)
+      expect(mocks.whitelistEmails).toHaveBeenCalledWith([
+        'personal@open.gov.sg',
+        'work@open.gov.sg',
+      ])
+    })
+
+    it('does not affect the decrypt result when whitelistEmails throws', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField',
+            fieldType: 'email',
+            question: 'Email',
+            answer: 'jack@open.gov.sg',
+            isUserVerified: true,
+          },
+        ],
+      })
+      mocks.whitelistEmails.mockRejectedValueOnce(new Error('db error'))
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.consoleError).toHaveBeenCalledWith(
+        'Failed to whitelist verified FormSG email(s) from suppression list',
+        expect.objectContaining({
+          event: 'formsg-verified-email-whitelist-failed',
+        }),
+      )
+    })
+
+    it('logs which emails were actually whitelisted', async () => {
+      $.flow.hasFileProcessingActions = false
+      mocks.cryptoDecrypt.mockReturnValueOnce({
+        responses: [
+          {
+            _id: 'emailField',
+            fieldType: 'email',
+            question: 'Email',
+            answer: 'jack@open.gov.sg',
+            isUserVerified: true,
+          },
+        ],
+      })
+      mocks.whitelistEmails.mockResolvedValueOnce(['jack@open.gov.sg'])
+
+      await expect(decryptFormResponse($)).resolves.toEqual(
+        SUCCESS_DECRYPT_RESPONSE,
+      )
+      expect(mocks.consoleInfo).toHaveBeenCalledWith(
+        'Removed verified FormSG email(s) from suppression list',
+        expect.objectContaining({
+          event: 'formsg-verified-email-whitelist',
+          emails: ['jack@open.gov.sg'],
         }),
       )
     })

--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v3-responses.test.ts
@@ -180,6 +180,51 @@ describe('processResponsesV3', () => {
       },
     )
 
+    it('includes signature for a verified email field', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Email', fieldType: 'email' }]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        f1: {
+          fieldType: 'email',
+          answer: { value: 'john@example.com', signature: 'some-signature' },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'email',
+          question: 'Email',
+          answer: 'john@example.com',
+          signature: 'some-signature',
+        },
+      ])
+    })
+
+    it('does not include signature for a mobile field even if present', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Mobile', fieldType: 'mobile' }]),
+      )
+
+      const result = await processResponsesV3($, 'formId', {
+        f1: {
+          fieldType: 'mobile',
+          answer: { value: '+6591234567', signature: 'some-signature' },
+        },
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'mobile',
+          question: 'Mobile',
+          answer: '+6591234567',
+        },
+      ])
+    })
+
     it('maps signature fields with answerArray from answer.value', async () => {
       mocks.fetchFormSchema.mockResolvedValueOnce(
         makeFormSchema([

--- a/packages/backend/src/apps/formsg/__tests__/auth/process-v4-responses.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/process-v4-responses.test.ts
@@ -155,30 +155,88 @@ describe('processResponsesV4', () => {
       ])
     })
 
-    it.each([
-      ['email', { value: 'test-value', signature: 'some-signature' }],
-      ['mobile', { value: 'test-value' }],
-    ] as const)(
-      'maps %s fields with answer from answer.value',
-      async (fieldType, answer) => {
-        mocks.fetchFormSchema.mockResolvedValueOnce(
-          makeFormSchema([{ _id: 'f1', title: 'Field', fieldType }]),
-        )
+    it('maps mobile fields with answer from answer.value', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Field', fieldType: 'mobile' }]),
+      )
 
-        const result = await processResponsesV4($, 'formId', {
-          f1: v4Response(fieldType, answer),
-        })
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('mobile', { value: 'test-value' }),
+      })
 
-        expect(result).toEqual([
-          {
-            _id: 'f1',
-            fieldType,
-            question: 'Field',
-            answer: 'test-value',
-          },
-        ])
-      },
-    )
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'mobile',
+          question: 'Field',
+          answer: 'test-value',
+        },
+      ])
+    })
+
+    it('includes signature for a verified email field', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Field', fieldType: 'email' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('email', {
+          value: 'test-value',
+          signature: 'some-signature',
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'email',
+          question: 'Field',
+          answer: 'test-value',
+          signature: 'some-signature',
+        },
+      ])
+    })
+
+    it('does not include signature for an unverified email field', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Field', fieldType: 'email' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('email', { value: 'test-value' }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'email',
+          question: 'Field',
+          answer: 'test-value',
+        },
+      ])
+    })
+
+    it('does not include signature for a mobile field even if present', async () => {
+      mocks.fetchFormSchema.mockResolvedValueOnce(
+        makeFormSchema([{ _id: 'f1', title: 'Field', fieldType: 'mobile' }]),
+      )
+
+      const result = await processResponsesV4($, 'formId', {
+        f1: v4Response('mobile', {
+          value: 'test-value',
+          signature: 'some-signature',
+        }),
+      })
+
+      expect(result).toEqual([
+        {
+          _id: 'f1',
+          fieldType: 'mobile',
+          question: 'Field',
+          answer: 'test-value',
+        },
+      ])
+    })
 
     it('maps radiobutton field with answer from answer.value', async () => {
       mocks.fetchFormSchema.mockResolvedValueOnce(
@@ -828,10 +886,18 @@ describe('processResponsesV4', () => {
         'Others: adw',
         'Option 1',
       ])
-      // verified email keeps only the value, not the verification signature
-      expect(byId('69eede812e18526ffea60af3')?.answer).toBe(
-        'ahkow@open.gov.local',
-      )
+      // verified email keeps both the value and the verification signature
+      expect(byId('69eede812e18526ffea60af3')).toMatchObject({
+        answer: 'ahkow@open.gov.local',
+        signature: expect.any(String),
+      })
+      // unverified email keeps only the value, no signature
+      expect(byId('69eede868c2bfbb8748c75d3')).toEqual({
+        _id: '69eede868c2bfbb8748c75d3',
+        fieldType: 'email',
+        question: 'Email',
+        answer: 'ahkow@open.gov.local',
+      })
       // address keeps all six subfields in Plumber order at this level
       // (processLocalAddress only runs downstream in decrypt-form-response)
       expect(byId('69eede9f2f788da6393fbd91')?.answerArray).toEqual([

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -8,6 +8,7 @@ import {
 
 import { sha256Hash } from '@/helpers/crypto'
 import logger from '@/helpers/logger'
+import EmailSuppressionEntry from '@/models/email-suppression-entry'
 
 import { getSdk, parseFormEnv } from '../common/form-env'
 import convertTableAnswerArrayToTableObject from '../common/process-table-field'
@@ -59,6 +60,27 @@ export function filterNric($: IGlobalVariable, value: string): string | null {
   }
 
   return value
+}
+
+/**
+ * Whether a decrypted email field was OTP-verified by FormSG.
+ *
+ * v1 forms carry `isUserVerified` natively; v3/v4 forms never have that
+ * property, so they're detected via the (mapping-preserved) `signature`
+ * field instead.
+ */
+function isVerifiedEmailField(
+  formField: DecryptedContent['responses'][number] & {
+    isUserVerified?: boolean
+  },
+): boolean {
+  if (formField.fieldType !== 'email') {
+    return false
+  }
+  if ('isUserVerified' in formField) {
+    return formField.isUserVerified === true
+  }
+  return !!formField.signature
 }
 
 export async function decryptFormResponse(
@@ -152,8 +174,13 @@ export async function decryptFormResponse(
     const workflowContent: FormsgPayloadWorkflowContent = data.workflowContent
 
     const parsedData: Record<string, any> = {}
+    const verifiedEmails: string[] = []
 
     for (const [index, formField] of submission.responses.entries()) {
+      if (isVerifiedEmailField(formField) && formField.answer) {
+        verifiedEmails.push(formField.answer)
+      }
+
       const { _id, ...rest } = formField
       // perform null character sanitisation for all answer fields so that it can be inserted into the DB
       if (rest.answer && typeof rest.answer === 'string') {
@@ -227,6 +254,35 @@ export async function decryptFormResponse(
       parsedData[_id.replaceAll('.', '_')] = {
         order: index + 1,
         ...rest,
+      }
+    }
+
+    if (verifiedEmails.length > 0) {
+      try {
+        const whitelisted = await EmailSuppressionEntry.whitelistEmails(
+          verifiedEmails,
+        )
+        if (whitelisted.length > 0) {
+          logger.info(
+            'Removed verified FormSG email(s) from suppression list',
+            {
+              event: 'formsg-verified-email-whitelist',
+              flowId: $.flow.id,
+              stepId: $.step.id,
+              emails: whitelisted,
+            },
+          )
+        }
+      } catch (error) {
+        logger.error(
+          'Failed to whitelist verified FormSG email(s) from suppression list',
+          {
+            event: 'formsg-verified-email-whitelist-failed',
+            flowId: $.flow.id,
+            stepId: $.step.id,
+            error,
+          },
+        )
       }
     }
 

--- a/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
+++ b/packages/backend/src/apps/formsg/auth/decrypt-form-response.ts
@@ -177,14 +177,15 @@ export async function decryptFormResponse(
     const verifiedEmails: string[] = []
 
     for (const [index, formField] of submission.responses.entries()) {
-      if (isVerifiedEmailField(formField) && formField.answer) {
-        verifiedEmails.push(formField.answer)
-      }
-
       const { _id, ...rest } = formField
       // perform null character sanitisation for all answer fields so that it can be inserted into the DB
       if (rest.answer && typeof rest.answer === 'string') {
         rest.answer = rest.answer.replaceAll('\u0000', '')
+      }
+
+      if (isVerifiedEmailField(formField) && rest.answer) {
+        verifiedEmails.push(rest.answer)
+        delete rest['signature'] // we dont need to store it
       }
 
       if (rest.answerArray && rest.answerArray.length > 0) {

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v3-responses.ts
@@ -103,6 +103,12 @@ export async function processResponsesV3(
         // we fallback to Question # if the question is not found in the form schema
         question: formSchemaFields[key]?.title ?? `Question ${questionNumber}`,
         answer: value.answer.value,
+        // preserve the OTP-verification signature for email fields so
+        // downstream code can detect verified emails; formSG only ever
+        // sets this for email, never mobile
+        ...(value.fieldType === 'email' && value.answer.signature
+          ? { signature: value.answer.signature }
+          : {}),
       })
       continue
     }

--- a/packages/backend/src/apps/formsg/auth/helpers/process-v4-responses.ts
+++ b/packages/backend/src/apps/formsg/auth/helpers/process-v4-responses.ts
@@ -106,6 +106,12 @@ export async function processResponsesV4(
         fieldType: value.fieldType,
         question,
         answer: answer.value,
+        // preserve the OTP-verification signature for email fields so
+        // downstream code can detect verified emails; formSG only ever
+        // sets this for email, never mobile
+        ...(value.fieldType === 'email' && answer.signature
+          ? { signature: answer.signature }
+          : {}),
       })
       continue
     }


### PR DESCRIPTION
## Problem

When a FormSG respondent submits a form with an OTP-verified email field, their email address may be on the suppression list, preventing downstream email delivery. There was no mechanism to automatically remove these verified addresses from the suppression list upon form submission.

## Solution

When decrypting a FormSG form response, verified email fields are now detected and their addresses are removed from the email suppression list via `EmailSuppressionEntry.whitelistEmails`.

**Features**:

- After decryption, all OTP-verified email field answers are collected and passed to `EmailSuppressionEntry.whitelistEmails` in a single batched call, removing them from the suppression list.
- Verified email detection handles both v1 forms (which carry `isUserVerified: true`) and v3/v4 forms (which are detected via the presence of a `signature` field).
- Successful removals are logged with the affected email addresses; failures are caught and logged without affecting the overall decryption result.

**Improvements**:

- The OTP-verification `signature` is now preserved on email fields when processing v3 and v4 responses, allowing downstream code to identify verified emails. The signature is intentionally not propagated for mobile fields.

## Tests
- Create your own open.gov email on the Email Suppression table
- Test with a v1 form connected to a pipe and see if the email gets whitelisted after submission
- Test with a v3 form (MRF)
- Test with a v4 form (MRF on UAT)
- Test that it is a no-op if email verified is not in the Email Suppression table


## Deploy Notes

No new environment variables, scripts, or dependencies are required.