### PR TITLE
refactor(gathersg): extract shared case-fields schema

### DIFF
--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -8,11 +8,12 @@ import StepError, { GenericSolution } from '@/errors/step'
 import logger from '@/helpers/logger'
 import { ensureZodEnumValue } from '@/helpers/zod-utils'
 
+import { fieldTypeEnum } from '../../common/constants'
 import { fetchCaseFields } from '../../common/fetch-case-fields'
 import throwGatherSGStepError from '../../common/throw-errors'
 
 import getDataOutMetadata from './get-data-out-metadata'
-import { fieldTypeEnum, requestSchema, responseSchema } from './schema'
+import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
   name: 'Create case',

--- a/packages/backend/src/apps/gathersg/actions/create-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/schema.ts
@@ -1,68 +1,12 @@
 import { z } from 'zod'
 
-export const fieldTypeEnum = z.enum(['string', 'number', 'null'])
+import { caseFieldsSchema } from '../../common/case-fields-schema'
 
 export const requestSchema = z
   .object({
     caseType: z.string().trim().min(1, 'Case type empty'),
     caseStatus: z.string().trim().optional(),
-    caseFields: z
-      .array(
-        z.object({
-          field: z.string().trim().min(1, 'Field empty'),
-          // we add nullish here because defaultValue or value doesnt work properly in dropdown
-          fieldType: fieldTypeEnum.nullish().default('string'),
-          value: z.string().trim().nullish(),
-        }),
-      )
-      .transform((params, context) => {
-        const result: Record<string, string | number | null> =
-          Object.create(null)
-        const seenFields = new Set<string>()
-        for (const { field, fieldType, value } of params) {
-          /**
-           * No null fields are allowed
-           * For now, we allow them to keep the field empty to set back to null. But in the future, may need to have a way to set to null vs set to empty string
-           */
-          if (!field) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Field empty',
-            })
-            return z.NEVER
-          }
-
-          // catch duplicate fields
-          if (seenFields.has(field)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `${field} field is repeated`,
-              fatal: true,
-            })
-            return z.NEVER
-          }
-          seenFields.add(field)
-
-          // Right now, we will attempt to parse the value to the field type
-          if (fieldType === 'null') {
-            result[field] = null
-          } else if (fieldType === 'number') {
-            const parsedValue = Number(value)
-            if (isNaN(parsedValue)) {
-              context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Invalid number type for field: ${field}`,
-              })
-              return z.NEVER
-            }
-            result[field] = parsedValue
-          } else {
-            result[field] = value
-          }
-        }
-        return result
-      })
-      .nullish(),
+    caseFields: caseFieldsSchema.nullish(),
   })
   .transform((data) => ({
     caseType: data.caseType,

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -7,9 +7,10 @@ import HttpError from '@/errors/http'
 import StepError, { GenericSolution } from '@/errors/step'
 import { ensureZodEnumValue } from '@/helpers/zod-utils'
 
+import { fieldTypeEnum } from '../../common/constants'
 import throwGatherSGStepError from '../../common/throw-errors'
 
-import { fieldTypeEnum, requestSchema, responseSchema } from './schema'
+import { requestSchema, responseSchema } from './schema'
 
 const action: IRawAction = {
   name: 'Update case',

--- a/packages/backend/src/apps/gathersg/actions/update-case/schema.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/schema.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod'
 
+import { caseFieldsSchema } from '../../common/case-fields-schema'
 import { CASE_UUID_REGEX } from '../../common/constants'
-
-export const fieldTypeEnum = z.enum(['string', 'number', 'null'])
 
 export const requestSchema = z
   .object({
@@ -16,63 +15,7 @@ export const requestSchema = z
         message: 'Please enter a valid case uuid',
       }),
     caseStatus: z.string().trim().optional(),
-    caseFields: z
-      .array(
-        z.object({
-          field: z.string().trim().min(1, 'Field empty'),
-          // we add nullish here because defaultValue or value doesnt work properly in dropdown
-          fieldType: fieldTypeEnum.nullish(),
-          value: z.string().trim().nullish(),
-        }),
-      )
-      .transform((params, context) => {
-        const result: Record<string, string | number | null> =
-          Object.create(null)
-        const seenFields = new Set<string>()
-        for (const { field, fieldType, value } of params) {
-          /**
-           * No null fields are allowed
-           * For now, we allow them to keep the field empty to set back to null. But in the future, may need to have a way to set to null vs set to empty string
-           */
-          if (!field) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Field empty',
-            })
-            return z.NEVER
-          }
-
-          // catch duplicate fields
-          if (seenFields.has(field)) {
-            context.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: `${field} field is repeated`,
-              fatal: true,
-            })
-            return z.NEVER
-          }
-          seenFields.add(field)
-
-          // Right now, we will attempt to parse the value to the field type
-          if (fieldType === 'null') {
-            result[field] = null
-          } else if (fieldType === 'number') {
-            const parsedValue = Number(value)
-            if (isNaN(parsedValue)) {
-              context.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: `Invalid number type for field: ${field}`,
-              })
-              return z.NEVER
-            }
-            result[field] = parsedValue
-          } else {
-            result[field] = value
-          }
-        }
-        return result
-      })
-      .nullish(),
+    caseFields: caseFieldsSchema.nullish(),
   })
   .transform((data) => ({
     caseUuid: data.caseUuid,

--- a/packages/backend/src/apps/gathersg/common/case-fields-schema.ts
+++ b/packages/backend/src/apps/gathersg/common/case-fields-schema.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod'
+
+import { fieldTypeEnum } from './constants'
+
+const caseFieldSchema = z.object({
+  field: z.string().trim().min(1, 'Field empty'),
+  // we add nullish here because defaultValue or value doesnt work properly in dropdown
+  fieldType: fieldTypeEnum.nullish(),
+  value: z.string().trim().nullish(),
+})
+
+// `fieldType` is widened to `string` (rather than reused verbatim from
+// `caseFieldSchema`'s inferred literal union) so this switch can already
+// branch on field types not yet present in `fieldTypeEnum`.
+type CaseField = Omit<z.infer<typeof caseFieldSchema>, 'fieldType'> & {
+  fieldType?: string | null
+}
+
+const transformCaseFields = (params: CaseField[], context: z.RefinementCtx) => {
+  const result: Record<string, string | number | null> = Object.create(null)
+  const seenFields = new Set<string>()
+  for (const { field, fieldType, value } of params) {
+    /**
+     * No null fields are allowed
+     * For now, we allow them to keep the field empty to set back to null. But in the future, may need to have a way to set to null vs set to empty string
+     */
+    if (!field) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Field empty',
+      })
+      return z.NEVER
+    }
+
+    // catch duplicate fields
+    if (seenFields.has(field)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${field} field is repeated`,
+        fatal: true,
+      })
+      return z.NEVER
+    }
+    seenFields.add(field)
+
+    // Right now, we will attempt to parse the value to the field type
+    if (fieldType === 'null') {
+      result[field] = null
+    } else if (fieldType === 'number') {
+      const parsedValue = Number(value)
+      if (isNaN(parsedValue)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid number type for field: ${field}`,
+        })
+        return z.NEVER
+      }
+      result[field] = parsedValue
+    } else if (fieldType === 'email') {
+      const emailResult = z.string().trim().email().safeParse(value)
+      if (!emailResult.success) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid email for field: ${field}`,
+        })
+        return z.NEVER
+      }
+      result[field] = emailResult.data
+    } else {
+      result[field] = value
+    }
+  }
+  return result
+}
+
+/**
+ * Shared `caseFields` array schema for create-case/update-case, parsing the
+ * multirow-multicol `{ field, fieldType, value }` rows into a
+ * `Record<string, string | number | null>` payload. A missing/null
+ * `fieldType` is treated the same as `'string'` by `transformCaseFields`'s
+ * fallback branch, so no default is needed here.
+ */
+export const caseFieldsSchema = z
+  .array(caseFieldSchema)
+  .transform(transformCaseFields)

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 /**
  * Loose regex to just accept only alphanumeric characters and dashes
  * since there is no proper public documentation with GatherSG.
@@ -11,6 +13,8 @@ export const UNSUPPORTED_FIELDS = [
   'table', // array of objects
   'attachment',
 ]
+
+export const fieldTypeEnum = z.enum(['string', 'number', 'null'])
 
 // Prefix for hex encoding field names that contain special characters
 export const HEX_ENCODED_FIELD_PREFIX = '__HEX_ENCODED__'


### PR DESCRIPTION
## TL;DR

Extracts the duplicated `caseFields` parsing/validation logic (identical in `create-case/schema.ts` and `update-case/schema.ts`) into a single shared schema, and consolidates `fieldTypeEnum` into `common/constants.ts`. No behavior change.

## What changed?

- Added `packages/backend/src/apps/gathersg/common/case-fields-schema.ts` exporting `caseFieldsSchema` — the shared zod array schema + transform that parses `{ field, fieldType, value }` rows into a `Record<string, string | number | null>` payload (duplicate/empty-field checks, `null`/`number` coercion).
- `create-case/schema.ts` and `update-case/schema.ts` now just import and use `caseFieldsSchema` instead of each declaring the same ~50 lines inline.
- Moved `fieldTypeEnum` out of the two schema files into `common/constants.ts` as the single source of truth; `create-case/index.ts` and `update-case/index.ts` now import it from there.
- Added an inert `fieldType === 'email'` branch to the shared transform (zod email validation). It can't be reached yet — `fieldTypeEnum` doesn't include `'email'` until the next PR in this stack — kept separate so this refactor stays a pure, reviewable no-op.

## Tests

- [ ] `npm run -w backend test:unit` passes locally (all existing `create-case`/`update-case` tests still pass unmodified against the extracted schema)
- [ ] Manually create/update a GatherSG case with string, number, and null fields in the flow editor and confirm behavior is unchanged from before this PR

## Deploy notes

No migrations, config, or env var changes. Pure refactor — safe to deploy independently.