### PR TITLE
[AI-FORMSG-SETUP-2]: PLU-805 add get_form_schema bridge tool for public FormSG schemas

### DIFF
--- a/packages/backend/src/apps/formsg/auth/verify-credentials.ts
+++ b/packages/backend/src/apps/formsg/auth/verify-credentials.ts
@@ -73,12 +73,12 @@ export const parseSecretKeyFormat = ($: IGlobalVariable): string => {
   return $.auth.data.privateKey as string
 }
 
-export const parseFormIdFormat = ($: IGlobalVariable): string => {
-  if (!$.auth.data?.formId || typeof $.auth.data.formId !== 'string') {
+export const parseFormIdFromInput = (rawFormId: unknown): string => {
+  if (!rawFormId || typeof rawFormId !== 'string') {
     throw new Error('No form id provided')
   }
 
-  let formId = $.auth.data.formId
+  let formId = rawFormId
 
   if (formId.length < FORM_ID_LENGTH) {
     throw new Error('Invalid form id')
@@ -99,6 +99,10 @@ export const parseFormIdFormat = ($: IGlobalVariable): string => {
   }
 
   return formId
+}
+
+export const parseFormIdFormat = ($: IGlobalVariable): string => {
+  return parseFormIdFromInput($.auth.data?.formId)
 }
 
 const verifyCredentials = async ($: IGlobalVariable) => {

--- a/packages/backend/src/apps/formsg/common/form-env.ts
+++ b/packages/backend/src/apps/formsg/common/form-env.ts
@@ -35,9 +35,7 @@ function isSupportedFormEnv(rawEnv: string): rawEnv is FormEnv {
   return envs.includes(rawEnv)
 }
 
-export function parseFormEnv($: IGlobalVariable): FormEnv {
-  const { formId } = $.auth.data
-
+export function parseFormEnvFromInput(formId: unknown): FormEnv {
   if (!formId || typeof formId !== 'string') {
     throw new Error('Provide a valid FormSG URL')
   }
@@ -66,6 +64,10 @@ export function parseFormEnv($: IGlobalVariable): FormEnv {
   // If we are here, then formId is the actual form ID itself without a url.
   // For legacy reasons, we assume that it's prod.
   return 'prod'
+}
+
+export function parseFormEnv($: IGlobalVariable): FormEnv {
+  return parseFormEnvFromInput($.auth.data.formId)
 }
 
 export function getSdk(env: FormEnv): ReturnType<typeof formsgSdk> {

--- a/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
+++ b/packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts
@@ -27,6 +27,17 @@ vi.mock('@/services/mcp/get-dynamic-data', () => ({
     .fn()
     .mockResolvedValue([{ name: 'Channel', value: 'C123' }]),
 }))
+vi.mock('@/services/mcp/get-form-schema', () => ({
+  getFormSchemaService: vi.fn().mockResolvedValue({
+    formId: 'a'.repeat(24),
+    env: 'prod',
+    title: 'Test Form',
+    isStorageMode: true,
+    isMrf: false,
+    fields: [],
+    warnings: [],
+  }),
+}))
 vi.mock('@/services/mcp/register-connection', () => ({
   registerConnectionService: vi
     .fn()
@@ -38,6 +49,7 @@ import { createFlowWithStepsService } from '@/services/mcp/create-flow-with-step
 import { createStepService } from '@/services/mcp/create-step'
 import { deleteStepService } from '@/services/mcp/delete-step'
 import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
+import { getFormSchemaService } from '@/services/mcp/get-form-schema'
 import { registerConnectionService } from '@/services/mcp/register-connection'
 import { updateStepParametersService } from '@/services/mcp/update-step-parameters'
 
@@ -58,6 +70,7 @@ describe('createMcpBridgeTools', () => {
       'delete_step',
       'get_dynamic_data',
       'execute_step',
+      'get_form_schema',
       'register_connection',
     ])
   })
@@ -143,6 +156,18 @@ describe('createMcpBridgeTools', () => {
       key: 'listChannels',
       parameters: { tableId: 'xyz' },
     })
+  })
+
+  it('get_form_schema calls getFormSchemaService with the form url', async () => {
+    const tools = createMcpBridgeTools(mockUser, mockTraceId)
+    const result = await tools.get_form_schema.execute(
+      { form_url: 'https://form.gov.sg/' + 'a'.repeat(24) },
+      { toolCallId: 'get_form_schema', messages: [] },
+    )
+    expect(vi.mocked(getFormSchemaService)).toHaveBeenCalledWith(
+      'https://form.gov.sg/' + 'a'.repeat(24),
+    )
+    expect(result).toMatchObject({ title: 'Test Form' })
   })
 
   it('register_connection calls registerConnectionService with correct args', async () => {

--- a/packages/backend/src/helpers/mcp-bridge-tools.ts
+++ b/packages/backend/src/helpers/mcp-bridge-tools.ts
@@ -19,6 +19,10 @@ import {
 } from '@/services/mcp/execute-step'
 import { getDynamicDataService } from '@/services/mcp/get-dynamic-data'
 import {
+  getFormSchemaService,
+  type McpFormSchemaResult,
+} from '@/services/mcp/get-form-schema'
+import {
   listConnectionsService,
   type McpConnection,
 } from '@/services/mcp/list-connections'
@@ -266,6 +270,25 @@ export function createMcpBridgeTools(
             onPipeChange?.(pipeId)
           }
         }
+      },
+    }),
+
+    get_form_schema: tool({
+      description:
+        'Fetch the PUBLIC schema of a FormSG form from its URL or bare 24-character form ID. ' +
+        'Requires no connection and no secret key, so it can be used before a pipe or connection exists. ' +
+        'Returns the form title, storage-mode/MRF flags, warnings, and per-field ' +
+        '{ id, title, fieldType, required, answerType, variablePath } for templating variables as ' +
+        '{{step.<triggerStepId>.<variablePath>}}. Errors are returned as { error } — relay them to the user.',
+      inputSchema: z.object({
+        form_url: z
+          .string()
+          .describe(
+            'FormSG form URL (e.g. https://form.gov.sg/<id>) or bare 24-character form ID.',
+          ),
+      }),
+      execute: async ({ form_url }): Promise<McpFormSchemaResult> => {
+        return getFormSchemaService(form_url)
       },
     }),
 

--- a/packages/backend/src/routes/api/chat/schema.ts
+++ b/packages/backend/src/routes/api/chat/schema.ts
@@ -131,6 +131,7 @@ const messagePartSchema = z.discriminatedUnion('type', [
   toolPart('tool-create_step'),
   toolPart('tool-delete_step'),
   toolPart('tool-get_dynamic_data'),
+  toolPart('tool-get_form_schema'),
   toolPart('tool-execute_step'),
   toolPart('tool-register_connection'),
 ])

--- a/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
+++ b/packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts
@@ -1,0 +1,284 @@
+import axios from 'axios'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getFormSchemaService } from '../get-form-schema'
+
+vi.mock('axios')
+
+const FORM_ID = '654ab1234abc1a012345f1e0'
+
+function mockForm(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      form: {
+        _id: FORM_ID,
+        title: 'Workshop Registration',
+        responseMode: 'encrypt',
+        publicKey: 'some-public-key',
+        form_fields: [] as unknown[],
+        ...overrides,
+      },
+    },
+  }
+}
+
+describe('getFormSchemaService', () => {
+  beforeEach(() => {
+    vi.mocked(axios.get).mockReset()
+  })
+
+  describe('input parsing (SSRF safety)', () => {
+    it('fetches against the prod API for a bare form id', async () => {
+      vi.mocked(axios.get).mockResolvedValue(mockForm())
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(vi.mocked(axios.get)).toHaveBeenCalledWith(
+        `https://form.gov.sg/api/v3/forms/${FORM_ID}`,
+        expect.anything(),
+      )
+      expect(result).toMatchObject({ formId: FORM_ID, env: 'prod' })
+    })
+
+    it('fetches against the prod API for a share URL', async () => {
+      vi.mocked(axios.get).mockResolvedValue(mockForm())
+
+      await getFormSchemaService(`https://form.gov.sg/${FORM_ID}`)
+
+      expect(vi.mocked(axios.get)).toHaveBeenCalledWith(
+        `https://form.gov.sg/api/v3/forms/${FORM_ID}`,
+        expect.anything(),
+      )
+    })
+
+    it('fetches against the staging API for a staging admin URL', async () => {
+      vi.mocked(axios.get).mockResolvedValue(mockForm())
+
+      const result = await getFormSchemaService(
+        `https://staging.form.gov.sg/admin/form/${FORM_ID}`,
+      )
+
+      expect(vi.mocked(axios.get)).toHaveBeenCalledWith(
+        `https://staging.form.gov.sg/api/v3/forms/${FORM_ID}`,
+        expect.anything(),
+      )
+      expect(result).toMatchObject({ env: 'staging' })
+    })
+
+    it('never fetches a non-form.gov.sg URL', async () => {
+      const result = await getFormSchemaService(
+        `https://evil.example.com/${FORM_ID}`,
+      )
+
+      expect(vi.mocked(axios.get)).not.toHaveBeenCalled()
+      expect(result).toEqual({ error: 'Invalid form url' })
+    })
+
+    it('rejects a URL whose trailing 24 chars are not a hex form id', async () => {
+      const result = await getFormSchemaService(
+        'https://form.gov.sg/admin/form/not-a-valid-hex-form-id!',
+      )
+
+      expect(vi.mocked(axios.get)).not.toHaveBeenCalled()
+      expect(result).toEqual({ error: 'Invalid form id' })
+    })
+
+    it('rejects inputs shorter than a form id', async () => {
+      const result = await getFormSchemaService('abc123')
+
+      expect(vi.mocked(axios.get)).not.toHaveBeenCalled()
+      expect(result).toEqual({ error: 'Invalid form id' })
+    })
+  })
+
+  describe('field mapping', () => {
+    it('maps wireable fields with answer/answerArray variable paths', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({
+          form_fields: [
+            {
+              _id: 'f1',
+              title: 'Full name',
+              fieldType: 'textfield',
+              required: true,
+            },
+            {
+              _id: 'f2',
+              title: 'Sessions attending',
+              fieldType: 'checkbox',
+              required: false,
+              fieldOptions: ['AM', 'PM'],
+            },
+          ],
+        }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({
+        fields: [
+          {
+            id: 'f1',
+            title: 'Full name',
+            fieldType: 'textfield',
+            required: true,
+            answerType: 'answer',
+            variablePath: 'fields.f1.answer',
+          },
+          {
+            id: 'f2',
+            answerType: 'answerArray',
+            variablePath: 'fields.f2.answerArray',
+            options: ['AM', 'PM'],
+          },
+        ],
+      })
+    })
+
+    it('skips non-wireable fields (section/statement/image/children)', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({
+          form_fields: [
+            { _id: 'f1', title: 'Header', fieldType: 'section' },
+            { _id: 'f2', title: 'Info', fieldType: 'statement' },
+            { _id: 'f3', title: 'Logo', fieldType: 'image' },
+            { _id: 'f4', title: 'Child', fieldType: 'children' },
+            { _id: 'f5', title: 'Email', fieldType: 'email' },
+          ],
+        }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({ fields: [{ id: 'f5' }] })
+      expect((result as { fields: unknown[] }).fields).toHaveLength(1)
+    })
+
+    it('caps options and reports the truncated count', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({
+          form_fields: [
+            {
+              _id: 'f1',
+              title: 'Country',
+              fieldType: 'dropdown',
+              fieldOptions: Array.from({ length: 25 }, (_, i) => `Option ${i}`),
+            },
+          ],
+        }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      const field = (result as { fields: any[] }).fields[0]
+      expect(field.options).toHaveLength(10)
+      expect(field.optionsTruncated).toBe(15)
+    })
+
+    it('maps table columns and myInfo attributes', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({
+          form_fields: [
+            {
+              _id: 'f1',
+              title: 'Attendees',
+              fieldType: 'table',
+              columns: [
+                { _id: 'c1', title: 'Name' },
+                { _id: 'c2', title: 'Role' },
+              ],
+            },
+            {
+              _id: 'f2',
+              title: 'NRIC',
+              fieldType: 'nric',
+              myInfo: { attr: 'nric' },
+            },
+          ],
+        }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({
+        fields: [
+          {
+            id: 'f1',
+            answerType: 'answerArray',
+            columns: [
+              { id: 'c1', title: 'Name' },
+              { id: 'c2', title: 'Role' },
+            ],
+          },
+          { id: 'f2', myInfoAttr: 'nric' },
+        ],
+      })
+    })
+  })
+
+  describe('warnings', () => {
+    it('warns when the form is not storage mode', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({ publicKey: undefined, responseMode: 'email' }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({
+        isStorageMode: false,
+        warnings: [expect.stringContaining('not a storage mode form')],
+      })
+    })
+
+    it('warns when the form is MRF', async () => {
+      vi.mocked(axios.get).mockResolvedValue(
+        mockForm({ responseMode: 'multirespondent' }),
+      )
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toMatchObject({
+        isMrf: true,
+        warnings: [expect.stringContaining('multi-respondent')],
+      })
+    })
+  })
+
+  describe('fetch errors returned as data', () => {
+    it('reports a non-public form (404 with isPageFound)', async () => {
+      vi.mocked(axios.get).mockRejectedValue({
+        message: 'Request failed',
+        response: { status: 404, data: { isPageFound: true } },
+      })
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toEqual({
+        error: expect.stringContaining('not public'),
+      })
+    })
+
+    it('reports a nonexistent form (plain 404)', async () => {
+      vi.mocked(axios.get).mockRejectedValue({
+        message: 'Request failed',
+        response: { status: 404, data: {} },
+      })
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toEqual({
+        error: expect.stringContaining('does not exist'),
+      })
+    })
+
+    it('reports a generic failure for network errors', async () => {
+      vi.mocked(axios.get).mockRejectedValue(new Error('ECONNRESET'))
+
+      const result = await getFormSchemaService(FORM_ID)
+
+      expect(result).toEqual({
+        error: expect.stringContaining('Unable to fetch form'),
+      })
+    })
+  })
+})

--- a/packages/backend/src/services/mcp/get-form-schema.ts
+++ b/packages/backend/src/services/mcp/get-form-schema.ts
@@ -1,0 +1,198 @@
+import axios from 'axios'
+
+import { parseFormIdFromInput } from '@/apps/formsg/auth/verify-credentials'
+import {
+  FormEnv,
+  getApiBaseUrl,
+  parseFormEnvFromInput,
+} from '@/apps/formsg/common/form-env'
+import logger from '@/helpers/logger'
+
+const FORM_ID_REGEX = /^[a-f0-9]{24}$/i
+
+const REQUEST_TIMEOUT_MS = 10_000
+
+const MAX_OPTIONS = 10
+
+// Fields that never produce a wireable answer.
+const NON_WIREABLE_FIELD_TYPES = new Set([
+  'section',
+  'statement',
+  'image',
+  'children', // MyInfo child records
+])
+
+// Fields whose answer arrives as `answerArray` instead of `answer` — see
+// process-v3-responses.ts / process-v4-responses.ts.
+const ANSWER_ARRAY_FIELD_TYPES = new Set([
+  'checkbox',
+  'table',
+  'address',
+  'signature',
+])
+
+export interface McpFormField {
+  id: string
+  title: string
+  fieldType: string
+  required: boolean
+  answerType: 'answer' | 'answerArray'
+  variablePath: string
+  options?: string[]
+  /** Number of options omitted when the list is longer than MAX_OPTIONS. */
+  optionsTruncated?: number
+  columns?: Array<{ id: string; title: string }>
+  myInfoAttr?: string
+}
+
+export interface McpFormSchema {
+  formId: string
+  env: FormEnv
+  title: string
+  isStorageMode: boolean
+  isMrf: boolean
+  fields: McpFormField[]
+  warnings: string[]
+}
+
+export type McpFormSchemaResult = McpFormSchema | { error: string }
+
+// Raw shape of the public GET /v3/forms/{id} response — only what we read.
+interface PublicFormField {
+  _id: string
+  title: string
+  fieldType: string
+  required?: boolean
+  fieldOptions?: string[]
+  columns?: Array<{ _id: string; title: string }>
+  myInfo?: { attr?: string }
+}
+
+interface PublicFormResponse {
+  form?: {
+    _id: string
+    title: string
+    responseMode: string
+    publicKey?: string
+    form_fields?: PublicFormField[]
+  }
+}
+
+function toMcpFormField(field: PublicFormField): McpFormField {
+  const answerType = ANSWER_ARRAY_FIELD_TYPES.has(field.fieldType)
+    ? 'answerArray'
+    : 'answer'
+
+  const result: McpFormField = {
+    id: field._id,
+    title: field.title,
+    fieldType: field.fieldType,
+    required: field.required ?? false,
+    answerType,
+    variablePath: `fields.${field._id}.${answerType}`,
+  }
+
+  if (field.fieldOptions?.length) {
+    result.options = field.fieldOptions.slice(0, MAX_OPTIONS)
+    if (field.fieldOptions.length > MAX_OPTIONS) {
+      result.optionsTruncated = field.fieldOptions.length - MAX_OPTIONS
+    }
+  }
+
+  if (field.columns?.length) {
+    result.columns = field.columns.map((c) => ({ id: c._id, title: c.title }))
+  }
+
+  if (field.myInfo?.attr) {
+    result.myInfoAttr = field.myInfo.attr
+  }
+
+  return result
+}
+
+/**
+ * Fetches the PUBLIC schema of a FormSG form — no connection or secret key
+ * involved. Errors are returned as data ({ error }), never thrown, so the
+ * LLM can relay them.
+ *
+ * SSRF-safe: the raw input is only ever parsed into a validated 24-hex-char
+ * form ID and a known environment; the fetched URL is constructed against
+ * the corresponding *.form.gov.sg API base and the user string is never
+ * fetched directly.
+ */
+export async function getFormSchemaService(
+  formUrlOrId: string,
+): Promise<McpFormSchemaResult> {
+  let formId: string
+  let env: FormEnv
+  try {
+    const trimmed = formUrlOrId.trim()
+    formId = parseFormIdFromInput(trimmed)
+    env = parseFormEnvFromInput(trimmed)
+  } catch (e) {
+    return { error: (e as Error).message }
+  }
+
+  if (!FORM_ID_REGEX.test(formId)) {
+    return { error: 'Invalid form id' }
+  }
+
+  let response: PublicFormResponse
+  try {
+    const { data } = await axios.get<PublicFormResponse>(
+      `${getApiBaseUrl(env)}/v3/forms/${formId}`,
+      { timeout: REQUEST_TIMEOUT_MS },
+    )
+    response = data
+  } catch (e) {
+    logger.warn('getFormSchemaService: error fetching public form schema', {
+      formId,
+      env,
+      error: e.message,
+    })
+    if (e.response?.status === 404) {
+      if (e.response.data?.isPageFound) {
+        return {
+          error:
+            'This form is not public. Ask the user to make the form public and try again.',
+        }
+      }
+      return { error: 'Form does not exist. Check the form URL.' }
+    }
+    return { error: 'Unable to fetch form. Try again later.' }
+  }
+
+  const form = response?.form
+  if (!form?.title) {
+    return { error: 'Unable to fetch form. Try again later.' }
+  }
+
+  const isStorageMode = Boolean(form.publicKey)
+  const isMrf = form.responseMode === 'multirespondent'
+
+  const warnings: string[] = []
+  if (!isStorageMode) {
+    warnings.push(
+      'This form is not a storage mode form, so it cannot be connected to Plumber.',
+    )
+  }
+  if (isMrf) {
+    warnings.push(
+      'This is a multi-respondent (MRF) form, which is not supported by Plumber.',
+    )
+  }
+
+  const fields = (form.form_fields ?? [])
+    .filter((f) => !NON_WIREABLE_FIELD_TYPES.has(f.fieldType))
+    .map(toMcpFormField)
+
+  return {
+    formId,
+    env,
+    title: form.title,
+    isStorageMode,
+    isMrf,
+    fields,
+    warnings,
+  }
+}


### PR DESCRIPTION
### TL;DR

Adds a `get_form_schema` MCP tool that fetches the public schema of a FormSG form without requiring a connection or secret key.

### What changed?

- Introduced `getFormSchemaService` which accepts a FormSG URL or bare 24-character form ID, validates and parses it in an SSRF-safe manner, then fetches the public form schema from the appropriate FormSG API endpoint (prod or staging).
- The service returns structured form metadata including the title, storage-mode/MRF flags, per-field details (`id`, `title`, `fieldType`, `required`, `answerType`, `variablePath`), field options (capped at 10 with a truncation count), table columns, myInfo attributes, and any relevant warnings. Errors are returned as `{ error }` rather than thrown.
- Refactored `parseFormIdFormat` and `parseFormEnv` to extract their core logic into `parseFormIdFromInput` and `parseFormEnvFromInput` respectively, accepting raw values instead of `IGlobalVariable`, so they can be reused by `getFormSchemaService`.
- Registered the `get_form_schema` tool in `createMcpBridgeTools` and added `tool-get_form_schema` to the chat message schema.

### How to test?

- Run the new unit tests: `packages/backend/src/services/mcp/__tests__/get-form-schema.test.ts` and `packages/backend/src/helpers/__tests__/mcp-bridge-tools.test.ts`.
- Via the MCP bridge, call `get_form_schema` with a valid FormSG URL (e.g. `https://form.gov.sg/<24-char-id>`) and verify it returns the form title, fields, and warnings.
- Call `get_form_schema` with an invalid URL (e.g. a non-`form.gov.sg` domain) and verify it returns `{ error: 'Invalid form url' }` without making any HTTP requests.
- Call `get_form_schema` with a form that is not set to public and verify the appropriate error message is returned.

### Why make this change?

The LLM assistant needs to inspect a form's fields and structure before a pipe or connection exists, so it can help users template variables correctly. Previously there was no way to retrieve this information without first setting up a connection. This tool enables the assistant to fetch public form metadata upfront, improving the guided pipe-creation experience.