### PR TITLE
[AI-SETUP-25] chore: show the connected form/account name in the step preview

### DIFF
--- a/packages/backend/src/routes/api/chat/index.test.ts
+++ b/packages/backend/src/routes/api/chat/index.test.ts
@@ -1,5 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const mocks = vi.hoisted(() => ({
+  writerWrite: vi.fn(),
+  // streamText's mock can't await onFinish itself (it must return
+  // { toUIMessageStream } synchronously, matching the real SDK's contract),
+  // so it stashes the promise here for tests to await before asserting on
+  // anything onFinish does asynchronously (Flow/Connection lookups, writes).
+  onFinishPromise: Promise.resolve() as Promise<unknown>,
+}))
+
 vi.mock('@ai-sdk/mcp', () => ({
   experimental_createMCPClient: vi.fn(),
 }))
@@ -17,7 +26,7 @@ vi.mock('ai', async (importOriginal) => {
           onFinish?: (event: { text: string }) => Promise<void>
         }) => {
           if (onFinish) {
-            void onFinish({ text: '' })
+            mocks.onFinishPromise = onFinish({ text: '' })
           }
           return { toUIMessageStream: vi.fn().mockReturnValue({}) }
         },
@@ -26,7 +35,9 @@ vi.mock('ai', async (importOriginal) => {
       .fn()
       .mockImplementation(
         ({ execute }: { execute: (arg: { writer: unknown }) => unknown }) => {
-          void execute({ writer: { merge: vi.fn(), write: vi.fn() } })
+          void execute({
+            writer: { merge: vi.fn(), write: mocks.writerWrite },
+          })
           return {}
         },
       ),
@@ -34,6 +45,14 @@ vi.mock('ai', async (importOriginal) => {
     convertToModelMessages: vi.fn((msgs) => msgs),
   }
 })
+
+vi.mock('@/models/flow', () => ({
+  default: { query: vi.fn() },
+}))
+
+vi.mock('@/models/connection', () => ({
+  default: { query: vi.fn() },
+}))
 
 vi.mock('@/helpers/ai/get-prompt', () => ({
   getPrompt: vi.fn().mockResolvedValue({
@@ -99,6 +118,10 @@ vi.mock('@opentelemetry/api', () => ({
 
 import { experimental_createMCPClient } from '@ai-sdk/mcp'
 import { streamText } from 'ai'
+
+import { getAiBuilderFlag } from '@/helpers/ai/get-ai-builder-flag'
+import Connection from '@/models/connection'
+import Flow from '@/models/flow'
 
 // @ts-expect-error top-level await is supported by Vitest's ESM runner
 const { default: router } = await import('./index')
@@ -177,5 +200,198 @@ describe('chat handler — GitBook MCP integration', () => {
         tools: { ...mockBridgeTools },
       }),
     )
+  })
+})
+
+describe('chat handler — data-pipeState connectionLabel resolution', () => {
+  function mockFlowSteps(steps: unknown[]) {
+    vi.mocked(Flow.query).mockReturnValue({
+      findById: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue({
+          $relatedQuery: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue(steps),
+          }),
+        }),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
+  function mockConnections(connections: unknown[]) {
+    vi.mocked(Connection.query).mockReturnValue({
+      findByIds: vi.fn().mockResolvedValue(connections),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+  }
+
+  function getWrittenPipeState() {
+    const call = mocks.writerWrite.mock.calls.find(
+      ([part]) => part.type === 'data-pipeState',
+    )
+    return call?.[0].data
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // This describe block only exercises the mcpStepConfig (Phase 2b+) path.
+    vi.mocked(getAiBuilderFlag).mockReturnValue({
+      enabled: true,
+      config: {
+        chatPromptName: 'chat',
+        chatSummaryPromptName: 'chat-summary',
+        generateStepsPromptName: 'generate-steps',
+        version: 'production',
+        mcpStepConfig: true,
+      },
+    })
+    // Simulate a create_pipe (or similar) tool call having already set the
+    // active pipe, the same way onPipeChange is invoked in real usage.
+    vi.mocked(createMcpBridgeTools).mockImplementation(
+      (_user, _traceId, onPipeChange) => {
+        onPipeChange?.('pipe-1')
+        return { plumber_tool: vi.fn() } as unknown as ReturnType<
+          typeof createMcpBridgeTools
+        >
+      },
+    )
+  })
+
+  it('includes connectionLabel resolved from the connection screenName', async () => {
+    mockFlowSteps([
+      {
+        id: 'step-1',
+        appKey: 'slack',
+        key: 'sendMessageToChannel',
+        type: 'action',
+        position: 1,
+        status: 'completed',
+        parameters: { channel: 'general' },
+        connectionId: 'conn-1',
+      },
+    ])
+    mockConnections([
+      { id: 'conn-1', formattedData: { screenName: 'My Workspace' } },
+    ])
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+    await mocks.onFinishPromise
+
+    expect(getWrittenPipeState()).toEqual(
+      expect.objectContaining({
+        pipeId: 'pipe-1',
+        steps: [
+          expect.objectContaining({
+            id: 'step-1',
+            parameters: { channel: 'general' },
+            connectionId: 'conn-1',
+            connectionLabel: 'My Workspace',
+          }),
+        ],
+      }),
+    )
+  })
+
+  it('sets connectionLabel to null when the step has no connection assigned', async () => {
+    mockFlowSteps([
+      {
+        id: 'step-1',
+        appKey: 'formsg',
+        key: 'newSubmission',
+        type: 'trigger',
+        position: 1,
+        status: 'incomplete',
+        parameters: {},
+        connectionId: null,
+      },
+    ])
+    mockConnections([])
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+    await mocks.onFinishPromise
+
+    expect(getWrittenPipeState().steps).toEqual([
+      expect.objectContaining({ connectionId: null, connectionLabel: null }),
+    ])
+    expect(vi.mocked(Connection.query)).not.toHaveBeenCalled()
+  })
+
+  it('sets connectionLabel to null when the referenced connection no longer exists', async () => {
+    mockFlowSteps([
+      {
+        id: 'step-1',
+        appKey: 'slack',
+        key: 'sendMessageToChannel',
+        type: 'action',
+        position: 1,
+        status: 'incomplete',
+        parameters: {},
+        connectionId: 'conn-deleted',
+      },
+    ])
+    // Dangling reference: the connection was deleted/inaccessible.
+    mockConnections([])
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+    await mocks.onFinishPromise
+
+    expect(getWrittenPipeState().steps).toEqual([
+      expect.objectContaining({
+        connectionId: 'conn-deleted',
+        connectionLabel: null,
+      }),
+    ])
+  })
+
+  it('dedupes connection lookups when multiple steps share the same connectionId', async () => {
+    mockFlowSteps([
+      {
+        id: 'step-1',
+        appKey: 'slack',
+        key: 'sendMessageToChannel',
+        type: 'action',
+        position: 1,
+        status: 'completed',
+        parameters: {},
+        connectionId: 'conn-1',
+      },
+      {
+        id: 'step-2',
+        appKey: 'slack',
+        key: 'sendMessageToChannel',
+        type: 'action',
+        position: 2,
+        status: 'completed',
+        parameters: {},
+        connectionId: 'conn-1',
+      },
+    ])
+    const findByIds = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'conn-1', formattedData: { screenName: 'My Workspace' } },
+      ])
+    vi.mocked(Connection.query).mockReturnValue({
+      findByIds,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
+
+    const handler = router.stack[0].route.stack[0].handle
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handler(makeReq() as any, makeRes() as any, vi.fn())
+    await mocks.onFinishPromise
+
+    expect(findByIds).toHaveBeenCalledTimes(1)
+    expect(findByIds).toHaveBeenCalledWith(['conn-1'])
+    expect(
+      getWrittenPipeState().steps.map(
+        (s: { connectionLabel: string | null }) => s.connectionLabel,
+      ),
+    ).toEqual(['My Workspace', 'My Workspace'])
   })
 })

--- a/packages/backend/src/routes/api/chat/index.ts
+++ b/packages/backend/src/routes/api/chat/index.ts
@@ -34,7 +34,9 @@ import logger from '@/helpers/logger'
 import { createMcpBridgeTools } from '@/helpers/mcp-bridge-tools'
 import { model, MODEL_TYPE } from '@/helpers/pair'
 import { pipeWebResponseToExpress } from '@/helpers/stream'
+import Connection from '@/models/connection'
 import Flow from '@/models/flow'
+import { connectionLabel } from '@/services/mcp/list-connections'
 import { AuthenticatedRequest } from '@/types/express/context'
 
 import { serializeMessagesForLangfuse } from './helpers'
@@ -262,20 +264,45 @@ const handleChatStream = observe(
                           .orderBy('position', 'asc')
                       : []
 
+                    // Resolve connection labels fresh each turn — a step's
+                    // connection can be repointed independently of the step row.
+                    const connectionIds = [
+                      ...new Set(
+                        steps
+                          .map((step) => step.connectionId)
+                          .filter((id): id is string => !!id),
+                      ),
+                    ]
+                    const connectionsById = connectionIds.length
+                      ? new Map(
+                          (
+                            await Connection.query().findByIds(connectionIds)
+                          ).map((connection) => [connection.id, connection]),
+                        )
+                      : new Map<string, Connection>()
+
                     writer.write({
                       type: 'data-pipeState',
                       data: {
                         pipeId: activePipeId,
-                        steps: steps.map((step) => ({
-                          id: step.id,
-                          appKey: step.appKey,
-                          key: step.key,
-                          type: step.type,
-                          position: step.position,
-                          status: step.status,
-                          parameters: step.parameters,
-                          connectionId: step.connectionId ?? null,
-                        })),
+                        steps: steps.map((step) => {
+                          const connection = step.connectionId
+                            ? connectionsById.get(step.connectionId)
+                            : undefined
+                          return {
+                            id: step.id,
+                            appKey: step.appKey,
+                            key: step.key,
+                            type: step.type,
+                            position: step.position,
+                            status: step.status,
+                            parameters: step.parameters,
+                            connectionId: step.connectionId ?? null,
+                            connectionLabel: connection
+                              ? connectionLabel(connection)
+                              : null,
+                          }
+                        }),
                       },
                     })
                   }

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -118,6 +118,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
           status: z.string(),
           parameters: z.record(z.string(), z.unknown()),
           connectionId: z.string().nullable(),
+          connectionLabel: z.string().nullable().optional(),
         }),
       ),
     }),

--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -66,6 +66,7 @@ export type PipeStateStep = {
   status: 'incomplete' | 'completed'
   parameters: Record<string, unknown>
   connectionId: string | null
+  connectionLabel?: string | null
 }
 
 export type PipeStatePart = {

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -26,6 +26,7 @@ interface AIBuilderSharedProps extends AIBuilderDraftState {
 
 interface AiBuilderStep extends IStep {
   description?: string
+  connectionLabel?: string | null
 }
 
 interface AIBuilderContextValue extends AIBuilderSharedProps {

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -16,6 +16,7 @@ import StepParameterRows from './StepParameterRows'
 
 interface AiStep extends IStep {
   description?: string
+  connectionLabel?: string | null
 }
 
 interface StepProps {
@@ -155,6 +156,7 @@ export default function Step(props: StepProps) {
               appKey={step.appKey ?? ''}
               stepKey={step.key ?? ''}
               stepId={step.id ?? ''}
+              connectionLabel={step.connectionLabel}
             />
           )}
         </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -1,6 +1,6 @@
 import type { IApp, IJSONObject } from '@plumber/types'
 
-import { Fragment } from 'react'
+import { Fragment, type ReactNode } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { isFieldHidden } from '@/helpers/isFieldHidden'
@@ -109,11 +109,38 @@ function resolveDisplayValue(
   return resolveOptionLabel(field, String(value))
 }
 
+interface ParameterRowProps {
+  label: string
+  children: ReactNode
+}
+
+// Shared row layout for both the connection row and each parameter row —
+// keeps the label column (width, alignment, styling) in one place.
+function ParameterRow({ label, children }: ParameterRowProps) {
+  return (
+    <Flex align="flex-start" gap={4} py={2}>
+      <Text
+        as="span"
+        display="inline-block"
+        fontSize="sm"
+        color="base.content.medium"
+        fontWeight={500}
+        w="80px"
+        flexShrink={0}
+      >
+        {label}
+      </Text>
+      {children}
+    </Flex>
+  )
+}
+
 interface StepParameterRowsProps {
   parameters: IJSONObject
   appKey: string
   stepKey: string
   stepId: string
+  connectionLabel?: string | null
 }
 
 export default function StepParameterRows({
@@ -121,6 +148,7 @@ export default function StepParameterRows({
   appKey,
   stepKey,
   stepId,
+  connectionLabel,
 }: StepParameterRowsProps) {
   const { allApps } = useAiBuilderContext()
   const { parameterLabelsByStepId } = useStepConfigContext()
@@ -153,7 +181,7 @@ export default function StepParameterRows({
       return posA - posB
     })
 
-  if (rows.length === 0) {
+  if (rows.length === 0 && !connectionLabel) {
     return null
   }
 
@@ -166,24 +194,21 @@ export default function StepParameterRows({
       borderTop="1px solid"
       borderColor="base.divider.medium"
     >
+      {connectionLabel && (
+        <ParameterRow label="Connection">
+          <Text as="span" fontSize="sm" color="base.content.default">
+            {connectionLabel}
+          </Text>
+        </ParameterRow>
+      )}
       {rows.map(({ key, label, displayValue }) => {
         const segments = parseParameterValue(displayValue as string)
 
         return (
-          <Flex key={key} align="center" gap={2.5} py="5px">
-            <Text
-              as="span"
-              fontSize="12px"
-              color="base.content.medium"
-              fontWeight={500}
-              minW="54px"
-              flexShrink={0}
-            >
-              {label}
-            </Text>
+          <ParameterRow key={key} label={label}>
             <Box
               as="span"
-              fontSize="13px"
+              fontSize="sm"
               color="base.content.default"
               lineHeight="1.6"
               display="flex"
@@ -201,7 +226,7 @@ export default function StepParameterRows({
                 ),
               )}
             </Box>
-          </Flex>
+          </ParameterRow>
         )
       })}
     </Box>


### PR DESCRIPTION
## TL;DR

AI Builder's step preview only showed a raw `connectionId` for FormSG (and any other connected app) — no indication of which form/account is actually wired up. This surfaces the connected account's human-readable name, and fixes a label/value alignment bug in the same component while touching it.

## What changed?

- Backend: resolve `connectionLabel` per step when building `data-pipeState` (batched `Connection` lookup by id, resolved fresh on every emission since a step's connection can be repointed independently of the step row). Reuses the existing `connectionLabel()` helper (`formattedData.screenName ?? description ?? key`) — same mechanism the regular flow editor already uses via `ChooseConnectionSubstep`, so no new data exposure.
- Frontend: thread `connectionLabel` through `data-pipeState` → `useChatStream` → `AiBuilderContext` → `Step` → `StepParameterRows`, rendered as a leading "Connection" row.
- `StepParameterRows`: fixed label column to a fixed width (was `minW`, which let a long label widen the column and misalign values across rows) so labels wrap onto a second line instead; extracted the repeated row markup (connection row + each parameter row) into a shared `ParameterRow` component.
- Added unit tests for the `connectionLabel` resolution logic in `chat/index.ts` (happy path, no connection assigned, dangling/deleted connection reference, dedup of repeated `connectionId`s across steps in one batched lookup).

## Tests

- `npm run test packages/backend/src/routes/api/chat/index.test.ts` — new `data-pipeState connectionLabel resolution` suite (4 cases) covers the backend resolution logic, including the deleted-connection edge case.
- Manual: connect a FormSG form (or any app) to a trigger/action step in AI Builder, confirm the step preview shows a "Connection" row with the account/form name.
- Manual: confirm parameter rows with long labels wrap onto a second line instead of pushing the value column out of alignment with other rows.
- `npm run -w backend lint` / `npm run -w frontend lint` — both clean.

## Deploy notes

None.