### PR TITLE
feat(archival): scope execution history to 3-month window

### DIFF
--- a/packages/backend/src/graphql/__tests__/queries/get-executions.itest.ts
+++ b/packages/backend/src/graphql/__tests__/queries/get-executions.itest.ts
@@ -529,6 +529,56 @@ describe('getExecutions', () => {
     })
   })
 
+  describe('execution history window', () => {
+    const OLD_DATE = '2020-01-01T00:00:00.000Z'
+
+    const createExecutionAt = async (flow: Flow, createdAt: string) => {
+      const execution = await flow
+        .$relatedQuery('executions')
+        .insertAndFetch(
+          createExecutionData({ internalId: `exec-${createdAt}` }),
+        )
+      await execution.$query().patch({ createdAt })
+      return execution
+    }
+
+    it('excludes executions older than 3 months for non-admin requests when archival is enabled', async () => {
+      await createExecutionAt(testFlow, OLD_DATE)
+      const recentExecution = await testFlow
+        .$relatedQuery('executions')
+        .insertAndFetch(createExecutionData({ internalId: 'exec-recent' }))
+
+      const result = await callGetExecutions(testFlow.id, context)
+
+      expect(result.edges).toHaveLength(1)
+      expect(result.edges[0].node.id).toBe(recentExecution.id)
+    })
+
+    it('includes executions older than 3 months when the flow has archival disabled', async () => {
+      await testFlow.$query().patch({ config: { archiveDisabled: true } })
+      await createExecutionAt(testFlow, OLD_DATE)
+      await testFlow
+        .$relatedQuery('executions')
+        .insertAndFetch(createExecutionData({ internalId: 'exec-recent' }))
+
+      const result = await callGetExecutions(testFlow.id, context)
+
+      expect(result.edges).toHaveLength(2)
+    })
+
+    it('includes executions older than 3 months for admin operations regardless of archival config', async () => {
+      await createExecutionAt(testFlow, OLD_DATE)
+      await testFlow
+        .$relatedQuery('executions')
+        .insertAndFetch(createExecutionData({ internalId: 'exec-recent' }))
+
+      const adminContext: Context = { ...context, isAdminOperation: true }
+      const result = await callGetExecutions(testFlow.id, adminContext)
+
+      expect(result.edges).toHaveLength(2)
+    })
+  })
+
   describe('access control', () => {
     it('should only return executions for flows owned by current user', async () => {
       // Create another user and their flow

--- a/packages/backend/src/graphql/queries/get-executions.ts
+++ b/packages/backend/src/graphql/queries/get-executions.ts
@@ -1,8 +1,17 @@
+import { DateTime } from 'luxon'
+
 import paginate from '@/helpers/pagination'
 import Execution from '@/models/execution'
+import Flow from '@/models/flow'
 import type ExtendedQueryBuilder from '@/models/query-builder'
 
 import type { QueryResolvers } from '../__generated__/types.generated'
+
+// Default execution history window shown on the (non-admin) frontend. Flows
+// that have opted out of archival (flow.config.archiveDisabled) keep every
+// execution in Postgres indefinitely, so we show all of them in that case
+// rather than hiding data the archival job will never remove.
+const EXECUTION_HISTORY_WINDOW = { months: 3 }
 
 const getExecutions: QueryResolvers['getExecutions'] = async (
   _parent,
@@ -39,6 +48,18 @@ const getExecutions: QueryResolvers['getExecutions'] = async (
     .where(filterBuilder)
     .withSoftDeleted()
     .orderBy('created_at', 'desc')
+
+  if (!context.isAdminOperation) {
+    const flow = await Flow.query().findById(params.flowId).select('config')
+
+    if (!flow?.config?.archiveDisabled) {
+      executionsQuery.where(
+        'executions.created_at',
+        '>=',
+        DateTime.now().minus(EXECUTION_HISTORY_WINDOW).toISO(),
+      )
+    }
+  }
 
   return paginate(executionsQuery, params.limit, params.offset)
 }


### PR DESCRIPTION
## TL;DR

Scopes the frontend's execution history to the last 3 months by default, while the separate admin app (and any flow with archival disabled) continues to see the full history.

## What changed?

- `getExecutions` (packages/backend/src/graphql/queries/get-executions.ts) now adds a `created_at >= now() - 3 months` filter for regular (non-admin) requests.
- The filter is skipped entirely for admin-app requests (`context.isAdminOperation`), which always see every execution regardless of DB size.
- The filter is also skipped for the frontend when the flow has `config.archiveDisabled` set — those flows keep every execution in Postgres forever (archival never removes them), so hiding anything older than 3 months would just be confusing.
- No frontend changes needed — this is a server-side default, so the existing `GET_EXECUTIONS` query just returns fewer rows.

## Tests

- [ ] On a flow with archival enabled (default), create/seed an execution older than 3 months (or patch `created_at` on an existing one) and confirm it no longer appears in the frontend's Executions page for that flow, while recent executions still do.
- [ ] Set `config.archiveDisabled = true` on that flow (e.g. via `UPDATE flows SET config = COALESCE(config, '{}') || '{"archiveDisabled": true}'::jsonb WHERE id = '<flow-id>'`) and confirm the same old execution now shows up again in the frontend.
- [ ] Using plumber-admin locally against this backend, view the execution history for that same flow (with archival still enabled, `archiveDisabled` unset) and confirm the old execution is visible there — the admin app should never be scoped to 3 months.
- [ ] Confirm normal pagination/status/test-run filtering on the Executions page still behaves as before (no regressions) for flows with only recent executions.

## Deploy notes

None — no new env vars or migrations. Uses the existing `(flow_id, test_run, created_at)` composite index and the pre-existing `flow.config.archiveDisabled` field.