### PR TITLE
[AI-SETUP-24] fix: stop returning decrypted connection credentials from list_connections

### DIFF
--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -55,7 +55,7 @@ export function createMcpBridgeTools(
 
     list_connections: tool<{ app_key?: string }, McpConnection[]>({
       description:
-        "List connections the user has set up, optionally filtered to a specific app. Returns each connection's ID, app key, verified status, label, and formattedData. Use the returned id as connection_id when calling update_step_parameters.",
+        "List connections the user has set up, optionally filtered to a specific app. Returns each connection's ID, app key, verified status, and label. Use the returned id as connection_id when calling update_step_parameters.",
       inputSchema: z.object({
         app_key: z
           .string()

--- a/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
+++ b/packages/backend/src/services/mcp/__tests__/list-connections.itest.ts
@@ -170,12 +170,14 @@ describe('listConnectionsService', () => {
         appKey: 'm365-excel',
         verified: true,
         label: 'Excel',
-        formattedData: { screenName: 'Excel' },
       },
     ])
   })
 
-  it('includes formattedData on the returned connection', async () => {
+  // formattedData holds the connection's decrypted credentials (it's used
+  // downstream as $.auth.data — see helpers/global-variable.ts), so it must
+  // never be exposed via the MCP tool surface, which is read by the LLM.
+  it('does not include formattedData in the returned connection', async () => {
     const user = await User.query().insertAndFetch({
       id: randomUUID(),
       email: `formatted-data-${randomUUID()}@example.com`,
@@ -186,12 +188,16 @@ describe('listConnectionsService', () => {
       userId: user.id,
       verified: true,
       draft: false,
-      formattedData: { screenName: 'My Workspace' },
+      formattedData: {
+        screenName: 'My Workspace',
+        accessToken: 'secret-token',
+      },
     })
 
     const result = await listConnectionsService(user)
     const found = result.find((c) => c.id === conn.id)
 
-    expect(found?.formattedData).toEqual({ screenName: 'My Workspace' })
+    expect(found?.label).toBe('My Workspace')
+    expect(found).not.toHaveProperty('formattedData')
   })
 })

--- a/packages/backend/src/services/mcp/list-connections.ts
+++ b/packages/backend/src/services/mcp/list-connections.ts
@@ -8,10 +8,9 @@ export interface McpConnection {
   appKey: string
   verified: boolean
   label: string
-  formattedData?: IJSONObject
 }
 
-function connectionLabel(c: {
+export function connectionLabel(c: {
   formattedData?: IJSONObject
   description?: string
   key: string
@@ -51,7 +50,6 @@ export async function listConnectionsService(
         appKey: c.key,
         verified: c.verified,
         label: connectionLabel(c),
-        formattedData: c.formattedData,
       }))
     }
   }
@@ -69,6 +67,5 @@ export async function listConnectionsService(
     appKey: c.key,
     verified: c.verified,
     label: connectionLabel(c),
-    formattedData: c.formattedData,
   }))
 }


### PR DESCRIPTION
## TL;DR

`list_connections` (an AI Builder MCP tool) was returning every connection's raw decrypted credentials to the LLM instead of just the display label — this drops the leak.

## What changed?

- Removed `formattedData` from `McpConnection` and both `listConnectionsService` return mappings. `connectionLabel()` still reads `formattedData.screenName` internally to compute the label — it just no longer echoes the raw object back to the tool caller.
- Updated the `list_connections` tool description in `mcp-bridge-tools.ts` to stop advertising `formattedData`.
- Swapped the itest that asserted `formattedData` was returned for one asserting it's **not** (fixture includes a fake `accessToken` to make the regression concrete), and fixed the system-added-connections test's exact-match expectation to drop the field.

## Tests

- `npm run -w backend test:integration -- src/services/mcp/__tests__/list-connections.itest.ts` — confirms `list_connections` no longer echoes `formattedData`, including for the system-added-connections path.
- Manual: in AI Builder, prompt the assistant to list your connections mid-chat; confirm the `list_connections` tool result only contains `id`/`appKey`/`verified`/`label` — no `formattedData` field.

## Deploy notes

None.