### PR TITLE
chore: cancel superseded CI runs, trim artifact retention, add job timeouts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,7 @@ jobs:
   build:
     name: Build and push image to ECR
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -115,6 +116,7 @@ jobs:
             ${{ steps.inspector.outputs.inspector_scan_results_csv }}
             ${{ steps.inspector.outputs.inspector_scan_results_markdown }}
             ${{ steps.inspector.outputs.artifact_sbom }}
+          retention-days: 7
 
       - name: Notify Slack if vulnerability threshold is exceeded
         if: steps.inspector.outputs.vulnerability_threshold_exceeded == '1'
@@ -138,6 +140,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -2,6 +2,10 @@ name: Test and build
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -9,6 +13,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
@@ -47,6 +52,7 @@ jobs:
     name: Lint and Build
     runs-on: ubuntu-latest
     needs: setup
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -70,6 +76,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: setup
+    timeout-minutes: 24
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## TL;DR

Three small GitHub Actions cost/hygiene improvements: cancel superseded CI runs on push, shorten Inspector scan artifact retention, and add per-job timeouts sized from real run history.

## What changed?

- `test-and-build.yml`: added `concurrency: { group: "${{ github.workflow }}-${{ github.ref }}", cancel-in-progress: true }` so pushing again to a branch cancels the in-flight run for that same branch instead of letting it run to completion.
- `deploy.yml`: added `retention-days: 7` to the Inspector vulnerability scan / SBOM artifact upload (previously unset, defaulting to the org/repo default of 90 days).
- Added `timeout-minutes` to every job in both workflows (previously none had one, so a hang would run for GitHub's 360-minute default cap). Each timeout is set to roughly 2x the max duration observed in recent run history, floored at 5 minutes for short jobs so a single slow cache-miss run doesn't cause false-positive timeouts.

The three `deploy-*.yml` workflows (staging/uat/production) already had concurrency cancellation on their protected-branch push events, so no change was needed there.

### Timeout benchmarks

Sampled from `gh api repos/opengovsg/plumber/actions/runs/<id>/jobs` across 11 recent `test-and-build` runs and 8 recent `deploy.yml` runs (staging/uat/prod):

| Workflow | Job | Observed range | Typical | Max seen | New timeout |
|---|---|---|---|---|---|
| test-and-build.yml | `setup` | 12s – 1m36s | ~15-90s | 1.6min | 5 min |
| test-and-build.yml | `lint-and-build` | 1m53s – 2m37s | ~2.2min | 2.6min | 5 min |
| test-and-build.yml | `test` | 6m37s – 11m57s | ~7.3min | 12min | 24 min |
| deploy.yml | `build` (docker build + ECR push + Inspector scan) | 2m16s – 7m16s | ~4.5min | 7.3min | 15 min |
| deploy.yml | `deploy` (ECS task def render + CodeDeploy trigger) | 14s – 3m50s | ~20s | 3.8min | 8 min |

## Tests

- [ ] Push twice in quick succession to a branch and confirm the first `Test and build` run gets cancelled.
- [ ] Confirm a deploy still runs cleanly and the scan-results artifact is downloadable, with a 7-day expiry shown in the Actions UI.
- [ ] Confirm none of the new timeouts trip on a normal run (all comfortably above observed max durations).

## Deploy notes

None — workflow-only change, no app code touched.
