### PR TITLE
PLU-862: fix overaggressive timeInJobQueue

### DIFF
--- a/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
@@ -228,21 +228,21 @@ describe('retryExecutionStep mutation', () => {
       expect(mockJob.retry).toHaveBeenCalled()
     })
 
-    it('should stamp retryQueuedAt on the job before calling retry', async () => {
+    it('should stamp retryTimestamp on the job before calling retry', async () => {
       vi.spyOn(Date, 'now').mockReturnValue(123456789)
 
       await retryExecutionStep(null, { input: genericInputParams }, context)
 
       expect(mockJob.updateData).toHaveBeenCalledWith({
         ...mockJobData,
-        retryQueuedAt: 123456789,
+        retryTimestamp: 123456789,
       })
       expect(mockJob.updateData.mock.invocationCallOrder[0]).toBeLessThan(
         mockJob.retry.mock.invocationCallOrder[0],
       )
     })
 
-    it('should revert the retryQueuedAt stamp if job.retry() throws', async () => {
+    it('should revert the retryTimestamp stamp if job.retry() throws', async () => {
       const retryErr = new Error('job is not in the failed state')
       mockJob.retry.mockRejectedValue(retryErr)
 
@@ -252,7 +252,7 @@ describe('retryExecutionStep mutation', () => {
 
       expect(mockJob.updateData).toHaveBeenNthCalledWith(1, {
         ...mockJobData,
-        retryQueuedAt: expect.any(Number),
+        retryTimestamp: expect.any(Number),
       })
       expect(mockJob.updateData).toHaveBeenNthCalledWith(2, mockJobData)
     })

--- a/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
+++ b/packages/backend/src/graphql/__tests__/mutations/retry-execution-step.itest.ts
@@ -29,8 +29,18 @@ describe('retryExecutionStep mutation', () => {
   let mockExecutionStep: ExecutionStep
   let mockStep: Step
   let getActionJobSpy: MockInstance
-  let mockJob: { retry: MockInstance }
+  let mockJob: {
+    retry: MockInstance
+    data: Record<string, unknown>
+    updateData: MockInstance
+  }
   let genericInputParams: { executionStepId: string }
+
+  const mockJobData = {
+    flowId: 'mock-flow-id',
+    executionId: 'mock-execution-id',
+    stepId: 'mock-step-id',
+  }
 
   beforeEach(async () => {
     vi.resetAllMocks()
@@ -38,6 +48,8 @@ describe('retryExecutionStep mutation', () => {
     // Initialize mock job
     mockJob = {
       retry: vi.fn().mockResolvedValue(undefined),
+      data: { ...mockJobData },
+      updateData: vi.fn().mockResolvedValue(undefined),
     }
 
     context = await generateMockContext()
@@ -214,6 +226,35 @@ describe('retryExecutionStep mutation', () => {
       expect(result).toBe(true)
       expect(getActionJobSpy).toHaveBeenCalledWith('test-job-id')
       expect(mockJob.retry).toHaveBeenCalled()
+    })
+
+    it('should stamp retryQueuedAt on the job before calling retry', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(123456789)
+
+      await retryExecutionStep(null, { input: genericInputParams }, context)
+
+      expect(mockJob.updateData).toHaveBeenCalledWith({
+        ...mockJobData,
+        retryQueuedAt: 123456789,
+      })
+      expect(mockJob.updateData.mock.invocationCallOrder[0]).toBeLessThan(
+        mockJob.retry.mock.invocationCallOrder[0],
+      )
+    })
+
+    it('should revert the retryQueuedAt stamp if job.retry() throws', async () => {
+      const retryErr = new Error('job is not in the failed state')
+      mockJob.retry.mockRejectedValue(retryErr)
+
+      await expect(
+        retryExecutionStep(null, { input: genericInputParams }, context),
+      ).rejects.toThrow(retryErr)
+
+      expect(mockJob.updateData).toHaveBeenNthCalledWith(1, {
+        ...mockJobData,
+        retryQueuedAt: expect.any(Number),
+      })
+      expect(mockJob.updateData).toHaveBeenNthCalledWith(2, mockJobData)
     })
   })
 

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -33,7 +33,21 @@ const retryExecutionStep: MutationResolvers['retryExecutionStep'] = async (
     await executionStep.$query().patch({ jobId: null })
     throw new Error('Job not found or has expired')
   }
-  await job.retry()
+
+  const originalJobData = job.data
+  await job.updateData({ ...originalJobData, retryQueuedAt: Date.now() })
+  try {
+    await job.retry()
+  } catch (err) {
+    // job.retry() throws if the job isn't actually in the terminal "failed"
+    // state (e.g. it's still sitting in BullMQ's own delayed/backoff state from
+    // an earlier attempt - ExecutionStep gets a status:'failure' row on every
+    // failed attempt, not just the terminal one, so a human can race this).
+    // Revert the stamp so we don't pollute telemetry for a retry that never
+    // took effect.
+    await job.updateData(originalJobData)
+    throw err
+  }
   // allow for status to change to null in case there are delay actions after
   await Execution.query()
     .patch({ status: null })

--- a/packages/backend/src/graphql/mutations/retry-execution-step.ts
+++ b/packages/backend/src/graphql/mutations/retry-execution-step.ts
@@ -35,7 +35,7 @@ const retryExecutionStep: MutationResolvers['retryExecutionStep'] = async (
   }
 
   const originalJobData = job.data
-  await job.updateData({ ...originalJobData, retryQueuedAt: Date.now() })
+  await job.updateData({ ...originalJobData, retryTimestamp: Date.now() })
   try {
     await job.retry()
   } catch (err) {

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -123,8 +123,8 @@ describe('Backoff', () => {
     )
   })
 
-  describe('retryQueuedAt stamping', () => {
-    it('stamps retryQueuedAt on the job before returning the delay', async () => {
+  describe('retryTimestamp stamping', () => {
+    it('stamps retryTimestamp on the job before returning the delay', async () => {
       const err = new RetriableError({
         error: 'test error',
         delayInMs: 1000,
@@ -146,7 +146,7 @@ describe('Backoff', () => {
         flowId: 'flow-id',
         executionId: 'exec-id',
         stepId: 'step-id',
-        retryQueuedAt: 123456789,
+        retryTimestamp: 123456789,
       })
     })
 
@@ -163,7 +163,7 @@ describe('Backoff', () => {
       )
     })
 
-    it('logs and still returns the delay if stamping retryQueuedAt fails', async () => {
+    it('logs and still returns the delay if stamping retryTimestamp fails', async () => {
       const err = new RetriableError({
         error: 'test error',
         delayInMs: 1000,
@@ -182,9 +182,9 @@ describe('Backoff', () => {
       ).resolves.toEqual(1000)
 
       expect(mocks.logError).toHaveBeenCalledWith(
-        'Failed to stamp retryQueuedAt for automatic retry',
+        'Failed to stamp retryTimestamp for automatic retry',
         {
-          event: 'backoff-stamp-retry-queued-at-failed',
+          event: 'backoff-stamp-retry-timestamp-failed',
           err: updateErr,
         },
       )

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -1,3 +1,6 @@
+import type { IActionJobData } from '@plumber/types'
+
+import { type JobPro } from '@taskforcesh/bullmq-pro'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import RetriableError, { DEFAULT_DELAY_MS } from '@/errors/retriable-error'
@@ -29,7 +32,7 @@ describe('Backoff', () => {
     { delayInMs: 1, expectedBaseDelay: 1 },
   ])(
     'applies jitter (delayInMs = $delayInMs)',
-    ({ delayInMs, expectedBaseDelay }) => {
+    async ({ delayInMs, expectedBaseDelay }) => {
       const err = new RetriableError({
         error: 'test error',
         delayInMs,
@@ -37,16 +40,16 @@ describe('Backoff', () => {
       })
       vi.spyOn(Math, 'random').mockReturnValue(0.5)
 
-      expect(exponentialBackoffWithJitter(1, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(1, null, err)).resolves.toEqual(
         Math.round(expectedBaseDelay + expectedBaseDelay / 2),
       )
-      expect(exponentialBackoffWithJitter(2, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(2, null, err)).resolves.toEqual(
         Math.round(
           expectedBaseDelay * 2 /* Full delay for 1st retry */ +
             expectedBaseDelay /* 50% of full delay*/,
         ),
       )
-      expect(exponentialBackoffWithJitter(3, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(3, null, err)).resolves.toEqual(
         Math.round(
           expectedBaseDelay * 4 /* Full delay for 2nd retry */ +
             expectedBaseDelay * 2 /* 50% of full delay*/,
@@ -64,7 +67,7 @@ describe('Backoff', () => {
     { delayInMs: 1, expectedBaseDelay: 1 },
   ])(
     'will wait at least the full duration of the previous default delay',
-    ({ delayInMs, expectedBaseDelay }) => {
+    async ({ delayInMs, expectedBaseDelay }) => {
       const err = new RetriableError({
         error: 'test error',
         delayInMs,
@@ -72,33 +75,35 @@ describe('Backoff', () => {
       })
       vi.spyOn(Math, 'random').mockReturnValue(0)
 
-      expect(exponentialBackoffWithJitter(1, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(1, null, err)).resolves.toEqual(
         expectedBaseDelay,
       )
-      expect(exponentialBackoffWithJitter(2, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(2, null, err)).resolves.toEqual(
         expectedBaseDelay * 2,
       )
-      expect(exponentialBackoffWithJitter(3, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(3, null, err)).resolves.toEqual(
         expectedBaseDelay * 4,
       )
-      expect(exponentialBackoffWithJitter(4, null, err)).toEqual(
+      await expect(exponentialBackoffWithJitter(4, null, err)).resolves.toEqual(
         expectedBaseDelay * 8,
       )
     },
   )
 
-  it("uses RetriableError's default delay and logs if error is not RetriableError", () => {
+  it("uses RetriableError's default delay and logs if error is not RetriableError", async () => {
     const err = new Error('test error')
     vi.spyOn(Math, 'random').mockReturnValue(0)
 
-    expect(exponentialBackoffWithJitter(1, null, err)).toEqual(DEFAULT_DELAY_MS)
+    await expect(exponentialBackoffWithJitter(1, null, err)).resolves.toEqual(
+      DEFAULT_DELAY_MS,
+    )
     expect(mocks.logError).toHaveBeenCalledWith(
       'Triggered BullMQ retry without RetriableError',
       { event: 'bullmq-retry-without-retriable-error' },
     )
   })
 
-  it('logs if error is RetriableError with non-step delayType', () => {
+  it('logs if error is RetriableError with non-step delayType', async () => {
     const err = new RetriableError({
       error: 'test error',
       delayInMs: 10,
@@ -106,7 +111,9 @@ describe('Backoff', () => {
     })
     vi.spyOn(Math, 'random').mockReturnValue(0)
 
-    expect(exponentialBackoffWithJitter(1, null, err)).toEqual(10)
+    await expect(exponentialBackoffWithJitter(1, null, err)).resolves.toEqual(
+      10,
+    )
     expect(mocks.logError).toHaveBeenCalledWith(
       'Triggered BullMQ retry with RetriableError of the wrong delay type',
       {
@@ -114,5 +121,73 @@ describe('Backoff', () => {
         delayType: 'queue',
       },
     )
+  })
+
+  describe('retryQueuedAt stamping', () => {
+    it('stamps retryQueuedAt on the job before returning the delay', async () => {
+      const err = new RetriableError({
+        error: 'test error',
+        delayInMs: 1000,
+        delayType: 'step',
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      vi.spyOn(Date, 'now').mockReturnValue(123456789)
+      const updateData = vi.fn().mockResolvedValue(undefined)
+      const job = {
+        data: { flowId: 'flow-id', executionId: 'exec-id', stepId: 'step-id' },
+        updateData,
+      } as unknown as JobPro<IActionJobData>
+
+      await expect(
+        exponentialBackoffWithJitter(1, null, err, job),
+      ).resolves.toEqual(1000)
+
+      expect(updateData).toHaveBeenCalledWith({
+        flowId: 'flow-id',
+        executionId: 'exec-id',
+        stepId: 'step-id',
+        retryQueuedAt: 123456789,
+      })
+    })
+
+    it('does not stamp anything when no job is provided', async () => {
+      const err = new RetriableError({
+        error: 'test error',
+        delayInMs: 1000,
+        delayType: 'step',
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+
+      await expect(exponentialBackoffWithJitter(1, null, err)).resolves.toEqual(
+        1000,
+      )
+    })
+
+    it('logs and still returns the delay if stamping retryQueuedAt fails', async () => {
+      const err = new RetriableError({
+        error: 'test error',
+        delayInMs: 1000,
+        delayType: 'step',
+      })
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const updateErr = new Error('redis down')
+      const updateData = vi.fn().mockRejectedValue(updateErr)
+      const job = {
+        data: { flowId: 'flow-id', executionId: 'exec-id', stepId: 'step-id' },
+        updateData,
+      } as unknown as JobPro<IActionJobData>
+
+      await expect(
+        exponentialBackoffWithJitter(1, null, err, job),
+      ).resolves.toEqual(1000)
+
+      expect(mocks.logError).toHaveBeenCalledWith(
+        'Failed to stamp retryQueuedAt for automatic retry',
+        {
+          event: 'backoff-stamp-retry-queued-at-failed',
+          err: updateErr,
+        },
+      )
+    })
   })
 })

--- a/packages/backend/src/helpers/__tests__/backoff.test.ts
+++ b/packages/backend/src/helpers/__tests__/backoff.test.ts
@@ -124,7 +124,7 @@ describe('Backoff', () => {
   })
 
   describe('retryTimestamp stamping', () => {
-    it('stamps retryTimestamp on the job before returning the delay', async () => {
+    it('stamps retryTimestamp as the time the job actually becomes eligible (now + delay), not now', async () => {
       const err = new RetriableError({
         error: 'test error',
         delayInMs: 1000,
@@ -146,7 +146,7 @@ describe('Backoff', () => {
         flowId: 'flow-id',
         executionId: 'exec-id',
         stepId: 'step-id',
-        retryTimestamp: 123456789,
+        retryTimestamp: 123456789 + 1000,
       })
     })
 

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -43,7 +43,17 @@ export const exponentialBackoffWithJitter: BackoffStrategy = async function (
 
   if (job) {
     try {
-      await job.updateData({ ...job.data, retryTimestamp: Date.now() })
+      // The job doesn't actually become eligible to run until `delay` ms from
+      // now - moveToFailed() computes the delayed job's eligibility score as
+      // Date.now() + delay right after this strategy returns (see
+      // node_modules/bullmq/dist/cjs/classes/job.js:428). Stamping now() alone
+      // would count the entire backoff wait as time in queue, even though
+      // it's an intentional wait, not queue congestion (same reasoning as
+      // why job.opts.delay is excluded for a job's first attempt).
+      await job.updateData({
+        ...job.data,
+        retryTimestamp: Date.now() + delay,
+      })
     } catch (updateErr) {
       // Never let a telemetry-stamp failure break the actual retry - this
       // await sits directly in BullMQ's moveToFailed() path, so a rejection

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -5,12 +5,12 @@ import RetriableError, { DEFAULT_DELAY_MS } from '@/errors/retriable-error'
 import logger from './logger'
 
 type BackoffStrategy = WorkerProOptions['settings']['backoffStrategy']
-export const exponentialBackoffWithJitter: BackoffStrategy = function (
+export const exponentialBackoffWithJitter: BackoffStrategy = async function (
   attemptsMade,
   _type,
   err,
-  _job,
-): number {
+  job,
+): Promise<number> {
   // This implements FullJitter-like jitter, with the following changes:
   //
   // * We wait _at least_ the full duration of the previous delay (or on the 1st
@@ -39,5 +39,21 @@ export const exponentialBackoffWithJitter: BackoffStrategy = function (
   const initialDelay =
     err instanceof RetriableError ? err.delayInMs : DEFAULT_DELAY_MS
   const prevFullDelay = Math.pow(2, attemptsMade - 1) * initialDelay
-  return prevFullDelay + Math.round(Math.random() * prevFullDelay)
+  const delay = prevFullDelay + Math.round(Math.random() * prevFullDelay)
+
+  if (job) {
+    try {
+      await job.updateData({ ...job.data, retryQueuedAt: Date.now() })
+    } catch (updateErr) {
+      // Never let a telemetry-stamp failure break the actual retry - this
+      // await sits directly in BullMQ's moveToFailed() path, so a rejection
+      // here would abort the retry scheduling itself.
+      logger.error('Failed to stamp retryQueuedAt for automatic retry', {
+        event: 'backoff-stamp-retry-queued-at-failed',
+        err: updateErr,
+      })
+    }
+  }
+
+  return delay
 }

--- a/packages/backend/src/helpers/backoff.ts
+++ b/packages/backend/src/helpers/backoff.ts
@@ -43,13 +43,13 @@ export const exponentialBackoffWithJitter: BackoffStrategy = async function (
 
   if (job) {
     try {
-      await job.updateData({ ...job.data, retryQueuedAt: Date.now() })
+      await job.updateData({ ...job.data, retryTimestamp: Date.now() })
     } catch (updateErr) {
       // Never let a telemetry-stamp failure break the actual retry - this
       // await sits directly in BullMQ's moveToFailed() path, so a rejection
       // here would abort the retry scheduling itself.
-      logger.error('Failed to stamp retryQueuedAt for automatic retry', {
-        event: 'backoff-stamp-retry-queued-at-failed',
+      logger.error('Failed to stamp retryTimestamp for automatic retry', {
+        event: 'backoff-stamp-retry-timestamp-failed',
         err: updateErr,
       })
     }

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -435,7 +435,7 @@ describe('Action worker', () => {
       vi.setSystemTime(startTime)
       await failedJob.updateData({
         ...failedJob.data,
-        retryQueuedAt: Date.now(),
+        retryTimestamp: Date.now(),
       })
 
       mocks.processAction.mockResolvedValueOnce({

--- a/packages/backend/src/workers/__tests__/action.itest.ts
+++ b/packages/backend/src/workers/__tests__/action.itest.ts
@@ -1,4 +1,6 @@
-import { UnrecoverableError } from '@taskforcesh/bullmq-pro'
+import type { IActionJobData } from '@plumber/types'
+
+import { type JobPro, UnrecoverableError } from '@taskforcesh/bullmq-pro'
 import {
   afterEach,
   beforeAll,
@@ -390,5 +392,77 @@ describe('Action worker', () => {
         )
       },
     )
+
+    it('measures time in job queue from a manual retry stamp instead of the stale original job creation time', async () => {
+      const DAYS_STALE_MS = 3 * 24 * 60 * 60 * 1000
+      const RETRY_WAIT_MS = 250
+
+      // Job originally created 3 days before it's manually retried.
+      vi.setSystemTime(startTime - DAYS_STALE_MS)
+
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: true },
+      })
+      mocks.handleFailedStepAndThrow.mockRejectedValueOnce(
+        new UnrecoverableError('not retriable error'),
+      )
+
+      // WorkerPro's 'failed' event is typed with base bullmq's Job (not
+      // JobPro) since WorkerPro doesn't override it, but the job instance is
+      // actually a JobPro at runtime - we need JobPro's updateData/retry below.
+      let failedJob: JobPro<IActionJobData>
+      const jobFailed = new Promise<void>((resolve) => {
+        mainActionWorker.on('failed', async (job) => {
+          failedJob = job as unknown as JobPro<IActionJobData>
+          resolve()
+        })
+      })
+
+      await enqueueActionJob({
+        appKey: null,
+        jobName: 'test-job',
+        jobData: {
+          flowId: 'test-flow-id',
+          executionId: 'test-exec-id',
+          stepId: 'test-step-id',
+        },
+        jobOptions: DEFAULT_JOB_OPTIONS,
+      })
+      await jobFailed
+
+      // The job then sits failed for days until a human manually retries it -
+      // mirrors retry-execution-step.ts's stamp-then-retry sequence.
+      vi.setSystemTime(startTime)
+      await failedJob.updateData({
+        ...failedJob.data,
+        retryQueuedAt: Date.now(),
+      })
+
+      mocks.processAction.mockResolvedValueOnce({
+        executionStep: { isFailed: false, nextStep: null },
+      })
+
+      const jobProcessed = new Promise<void>((resolve) => {
+        mainActionWorker.on('completed', async (_) => {
+          resolve()
+        })
+      })
+      mainActionWorker.on('active', async (_) => {
+        // Advance clock by the mocked wait between the manual retry stamp and
+        // the worker actually picking the job back up.
+        vi.setSystemTime(startTime + RETRY_WAIT_MS)
+      })
+
+      await failedJob.retry()
+      await jobProcessed
+
+      expect(mocks.addSpanTags).toBeCalledWith(
+        expect.objectContaining({
+          jobEnqueueTime: startTime,
+          jobDelay: 0,
+          timeInJobQueue: RETRY_WAIT_MS,
+        }),
+      )
+    })
   })
 })

--- a/packages/backend/src/workers/helpers/__tests__/job-queue-timing.test.ts
+++ b/packages/backend/src/workers/helpers/__tests__/job-queue-timing.test.ts
@@ -1,0 +1,78 @@
+import type { IActionJobData } from '@plumber/types'
+
+import { type JobPro } from '@taskforcesh/bullmq-pro'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getJobQueueTimingTags } from '../job-queue-timing'
+
+function makeJob(
+  overrides: Partial<JobPro<IActionJobData>> &
+    Pick<JobPro<IActionJobData>, 'timestamp' | 'data'>,
+): JobPro<IActionJobData> {
+  return {
+    opts: {},
+    attemptsStarted: 1,
+    ...overrides,
+  } as unknown as JobPro<IActionJobData>
+}
+
+describe('getJobQueueTimingTags', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('measures from job.timestamp when retryQueuedAt is absent', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5000)
+    const job = makeJob({
+      timestamp: 1000,
+      opts: { delay: 500 },
+      attemptsStarted: 2,
+      data: { flowId: 'f', executionId: 'e', stepId: 's' },
+    })
+
+    expect(getJobQueueTimingTags(job)).toEqual({
+      jobEnqueueTime: 1000,
+      jobDelay: 500,
+      attempts: 2,
+      timeInJobQueue: 5000 - 1000 - 500,
+    })
+  })
+
+  it('defaults jobDelay to 0 when opts.delay is absent and retryQueuedAt is absent', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(5000)
+    const job = makeJob({
+      timestamp: 1000,
+      opts: {},
+      data: { flowId: 'f', executionId: 'e', stepId: 's' },
+    })
+
+    expect(getJobQueueTimingTags(job)).toEqual({
+      jobEnqueueTime: 1000,
+      jobDelay: 0,
+      attempts: 1,
+      timeInJobQueue: 5000 - 1000,
+    })
+  })
+
+  it('measures from retryQueuedAt and ignores opts.delay once a retry has been stamped', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10000)
+    const job = makeJob({
+      timestamp: 1000, // stale original enqueue time
+      opts: { delay: 500 }, // stale original delay - retries requeue to wait, not delayed
+      attemptsStarted: 3,
+      data: {
+        flowId: 'f',
+        executionId: 'e',
+        stepId: 's',
+        retryQueuedAt: 8000,
+      },
+    })
+
+    expect(getJobQueueTimingTags(job)).toEqual({
+      jobEnqueueTime: 8000,
+      jobDelay: 0,
+      attempts: 3,
+      timeInJobQueue: 10000 - 8000,
+    })
+  })
+})

--- a/packages/backend/src/workers/helpers/__tests__/job-queue-timing.test.ts
+++ b/packages/backend/src/workers/helpers/__tests__/job-queue-timing.test.ts
@@ -21,7 +21,7 @@ describe('getJobQueueTimingTags', () => {
     vi.restoreAllMocks()
   })
 
-  it('measures from job.timestamp when retryQueuedAt is absent', () => {
+  it('measures from job.timestamp when retryTimestamp is absent', () => {
     vi.spyOn(Date, 'now').mockReturnValue(5000)
     const job = makeJob({
       timestamp: 1000,
@@ -38,7 +38,7 @@ describe('getJobQueueTimingTags', () => {
     })
   })
 
-  it('defaults jobDelay to 0 when opts.delay is absent and retryQueuedAt is absent', () => {
+  it('defaults jobDelay to 0 when opts.delay is absent and retryTimestamp is absent', () => {
     vi.spyOn(Date, 'now').mockReturnValue(5000)
     const job = makeJob({
       timestamp: 1000,
@@ -54,7 +54,7 @@ describe('getJobQueueTimingTags', () => {
     })
   })
 
-  it('measures from retryQueuedAt and ignores opts.delay once a retry has been stamped', () => {
+  it('measures from retryTimestamp and ignores opts.delay once a retry has been stamped', () => {
     vi.spyOn(Date, 'now').mockReturnValue(10000)
     const job = makeJob({
       timestamp: 1000, // stale original enqueue time
@@ -64,7 +64,7 @@ describe('getJobQueueTimingTags', () => {
         flowId: 'f',
         executionId: 'e',
         stepId: 's',
-        retryQueuedAt: 8000,
+        retryTimestamp: 8000,
       },
     })
 

--- a/packages/backend/src/workers/helpers/job-queue-timing.ts
+++ b/packages/backend/src/workers/helpers/job-queue-timing.ts
@@ -3,12 +3,12 @@ import type { IActionJobData } from '@plumber/types'
 import type { JobPro } from '@taskforcesh/bullmq-pro'
 
 export function getJobQueueTimingTags(job: JobPro<IActionJobData>) {
-  const { retryQueuedAt } = job.data
-  const jobEnqueueTime = retryQueuedAt ?? job.timestamp
+  const { retryTimestamp } = job.data
+  const jobEnqueueTime = retryTimestamp ?? job.timestamp
   // Once a job has been retried (manually or automatically), the original
   // static opts.delay no longer applies - retries re-queue directly to wait,
   // bypassing delay entirely.
-  const jobDelay = retryQueuedAt ? 0 : job.opts?.delay ?? 0
+  const jobDelay = retryTimestamp ? 0 : job.opts?.delay ?? 0
 
   return {
     jobEnqueueTime,

--- a/packages/backend/src/workers/helpers/job-queue-timing.ts
+++ b/packages/backend/src/workers/helpers/job-queue-timing.ts
@@ -1,0 +1,19 @@
+import type { IActionJobData } from '@plumber/types'
+
+import type { JobPro } from '@taskforcesh/bullmq-pro'
+
+export function getJobQueueTimingTags(job: JobPro<IActionJobData>) {
+  const { retryQueuedAt } = job.data
+  const jobEnqueueTime = retryQueuedAt ?? job.timestamp
+  // Once a job has been retried (manually or automatically), the original
+  // static opts.delay no longer applies - retries re-queue directly to wait,
+  // bypassing delay entirely.
+  const jobDelay = retryQueuedAt ? 0 : job.opts?.delay ?? 0
+
+  return {
+    jobEnqueueTime,
+    jobDelay,
+    attempts: job.attemptsStarted,
+    timeInJobQueue: Date.now() - jobEnqueueTime - jobDelay,
+  }
+}

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -21,6 +21,7 @@ import { enqueueActionJob, makeActionJobId } from '@/queues/action'
 import { processAction } from '@/services/action'
 
 import processForEachStatus from './for-each-status-manager'
+import { getJobQueueTimingTags } from './job-queue-timing'
 import { registerWorkerEventHandlers } from './worker-event-handlers'
 
 function convertParamsToBullMqOptions(
@@ -116,12 +117,16 @@ export function makeActionWorker(
           actionKey: currStep?.key,
           appKey: currStep?.appKey,
           jobId,
-          jobEnqueueTime: job.timestamp,
-          jobDelay: job.opts?.delay ?? 0,
-          attempts: job.attemptsStarted,
-          timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
+          ...getJobQueueTimingTags(job),
           workerVersion: appConfig.version,
         })
+
+        const {
+          flowId: jobFlowId,
+          executionId: jobExecutionId,
+          stepId: jobStepId,
+          metadata: jobMetadata,
+        } = jobData
 
         const {
           flowId,
@@ -130,7 +135,13 @@ export function makeActionWorker(
           executionStep,
           nextStepMetadata,
           executionError,
-        } = await processAction({ ...jobData, jobId }).catch(async (err) => {
+        } = await processAction({
+          flowId: jobFlowId,
+          executionId: jobExecutionId,
+          stepId: jobStepId,
+          metadata: jobMetadata,
+          jobId,
+        }).catch(async (err) => {
           // This happens when the prerequisite steps for the action fails (e.g.
           // db error, missing execution, flow, step, etc...) in such cases, we
           // do not want to retry

--- a/packages/backend/src/workers/helpers/make-action-worker.ts
+++ b/packages/backend/src/workers/helpers/make-action-worker.ts
@@ -122,13 +122,6 @@ export function makeActionWorker(
         })
 
         const {
-          flowId: jobFlowId,
-          executionId: jobExecutionId,
-          stepId: jobStepId,
-          metadata: jobMetadata,
-        } = jobData
-
-        const {
           flowId,
           executionId,
           nextStep,
@@ -136,10 +129,7 @@ export function makeActionWorker(
           nextStepMetadata,
           executionError,
         } = await processAction({
-          flowId: jobFlowId,
-          executionId: jobExecutionId,
-          stepId: jobStepId,
-          metadata: jobMetadata,
+          ...jobData,
           jobId,
         }).catch(async (err) => {
           // This happens when the prerequisite steps for the action fails (e.g.

--- a/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
+++ b/packages/backend/src/workers/helpers/make-sub-trigger-worker.ts
@@ -21,6 +21,7 @@ import Flow from '@/models/flow'
 import Step from '@/models/step'
 import { enqueueActionJob } from '@/queues/action'
 
+import { getJobQueueTimingTags } from './job-queue-timing'
 import { registerWorkerEventHandlers } from './worker-event-handlers'
 
 interface MakeSubTriggerWorkerParams {
@@ -76,10 +77,7 @@ export function makeSubTriggerWorker(
         stepId: jobData.stepId,
         actionKey: step?.key,
         appKey: step?.appKey,
-        jobEnqueueTime: job.timestamp,
-        jobDelay: job.opts?.delay ?? 0,
-        attempts: job.attemptsStarted,
-        timeInJobQueue: Date.now() - job.timestamp - (job.opts?.delay ?? 0),
+        ...getJobQueueTimingTags(job),
         workerVersion: appConfig.version,
       })
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -967,6 +967,13 @@ export interface IActionJobData {
   executionId: string
   stepId: string
   metadata?: NextStepMetadata
+  /**
+   * Timestamp of the most recent retry (manual, via retryExecutionStep, or
+   * automatic, via exponentialBackoffWithJitter) that made this job eligible
+   * to run again, so queue-timing telemetry measures from that retry instead
+   * of the job's original (potentially very stale) enqueue time.
+   */
+  retryQueuedAt?: number
 }
 
 export interface IActionRunResult {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -973,7 +973,7 @@ export interface IActionJobData {
    * to run again, so queue-timing telemetry measures from that retry instead
    * of the job's original (potentially very stale) enqueue time.
    */
-  retryQueuedAt?: number
+  retryTimestamp?: number
 }
 
 export interface IActionRunResult {


### PR DESCRIPTION
# Problem

`timeInJobQueue` includes time spent in our DLQ. Root cause is because BullMQ populates `job.timestamp` with job creation time, not "job entered queue" time.

# Fix

Create a new `retryTimestamp` in job data that gets populated on manual retry and auto-retry.

# Tests

- Check that timeInJobQueue counts from job retry time if it has been retried.
- [Regression test] Check that timeInJobQueue counts job creation time and accounts for delay if job has not been retried
- [Regression test] Check that manual retry works
- [Regression test] Check that auto retry works