### PR TITLE
[AI-SETUP-19] fix(mcp): strip HTML comment blocks from chat messages before rendering

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
-import { stripHtmlComments } from '@/pages/AiBuilder/helpers'
+import { prepareAiText } from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import ChatMessageToolbar from './ChatMessageToolbar'
@@ -19,7 +19,7 @@ const AiMessage = memo(
       <Flex gap={3} w="full" align="start">
         <Box flex={1} px={2} color="gray.900">
           <ChakraStreamdown isAnimating={false}>
-            {stripHtmlComments(message.text || '')}
+            {prepareAiText(message.text || '')}
           </ChakraStreamdown>
           {shouldShowToolbar && (
             <ChatMessageToolbar

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
+import { stripHtmlComments } from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import ChatMessageToolbar from './ChatMessageToolbar'
@@ -18,7 +19,7 @@ const AiMessage = memo(
       <Flex gap={3} w="full" align="start">
         <Box flex={1} px={2} color="gray.900">
           <ChakraStreamdown isAnimating={false}>
-            {message.text || ''}
+            {stripHtmlComments(message.text || '')}
           </ChakraStreamdown>
           {shouldShowToolbar && (
             <ChatMessageToolbar

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex } from '@chakra-ui/react'
 
-import { stripHtmlComments } from '@/pages/AiBuilder/helpers'
+import { prepareAiText } from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import Loader from './Loader'
@@ -15,7 +15,7 @@ const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
       <Flex gap={3} w="full" align="start">
         <Box flex={1} px={2} color="gray.900">
           <ChakraStreamdown isAnimating={true}>
-            {stripHtmlComments(currentResponse)}
+            {prepareAiText(currentResponse)}
           </ChakraStreamdown>
         </Box>
       </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/StreamingMessage.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex } from '@chakra-ui/react'
 
+import { stripHtmlComments } from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import Loader from './Loader'
@@ -14,7 +15,7 @@ const StreamingMessage = ({ currentResponse }: StreamingMessageProps) => {
       <Flex gap={3} w="full" align="start">
         <Box flex={1} px={2} color="gray.900">
           <ChakraStreamdown isAnimating={true}>
-            {currentResponse}
+            {stripHtmlComments(currentResponse)}
           </ChakraStreamdown>
         </Box>
       </Flex>

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -8,6 +8,13 @@ import {
   Message,
 } from '@/hooks/useChatStream'
 
+// Strip HTML comment blocks from AI chat text before display.
+// Complete comments (<!-- ... -->) are invisible in HTML but some markdown parsers
+// surface them as raw text. Incomplete comments that haven't reached --> yet
+// (common mid-stream) are stripped so they never flash as visible content.
+export const stripHtmlComments = (text: string): string =>
+  text.replace(/<!--[\s\S]*?-->/g, '').replace(/<!--[\s\S]*$/, '')
+
 // deduplicate messages by id
 // there may be duplicates when the messages are combined
 export const deduplicateMessages = (messages: Message[]) => {

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -15,6 +15,15 @@ import {
 export const stripHtmlComments = (text: string): string =>
   text.replace(/<!--[\s\S]*?-->/g, '').replace(/<!--[\s\S]*$/, '')
 
+// Ensure markdown headings are preceded by a newline so the parser treats them
+// as block-level elements. Only fires when a heading marker immediately follows
+// non-newline content (e.g. "text.##### Heading" → "text.\n##### Heading").
+export const normalizeMarkdownHeadings = (text: string): string =>
+  text.replace(/([^\n])(#{1,6} )/g, '$1\n$2')
+
+export const prepareAiText = (text: string): string =>
+  normalizeMarkdownHeadings(stripHtmlComments(text))
+
 // deduplicate messages by id
 // there may be duplicates when the messages are combined
 export const deduplicateMessages = (messages: Message[]) => {


### PR DESCRIPTION
## TL;DR

Strip HTML comment blocks (`<!-- ... -->`) from AI chat messages before rendering, so machine-readable annotations never flash as visible text in the chat UI.

## What changed?

The AI responses embed machine-readable HTML comment blocks (`<!-- WORKFLOW_METADATA ... -->`, `<!-- CLARIFICATION_DATA ... -->`, `<!-- DYNAMIC_PICKER_DATA ... -->`) that are parsed by stream hooks but should never appear in the UI.

The markdown renderer (`streamdown` via `rehype-raw`) can surface these as raw visible text in two cases:
- **Completed comments** — some markdown parsers don't treat `<!-- -->` as invisible
- **Incomplete comments mid-stream** — the closing `-->` hasn't arrived yet, so the open `<!--` and its content render as plain text until the stream catches up

Added a `stripHtmlComments` helper in `helpers.ts` that strips both cases with two regex passes, and applied it before passing text to `ChakraStreamdown` in both render paths:
- `StreamingMessage.tsx` — live streaming case
- `ChatMessage.tsx` — completed message case

The raw `message.text` in state is unchanged; stripping is display-only.

## Tests

1. Start a new AI Builder conversation and ask it to create a workflow (e.g. "create a flow that sends a Slack message when a FormSG form is submitted")
2. While the response streams, verify no `<!--` or `-->` characters or comment content flashes as visible text in the chat bubble
3. After the response completes, verify the same — no HTML comment content visible in the finished message
4. Verify the Steps Preview panel still populates correctly (the stream annotations are still parsed from the raw text before rendering)

## Deploy notes

None.
