### PR TITLE
chore: bump dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32194,9 +32194,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12400,15 +12400,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
Bumps two transitive dependencies (lockfile-only, no `package.json` changes) to pick up security fixes:

- **`brace-expansion`**: `5.0.5` → `5.0.8` — fixes [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (CVE-2026-14257, high severity), a DoS via unbounded expansion length causing an out-of-memory crash. Not a dev-only dependency in the lockfile, so this is in the prod tree.
- **`tmp`**: `0.2.5` → `0.2.7` — fixes [CVE-2026-44705](https://github.com/advisories/GHSA-ph9p-34f9-6g65), a path traversal via unsanitized `prefix`/`postfix` allowing directory escape. `tmp` is a dev-only dependency here.

No API/behavior changes expected — both are patch-level fixes within their existing major versions.

### Testing

- [ ] `npm install` and confirm lockfile resolves cleanly with no peer-dep or engine warnings
- [ ] Run `npm run lint` and `npm test` to confirm nothing in the build/test tooling (which pulls in `brace-expansion` via glob/minimatch) broke
- [ ] Spot-check a local build (`npm run dev` / `npm run -w backend build`) still starts up normally

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>