### PR TITLE
chore: add isActive flag to OG infinite loop logs

### DIFF
--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.mrf.test.ts
@@ -138,6 +138,7 @@ function makeGlobalVariable(): IGlobalVariable {
       userId: 'userid',
       hasFileProcessingActions: false,
       name: 'test flow',
+      isActive: true,
     },
     user: {
       id: 'userid',

--- a/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
+++ b/packages/backend/src/apps/formsg/__tests__/auth/decrypt-form-response.test.ts
@@ -115,6 +115,7 @@ describe('decrypt form response', () => {
         userId: 'userid',
         hasFileProcessingActions: false,
         name: 'test flow',
+        isActive: true,
       },
       user: {
         id: 'userid',

--- a/packages/backend/src/apps/gathersg/__tests__/auth/decrypt-response.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/auth/decrypt-response.test.ts
@@ -1,7 +1,27 @@
-import { describe, expect, it } from 'vitest'
+import type { IGlobalVariable } from '@plumber/types'
 
-import { processFields } from '../../auth/decrypt-response'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}))
+
+vi.mock('@/helpers/logger', () => ({
+  default: {
+    error: mocks.error,
+  },
+}))
+
+import { processFields, validateData } from '../../auth/decrypt-response'
 import { HEX_ENCODED_FIELD_PREFIX } from '../../common/constants'
+
+const MOCK_FLOW: NonNullable<IGlobalVariable['flow']> = {
+  id: 'flow-1',
+  name: 'test flow',
+  hasFileProcessingActions: false,
+  userId: 'user-1',
+  isActive: true,
+}
 
 describe('processFields', () => {
   it('should process fields with whitespace, -, _', () => {
@@ -39,5 +59,53 @@ describe('processFields', () => {
       name: 'John Doe',
       [hexEncodedField]: 'john.doe@example.com',
     })
+  })
+})
+
+describe('validateData', () => {
+  beforeEach(() => {
+    mocks.error.mockClear()
+  })
+
+  it('returns the parsed data when it passes schema validation', () => {
+    const data = {
+      updatedBy: { email: 'user@example.com', name: 'John Doe' },
+      fields: { name: 'value' },
+    }
+
+    const result = validateData(data, MOCK_FLOW, 'gathersg')
+
+    expect(result).toEqual(data)
+    expect(mocks.error).not.toHaveBeenCalled()
+  })
+
+  it('throws and logs a potential infinite loop when data fails schema validation', () => {
+    const data = { type: 'case', uuid: 'case-uuid-1' }
+
+    expect(() => validateData(data, MOCK_FLOW, 'gathersg')).toThrow(
+      'GatherSG: potential infinite loop! Webhook not triggered by user!',
+    )
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      'GatherSG: potential infinite loop! Webhook not triggered by user! flowId: flow-1. app: gathersg. case type: case. case uuid: case-uuid-1',
+      {
+        event: 'ownself-gather-potential-infinite-loop',
+        flowId: MOCK_FLOW.id,
+        isFlowActive: MOCK_FLOW.isActive,
+      },
+    )
+  })
+
+  it('handles missing case type/uuid in the log message when data is undefined', () => {
+    expect(() => validateData(undefined, MOCK_FLOW, 'gathersg')).toThrow(
+      'GatherSG: potential infinite loop! Webhook not triggered by user!',
+    )
+
+    expect(mocks.error).toHaveBeenCalledWith(
+      'GatherSG: potential infinite loop! Webhook not triggered by user! flowId: flow-1. app: gathersg. case type: undefined. case uuid: undefined',
+      expect.objectContaining({
+        event: 'ownself-gather-potential-infinite-loop',
+      }),
+    )
   })
 })

--- a/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
+++ b/packages/backend/src/apps/gathersg/auth/decrypt-response.ts
@@ -20,12 +20,20 @@ function getInternalId(data: any) {
   return ''
 }
 
-function validateData(data: any, flowId: string, app: string) {
+export function validateData(
+  data: any,
+  flow: NonNullable<IGlobalVariable['flow']>,
+  app: string,
+) {
   const validationResult = schema.safeParse(data)
   if (!validationResult.success) {
     logger.error(
-      `GatherSG: potential infinite loop! Webhook not triggered by user! flowId: ${flowId}. app: ${app}. case type: ${data?.type}. case uuid: ${data?.uuid}`,
-      { event: 'ownself-gather-potential-infinite-loop', flowId },
+      `GatherSG: potential infinite loop! Webhook not triggered by user! flowId: ${flow.id}. app: ${app}. case type: ${data?.type}. case uuid: ${data?.uuid}`,
+      {
+        event: 'ownself-gather-potential-infinite-loop',
+        flowId: flow.id,
+        isFlowActive: flow.isActive,
+      },
     )
     throw new Error(
       'GatherSG: potential infinite loop! Webhook not triggered by user!',
@@ -116,7 +124,7 @@ export async function decryptResponse(
         decipher.final(),
       ]).toString()
       const decryptedData = JSON.parse(decryptedStr)
-      validateData(decryptedData, $.flow.id, app)
+      validateData(decryptedData, $.flow, app)
 
       const processedFields = processFields(decryptedData.fields)
 
@@ -135,7 +143,7 @@ export async function decryptResponse(
         internalId: getInternalId(decryptedData),
       }
     } else {
-      validateData(data, $.flow.id, app)
+      validateData(data, $.flow, app)
       const processedFields = processFields(data.fields)
       $.request.body = {
         app,

--- a/packages/backend/src/helpers/global-variable.ts
+++ b/packages/backend/src/helpers/global-variable.ts
@@ -73,6 +73,7 @@ const globalVariable = async (
       userId: flow?.userId,
       hasFileProcessingActions:
         (await flow?.containsFileProcessingActions()) ?? false,
+      isActive: flow?.active ?? false,
     },
     step: {
       id: step?.id,

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1108,6 +1108,7 @@ export type IGlobalVariable = {
     userId: string
     remoteWebhookId?: string
     setRemoteWebhookId?: (remoteWebhookId: string) => Promise<void>
+    isActive: boolean
   }
   step?: {
     id: string


### PR DESCRIPTION
## Problem

We only want to alert on potential OG infinite loops with published pipes.

## Fix

Add a `isActive` flag to our DD logs

## Tests

- Check that `isActive` flag shows up on infinite loop logs
- [Regression test] Check that OG pipe still works
- [Regression test] Check that normal pipes still work

---

### TL;DR

Expose `isActive` on the flow global variable and include it in GatherSG's infinite loop detection logging.

### What changed?

- Added `isActive` to the `IGlobalVariable` flow type and populated it from `flow.active` in `global-variable.ts`.
- Updated `validateData` in `decrypt-response.ts` to accept the full `flow` object instead of just `flowId`, allowing it to include `isFlowActive` in the error log when a potential infinite loop is detected.
- Exported `validateData` and added unit tests covering successful validation, failed validation with a known case type/uuid, and failed validation with undefined data.

### How to test?

- Run the existing and new unit tests for `decrypt-response`:
- Trigger a GatherSG webhook from a non-user source (e.g. a system-generated event) and verify that the error log now includes `isFlowActive` alongside `flowId` and the event name.

### Why make this change?

When investigating potential infinite loop incidents in GatherSG, knowing whether the flow was active at the time of the event provides useful context for debugging. Including `isFlowActive` in the log makes it easier to correlate incidents with flow state without needing to look it up separately.