### PR TITLE
[AI-SETUP-27] feat: match variable pills to the real editor and resolve real labels/values

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -107,11 +107,17 @@ export function useChatStream(options: UseChatStreamOptions) {
   const toast = useToast()
   const navigate = useNavigate()
   const location = useLocation()
-  const { ddSessionId, output } = useAiBuilderContext()
+  const { ddSessionId, output, refetchTestExecutionSteps } =
+    useAiBuilderContext()
 
   // Use ref to always access the latest pipe output in prepareSendMessagesRequest
   const outputRef = useRef(output)
   outputRef.current = output
+
+  // useChat captures onFinish on mount, so without a ref this would call a
+  // stale refetch function tied to whatever query instance existed at mount.
+  const refetchTestExecutionStepsRef = useRef(refetchTestExecutionSteps)
+  refetchTestExecutionStepsRef.current = refetchTestExecutionSteps
 
   // After a refresh, chatMessages (persisted, text-only) is all that's left of
   // the conversation — every tool result and data-pipeState part (the only
@@ -272,6 +278,24 @@ export function useChatStream(options: UseChatStreamOptions) {
 
       if (pipeStatePart || isChatReady) {
         setIsReady(true)
+      }
+
+      // A step may have just been test-executed via the execute_step tool
+      // this turn — refetch so newly-available dataOutMetadata labels show
+      // up in variable pills without needing a page refresh. Best-effort:
+      // a failed refetch just leaves labels/values on their naive fallback.
+      //
+      // NOTE: this fires unconditionally every finished turn (not just ones
+      // where a step was actually executed), since precisely detecting an
+      // execute_step tool call requires reading AI SDK tool-* parts, which
+      // is unprecedented and type-unsafe in this codebase today (no shared
+      // type for the tool's output, no compile-time check on the state
+      // string). Revisit if turn volume or this query's cost ever becomes
+      // a real concern — see execute-step tool part detection discussion.
+      if (outputRef.current?.pipeId) {
+        refetchTestExecutionStepsRef.current().catch(() => {
+          // no-op: naive label/value fallback is an acceptable outcome
+        })
       }
 
       // Get current output from the ref (ensures we see latest state from other navigates)

--- a/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
+++ b/packages/frontend/src/pages/AiBuilder/AiBuilderContext.tsx
@@ -1,12 +1,15 @@
-import { IApp, IStep } from '@plumber/types'
+import { IApp, IExecutionStep, IStep } from '@plumber/types'
 
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@apollo/client'
 import { Center } from '@chakra-ui/react'
 import { datadogRum } from '@datadog/browser-rum'
 import { useIsMobile } from '@opengovsg/design-system-react'
 
 import PrimarySpinner from '@/components/PrimarySpinner'
+import { GET_TEST_EXECUTION_STEPS } from '@/graphql/queries/get-test-execution-steps'
 import { getStepGroupTypeAndCaption, getStepStructure } from '@/helpers/toolbox'
+import { extractVariables } from '@/helpers/variables'
 import { useApps } from '@/hooks/useApps'
 import { Message, PipeStatePart } from '@/hooks/useChatStream'
 
@@ -48,6 +51,13 @@ interface AIBuilderContextValue extends AIBuilderSharedProps {
   ddSessionId: string
   isDrawerOpen: boolean
   setIsDrawerOpen: (open: boolean) => void
+  // Real output-field labels (from dataOutMetadata) and their test-executed
+  // values, keyed the same way as the {{step.<id>.<path>}} placeholders —
+  // only populated for steps that have actually been test-executed. Labels
+  // fall back to a naive transform elsewhere; values simply aren't shown.
+  variableLabelsByPath: Map<string, string>
+  variableValuesByPath: Map<string, string>
+  refetchTestExecutionSteps: () => Promise<unknown>
 }
 
 const AiBuilderContext = createContext<AIBuilderContextValue | undefined>(
@@ -132,6 +142,43 @@ export const AiBuilderContextProvider = ({
     [groupedSteps],
   )
 
+  const { data: testExecutionStepsData, refetch: refetchTestExecutionSteps } =
+    useQuery<{ getTestExecutionSteps: IExecutionStep[] }>(
+      GET_TEST_EXECUTION_STEPS,
+      {
+        variables: { flowId: output?.pipeId },
+        skip: !output?.pipeId,
+      },
+    )
+
+  // Only override the naive parseParameterValue label when the app actually
+  // defined a real one — extractVariables falls back to the raw lodash path
+  // itself when a field has no metadata label, which is worse than the
+  // naive transform, not better. Values have no such fallback: they're only
+  // ever populated for steps that have actually been test-executed.
+  const { variableLabelsByPath, variableValuesByPath } = useMemo(() => {
+    const labels = new Map<string, string>()
+    const values = new Map<string, string>()
+    const stepsWithVars = extractVariables(
+      testExecutionStepsData?.getTestExecutionSteps ?? [],
+      undefined,
+      allApps,
+    )
+    for (const step of stepsWithVars) {
+      for (const variable of step.output) {
+        const path = variable.name.slice(`step.${step.id}.`.length)
+        if (variable.label && variable.label !== path) {
+          labels.set(variable.name, variable.label)
+        }
+        const displayValue = variable.displayedValue ?? variable.value
+        if (displayValue != null && displayValue !== '') {
+          values.set(variable.name, String(displayValue))
+        }
+      }
+    }
+    return { variableLabelsByPath: labels, variableValuesByPath: values }
+  }, [testExecutionStepsData, allApps])
+
   if (isLoadingAllApps) {
     return (
       <Center h="100vh">
@@ -166,6 +213,9 @@ export const AiBuilderContextProvider = ({
         setChatState,
         isDrawerOpen,
         setIsDrawerOpen,
+        variableLabelsByPath,
+        variableValuesByPath,
+        refetchTestExecutionSteps,
       }}
     >
       {children}

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/Step.tsx
@@ -1,6 +1,6 @@
 import { IApp, IJSONObject, IStep } from '@plumber/types'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { BiInfoCircle } from 'react-icons/bi'
 import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri'
 import { Box, Divider, Flex, Icon, Text } from '@chakra-ui/react'
@@ -31,13 +31,24 @@ interface StepProps {
 export default function Step(props: StepProps) {
   const { step, isNested, isLastStep, isActive, isConfigured, parameters } =
     props
-  const { allApps } = useAiBuilderContext()
+  const { allApps, steps } = useAiBuilderContext()
   const [isExpanded, setIsExpanded] = useState(false)
 
   const app = allApps?.find(
     (currentApp: IApp) => currentApp.key === step?.appKey,
   )
   const { stepName } = getStepName(allApps, step as IStep)
+
+  const stepNameById = useMemo(
+    () =>
+      new Map(
+        steps.map((s) => [
+          s.id,
+          `${s.position}. ${getStepName(allApps, s).stepName}`,
+        ]),
+      ),
+    [steps, allApps],
+  )
 
   // Only mute when we're in configuration mode (props explicitly set to false)
   // Undefined means proposal mode — show all steps at full opacity
@@ -157,6 +168,7 @@ export default function Step(props: StepProps) {
               stepKey={step.key ?? ''}
               stepId={step.id ?? ''}
               connectionLabel={step.connectionLabel}
+              stepNameById={stepNameById}
             />
           )}
         </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/StepParameterRows.tsx
@@ -141,6 +141,7 @@ interface StepParameterRowsProps {
   stepKey: string
   stepId: string
   connectionLabel?: string | null
+  stepNameById: Map<string, string>
 }
 
 export default function StepParameterRows({
@@ -149,8 +150,10 @@ export default function StepParameterRows({
   stepKey,
   stepId,
   connectionLabel,
+  stepNameById,
 }: StepParameterRowsProps) {
-  const { allApps } = useAiBuilderContext()
+  const { allApps, variableLabelsByPath, variableValuesByPath } =
+    useAiBuilderContext()
   const { parameterLabelsByStepId } = useStepConfigContext()
   const parameterLabels = parameterLabelsByStepId[stepId] ?? {}
 
@@ -216,15 +219,22 @@ export default function StepParameterRows({
               alignItems="center"
               gap={0.75}
             >
-              {segments.map((seg, i) =>
-                seg.type === 'text' ? (
+              {segments.map((seg, i) => {
+                if (seg.type === 'text') {
                   // eslint-disable-next-line react/no-array-index-key
-                  <Fragment key={i}>{seg.text}</Fragment>
-                ) : (
+                  return <Fragment key={i}>{seg.text}</Fragment>
+                }
+                const variableKey = `step.${seg.stepId}.${seg.path}`
+                return (
                   // eslint-disable-next-line react/no-array-index-key
-                  <VariablePill key={i} label={seg.label} />
-                ),
-              )}
+                  <VariablePill
+                    key={i}
+                    label={variableLabelsByPath.get(variableKey) ?? seg.label}
+                    value={variableValuesByPath.get(variableKey)}
+                    stepName={stepNameById.get(seg.stepId)}
+                  />
+                )
+              })}
             </Box>
           </ParameterRow>
         )

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/VariablePill.tsx
@@ -1,29 +1,52 @@
-import { Box } from '@chakra-ui/react'
+import { Badge, Text } from '@chakra-ui/react'
+import { TouchableTooltip } from '@opengovsg/design-system-react'
+
+import { POPOVER_OPACITY_MOTION_PROPS } from '@/theme/constants'
 
 interface VariablePillProps {
   label: string
+  value?: string
+  stepName?: string
 }
 
-export default function VariablePill({ label }: VariablePillProps) {
+export default function VariablePill({
+  label,
+  value,
+  stepName,
+}: VariablePillProps) {
+  const hasValue = Boolean(value)
+
   return (
-    <Box
-      as="span"
-      display="inline-flex"
-      alignItems="center"
-      bg="primary.100"
-      borderRadius="50px"
-      px="10px"
-      py="2px"
-      fontSize="12px"
-      color="base.content.strong"
-      fontWeight={500}
-      whiteSpace="nowrap"
-      lineHeight={1.4}
+    <TouchableTooltip
+      motionProps={POPOVER_OPACITY_MOTION_PROPS}
+      label={stepName}
+      aria-label="variable pill tooltip"
     >
-      <Box as="span" color="base.content.medium" fontWeight={400} mr="2px">
-        {'{}'}
-      </Box>
-      {label}
-    </Box>
+      <Badge
+        maxW="full"
+        variant="solid"
+        borderRadius="50px"
+        px={3}
+        py={1}
+        cursor="default"
+        bg="primary.100"
+        fontSize="sm"
+      >
+        <Text
+          as="span"
+          isTruncated
+          maxW={hasValue ? '20ch' : 'full'}
+          color="base.content.strong"
+          mr={hasValue ? '0.25rem' : undefined}
+        >
+          {label}
+        </Text>
+        {hasValue && (
+          <Text as="span" isTruncated maxW="40ch" color="base.content.medium">
+            {value}
+          </Text>
+        )}
+      </Badge>
+    </TouchableTooltip>
   )
 }

--- a/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/StepsPreview/index.tsx
@@ -294,7 +294,7 @@ export default function StepsPreview() {
           </GroupedStepContainer>
         )}
         <VStack mt={10} gap={2}>
-          <Text textStyle="body-1">Looks good?</Text>
+          {!isMcpPipeMode && <Text textStyle="body-1">Looks good?</Text>}
           <HStack alignItems="center" justifyContent="center" gap={2}>
             {isMcpPipeMode ? (
               <Button

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.test.ts
@@ -15,19 +15,34 @@ describe('parseParameterValue', () => {
 
   it('returns a single variable segment for a lone variable', () => {
     expect(parseParameterValue('{{step.abc123.email_address}}')).toEqual([
-      { type: 'variable', label: 'Email address' },
+      {
+        type: 'variable',
+        label: 'Email address',
+        stepId: 'abc123',
+        path: 'email_address',
+      },
     ])
   })
 
   it('sentence-cases and replaces underscores for the label', () => {
     expect(parseParameterValue('{{step.abc.full_name}}')).toEqual([
-      { type: 'variable', label: 'Full name' },
+      {
+        type: 'variable',
+        label: 'Full name',
+        stepId: 'abc',
+        path: 'full_name',
+      },
     ])
   })
 
   it('uses only the last dot-separated segment of the path', () => {
     expect(parseParameterValue('{{step.abc.response.email_address}}')).toEqual([
-      { type: 'variable', label: 'Email address' },
+      {
+        type: 'variable',
+        label: 'Email address',
+        stepId: 'abc',
+        path: 'response.email_address',
+      },
     ])
   })
 
@@ -36,7 +51,12 @@ describe('parseParameterValue', () => {
       parseParameterValue('Hello {{step.abc.first_name}}, welcome!'),
     ).toEqual([
       { type: 'text', text: 'Hello ' },
-      { type: 'variable', label: 'First name' },
+      {
+        type: 'variable',
+        label: 'First name',
+        stepId: 'abc',
+        path: 'first_name',
+      },
       { type: 'text', text: ', welcome!' },
     ])
   })
@@ -45,21 +65,38 @@ describe('parseParameterValue', () => {
     expect(
       parseParameterValue('{{step.abc.first_name}} {{step.def.last_name}}'),
     ).toEqual([
-      { type: 'variable', label: 'First name' },
+      {
+        type: 'variable',
+        label: 'First name',
+        stepId: 'abc',
+        path: 'first_name',
+      },
       { type: 'text', text: ' ' },
-      { type: 'variable', label: 'Last name' },
+      {
+        type: 'variable',
+        label: 'Last name',
+        stepId: 'def',
+        path: 'last_name',
+      },
     ])
   })
 
   it('handles all-uppercase variable path segment', () => {
     expect(parseParameterValue('{{step.abc.BODY}}')).toEqual([
-      { type: 'variable', label: 'Body' },
+      { type: 'variable', label: 'Body', stepId: 'abc', path: 'BODY' },
     ])
   })
 
   it('strips the hex-modifier suffix from table variables', () => {
     expect(
       parseParameterValue('{{step.abc-123-def.data|7461626c653a636f6c31}}'),
-    ).toEqual([{ type: 'variable', label: 'Data' }])
+    ).toEqual([
+      {
+        type: 'variable',
+        label: 'Data',
+        stepId: 'abc-123-def',
+        path: 'data',
+      },
+    ])
   })
 })

--- a/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/parseParameterValue.ts
@@ -1,8 +1,8 @@
 export type Segment =
   | { type: 'text'; text: string }
-  | { type: 'variable'; label: string }
+  | { type: 'variable'; label: string; stepId: string; path: string }
 
-const VARIABLE_REGEX = /\{\{step\.[^.}]+\.([^}]+)\}\}/g
+const VARIABLE_REGEX = /\{\{step\.([^.}]+)\.([^}]+)\}\}/g
 const HEX_MODIFIER_SUFFIX_REGEX = /\|[a-fA-F0-9]+$/
 
 export function parseParameterValue(value: string): Segment[] {
@@ -15,12 +15,13 @@ export function parseParameterValue(value: string): Segment[] {
     if (match.index > lastIndex) {
       segments.push({ type: 'text', text: value.slice(lastIndex, match.index) })
     }
-    const rawPath = match[1].replace(HEX_MODIFIER_SUFFIX_REGEX, '')
+    const stepId = match[1]
+    const rawPath = match[2].replace(HEX_MODIFIER_SUFFIX_REGEX, '')
     const lastSegment = rawPath.split('.').pop() ?? rawPath
     const withSpaces = lastSegment.replace(/_/g, ' ')
     const label =
       withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1).toLowerCase()
-    segments.push({ type: 'variable', label })
+    segments.push({ type: 'variable', label, stepId, path: rawPath })
     lastIndex = match.index + match[0].length
   }
 


### PR DESCRIPTION
## Stack Context

Part of the MCP AI Builder stack. This PR is a polish pass on top of the step-state-persistence work: it brings the AI Builder's step-preview UI closer to what the user will actually see once they open the real flow Editor.

## TL;DR

Restyles the AI Builder's variable pills to match the real Editor, resolves real variable labels/values once a step has been test-executed, and hides the now-irrelevant "Looks good?" prompt once a Pipe already exists.

## What changed?

- `VariablePill` now uses the same `Badge` styling as the real Editor's `VariableBadge` (padding, font size, border radius), dropping the old `{}` prefix icon.
- The pill's tooltip shows the source step's number and name (e.g. `"2. Send Slack message"`).
- Variable labels resolve to the app's real `dataOutMetadata` label (e.g. `"Recipient email(s)"`) once a step has been test-executed in the session, refetched after every chat turn; falls back to the existing naive last-segment label transform for untested steps or fields with no explicit metadata label.
- Variable pills also show the actual test-executed value as a second, muted line, matching the Editor.
- The side-drawer's "Looks good?" prompt is now hidden once `output.pipeId` is set (i.e. once the Pipe already exists in the DB) — only the "Open in editor" button remains, since there's nothing left to confirm at that point.

## Tests

- [ ] Build a flow in the AI Builder, reference an earlier step's output field in a later step's parameter, and confirm the pill in the side-drawer preview matches the real Editor's badge styling and shows the correct step-number tooltip.
- [ ] Test-execute a step whose output has app-defined `dataOutMetadata` labels (e.g. Postman's "send transactional email" action), then confirm a variable pill referencing that step's output shows the real label and value instead of the naive transform.
- [ ] Confirm a step that has **not** been test-executed still falls back to the naive label with no value shown (no crash, no blank pill).
- [ ] Confirm "Looks good?" still shows before a Pipe is created, and disappears once it exists (only "Open in editor" remains).

## Deploy notes

None — frontend-only change, no schema/migration/config changes. Reuses the existing `GetTestExecutionSteps` query already used by the real flow Editor.
