### PR TITLE
fix: add 404 handling for invalid version error blips

### DIFF
--- a/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
+++ b/packages/backend/src/apps/m365-excel/__tests__/common/interceptors.error-handlers.test.ts
@@ -22,6 +22,7 @@ import { EXCEL_504_MAX_ATTEMPTS } from '../../common/interceptors/request-error-
 function mockAxiosAdapterToThrowOnce(
   status: AxiosResponse['status'],
   headers?: AxiosResponse['headers'],
+  data?: AxiosResponse['data'],
 ): void {
   mocks.axiosAdapter.mockImplementationOnce((config) => {
     throw new AxiosError(
@@ -32,6 +33,7 @@ function mockAxiosAdapterToThrowOnce(
       {
         status,
         headers,
+        data,
         config,
       } as unknown as AxiosResponse,
     )
@@ -110,6 +112,56 @@ describe('M365 request error handlers', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
+
+  it('logs an error and throws a RetriableError with default step delay on the intermittent 404 "Invalid version" blip', async () => {
+    mockAxiosAdapterToThrowOnce(404, undefined, {
+      error: { code: 'ResourceNotFound', message: 'Invalid version: error' },
+    })
+    await http
+      .get('/test-url')
+      .then(() => {
+        expect.unreachable()
+      })
+      .catch((error): void => {
+        expect(error).toBeInstanceOf(RetriableError)
+        expect(error.delayType).toEqual('step')
+        expect(error.delayInMs).toEqual(DEFAULT_DELAY_MS)
+        expect(error.message).toEqual('Retrying HTTP 404 from M365 Excel')
+      })
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 404'),
+      expect.objectContaining({ event: 'm365-http-404-invalid-version' }),
+    )
+  })
+
+  it.each([
+    {
+      name: 'the error code does not match',
+      data: {
+        error: { code: 'ItemNotFound', message: 'Invalid version: error' },
+      },
+    },
+    {
+      name: 'the error message does not match',
+      data: {
+        error: { code: 'ResourceNotFound', message: 'Item not found' },
+      },
+    },
+    {
+      name: 'the body is not a parseable Graph API error',
+      data: { unexpected: 'body' },
+    },
+  ])(
+    'rethrows the original HttpError on a 404 when $name',
+    async ({ data }) => {
+      mockAxiosAdapterToThrowOnce(404, undefined, data)
+      await expect(http.get('/test-url')).rejects.toThrow(HttpError)
+      expect(mocks.logError).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ event: 'm365-http-404-invalid-version' }),
+      )
+    },
+  )
 
   it.each([500, 502, 503])(
     'logs a warning and throws a RetriableError with default step delay on %s',

--- a/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
+++ b/packages/backend/src/apps/m365-excel/common/interceptors/request-error-handler.ts
@@ -26,6 +26,40 @@ const handleIntermittentError: MaybeThrowingHandler = ($, error) => {
   }
 }
 //
+// Unknown intermittent error from m365
+//
+const handle404: ThrowingHandler = ($, error) => {
+  const graphApiError = tryParseGraphApiError(error)
+  if (!graphApiError) {
+    throw error
+  }
+  // We only want to retry this specific error since it's a temporary blip
+  if (
+    graphApiError.code !== 'ResourceNotFound' ||
+    graphApiError.message !== 'Invalid version: error'
+  ) {
+    throw error
+  }
+
+  logger.error('Received HTTP 404 from MS Graph', {
+    event: 'm365-http-404-invalid-version',
+    tenant: $.auth?.data?.tenantKey as string,
+    baseUrl: error.response.config.baseURL,
+    url: error.response.config.url,
+    flowId: $.flow?.id,
+    stepId: $.step?.id,
+    executionId: $.execution?.id,
+    graphApiError,
+  })
+
+  throw new RetriableError({
+    error: 'Retrying HTTP 404 from M365 Excel',
+    delayType: 'step',
+    delayInMs: 'default',
+  })
+}
+
+//
 // Handle MS rate limiting us
 //
 const handle429: ThrowingHandler = ($, error) => {
@@ -172,6 +206,8 @@ const handle509: ThrowingHandler = function ($, error) {
 
 const errorHandler: IApp['requestErrorHandler'] = async function ($, error) {
   switch (error.response.status) {
+    case 404: // Not found error (specifically Invalid version error blip, caused by intermittent m365 error)
+      return handle404($, error)
     case 429: // Rate limited
       return handle429($, error)
     case 500:


### PR DESCRIPTION
## Problem

M365 giving intermitternt

```
{"status": 404, "details": {"error": {"code": "ResourceNotFound", "message": "Invalid version: error", "innerError": {"date": "2026-07-24T18:00:01", "request-id": "4ebbca7f-8540-42fd-9f43-789de4933faf", "client-request-id": "4ebbca7f-8540-42fd-9f43-789de4933faf"}}}, "statusText": "Not Found"}
```

## Solution

Retry like normal retriable error

