### PR TITLE
fix: resolve client IP from X-Forwarded-For for rate limiting

### DIFF
--- a/packages/backend/src/helpers/__tests__/get-client-ip.test.ts
+++ b/packages/backend/src/helpers/__tests__/get-client-ip.test.ts
@@ -3,72 +3,134 @@ import { describe, expect, it } from 'vitest'
 
 import { getClientIp } from '../get-client-ip'
 
+function mockRequest({
+  xForwardedFor,
+  cfConnectingIp,
+  remoteAddress,
+}: {
+  xForwardedFor?: string
+  cfConnectingIp?: string
+  remoteAddress?: string
+}): Request {
+  const headers: Record<string, string> = {}
+  if (xForwardedFor !== undefined) {
+    headers['x-forwarded-for'] = xForwardedFor
+  }
+  if (cfConnectingIp !== undefined) {
+    headers['cf-connecting-ip'] = cfConnectingIp
+  }
+  return {
+    headers,
+    socket: { remoteAddress },
+  } as unknown as Request
+}
+
+// 173.245.48.0/20 and 2400:cb00::/32 are published Cloudflare edge ranges.
+// 203.0.113.x / 198.51.100.x / 2001:db8:: are non-Cloudflare documentation ranges.
 describe('getClientIp', () => {
-  it('should return Cloudflare IP when cf-connecting-ip header is present', () => {
-    const mockReq = {
-      headers: {
-        'cf-connecting-ip': '203.0.113.42',
-      },
-      socket: {
-        remoteAddress: '192.168.1.1',
-      },
-    } as unknown as Request
+  describe('orange cloud — peer is a Cloudflare edge IP', () => {
+    it('returns cf-connecting-ip, which Cloudflare sets authoritatively', () => {
+      // Values differ to prove the client is sourced from cf-connecting-ip, not
+      // from an X-Forwarded-For entry.
+      const req = mockRequest({
+        xForwardedFor: '198.51.100.99, 173.245.48.1',
+        cfConnectingIp: '203.0.113.42',
+      })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
 
-    expect(getClientIp(mockReq)).toBe('203.0.113.42')
+    it('ignores forged X-Forwarded-For entries to the left of the edge', () => {
+      const req = mockRequest({
+        xForwardedFor: '6.6.6.6, 7.7.7.7, 173.245.48.1',
+        cfConnectingIp: '203.0.113.42',
+      })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
+
+    it('resolves an IPv6 client via cf-connecting-ip', () => {
+      const req = mockRequest({
+        xForwardedFor: '2001:db8::5, 2400:cb00::1',
+        cfConnectingIp: '2001:db8::99',
+      })
+      expect(getClientIp(req)).toBe('2001:db8::99')
+    })
+
+    it('normalizes an IPv4-mapped IPv6 cf-connecting-ip to IPv4', () => {
+      const req = mockRequest({
+        xForwardedFor: '198.51.100.99, 173.245.48.1',
+        cfConnectingIp: '::ffff:203.0.113.42',
+      })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
+
+    it('falls back to the edge IP when cf-connecting-ip is missing (anomalous)', () => {
+      const req = mockRequest({ xForwardedFor: '198.51.100.99, 173.245.48.1' })
+      expect(getClientIp(req)).toBe('173.245.48.1')
+    })
   })
 
-  it('should return socket remote address when no CF header', () => {
-    const mockReq = {
-      headers: {},
-      socket: {
-        remoteAddress: '192.168.1.1',
-      },
-    } as unknown as Request
+  describe('grey cloud — peer is not a Cloudflare IP', () => {
+    it('returns the ALB-appended rightmost entry', () => {
+      const req = mockRequest({ xForwardedFor: '203.0.113.42' })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
 
-    expect(getClientIp(mockReq)).toBe('192.168.1.1')
+    it('ignores a spoofed entry to the left of the real peer', () => {
+      const req = mockRequest({ xForwardedFor: '1.2.3.4, 203.0.113.42' })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
+
+    it('does NOT trust cf-connecting-ip — a direct caller can forge it', () => {
+      const req = mockRequest({
+        xForwardedFor: '203.0.113.42',
+        cfConnectingIp: '9.9.9.9',
+      })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
+
+    it('returns an IPv6 client directly', () => {
+      const req = mockRequest({ xForwardedFor: '2001:db8::5' })
+      expect(getClientIp(req)).toBe('2001:db8::5')
+    })
+
+    it('normalizes an IPv4-mapped IPv6 peer to IPv4', () => {
+      const req = mockRequest({ xForwardedFor: '::ffff:203.0.113.42' })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
+
+    it('trims surrounding whitespace around entries', () => {
+      const req = mockRequest({ xForwardedFor: '  1.2.3.4 ,  203.0.113.42  ' })
+      expect(getClientIp(req)).toBe('203.0.113.42')
+    })
   })
 
-  it('should trim and return first IP when multiple IPs in remote address', () => {
-    const mockReq = {
-      headers: {},
-      socket: {
-        remoteAddress: '192.168.1.1, 10.0.0.1, 172.16.0.1',
-      },
-    } as unknown as Request
+  describe('fallback to the transport peer — no X-Forwarded-For', () => {
+    it('falls back to the socket remote address', () => {
+      const req = mockRequest({ remoteAddress: '198.51.100.7' })
+      expect(getClientIp(req)).toBe('198.51.100.7')
+    })
 
-    expect(getClientIp(mockReq)).toBe('192.168.1.1')
-  })
+    it('does not trust cf-connecting-ip without an X-Forwarded-For peer', () => {
+      const req = mockRequest({
+        cfConnectingIp: '9.9.9.9',
+        remoteAddress: '198.51.100.7',
+      })
+      expect(getClientIp(req)).toBe('198.51.100.7')
+    })
 
-  it('should return "unknown" when no IP information is available', () => {
-    const mockReq = {
-      headers: {},
-      socket: {},
-    } as unknown as Request
+    it('normalizes an IPv4-mapped IPv6 socket address', () => {
+      const req = mockRequest({ remoteAddress: '::ffff:198.51.100.7' })
+      expect(getClientIp(req)).toBe('198.51.100.7')
+    })
 
-    expect(getClientIp(mockReq)).toBe('unknown')
-  })
+    it('returns an IPv6 socket address', () => {
+      const req = mockRequest({ remoteAddress: '2001:db8::1' })
+      expect(getClientIp(req)).toBe('2001:db8::1')
+    })
 
-  it('should prioritize CF header over socket address', () => {
-    const mockReq = {
-      headers: {
-        'cf-connecting-ip': '203.0.113.1',
-      },
-      socket: {
-        remoteAddress: '192.168.1.100',
-      },
-    } as unknown as Request
-
-    expect(getClientIp(mockReq)).toBe('203.0.113.1')
-  })
-
-  it('should handle IPv6 addresses', () => {
-    const mockReq = {
-      headers: {},
-      socket: {
-        remoteAddress: '2001:db8::1',
-      },
-    } as unknown as Request
-
-    expect(getClientIp(mockReq)).toBe('2001:db8::1')
+    it('returns "unknown" when no IP information is available', () => {
+      const req = mockRequest({})
+      expect(getClientIp(req)).toBe('unknown')
+    })
   })
 })

--- a/packages/backend/src/helpers/get-client-ip.ts
+++ b/packages/backend/src/helpers/get-client-ip.ts
@@ -1,23 +1,135 @@
 import type { Request } from 'express'
+import ipaddr from 'ipaddr.js'
 
 /**
- * Get client IP address from request.
- * Checks in this order:
- * 1. Cloudflare header (cf-connecting-ip)
- * 2. Socket remote address
+ * Cloudflare's published edge IP ranges (https://www.cloudflare.com/ips/).
+ */
+const CLOUDFLARE_CIDRS: ReadonlyArray<[ipaddr.IPv4 | ipaddr.IPv6, number]> = [
+  // IPv4 — https://www.cloudflare.com/ips-v4/
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/13',
+  '104.24.0.0/14',
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+  // IPv6 — https://www.cloudflare.com/ips-v6/
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+].map((cidr) => ipaddr.parseCIDR(cidr))
+
+/**
+ * Parses a forwarded / socket address into a canonical IP, or null if it is not
+ * a valid IP. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) is folded to plain IPv4 so it
+ * compares correctly against the IPv4 Cloudflare ranges.
  *
- * This is the same logic used in GraphQL authentication.
+ * Entries are assumed to be bare IPs. The ALB's client-port preservation
+ * (`routing.http.xff_client_port`) is disabled, so it never appends an
+ * `ip:port` suffix — re-add port stripping here if that setting is ever enabled.
+ */
+function parseIp(value: string | undefined): ipaddr.IPv4 | ipaddr.IPv6 | null {
+  if (!value) {
+    return null
+  }
+  const trimmed = value.trim()
+  if (!ipaddr.isValid(trimmed)) {
+    return null
+  }
+  return ipaddr.process(trimmed)
+}
+
+function isCloudflareIp(addr: ipaddr.IPv4 | ipaddr.IPv6): boolean {
+  return CLOUDFLARE_CIDRS.some(
+    ([range, bits]) => range.kind() === addr.kind() && addr.match(range, bits),
+  )
+}
+
+/**
+ * The rightmost `X-Forwarded-For` entry — the address the ALB appended, i.e. the
+ * peer that actually connected to it. A client cannot forge this: the ALB always
+ * appends it AFTER any client-supplied entries, so nothing the client sends can
+ * appear to its right. Returns null when there is no usable X-Forwarded-For.
+ */
+function getForwardedPeer(req: Request): ipaddr.IPv4 | ipaddr.IPv6 | null {
+  const forwardedFor = req.headers['x-forwarded-for']
+  const chain = Array.isArray(forwardedFor)
+    ? forwardedFor.join(',')
+    : forwardedFor ?? ''
+  const entries = chain
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  return parseIp(entries.at(-1))
+}
+
+/**
+ * Resolves the client IP for a request behind the ALB, spoof-resistant in both
+ * Cloudflare "orange cloud" (proxied) and "grey cloud" (DNS-only) modes.
+ *
+ * We only need the RIGHTMOST `X-Forwarded-For` entry — the peer the ALB appended
+ * (see getForwardedPeer). That single, unspoofable entry tells us which mode we
+ * are in and therefore which source to trust:
+ *
+ *   rightmost X-Forwarded-For entry  (ALB-appended peer — unspoofable)
+ *                 |
+ *        published CF edge IP? ---- yes ---> return cf-connecting-ip   (orange)
+ *                 |
+ *                 no
+ *                 v
+ *          return the entry itself         (grey — the real client)
+ *
+ *   - Orange cloud: the peer is one of Cloudflare's published edge IPs, so the
+ *     request transited Cloudflare. Cloudflare strips any client-supplied
+ *     `cf-connecting-ip` and sets it from the real connection, so it is
+ *     authoritative here — and, unlike an X-Forwarded-For entry, it cannot be
+ *     forged from a Cloudflare-range peer (reaching the ALB from such an IP means
+ *     going through Cloudflare, and Workers cannot set `cf-*` headers).
+ *
+ *   - Grey cloud: the peer is not a Cloudflare IP, so Cloudflare is not in the
+ *     path and the peer IS the real client. We ignore `cf-connecting-ip` here —
+ *     a direct caller can forge it.
+ *
+ * We deliberately do NOT walk the chain: in orange mode the client comes from
+ * `cf-connecting-ip`, not from an entry to the left of the edge, so there is
+ * nothing further left to read. This also keeps us free of any fixed hop-count
+ * assumption (Express `trust proxy` is avoided for the same reason).
+ *
+ * Residual risk: "Cloudflare edge IP" is judged against Cloudflare's *published*
+ * ranges, which must be kept fresh — a stale list would misclassify a new edge
+ * range. Those ranges only carry Cloudflare's reverse-proxy traffic (which
+ * sanitises `cf-connecting-ip`); WARP / Worker egress uses different, unpublished
+ * IPs that fail the check and are treated as grey.
  */
 export function getClientIp(req: Request): string {
-  const cfIp = req.headers['cf-connecting-ip'] as string
-  if (cfIp) {
-    return cfIp
+  const peer = getForwardedPeer(req)
+
+  if (peer) {
+    if (isCloudflareIp(peer)) {
+      // Orange cloud: cf-connecting-ip is authoritative. Fall back to the edge
+      // peer only in the anomalous case where it is missing or invalid.
+      const cfHeader = req.headers['cf-connecting-ip']
+      const cfIp = parseIp(typeof cfHeader === 'string' ? cfHeader : undefined)
+      return (cfIp ?? peer).toString()
+    }
+    // Grey cloud: the ALB-appended peer is the real client.
+    return peer.toString()
   }
 
-  const remoteAddress = req.socket.remoteAddress
-  if (remoteAddress) {
-    return remoteAddress.split(',')[0].trim()
-  }
-
-  return 'unknown'
+  // No X-Forwarded-For (e.g. a direct internal call). Fall back to the transport
+  // peer, then give up.
+  const socketIp = parseIp(req.socket?.remoteAddress)
+  return socketIp ? socketIp.toString() : 'unknown'
 }

--- a/packages/backend/src/routes/api/__tests__/middleware/rate-limit.test.ts
+++ b/packages/backend/src/routes/api/__tests__/middleware/rate-limit.test.ts
@@ -111,13 +111,16 @@ describe('Rate Limiting Middleware', () => {
       expect(mockNext).toHaveBeenCalledOnce()
     })
 
-    it('should use Cloudflare IP when available', async () => {
+    it('should key off cf-connecting-ip when the request is proxied through Cloudflare', async () => {
       mockReq.context = {
         currentUser: null,
         isAdminOperation: false,
       } as any
+      // 173.245.48.1 is the Cloudflare edge appended by the ALB (orange cloud),
+      // so cf-connecting-ip is authoritative; the X-Forwarded-For junk is ignored.
       mockReq.headers = {
         'cf-connecting-ip': '203.0.113.42',
+        'x-forwarded-for': '198.51.100.99, 173.245.48.1',
       }
 
       mocks.rateLimiterRedis.consume.mockResolvedValueOnce({})


### PR DESCRIPTION
# Context

Currently, turning off orange cloud enables malicious users to bypass login rate limiting because we always trust cf-connecting-ip This is non-ideal (tm).

# Fix

Inspect the last element of x-forwarded-for (which we can trust because of ALB). Only trust cf-connecting-ip when the request comes from cloudflare ranges.

# Tests

- Check that rate limiting doesn't use cf-connecting-ip when orange cloud is disabled.
- Regression test: check that I can login
- Regression test: check that rate limiting still applies in orange cloud