### PR TITLE
[AI-SETUP-23] feat: add retry action for DynamicPicker fetch errors

### DIFF
--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -216,23 +216,22 @@ export default function DynamicPicker({
               ))
             )
           ) : isError ? (
-            <Flex align="center" gap={2} px={2}>
-              <Text color="red.400" fontSize="sm">
-                {isAppKeyMode
-                  ? "Couldn't load connections."
-                  : "Couldn't load options — enter a value manually below."}
-              </Text>
-              <Button
-                variant="link"
-                size="sm"
-                color="primary.500"
-                isDisabled={isStreaming}
+            <Text color="red.400" fontSize="sm">
+              {isAppKeyMode
+                ? "Couldn't load connections. "
+                : "Couldn't load options — enter a value manually below, or "}
+              <Text
+                as="button"
+                type="button"
+                disabled={isStreaming}
                 onClick={() => setRetryCount((c) => c + 1)}
-                fontWeight="normal"
+                textDecoration="underline"
+                fontWeight="medium"
+                _disabled={{ opacity: 0.5, cursor: 'not-allowed' }}
               >
                 Retry
-              </Button>
-            </Flex>
+              </Text>
+            </Text>
           ) : null}
         </Flex>
 

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -47,6 +47,7 @@ export default function DynamicPicker({
   const [options, setOptions] = useState<DynamicPickerOption[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(false)
+  const [retryCount, setRetryCount] = useState(0)
   const [query, setQuery] = useState('')
   const [selectedOption, setSelectedOption] =
     useState<DynamicPickerOption | null>(null)
@@ -108,7 +109,7 @@ export default function DynamicPicker({
       })
 
     return () => controller.abort()
-  }, [stepId, dynamicKey, appKey]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [stepId, dynamicKey, appKey, retryCount]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const filtered = query
     ? options.filter((o) => o.name.toLowerCase().includes(query.toLowerCase()))
@@ -215,9 +216,23 @@ export default function DynamicPicker({
               ))
             )
           ) : isError ? (
-            <Text color="red.400" fontSize="sm" px={2}>
-              Couldn&apos;t load options — enter a value manually below.
-            </Text>
+            <Flex align="center" gap={2} px={2}>
+              <Text color="red.400" fontSize="sm">
+                {isAppKeyMode
+                  ? "Couldn't load connections."
+                  : "Couldn't load options — enter a value manually below."}
+              </Text>
+              <Button
+                variant="link"
+                size="sm"
+                color="primary.500"
+                isDisabled={isStreaming}
+                onClick={() => setRetryCount((c) => c + 1)}
+                fontWeight="normal"
+              >
+                Retry
+              </Button>
+            </Flex>
           ) : null}
         </Flex>
 


### PR DESCRIPTION
## TL;DR

Add a "Retry" action to `DynamicPicker` so a failed connection/dynamic-data fetch isn't a dead end.

## What changed?

- `DynamicPicker.tsx` previously showed a static error message on fetch failure with no way to recover other than "skip this step". Surfacing the raw server error string wouldn't have helped either — it's generic ("Internal server error") and doesn't unlock any new action for the user.
- Added a `retryCount` state that's included in the fetch `useEffect`'s dependency array, so clicking **Retry** re-runs the same fetch (appKey mode → `/api/connections`, stepId/dynamicKey mode → `/api/dynamic-data`).
- Added a **Retry** button next to the error text, disabled while `isStreaming` (consistent with the existing skip/submit buttons).
- Fixed the error copy for appKey mode: it previously said "enter a value manually below," which doesn't apply there since appKey mode hides the freetext input (connection IDs must be exact). It now shows a mode-appropriate message.

## Tests

- [ ] In appKey mode (e.g. connecting a FormSG step), force the `/api/connections` fetch to fail (e.g. block the request in devtools) and confirm the error state shows "Couldn't load connections." with a Retry button, and no misleading "enter a value manually" text
- [ ] Click Retry after the forced failure is removed and confirm connections load successfully
- [ ] In stepId/dynamicKey mode, force `/api/dynamic-data` to fail and confirm the original message ("Couldn't load options — enter a value manually below.") still shows alongside Retry, and the freetext input still works as a fallback
- [ ] While streaming (`isStreaming` true), confirm the Retry button is disabled
- [ ] Click Retry multiple times in quick succession and confirm only the latest request's result is applied (no stale options flashing in)
- [ ] Confirm "skip this step" still works from the error state in both modes
