### PR TITLE
chore: bump axios to 1.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12258,9 +12258,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -34880,7 +34880,7 @@
         "ai": "5.0.81",
         "ajv-formats": "2.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.17.0",
+        "axios": "1.18.1",
         "big.js": "6.2.1",
         "cookie-parser": "1.4.7",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "overrides": {
-    "axios": "1.17.0",
+    "axios": "1.18.1",
     "graphql-rate-limit": {
       "@graphql-tools/utils": {
         "graphql": "16.11.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -55,7 +55,7 @@
     "ai": "5.0.81",
     "ajv-formats": "2.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.17.0",
+    "axios": "1.18.1",
     "big.js": "6.2.1",
     "cookie-parser": "1.4.7",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Stack Context

Part of a stack bumping several dependencies to their latest patch versions to pick up security fixes (see #1900 below this one for the transitive-dep bumps). This PR handles `axios`, which is a direct dependency here rather than transitive, so it gets its own PR for a more focused review.

## What changed?

`axios` `1.17.0` → `1.18.1` (root `overrides` + `packages/backend/package.json`). Notable fixes in this range:

- **1.17.0**: prototype-pollution guards on `socketPath`, `params`, and `paramsSerializer` reads (own-property checks).
- **1.18.0**: Node HTTP adapter now strips caller-set sensitive headers (e.g. `Authorization`) on cross-origin redirects, and rejects malformed `http:`/`https:` URLs missing `//` with `ERR_INVALID_URL`.
- **1.18.1**: makes `AxiosError#cause` non-enumerable (avoids circular JSON serialization failures), proxy-agent/keep-alive fixes.

No breaking API changes in this range.

## Why?

Checked both 1.18.0 behavior changes against actual usage since axios is used directly across backend app integrations, not just transitively:

- **Malformed-URL rejection**: not new exposure — the shared HTTP client (`packages/backend/src/helpers/http-client/index.ts`) already round-trips every URL through `new URL()` in a request interceptor before axios sees it. No code in the backend builds URLs via raw scheme+host string concatenation.
- **Cross-origin redirect header stripping**: the one place combining a user-configured arbitrary URL with user-supplied headers — the "Make a HTTP request" custom-api action (`packages/backend/src/apps/custom-api/actions/http-request/index.ts`) — sets `maxRedirects: 0` and implements its own single-hop redirect logic with its own SSRF checks, bypassing axios's automatic redirect-following entirely. Everywhere else, auth headers are attached per-app to fixed first-party hosts, never a redirect target.

Both changes are safe to take as-is.

## Tests

- [ ] Existing unit/integration tests for the apps using axios directly (auth helpers, send-email, databricks token persistence, formsg attachment decryption) pass
- [ ] `custom-api`'s "Make a HTTP request" action tests pass (highest-risk path for the redirect-handling change)

## Deploy notes

None — dependency-only change, no code or config changes.