### PR TITLE
PLU-649 fix(gathersg): allow instant workflow trigger for cases created via email

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/schema.test.ts
@@ -64,6 +64,62 @@ describe('gathersg auth schema', () => {
       })
       expect(result.success).toBe(true)
     })
+
+    it('accepts the email-sourced createdBy sentinel (name/role/uuid all "Email"/"email") without a createdBy.email field', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Email',
+          role: 'email',
+          uuid: 'email',
+        },
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('email-sourced createdBy invalid cases', () => {
+    it('rejects when uuid is missing (not the exact sentinel shape)', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Email',
+          role: 'email',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects when name does not match "Email"', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Not Email',
+          role: 'email',
+          uuid: 'email',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects when role does not match "email"', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Email',
+          role: 'user',
+          uuid: 'email',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects when uuid does not match "email"', () => {
+      const result = schema.safeParse({
+        createdBy: {
+          name: 'Email',
+          role: 'email',
+          uuid: 'some-real-uuid',
+        },
+      })
+      expect(result.success).toBe(false)
+    })
   })
 
   describe('invalid cases - missing email', () => {

--- a/packages/backend/src/apps/gathersg/__tests__/triggers/new-instant-workflow/get-data-out-metadata.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/triggers/new-instant-workflow/get-data-out-metadata.test.ts
@@ -114,6 +114,29 @@ describe('getDataOutMetadata', () => {
       expect(result?.data.createdBy).toEqual({
         email: { label: 'Created by (email)' },
         name: { label: 'Created by (name)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
+      })
+    })
+
+    it('should show createdBy metadata for a case created via email', async () => {
+      const executionStep = createMockExecutionStep({
+        data: {
+          caseRef: 'CASE-001',
+          createdBy: {
+            name: 'Email',
+            role: 'email',
+            uuid: 'email',
+          },
+        },
+      })
+
+      const result = await getDataOutMetadata(executionStep)
+      expect(result?.data.createdBy).toEqual({
+        email: { label: 'Created by (email)' },
+        name: { label: 'Created by (name)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
       })
     })
 
@@ -499,6 +522,8 @@ describe('getDataOutMetadata', () => {
       expect(result?.data.createdBy).toEqual({
         email: { label: 'Created by (email)' },
         name: { label: 'Created by (name)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
       })
       expect(result?.data.fields.name).toEqual({ label: 'name' })
       expect(result?.data.fields[hexEncodedField]).toEqual({

--- a/packages/backend/src/apps/gathersg/auth/schema.ts
+++ b/packages/backend/src/apps/gathersg/auth/schema.ts
@@ -17,6 +17,8 @@ const schema = z
       .object({
         email: z.string().min(1).optional(),
         name: z.string().min(1).optional(),
+        role: z.string().min(1).optional(),
+        uuid: z.string().min(1).optional(),
       })
       .nullish(),
     formsg: z
@@ -49,6 +51,17 @@ const schema = z
           createdBy?.name === 'FormSG' &&
           formsg?.formId &&
           formsg?.submissionId
+        ) {
+          return true
+        }
+
+        // when the case is auto-created from an inbound email, Gather sends a
+        // sentinel createdBy of exactly { name: 'Email', role: 'email', uuid: 'email' }
+        // instead of a real user's email.
+        if (
+          createdBy?.name === 'Email' &&
+          createdBy?.role === 'email' &&
+          createdBy?.uuid === 'email'
         ) {
           return true
         }

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/get-data-out-metadata.ts
@@ -35,10 +35,21 @@ async function getDataOutMetadata(
     submissionId: 'FormSG (submission ID)',
   })
 
-  const createdByMetadata = createOptionalNestedMetadata(dataOut?.createdBy, {
-    email: 'Created by (email)',
-    name: 'Created by (name)',
-  })
+  // Built inline rather than via createOptionalNestedMetadata: createdBy's
+  // role/uuid are only ever sentinel values (e.g. when a case is auto-created
+  // from an inbound email), so they must always stay hidden rather than
+  // getting a label. createOptionalNestedMetadata expects a single label per
+  // key, so forcing role/uuid through it would mean passing throwaway label
+  // strings that could accidentally leak into the UI if the hiding logic is
+  // ever refactored away.
+  const createdByMetadata = dataOut?.createdBy
+    ? {
+        email: { label: 'Created by (email)' },
+        name: { label: 'Created by (name)' },
+        role: { isHidden: true },
+        uuid: { isHidden: true },
+      }
+    : { isHidden: true }
 
   const updatedByMetadata = createOptionalNestedMetadata(dataOut?.updatedBy, {
     email: 'Updated by (email)',

--- a/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
+++ b/packages/backend/src/apps/gathersg/triggers/new-instant-workflow/schema.ts
@@ -43,6 +43,8 @@ export const dataOutSchema = z.object({
         .object({
           email: z.string().min(1).nullish(),
           name: z.string().min(1),
+          role: z.string().min(1).nullish(),
+          uuid: z.string().min(1).nullish(),
         })
         .nullish(),
       finalisedBy: z


### PR DESCRIPTION
## TL;DR

Ownself Gather's "New instant workflow" trigger was silently rejecting webhook events for cases auto-created via inbound email. This PR allows that case through and exposes the new `createdBy` fields Gather sends for it.

## What changed?

- `auth/schema.ts`: the webhook's infinite-loop guard requires `createdBy.email` to be present unless the payload matches the existing FormSG exemption (`createdBy.name === 'FormSG'` + `formsg` data). Cases created from an inbound email send `createdBy: { name: 'Email', role: 'email', uuid: 'email' }` with no `email` field, so they always failed this check and were dropped before reaching the flow. Added a second exemption matching that exact sentinel shape.
- `triggers/new-instant-workflow/schema.ts`: added optional `role`/`uuid` to `createdBy` so the new fields parse instead of being silently stripped.
- `triggers/new-instant-workflow/get-data-out-metadata.ts`: surfaces `role`/`uuid` as hidden data-out metadata on `createdBy` (matching the existing convention in `get-case-details`), since they're sentinel values rather than user-facing data.
- Added/updated unit tests for both the auth bypass (including negative cases where any one of `name`/`role`/`uuid` doesn't match) and the data-out metadata shape.

Fixes [PLU-860](https://linear.app/ogp/issue/PLU-860/update-ownself-gather-new-instant-workflow-to-allow-case-creation-via).

## Why?

Users building "New instant workflow" pipes in Ownself Gather want the flow to trigger when a case is created via email, not just via a real user or FormSG submission. The guard's intent is to prevent an infinite loop (Plumber's own actions writing back to Gather re-triggering the webhook), which only applies to genuinely automated, non-human-initiated payloads — email-initiated case creation is a legitimate external trigger, not a loop risk, so it should pass through like the existing FormSG case.

## Tests

- [ ] Confirm a real "instant workflow" case creation via email in Ownself Gather now successfully triggers the Plumber pipe (previously it silently failed with "potential infinite loop" logged).
- [ ] Confirm case creation/updates from a real user (with `createdBy.email`) and FormSG submissions still trigger as before (no regression).
- [ ] Confirm the "Created by (name)"/"Created by (email)" variables still populate correctly for the email-created case's `createdBy.name` field, and that `role`/`uuid` don't appear as pickable variables.

## Deploy notes

None — no migrations, config, or infra changes.
