### PR TITLE
feat(gathersg): add email field type for case fields

### DIFF
--- a/packages/backend/src/apps/gathersg/__tests__/actions/update-case.test.ts
+++ b/packages/backend/src/apps/gathersg/__tests__/actions/update-case.test.ts
@@ -282,6 +282,38 @@ describe('update case', () => {
     )
   })
 
+  it('builds the payload correctly with a valid email field', async () => {
+    $.step.parameters.caseFields = [
+      { field: 'email', fieldType: 'email', value: 'peter@example.com' },
+    ]
+    await updateCaseAction.run($)
+
+    expect(mocks.httpPatch).toHaveBeenCalledWith(
+      '/cases/:caseUuid',
+      {
+        caseUuid: MOCK_CASE_UUID,
+        status: MOCK_CASE_STATUS,
+        fields: {
+          email: 'peter@example.com',
+        },
+      },
+      {
+        urlPathParams: {
+          caseUuid: MOCK_CASE_UUID,
+        },
+      },
+    )
+  })
+
+  it('should throw step error for invalid email field type', async () => {
+    $.step.parameters.caseFields = [
+      { field: 'email', fieldType: 'email', value: 'not-an-email' },
+    ]
+    await expect(updateCaseAction.run($)).rejects.toThrow(
+      'Invalid email for field: email',
+    )
+  })
+
   it('should handle mixed field types correctly', async () => {
     $.step.parameters.caseFields = [
       { field: 'name', fieldType: 'string', value: 'Bruce Wayne' },

--- a/packages/backend/src/apps/gathersg/actions/create-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/create-case/index.ts
@@ -111,6 +111,10 @@ const action: IRawAction = {
               value: ensureZodEnumValue(fieldTypeEnum, 'number'),
             },
             {
+              label: 'Email',
+              value: ensureZodEnumValue(fieldTypeEnum, 'email'),
+            },
+            {
               label: 'Null',
               value: ensureZodEnumValue(fieldTypeEnum, 'null'),
             },

--- a/packages/backend/src/apps/gathersg/actions/update-case/index.ts
+++ b/packages/backend/src/apps/gathersg/actions/update-case/index.ts
@@ -94,6 +94,10 @@ const action: IRawAction = {
               value: ensureZodEnumValue(fieldTypeEnum, 'number'),
             },
             {
+              label: 'Email',
+              value: ensureZodEnumValue(fieldTypeEnum, 'email'),
+            },
+            {
               label: 'Null',
               value: ensureZodEnumValue(fieldTypeEnum, 'null'),
             },

--- a/packages/backend/src/apps/gathersg/common/constants.ts
+++ b/packages/backend/src/apps/gathersg/common/constants.ts
@@ -14,7 +14,7 @@ export const UNSUPPORTED_FIELDS = [
   'attachment',
 ]
 
-export const fieldTypeEnum = z.enum(['string', 'number', 'null'])
+export const fieldTypeEnum = z.enum(['string', 'number', 'null', 'email'])
 
 // Prefix for hex encoding field names that contain special characters
 export const HEX_ENCODED_FIELD_PREFIX = '__HEX_ENCODED__'


### PR DESCRIPTION
## TL;DR

Adds `email` as a supported case-field type in `create-case`/`update-case`, validated via the email branch added in #1911.

## What changed?

- Extended `fieldTypeEnum` in `common/constants.ts` from `['string', 'number', 'null']` to include `'email'`.
- Added an "Email" option to the `fieldType` dropdown in both `create-case/index.ts` and `update-case/index.ts`, alongside the existing Text/Number/Null options.
- This makes the `fieldType === 'email'` branch in `case-fields-schema.ts` (added in #1911, previously unreachable) live — values are validated with zod's `.email()` and rejected with `Invalid email for field: <field>` if malformed.
- Added test coverage in `update-case.test.ts` for a valid email payload and an invalid-email rejection.

## Tests

- [ ] `npm run -w backend test:unit` passes locally (17/17 `update-case` tests, including the 2 new email cases)
- [ ] Manually add a case field with type "Email" in the flow editor, submit a valid email, and confirm the case is created/updated correctly
- [ ] Manually submit an invalid email value and confirm the step fails with `Invalid email for field: <field>`

## Deploy notes

No migrations, config, or env var changes. Base: #1911 (merge that first).