### PR TITLE
feat(mcp): connect-first start — Connect your form entry on empty state

### DIFF
--- a/packages/frontend/src/hooks/useChatStream.ts
+++ b/packages/frontend/src/hooks/useChatStream.ts
@@ -418,10 +418,17 @@ export function useChatStream(options: UseChatStreamOptions) {
     parameterLabelsByStepId,
     activeStepId,
     completedStepIds,
+    hasPipe,
+    knownFormSchema,
   } = useMemo(() => {
     const byStepId: Record<string, IJSONObject> = {}
     const labelsByStepId: Record<string, Record<string, string>> = {}
     let latestStepId: string | null = null
+    let pipeSeen = false
+    // Latest successful get_form_schema tool result — the AI SDK streams
+    // tool outputs as message parts, so the form's real title is already
+    // client-side once the LLM fetches the schema.
+    let latestFormSchema: { title: string; formId: string } | null = null
     const completed = new Set<string>()
 
     for (const msg of aiMessages) {
@@ -440,10 +447,31 @@ export function useChatStream(options: UseChatStreamOptions) {
           latestStepId = stepId
         }
         if (part.type === 'data-pipeState') {
+          pipeSeen = true
           for (const step of (part as PipeStatePart).data.steps) {
             if (step.status === 'completed') {
               completed.add(step.id)
             }
+          }
+        }
+        const toolPart = part as {
+          type: string
+          toolName?: string
+          output?: { title?: unknown; formId?: unknown; error?: unknown }
+        }
+        const isFormSchemaResult =
+          toolPart.type === 'tool-get_form_schema' ||
+          (toolPart.type === 'dynamic-tool' &&
+            toolPart.toolName === 'get_form_schema')
+        if (
+          isFormSchemaResult &&
+          typeof toolPart.output?.title === 'string' &&
+          typeof toolPart.output?.formId === 'string' &&
+          !toolPart.output.error
+        ) {
+          latestFormSchema = {
+            title: toolPart.output.title,
+            formId: toolPart.output.formId,
           }
         }
       }
@@ -454,6 +482,8 @@ export function useChatStream(options: UseChatStreamOptions) {
       parameterLabelsByStepId: labelsByStepId,
       activeStepId: latestStepId,
       completedStepIds: completed,
+      hasPipe: pipeSeen,
+      knownFormSchema: latestFormSchema,
     }
   }, [aiMessages])
 
@@ -489,5 +519,7 @@ export function useChatStream(options: UseChatStreamOptions) {
     stepParametersByStepId,
     parameterLabelsByStepId,
     completedStepIds,
+    hasPipe,
+    knownFormSchema,
   }
 }

--- a/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/AddFormsgConnectionModal.tsx
@@ -30,6 +30,10 @@ import {
 import FileUpload from '@/components/FileUpload'
 import { CREATE_CONNECTION } from '@/graphql/mutations/create-connection'
 import { VERIFY_CONNECTION } from '@/graphql/mutations/verify-connection'
+import {
+  isValidFormUrlInput,
+  normalizeFormUrlInput,
+} from '@/pages/AiBuilder/helpers'
 
 // Matches the format of a form's private key downloaded from FormSG, same
 // check the editor's DragDropInput uses for the same field.
@@ -38,19 +42,32 @@ const SECRET_KEY_REGEX = /^[a-zA-Z0-9/+]+={0,2}$/
 interface AddFormsgConnectionModalProps {
   isOpen: boolean
   // A connection can only be created once the pipe exists (see
-  // AiBuilder/index.tsx's onAddConnection gating) — this is that pipe's id.
+  // AiBuilder/index.tsx's onAddConnection/onConnectForm gating) — this is
+  // that pipe's id. Only meaningful for the 'full' variant, the only one
+  // that calls createConnection.
   flowId?: string
+  // 'url-only': pre-pipe "Connect your form" pill — collects just the URL,
+  // no secret key, no connection row (see onSubmitUrl).
+  // 'full': URL + secret key, creates a real connection (see onSuccess).
+  variant: 'url-only' | 'full'
   prefillFormUrl?: string
+  // The URL is already known from the conversation and hard-locked to that
+  // form — only reachable for the 'full' variant's key-completion path.
+  lockFormUrl?: boolean
   onClose: () => void
   onSuccess: (connectionLabel: string, connectionId: string) => void
+  onSubmitUrl: (formUrl: string) => void
 }
 
 export default function AddFormsgConnectionModal({
   isOpen,
   flowId,
+  variant,
   prefillFormUrl,
+  lockFormUrl,
   onClose,
   onSuccess,
+  onSubmitUrl,
 }: AddFormsgConnectionModalProps) {
   const [formUrl, setFormUrl] = useState('')
   const [secretKey, setSecretKey] = useState('')
@@ -139,7 +156,23 @@ export default function AddFormsgConnectionModal({
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
-    if (!formUrl.trim() || !secretKey.trim() || !flowId || inProgress) {
+    if (inProgress) {
+      return
+    }
+
+    const trimmedUrl = formUrl.trim()
+    if (!isValidFormUrlInput(trimmedUrl)) {
+      return
+    }
+    const normalizedUrl = normalizeFormUrlInput(trimmedUrl)
+
+    if (variant === 'url-only') {
+      onSubmitUrl(normalizedUrl)
+      onClose()
+      return
+    }
+
+    if (!secretKey.trim() || !flowId) {
       return
     }
 
@@ -154,7 +187,7 @@ export default function AddFormsgConnectionModal({
           input: {
             key: 'formsg',
             formattedData: {
-              formId: formUrl.trim(),
+              formId: normalizedUrl,
               privateKey: secretKey.trim(),
             },
             flowId,
@@ -174,7 +207,7 @@ export default function AddFormsgConnectionModal({
       const label =
         (verifyData?.verifyConnection?.formattedData?.screenName as
           | string
-          | undefined) ?? formUrl.trim()
+          | undefined) ?? normalizedUrl
 
       onSuccess(label, connectionId)
       onClose()
@@ -188,13 +221,24 @@ export default function AddFormsgConnectionModal({
     }
   }
 
+  const modalTitle =
+    variant === 'url-only'
+      ? 'Share your form'
+      : lockFormUrl
+      ? 'Add your Form Secret Key'
+      : 'Add new form'
+
+  const isSubmitDisabled =
+    !isValidFormUrlInput(formUrl) ||
+    (variant === 'full' && (!secretKey.trim() || !flowId))
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md" isCentered>
       <ModalOverlay />
       <ModalContent borderRadius="lg">
         <form onSubmit={handleSubmit}>
           <ModalHeader>
-            Add new form
+            {modalTitle}
             <ModalCloseButton isDisabled={inProgress} />
           </ModalHeader>
           <ModalBody display="flex" flexDirection="column" gap={4}>
@@ -215,68 +259,70 @@ export default function AddFormsgConnectionModal({
                 onChange={(e) => setFormUrl(e.target.value)}
                 placeholder="https://form.gov.sg/…"
                 autoComplete="url"
-                isDisabled={inProgress}
+                isDisabled={inProgress || lockFormUrl}
               />
             </FormControl>
 
-            <FormControl isInvalid={!!secretKeyFileError}>
-              <RequiredFormLabel isRequired mb={1}>
-                Form Secret Key
-              </RequiredFormLabel>
-              <Text textStyle="body-2" color="base.content.medium" mb={2}>
-                This is the key you downloaded/saved when you created the form
-              </Text>
-              <Stack spacing="0.5rem" direction="row">
-                <Input
-                  type="password"
-                  value={secretKey}
-                  onChange={(e) => {
-                    setSecretKeyFileError(null)
-                    setSecretKey(e.target.value)
-                  }}
-                  {...(dragging
-                    ? {
-                        py: 12,
-                        backgroundColor: 'primary.50',
-                        borderColor: 'primary.500',
-                        borderWidth: 2,
-                        borderStyle: 'dashed',
-                        _focusVisible: {
-                          boxShadow: 'none',
-                        },
-                      }
-                    : undefined)}
-                  onDragEnter={inProgress ? undefined : handleDragEnter}
-                  onDragLeave={inProgress ? undefined : handleDragLeave}
-                  onDragOver={inProgress ? undefined : handleDragOver}
-                  onDrop={inProgress ? undefined : handleDrop}
-                  placeholder={
-                    dragging
-                      ? 'Drop your file here'
-                      : 'Enter or drop your Secret Key here to continue'
-                  }
-                  autoComplete="off"
-                  isDisabled={inProgress}
-                  transition="padding 0.2s ease-out"
-                />
-                <FileUpload
-                  accept="text/plain"
-                  processFile={processSecretKeyFile}
-                  disabled={inProgress}
-                />
-              </Stack>
-              {secretKeyFileError && (
-                <FormErrorMessage>{secretKeyFileError}</FormErrorMessage>
-              )}
-            </FormControl>
+            {variant === 'full' && (
+              <FormControl isInvalid={!!secretKeyFileError}>
+                <RequiredFormLabel isRequired mb={1}>
+                  Form Secret Key
+                </RequiredFormLabel>
+                <Text textStyle="body-2" color="base.content.medium" mb={2}>
+                  This is the key you downloaded/saved when you created the form
+                </Text>
+                <Stack spacing="0.5rem" direction="row">
+                  <Input
+                    type="password"
+                    value={secretKey}
+                    onChange={(e) => {
+                      setSecretKeyFileError(null)
+                      setSecretKey(e.target.value)
+                    }}
+                    {...(dragging
+                      ? {
+                          py: 12,
+                          backgroundColor: 'primary.50',
+                          borderColor: 'primary.500',
+                          borderWidth: 2,
+                          borderStyle: 'dashed',
+                          _focusVisible: {
+                            boxShadow: 'none',
+                          },
+                        }
+                      : undefined)}
+                    onDragEnter={inProgress ? undefined : handleDragEnter}
+                    onDragLeave={inProgress ? undefined : handleDragLeave}
+                    onDragOver={inProgress ? undefined : handleDragOver}
+                    onDrop={inProgress ? undefined : handleDrop}
+                    placeholder={
+                      dragging
+                        ? 'Drop your file here'
+                        : 'Enter or drop your Secret Key here to continue'
+                    }
+                    autoComplete="off"
+                    isDisabled={inProgress}
+                    transition="padding 0.2s ease-out"
+                  />
+                  <FileUpload
+                    accept="text/plain"
+                    processFile={processSecretKeyFile}
+                    disabled={inProgress}
+                  />
+                </Stack>
+                {secretKeyFileError && (
+                  <FormErrorMessage>{secretKeyFileError}</FormErrorMessage>
+                )}
+              </FormControl>
+            )}
           </ModalBody>
           <ModalFooter>
             <Button
               type="submit"
               isLoading={inProgress}
-              isDisabled={!formUrl.trim() || !secretKey.trim() || !flowId}
+              isDisabled={isSubmitDisabled}
             >
-              Connect
+              {variant === 'url-only' ? 'Share' : 'Connect'}
             </Button>
           </ModalFooter>
         </form>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/DynamicPicker.tsx
@@ -32,6 +32,13 @@ interface DynamicPickerProps {
   onSelect: (name: string, value: string) => void
   onSkip: () => void
   onAddConnection?: () => void
+  /**
+   * FormSG only: a form URL already shared in the conversation. When set,
+   * the picker skips the connections list entirely and shows a single
+   * "finish connecting" card — the user just adds their secret key for the
+   * form they already chose.
+   */
+  knownFormUrl?: string
   cancelStream: () => void
 }
 
@@ -44,6 +51,7 @@ export default function DynamicPicker({
   onSelect,
   onSkip,
   onAddConnection,
+  knownFormUrl,
   cancelStream,
 }: DynamicPickerProps) {
   const [options, setOptions] = useState<DynamicPickerOption[]>([])
@@ -59,7 +67,18 @@ export default function DynamicPicker({
 
   const isAppKeyMode = Boolean(appKey)
 
+  // Forced key-completion mode: the form is already known from the
+  // conversation, so listing other connections would only invite a mismatch.
+  const isKnownFormMode = Boolean(
+    isAppKeyMode && appKey === 'formsg' && knownFormUrl && onAddConnection,
+  )
+
   useEffect(() => {
+    if (isKnownFormMode) {
+      setIsLoading(false)
+      return
+    }
+
     abortRef.current?.abort()
     const controller = new AbortController()
     abortRef.current = controller
@@ -111,7 +130,7 @@ export default function DynamicPicker({
       })
 
     return () => controller.abort()
-  }, [stepId, dynamicKey, appKey, retryCount]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [stepId, dynamicKey, appKey, retryCount, isKnownFormMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const filtered = query
     ? options.filter((o) => o.name.toLowerCase().includes(query.toLowerCase()))
@@ -179,7 +198,27 @@ export default function DynamicPicker({
         )}
 
         <Flex direction="column" gap={2} maxH="240px" overflowY="auto">
-          {isLoading ? (
+          {isKnownFormMode ? (
+            <Flex
+              direction="column"
+              align="flex-start"
+              gap={3}
+              bg="gray.50"
+              borderRadius="lg"
+              p={4}
+            >
+              <Text textStyle="body-2" color="gray.700">
+                We already have your form&apos;s URL — add your{' '}
+                <Text as="span" fontWeight="medium">
+                  Form Secret Key
+                </Text>{' '}
+                to connect it.
+              </Text>
+              <Button isDisabled={isStreaming} onClick={onAddConnection}>
+                Connect your form
+              </Button>
+            </Flex>
+          ) : isLoading ? (
             <Flex justify="center" py={4}>
               <Spinner size="sm" color="primary.500" />
             </Flex>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -18,11 +18,7 @@ import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicke
 import DynamicPicker from '@/pages/AiBuilder/components/ChatInterface/DynamicPicker'
 import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
-import {
-  AI_CHAT_IDEAS,
-  type AiChatIdea,
-  EMPTY_STATE_FORM_HINT,
-} from '@/pages/AiBuilder/constants'
+import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
 
 interface PromptInputProps {
   isStreaming: boolean
@@ -114,6 +110,22 @@ export default function PromptInput({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // The resize handler above only fires on typed input, but a long
+  // placeholder wraps onto multiple lines too — without this, the fixed
+  // single-row height overflows and shows a spurious scrollbar. Measure the
+  // placeholder's wrapped height the same way (swap it into the DOM value
+  // just for the measurement) whenever the box is empty.
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el || input) {
+      return
+    }
+    const original = el.value
+    el.value = placeholder
+    handleResize({ currentTarget: el } as FormEvent<HTMLTextAreaElement>)
+    el.value = original
+  }, [placeholder, input])
 
   const handleAnswer = (answer: string) => {
     if (isStreaming || !clarification) {
@@ -328,12 +340,6 @@ export default function PromptInput({
           </Flex>
         )}
       </Flex>
-
-      {showIdeas && onConnectForm && (
-        <Text textStyle="caption-1" color="gray.500" mt={2} px={1}>
-          {EMPTY_STATE_FORM_HINT}
-        </Text>
-      )}
 
       {showIdeas && (
         <Box minH={{ base: '200px', md: '60px' }} mt={6}>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -18,7 +18,11 @@ import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicke
 import DynamicPicker from '@/pages/AiBuilder/components/ChatInterface/DynamicPicker'
 import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
-import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
+import {
+  AI_CHAT_IDEAS,
+  type AiChatIdea,
+  EMPTY_STATE_FORM_HINT,
+} from '@/pages/AiBuilder/constants'
 
 interface PromptInputProps {
   isStreaming: boolean
@@ -30,12 +34,18 @@ interface PromptInputProps {
   clarification?: ClarificationQuestion[]
   dynamicPicker?: DynamicPickerPart['data']
   onAddConnection?: (context: { question: string }) => void
+  /** Form URL already shared in the conversation (drives the picker's forced key-completion card). */
+  knownFormUrl?: string
   /** Opens the Add-new-form modal (empty-state "Connect your form" entry). */
   onConnectForm?: () => void
   /** Kicks off the chat with an existing connection. */
   onSelectExistingForm?: (label: string, connectionId: string) => void
-  /** Display-only chip anchoring the connected form to the composer. */
-  attachedForm?: { label: string } | null
+  /**
+   * Display-only chip anchoring the conversation's form to the composer —
+   * the connected form's title, or the shared URL (isConnected: false)
+   * before a secret key has been added.
+   */
+  attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
 export default function PromptInput({
@@ -48,6 +58,7 @@ export default function PromptInput({
   clarification,
   dynamicPicker,
   onAddConnection,
+  knownFormUrl,
   onConnectForm,
   onSelectExistingForm,
   attachedForm,
@@ -169,6 +180,7 @@ export default function PromptInput({
             ? () => onAddConnection({ question: dynamicPicker.question })
             : undefined
         }
+        knownFormUrl={knownFormUrl}
         cancelStream={cancelStream}
       />
     )
@@ -295,6 +307,16 @@ export default function PromptInput({
                 <Text textStyle="caption-1" noOfLines={1} color="gray.700">
                   {attachedForm.label}
                 </Text>
+                {attachedForm.isConnected === false && (
+                  <Text
+                    textStyle="caption-1"
+                    color="gray.400"
+                    flexShrink={0}
+                    whiteSpace="nowrap"
+                  >
+                    · not connected
+                  </Text>
+                )}
               </Flex>
             ) : onConnectForm && onSelectExistingForm ? (
               <ConnectFormPopover
@@ -306,6 +328,12 @@ export default function PromptInput({
           </Flex>
         )}
       </Flex>
+
+      {showIdeas && onConnectForm && (
+        <Text textStyle="caption-1" color="gray.500" mt={2} px={1}>
+          {EMPTY_STATE_FORM_HINT}
+        </Text>
+      )}
 
       {showIdeas && (
         <Box minH={{ base: '200px', md: '60px' }} mt={6}>

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/PromptInput.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { FaArrowCircleUp } from 'react-icons/fa'
 import { FaCircleStop } from 'react-icons/fa6'
-import { Box, Flex, Icon, Textarea } from '@chakra-ui/react'
+import { Box, Flex, Icon, Image, Text, Textarea } from '@chakra-ui/react'
 
 import {
   type ClarificationQuestion,
@@ -16,6 +16,7 @@ import {
 } from '@/hooks/useChatStream'
 import ChoicePicker from '@/pages/AiBuilder/components/ChatInterface/ChoicePicker'
 import DynamicPicker from '@/pages/AiBuilder/components/ChatInterface/DynamicPicker'
+import ConnectFormPopover from '@/pages/AiBuilder/components/ConnectFormPopover'
 import IdeaButtons from '@/pages/AiBuilder/components/IdeaButtons'
 import { AI_CHAT_IDEAS, type AiChatIdea } from '@/pages/AiBuilder/constants'
 
@@ -29,6 +30,12 @@ interface PromptInputProps {
   clarification?: ClarificationQuestion[]
   dynamicPicker?: DynamicPickerPart['data']
   onAddConnection?: (context: { question: string }) => void
+  /** Opens the Add-new-form modal (empty-state "Connect your form" entry). */
+  onConnectForm?: () => void
+  /** Kicks off the chat with an existing connection. */
+  onSelectExistingForm?: (label: string, connectionId: string) => void
+  /** Display-only chip anchoring the connected form to the composer. */
+  attachedForm?: { label: string } | null
 }
 
 export default function PromptInput({
@@ -41,6 +48,9 @@ export default function PromptInput({
   clarification,
   dynamicPicker,
   onAddConnection,
+  onConnectForm,
+  onSelectExistingForm,
+  attachedForm,
 }: PromptInputProps) {
   const [input, setInput] = useState<string>(initialValue)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -181,11 +191,12 @@ export default function PromptInput({
     )
   }
 
+  const showChipsRow = Boolean(onConnectForm || attachedForm)
+
   return (
     <Box w="full" maxW="4xl">
       <Flex
-        direction="row"
-        align="stretch"
+        direction="column"
         bg="white"
         border="1px"
         borderColor="gray.200"
@@ -196,71 +207,104 @@ export default function PromptInput({
         minH={showIdeas ? '120px' : '50px'}
         height="auto"
       >
-        <Textarea
-          ref={textareaRef}
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyPress}
-          placeholder={placeholder}
-          w="full"
-          resize="none"
-          border="none"
-          bg="transparent"
-          p={3}
-          color="gray.900"
-          _placeholder={{ color: 'gray.500' }}
-          _focus={{ outline: 'none', boxShadow: 'none' }}
-          fontSize="base"
-          lineHeight="6"
-          maxH="calc(40vh - 100px)"
-          rows={1}
-          overflowY="auto"
-          sx={{
-            '&::-webkit-scrollbar': {
-              width: '8px',
-            },
-            '&::-webkit-scrollbar-track': {
-              background: 'transparent',
-            },
-            '&::-webkit-scrollbar-thumb': {
-              backgroundColor: 'rgba(0, 0, 0, 0.2)',
-              borderRadius: '4px',
-            },
-            '&::-webkit-scrollbar-thumb:hover': {
-              backgroundColor: 'rgba(0, 0, 0, 0.3)',
-            },
-          }}
-          onInput={handleResize}
-          onFocus={(e) => {
-            // prevent iOS Safari from zooming in on input focus
-            e.currentTarget.style.fontSize = '16px'
-          }}
-        />
+        <Flex direction="row" align="stretch" flex={1}>
+          <Textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyPress}
+            placeholder={placeholder}
+            w="full"
+            resize="none"
+            border="none"
+            bg="transparent"
+            p={3}
+            color="gray.900"
+            _placeholder={{ color: 'gray.500' }}
+            _focus={{ outline: 'none', boxShadow: 'none' }}
+            fontSize="base"
+            lineHeight="6"
+            maxH="calc(40vh - 100px)"
+            rows={1}
+            overflowY="auto"
+            sx={{
+              '&::-webkit-scrollbar': {
+                width: '8px',
+              },
+              '&::-webkit-scrollbar-track': {
+                background: 'transparent',
+              },
+              '&::-webkit-scrollbar-thumb': {
+                backgroundColor: 'rgba(0, 0, 0, 0.2)',
+                borderRadius: '4px',
+              },
+              '&::-webkit-scrollbar-thumb:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.3)',
+              },
+            }}
+            onInput={handleResize}
+            onFocus={(e) => {
+              // prevent iOS Safari from zooming in on input focus
+              e.currentTarget.style.fontSize = '16px'
+            }}
+          />
 
-        <Flex justify="end" align="flex-end" p={3}>
-          {isStreaming ? (
-            <Icon
-              as={FaCircleStop}
-              fontSize="24px"
-              color="red.500"
-              cursor="pointer"
-              onClick={cancelStream}
-              _hover={{ color: 'red.600' }}
-            />
-          ) : (
-            <Icon
-              as={FaArrowCircleUp}
-              fontSize="24px"
-              color={
-                input?.trim()
-                  ? 'primary.500'
-                  : 'interaction.support.disabled-content'
-              }
-              onClick={handleSubmit}
-              cursor={input?.trim() ? 'pointer' : 'default'}
-            />
-          )}
+          <Flex justify="end" align="flex-end" p={3}>
+            {isStreaming ? (
+              <Icon
+                as={FaCircleStop}
+                fontSize="24px"
+                color="red.500"
+                cursor="pointer"
+                onClick={cancelStream}
+                _hover={{ color: 'red.600' }}
+              />
+            ) : (
+              <Icon
+                as={FaArrowCircleUp}
+                fontSize="24px"
+                color={
+                  input?.trim()
+                    ? 'primary.500'
+                    : 'interaction.support.disabled-content'
+                }
+                onClick={handleSubmit}
+                cursor={input?.trim() ? 'pointer' : 'default'}
+              />
+            )}
+          </Flex>
         </Flex>
+
+        {showChipsRow && (
+          <Flex px={2} pb={1} pt={1} align="center" gap={2}>
+            {attachedForm ? (
+              <Flex
+                align="center"
+                gap={1.5}
+                bg="gray.50"
+                borderRadius="full"
+                px={2.5}
+                py={1}
+                maxW="full"
+              >
+                <Image
+                  src="/apps/formsg/assets/favicon.svg"
+                  boxSize="14px"
+                  alt="FormSG"
+                />
+                <Text textStyle="caption-1" noOfLines={1} color="gray.700">
+                  {attachedForm.label}
+                </Text>
+              </Flex>
+            ) : onConnectForm && onSelectExistingForm ? (
+              <ConnectFormPopover
+                isStreaming={isStreaming}
+                onSelectExisting={onSelectExistingForm}
+                onAddNewForm={onConnectForm}
+              />
+            ) : null}
+          </Flex>
+        )}
       </Flex>
 
       {showIdeas && (

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -24,6 +24,9 @@ interface ChatInterfaceProps {
   resetChat: () => void
   hasReachedLimit: boolean
   onAddConnection?: (context: { question: string }) => void
+  onConnectForm?: () => void
+  onSelectExistingForm?: (label: string, connectionId: string) => void
+  attachedForm?: { label: string } | null
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
@@ -37,6 +40,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat,
     hasReachedLimit,
     onAddConnection,
+    onConnectForm,
+    onSelectExistingForm,
+    attachedForm,
   } = props
   const navigate = useNavigate()
   const location = useLocation()
@@ -134,6 +140,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
             placeholder={
               PLACEHOLDER_MESSAGES[Date.now() % PLACEHOLDER_MESSAGES.length]
             }
+            onConnectForm={onConnectForm}
+            onSelectExistingForm={onSelectExistingForm}
+            attachedForm={attachedForm}
           />
         </Flex>
       </Flex>
@@ -195,6 +204,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   clarification={activeClarification}
                   dynamicPicker={activeDynamicPicker}
                   onAddConnection={onAddConnection}
+                  attachedForm={attachedForm}
                 />
               )}
               {!isMobile && (

--- a/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatInterface/index.tsx
@@ -24,9 +24,10 @@ interface ChatInterfaceProps {
   resetChat: () => void
   hasReachedLimit: boolean
   onAddConnection?: (context: { question: string }) => void
+  knownFormUrl?: string
   onConnectForm?: () => void
   onSelectExistingForm?: (label: string, connectionId: string) => void
-  attachedForm?: { label: string } | null
+  attachedForm?: { label: string; isConnected?: boolean } | null
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
@@ -40,6 +41,7 @@ export default function ChatInterface(props: ChatInterfaceProps) {
     resetChat,
     hasReachedLimit,
     onAddConnection,
+    knownFormUrl,
     onConnectForm,
     onSelectExistingForm,
     attachedForm,
@@ -204,6 +206,9 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                   clarification={activeClarification}
                   dynamicPicker={activeDynamicPicker}
                   onAddConnection={onAddConnection}
+                  knownFormUrl={knownFormUrl}
+                  onConnectForm={onConnectForm}
+                  onSelectExistingForm={onSelectExistingForm}
                   attachedForm={attachedForm}
                 />
               )}

--- a/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ChatMessages/ChatMessage.tsx
@@ -2,7 +2,10 @@ import { memo } from 'react'
 import { Box, Flex, Text } from '@chakra-ui/react'
 
 import { Message } from '@/hooks/useChatStream'
-import { prepareAiText } from '@/pages/AiBuilder/helpers'
+import {
+  formatUserMessageForDisplay,
+  prepareAiText,
+} from '@/pages/AiBuilder/helpers'
 import { ChakraStreamdown } from '@/theme/components/Streamdown'
 
 import ChatMessageToolbar from './ChatMessageToolbar'
@@ -36,7 +39,7 @@ const AiMessage = memo(
 AiMessage.displayName = 'AiMessage'
 
 const UserMessage = memo(({ message }: ChatMessageProps) => {
-  const displayText = message.text.replace(/ \(id: [^)]+\)$/gm, '')
+  const displayText = formatUserMessageForDisplay(message.text)
   return (
     <Flex justify="flex-end">
       <Box

--- a/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
+++ b/packages/frontend/src/pages/AiBuilder/components/ConnectFormPopover.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Image,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Spinner,
+  Text,
+  Tooltip,
+  useDisclosure,
+} from '@chakra-ui/react'
+
+import { stripFormIdPrefix } from '../helpers'
+
+interface FormConnectionOption {
+  name: string
+  value: string
+}
+
+interface ConnectFormPopoverProps {
+  isStreaming: boolean
+  /** Called with the connection's full label and id when an existing form is picked. */
+  onSelectExisting: (label: string, connectionId: string) => void
+  /** Opens the Add-new-form modal. */
+  onAddNewForm: () => void
+}
+
+/**
+ * Empty-state "Connect your form" chip. Clicking it lists the user's existing
+ * FormSG connections so they can reuse one instead of creating a duplicate;
+ * users with no connections go straight to the Add-new-form modal.
+ */
+export default function ConnectFormPopover({
+  isStreaming,
+  onSelectExisting,
+  onAddNewForm,
+}: ConnectFormPopoverProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [options, setOptions] = useState<FormConnectionOption[] | null>(null)
+
+  const handleOpen = async () => {
+    setOptions(null)
+    onOpen()
+
+    try {
+      const res = await fetch('/api/connections?appKey=formsg', {
+        method: 'GET',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        throw new Error(`Fetch failed: ${res.status}`)
+      }
+      const json = await res.json()
+      const data: FormConnectionOption[] = json.data ?? []
+
+      if (data.length === 0) {
+        onClose()
+        onAddNewForm()
+        return
+      }
+      setOptions(data)
+    } catch {
+      // Can't list existing connections — fall back to adding a new form.
+      onClose()
+      onAddNewForm()
+    }
+  }
+
+  return (
+    <Popover isOpen={isOpen} onClose={onClose} placement="top-start" isLazy>
+      <Tooltip
+        label="Most workflows start with a FormSG form. Connect yours and I'll guide you based on its actual fields."
+        hasArrow
+        placement="top-start"
+        isDisabled={isOpen}
+      >
+        <Flex display="inline-flex">
+          <PopoverTrigger>
+            <Button
+              variant="outline"
+              size="xs"
+              borderRadius="full"
+              color="gray.700"
+              borderColor="gray.200"
+              fontWeight="medium"
+              px={2.5}
+              leftIcon={
+                <Image
+                  src="/apps/formsg/assets/favicon.svg"
+                  boxSize="14px"
+                  alt=""
+                />
+              }
+              isDisabled={isStreaming}
+              onClick={handleOpen}
+            >
+              Connect your form
+            </Button>
+          </PopoverTrigger>
+        </Flex>
+      </Tooltip>
+      <PopoverContent w="320px" border="none" boxShadow="lg" borderRadius="lg">
+        <PopoverBody p={2}>
+          {options === null ? (
+            <Flex justify="center" py={3}>
+              <Spinner size="sm" color="primary.500" />
+            </Flex>
+          ) : (
+            <Flex direction="column">
+              <Text textStyle="caption-1" color="gray.500" px={2} py={1}>
+                Choose a form to build with
+              </Text>
+              <Flex direction="column" maxH="240px" overflowY="auto">
+                {options.map((opt, idx) => (
+                  <Box
+                    key={opt.value}
+                    as="button"
+                    type="button"
+                    w="full"
+                    textAlign="left"
+                    px={3}
+                    py={2}
+                    borderRadius="md"
+                    bg={idx % 2 === 0 ? 'gray.50' : 'white'}
+                    _hover={{ bg: 'primary.50' }}
+                    _active={{ bg: 'primary.100' }}
+                    onClick={() => {
+                      onClose()
+                      onSelectExisting(opt.name, opt.value)
+                    }}
+                  >
+                    <Text
+                      textStyle="body-2"
+                      whiteSpace="normal"
+                      color="gray.800"
+                    >
+                      {stripFormIdPrefix(opt.name)}
+                    </Text>
+                  </Box>
+                ))}
+              </Flex>
+              <Divider my={1} />
+              <Box
+                as="button"
+                type="button"
+                w="full"
+                textAlign="left"
+                px={3}
+                py={2}
+                borderRadius="md"
+                _hover={{ bg: 'primary.50' }}
+                _active={{ bg: 'primary.100' }}
+                onClick={() => {
+                  onClose()
+                  onAddNewForm()
+                }}
+              >
+                <Text
+                  textStyle="body-2"
+                  fontWeight="medium"
+                  color="primary.500"
+                >
+                  Add a new form
+                </Text>
+              </Box>
+            </Flex>
+          )}
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -36,7 +36,12 @@ export const PLACEHOLDER_MESSAGES = [
   'Think in order. What happens first, and what follows',
   "Describe what you have in mind and we'll show you what's possible",
   "Share what you're trying to do and we'll help you figure out the best way to automate it",
+  "Paste your FormSG form link and we'll suggest workflows built on its fields",
 ]
+
+// Shown under the empty-state composer alongside the Connect-your-form pill.
+export const EMPTY_STATE_FORM_HINT =
+  'Have a form? Paste its link, or connect it with your Secret Key and we will suggest workflows for you to build on it.'
 
 // Maximum number of messages allowed in a conversation (hard limit)
 export const MAX_MESSAGES = 50

--- a/packages/frontend/src/pages/AiBuilder/constants.ts
+++ b/packages/frontend/src/pages/AiBuilder/constants.ts
@@ -36,12 +36,7 @@ export const PLACEHOLDER_MESSAGES = [
   'Think in order. What happens first, and what follows',
   "Describe what you have in mind and we'll show you what's possible",
   "Share what you're trying to do and we'll help you figure out the best way to automate it",
-  "Paste your FormSG form link and we'll suggest workflows built on its fields",
 ]
-
-// Shown under the empty-state composer alongside the Connect-your-form pill.
-export const EMPTY_STATE_FORM_HINT =
-  'Have a form? Paste its link, or connect it with your Secret Key and we will suggest workflows for you to build on it.'
 
 // Maximum number of messages allowed in a conversation (hard limit)
 export const MAX_MESSAGES = 50

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -31,7 +31,7 @@ export const prepareAiText = (text: string): string =>
 // formatUserMessageForDisplay) and the user only sees the form title. The
 // exact shape is a contract with the system prompt's connect-first intake
 // branch — change both together.
-export const buildKickoffMessage = (
+export const buildFormConnectedMessage = (
   formTitle: string,
   connectionId: string,
   formId: string | null,
@@ -39,8 +39,57 @@ export const buildKickoffMessage = (
   const technicalRef = formId
     ? `(id: ${connectionId}, form id: ${formId})`
     : `(id: ${connectionId})`
-  return `I've connected my FormSG form "${formTitle}" ${technicalRef}. Suggest workflows I can build with this form.`
+  return `I've connected my FormSG form "${formTitle}" ${technicalRef}.`
 }
+
+export const buildKickoffMessage = (
+  formTitle: string,
+  connectionId: string,
+  formId: string | null,
+): string =>
+  `${buildFormConnectedMessage(
+    formTitle,
+    connectionId,
+    formId,
+  )} Suggest workflows I can build with this form.`
+
+// Sent when the user shares their form URL (url-only modal) without
+// connecting it — the LLM's URL-first intake branch picks the URL up and
+// fetches the public schema.
+export const buildUrlSharedMessage = (formUrl: string): string =>
+  `Here's my form: ${formUrl}.`
+
+export const buildUrlSharedKickoffMessage = (formUrl: string): string =>
+  `${buildUrlSharedMessage(formUrl)} Suggest workflows I can build with it.`
+
+// Accepts a FormSG share/admin URL in any supported environment, or a bare
+// 24-hex-char form ID (both shapes work with get_form_schema).
+export const isValidFormUrlInput = (input: string): boolean => {
+  const trimmed = input.trim()
+  return (
+    /^[a-f0-9]{24}$/i.test(trimmed) ||
+    /^https:\/\/(?:[a-z0-9-]+\.)?form\.gov\.sg\/(?:[a-zA-Z0-9/]*\/)?[a-f0-9]{24}\/?$/i.test(
+      trimmed,
+    )
+  )
+}
+
+// Bare 24-hex form IDs become a full prod share URL so everything downstream
+// (extractLastFormUrl, the forced key card, modal prefill) sees one shape.
+export const normalizeFormUrlInput = (input: string): string => {
+  const trimmed = input.trim()
+  return /^[a-f0-9]{24}$/i.test(trimmed)
+    ? `https://form.gov.sg/${trimmed}`
+    : trimmed
+}
+
+// Compact display label for a shared-but-not-connected form URL, e.g.
+// "form.gov.sg/654ab1…f1e0" — used for the composer chip before the real
+// form title is known (which requires a connection).
+export const formatFormUrlLabel = (formUrl: string): string =>
+  formUrl
+    .replace(/^https:\/\//i, '')
+    .replace(/([a-f0-9]{6})[a-f0-9]{14}([a-f0-9]{4})/i, '$1…$2')
 
 // Pull the 24-hex-char form ID out of a FormSG connection screenName.
 export const extractFormIdFromLabel = (label: string): string | null =>

--- a/packages/frontend/src/pages/AiBuilder/helpers.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers.ts
@@ -24,6 +24,40 @@ export const normalizeMarkdownHeadings = (text: string): string =>
 export const prepareAiText = (text: string): string =>
   normalizeMarkdownHeadings(stripHtmlComments(text))
 
+// First user message sent after connecting a form from the empty state.
+// The parenthetical carries the connection id (for assigning the trigger in
+// Phase 2b) and form id (for get_form_schema); it follows the same "(id: …)"
+// convention as picker answers, so the chat display strips it (see
+// formatUserMessageForDisplay) and the user only sees the form title. The
+// exact shape is a contract with the system prompt's connect-first intake
+// branch — change both together.
+export const buildKickoffMessage = (
+  formTitle: string,
+  connectionId: string,
+  formId: string | null,
+): string => {
+  const technicalRef = formId
+    ? `(id: ${connectionId}, form id: ${formId})`
+    : `(id: ${connectionId})`
+  return `I've connected my FormSG form "${formTitle}" ${technicalRef}. Suggest workflows I can build with this form.`
+}
+
+// Pull the 24-hex-char form ID out of a FormSG connection screenName.
+export const extractFormIdFromLabel = (label: string): string | null =>
+  label.match(/[a-f0-9]{24}/i)?.[0] ?? null
+
+// FormSG connection screenNames look like "[STAGING] [MRF] <24-hex-form-id> -
+// <form title>". Drop the form-id segment for display; keep any env/MRF
+// prefixes since they are informative.
+export const stripFormIdPrefix = (label: string): string =>
+  label.replace(/^((?:\[[A-Z]+\] )*)[a-f0-9]{24} - /i, '$1')
+
+// User messages are displayed verbatim except for machine detail: picker
+// answers and the kickoff message carry "(id: …)" / "(id: …, form id: …)"
+// suffixes that are stripped from display.
+export const formatUserMessageForDisplay = (text: string): string =>
+  text.replace(/ \(id: [a-f0-9-]+(?:, form id: [a-f0-9]+)?\)/g, '').trim()
+
 // Matches FormSG share links across environments (form.gov.sg,
 // staging.form.gov.sg, …) ending in a 24-hex-char form ID.
 const FORM_URL_REGEX =

--- a/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildKickoffMessage,
+  extractFormIdFromLabel,
+  formatUserMessageForDisplay,
+  stripFormIdPrefix,
+} from '../helpers'
+
+describe('buildKickoffMessage', () => {
+  // The exact shape is a contract with the system prompt's connect-first
+  // intake branch (Langfuse) — if this test needs updating, the prompt's
+  // recognition rule must be updated in the same release.
+  it('carries the connection and form ids in the parenthetical', () => {
+    expect(
+      buildKickoffMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        '654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678, ' +
+        'form id: 654ab1234abc1a012345f1e0). ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+
+  it('omits the form id when unknown', () => {
+    expect(
+      buildKickoffMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        null,
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678). ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+
+  it('displays without the technical parenthetical', () => {
+    const message = buildKickoffMessage(
+      'Workshop Registration 2026',
+      '3f2c8e10-1234-5678-9abc-def012345678',
+      '654ab1234abc1a012345f1e0',
+    )
+    expect(formatUserMessageForDisplay(message)).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026". ' +
+        'Suggest workflows I can build with this form.',
+    )
+  })
+})
+
+describe('extractFormIdFromLabel', () => {
+  it('pulls the form id out of a screenName', () => {
+    expect(
+      extractFormIdFromLabel(
+        '654ab1234abc1a012345f1e0 - Workshop Registration',
+      ),
+    ).toBe('654ab1234abc1a012345f1e0')
+  })
+
+  it('returns null when no form id is present', () => {
+    expect(extractFormIdFromLabel('My Custom Label')).toBeNull()
+  })
+})
+
+describe('stripFormIdPrefix', () => {
+  it('drops the form-id segment from a screenName', () => {
+    expect(
+      stripFormIdPrefix('654ab1234abc1a012345f1e0 - Workshop Registration'),
+    ).toBe('Workshop Registration')
+  })
+
+  it('keeps env/MRF prefixes', () => {
+    expect(
+      stripFormIdPrefix(
+        '[STAGING] [MRF] 654ab1234abc1a012345f1e0 - Workshop Registration',
+      ),
+    ).toBe('[STAGING] [MRF] Workshop Registration')
+  })
+
+  it('returns labels without a form-id prefix unchanged', () => {
+    expect(stripFormIdPrefix('My Custom Label')).toBe('My Custom Label')
+  })
+})
+
+describe('formatUserMessageForDisplay', () => {
+  it('strips picker id suffixes', () => {
+    expect(
+      formatUserMessageForDisplay(
+        'Q: Which form?\nA: My Form (id: 3f2c8e10-1234-5678-9abc-def012345678)',
+      ),
+    ).toBe('Q: Which form?\nA: My Form')
+  })
+})

--- a/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
+++ b/packages/frontend/src/pages/AiBuilder/helpers/buildKickoffMessage.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildFormConnectedMessage,
   buildKickoffMessage,
+  buildUrlSharedKickoffMessage,
+  buildUrlSharedMessage,
   extractFormIdFromLabel,
+  formatFormUrlLabel,
   formatUserMessageForDisplay,
+  isValidFormUrlInput,
+  normalizeFormUrlInput,
   stripFormIdPrefix,
 } from '../helpers'
 
@@ -50,6 +56,89 @@ describe('buildKickoffMessage', () => {
       'I\'ve connected my FormSG form "Workshop Registration 2026". ' +
         'Suggest workflows I can build with this form.',
     )
+  })
+})
+
+describe('buildFormConnectedMessage', () => {
+  // Mid-conversation announcement — same shape as the kickoff but without
+  // the suggestion request, so the LLM continues from where it left off.
+  it('omits the workflow-suggestion request', () => {
+    expect(
+      buildFormConnectedMessage(
+        'Workshop Registration 2026',
+        '3f2c8e10-1234-5678-9abc-def012345678',
+        '654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      'I\'ve connected my FormSG form "Workshop Registration 2026" ' +
+        '(id: 3f2c8e10-1234-5678-9abc-def012345678, ' +
+        'form id: 654ab1234abc1a012345f1e0).',
+    )
+  })
+})
+
+describe('buildUrlSharedMessage', () => {
+  it('shares the url plainly mid-conversation', () => {
+    expect(
+      buildUrlSharedMessage('https://form.gov.sg/654ab1234abc1a012345f1e0'),
+    ).toBe("Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0.")
+  })
+
+  it('asks for suggestions as the first message', () => {
+    expect(
+      buildUrlSharedKickoffMessage(
+        'https://form.gov.sg/654ab1234abc1a012345f1e0',
+      ),
+    ).toBe(
+      "Here's my form: https://form.gov.sg/654ab1234abc1a012345f1e0. " +
+        'Suggest workflows I can build with it.',
+    )
+  })
+})
+
+describe('isValidFormUrlInput', () => {
+  it.each([
+    'https://form.gov.sg/654ab1234abc1a012345f1e0',
+    'https://form.gov.sg/654ab1234abc1a012345f1e0/',
+    'https://staging.form.gov.sg/admin/form/654ab1234abc1a012345f1e0',
+    '654ab1234abc1a012345f1e0',
+    '  https://form.gov.sg/654ab1234abc1a012345f1e0  ',
+  ])('accepts %s', (input) => {
+    expect(isValidFormUrlInput(input)).toBe(true)
+  })
+
+  it.each([
+    'https://example.com/654ab1234abc1a012345f1e0',
+    'https://form.gov.sg/not-a-form-id',
+    'my form is https://form.gov.sg/654ab1234abc1a012345f1e0',
+    'abc123',
+    '',
+  ])('rejects %s', (input) => {
+    expect(isValidFormUrlInput(input)).toBe(false)
+  })
+})
+
+describe('normalizeFormUrlInput', () => {
+  it('expands a bare form id into a prod share URL', () => {
+    expect(normalizeFormUrlInput('  654ab1234abc1a012345f1e0 ')).toBe(
+      'https://form.gov.sg/654ab1234abc1a012345f1e0',
+    )
+  })
+
+  it('leaves full URLs untouched', () => {
+    expect(
+      normalizeFormUrlInput(
+        'https://staging.form.gov.sg/654ab1234abc1a012345f1e0',
+      ),
+    ).toBe('https://staging.form.gov.sg/654ab1234abc1a012345f1e0')
+  })
+})
+
+describe('formatFormUrlLabel', () => {
+  it('drops the protocol and shortens the form id', () => {
+    expect(
+      formatFormUrlLabel('https://form.gov.sg/654ab1234abc1a012345f1e0'),
+    ).toBe('form.gov.sg/654ab1…f1e0')
   })
 })
 

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -18,9 +18,13 @@ import {
   useAiBuilderContext,
 } from './AiBuilderContext'
 import {
+  buildFormConnectedMessage,
   buildKickoffMessage,
+  buildUrlSharedKickoffMessage,
+  buildUrlSharedMessage,
   extractFormIdFromLabel,
   extractLastFormUrl,
+  formatFormUrlLabel,
   stripFormIdPrefix,
 } from './helpers'
 import StepConfigContext from './StepConfigContext'
@@ -51,6 +55,8 @@ function AiBuilderContent() {
     parameterLabelsByStepId,
     completedStepIds,
     activeStepId,
+    hasPipe,
+    knownFormSchema,
   } = useChatStream({ initialMessages: chatMessages })
 
   // Merge labels persisted in the draft (survive refresh, committed once a
@@ -96,6 +102,11 @@ function AiBuilderContent() {
     return merged
   }, [steps, completedStepIds])
 
+  // Connecting a form only makes sense before the pipe exists — once created,
+  // connection changes go through the LLM's picker flow. hasPipe covers the
+  // live turn; output.pipeId covers persisted state after a refresh.
+  const pipeCreated = hasPipe || Boolean(output?.pipeId)
+
   const cancelRef = useRef(null)
 
   // A connection can only be created once the pipe (Flow row) exists —
@@ -104,13 +115,15 @@ function AiBuilderContent() {
   const flowId: string | undefined = output?.pipeId
 
   // In-chat "Add new form" modal (FormSG), reached two ways:
-  // - 'picker': mid-chat from the connection picker — the answer goes back in
-  //   the same Q/A format as a manual selection.
-  // - 'kickoff': from the empty-state "Connect your form" chip — connecting
-  //   starts the conversation with a kickoff message.
-  // Either way the secret key stays browser → GraphQL only (never through
-  // the chat route or the LLM), and either way creating a *new* connection
-  // requires flowId (the pipe) to already exist — see the gating below.
+  // - 'picker' (post-pipe, from the connection picker / forced key card):
+  //   full modal (URL + secret key), URL locked when already known; the
+  //   answer goes back in the same Q/A format as a manual selection. Creates
+  //   a real connection, so it requires flowId (the pipe) to already exist.
+  // - 'kickoff' (pre-pipe, from the "Connect your form" pill): url-only
+  //   modal — no secret key, no connection created; the URL just enters the
+  //   conversation so the LLM can fetch the public schema.
+  // The secret key stays browser → GraphQL only (never through the chat
+  // route or the LLM).
   const [addFormContext, setAddFormContext] = useState<
     { kind: 'picker'; question: string } | { kind: 'kickoff' } | null
   >(null)
@@ -121,6 +134,29 @@ function AiBuilderContent() {
   )
 
   const prefillFormUrl = useMemo(() => extractLastFormUrl(messages), [messages])
+
+  // The composer chip anchors whatever form the conversation is about: the
+  // connected form's title once a connection exists; otherwise the shared
+  // form's real title (from the LLM's streamed get_form_schema result) with
+  // a "not connected" cue, falling back to the compact URL until the schema
+  // has been fetched.
+  const displayedForm = useMemo(() => {
+    if (attachedForm) {
+      return { ...attachedForm, isConnected: true }
+    }
+    if (prefillFormUrl) {
+      const urlFormId = extractFormIdFromLabel(prefillFormUrl)
+      const title =
+        knownFormSchema && knownFormSchema.formId === urlFormId
+          ? knownFormSchema.title
+          : null
+      return {
+        label: title ?? formatFormUrlLabel(prefillFormUrl),
+        isConnected: false,
+      }
+    }
+    return null
+  }, [attachedForm, prefillFormUrl, knownFormSchema])
 
   const handleAddConnection = useCallback(
     (context: { question: string }) =>
@@ -133,35 +169,57 @@ function AiBuilderContent() {
     [],
   )
 
-  // Kicks off the chat with a connected form. The connection/form ids ride in
+  // Announces a connected form to the chat. The connection/form ids ride in
   // the message's "(id: …)" parenthetical (stripped from display) so the LLM
-  // can assign the connection and fetch the schema in later setup.
+  // can assign the connection and fetch the schema in later setup. As the
+  // first message it kicks off the conversation with a request for workflow
+  // suggestions; mid-conversation it is a plain announcement so the LLM
+  // continues from wherever the conversation is.
   const kickoffWithForm = useCallback(
     (connectionLabel: string, connectionId: string) => {
       const formTitle = stripFormIdPrefix(connectionLabel)
       const formId = extractFormIdFromLabel(connectionLabel)
       setAttachedForm({ label: formTitle })
-      sendMessage(buildKickoffMessage(formTitle, connectionId, formId))
+      sendMessage(
+        messages.length === 0
+          ? buildKickoffMessage(formTitle, connectionId, formId)
+          : buildFormConnectedMessage(formTitle, connectionId, formId),
+      )
     },
-    [sendMessage],
+    [sendMessage, messages.length],
   )
 
   // Reusing an existing connection kicks off the chat exactly like a freshly
   // added one — no new connection row is created.
   const handleSelectExistingForm = kickoffWithForm
 
+  // Full-variant (URL + key) success — only reachable from the 'picker' kind.
   const handleAddFormSuccess = useCallback(
     (connectionLabel: string, connectionId: string) => {
       if (addFormContext?.kind === 'picker') {
+        setAttachedForm({ label: stripFormIdPrefix(connectionLabel) })
         sendMessage(
           `Q: ${addFormContext.question}\nA: ${connectionLabel} (id: ${connectionId})`,
         )
-      } else if (addFormContext?.kind === 'kickoff') {
-        kickoffWithForm(connectionLabel, connectionId)
       }
       setAddFormContext(null)
     },
-    [addFormContext, sendMessage, kickoffWithForm],
+    [addFormContext, sendMessage],
+  )
+
+  // Url-only-variant submit — the user shared their form without a key. As
+  // the first message it asks for suggestions; mid-conversation it is a
+  // plain share the LLM picks up from where it is.
+  const handleSubmitUrl = useCallback(
+    (formUrl: string) => {
+      sendMessage(
+        messages.length === 0
+          ? buildUrlSharedKickoffMessage(formUrl)
+          : buildUrlSharedMessage(formUrl),
+      )
+      setAddFormContext(null)
+    },
+    [sendMessage, messages.length],
   )
 
   // Determine if we have unsaved work
@@ -244,18 +302,26 @@ function AiBuilderContent() {
               resetChat={resetChat}
               hasReachedLimit={hasReachedLimit}
               onAddConnection={flowId ? handleAddConnection : undefined}
-              onConnectForm={flowId ? handleConnectForm : undefined}
-              onSelectExistingForm={handleSelectExistingForm}
-              attachedForm={attachedForm}
+              knownFormUrl={prefillFormUrl}
+              onConnectForm={pipeCreated ? undefined : handleConnectForm}
+              onSelectExistingForm={
+                pipeCreated ? undefined : handleSelectExistingForm
+              }
+              attachedForm={displayedForm}
             />
           </Container>
         </Flex>
         <AddFormsgConnectionModal
           isOpen={addFormContext !== null}
           flowId={flowId}
+          variant={addFormContext?.kind === 'kickoff' ? 'url-only' : 'full'}
           prefillFormUrl={prefillFormUrl}
+          lockFormUrl={
+            addFormContext?.kind === 'picker' && Boolean(prefillFormUrl)
+          }
           onClose={() => setAddFormContext(null)}
           onSuccess={handleAddFormSuccess}
+          onSubmitUrl={handleSubmitUrl}
         />
         <ExitAlert
           cancelRef={cancelRef}

--- a/packages/frontend/src/pages/AiBuilder/index.tsx
+++ b/packages/frontend/src/pages/AiBuilder/index.tsx
@@ -17,7 +17,12 @@ import {
   AiBuilderContextProvider,
   useAiBuilderContext,
 } from './AiBuilderContext'
-import { extractLastFormUrl } from './helpers'
+import {
+  buildKickoffMessage,
+  extractFormIdFromLabel,
+  extractLastFormUrl,
+  stripFormIdPrefix,
+} from './helpers'
 import StepConfigContext from './StepConfigContext'
 
 function AiBuilderContent() {
@@ -98,26 +103,65 @@ function AiBuilderContent() {
   // has run.
   const flowId: string | undefined = output?.pipeId
 
-  // In-chat "Add new form" modal (FormSG). Holds the picker question that
-  // opened it so the eventual answer is sent back in the same Q/A format as a
-  // manual selection. The secret key stays browser → GraphQL only (never
-  // through the chat route or the LLM).
-  const [addFormContext, setAddFormContext] = useState<{
-    question: string
-  } | null>(null)
+  // In-chat "Add new form" modal (FormSG), reached two ways:
+  // - 'picker': mid-chat from the connection picker — the answer goes back in
+  //   the same Q/A format as a manual selection.
+  // - 'kickoff': from the empty-state "Connect your form" chip — connecting
+  //   starts the conversation with a kickoff message.
+  // Either way the secret key stays browser → GraphQL only (never through
+  // the chat route or the LLM), and either way creating a *new* connection
+  // requires flowId (the pipe) to already exist — see the gating below.
+  const [addFormContext, setAddFormContext] = useState<
+    { kind: 'picker'; question: string } | { kind: 'kickoff' } | null
+  >(null)
+
+  // Display-only composer chip anchoring the connected form (S3).
+  const [attachedForm, setAttachedForm] = useState<{ label: string } | null>(
+    null,
+  )
 
   const prefillFormUrl = useMemo(() => extractLastFormUrl(messages), [messages])
 
+  const handleAddConnection = useCallback(
+    (context: { question: string }) =>
+      setAddFormContext({ kind: 'picker', ...context }),
+    [],
+  )
+
+  const handleConnectForm = useCallback(
+    () => setAddFormContext({ kind: 'kickoff' }),
+    [],
+  )
+
+  // Kicks off the chat with a connected form. The connection/form ids ride in
+  // the message's "(id: …)" parenthetical (stripped from display) so the LLM
+  // can assign the connection and fetch the schema in later setup.
+  const kickoffWithForm = useCallback(
+    (connectionLabel: string, connectionId: string) => {
+      const formTitle = stripFormIdPrefix(connectionLabel)
+      const formId = extractFormIdFromLabel(connectionLabel)
+      setAttachedForm({ label: formTitle })
+      sendMessage(buildKickoffMessage(formTitle, connectionId, formId))
+    },
+    [sendMessage],
+  )
+
+  // Reusing an existing connection kicks off the chat exactly like a freshly
+  // added one — no new connection row is created.
+  const handleSelectExistingForm = kickoffWithForm
+
   const handleAddFormSuccess = useCallback(
     (connectionLabel: string, connectionId: string) => {
-      if (addFormContext) {
+      if (addFormContext?.kind === 'picker') {
         sendMessage(
           `Q: ${addFormContext.question}\nA: ${connectionLabel} (id: ${connectionId})`,
         )
+      } else if (addFormContext?.kind === 'kickoff') {
+        kickoffWithForm(connectionLabel, connectionId)
       }
       setAddFormContext(null)
     },
-    [addFormContext, sendMessage],
+    [addFormContext, sendMessage, kickoffWithForm],
   )
 
   // Determine if we have unsaved work
@@ -199,7 +243,10 @@ function AiBuilderContent() {
               cancelStream={cancelStream}
               resetChat={resetChat}
               hasReachedLimit={hasReachedLimit}
-              onAddConnection={flowId ? setAddFormContext : undefined}
+              onAddConnection={flowId ? handleAddConnection : undefined}
+              onConnectForm={flowId ? handleConnectForm : undefined}
+              onSelectExistingForm={handleSelectExistingForm}
+              attachedForm={attachedForm}
             />
           </Container>
         </Flex>


### PR DESCRIPTION
feat(mcp): connect-first start — Connect your form entry on empty state

Adds a 'Connect your form' pill (with tooltip) to the AI Builder
empty-state composer. Clicking it lists the user's existing FormSG
connections in a popover (borderless zebra rows) so one can be reused
instead of creating a duplicate; users with none go straight to the
Add-new-form modal from PR 1.

Selecting or adding a form kicks off the conversation with a message
carrying the connection and form ids in a '(id: …, form id: …)'
parenthetical — the same convention as picker answers, stripped from
the chat display — so the LLM can assign the trigger connection and
call get_form_schema without re-asking. The composer then shows a
non-dismissable attached-form chip with the form title.

The mid-chat picker/modal path from PR 1 is unchanged and remains the
fallback for conversations that don't start with a form.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

feat(mcp): split form connection into URL capture and key completion

Before the pipe exists the 'Add your form' modal collects only the
form URL (no secret key, no connection row) — the URL enters the chat
('Here's my form: …') and the LLM fetches the public schema for
field-aware suggestions. Bare 24-char IDs are normalised to full URLs.

Once the pipe exists and the LLM emits the FormSG connection picker:
if a URL is known from the conversation the picker renders as a single
key-completion card ('add your Form Secret Key') opening the full
modal with the URL prefilled and hard-locked to the same form; with no
URL known the existing picker + full modal applies.

The composer chip now always reflects the conversation's form: the
real title (read from the streamed get_form_schema tool result,
matched by form id) with a 'not connected' cue until a key is added,
then the connected title. The 'Connect your form' pill persists
mid-conversation for plain announcements and disappears once the pipe
is created (data-pipeState seen live, or output.pipeId after refresh).

Also adds the empty-state paste-your-link placeholder and form hint
copy.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>