### PR TITLE
feat(archival): bucket stepCounts meta by SGT date

### DIFF
--- a/packages/backend-archive/README.md
+++ b/packages/backend-archive/README.md
@@ -167,7 +167,7 @@ UPDATE flows SET config = config - 'archiveDisabled' WHERE id = '<flow-id>';
 
 ## Counting archived steps by app and action
 
-Each archival run writes a summary object to `_meta/runs/{runAt}.json` in the bucket. The `stepCounts` field breaks down the number of archived steps by `appKey` → `actionKey` for that run.
+Each archival run writes a summary object to `_meta/runs/{runAt}.json` in the bucket. The `stepCounts` field breaks down the number of archived steps by SGT date → `appKey` → `actionKey` for that run.
 
 ### Single run (local / MinIO)
 
@@ -180,11 +180,15 @@ Output shape:
 
 ```json
 {
-  "formsg": { "submitForm": 42 },
-  "slack":  { "sendMessage": 17, "findMessage": 3 },
+  "2026-07-27": {
+    "formsg": { "submitForm": 42 },
+    "slack":  { "sendMessage": 17, "findMessage": 3 }
+  },
   ...
 }
 ```
+
+Dates are keyed by the step's `created_at`, converted to SGT (not the archival run date) — a single run can span many historical dates since it works through a backlog of eligible executions.
 
 `nullStepCount` in the same object captures steps where `appKey` or `key` could not be resolved (pre-denormalisation rows).
 
@@ -192,7 +196,7 @@ Output shape:
 
 ### Aggregate across all runs (local)
 
-To get cumulative counts across every run stored in the bucket, download all meta files and sum them:
+To get cumulative counts by date across every run stored in the bucket, download all meta files and sum them. Because the same date can appear in multiple run files (old backlog dates get touched across several runs), group by date + app + action rather than assuming one date lives in one file:
 
 ```bash
 mc ls local/plumber-archive-dev/_meta/runs/ \
@@ -202,12 +206,13 @@ mc ls local/plumber-archive-dev/_meta/runs/ \
     done \
   | jq -s '
       [ .[] | select(.dryRun == false) | .stepCounts | to_entries[] |
+        .key as $date | .value | to_entries[] |
         .key as $app | .value | to_entries[] |
-        { app: $app, action: .key, count: .value } ]
-      | group_by(.app + "." + .action)[]
-      | { app: .[0].app, action: .[0].action, count: ([.[].count] | add) }
+        { date: $date, app: $app, action: .key, count: .value } ]
+      | group_by(.date + "." + .app + "." + .action)[]
+      | { date: .[0].date, app: .[0].app, action: .[0].action, count: ([.[].count] | add) }
     ' \
-  | jq -s 'sort_by(-.count)'
+  | jq -s 'sort_by(.date, -.count)'
 ```
 
 The `select(.dryRun == false)` filter excludes dry-run files, which would double-count executions that were never actually deleted.
@@ -222,12 +227,13 @@ aws s3 ls s3://<bucket>/_meta/runs/ \
     done \
   | jq -s '
       [ .[] | select(.dryRun == false) | .stepCounts | to_entries[] |
+        .key as $date | .value | to_entries[] |
         .key as $app | .value | to_entries[] |
-        { app: $app, action: .key, count: .value } ]
-      | group_by(.app + "." + .action)[]
-      | { app: .[0].app, action: .[0].action, count: ([.[].count] | add) }
+        { date: $date, app: $app, action: .key, count: .value } ]
+      | group_by(.date + "." + .app + "." + .action)[]
+      | { date: .[0].date, app: .[0].app, action: .[0].action, count: ([.[].count] | add) }
     ' \
-  | jq -s 'sort_by(-.count)'
+  | jq -s 'sort_by(.date, -.count)'
 ```
 
 ---

--- a/packages/backend-archive/src/helpers/archival/__tests__/run-archival-loop.test.ts
+++ b/packages/backend-archive/src/helpers/archival/__tests__/run-archival-loop.test.ts
@@ -1,4 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Settings as LuxonSettings } from 'luxon'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 
 vi.mock('../config', () => ({
   archivalConfig: {
@@ -159,6 +168,13 @@ function setupDb(
 }
 
 describe('runArchivalLoop', () => {
+  // TZ formatting replicated here (see appConfig) as tests don't load the app
+  // config module.
+  beforeAll(() => {
+    LuxonSettings.defaultZone = 'Asia/Singapore'
+    LuxonSettings.defaultLocale = 'en-SG'
+  })
+
   beforeEach(() => {
     vi.mocked(archiveExecution).mockResolvedValue('archived')
   })
@@ -599,8 +615,44 @@ describe('runArchivalLoop', () => {
       expect(metaCall).toBeDefined()
       const payload = JSON.parse(metaCall![0].body as string)
       expect(payload.stepCounts).toEqual({
-        formsg: { trigger: 2 },
-        postman: { 'send-sms': 1 },
+        '2024-01-01': {
+          formsg: { trigger: 2 },
+          postman: { 'send-sms': 1 },
+        },
+      })
+    })
+
+    it('buckets counts per appKey:key by SGT date, not UTC date', async () => {
+      const exec1 = makeExecution('e1')
+      setupDb([[exec1], []], {
+        e1: [
+          // 2024-01-01T23:30 UTC is 2024-01-02T07:30 SGT (UTC+8).
+          makeStep({
+            id: 's1',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+            createdAt: '2024-01-01T23:30:00.000Z',
+          }),
+          makeStep({
+            id: 's2',
+            executionId: 'e1',
+            appKey: 'formsg',
+            key: 'trigger',
+            createdAt: '2024-01-01T01:00:00.000Z',
+          }),
+        ],
+      })
+
+      await runArchivalLoop(new AbortController().signal)
+
+      const metaCall = vi
+        .mocked(putArchiveObject)
+        .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))!
+      const payload = JSON.parse(metaCall[0].body as string)
+      expect(payload.stepCounts).toEqual({
+        '2024-01-01': { formsg: { trigger: 1 } },
+        '2024-01-02': { formsg: { trigger: 1 } },
       })
     })
 
@@ -636,7 +688,9 @@ describe('runArchivalLoop', () => {
         .mock.calls.find(([args]) => args.key.startsWith('_meta/runs/'))!
       const payload = JSON.parse(metaCall[0].body as string)
       expect(payload.nullStepCount).toBe(2)
-      expect(payload.stepCounts).toEqual({ formsg: { trigger: 1 } })
+      expect(payload.stepCounts).toEqual({
+        '2024-01-01': { formsg: { trigger: 1 } },
+      })
     })
 
     it('does not count steps from skipped executions', async () => {

--- a/packages/backend-archive/src/helpers/archival/run-archival-loop.ts
+++ b/packages/backend-archive/src/helpers/archival/run-archival-loop.ts
@@ -1,3 +1,6 @@
+import '@/types/luxon-extensions'
+
+import { DateTime } from 'luxon'
 import pLimit from 'p-limit'
 
 import { archiveExecution } from './archive-execution'
@@ -32,7 +35,8 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     string,
     { executionIds: string[]; testExecutionIds: string[] }
   >()
-  const stepCounts = new Map<string, Map<string, number>>()
+  // SGT date (yyyy-MM-dd) -> appKey -> key -> count
+  const stepCounts = new Map<string, Map<string, Map<string, number>>>()
   let nullStepCount = 0
   const startedAt = Date.now()
   const runAt = new Date(startedAt).toISOString()
@@ -245,10 +249,18 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
         if (!execution.testRun) {
           for (const step of steps) {
             if (step.appKey && step.key) {
+              // Partition by SGT so usage rollups match user-reported run times.
+              const date = DateTime.fromJSDate(
+                new Date(step.createdAt),
+              ).toPlumberFormat('yyyy-MM-dd')
+
+              const appMap =
+                stepCounts.get(date) ?? new Map<string, Map<string, number>>()
               const keyMap =
-                stepCounts.get(step.appKey) ?? new Map<string, number>()
+                appMap.get(step.appKey) ?? new Map<string, number>()
               keyMap.set(step.key, (keyMap.get(step.key) ?? 0) + 1)
-              stepCounts.set(step.appKey, keyMap)
+              appMap.set(step.appKey, keyMap)
+              stepCounts.set(date, appMap)
             } else {
               nullStepCount++
             }
@@ -296,9 +308,16 @@ export async function runArchivalLoop(signal: AbortSignal): Promise<void> {
     durationMs: Date.now() - startedAt,
   })
 
-  const stepCountsObj: Record<string, Record<string, number>> = {}
-  for (const [appKey, keyMap] of stepCounts) {
-    stepCountsObj[appKey] = Object.fromEntries(keyMap)
+  const stepCountsObj: Record<
+    string,
+    Record<string, Record<string, number>>
+  > = {}
+  for (const [date, appMap] of stepCounts) {
+    const appObj: Record<string, Record<string, number>> = {}
+    for (const [appKey, keyMap] of appMap) {
+      appObj[appKey] = Object.fromEntries(keyMap)
+    }
+    stepCountsObj[date] = appObj
   }
 
   await putArchiveObject({


### PR DESCRIPTION
## TL;DR

Break down the archival run meta file's `stepCounts` by SGT date so usage can be aggregated across many run files.

## What changed?

- `stepCounts` in `_meta/runs/{runAt}.json` is now keyed `date (SGT, yyyy-MM-dd) -> appKey -> key -> count`, instead of `appKey -> key -> count`. A single archival run can span a backlog of many historical dates, so date needed to be a first-class axis rather than folded away.
- Date is derived from each step's `created_at`, converted to SGT (consistent with the existing SGT partitioning in `buildS3Key`).
- Updated `packages/backend-archive/README.md`'s usage docs and jq aggregation examples to match the new shape, and noted that the same date can reappear across multiple run files (so aggregation must sum by date, not assume one date per file).
- Added/updated unit tests in `run-archival-loop.test.ts`, including a case asserting steps are bucketed by SGT date rather than UTC date (a UTC timestamp late in the day can fall on the next SGT calendar date).

## Tests

- [ ] `npm run -w backend-archive test:unit` passes locally
- [ ] `npm run -w backend-archive lint` passes locally
- [ ] Run the archival job (or dry-run) locally and inspect `_meta/runs/<runAt>.json` in MinIO — confirm `stepCounts` is now nested by date, e.g. `{ "2026-07-27": { "formsg": { "submitForm": 3 } } }`
- [ ] Confirm steps archived from test-run executions are still excluded from `stepCounts` (only non-test executions contribute)
- [ ] Confirm `nullStepCount` still increments correctly for steps missing `appKey`/`key`
- [ ] Spot-check that a step created late in the UTC day lands under the correct SGT date bucket (SGT is UTC+8)