### PR TITLE
PLU-849: allow longer descriptions in pair image action

### DIFF
--- a/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
+++ b/packages/backend/src/apps/pair/__tests__/actions/process-image/schema.test.ts
@@ -236,8 +236,8 @@ describe('process-image schema', () => {
         assert(result.success === false)
       })
 
-      it('should reject descriptions longer than 128 characters', () => {
-        const longDescription = 'a'.repeat(129)
+      it('should accept a single long description under the total limit', () => {
+        const longDescription = 'a'.repeat(5000)
         const result = schema.safeParse({
           image: ['s3-id-123'],
           responseFields: [
@@ -247,17 +247,42 @@ describe('process-image schema', () => {
             },
           ],
         })
-        assert(result.success === false)
+        assert(result.success === true)
       })
 
-      it('should accept descriptions exactly 128 characters long', () => {
-        const maxDescription = 'a'.repeat(128)
+      it('should reject when total description length across all fields exceeds 10,000 characters', () => {
         const result = schema.safeParse({
           image: ['s3-id-123'],
           responseFields: [
             {
               fieldName: 'field1',
-              description: maxDescription,
+              description: 'a'.repeat(5000),
+            },
+            {
+              fieldName: 'field2',
+              description: 'b'.repeat(5001),
+            },
+          ],
+        })
+        assert(result.success === false)
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            'Total length of all descriptions cannot exceed 10000 characters',
+          )
+        }
+      })
+
+      it('should accept when total description length across all fields is exactly 10,000 characters', () => {
+        const result = schema.safeParse({
+          image: ['s3-id-123'],
+          responseFields: [
+            {
+              fieldName: 'field1',
+              description: 'a'.repeat(5000),
+            },
+            {
+              fieldName: 'field2',
+              description: 'b'.repeat(5000),
             },
           ],
         })

--- a/packages/backend/src/apps/pair/actions/process-image/schema.ts
+++ b/packages/backend/src/apps/pair/actions/process-image/schema.ts
@@ -5,6 +5,8 @@ import {
   toSanitizedOutputFieldNamePair,
 } from '../../common/schema'
 
+const TOTAL_DESCRIPTION_LENGTH_LIMIT = 10_000
+
 export const schema = z.object({
   // NOTE: this is an array because the attachment field returns an array
   image: z
@@ -21,10 +23,7 @@ export const schema = z.object({
 
           description: z
             .string()
-            .min(1, { message: 'Description is required' })
-            .max(128, {
-              message: 'Description cannot be more than 128 characters',
-            }),
+            .min(1, { message: 'Description is required' }),
         })
         .transform((field) => ({
           ...toSanitizedOutputFieldNamePair(field.fieldName),
@@ -40,6 +39,18 @@ export const schema = z.object({
       },
       {
         message: 'Output names must be unique (case-insensitive)',
+      },
+    )
+    .refine(
+      (fields) => {
+        const totalLength = fields.reduce(
+          (sum, field) => sum + field.description.length,
+          0,
+        )
+        return totalLength <= TOTAL_DESCRIPTION_LENGTH_LIMIT
+      },
+      {
+        message: `Total length of all descriptions cannot exceed ${TOTAL_DESCRIPTION_LENGTH_LIMIT} characters`,
       },
     ),
 })


### PR DESCRIPTION
## What?

Replace the pair app's "Process an image" action's flat 128-character-per-field cap on the "what to find" description with a 10,000-character cap on the total length across all response field descriptions.

## Why?

Users want longer descriptions than 128 characters allow. Per the ticket, capping the sum across all fields (rather than each field individually) still bounds the total prompt size sent to the model while letting any single field be as long as needed.

Closes [PLU-849](https://linear.app/ogp/issue/PLU-849/allow-longer-what-to-find-in-pair-image-action).

## Testing

- [ ] Create/edit a flow with a "Process an image" (pair) step, add a response field with a "what to find" description longer than 128 characters (e.g. ~500 chars), and confirm it saves without a validation error.
- [ ] Add several response fields whose descriptions sum to over 10,000 characters and confirm the flow builder shows a validation error and blocks saving.
- [ ] Add response fields whose descriptions sum to under 10,000 characters (mix of short and long) and confirm the flow saves and the step runs successfully end-to-end.
- [ ] Confirm a response field with an empty description is still rejected.
- [ ] Confirm existing flows that already have descriptions under 128 characters are unaffected (still validate and run normally).

