### PR TITLE
[AI-SETUP-26] fix: recover step state lost on a browser refresh

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -107,7 +107,19 @@ export function useChatStream(options: UseChatStreamOptions) {
   const toast = useToast()
   const navigate = useNavigate()
   const location = useLocation()
-  const { ddSessionId } = useAiBuilderContext()
+  const { ddSessionId, output } = useAiBuilderContext()
+
+  // Use ref to always access the latest pipe output in prepareSendMessagesRequest
+  const outputRef = useRef(output)
+  outputRef.current = output
+
+  // After a refresh, chatMessages (persisted, text-only) is all that's left of
+  // the conversation — every tool result and data-pipeState part (the only
+  // places real step IDs ever appeared) is gone. Without this, the model has
+  // no ground truth for step IDs on its first post-refresh turn and guesses.
+  // Fires once per mount only — after that, the live conversation carries its
+  // own tool-call history forward same as before.
+  const hasSentPipeContextRef = useRef(false)
 
   // Track step readiness from data-isChatReady annotation
   // Initialize based on whether initialMessages contains a ready message.
@@ -153,11 +165,54 @@ export function useChatStream(options: UseChatStreamOptions) {
             ...(msg.traceId && { metadata: { traceId: msg.traceId } }),
           }))
 
+        // First request since mount: if a pipe already has real step IDs
+        // (data-pipeState survived in the persisted draft) but this mount's
+        // own conversation history doesn't carry them (post-refresh), resync
+        // the model with just the ID mapping it needs — not the full step
+        // config — so it doesn't have to guess a step_id for tool calls like
+        // get_dynamic_data.
+        const pipeContextMsgs = []
+        if (!hasSentPipeContextRef.current) {
+          hasSentPipeContextRef.current = true
+          const currentSteps = outputRef.current?.pipeId
+            ? outputRef.current?.steps
+            : undefined
+          const configuredSteps = Array.isArray(currentSteps)
+            ? currentSteps.filter(
+                (s: { appKey?: string; key?: string }) => s.appKey && s.key,
+              )
+            : []
+          if (configuredSteps.length > 0) {
+            const stepIdMapping = configuredSteps
+              .map(
+                (
+                  s: { id: string; appKey: string; key: string; type: string },
+                  i: number,
+                ) => `${i + 1}. ${s.appKey}/${s.key} (${s.type}) — id: ${s.id}`,
+              )
+              .join('\n')
+            pipeContextMsgs.push({
+              id: 'pipe-context-resync',
+              role: 'assistant' as const,
+              parts: [
+                {
+                  type: 'text' as const,
+                  text: `[Internal resync — do not mention this to the user] Current pipe steps and their real IDs, for use as step_id in tool calls:\n${stepIdMapping}`,
+                },
+              ],
+            })
+          }
+        }
+
         // Prepend initial messages to maintain full conversation context.
         // Filter out assistant messages with no text content — these can be left
         // behind when the user stops the stream before any output is produced,
         // and would fail backend schema validation.
-        const allMessages = [...initialMsgs, ...messages].filter((msg) => {
+        const allMessages = [
+          ...initialMsgs,
+          ...pipeContextMsgs,
+          ...messages,
+        ].filter((msg) => {
           if (msg.role !== 'assistant') {
             return true
           }
@@ -222,11 +277,32 @@ export function useChatStream(options: UseChatStreamOptions) {
       // Get current output from the ref (ensures we see latest state from other navigates)
       const currentOutput = locationRef.current.state?.output
 
+      // Accumulate parameter labels alongside the rest of the draft (never
+      // persisted server-side) so they survive a refresh in lockstep with
+      // chatMessages/output instead of drifting via a separate store.
+      const previousParameterLabels: Record<
+        string,
+        Record<string, string>
+      > = locationRef.current.state?.parameterLabelsByStepId ?? {}
+      const parameterLabelsByStepId = { ...previousParameterLabels }
+      for (const part of lastMessage.parts ?? []) {
+        if (part.type === 'data-stepUpdate') {
+          const { stepId, parameterLabels } = (part as StepUpdatePart).data
+          if (parameterLabels) {
+            parameterLabelsByStepId[stepId] = {
+              ...parameterLabelsByStepId[stepId],
+              ...parameterLabels,
+            }
+          }
+        }
+      }
+
       navigate(`${URLS.EDITOR}/ai`, {
         state: {
           ...locationRef.current.state,
           chatInput: allMessages[allMessages.length - 1].text,
           chatMessages: allMessages,
+          parameterLabelsByStepId,
           // pipeStatePart: replace output with DB pipe state (Phase 2b+)
           // isChatReady: populate output from stream (steps or error), drawer opens
           // neither: preserve current output

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -17,6 +17,11 @@ export interface AIBuilderDraftState {
   // output can be populated (IStep values) or the initial empty state (empty strings)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   output: Record<string, any>
+  // Human-readable overrides for opaque parameter values (e.g. a resolved
+  // Slack channel name), keyed by stepId then parameter key. Display-only —
+  // never persisted server-side, so it's carried in the same draft blob as
+  // the rest of the session to survive a refresh.
+  parameterLabelsByStepId?: Record<string, Record<string, string>>
 }
 
 interface AIBuilderSharedProps extends AIBuilderDraftState {
@@ -69,6 +74,7 @@ export const AiBuilderContextProvider = ({
   chatInput,
   chatMessages,
   output,
+  parameterLabelsByStepId = {},
   clearPersistedState,
   setChatState,
 }: AiBuilderContextProviderProps) => {
@@ -142,6 +148,7 @@ export const AiBuilderContextProvider = ({
         chatInput,
         chatMessages,
         output,
+        parameterLabelsByStepId,
         isMobile,
         steps,
         triggerStep,

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -1,3 +1,5 @@
+import type { IJSONObject } from '@plumber/types'
+
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { Helmet } from 'react-helmet'
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -21,9 +23,11 @@ function AiBuilderContent() {
   const {
     flowName,
     chatMessages,
+    parameterLabelsByStepId: persistedParameterLabelsByStepId,
     clearPersistedState,
     isMobile,
     isDrawerOpen,
+    steps,
   } = useAiBuilderContext()
 
   const {
@@ -40,6 +44,49 @@ function AiBuilderContent() {
     completedStepIds,
     activeStepId,
   } = useChatStream({ initialMessages: chatMessages })
+
+  // Merge labels persisted in the draft (survive refresh, committed once a
+  // turn finishes) with labels from the current streaming turn (live wins —
+  // it's the freshest within this session, ahead of the next draft commit).
+  const mergedParameterLabelsByStepId = useMemo(() => {
+    const merged = { ...persistedParameterLabelsByStepId }
+    for (const [stepId, labels] of Object.entries(parameterLabelsByStepId)) {
+      merged[stepId] = { ...merged[stepId], ...labels }
+    }
+    return merged
+  }, [persistedParameterLabelsByStepId, parameterLabelsByStepId])
+
+  // stepParametersByStepId from useChatStream is derived by re-scanning the
+  // live aiMessages for data-stepUpdate parts, which resets on refresh. The
+  // steps' own `parameters` field (already persisted via data-pipeState/
+  // output) carries the same saved values across refresh, so fall back to it
+  // per-step; live (this turn's freshest tool result) wins when present.
+  const mergedStepParametersByStepId = useMemo(() => {
+    const merged: Record<string, IJSONObject> = {}
+    for (const step of steps) {
+      if (step.id && step.parameters) {
+        merged[step.id] = step.parameters
+      }
+    }
+    for (const [stepId, parameters] of Object.entries(stepParametersByStepId)) {
+      merged[stepId] = parameters
+    }
+    return merged
+  }, [steps, stepParametersByStepId])
+
+  // completedStepIds from useChatStream is derived by re-scanning the live
+  // aiMessages, which resets on refresh. The steps' own `status` field
+  // (already persisted via data-pipeState/output) carries this same fact
+  // across refresh, so fold it in rather than relying on the live scan alone.
+  const mergedCompletedStepIds = useMemo(() => {
+    const merged = new Set(completedStepIds)
+    for (const step of steps) {
+      if (step.id && step.status === 'completed') {
+        merged.add(step.id)
+      }
+    }
+    return merged
+  }, [steps, completedStepIds])
 
   const cancelRef = useRef(null)
 
@@ -71,9 +118,9 @@ function AiBuilderContent() {
   return (
     <StepConfigContext.Provider
       value={{
-        stepParametersByStepId,
-        parameterLabelsByStepId,
-        completedStepIds,
+        stepParametersByStepId: mergedStepParametersByStepId,
+        parameterLabelsByStepId: mergedParameterLabelsByStepId,
+        completedStepIds: mergedCompletedStepIds,
         activeStepId,
       }}
     >
@@ -152,6 +199,7 @@ export default function AiBuilder() {
           actions: '',
           name: 'Build with AI',
         },
+        parameterLabelsByStepId: {},
       },
     )
 
@@ -162,7 +210,8 @@ export default function AiBuilder() {
     }
   }, [locationState, setPersistedState])
 
-  const { flowName, output, chatInput, chatMessages } = persistedState
+  const { flowName, output, chatInput, chatMessages, parameterLabelsByStepId } =
+    persistedState
 
   return (
     <AiBuilderContextProvider
@@ -170,6 +219,7 @@ export default function AiBuilder() {
       chatInput={chatInput}
       chatMessages={chatMessages}
       output={output}
+      parameterLabelsByStepId={parameterLabelsByStepId}
       clearPersistedState={clearPersistedState}
       setChatState={setPersistedState}
     >


### PR DESCRIPTION
## TL;DR

Several pieces of AI Builder's step-preview state (AI-resolved parameter labels, completed-step status, step parameters, and the model's own memory of real step IDs) were derived purely from the live in-memory chat session, so they silently vanished on a browser refresh even though the underlying data had already been saved.

## What changed?

- **parameterLabelsByStepId**: previously only ever existed in the AI SDK's live message list. Now accumulated in `useChatStream`'s `onFinish` and carried in the same router-state/sessionStorage draft as `chatMessages`/`output` — one committed blob, not a second store that could drift out of sync.
- **completedStepIds / stepParametersByStepId**: previously derived only by re-scanning the live message list (which resets on refresh). Now merged with the already-persisted `steps[].status` / `steps[].parameters` (from `data-pipeState`), with the live scan winning when present (it's fresher within the current turn).
- **Real step IDs disappearing from the model's own context**: `chatMessages` (the only thing that survives a refresh) is stripped to text-only, discarding every tool-call result and `data-pipeState` part — the only places real step IDs ever appeared. On the first turn after a refresh, the model had no ground truth for `step_id` and would guess (visible as `get_dynamic_data` being called with a random UUID). Fixed by resyncing the model with a minimal step-ID mapping (id/appKey/key/type per step, not full config) on the first request since mount when a persisted pipe exists — invisible to the user, fires once per mount. Steps without a configured app/action key (e.g. an empty trigger slot left by `delete_step`) are filtered out of this mapping rather than rendering as `undefined/undefined`.

## Tests

- Manual: build a pipe in AI Builder with the assistant resolving a dynamic label (e.g. a Slack channel name) and completing a step, refresh the page, confirm the step preview still shows the resolved label and completed status instead of falling back to raw IDs / losing the checkmark.
- Manual: mid-flow (before a step has an assigned connection), refresh, then prompt the assistant to do something requiring `get_dynamic_data` on an existing step — confirm it uses the correct `step_id` instead of a hallucinated UUID.
- `npm run -w frontend lint` — clean (no dedicated unit tests added yet for the three merge functions or the resync logic; tracked as a follow-up, see review discussion on this PR).

## Deploy notes

None.