### PR TITLE
fix: gathersg get case details attachment

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/get-case-details.test.ts
@@ -119,7 +119,6 @@ describe('get case details', () => {
         executionId: MOCK_EXECUTION_ID,
         caseUuid: MOCK_CASE_UUID,
         attachmentUuid: MOCK_ATTACHMENT_UUID,
-        filename: MOCK_ATTACHMENT_NAME,
       },
     })
 

--- a/packages/backend/src/apps/gathersg/common/attachment.ts
+++ b/packages/backend/src/apps/gathersg/common/attachment.ts
@@ -73,7 +73,6 @@ async function downloadAndStoreAttachmentInS3(
         executionId: String($.execution.id),
         caseUuid: String(caseUuid),
         attachmentUuid,
-        filename,
       },
     })
 


### PR DESCRIPTION
## Problem

Running the GatherSG **Get case details** action on a case with attachments failed with:

```
TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["x-amz-meta-filename"]
```

**Root cause**: when storing a case attachment to S3 via `PutObjectCommand`, user-defined metadata is transmitted as literal HTTP request headers (`x-amz-meta-filename: <raw value>`). Node's HTTP layer rejects header values with characters outside the latin1 range, so any attachment filename containing non-ASCII characters (CJK, curly quotes, emoji, etc.) threw before the request was sent. Gather attachment filenames are user-controlled, so this was triggered by a case attachment with a non-ASCII filename. (S3 itself also requires user-defined metadata to be US-ASCII, so storing raw filenames there was always out of spec.)

Only the metadata was affected — the same filename in the S3 **object key** is fine because the SDK URL-encodes the request path.

## Solution

**Bug Fixes**:

- Removed `filename` from the S3 object metadata in `gathersg/common/attachment.ts` (and the matching test assertion).

**Why removing it is safe**:

1. **It was write-only for Gather objects.** The only reader of `metadata.filename` is the malware-scan error path in `s3.ts` (`throwAttachmentError`), which only runs for objects flagged `manualupload` — set exclusively by the presigned-POST browser-upload flow. Gather-stored objects never carry that flag.
2. **The filename isn't lost.** It remains the last segment of the object key (`{executionId}/{appKey}/{caseUuid}/{attachmentUuid}/{filename}`), and `getObjectFromS3Id` derives the download name from the object key, not metadata.
3. **Matches existing precedent.** FormSG and LetterSG `putObject` calls already store only IDs in metadata, without filename.

Manual (browser) uploads are unaffected: the presigned-POST flow sends `x-amz-meta-filename` as multipart form-body fields directly to S3, bypassing Node's header validation, and legitimately needs it for scan-failure error messages — that path is untouched.

## Tests

- `npx vitest run packages/backend/src/apps/gathersg/__tests__/actions/get-case-details.test.ts` — 5/5 pass, including the updated `putObject` metadata assertion.
- Manual: run **Get case details** on a Gather case with a non-ASCII attachment filename; attachment now stores and downloads correctly.

## Deploy Notes

None — no new env vars, scripts, or dependencies.
